### PR TITLE
feat: add user-facing UI for list and fighter narrative editing

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -1,4 +1,5 @@
 from django import forms
+from tinymce.widgets import TinyMCE
 
 from gyrinx.content.models import ContentFighter, ContentHouse, ContentWeaponAccessory
 from gyrinx.core.forms import BsCheckboxSelectMultiple
@@ -6,23 +7,79 @@ from gyrinx.core.models.list import List, ListFighter, ListFighterEquipmentAssig
 from gyrinx.forms import group_select
 from gyrinx.models import FighterCategoryChoices
 
+# TinyMCE configuration for narrative fields
+TINYMCE_CONFIG = {
+    "relative_urls": False,
+    "promotion": False,
+    "resize": "both",
+    "width": "100%",
+    "height": "400px",
+    "plugins": "autoresize autosave code emoticons fullscreen help link lists quickbars textpattern visualblocks",
+    "toolbar": "undo redo | blocks | bold italic underline link | numlist bullist align | code",
+    "menubar": "edit view insert format table tools help",
+    "menu": {
+        "edit": {
+            "title": "Edit",
+            "items": "undo redo | cut copy paste pastetext | selectall | searchreplace",
+        },
+        "view": {
+            "title": "View",
+            "items": "code revisionhistory | visualaid visualchars visualblocks | spellchecker | preview fullscreen | showcomments",
+        },
+        "insert": {
+            "title": "Insert",
+            "items": "image link media addcomment pageembed codesample inserttable | math | charmap emoticons hr | pagebreak nonbreaking anchor tableofcontents | insertdatetime",
+        },
+        "format": {
+            "title": "Format",
+            "items": "bold italic underline strikethrough superscript subscript codeformat | styles blocks fontfamily fontsize align lineheight | forecolor backcolor | language | removeformat",
+        },
+        "tools": {
+            "title": "Tools",
+            "items": "spellchecker spellcheckerlanguage | a11ycheck code wordcount",
+        },
+        "table": {
+            "title": "Table",
+            "items": "inserttable | cell row column | advtablesort | tableprops deletetable",
+        },
+    },
+    "textpattern_patterns": [
+        {"start": "# ", "replacement": "<h1>%</h1>"},
+        {"start": "## ", "replacement": "<h2>%</h2>"},
+        {"start": "### ", "replacement": "<h3>%</h3>"},
+        {"start": "#### ", "replacement": "<h4>%</h4>"},
+        {"start": "##### ", "replacement": "<h5>%</h5>"},
+        {"start": "###### ", "replacement": "<h6>%</h6>"},
+        {
+            "start": r"\*\*([^\*]+)\*\*",
+            "replacement": "<strong>%</strong>",
+        },
+        {"start": r"\*([^\*]+)\*", "replacement": "<em>%</em>"},
+    ],
+}
+
 
 class NewListForm(forms.ModelForm):
     class Meta:
         model = List
-        fields = ["name", "content_house", "public"]
+        fields = ["name", "content_house", "narrative", "public"]
         labels = {
             "name": "Name",
             "content_house": "House",
+            "narrative": "About",
             "public": "Public",
         }
         help_texts = {
             "name": "The name you use to identify this List. This may be public.",
+            "narrative": "Narrative description of the gang in this list: their history and how to play them.",
             "public": "If checked, this list will be visible to all users of Gyrinx. You can edit this later.",
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
             "content_house": forms.Select(attrs={"class": "form-select"}),
+            "narrative": TinyMCE(
+                attrs={"cols": 80, "rows": 20}, mce_attrs=TINYMCE_CONFIG
+            ),
             "public": forms.CheckboxInput(attrs={"class": "form-check-input"}),
         }
 
@@ -30,17 +87,22 @@ class NewListForm(forms.ModelForm):
 class CloneListForm(forms.ModelForm):
     class Meta:
         model = List
-        fields = ["name", "public"]
+        fields = ["name", "narrative", "public"]
         labels = {
             "name": "Name",
+            "narrative": "About",
             "public": "Public",
         }
         help_texts = {
             "name": "The name you use to identify this List. This may be public.",
+            "narrative": "Narrative description of the gang in this list: their history and how to play them.",
             "public": "If checked, this List will be visible to all users of Gyrinx. You can edit this later.",
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
+            "narrative": TinyMCE(
+                attrs={"cols": 80, "rows": 20}, mce_attrs=TINYMCE_CONFIG
+            ),
             "public": forms.CheckboxInput(attrs={"class": "form-check-input"}),
         }
 
@@ -48,17 +110,22 @@ class CloneListForm(forms.ModelForm):
 class EditListForm(forms.ModelForm):
     class Meta:
         model = List
-        fields = ["name", "public"]
+        fields = ["name", "narrative", "public"]
         labels = {
             "name": "Name",
+            "narrative": "About",
             "public": "Public",
         }
         help_texts = {
             "name": "The name you use to identify this list. This may be public.",
+            "narrative": "Narrative description of the gang in this list: their history and how to play them.",
             "public": "If checked, this list will be visible to all users.",
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
+            "narrative": TinyMCE(
+                attrs={"cols": 80, "rows": 20}, mce_attrs=TINYMCE_CONFIG
+            ),
             "public": forms.CheckboxInput(attrs={"class": "form-check-input"}),
         }
 
@@ -374,5 +441,22 @@ class ListFighterEquipmentAssignmentUpgradeForm(forms.ModelForm):
         widgets = {
             "upgrades_field": BsCheckboxSelectMultiple(
                 attrs={"class": "form-check-input"},
+            ),
+        }
+
+
+class EditListFighterNarrativeForm(forms.ModelForm):
+    class Meta:
+        model = ListFighter
+        fields = ["narrative"]
+        labels = {
+            "narrative": "About",
+        }
+        help_texts = {
+            "narrative": "Narrative description of the Fighter: their history and how to play them.",
+        }
+        widgets = {
+            "narrative": TinyMCE(
+                attrs={"cols": 80, "rows": 20}, mce_attrs=TINYMCE_CONFIG
             ),
         }

--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -16,15 +16,51 @@
         {% endfor %}
     </nav>
     <div id="list-overview">
-        <h3 class="h4" id="about-list">Overview</h3>
-        {{ list.narrative|safe }}
+        <div class="hstack">
+            <h3 class="h4" id="about-list">Overview</h3>
+            {% if list.owner_cached == user %}
+                <div class="ms-auto">
+                    <a href="{% url 'core:list-edit' list.id %}" class="btn btn-outline-secondary btn-sm">
+                        <i class="bi-pencil"></i> Edit
+                    </a>
+                </div>
+            {% endif %}
+        </div>
+        {% if list.narrative %}
+            {{ list.narrative|safe }}
+        {% elif list.owner_cached == user %}
+            <div class="text-muted fst-italic">No narrative added yet. <a href="{% url 'core:list-edit' list.id %}">Add one</a> to tell the story of your gang.</div>
+        {% else %}
+            <div class="text-muted fst-italic">No narrative added yet.</div>
+        {% endif %}
     </div>
     <div class="grid">
         {% for fighter in list.fighters %}
             {% if fighter.narrative %}
                 <div class="g-col-12 g-col-md-6" id="about-{{ fighter.id }}">
-                    <h3 class="h4">{{ fighter.name }}</h3>
+                    <div class="hstack">
+                        <h3 class="h4">{{ fighter.name }}</h3>
+                        {% if list.owner_cached == user %}
+                            <div class="ms-auto">
+                                <a href="{% url 'core:list-fighter-narrative-edit' list.id fighter.id %}" class="btn btn-outline-secondary btn-sm">
+                                    <i class="bi-pencil"></i> Edit
+                                </a>
+                            </div>
+                        {% endif %}
+                    </div>
                     {{ fighter.narrative|safe }}
+                </div>
+            {% elif list.owner_cached == user %}
+                <div class="g-col-12 g-col-md-6" id="about-{{ fighter.id }}">
+                    <div class="hstack">
+                        <h3 class="h4">{{ fighter.name }}</h3>
+                        <div class="ms-auto">
+                            <a href="{% url 'core:list-fighter-narrative-edit' list.id fighter.id %}" class="btn btn-outline-secondary btn-sm">
+                                <i class="bi-plus"></i> Add About
+                            </a>
+                        </div>
+                    </div>
+                    <div class="text-muted fst-italic">No narrative added yet.</div>
                 </div>
             {% endif %}
             {% include "core/includes/fighter_card.html" with fighter=fighter list=list print=True classes="g-col-12 g-col-md-6" %}

--- a/gyrinx/core/templates/core/list_clone.html
+++ b/gyrinx/core/templates/core/list_clone.html
@@ -9,6 +9,7 @@
         <h1 class="h3">Clone: {{ form.instance.name }}</h1>
         <form action="{% url 'core:list-clone' form.instance.id %}" method="post">
             {% csrf_token %}
+            {{ form.media }}
             {{ form }}
             <div class="mt-3">
                 <input type="submit" class="btn btn-primary" value="Clone">

--- a/gyrinx/core/templates/core/list_edit.html
+++ b/gyrinx/core/templates/core/list_edit.html
@@ -9,6 +9,7 @@
         <h1 class="h3">Edit</h1>
         <form action="{% url 'core:list-edit' form.instance.id %}" method="post">
             {% csrf_token %}
+            {{ form.media }}
             {{ form }}
             <div class="mt-3">
                 <input type="submit" class="btn btn-primary" value="Save">

--- a/gyrinx/core/templates/core/list_fighter_narrative_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_narrative_edit.html
@@ -1,0 +1,21 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    About - {{ form.instance.name }} - {{ form.instance.content_fighter.name }} - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with text=list.name %}
+    <div class="col-lg-12 px-0 vstack gap-3">
+        <h1 class="h3">About: {{ form.instance.name }} - {{ form.instance.content_fighter.name }}</h1>
+        <form action="{% url 'core:list-fighter-narrative-edit' list.id form.instance.id %}"
+              method="post">
+            {% csrf_token %}
+            {{ form.media }}
+            {{ form }}
+            <div class="mt-3">
+                <input type="submit" class="btn btn-primary" value="Save">
+                <a href="{% url 'core:list' list.id %}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/list_new.html
+++ b/gyrinx/core/templates/core/list_new.html
@@ -11,6 +11,7 @@
               method="post"
               class="vstack gap-3">
             {% csrf_token %}
+            {{ form.media }}
             {{ form }}
             <div class="mt-3">
                 <input type="submit" class="btn btn-primary" value="Create">

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -47,6 +47,11 @@ urlpatterns = [
         name="list-fighter-powers-edit",
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/narrative",
+        list.edit_list_fighter_narrative,
+        name="list-fighter-narrative-edit",
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/gear",
         list.edit_list_fighter_equipment,
         name="list-fighter-gear-edit",

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -659,7 +659,7 @@ def edit_list_fighter_narrative(request, id, fighter_id):
         if form.is_valid():
             form.save()
             return HttpResponseRedirect(
-                reverse("core:list", args=(lst.id,)) + f"#{str(fighter.id)}"
+                reverse("core:list-about", args=(lst.id,)) + f"#about-{str(fighter.id)}"
             )
     else:
         form = EditListFighterNarrativeForm(instance=fighter)

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -25,6 +25,7 @@ from gyrinx.core.forms.list import (
     CloneListFighterForm,
     CloneListForm,
     EditListForm,
+    EditListFighterNarrativeForm,
     ListFighterEquipmentAssignmentAccessoriesForm,
     ListFighterEquipmentAssignmentCostForm,
     ListFighterEquipmentAssignmentForm,
@@ -626,6 +627,49 @@ def edit_list_fighter_powers(request, id, fighter_id):
             "fighter": fighter,
             "powers": powers,
             "assigns": assigns,
+            "error_message": error_message,
+        },
+    )
+
+
+@login_required
+def edit_list_fighter_narrative(request, id, fighter_id):
+    """
+    Edit the narrative of an existing :model:`core.ListFighter`.
+
+    **Context**
+
+    ``form``
+        A EditListFighterNarrativeForm for editing fighter narrative.
+    ``list``
+        The :model:`core.List` that owns this fighter.
+    ``error_message``
+        None or a string describing a form error.
+
+    **Template**
+
+    :template:`core/list_fighter_narrative_edit.html`
+    """
+    lst = get_object_or_404(List, id=id, owner=request.user)
+    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+
+    error_message = None
+    if request.method == "POST":
+        form = EditListFighterNarrativeForm(request.POST, instance=fighter)
+        if form.is_valid():
+            form.save()
+            return HttpResponseRedirect(
+                reverse("core:list", args=(lst.id,)) + f"#{str(fighter.id)}"
+            )
+    else:
+        form = EditListFighterNarrativeForm(instance=fighter)
+
+    return render(
+        request,
+        "core/list_fighter_narrative_edit.html",
+        {
+            "form": form,
+            "list": lst,
             "error_message": error_message,
         },
     )


### PR DESCRIPTION
Adds user-facing forms for editing list and fighter narratives using TinyMCE, building on the existing list about page.

## Changes
- Add narrative fields with TinyMCE to NewListForm, EditListForm, and CloneListForm
- Create EditListFighterNarrativeForm for fighter narrative editing
- Add edit_list_fighter_narrative view with proper owner permissions
- Add URL pattern for fighter narrative editing route
- Create template for fighter narrative editing
- Update all list form templates to include form.media for TinyMCE
- Add edit/add buttons to list about page for narratives
- Ensure TinyMCE integration matches existing campaign form patterns

Fixes #69

Generated with [Claude Code](https://claude.ai/code)