### PR TITLE
feat: add group-based feature toggles

### DIFF
--- a/docs/group-based-features.md
+++ b/docs/group-based-features.md
@@ -1,0 +1,93 @@
+# Group-Based Feature Toggles
+
+This document describes how to use group-based feature toggles in Gyrinx templates.
+
+## Overview
+
+Group-based feature toggles allow you to show or hide features based on a user's membership in specific Django groups. This is useful for:
+- Alpha/beta testing features with select users
+- Gradual feature rollouts
+- Access control for premium features
+
+## Template Tag Usage
+
+### Basic Usage
+
+First, load the `group_tags` in your template:
+
+```django
+{% load group_tags %}
+```
+
+Then use the `in_group` filter to check membership:
+
+```django
+{% if user|in_group:"Group Name" %}
+    <!-- Content only visible to group members -->
+{% endif %}
+```
+
+### Examples
+
+#### Navigation Items
+```django
+{% if user|in_group:"Campaigns Alpha" %}
+    <li class="nav-item">
+        <a class="nav-link" href="{% url 'core:campaigns' %}">Campaigns</a>
+    </li>
+{% endif %}
+```
+
+#### Feature Sections
+```django
+{% if user|in_group:"Beta Testers" %}
+    <div class="card">
+        <div class="card-header">Beta Features</div>
+        <div class="card-body">
+            <!-- Beta feature content -->
+        </div>
+    </div>
+{% endif %}
+```
+
+#### Conditional Buttons
+```django
+{% if user|in_group:"Premium Users" %}
+    <button class="btn btn-primary">Export to PDF</button>
+{% else %}
+    <button class="btn btn-secondary" disabled>Export to PDF (Premium)</button>
+{% endif %}
+```
+
+## How It Works
+
+The `in_group` filter:
+1. Checks if the user is authenticated
+2. Looks up the group by exact name match
+3. Returns `True` if the user is a member, `False` otherwise
+4. Returns `False` if the group doesn't exist (fail-safe behavior)
+
+## Creating Groups
+
+Groups can be created via:
+1. Django Admin interface: `/admin/auth/group/`
+2. Django shell: `Group.objects.create(name="Group Name")`
+3. Data migration
+
+## Adding Users to Groups
+
+Users can be added to groups via:
+1. Django Admin interface
+2. Django shell:
+   ```python
+   user = User.objects.get(username="username")
+   group = Group.objects.get(name="Campaigns Alpha")
+   user.groups.add(group)
+   ```
+
+## Best Practices
+
+1. **Use descriptive group names**: "Campaigns Alpha", "Beta Testers", "Premium Users"
+2. **Document groups**: Keep a list of active feature groups and their purposes
+3. **Clean up old groups**: Remove groups for features that have been fully released
+4. **Fail gracefully**: The filter returns `False` for non-existent groups, so features stay hidden if groups are deleted

--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -1,5 +1,5 @@
 {% extends "core/layouts/foundation.html" %}
-{% load static custom_tags pages %}
+{% load static custom_tags pages group_tags %}
 {% block base %}
     <a class="visually-hidden-focusable" href="#content">Skip to main content</a>
     <nav class="navbar navbar-expand-lg bg-dark" data-bs-theme="dark">
@@ -42,6 +42,13 @@
                            {% active_aria 'core:lists' %}
                            href="{% url 'core:lists' %}">Lists</a>
                     </li>
+                    {% if user|in_group:"Campaigns Alpha" %}
+                        <li class="nav-item">
+                            <a class="nav-link {% active_view 'core:campaigns' %}"
+                               {% active_aria 'core:campaigns' %}
+                               href="{% url 'core:campaigns' %}">Campaigns</a>
+                        </li>
+                    {% endif %}
                     <li class="nav-item dropdown">
                         <button class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center"
                                 id="bd-theme"

--- a/gyrinx/core/templatetags/group_tags.py
+++ b/gyrinx/core/templatetags/group_tags.py
@@ -1,0 +1,29 @@
+from django import template
+from django.contrib.auth.models import Group
+
+register = template.Library()
+
+
+@register.filter
+def in_group(user, group_name):
+    """
+    Check if a user is in a specific group by name.
+
+    Usage in templates:
+        {% if user|in_group:"Campaigns Alpha" %}
+            <!-- Content only visible to group members -->
+        {% endif %}
+
+    Returns False if:
+    - User is not authenticated
+    - Group doesn't exist
+    - User is not in the group
+    """
+    if not user or not user.is_authenticated:
+        return False
+
+    try:
+        group = Group.objects.get(name=group_name)
+        return user.groups.filter(pk=group.pk).exists()
+    except Group.DoesNotExist:
+        return False

--- a/gyrinx/core/tests/test_group_tags.py
+++ b/gyrinx/core/tests/test_group_tags.py
@@ -1,0 +1,119 @@
+import pytest
+from django.contrib.auth.models import User, Group, AnonymousUser
+from django.template import Context, Template
+
+from gyrinx.core.templatetags.group_tags import in_group
+
+
+@pytest.mark.django_db
+def test_in_group_filter_with_member():
+    """Test that in_group returns True when user is in the group."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    group = Group.objects.create(name="Campaigns Alpha")
+    user.groups.add(group)
+
+    assert in_group(user, "Campaigns Alpha") is True
+
+
+@pytest.mark.django_db
+def test_in_group_filter_with_non_member():
+    """Test that in_group returns False when user is not in the group."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    Group.objects.create(name="Campaigns Alpha")  # Group exists but user not in it
+
+    assert in_group(user, "Campaigns Alpha") is False
+
+
+@pytest.mark.django_db
+def test_in_group_filter_with_nonexistent_group():
+    """Test that in_group returns False when group doesn't exist."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+
+    assert in_group(user, "Nonexistent Group") is False
+
+
+@pytest.mark.django_db
+def test_in_group_filter_with_anonymous_user():
+    """Test that in_group returns False for anonymous users."""
+    anonymous_user = AnonymousUser()
+    Group.objects.create(name="Campaigns Alpha")
+
+    assert in_group(anonymous_user, "Campaigns Alpha") is False
+
+
+@pytest.mark.django_db
+def test_in_group_filter_with_none_user():
+    """Test that in_group returns False when user is None."""
+    Group.objects.create(name="Campaigns Alpha")
+
+    assert in_group(None, "Campaigns Alpha") is False
+
+
+@pytest.mark.django_db
+def test_in_group_filter_in_template():
+    """Test that the in_group filter works correctly in templates."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    group = Group.objects.create(name="Campaigns Alpha")
+    user.groups.add(group)
+
+    template = Template(
+        "{% load group_tags %}"
+        '{% if user|in_group:"Campaigns Alpha" %}VISIBLE{% else %}HIDDEN{% endif %}'
+    )
+    context = Context({"user": user})
+    result = template.render(context)
+
+    assert result == "VISIBLE"
+
+
+@pytest.mark.django_db
+def test_in_group_filter_in_template_non_member():
+    """Test that the in_group filter hides content for non-members in templates."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    Group.objects.create(name="Campaigns Alpha")  # Group exists but user not in it
+
+    template = Template(
+        "{% load group_tags %}"
+        '{% if user|in_group:"Campaigns Alpha" %}VISIBLE{% else %}HIDDEN{% endif %}'
+    )
+    context = Context({"user": user})
+    result = template.render(context)
+
+    assert result == "HIDDEN"
+
+
+@pytest.mark.django_db
+def test_campaigns_link_visible_for_group_members(client):
+    """Test that the Campaigns link is visible for group members."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    group = Group.objects.create(name="Campaigns Alpha")
+    user.groups.add(group)
+
+    client.login(username="testuser", password="testpass")
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b'href="/campaigns/"' in response.content
+    assert b">Campaigns</a>" in response.content
+
+
+@pytest.mark.django_db
+def test_campaigns_link_hidden_for_non_members(client):
+    """Test that the Campaigns link is hidden for non-members."""
+    User.objects.create_user(username="testuser", password="testpass")
+    # User exists but not in the Campaigns Alpha group
+
+    client.login(username="testuser", password="testpass")
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b">Campaigns</a>" not in response.content
+
+
+@pytest.mark.django_db
+def test_campaigns_link_hidden_for_anonymous_users(client):
+    """Test that the Campaigns link is hidden for anonymous users."""
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b">Campaigns</a>" not in response.content


### PR DESCRIPTION
## Summary
- Add template filter for checking Django group membership
- Implement fail-safe group-based feature toggles
- Add Campaigns navigation link for "Campaigns Alpha" group members

## Features
### Template Tag
- Created `in_group` filter in `group_tags.py`
- Checks if authenticated user is member of specified group
- Returns `False` if group doesn't exist (fail-safe behavior)
- Easy to use: `{% if user|in_group:"Group Name" %}`

### Navigation Integration
- Added Campaigns link to main navigation
- Only visible to users in "Campaigns Alpha" group
- Maintains consistent styling with other nav items

### Testing
- 10 comprehensive tests covering all scenarios
- Tests for authenticated/anonymous users
- Tests for existing/non-existent groups
- Template integration tests
- Navigation visibility tests

### Documentation
- Created `docs/group-based-features.md`
- Usage examples and best practices
- Group management instructions
- Multiple use case examples

## Usage
```django
{% load group_tags %}

{% if user|in_group:"Campaigns Alpha" %}
    <\!-- Feature only visible to group members -->
{% endif %}
```

This provides a clean, reusable way to gate features based on group membership, perfect for alpha/beta testing or gradual feature rollouts.

🤖 Generated with [Claude Code](https://claude.ai/code)