### PR TITLE
feat: add cost override for gear assignments

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -64,9 +64,16 @@
                                         {% if assign.cost_int != 0 %}({{ assign.cost_display }}){% endif %}
                                         {% if list.owner_cached == user and not print %}
                                             {% if assign.kind == 'assigned' and not assign.is_linked %}
+                                                <br>
+                                                {% if not assign.is_from_default_assignment %}
+                                                    <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
+                                                       class="link-secondary">Edit</a>
+                                                    <span class="text-muted">·</span>
+                                                {% endif %}
                                                 <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
                                                    class="link-danger">Remove</a>
                                             {% elif assign.kind == 'default' %}
+                                                <br>
                                                 <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
                                                    class="link-danger">Remove</a>
                                             {% endif %}
@@ -148,9 +155,16 @@
                                     {% if assign.cost_int != 0 %}({{ assign.cost_display }}){% endif %}
                                     {% if list.owner_cached == user and not print %}
                                         {% if assign.kind == 'assigned' and not assign.is_linked %}
+                                            <br>
+                                            {% if not assign.is_from_default_assignment %}
+                                                <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
+                                                   class="link-secondary">Edit</a>
+                                                <span class="text-muted">·</span>
+                                            {% endif %}
                                             <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
                                                class="link-danger">Remove</a>
                                         {% elif assign.kind == 'default' %}
+                                            <br>
                                             <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
                                                class="link-danger">Remove</a>
                                         {% endif %}

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -60,6 +60,15 @@ urlpatterns = [
         ),
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/gear/<assign_id>/cost",
+        list.edit_list_fighter_assign_cost,
+        name="list-fighter-gear-cost-edit",
+        kwargs=dict(
+            back_name="core:list-fighter-gear-edit",
+            action_name="core:list-fighter-gear-cost-edit",
+        ),
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/gear/<assign_id>/delete",
         list.delete_list_fighter_assign,
         name="list-fighter-gear-delete",


### PR DESCRIPTION
Fixes #171

This PR adds the ability to override costs on gear assignments, matching the existing functionality for weapons.

## Changes

- Add URL pattern for gear cost edit that reuses existing `edit_list_fighter_assign_cost` view
- Add Edit button alongside Remove button for gear assignments
- Only show Edit button for assigned gear that is not linked (same conditions as Remove)
- Layout matches requested design with buttons underneath name + cost

Generated with [Claude Code](https://claude.ai/code)