### PR TITLE
feat: expand campaign colors to 24 options with tooltips

### DIFF
--- a/gyrinx/core/templates/core/widgets/color_radio_option.html
+++ b/gyrinx/core/templates/core/widgets/color_radio_option.html
@@ -1,34 +1,42 @@
 {% load color_tags %}
 <input type="radio"
-       class="btn-check"
+       class="visually-hidden color-radio-input"
        name="{{ widget.name }}"
        value="{{ widget.value|stringformat:'s' }}"
        id="{{ widget.attrs.id }}"
        {% if widget.selected %}checked{% endif %}
        {% if widget.attrs.disabled %}disabled{% endif %}
        {% include "django/forms/widgets/attrs.html" %}>
-<label class="btn position-relative p-2"
+<label class="color-radio-label position-relative p-0 border-0 rounded-2"
        for="{{ widget.attrs.id }}"
-       style="width: 3em;
-              height: 3em"
-       title="{{ widget.label }}">
+       style="width: 3rem;
+              height: 3rem;
+              cursor: pointer;
+              transition: all 0.2s ease;"
+       title="{{ widget.label }}"
+       data-bs-toggle="tooltip"
+       data-bs-placement="top">
     {% if widget.color %}
-        <span class="position-absolute top-50 start-50 translate-middle d-block rounded-1"
-              style="width: 2em;
-                     height: 2em;
-                     background-color: {{ widget.color }};
-                     border: 2px solid rgba(0,0,0,0.2)"></span>
-        {% if widget.color == "#fefdfb" %}
-            {# djlint:off H021 #}
-            <span class="position-absolute top-50 start-50 translate-middle"
-                  style="font-size: 0.7rem;
-                         color: black">W</span>
-            {# djlint:on #}
-        {% endif %}
+        <span class="d-block w-100 h-100 rounded-2"
+              style="background-color: {{ widget.color }};
+                     border: 2px solid rgba(0,0,0,0.15);
+                     box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+            {% if widget.color == "#fefdfb" %}
+                {# djlint:off H021 #}
+                <span class="position-absolute top-50 start-50 translate-middle fw-bold"
+                      style="font-size: 0.8rem;
+                             color: #666;
+                             text-shadow: 1px 1px 1px rgba(255,255,255,0.5);">W</span>
+                {# djlint:on #}
+            {% endif %}
+        </span>
     {% else %}
         {# djlint:off H021 #}
-        <span class="position-absolute top-50 start-50 translate-middle text-muted"
-              style="font-size: 0.7rem">None</span>
+        <span class="d-flex align-items-center justify-content-center w-100 h-100 border border-2 rounded-2"
+              style="border-style: dashed;">
+            <span class="text-muted"
+                  style="font-size: 0.7rem">None</span>
+        </span>
         {# djlint:on #}
     {% endif %}
 </label>

--- a/gyrinx/core/templates/core/widgets/color_radio_select.html
+++ b/gyrinx/core/templates/core/widgets/color_radio_select.html
@@ -1,8 +1,9 @@
 {% with id=widget.attrs.id %}
     <div {% if id %}id="{{ id }}"{% endif %}
          {% if widget.attrs.class %}class="{{ widget.attrs.class }}"{% endif %}>
-        <div class="btn-group flex-wrap"
-             role="group"
+        <div class="d-grid gap-2"
+             style="grid-template-columns: repeat(auto-fill, minmax(3.5rem, 1fr)); max-width: 24rem;"
+             role="radiogroup"
              aria-label="Theme color selection">
             {% for group, options, index in widget.optgroups %}
                 {% for option in options %}
@@ -11,4 +12,17 @@
             {% endfor %}
         </div>
     </div>
+    <style>
+        .color-radio-label:hover {
+            transform: scale(1.1);
+            z-index: 1;
+        }
+        .color-radio-input:checked + .color-radio-label {
+            box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.5);
+            transform: scale(1.05);
+        }
+        .color-radio-input:focus + .color-radio-label {
+            box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.25);
+        }
+    </style>
 {% endwith %}

--- a/gyrinx/core/widgets.py
+++ b/gyrinx/core/widgets.py
@@ -138,13 +138,31 @@ class ColorRadioSelect(forms.RadioSelect):
     # Predefined color palette
     COLOR_PALETTE = [
         ("", "None (Default)"),
-        ("#386b33", "Fern Green"),
-        ("#4e9e47", "Pigment Green"),
-        ("#ffa629", "Orange Peel"),
-        ("#ffbb5c", "Hunyadi Yellow"),
-        ("#d62e31", "Persian Red"),
-        ("#4593c4", "Celestial Blue"),
-        ("#a1c8e2", "Uranian Blue"),
+        # Base colors
+        ("#386b33", "Green"),
+        ("#6bb261", "Bright Green"),
+        ("#a7d9a3", "Pastel Green"),
+        ("#d62e31", "Red"),
+        ("#ff5a5e", "Bright Red"),
+        ("#ffb3b5", "Pastel Red"),
+        ("#ffa629", "Orange"),
+        ("#ffbc5c", "Bright Orange"),
+        ("#ffd6a6", "Pastel Orange"),
+        ("#ffbb5c", "Yellow"),
+        ("#ffcc77", "Bright Yellow"),
+        ("#ffe4b3", "Pastel Yellow"),
+        ("#4593c4", "Blue"),
+        ("#5fa9d9", "Bright Blue"),
+        ("#a1c8e2", "Pastel Blue"),
+        ("#7b68ee", "Purple"),
+        ("#9d8fff", "Bright Purple"),
+        ("#c4b5fd", "Pastel Purple"),
+        ("#ff69b4", "Pink"),
+        ("#ff8ec4", "Bright Pink"),
+        ("#ffb6d9", "Pastel Pink"),
+        ("#40e0d0", "Turquoise"),
+        ("#66e9de", "Bright Turquoise"),
+        ("#a3f0e8", "Pastel Turquoise"),
         ("#fefdfb", "White"),
     ]
 
@@ -159,4 +177,5 @@ class ColorRadioSelect(forms.RadioSelect):
         )
         # Add the color value to the option context for use in the template
         option["color"] = value
+        option["label"] = label  # Ensure label is available for tooltip
         return option

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ nodeenv==1.9.1
 playwright==1.48.0
 pre-commit==4.2.0
 psycopg2-binary==2.9.10
+pycolornames==0.4.0
 pydot==4.0.0
 pyparsing==3.2.3
 pytest==8.4.0


### PR DESCRIPTION
## Summary

Expanded the campaign color selection from 8 to 25 colors by adding bright and pastel variants of base colors. Updated the UI from a button group to a responsive CSS grid layout that handles multiple rows gracefully. Added Bootstrap tooltips showing color names on hover.

Fixes #219

Generated with [Claude Code](https://claude.ai/code)