### PR TITLE
fix: Change navigation from gang page to campaign when in a campaign

### DIFF
--- a/gyrinx/core/templates/core/list.html
+++ b/gyrinx/core/templates/core/list.html
@@ -4,7 +4,10 @@
     {{ list.name }} | {{ list.owner_cached }}
 {% endblock head_title %}
 {% block content %}
-    {% if list.owner_cached == request.user %}
+    {% if list.campaign %}
+        {% url 'core:campaign' list.campaign.id as campaign_url %}
+        {% include "core/includes/back.html" with url=campaign_url text=list.campaign.name %}
+    {% elif list.owner_cached == request.user %}
         {% include "core/includes/home.html" %}
     {% else %}
         {% url 'core:lists' as lists_url %}


### PR DESCRIPTION
When viewing a gang/list that is part of a campaign, the back navigation now shows the campaign name and links to the campaign overview page instead of showing "< Home".

Fixes #220

Generated with [Claude Code](https://claude.ai/code)