### PR TITLE
fix: reorder campaign page modules

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -88,66 +88,49 @@
                     <i class="bi-info-circle"></i> No campaign details have been added yet.
                 </div>
             {% endif %}
-            <!-- Campaign Actions -->
+            <!-- Campaign Lists -->
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
-                    <h2 class="card-title h5 mb-0">Action Log</h2>
-                    <div class="hstack gap-2">
-                        {% if can_log_actions %}
-                            <a href="{% url 'core:campaign-action-new' campaign.id %}"
-                               class="btn btn-primary btn-sm">
-                                <i class="bi-plus-circle"></i> Log Action
-                            </a>
-                        {% endif %}
-                        <a href="{% url 'core:campaign-actions' campaign.id %}"
-                           class="btn btn-outline-secondary btn-sm">
-                            <i class="bi-list-ul"></i> View All
+                    <h2 class="card-title h5 mb-0">Lists</h2>
+                    {% if campaign.owner == user and campaign.is_pre_campaign %}
+                        <a href="{% url 'core:campaign-add-lists' campaign.id %}"
+                           class="btn btn-primary btn-sm">
+                            <i class="bi-plus-circle"></i> Add Lists
                         </a>
-                    </div>
+                    {% endif %}
                 </div>
                 <div class="card-body p-0">
-                    {% with recent_actions=campaign.actions.all|slice:":5" %}
-                        {% if recent_actions %}
-                            <div class="list-group list-group-flush">
-                                {% for action in recent_actions %}
-                                    <div class="list-group-item">
-                                        <div class="d-flex w-100 justify-content-between">
-                                            <small class="text-muted">
-                                                <strong>{{ action.user.username }}</strong> • {{ action.created|timesince }} ago
-                                            </small>
-                                        </div>
-                                        <p class="mb-1 text-truncate">{{ action.description }}</p>
-                                        {% if action.dice_count > 0 %}
-                                            <small class="text-muted">
-                                                <i class="bi bi-dice-6"></i> Rolled {{ action.dice_count }}D6:
-                                                {% for result in action.dice_results %}
-                                                    {{ result }}
-                                                    {% if not forloop.last %},{% endif %}
-                                                {% endfor %}
-                                                = <strong>{{ action.dice_total }}</strong>
-                                            </small>
-                                        {% endif %}
-                                        {% if action.outcome %}
-                                            <small class="text-muted d-block">
-                                                <strong>Outcome:</strong> {{ action.outcome|truncatewords:10 }}
-                                            </small>
-                                        {% elif action.user == user %}
-                                            <small>
-                                                <a href="{% url 'core:campaign-action-outcome' campaign.id action.id %}"
-                                                   class="link-primary">Add outcome</a>
-                                            </small>
-                                        {% endif %}
+                    {% if campaign.lists.all %}
+                        <div class="list-group list-group-flush">
+                            {% for list in campaign.lists.all %}
+                                <a href="{% url 'core:list' list.id %}"
+                                   class="list-group-item list-group-item-action">
+                                    <div class="d-flex w-100 justify-content-between">
+                                        <h6 class="mb-1">
+                                            {% list_with_theme list "me-1" %}
+                                            {% if list.content_house %}<span class="badge bg-secondary">{{ list.content_house.name }}</span>{% endif %}
+                                        </h6>
+                                        <small>{{ list.cost_display }}</small>
                                     </div>
-                                {% endfor %}
-                            </div>
-                            <div class="text-center mt-1">
-                                <a href="{% url 'core:campaign-actions' campaign.id %}"
-                                   class="btn btn-sm btn-link">View all actions →</a>
-                            </div>
-                        {% else %}
-                            <div class="p-3 text-center text-muted">No actions logged yet.</div>
-                        {% endif %}
-                    {% endwith %}
+                                    <p class="mb-1 text-muted small">
+                                        By {{ list.owner.username }}
+                                        • {{ list.fighters.count }} fighter{{ list.fighters.count|pluralize }}
+                                    </p>
+                                </a>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <div class="p-3 text-center text-muted">
+                            No lists have been added to this campaign yet.
+                            {% if campaign.owner == user and campaign.is_pre_campaign %}
+                                <br>
+                                <a href="{% url 'core:campaign-add-lists' campaign.id %}"
+                                   class="btn btn-primary btn-sm mt-2">
+                                    <i class="bi-plus-circle"></i> Add Lists
+                                </a>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             <!-- Campaign Assets -->
@@ -281,49 +264,66 @@
                     {% endif %}
                 </div>
             </div>
-            <!-- Campaign Lists -->
+            <!-- Campaign Actions -->
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
-                    <h2 class="card-title h5 mb-0">Lists</h2>
-                    {% if campaign.owner == user and campaign.is_pre_campaign %}
-                        <a href="{% url 'core:campaign-add-lists' campaign.id %}"
-                           class="btn btn-primary btn-sm">
-                            <i class="bi-plus-circle"></i> Add Lists
+                    <h2 class="card-title h5 mb-0">Action Log</h2>
+                    <div class="hstack gap-2">
+                        {% if can_log_actions %}
+                            <a href="{% url 'core:campaign-action-new' campaign.id %}"
+                               class="btn btn-primary btn-sm">
+                                <i class="bi-plus-circle"></i> Log Action
+                            </a>
+                        {% endif %}
+                        <a href="{% url 'core:campaign-actions' campaign.id %}"
+                           class="btn btn-outline-secondary btn-sm">
+                            <i class="bi-list-ul"></i> View All
                         </a>
-                    {% endif %}
+                    </div>
                 </div>
                 <div class="card-body p-0">
-                    {% if campaign.lists.all %}
-                        <div class="list-group list-group-flush">
-                            {% for list in campaign.lists.all %}
-                                <a href="{% url 'core:list' list.id %}"
-                                   class="list-group-item list-group-item-action">
-                                    <div class="d-flex w-100 justify-content-between">
-                                        <h6 class="mb-1">
-                                            {% list_with_theme list "me-1" %}
-                                            {% if list.content_house %}<span class="badge bg-secondary">{{ list.content_house.name }}</span>{% endif %}
-                                        </h6>
-                                        <small>{{ list.cost_display }}</small>
+                    {% with recent_actions=campaign.actions.all|slice:":5" %}
+                        {% if recent_actions %}
+                            <div class="list-group list-group-flush">
+                                {% for action in recent_actions %}
+                                    <div class="list-group-item">
+                                        <div class="d-flex w-100 justify-content-between">
+                                            <small class="text-muted">
+                                                <strong>{{ action.user.username }}</strong> • {{ action.created|timesince }} ago
+                                            </small>
+                                        </div>
+                                        <p class="mb-1 text-truncate">{{ action.description }}</p>
+                                        {% if action.dice_count > 0 %}
+                                            <small class="text-muted">
+                                                <i class="bi bi-dice-6"></i> Rolled {{ action.dice_count }}D6:
+                                                {% for result in action.dice_results %}
+                                                    {{ result }}
+                                                    {% if not forloop.last %},{% endif %}
+                                                {% endfor %}
+                                                = <strong>{{ action.dice_total }}</strong>
+                                            </small>
+                                        {% endif %}
+                                        {% if action.outcome %}
+                                            <small class="text-muted d-block">
+                                                <strong>Outcome:</strong> {{ action.outcome|truncatewords:10 }}
+                                            </small>
+                                        {% elif action.user == user %}
+                                            <small>
+                                                <a href="{% url 'core:campaign-action-outcome' campaign.id action.id %}"
+                                                   class="link-primary">Add outcome</a>
+                                            </small>
+                                        {% endif %}
                                     </div>
-                                    <p class="mb-1 text-muted small">
-                                        By {{ list.owner.username }}
-                                        • {{ list.fighters.count }} fighter{{ list.fighters.count|pluralize }}
-                                    </p>
-                                </a>
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        <div class="p-3 text-center text-muted">
-                            No lists have been added to this campaign yet.
-                            {% if campaign.owner == user and campaign.is_pre_campaign %}
-                                <br>
-                                <a href="{% url 'core:campaign-add-lists' campaign.id %}"
-                                   class="btn btn-primary btn-sm mt-2">
-                                    <i class="bi-plus-circle"></i> Add Lists
-                                </a>
-                            {% endif %}
-                        </div>
-                    {% endif %}
+                                {% endfor %}
+                            </div>
+                            <div class="text-center mt-1">
+                                <a href="{% url 'core:campaign-actions' campaign.id %}"
+                                   class="btn btn-sm btn-link">View all actions →</a>
+                            </div>
+                        {% else %}
+                            <div class="p-3 text-center text-muted">No actions logged yet.</div>
+                        {% endif %}
+                    {% endwith %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Reordered campaign page modules from top to bottom as:
- Lists
- Assets
- Resources
- Action Log

Fixes #221

Generated with [Claude Code](https://claude.ai/code)