### PR TITLE
fix: add queueTtl to ensure cloud builds are queued sequentially

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -70,6 +70,7 @@ images:
 options:
   substitutionOption: ALLOW_LOOSE
   logging: CLOUD_LOGGING_ONLY
+  queueTtl: "3600s"  # Queue builds for up to 1 hour if needed
 substitutions:
   _TRIGGER_ID: bd49e415-bc5c-411a-a19d-ec77599c3ddf
   _AR_HOSTNAME: europe-west2-docker.pkg.dev

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -70,9 +70,10 @@ images:
 options:
   substitutionOption: ALLOW_LOOSE
   logging: CLOUD_LOGGING_ONLY
-  queueTtl: "3600s"  # Queue builds for up to 1 hour if needed
+  queueTtl: "${_QUEUE_TTL}"  # Queue builds for up to 1 hour if needed
 substitutions:
   _TRIGGER_ID: bd49e415-bc5c-411a-a19d-ec77599c3ddf
+  _QUEUE_TTL: "3600s"
   _AR_HOSTNAME: europe-west2-docker.pkg.dev
   _PLATFORM: managed
   _SERVICE_NAME: gyrinx


### PR DESCRIPTION
This PR fixes the cloud build race condition issue where builds triggered around the same time could deploy out of order.

## Changes
- Added `queueTtl: "3600s"` to `cloudbuild.yaml` options
- This ensures builds wait in a queue if another build is running
- Maintains the correct deployment sequence

Fixes #228

Generated with [Claude Code](https://claude.ai/code)