### PR TITLE
fix: active campaign versions should link to gang, not campaign

### DIFF
--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -115,7 +115,7 @@
                 <ul class="mb-0 mt-1">
                     {% for clone in list.active_campaign_clones %}
                         <li>
-                            <a href="{% url 'core:campaign' clone.campaign.id %}"
+                            <a href="{% url 'core:list' clone.id %}"
                                class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ clone.campaign.name }}</a>
                             ({{ clone.campaign.owner.username }})
                         </li>

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -116,6 +116,9 @@
                     {% for clone in list.active_campaign_clones %}
                         <li>
                             <a href="{% url 'core:list' clone.id %}"
+                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">View gang</a>
+                            in
+                            <a href="{% url 'core:campaign' clone.campaign.id %}"
                                class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ clone.campaign.name }}</a>
                             ({{ clone.campaign.owner.username }})
                         </li>


### PR DESCRIPTION
Fixes #234

Updated the link in the list template so that active campaign versions link to the campaign version of the list (the gang) instead of the campaign itself.

This provides a better user experience by taking users directly to the campaign version of their list when they click on it.

Generated with [Claude Code](https://claude.ai/code)