### PR TITLE
feat: add reopen functionality for ended campaigns

### DIFF
--- a/gyrinx/core/models/campaign.py
+++ b/gyrinx/core/models/campaign.py
@@ -89,6 +89,10 @@ class Campaign(AppBase):
         """Check if the campaign can be ended."""
         return self.status == self.IN_PROGRESS
 
+    def can_reopen_campaign(self):
+        """Check if the campaign can be reopened."""
+        return self.status == self.POST_CAMPAIGN
+
     def start_campaign(self):
         """Start the campaign (transition from pre-campaign to in-progress).
 
@@ -126,6 +130,14 @@ class Campaign(AppBase):
         """End the campaign (transition from in-progress to post-campaign)."""
         if self.can_end_campaign():
             self.status = self.POST_CAMPAIGN
+            self.save()
+            return True
+        return False
+
+    def reopen_campaign(self):
+        """Reopen the campaign (transition from post-campaign back to in-progress)."""
+        if self.can_reopen_campaign():
+            self.status = self.IN_PROGRESS
             self.save()
             return True
         return False

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -68,6 +68,11 @@
                                    class="btn btn-danger btn-sm">
                                     <i class="bi-stop-circle"></i> End
                                 </a>
+                            {% elif campaign.can_reopen_campaign %}
+                                <a href="{% url 'core:campaign-reopen' campaign.id %}"
+                                   class="btn btn-success btn-sm">
+                                    <i class="bi-arrow-clockwise"></i> Reopen
+                                </a>
                             {% endif %}
                         </nav>
                     {% endif %}

--- a/gyrinx/core/templates/core/campaign/campaign_end.html
+++ b/gyrinx/core/templates/core/campaign/campaign_end.html
@@ -12,7 +12,7 @@
             {% csrf_token %}
             <p>Are you sure you want to end this campaign?</p>
             <div class="alert alert-warning" role="alert">
-                <i class="bi-exclamation-triangle"></i> This action cannot be undone. Once ended, the campaign will move from <strong>In Progress</strong> to <strong>Post-Campaign</strong> status.
+                <i class="bi-exclamation-triangle"></i> Once ended, the campaign will move from <strong>In Progress</strong> to <strong>Post-Campaign</strong> status. However, you will be able to reopen it later if needed.
             </div>
             <p>After ending the campaign, you will still be able to:</p>
             <ul>
@@ -26,8 +26,10 @@
             <ul>
                 <li>Add new lists to the campaign</li>
                 <li>Log new actions</li>
-                <li>Restart the campaign</li>
             </ul>
+            <p class="text-muted">
+                <i class="bi-info-circle"></i> <strong>Note:</strong> If you need to continue the campaign later, you can reopen it from the campaign page.
+            </p>
             <div class="mt-3">
                 <input type="submit" class="btn btn-danger" value="End Campaign">
                 <a href="{% url 'core:campaign' campaign.id %}" class="btn btn-link">Cancel</a>

--- a/gyrinx/core/templates/core/campaign/campaign_reopen.html
+++ b/gyrinx/core/templates/core/campaign/campaign_reopen.html
@@ -1,0 +1,32 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Reopen Campaign - {{ campaign.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:campaign' campaign.id as campaign_url %}
+    {% include "core/includes/back.html" with url=campaign_url text=campaign.name %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">Reopen Campaign: {{ campaign.name }}</h1>
+        <form action="{% url 'core:campaign-reopen' campaign.id %}" method="post">
+            {% csrf_token %}
+            <p>Are you sure you want to reopen this campaign?</p>
+            <div class="alert alert-info" role="alert">
+                <i class="bi-info-circle"></i> The campaign will return from <strong>Post-Campaign</strong> to <strong>In Progress</strong> status.
+            </div>
+            <p>After reopening the campaign, you will be able to:</p>
+            <ul>
+                <li>Log new actions</li>
+                <li>Modify campaign assets and resources</li>
+                <li>Continue where you left off</li>
+            </ul>
+            <p class="text-muted">
+                <i class="bi-exclamation-circle"></i> <strong>Note:</strong> The existing lists will remain in the campaign. No new clones will be created.
+            </p>
+            <div class="mt-3">
+                <input type="submit" class="btn btn-primary" value="Reopen Campaign">
+                <a href="{% url 'core:campaign' campaign.id %}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_campaign_status.py
+++ b/gyrinx/core/tests/test_campaign_status.py
@@ -91,6 +91,7 @@ def test_campaign_status_transitions(client):
     response = client.get(reverse("core:campaign-end", args=[campaign.id]))
     assert response.status_code == 200
     assert b"Are you sure you want to end this campaign?" in response.content
+    assert b"you will be able to reopen it later if needed" in response.content
 
     # Then POST to actually end it
     response = client.post(reverse("core:campaign-end", args=[campaign.id]))
@@ -101,6 +102,123 @@ def test_campaign_status_transitions(client):
     assert campaign.is_post_campaign
     assert not campaign.can_start_campaign()
     assert not campaign.can_end_campaign()
+
+
+@pytest.mark.django_db
+def test_campaign_reopen_functionality(client):
+    """Test that ended campaigns can be reopened."""
+    owner = User.objects.create_user(username="owner", password="password")
+    client.login(username="owner", password="password")
+
+    # Create a house
+    house = ContentHouse.objects.create(
+        name="Test House",
+    )
+
+    # Create a campaign
+    campaign = Campaign.objects.create_with_user(
+        user=owner,
+        name="Test Campaign",
+        owner=owner,
+    )
+
+    # Add a list so we can start the campaign
+    list_obj = List.objects.create_with_user(
+        user=owner,
+        name="Test List",
+        owner=owner,
+        content_house=house,
+    )
+    campaign.lists.add(list_obj)
+
+    # Start the campaign
+    campaign.start_campaign()
+    assert campaign.status == Campaign.IN_PROGRESS
+
+    # End the campaign
+    campaign.end_campaign()
+    assert campaign.status == Campaign.POST_CAMPAIGN
+    assert campaign.can_reopen_campaign()
+
+    # Get the number of lists before reopening
+    lists_before = campaign.lists.count()
+
+    # Test reopening via view
+    # First, GET should show confirmation page
+    response = client.get(reverse("core:campaign-reopen", args=[campaign.id]))
+    assert response.status_code == 200
+    assert b"Are you sure you want to reopen this campaign?" in response.content
+    assert b"No new clones will be created" in response.content
+
+    # Then POST to actually reopen it
+    response = client.post(reverse("core:campaign-reopen", args=[campaign.id]))
+    assert response.status_code == 302
+
+    campaign.refresh_from_db()
+    assert campaign.status == Campaign.IN_PROGRESS
+    assert campaign.is_in_progress
+    assert not campaign.can_reopen_campaign()
+    assert campaign.can_end_campaign()
+
+    # Verify no new lists were cloned
+    assert campaign.lists.count() == lists_before
+
+    # Check that the campaign detail page shows "End" button again
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert b"End" in response.content
+    assert b"bi-stop-circle" in response.content
+
+
+@pytest.mark.django_db
+def test_campaign_reopen_button_display(client):
+    """Test that the reopen button is displayed correctly for ended campaigns."""
+    user = User.objects.create_user(username="testuser", password="password")
+    client.login(username="testuser", password="password")
+
+    # Create a post-campaign
+    campaign = Campaign.objects.create_with_user(
+        user=user,
+        name="Ended Campaign",
+        owner=user,
+        status=Campaign.POST_CAMPAIGN,
+        public=True,
+    )
+
+    # Check that the reopen button is shown on campaign detail page
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert response.status_code == 200
+    assert b"Reopen" in response.content
+    assert b"bi-arrow-clockwise" in response.content
+
+
+@pytest.mark.django_db
+def test_campaign_reopen_permissions(client):
+    """Test that only the owner can reopen a campaign."""
+    owner = User.objects.create_user(username="owner", password="password")
+    other = User.objects.create_user(username="other", password="password")
+
+    campaign = Campaign.objects.create_with_user(
+        user=owner,
+        name="Test Campaign",
+        owner=owner,
+        status=Campaign.POST_CAMPAIGN,
+    )
+
+    # Try to reopen campaign as non-owner
+    client.login(username="other", password="password")
+    response = client.post(reverse("core:campaign-reopen", args=[campaign.id]))
+    assert response.status_code == 404  # Should not find campaign for non-owner
+
+    campaign.refresh_from_db()
+    assert campaign.status == Campaign.POST_CAMPAIGN  # Status unchanged
+
+    # Reopen campaign as owner
+    client.login(username="owner", password="password")
+    response = client.post(reverse("core:campaign-reopen", args=[campaign.id]))
+    assert response.status_code == 302
+
+    campaign.refresh_from_db()
+    assert campaign.status == Campaign.IN_PROGRESS
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -231,6 +231,11 @@ urlpatterns = [
         campaign.end_campaign,
         name="campaign-end",
     ),
+    path(
+        "campaign/<id>/reopen",
+        campaign.reopen_campaign,
+        name="campaign-reopen",
+    ),
     # Campaign Assets
     path(
         "campaign/<id>/assets",

--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -581,6 +581,43 @@ def end_campaign(request, id):
 
 
 @login_required
+def reopen_campaign(request, id):
+    """
+    Reopen a campaign (transition from post-campaign back to in-progress).
+
+    Only the campaign owner can reopen a campaign.
+
+    **Context**
+
+    ``campaign``
+        The :model:`core.Campaign` to be reopened.
+
+    **Template**
+
+    :template:`core/campaign/campaign_reopen.html`
+    """
+    campaign = get_object_or_404(Campaign, id=id, owner=request.user)
+
+    if request.method == "POST":
+        if campaign.reopen_campaign():
+            messages.success(request, "Campaign has been reopened!")
+        else:
+            messages.error(request, "Campaign cannot be reopened.")
+        return HttpResponseRedirect(reverse("core:campaign", args=(campaign.id,)))
+
+    # For GET request, show confirmation page
+    if not campaign.can_reopen_campaign():
+        messages.error(request, "This campaign cannot be reopened.")
+        return HttpResponseRedirect(reverse("core:campaign", args=(campaign.id,)))
+
+    return render(
+        request,
+        "core/campaign/campaign_reopen.html",
+        {"campaign": campaign},
+    )
+
+
+@login_required
 def campaign_assets(request, id):
     """
     Manage assets for a campaign.

--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -523,6 +523,14 @@ def start_campaign(request, id):
 
     if request.method == "POST":
         if campaign.start_campaign():
+            # Log the campaign start action
+            CampaignAction.objects.create(
+                user=request.user,
+                owner=request.user,
+                campaign=campaign,
+                description=f"Campaign Started: {campaign.name} is now active",
+                outcome="Campaign transitioned from pre-campaign to active status",
+            )
             messages.success(request, "Campaign has been started!")
         else:
             if not campaign.lists.exists():
@@ -563,6 +571,14 @@ def end_campaign(request, id):
 
     if request.method == "POST":
         if campaign.end_campaign():
+            # Log the campaign end action
+            CampaignAction.objects.create(
+                user=request.user,
+                owner=request.user,
+                campaign=campaign,
+                description=f"Campaign Ended: {campaign.name} has concluded",
+                outcome="Campaign transitioned from active to post-campaign status",
+            )
             messages.success(request, "Campaign has been ended!")
         else:
             messages.error(request, "Campaign cannot be ended.")
@@ -600,6 +616,14 @@ def reopen_campaign(request, id):
 
     if request.method == "POST":
         if campaign.reopen_campaign():
+            # Log the campaign reopen action
+            CampaignAction.objects.create(
+                user=request.user,
+                owner=request.user,
+                campaign=campaign,
+                description=f"Campaign Reopened: {campaign.name} is active again",
+                outcome="Campaign transitioned from post-campaign back to active status",
+            )
             messages.success(request, "Campaign has been reopened!")
         else:
             messages.error(request, "Campaign cannot be reopened.")


### PR DESCRIPTION
At present, a campaign state can only move from pre-campaign, to active campaign, to a campaign being ended. This is overly restrictive. We need to make it so a campaign that has been ended can be reopened if needed.

This PR adds a "Reopen" button for ended campaigns that will return them to an active state, and updates the warning page when ending a campaign to mention that campaigns can be reopened later.

Importantly, lists are NOT cloned again when a campaign is reopened - it simply continues with the existing lists.

Closes #250

Generated with [Claude Code](https://claude.ai/code)