### PR TITLE
feat: Allow lists to be added to in-progress campaigns with immediate cloning

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -97,7 +97,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h2 class="card-title h5 mb-0">Lists</h2>
-                    {% if campaign.owner == user and campaign.is_pre_campaign %}
+                    {% if campaign.owner == user and not campaign.is_post_campaign %}
                         <a href="{% url 'core:campaign-add-lists' campaign.id %}"
                            class="btn btn-primary btn-sm">
                             <i class="bi-plus-circle"></i> Add Lists

--- a/gyrinx/core/templates/core/campaign/campaign_add_lists.html
+++ b/gyrinx/core/templates/core/campaign/campaign_add_lists.html
@@ -23,6 +23,34 @@
                 </p>
             </div>
         {% endif %}
+        {% if show_confirmation and list_to_confirm %}
+            <div class="alert alert-warning">
+                <h4 class="alert-heading">Confirm Add List to Active Campaign</h4>
+                <p>
+                    This campaign is currently in progress. Adding 
+                    <strong>{% list_with_theme list_to_confirm %}</strong>
+                    will immediately clone it for campaign use.
+                </p>
+                <p class="mb-0">
+                    <strong>Important:</strong> The list will be cloned to preserve its current state, 
+                    and default campaign resources will be allocated to it.
+                </p>
+                <hr>
+                <div class="d-flex gap-2">
+                    <form method="post" action="{% url 'core:campaign-add-lists' campaign.id %}">
+                        {% csrf_token %}
+                        <input type="hidden" name="list_id" value="{{ list_to_confirm.id }}">
+                        <input type="hidden" name="confirm" value="true">
+                        <button type="submit" class="btn btn-warning">
+                            <i class="bi-check-lg"></i> Yes, Add List
+                        </button>
+                    </form>
+                    <a href="{% url 'core:campaign-add-lists' campaign.id %}" class="btn btn-secondary">
+                        <i class="bi-x-lg"></i> Cancel
+                    </a>
+                </div>
+            </div>
+        {% endif %}
         <!-- Search and Filter Section -->
         <div>
             <form id="search"

--- a/gyrinx/core/tests/test_campaign_lists.py
+++ b/gyrinx/core/tests/test_campaign_lists.py
@@ -266,6 +266,9 @@ def test_add_list_to_in_progress_campaign_shows_confirmation():
     initial_list = List.objects.create(name="Initial List", owner=user, content_house=house)
     campaign.lists.add(initial_list)
     assert campaign.start_campaign()  # This starts the campaign
+    
+    # Refresh the campaign to get updated status
+    campaign.refresh_from_db()
 
     # Create a new list to add
     new_list = List.objects.create(name="New List", owner=user, content_house=house)
@@ -401,6 +404,9 @@ def test_cannot_add_list_to_post_campaign():
     assert campaign.start_campaign()
     assert campaign.end_campaign()
     
+    # Refresh the campaign to get updated status
+    campaign.refresh_from_db()
+    
     client.login(username="testuser", password="testpass")
     
     # Try to access the add lists page
@@ -424,6 +430,9 @@ def test_campaign_detail_shows_add_lists_for_in_progress():
     initial_list = List.objects.create(name="Initial List", owner=user, content_house=house)
     campaign.lists.add(initial_list)
     assert campaign.start_campaign()
+    
+    # Refresh the campaign to get updated status
+    campaign.refresh_from_db()
     
     client.login(username="testuser", password="testpass")
     

--- a/gyrinx/core/tests/test_campaign_lists.py
+++ b/gyrinx/core/tests/test_campaign_lists.py
@@ -4,7 +4,7 @@ from django.test import Client
 from django.urls import reverse
 
 from gyrinx.content.models import ContentHouse
-from gyrinx.core.models.campaign import Campaign
+from gyrinx.core.models.campaign import Campaign, CampaignResourceType
 from gyrinx.core.models.list import List
 
 
@@ -251,3 +251,184 @@ def test_campaign_detail_shows_add_lists_button_for_owner():
         reverse("core:campaign-add-lists", args=[campaign.id]).encode()
         in response.content
     )
+
+
+@pytest.mark.django_db
+def test_add_list_to_in_progress_campaign_shows_confirmation():
+    """Test that adding a list to an in-progress campaign shows a confirmation."""
+    client = Client()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+
+    # Add an initial list and start the campaign
+    initial_list = List.objects.create(name="Initial List", owner=user, content_house=house)
+    campaign.lists.add(initial_list)
+    assert campaign.start_campaign()  # This starts the campaign
+
+    # Create a new list to add
+    new_list = List.objects.create(name="New List", owner=user, content_house=house)
+
+    client.login(username="testuser", password="testpass")
+
+    # Try to add the list - should show confirmation
+    response = client.post(
+        reverse("core:campaign-add-lists", args=[campaign.id]),
+        {"list_id": str(new_list.id)},
+    )
+
+    # Should show the confirmation page, not redirect
+    assert response.status_code == 200
+    assert b"Confirm Add List to Active Campaign" in response.content
+    assert b"will immediately clone it for campaign use" in response.content
+    assert new_list.name.encode() in response.content
+    
+    # List should NOT be added yet
+    assert new_list not in campaign.lists.all()
+
+
+@pytest.mark.django_db
+def test_confirm_add_list_to_in_progress_campaign():
+    """Test confirming the addition of a list to an in-progress campaign."""
+    client = Client()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    
+    # Add resources to the campaign
+    resource_type = CampaignResourceType.objects.create(
+        campaign=campaign,
+        name="Credits",
+        default_amount=100,
+        owner=user,
+    )
+    
+    # Add an initial list and start the campaign
+    initial_list = List.objects.create(name="Initial List", owner=user, content_house=house)
+    campaign.lists.add(initial_list)
+    assert campaign.start_campaign()
+    
+    # After starting, the initial list is cloned, so get the cloned version
+    campaign.refresh_from_db()
+    initial_clone = campaign.lists.get(original_list=initial_list)
+    
+    # Create a new list to add
+    new_list = List.objects.create(name="New List", owner=user, content_house=house)
+    
+    client.login(username="testuser", password="testpass")
+    
+    # Confirm adding the list
+    response = client.post(
+        reverse("core:campaign-add-lists", args=[campaign.id]),
+        {
+            "list_id": str(new_list.id),
+            "confirm": "true",
+        },
+    )
+    
+    # Should redirect after successful addition
+    assert response.status_code == 302
+    
+    # Refresh the campaign
+    campaign.refresh_from_db()
+    
+    # The new list should be cloned and added
+    assert campaign.lists.count() == 2  # Initial + new
+    
+    # Find the newly cloned list (not the initial clone)
+    cloned_list = campaign.lists.exclude(id=initial_clone.id).first()
+    assert cloned_list is not None
+    assert cloned_list.name == new_list.name
+    assert cloned_list.original_list == new_list
+    assert cloned_list.status == List.CAMPAIGN_MODE
+    assert cloned_list.campaign == campaign
+    
+    # Check that resources were allocated
+    from gyrinx.core.models.campaign import CampaignListResource
+    resource = CampaignListResource.objects.get(
+        campaign=campaign,
+        resource_type=resource_type,
+        list=cloned_list
+    )
+    assert resource.amount == 100  # Default amount
+
+
+@pytest.mark.django_db
+def test_add_list_to_pre_campaign_no_cloning():
+    """Test that adding a list to a pre-campaign doesn't clone it."""
+    client = Client()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    list_to_add = List.objects.create(name="Test List", owner=user, content_house=house)
+    
+    client.login(username="testuser", password="testpass")
+    
+    # Add the list (no confirmation needed for pre-campaign)
+    response = client.post(
+        reverse("core:campaign-add-lists", args=[campaign.id]),
+        {"list_id": str(list_to_add.id)},
+    )
+    
+    # Should redirect immediately
+    assert response.status_code == 302
+    
+    # List should be added directly (not cloned)
+    assert list_to_add in campaign.lists.all()
+    assert campaign.lists.count() == 1
+    
+    # Verify it's the original list, not a clone
+    added_list = campaign.lists.first()
+    assert added_list.id == list_to_add.id
+    assert added_list.status == List.LIST_BUILDING  # Not in campaign mode
+
+
+@pytest.mark.django_db
+def test_cannot_add_list_to_post_campaign():
+    """Test that lists cannot be added to a completed campaign."""
+    client = Client()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    
+    # Start and end the campaign
+    initial_list = List.objects.create(name="Initial List", owner=user, content_house=house)
+    campaign.lists.add(initial_list)
+    assert campaign.start_campaign()
+    assert campaign.end_campaign()
+    
+    client.login(username="testuser", password="testpass")
+    
+    # Try to access the add lists page
+    response = client.get(reverse("core:campaign-add-lists", args=[campaign.id]))
+    
+    # Should redirect with error message
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaign", args=[campaign.id])
+
+
+@pytest.mark.django_db
+def test_campaign_detail_shows_add_lists_for_in_progress():
+    """Test that the add lists button is shown for in-progress campaigns."""
+    client = Client()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    
+    # Start the campaign
+    initial_list = List.objects.create(name="Initial List", owner=user, content_house=house)
+    campaign.lists.add(initial_list)
+    assert campaign.start_campaign()
+    
+    client.login(username="testuser", password="testpass")
+    
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert response.status_code == 200
+    
+    # Should still show the Add Lists button for in-progress campaigns
+    assert b"Add Lists" in response.content


### PR DESCRIPTION
Fixes #251

## Summary

This PR implements the ability to add lists/gangs to campaigns that are already in progress. When a list is added to an active campaign, it is immediately cloned to preserve its state and allocated the default campaign resources.

## Changes

- Added `add_list_to_campaign()` method to Campaign model for proper state handling
- Updated campaign_add_lists view to support in-progress campaigns
- Added confirmation dialog when adding to active campaigns
- Ensured new lists receive default campaign resources
- Added comprehensive test coverage

## Testing

Added tests to verify:
- Confirmation required for in-progress campaigns
- Immediate cloning happens on confirmation
- Resources are allocated correctly
- Pre-campaign behavior unchanged
- Post-campaign restrictions work

Generated with [Claude Code](https://claude.ai/code)