### PR TITLE
feat: Compress campaign info in list view

### DIFF
--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -37,6 +37,44 @@
                             </span>
                         {% endif %}
                     </div>
+                    {% if list.is_campaign_mode and list.original_list %}
+                        <div class="text-secondary">
+                            <i class="bi-copy"></i>
+                            {% url 'core:list' list.original_list.id as original_url %}
+                            <a href="{{ original_url }}"
+                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover"
+                               data-bs-toggle="tooltip"
+                               data-bs-title="This list was created via cloning">
+                                {{ list.original_list.name }}
+                            </a>
+                        </div>
+                    {% endif %}
+                    {% if list.campaign %}
+                        <div class="text-secondary">
+                            <i class="bi-award"></i>
+                            {% url 'core:campaign' list.campaign.id as campaign_url %}
+                            <a href="{{ campaign_url }}"
+                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">
+                                {{ list.campaign.name }}
+                            </a>
+                            {% if list.campaign.is_pre_campaign %}
+                                <span class="badge bg-secondary ms-1">Pre</span>
+                            {% elif list.campaign.is_in_progress %}
+                                <span class="badge bg-success ms-1">In Progress</span>
+                            {% elif list.campaign.is_post_campaign %}
+                                <span class="badge bg-secondary ms-1">Post</span>
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                    {% if list.is_list_building and list.active_campaign_clones.exists %}
+                        <div class="text-secondary">
+                            <i class="bi-award"></i>
+                            <a href="{% url 'core:list-campaign-clones' list.id %}"
+                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">
+                                Active in Campaigns
+                            </a>
+                        </div>
+                    {% endif %}
                     {% if list.owner_cached == user and list.archived_fighters_cached > 0 %}
                         <div class="text-secondary">
                             <i class="bi-archive"></i>
@@ -109,33 +147,6 @@
                 {% endif %}
             </div>
         </div>
-        {% if list.is_list_building and list.active_campaign_clones.exists %}
-            <div class="text-secondary mt-2">
-                <i class="bi-flag"></i> This list has active campaign versions:
-                <ul class="mb-0 mt-1">
-                    {% for clone in list.active_campaign_clones %}
-                        <li>
-                            <a href="{% url 'core:list' clone.id %}"
-                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">View gang</a>
-                            in
-                            <a href="{% url 'core:campaign' clone.campaign.id %}"
-                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ clone.campaign.name }}</a>
-                            ({{ clone.campaign.owner.username }})
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        {% endif %}
-        {% if list.is_campaign_mode and list.original_list %}
-            <div class="text-secondary mt-2">
-                <i class="bi-arrow-return-right"></i> This is a campaign version of <a href="{% url 'core:list' list.original_list.id %}"
-    class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.original_list.name }}</a>
-                {% if list.campaign %}
-                    in <a href="{% url 'core:campaign' list.campaign.id %}"
-    class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.campaign.name }}</a>
-                {% endif %}
-            </div>
-        {% endif %}
     </div>
     <div class="grid {% if print %}gap-2{% endif %}">
         {% for fighter in list.fighters_cached %}

--- a/gyrinx/core/templates/core/list_campaign_clones.html
+++ b/gyrinx/core/templates/core/list_campaign_clones.html
@@ -1,0 +1,83 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags color_tags %}
+{% block head_title %}
+    Campaign Versions - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:list' list.id as list_url %}
+    {% include "core/includes/back.html" with url=list_url text="Back to List" %}
+    
+    <div class="col-lg-12 px-0 vstack gap-3">
+        <h1>Campaign Versions</h1>
+        <p class="text-secondary">
+            All campaign versions of {% list_with_theme list %}
+        </p>
+        
+        {% if clones %}
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>List Name</th>
+                            <th>Campaign</th>
+                            <th>Campaign Status</th>
+                            <th>Campaign Owner</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for clone in clones %}
+                            <tr>
+                                <td>
+                                    {% url 'core:list' clone.id as clone_url %}
+                                    <a href="{{ clone_url }}" class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">
+                                        {% list_with_theme clone %}
+                                    </a>
+                                </td>
+                                <td>
+                                    {% if clone.campaign %}
+                                        {% url 'core:campaign' clone.campaign.id as campaign_url %}
+                                        <a href="{{ campaign_url }}" class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">
+                                            {{ clone.campaign.name }}
+                                        </a>
+                                    {% else %}
+                                        <span class="text-muted">No campaign</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if clone.campaign %}
+                                        {% if clone.campaign.is_pre_campaign %}
+                                            <span class="badge bg-secondary">Pre-Campaign</span>
+                                        {% elif clone.campaign.is_in_progress %}
+                                            <span class="badge bg-success">In Progress</span>
+                                        {% elif clone.campaign.is_post_campaign %}
+                                            <span class="badge bg-secondary">Post-Campaign</span>
+                                        {% endif %}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if clone.campaign %}
+                                        <a href="{% url 'core:user' clone.campaign.owner.username %}" class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">
+                                            {{ clone.campaign.owner.username }}
+                                        </a>
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <a href="{% url 'core:list' clone.id %}" class="btn btn-outline-secondary btn-sm">
+                                        <i class="bi-eye"></i> View
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted">This list has no campaign versions.</p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templatetags/color_tags.py
+++ b/gyrinx/core/templatetags/color_tags.py
@@ -42,3 +42,27 @@ def list_with_theme(list_obj, extra_classes="", square_size="0.8em"):
         return mark_safe(f'<span class="{extra_classes}">{square}{name}</span>')
     else:
         return mark_safe(f'<span class="{extra_classes}">{name}</span>')
+
+
+@register.simple_tag
+def link_with_theme(list_obj, url, extra_classes="", square_size="0.8em"):
+    """
+    Display a list name with its theme color square as a link.
+    """
+    if not list_obj:
+        return ""
+
+    name = getattr(list_obj, "name", str(list_obj))
+    theme_color = getattr(list_obj, "theme_color", None)
+
+    if theme_color:
+        square = theme_square(list_obj, extra_classes="me-1", size=square_size)
+        return mark_safe(
+            f'<a href="{url}" class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover {extra_classes}">'
+            f'{square}{name}</a>'
+        )
+    else:
+        return mark_safe(
+            f'<a href="{url}" class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover {extra_classes}">'
+            f'{name}</a>'
+        )

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -199,6 +199,7 @@ urlpatterns = [
         name="list-fighter-embed",
     ),
     path("list/<id>/print", list.ListPrintView.as_view(), name="list-print"),
+    path("list/<id>/clones", list.ListCampaignClonesView.as_view(), name="list-campaign-clones"),
     # Users
     path("user/<slug_or_id>", gyrinx.core.views.user, name="user"),
     # Campaigns


### PR DESCRIPTION
This PR implements UI changes to compress campaign information in the list view.

## Changes

- Move campaign info inline with owner/public info
- Use Copy icon for parent list link with tooltip
- Use Award icon for campaign link with status badges
- Add "Active in Campaigns" link for lists with clones
- Create new page showing all campaign clones in a table
- Add link_with_theme template tag

Fixes #267

Generated with [Claude Code](https://claude.ai/code)