### PR TITLE
feat: Compress campaign info in list view

### DIFF
--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -53,6 +53,34 @@
                                href="{% url 'core:list-about' list.id %}">About</a>
                         </div>
                     {% endif %}
+                    {% if list.is_campaign_mode and list.original_list %}
+                        <div class="text-secondary">
+                            <i class="bi-copy" data-bs-toggle="tooltip" data-bs-title="This list was created via cloning"></i>
+                            <a href="{% url 'core:list' list.original_list.id %}"
+                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.original_list.name }}</a>
+                        </div>
+                        {% if list.campaign %}
+                            <div class="text-secondary">
+                                <i class="bi-award"></i>
+                                <a href="{% url 'core:campaign' list.campaign.id %}"
+                                   class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.campaign.name }}</a>
+                                {% if list.campaign.is_pre_campaign %}
+                                    <span class="badge bg-secondary ms-1">Pre-Campaign</span>
+                                {% elif list.campaign.is_in_progress %}
+                                    <span class="badge bg-success ms-1">In Progress</span>
+                                {% elif list.campaign.is_post_campaign %}
+                                    <span class="badge bg-secondary ms-1">Post-Campaign</span>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    {% endif %}
+                    {% if list.is_list_building and list.active_campaign_clones.exists %}
+                        <div class="text-secondary">
+                            <i class="bi-award"></i>
+                            <a href="{% url 'core:list-campaign-clones' list.id %}"
+                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">Active in Campaigns</a>
+                        </div>
+                    {% endif %}
                 {% endif %}
             </div>
             <div class="ms-sm-auto mt-2 mt-sm-0">
@@ -109,33 +137,6 @@
                 {% endif %}
             </div>
         </div>
-        {% if list.is_list_building and list.active_campaign_clones.exists %}
-            <div class="text-secondary mt-2">
-                <i class="bi-flag"></i> This list has active campaign versions:
-                <ul class="mb-0 mt-1">
-                    {% for clone in list.active_campaign_clones %}
-                        <li>
-                            <a href="{% url 'core:list' clone.id %}"
-                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">View gang</a>
-                            in
-                            <a href="{% url 'core:campaign' clone.campaign.id %}"
-                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ clone.campaign.name }}</a>
-                            ({{ clone.campaign.owner.username }})
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        {% endif %}
-        {% if list.is_campaign_mode and list.original_list %}
-            <div class="text-secondary mt-2">
-                <i class="bi-arrow-return-right"></i> This is a campaign version of <a href="{% url 'core:list' list.original_list.id %}"
-    class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.original_list.name }}</a>
-                {% if list.campaign %}
-                    in <a href="{% url 'core:campaign' list.campaign.id %}"
-    class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.campaign.name }}</a>
-                {% endif %}
-            </div>
-        {% endif %}
     </div>
     <div class="grid {% if print %}gap-2{% endif %}">
         {% for fighter in list.fighters_cached %}

--- a/gyrinx/core/templates/core/list_campaign_clones.html
+++ b/gyrinx/core/templates/core/list_campaign_clones.html
@@ -1,0 +1,73 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Campaign Versions of {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:list' list.id as list_url %}
+    {% include "core/includes/back.html" with url=list_url text="Back to List" %}
+    
+    <div class="col-lg-8 px-0">
+        <h1>Campaign Versions</h1>
+        <p class="text-secondary">
+            All campaign versions of <a href="{{ list_url }}" class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.name }}</a>
+        </p>
+        
+        {% if campaign_clones %}
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>List Name</th>
+                            <th>Campaign</th>
+                            <th>Campaign Owner</th>
+                            <th>Status</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for clone in campaign_clones %}
+                            <tr>
+                                <td>
+                                    <a href="{% url 'core:list' clone.id %}" class="link-primary">{{ clone.name }}</a>
+                                </td>
+                                <td>
+                                    {% if clone.campaign %}
+                                        <a href="{% url 'core:campaign' clone.campaign.id %}" class="link-primary">{{ clone.campaign.name }}</a>
+                                    {% else %}
+                                        <span class="text-muted">No campaign</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if clone.campaign %}
+                                        <a href="{% url 'core:user' clone.campaign.owner.username %}" class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ clone.campaign.owner.username }}</a>
+                                    {% else %}
+                                        <span class="text-muted">-</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if clone.campaign %}
+                                        {% if clone.campaign.is_pre_campaign %}
+                                            <span class="badge bg-secondary">Pre-Campaign</span>
+                                        {% elif clone.campaign.is_in_progress %}
+                                            <span class="badge bg-success">In Progress</span>
+                                        {% elif clone.campaign.is_post_campaign %}
+                                            <span class="badge bg-secondary">Post-Campaign</span>
+                                        {% endif %}
+                                    {% else %}
+                                        <span class="text-muted">-</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <a href="{% url 'core:list' clone.id %}" class="btn btn-outline-secondary btn-sm">View</a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted">This list has no campaign versions.</p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -199,6 +199,11 @@ urlpatterns = [
         name="list-fighter-embed",
     ),
     path("list/<id>/print", list.ListPrintView.as_view(), name="list-print"),
+    path(
+        "list/<id>/campaign-clones",
+        list.ListCampaignClonesView.as_view(),
+        name="list-campaign-clones",
+    ),
     # Users
     path("user/<slug_or_id>", gyrinx.core.views.user, name="user"),
     # Campaigns

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -1759,3 +1759,37 @@ def edit_list_fighter_xp(request, id, fighter_id):
             "fighter": fighter,
         },
     )
+
+
+class ListCampaignClonesView(generic.DetailView):
+    """
+    Display the campaign clones of a :model:`core.List` object.
+
+    **Context**
+
+    ``list``
+        The requested :model:`core.List` object.
+    ``campaign_clones``
+        QuerySet of campaign mode clones of this list.
+
+    **Template**
+
+    :template:`core/list_campaign_clones.html`
+    """
+
+    template_name = "core/list_campaign_clones.html"
+    context_object_name = "list"
+
+    def get_object(self):
+        """
+        Retrieve the :model:`core.List` by its `id`.
+        """
+        return get_object_or_404(List, id=self.kwargs["id"])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Get all campaign clones, not just active ones
+        context["campaign_clones"] = self.object.campaign_clones.all().select_related(
+            "campaign", "campaign__owner"
+        )
+        return context


### PR DESCRIPTION
This PR addresses issue #267 by compressing the campaign information in the list view.

## Changes

- Move campaign/clone info inline with owner and public/private info
- Replace text links with icons (Copy icon for parent list, Award icon for campaigns)
- Add tooltips to the Copy icon
- Add campaign status badges (Pre/Post as secondary, In Progress as success)
- Create new page for lists with active campaign versions
- Remove old separate campaign info sections

Closes #267

Generated with [Claude Code](https://claude.ai/code)