### PR TITLE
feat: add gang asset/resource panel

### DIFF
--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -147,6 +147,7 @@
     <div class="grid {% if print %}gap-2{% endif %}">
         {% if not print %}
             {% include "core/includes/list_campaign_actions.html" with list=list %}
+            {% include "core/includes/list_campaign_resources_assets.html" with list=list campaign_resources=campaign_resources held_assets=held_assets %}
         {% endif %}
         {% for fighter in list.fighters_cached %}
             {% include "core/includes/fighter_card.html" with fighter=fighter list=list print=print %}

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -13,9 +13,32 @@
             </div>
         </div>
         <div class="card-body p-2">
-            <div class="row g-2">
+            <div class="row g-3">
+                {% if held_assets %}
+                    <div class="col-12">
+                        <h4 class="h6 mb-2 text-muted">Assets</h4>
+                        <ul class="list-group list-group-flush">
+                            {% for asset in held_assets %}
+                                <li class="list-group-item px-0 py-1 fs-7">
+                                    <div class="vstack">
+                                        <div>
+                                            <strong>{{ asset.name }}</strong>
+                                            {% if asset.asset_type.name_singular %}
+                                                <span class="text-muted">({{ asset.asset_type.name_singular }})</span>
+                                            {% endif %}
+                                        </div>
+                                        <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}"
+                                           class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7 ms-2">
+                                            <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
+                                        </a>
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
                 {% if campaign_resources %}
-                    <div class="col-12 col-md-6">
+                    <div class="col-12">
                         <h4 class="h6 mb-2 text-muted">Resources</h4>
                         <table class="table table-sm mb-0 fs-7">
                             <tbody>
@@ -27,7 +50,7 @@
                                         </td>
                                         <td class="text-end">
                                             <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.resource_type.id %}"
-                                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">
+                                               class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">
                                                 <i class="bi-pencil-square" aria-hidden="true"></i> Modify
                                             </a>
                                         </td>
@@ -37,34 +60,6 @@
                         </table>
                     </div>
                 {% endif %}
-                
-                {% if held_assets %}
-                    <div class="col-12 col-md-6">
-                        <h4 class="h6 mb-2 text-muted">Assets</h4>
-                        <ul class="list-group list-group-flush">
-                            {% for asset in held_assets %}
-                                <li class="list-group-item px-0 py-1 fs-7">
-                                    <div class="d-flex justify-content-between align-items-start">
-                                        <div>
-                                            <strong>{{ asset.name }}</strong>
-                                            {% if asset.asset_type.name_singular %}
-                                                <small class="text-muted">({{ asset.asset_type.name_singular }})</small>
-                                            {% endif %}
-                                        </div>
-                                        <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}"
-                                           class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7 ms-2">
-                                            <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
-                                        </a>
-                                    </div>
-                                    {% if asset.description %}
-                                        <small class="text-muted">{{ asset.description|safe|truncatewords:10 }}</small>
-                                    {% endif %}
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                {% endif %}
-                
                 {% if not campaign_resources and not held_assets %}
                     <div class="col-12">
                         <p class="text-muted fs-7 mb-0">No assets or resources held.</p>

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -1,0 +1,76 @@
+{% load allauth custom_tags humanize %}
+{% if list.is_campaign_mode and list.campaign %}
+    <div class="card g-col-12 g-col-md-12 g-col-xl-6">
+        <div class="card-header p-2">
+            <div class="hstack">
+                <h3 class="h5 mb-0">Assets & Resources</h3>
+                <div class="ms-auto">
+                    <a href="{% url 'core:campaign' list.campaign.id %}"
+                       class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">
+                        <i class="bi-award" aria-hidden="true"></i> {{ list.campaign.name }}
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="card-body p-2">
+            <div class="row g-2">
+                {% if campaign_resources %}
+                    <div class="col-12 col-md-6">
+                        <h4 class="h6 mb-2 text-muted">Resources</h4>
+                        <table class="table table-sm mb-0 fs-7">
+                            <tbody>
+                                {% for resource in campaign_resources %}
+                                    <tr>
+                                        <td>{{ resource.resource_type.name }}</td>
+                                        <td class="text-end">
+                                            <span class="badge bg-secondary">{{ resource.amount }}</span>
+                                        </td>
+                                        <td class="text-end">
+                                            <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.resource_type.id %}"
+                                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">
+                                                <i class="bi-pencil-square" aria-hidden="true"></i> Modify
+                                            </a>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+                
+                {% if held_assets %}
+                    <div class="col-12 col-md-6">
+                        <h4 class="h6 mb-2 text-muted">Assets</h4>
+                        <ul class="list-group list-group-flush">
+                            {% for asset in held_assets %}
+                                <li class="list-group-item px-0 py-1 fs-7">
+                                    <div class="d-flex justify-content-between align-items-start">
+                                        <div>
+                                            <strong>{{ asset.name }}</strong>
+                                            {% if asset.asset_type.name_singular %}
+                                                <small class="text-muted">({{ asset.asset_type.name_singular }})</small>
+                                            {% endif %}
+                                        </div>
+                                        <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}"
+                                           class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7 ms-2">
+                                            <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
+                                        </a>
+                                    </div>
+                                    {% if asset.description %}
+                                        <small class="text-muted">{{ asset.description|safe|truncatewords:10 }}</small>
+                                    {% endif %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
+                
+                {% if not campaign_resources and not held_assets %}
+                    <div class="col-12">
+                        <p class="text-muted fs-7 mb-0">No assets or resources held.</p>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -49,7 +49,7 @@
                                             <span class="badge bg-secondary">{{ resource.amount }}</span>
                                         </td>
                                         <td class="text-end">
-                                            <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.resource_type.id %}"
+                                            <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.id %}"
                                                class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">
                                                 <i class="bi-pencil-square" aria-hidden="true"></i> Modify
                                             </a>

--- a/gyrinx/core/tests/test_list_resources_assets.py
+++ b/gyrinx/core/tests/test_list_resources_assets.py
@@ -1,0 +1,180 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+from gyrinx.content.models import ContentHouse
+from gyrinx.core.models.campaign import (
+    Campaign,
+    CampaignAsset,
+    CampaignAssetType,
+    CampaignListResource,
+    CampaignResourceType,
+)
+from gyrinx.core.models.list import List
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_list_view_shows_resources_and_assets_in_campaign_mode():
+    """Test that the list view shows resources and assets when list is in campaign mode."""
+    # Create test data
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+    
+    # Create campaign
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+    )
+    
+    # Create a list in campaign mode
+    list_obj = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        content_house=house,
+        status=List.CAMPAIGN_MODE,
+        campaign=campaign,
+    )
+    
+    # Create resource types and resources
+    resource_type1 = CampaignResourceType.objects.create(
+        campaign=campaign,
+        name="Credits",
+        description="Gang credits",
+        default_amount=100,
+        owner=user,
+    )
+    resource_type2 = CampaignResourceType.objects.create(
+        campaign=campaign,
+        name="Reputation",
+        description="Gang reputation",
+        default_amount=5,
+        owner=user,
+    )
+    
+    # Create resources for the list
+    CampaignListResource.objects.create(
+        campaign=campaign,
+        list=list_obj,
+        resource_type=resource_type1,
+        amount=150,
+        owner=user,
+    )
+    CampaignListResource.objects.create(
+        campaign=campaign,
+        list=list_obj,
+        resource_type=resource_type2,
+        amount=10,
+        owner=user,
+    )
+    
+    # Create asset types and assets
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        description="Gang territories",
+        owner=user,
+    )
+    
+    asset1 = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description="A toxic wasteland",
+        holder=list_obj,
+        owner=user,
+    )
+    asset2 = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="Trading Post",
+        description="A bustling marketplace",
+        holder=list_obj,
+        owner=user,
+    )
+    
+    # Login and access the list view
+    client = Client()
+    client.login(username="testuser", password="testpass")
+    
+    response = client.get(reverse("core:list", args=[list_obj.id]))
+    assert response.status_code == 200
+    
+    # Check that resources are displayed
+    assert b"Assets &amp; Resources" in response.content
+    assert b"Credits" in response.content
+    assert b"150" in response.content  # Credits amount
+    assert b"Reputation" in response.content
+    assert b"10" in response.content  # Reputation amount
+    
+    # Check that assets are displayed
+    assert b"The Sump" in response.content
+    assert b"Trading Post" in response.content
+    assert b"Territory" in response.content
+    
+    # Check that links are present
+    assert b"Modify" in response.content
+    assert b"Transfer" in response.content
+
+
+@pytest.mark.django_db
+def test_list_view_does_not_show_resources_assets_for_non_campaign_lists():
+    """Test that resources/assets panel is not shown for lists not in campaign mode."""
+    # Create test data
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+    
+    # Create a regular list (not in campaign mode)
+    list_obj = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        content_house=house,
+        status=List.LIST_BUILDING,
+    )
+    
+    # Login and access the list view
+    client = Client()
+    client.login(username="testuser", password="testpass")
+    
+    response = client.get(reverse("core:list", args=[list_obj.id]))
+    assert response.status_code == 200
+    
+    # Check that resources/assets panel is not displayed
+    assert b"Assets &amp; Resources" not in response.content
+
+
+@pytest.mark.django_db
+def test_list_view_shows_empty_state_when_no_resources_or_assets():
+    """Test that empty state is shown when gang has no resources or assets."""
+    # Create test data
+    user = User.objects.create_user(username="testuser", password="testpass")
+    house = ContentHouse.objects.create(name="Test House")
+    
+    # Create campaign
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+    )
+    
+    # Create a list in campaign mode but with no resources/assets
+    list_obj = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        content_house=house,
+        status=List.CAMPAIGN_MODE,
+        campaign=campaign,
+    )
+    
+    # Login and access the list view
+    client = Client()
+    client.login(username="testuser", password="testpass")
+    
+    response = client.get(reverse("core:list", args=[list_obj.id]))
+    assert response.status_code == 200
+    
+    # Check that the panel is displayed with empty state
+    assert b"Assets &amp; Resources" in response.content
+    assert b"No assets or resources held." in response.content

--- a/gyrinx/core/tests/test_list_resources_assets.py
+++ b/gyrinx/core/tests/test_list_resources_assets.py
@@ -1,5 +1,6 @@
+"""Test list view displays campaign resources and assets correctly."""
+
 import pytest
-from django.contrib.auth import get_user_model
 from django.test import Client
 from django.urls import reverse
 
@@ -13,168 +14,163 @@ from gyrinx.core.models.campaign import (
 )
 from gyrinx.core.models.list import List
 
-User = get_user_model()
-
 
 @pytest.mark.django_db
-def test_list_view_shows_resources_and_assets_in_campaign_mode():
-    """Test that the list view shows resources and assets when list is in campaign mode."""
+def test_list_view_displays_campaign_resources_and_assets(django_user_model):
+    """Test that list detail view includes campaign resources and assets in context."""
+    # Create test user
+    user = django_user_model.objects.create_user(
+        username="testuser", password="testpass"
+    )
+    client = Client()
+    client.login(username="testuser", password="testpass")
+
     # Create test data
-    user = User.objects.create_user(username="testuser", password="testpass")
     house = ContentHouse.objects.create(name="Test House")
-    
-    # Create campaign
     campaign = Campaign.objects.create(
         name="Test Campaign",
         owner=user,
         status=Campaign.IN_PROGRESS,
     )
-    
+
     # Create a list in campaign mode
-    list_obj = List.objects.create(
+    test_list = List.objects.create(
         name="Test Gang",
-        owner=user,
         content_house=house,
+        owner=user,
         status=List.CAMPAIGN_MODE,
         campaign=campaign,
     )
-    
-    # Create resource types and resources
-    resource_type1 = CampaignResourceType.objects.create(
+
+    # Create resource type and resource
+    resource_type = CampaignResourceType.objects.create(
         campaign=campaign,
         name="Credits",
-        description="Gang credits",
-        default_amount=100,
         owner=user,
     )
-    resource_type2 = CampaignResourceType.objects.create(
-        campaign=campaign,
-        name="Reputation",
-        description="Gang reputation",
-        default_amount=5,
-        owner=user,
-    )
-    
-    # Create resources for the list
+
     CampaignListResource.objects.create(
         campaign=campaign,
-        list=list_obj,
-        resource_type=resource_type1,
-        amount=150,
+        resource_type=resource_type,
+        list=test_list,
+        amount=100,
         owner=user,
     )
-    CampaignListResource.objects.create(
-        campaign=campaign,
-        list=list_obj,
-        resource_type=resource_type2,
-        amount=10,
-        owner=user,
-    )
-    
-    # Create asset types and assets
+
+    # Create asset type and asset
     asset_type = CampaignAssetType.objects.create(
         campaign=campaign,
         name_singular="Territory",
         name_plural="Territories",
-        description="Gang territories",
         owner=user,
     )
-    
-    asset1 = CampaignAsset.objects.create(
+
+    CampaignAsset.objects.create(
         asset_type=asset_type,
         name="The Sump",
-        description="A toxic wasteland",
-        holder=list_obj,
+        description="A valuable territory",
+        holder=test_list,
         owner=user,
     )
-    asset2 = CampaignAsset.objects.create(
-        asset_type=asset_type,
-        name="Trading Post",
-        description="A bustling marketplace",
-        holder=list_obj,
-        owner=user,
-    )
-    
-    # Login and access the list view
-    client = Client()
-    client.login(username="testuser", password="testpass")
-    
-    response = client.get(reverse("core:list", args=[list_obj.id]))
+
+    # Test the view
+    response = client.get(reverse("core:list", kwargs={"id": test_list.id}))
     assert response.status_code == 200
-    
-    # Check that resources are displayed
-    assert b"Assets &amp; Resources" in response.content
-    assert b"Credits" in response.content
-    assert b"150" in response.content  # Credits amount
-    assert b"Reputation" in response.content
-    assert b"10" in response.content  # Reputation amount
-    
-    # Check that assets are displayed
-    assert b"The Sump" in response.content
-    assert b"Trading Post" in response.content
-    assert b"Territory" in response.content
-    
-    # Check that links are present
-    assert b"Modify" in response.content
-    assert b"Transfer" in response.content
+
+    # Check context contains resources and assets
+    assert "campaign_resources" in response.context
+    assert "held_assets" in response.context
+
+    # Verify the resources are included
+    resources = list(response.context["campaign_resources"])
+    assert len(resources) == 1
+    assert resources[0].amount == 100
+    assert resources[0].resource_type.name == "Credits"
+
+    # Verify the assets are included
+    assets = list(response.context["held_assets"])
+    assert len(assets) == 1
+    assert assets[0].name == "The Sump"
+    assert assets[0].asset_type.name_singular == "Territory"
+
+    # Check that the content is rendered in the HTML
+    # HTML entities are encoded in the response
+    assert (
+        "Assets &amp; Resources" in response.content.decode()
+        or "Assets & Resources" in response.content.decode()
+    )
+    assert "Credits" in response.content.decode()
+    assert "100" in response.content.decode()
+    assert "The Sump" in response.content.decode()
+    assert "Territory" in response.content.decode()
 
 
 @pytest.mark.django_db
-def test_list_view_does_not_show_resources_assets_for_non_campaign_lists():
-    """Test that resources/assets panel is not shown for lists not in campaign mode."""
-    # Create test data
-    user = User.objects.create_user(username="testuser", password="testpass")
-    house = ContentHouse.objects.create(name="Test House")
-    
-    # Create a regular list (not in campaign mode)
-    list_obj = List.objects.create(
-        name="Test Gang",
-        owner=user,
-        content_house=house,
-        status=List.LIST_BUILDING,
+def test_list_view_no_resources_or_assets_shows_message(django_user_model):
+    """Test that list detail view shows 'No assets or resources held' when empty."""
+    # Create test user
+    user = django_user_model.objects.create_user(
+        username="testuser2", password="testpass"
     )
-    
-    # Login and access the list view
     client = Client()
-    client.login(username="testuser", password="testpass")
-    
-    response = client.get(reverse("core:list", args=[list_obj.id]))
-    assert response.status_code == 200
-    
-    # Check that resources/assets panel is not displayed
-    assert b"Assets &amp; Resources" not in response.content
+    client.login(username="testuser2", password="testpass")
 
-
-@pytest.mark.django_db
-def test_list_view_shows_empty_state_when_no_resources_or_assets():
-    """Test that empty state is shown when gang has no resources or assets."""
     # Create test data
-    user = User.objects.create_user(username="testuser", password="testpass")
-    house = ContentHouse.objects.create(name="Test House")
-    
-    # Create campaign
+    house = ContentHouse.objects.create(name="Test House 2")
     campaign = Campaign.objects.create(
-        name="Test Campaign",
+        name="Test Campaign 2",
         owner=user,
         status=Campaign.IN_PROGRESS,
     )
-    
-    # Create a list in campaign mode but with no resources/assets
-    list_obj = List.objects.create(
-        name="Test Gang",
-        owner=user,
+
+    # Create a list in campaign mode with no resources or assets
+    test_list = List.objects.create(
+        name="Empty Gang",
         content_house=house,
+        owner=user,
         status=List.CAMPAIGN_MODE,
         campaign=campaign,
     )
-    
-    # Login and access the list view
-    client = Client()
-    client.login(username="testuser", password="testpass")
-    
-    response = client.get(reverse("core:list", args=[list_obj.id]))
+
+    # Test the view
+    response = client.get(reverse("core:list", kwargs={"id": test_list.id}))
     assert response.status_code == 200
-    
-    # Check that the panel is displayed with empty state
-    assert b"Assets &amp; Resources" in response.content
-    assert b"No assets or resources held." in response.content
+
+    # Check that the empty message is shown
+    assert "No assets or resources held." in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_list_building_mode_does_not_show_resources_assets(django_user_model):
+    """Test that lists in list building mode don't show resources/assets card."""
+    # Create test user
+    user = django_user_model.objects.create_user(
+        username="testuser3", password="testpass"
+    )
+    client = Client()
+    client.login(username="testuser3", password="testpass")
+
+    # Create test data
+    house = ContentHouse.objects.create(name="Test House 3")
+
+    # Create a list in list building mode
+    test_list = List.objects.create(
+        name="List Building Gang",
+        content_house=house,
+        owner=user,
+        status=List.LIST_BUILDING,  # Not in campaign mode
+    )
+
+    # Test the view
+    response = client.get(reverse("core:list", kwargs={"id": test_list.id}))
+    assert response.status_code == 200
+
+    # Check that resources/assets are not in context or are empty
+    # The template may pass empty strings for these variables
+    if "campaign_resources" in response.context:
+        assert response.context["campaign_resources"] == ""
+    if "held_assets" in response.context:
+        assert response.context["held_assets"] == ""
+
+    # Check that the card is not rendered
+    assert "Assets &amp; Resources" not in response.content.decode()

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -84,6 +84,10 @@ class ListDetailView(generic.DetailView):
         The requested :model:`core.List` object.
     ``recent_actions``
         Recent campaign actions related to this list (if in campaign mode).
+    ``campaign_resources``
+        Resources held by this list in the campaign (if in campaign mode).
+    ``held_assets``
+        Assets held by this list in the campaign (if in campaign mode).
 
     **Template**
 
@@ -116,6 +120,16 @@ class ListDetailView(generic.DetailView):
             )
 
             context["recent_actions"] = recent_actions
+
+            # Get campaign resources held by this list
+            campaign_resources = list_obj.campaign_resources.filter(
+                amount__gt=0
+            ).select_related("resource_type")
+            context["campaign_resources"] = campaign_resources
+
+            # Get assets held by this list
+            held_assets = list_obj.held_assets.select_related("asset_type")
+            context["held_assets"] = held_assets
 
         return context
 


### PR DESCRIPTION
Add a card to the list view for all lists that are in campaign mode that contains a dense summary of the Resources and Assets in the campaign held by that particular gang.

This card is structured like the Actions card and contains the title 'Assets & Resources' with a link to the campaign page.

- Resources: Name, Amount (badge), Link to Modify — only resources held by this gang
- Assets: Name, Type, Link to Transfer — only assets held by this gang

Closes #276

Generated with [Claude Code](https://claude.ai/code)