### PR TITLE
feat: Add ability to archive gang/lists

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card.html
+++ b/gyrinx/core/templates/core/includes/fighter_card.html
@@ -1,4 +1,9 @@
 {% load allauth custom_tags %}
+{% if list.owner_cached == user and not list.archived %}
+    {% with can_edit=True %}
+{% else %}
+    {% with can_edit=False %}
+{% endif %}
 {% if print %}
     {% firstof classes 'g-col-12 g-col-sm-6 g-col-md-4 g-col-xl-3' as card_classes %}
 {% else %}
@@ -48,7 +53,7 @@
                     </div>
                 </div>
             {% elif fighter.can_take_legacy %}
-                {% if list.owner_cached == user and not print %}
+                {% if can_edit and not print %}
                     <div class="hstack text-muted fs-7">
                         Legacy:&nbsp;
                         <a href="{% url 'core:list-fighter-edit' list.id fighter.id %}"
@@ -57,7 +62,7 @@
                 {% endif %}
             {% endif %}
             {% if not print %}
-                {% if list.owner_cached == user %}
+                {% if can_edit %}
                     <div class="btn-group">
                         <a href="{% url 'core:list-fighter-edit' list.id fighter.id %}"
                            class="btn btn-outline-secondary btn-sm">
@@ -152,7 +157,7 @@
                         <th scope="row" colspan="3">XP</th>
                         <td colspan="12">
                             <span class="badge text-bg-primary">{{ fighter.xp_current }} XP</span>
-                            {% if not print and list.owner_cached == user %}
+                            {% if not print and can_edit %}
                                 <a href="{% url 'core:list-fighter-xp-edit' list.id fighter.id %}">Edit XP</a>
                             {% endif %}
                         </td>
@@ -177,14 +182,14 @@
                                 {% endif %}
                             {% endfor %}
                             {% if not print %}
-                                {% if list.owner_cached == user %}
+                                {% if can_edit %}
                                     <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Edit skills</a>
                                 {% endif %}
                             {% endif %}
                         </td>
                     </tr>
                 {% else %}
-                    {% if list.owner_cached == user and not print %}
+                    {% if can_edit and not print %}
                         <tr class="fs-7">
                             <th scope="row" colspan="3">Skills</th>
                             <td colspan="12">
@@ -207,7 +212,7 @@
                                 <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Add powers</a>
                             {% endfor %}
                             {% if fighter.powers_cached|length > 0 and not print %}
-                                {% if list.owner_cached == user %}
+                                {% if can_edit %}
                                     <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Edit powers</a>
                                 {% endif %}
                             {% endif %}
@@ -236,7 +241,7 @@
                                     {% endspaceless %}
                                 {% endfor %}
                                 {% if not print %}
-                                    {% if list.owner_cached == user %}
+                                    {% if can_edit %}
                                         {% if line.assignments|length > 0 %}
                                             <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter=all&al=E&cat={{ line.id }}#search">Edit</a>
                                         {% else %}
@@ -261,7 +266,7 @@
                                 {% endspaceless %}
                             {% endfor %}
                             {% if not print %}
-                                {% if list.owner_cached == user %}
+                                {% if can_edit %}
                                     <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
                                        class="d-inline-block">Edit gear</a>
                                 {% endif %}
@@ -269,7 +274,7 @@
                         </td>
                     </tr>
                 {% else %}
-                    {% if list.owner_cached == user and not print %}
+                    {% if can_edit and not print %}
                         <tr class="fs-7">
                             <th scope="row" colspan="3">Gear</th>
                             <td colspan="12">
@@ -287,12 +292,12 @@
                                 {% if not forloop.first %},{% endif %}
                                 {{ injury.injury.name }}
                             {% endfor %}
-                            {% if not print and list.owner_cached == user %}
+                            {% if not print and can_edit %}
                                 <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Edit injuries</a>
                             {% endif %}
                         </td>
                     </tr>
-                {% elif list.is_campaign_mode and list.owner_cached == user and not print %}
+                {% elif list.is_campaign_mode and can_edit and not print %}
                     <tr class="fs-7">
                         <th scope="row" colspan="3">Injuries</th>
                         <td colspan="12">
@@ -305,7 +310,7 @@
         {% comment %} Wargear {% endcomment %}
         {% include "core/includes/list_fighter_weapons.html" with weapons=fighter.weapons_cached show_edit_link=False %}
         {% if not print %}
-            {% if list.owner_cached == user %}
+            {% if can_edit %}
                 <div class="btn-group p-1">
                     <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
                        class="btn btn-outline-primary btn-sm">
@@ -316,3 +321,5 @@
         {% endif %}
     </div>
 </div>
+    {% endwith %}
+{% endif %}

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -1,5 +1,14 @@
 {% load allauth custom_tags color_tags %}
 <div>
+    {% if list.archived %}
+        <div class="alert alert-secondary d-flex align-items-center mb-3" role="alert">
+            <i class="bi-archive me-2"></i>
+            <strong>This gang has been archived by its owner.</strong>
+            {% if list.owner_cached == user %}
+                <a href="{% url 'core:list-archive' list.id %}" class="ms-auto btn btn-sm btn-secondary">Unarchive</a>
+            {% endif %}
+        </div>
+    {% endif %}
     <div class="vstack gap-0 mb-2">
         <div class="hstack gap-2 mb-2 align-items-start align-items-md-center">
             <div class="d-flex flex-column flex-md-row flex-grow-1 align-items-start align-items-md-center gap-2">
@@ -92,7 +101,7 @@
             <div class="ms-sm-auto mt-2 mt-sm-0">
                 {% if not print %}
                     <nav class="nav btn-group flex-nowrap">
-                        {% if list.owner_cached == user %}
+                        {% if list.owner_cached == user and not list.archived %}
                             <a href="{% url 'core:list-fighter-new' list.id %}"
                                class="btn btn-primary btn-sm">
                                 <i class="bi-person-add"></i> Add fighter</a>
@@ -132,8 +141,8 @@
                                 </li>
                                 {% if list.owner_cached == user %}
                                     <li>
-                                        <a href="#" class="dropdown-item icon-link disabled">
-                                            <i class="bi-archive"></i> Archive
+                                        <a href="{% url 'core:list-archive' list.id %}" class="dropdown-item icon-link">
+                                            <i class="bi-archive"></i> {% if list.archived %}Unarchive{% else %}Archive{% endif %}
                                         </a>
                                     </li>
                                 {% endif %}

--- a/gyrinx/core/templates/core/list_archive.html
+++ b/gyrinx/core/templates/core/list_archive.html
@@ -1,0 +1,67 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    {% if list.archived %}Unarchive{% else %}Archive{% endif %} - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with url="core:list" url_param=list.id text=list.name %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">{% if list.archived %}Unarchive{% else %}Archive{% endif %}: {{ list.name }}</h1>
+        
+        {% if not list.archived %}
+            <p>Are you sure you want to archive this gang/list?</p>
+            
+            <div class="border rounded p-3 bg-light">
+                <p class="mb-2"><strong>What happens when you archive:</strong></p>
+                <ul class="mb-0">
+                    <li>The list will be hidden from your main lists page</li>
+                    <li>You won't be able to edit the list or its fighters</li>
+                    <li>You can unarchive it at any time to restore full functionality</li>
+                </ul>
+            </div>
+            
+            {% if is_in_active_campaign %}
+                <div class="border border-warning rounded p-3 bg-warning bg-opacity-10">
+                    <p class="mb-2"><strong class="text-warning">⚠️ Warning: Active Campaign</strong></p>
+                    <p class="mb-2">This gang is currently participating in the following active campaign{{ active_campaigns|length|pluralize }}:</p>
+                    <ul class="mb-2">
+                        {% for campaign in active_campaigns %}
+                            <li>{{ campaign.name }}</li>
+                        {% endfor %}
+                    </ul>
+                    <p class="mb-0">The gang will remain visible in the campaign{{ active_campaigns|length|pluralize }}, but an action log entry will be added noting that it has been archived.</p>
+                </div>
+            {% endif %}
+        {% else %}
+            <p>Are you sure you want to unarchive this gang/list?</p>
+            
+            <div class="border rounded p-3 bg-light">
+                <p class="mb-2"><strong>What happens when you unarchive:</strong></p>
+                <ul class="mb-0">
+                    <li>The list will be visible on your main lists page again</li>
+                    <li>You'll be able to edit the list and its fighters</li>
+                    <li>All functionality will be restored</li>
+                </ul>
+            </div>
+            
+            {% if is_in_active_campaign %}
+                <div class="border border-info rounded p-3 bg-info bg-opacity-10">
+                    <p class="mb-0"><strong>Note:</strong> An action log entry will be added to the campaign{{ active_campaigns|length|pluralize }} noting that the gang has been unarchived.</p>
+                </div>
+            {% endif %}
+        {% endif %}
+        
+        <form action="{% url 'core:list-archive' list.id %}" method="post">
+            {% csrf_token %}
+            <div class="mt-3">
+                {% if not list.archived %}
+                    <input type="hidden" name="archive" value="1">
+                    <input type="submit" class="btn btn-danger" value="Archive">
+                {% else %}
+                    <input type="submit" class="btn btn-primary" value="Unarchive">
+                {% endif %}
+                <a href="{% url 'core:list' list.id %}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_list_archive.py
+++ b/gyrinx/core/tests/test_list_archive.py
@@ -1,0 +1,332 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from gyrinx.content.models import ContentHouse
+from gyrinx.core.models.campaign import Campaign, CampaignAction
+from gyrinx.core.models.list import List
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_archive_list_url_exists(client, user, content_house):
+    """Test that the archive URL exists and requires login."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+    
+    # Test unauthenticated access
+    url = reverse("core:list-archive", args=[lst.id])
+    response = client.get(url)
+    assert response.status_code == 302  # Redirect to login
+    
+    # Test authenticated access
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_archive_list_requires_ownership(client, user, other_user, content_house):
+    """Test that only the owner can archive their list."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=other_user,
+        content_house=content_house,
+    )
+    
+    client.force_login(user)
+    url = reverse("core:list-archive", args=[lst.id])
+    response = client.get(url)
+    assert response.status_code == 404  # Not found for non-owner
+
+
+@pytest.mark.django_db
+def test_archive_list_get_request(client, user, content_house):
+    """Test the archive list confirmation page."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+    
+    client.force_login(user)
+    url = reverse("core:list-archive", args=[lst.id])
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert "Are you sure you want to archive this gang/list?" in response.content.decode()
+    assert "Archive" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_archive_list_post_request(client, user, content_house):
+    """Test archiving a list."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+    
+    assert lst.archived is False
+    assert lst.archived_at is None
+    
+    client.force_login(user)
+    url = reverse("core:list-archive", args=[lst.id])
+    response = client.post(url, {"archive": "1"})
+    
+    assert response.status_code == 302  # Redirect
+    assert response.url == reverse("core:list", args=[lst.id])
+    
+    lst.refresh_from_db()
+    assert lst.archived is True
+    assert lst.archived_at is not None
+
+
+@pytest.mark.django_db
+def test_unarchive_list_post_request(client, user, content_house):
+    """Test unarchiving a list."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+    lst.archive()
+    
+    assert lst.archived is True
+    assert lst.archived_at is not None
+    
+    client.force_login(user)
+    url = reverse("core:list-archive", args=[lst.id])
+    response = client.post(url)  # No archive=1 parameter means unarchive
+    
+    assert response.status_code == 302  # Redirect
+    assert response.url == reverse("core:list", args=[lst.id])
+    
+    lst.refresh_from_db()
+    assert lst.archived is False
+    assert lst.archived_at is None
+
+
+@pytest.mark.django_db
+def test_archive_list_with_active_campaign(client, user, content_house):
+    """Test archiving a list that's in an active campaign."""
+    # Create a list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+    
+    # Create an active campaign and add the list
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+    )
+    campaign.lists.add(lst)
+    
+    client.force_login(user)
+    url = reverse("core:list-archive", args=[lst.id])
+    
+    # Check the warning is shown
+    response = client.get(url)
+    assert response.status_code == 200
+    assert "Active Campaign" in response.content.decode()
+    assert campaign.name in response.content.decode()
+    
+    # Archive the list
+    response = client.post(url, {"archive": "1"})
+    assert response.status_code == 302
+    
+    lst.refresh_from_db()
+    assert lst.archived is True
+    
+    # Check that a campaign action was created
+    action = CampaignAction.objects.filter(campaign=campaign).first()
+    assert action is not None
+    assert f"Gang '{lst.name}' has been archived by its owner" in action.description
+    assert action.user == user
+    assert action.list == lst
+
+
+@pytest.mark.django_db
+def test_archived_list_display(client, user, content_house):
+    """Test that archived lists show the archived banner."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+    lst.archive()
+    
+    client.force_login(user)
+    url = reverse("core:list", args=[lst.id])
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert "This gang has been archived by its owner" in response.content.decode()
+    assert "Unarchive" in response.content.decode()
+    
+    # Check that edit buttons are not shown
+    assert 'href="' + reverse("core:list-fighter-new", args=[lst.id]) not in response.content.decode()
+    assert 'href="' + reverse("core:list-edit", args=[lst.id]) not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_archived_lists_hidden_from_lists_page(client, user, content_house):
+    """Test that archived lists are not shown on the lists page."""
+    # Create active and archived lists
+    active_list = List.objects.create(
+        name="Active List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+    
+    archived_list = List.objects.create(
+        name="Archived List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+    archived_list.archive()
+    
+    # Check public lists page
+    url = reverse("core:lists")
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert active_list.name in response.content.decode()
+    assert archived_list.name not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_archived_lists_hidden_from_home_page(client, user, content_house):
+    """Test that archived lists are not shown on the home page."""
+    # Create active and archived lists
+    active_list = List.objects.create(
+        name="Active List",
+        owner=user,
+        content_house=content_house,
+    )
+    
+    archived_list = List.objects.create(
+        name="Archived List",
+        owner=user,
+        content_house=content_house,
+    )
+    archived_list.archive()
+    
+    client.force_login(user)
+    url = reverse("core:index")
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert active_list.name in response.content.decode()
+    assert archived_list.name not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_archived_lists_hidden_from_user_profile(client, user, content_house):
+    """Test that archived lists are not shown on user profile pages."""
+    # Create active and archived lists
+    active_list = List.objects.create(
+        name="Active List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+    
+    archived_list = List.objects.create(
+        name="Archived List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+    archived_list.archive()
+    
+    url = reverse("core:user", args=[user.username])
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert active_list.name in response.content.decode()
+    assert archived_list.name not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_archived_lists_hidden_from_campaign_add_lists(client, user, content_house):
+    """Test that archived lists cannot be added to campaigns."""
+    # Create active and archived lists
+    active_list = List.objects.create(
+        name="Active List",
+        owner=user,
+        content_house=content_house,
+    )
+    
+    archived_list = List.objects.create(
+        name="Archived List",
+        owner=user,
+        content_house=content_house,
+    )
+    archived_list.archive()
+    
+    # Create a campaign
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.PRE_CAMPAIGN,
+    )
+    
+    client.force_login(user)
+    url = reverse("core:campaign-add-lists", args=[campaign.id])
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert active_list.name in response.content.decode()
+    assert archived_list.name not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_archive_button_in_dropdown_menu(client, user, content_house):
+    """Test that the archive/unarchive button appears in the dropdown menu."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+    
+    client.force_login(user)
+    url = reverse("core:list", args=[lst.id])
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert 'href="' + reverse("core:list-archive", args=[lst.id]) in response.content.decode()
+    assert "Archive" in response.content.decode()
+    
+    # Archive the list and check again
+    lst.archive()
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert 'href="' + reverse("core:list-archive", args=[lst.id]) in response.content.decode()
+    assert "Unarchive" in response.content.decode()
+
+
+# Fixtures
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="testuser", password="testpass")
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(username="otheruser", password="testpass")
+
+
+@pytest.fixture
+def content_house(db):
+    return ContentHouse.objects.create(name="Test House")

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path("lists/new", list.new_list, name="lists-new"),
     path("list/<id>", list.ListDetailView.as_view(), name="list"),
     path("list/<id>/about", list.ListAboutDetailView.as_view(), name="list-about"),
+    path("list/<id>/archive", list.archive_list, name="list-archive"),
     path("list/<id>/edit", list.edit_list, name="list-edit"),
     path("list/<id>/clone", list.clone_list, name="list-clone"),
     path("list/<id>/fighters/new", list.new_list_fighter, name="list-fighter-new"),

--- a/gyrinx/core/views/__init__.py
+++ b/gyrinx/core/views/__init__.py
@@ -42,7 +42,7 @@ def index(request):
     else:
         # Regular lists (not in campaigns)
         lists = List.objects.filter(
-            owner=request.user, status=List.LIST_BUILDING
+            owner=request.user, status=List.LIST_BUILDING, archived=False
         ).select_related("content_house")
 
         # Campaign gangs - user's lists that are in active campaigns
@@ -168,7 +168,7 @@ def user(request, slug_or_id):
         query = Q(username__iexact=slug_or_id)
     user = get_object_or_404(User, query)
     public_lists = List.objects.filter(
-        owner=user, public=True, status=List.LIST_BUILDING
+        owner=user, public=True, status=List.LIST_BUILDING, archived=False
     )
     return render(
         request,

--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -184,10 +184,11 @@ def campaign_add_lists(request, id):
                 error_message = "List not found."
 
     # Get lists that can be added (user's own lists or public lists)
-    # Only show lists in list building mode
+    # Only show lists in list building mode and not archived
     lists = List.objects.filter(
         (models.Q(owner=request.user) | models.Q(public=True))
         & models.Q(status=List.LIST_BUILDING)
+        & models.Q(archived=False)
     )
 
     # If the campaign has started, exclude lists that have been cloned into it

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -70,8 +70,9 @@ class ListsListView(generic.ListView):
         """
         Return :model:`core.List` objects that are public and in list building mode.
         Campaign mode lists are only visible within their campaigns.
+        Archived lists are excluded from this view.
         """
-        return List.objects.filter(public=True, status=List.LIST_BUILDING)
+        return List.objects.filter(public=True, status=List.LIST_BUILDING, archived=False)
 
 
 class ListDetailView(generic.DetailView):
@@ -256,6 +257,71 @@ def edit_list(request, id):
         request,
         "core/list_edit.html",
         {"form": form, "error_message": error_message},
+    )
+
+
+@login_required
+def archive_list(request, id):
+    """
+    Archive or unarchive a :model:`core.List`.
+
+    **Context**
+
+    ``list``
+        The :model:`core.List` to be archived or unarchived.
+    ``is_in_active_campaign``
+        Boolean indicating if the list is in an active campaign.
+    ``active_campaigns``
+        List of active campaigns this list is participating in.
+
+    **Template**
+
+    :template:`core/list_archive.html`
+    """
+    lst = get_object_or_404(List, id=id, owner=request.user)
+    
+    # Check if the list is in any active campaigns
+    active_campaigns = lst.campaigns.filter(status="in_progress")
+    is_in_active_campaign = active_campaigns.exists()
+    
+    if request.method == "POST":
+        from gyrinx.core.models.campaign import CampaignAction
+        
+        if request.POST.get("archive") == "1":
+            lst.archive()
+            
+            # Add campaign action log entries for active campaigns
+            for campaign in active_campaigns:
+                CampaignAction.objects.create(
+                    campaign=campaign,
+                    user=request.user,
+                    list=lst,
+                    description=f"Gang '{lst.name}' has been archived by its owner",
+                    owner=request.user,
+                )
+        elif lst.archived:
+            lst.unarchive()
+            
+            # Add campaign action log entries for active campaigns when unarchiving
+            for campaign in active_campaigns:
+                CampaignAction.objects.create(
+                    campaign=campaign,
+                    user=request.user,
+                    list=lst,
+                    description=f"Gang '{lst.name}' has been unarchived by its owner",
+                    owner=request.user,
+                )
+        
+        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+
+    return render(
+        request,
+        "core/list_archive.html",
+        {
+            "list": lst,
+            "is_in_active_campaign": is_in_active_campaign,
+            "active_campaigns": active_campaigns,
+        },
     )
 
 


### PR DESCRIPTION
Closes #265

This PR implements the ability to archive and unarchive gang/lists.

## Changes

- Added archive/unarchive functionality with confirmation page
- Show archived banner and disable editing on archived lists
- Hide archived lists from list views, home page, and user profiles
- Add campaign action log entries when archiving/unarchiving lists in active campaigns
- Update fighter cards to disable editing when list is archived
- Add comprehensive tests for archiving functionality

Generated with [Claude Code](https://claude.ai/code)