### PR TITLE
fix: preserve theme_color when cloning lists for campaigns

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -213,6 +213,7 @@ class List(AppBase):
         values = {
             "public": self.public if for_campaign is None else False,
             "narrative": self.narrative,
+            "theme_color": self.theme_color,
             **kwargs,
         }
 


### PR DESCRIPTION
When a list is added to a campaign and cloned, the gang colours (theme_color)
are now preserved. This ensures visual consistency as lists transition from
pre-campaign to active campaign gangs.

Fixes #289

Generated with [Claude Code](https://claude.ai/code)