### PR TITLE
refactor: replace SimpleTestCase with pytest-style functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ The list view establishes the standard UI pattern for detail pages:
 
 - Tests use pytest with `@pytest.mark.django_db` decorator
 - Test functions at module level, not in classes
+- Do not use Django's TestCase or SimpleTestCase - use plain pytest functions
 - Use Django test client for view testing
 - Static files must be collected before running tests that render templates
 - The conftest.py configures tests to use StaticFilesStorage to avoid manifest issues

--- a/gyrinx/core/tests/test_color_tags.py
+++ b/gyrinx/core/tests/test_color_tags.py
@@ -1,51 +1,51 @@
-from django.test import SimpleTestCase
-
 from gyrinx.core.templatetags.color_tags import (
     list_with_theme,
     theme_square,
 )
 
 
-class TestColorTags(SimpleTestCase):
-    def test_theme_square_with_color(self):
-        """Test theme square generation with a theme color."""
+def test_theme_square_with_color():
+    """Test theme square generation with a theme color."""
 
-        class MockList:
-            name = "Test Gang"
-            theme_color = "#386b33"
+    class MockList:
+        name = "Test Gang"
+        theme_color = "#386b33"
 
-        square = theme_square(MockList())
-        assert 'class="d-inline-block rounded "' in square
-        assert "background-color: #386b33;" in square
-        assert "border: 1px solid rgba(0,0,0,0.15);" in square
+    square = theme_square(MockList())
+    assert 'class="d-inline-block rounded "' in square
+    assert "background-color: #386b33;" in square
+    assert "border: 1px solid rgba(0,0,0,0.15);" in square
 
-    def test_theme_square_without_color(self):
-        """Test theme square with no color returns empty."""
 
-        class MockList:
-            name = "Test Gang"
-            theme_color = None
+def test_theme_square_without_color():
+    """Test theme square with no color returns empty."""
 
-        square = theme_square(MockList())
-        assert square == ""
+    class MockList:
+        name = "Test Gang"
+        theme_color = None
 
-    def test_list_with_theme_colored(self):
-        """Test list display with theme color."""
+    square = theme_square(MockList())
+    assert square == ""
 
-        class MockList:
-            name = "Test Gang"
-            theme_color = "#386b33"
 
-        display = list_with_theme(MockList())
-        assert "Test Gang</span>" in display
-        assert "background-color: #386b33;" in display
+def test_list_with_theme_colored():
+    """Test list display with theme color."""
 
-    def test_list_with_theme_no_color(self):
-        """Test list display without theme color."""
+    class MockList:
+        name = "Test Gang"
+        theme_color = "#386b33"
 
-        class MockList:
-            name = "Test Gang"
-            theme_color = None
+    display = list_with_theme(MockList())
+    assert "Test Gang</span>" in display
+    assert "background-color: #386b33;" in display
 
-        display = list_with_theme(MockList())
-        assert display == '<span class="">Test Gang</span>'
+
+def test_list_with_theme_no_color():
+    """Test list display without theme color."""
+
+    class MockList:
+        name = "Test Gang"
+        theme_color = None
+
+    display = list_with_theme(MockList())
+    assert display == '<span class="">Test Gang</span>'


### PR DESCRIPTION
Converted test_color_tags.py from Django's SimpleTestCase to plain pytest functions, following the house testing style. Updated CLAUDE.md to document this testing pattern.

Fixes #275

Generated with [Claude Code](https://claude.ai/code)