### PR TITLE
fix: adjust typography for lists in campaign view

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -112,8 +112,8 @@
                                    class="list-group-item list-group-item-action">
                                     <div class="d-flex w-100 justify-content-between">
                                         <h6 class="mb-1">
-                                            {% list_with_theme list "me-1" %}
-                                            {% if list.content_house %}<span class="badge bg-secondary">{{ list.content_house.name }}</span>{% endif %}
+                                            <strong>{% list_with_theme list "me-1" %}</strong>
+                                            {% if list.content_house %}• {{ list.content_house.name }}{% endif %}
                                         </h6>
                                         <small>{{ list.cost_display }}</small>
                                     </div>

--- a/gyrinx/core/templates/core/campaign/campaign_add_lists.html
+++ b/gyrinx/core/templates/core/campaign/campaign_add_lists.html
@@ -120,8 +120,8 @@
                                 <div class="row align-items-center">
                                     <div class="col">
                                         <h6 class="mb-1">
-                                            {% list_with_theme list %}
-                                            {% if list.content_house %}<span class="badge bg-secondary ms-1">{{ list.content_house.name }}</span>{% endif %}
+                                            <strong>{% list_with_theme list %}</strong>
+                                            {% if list.content_house %}• {{ list.content_house.name }}{% endif %}
                                         </h6>
                                         <p class="mb-0 text-muted small">
                                             {% if list.owner == request.user %}


### PR DESCRIPTION
Closes #288

- Make gang names bold in campaign list displays
- Remove badge styling from house names (show as regular text)
- Add bullet separator between gang name and house type
- Apply consistent styling in campaign.html and campaign_add_lists.html

Generated with [Claude Code](https://claude.ai/code)