### PR TITLE
feat: Update account template forms to use Bootstrap styling

### DIFF
--- a/gyrinx/core/templates/account/email_change.html
+++ b/gyrinx/core/templates/account/email_change.html
@@ -2,11 +2,11 @@
 {% load i18n %}
 {% load allauth %}
 {% block head_title %}
-    {% trans "Email Address" %}
+    {% trans "Change Email Address" %}
 {% endblock head_title %}
 {% block content %}
     {% element h1 %}
-        {% trans "Email Address" %}
+        {% trans "Change Email Address" %}
     {% endelement %}
     {% if not emailaddresses %}
         {% include "account/snippets/warn_no_email.html" %}

--- a/gyrinx/core/templates/allauth/elements/alert.html
+++ b/gyrinx/core/templates/allauth/elements/alert.html
@@ -1,5 +1,5 @@
 {% load allauth %}
-<p>
+<div class="alert alert-{{ attrs.level|default:'info' }}" role="alert">
     {% slot message %}
     {% endslot %}
-</p>
+</div>

--- a/gyrinx/core/templates/allauth/elements/button.html
+++ b/gyrinx/core/templates/allauth/elements/button.html
@@ -6,7 +6,7 @@
 {% if attrs.name %}name="{{ attrs.name }}"{% endif %}
 {% if attrs.value %}value="{{ attrs.value }}"{% endif %}
 {% if attrs.type %}type="{{ attrs.type }}"{% endif %}
-{% if attrs.id %}id="{{ attrs.id }}"{% endif %}
+class="btn {% if attrs.type == 'submit' or not attrs.secondary %}btn-primary{% else %}btn-secondary{% endif %}"
 >
 {% slot %}
 {% endslot %}

--- a/gyrinx/core/templates/allauth/elements/field.html
+++ b/gyrinx/core/templates/allauth/elements/field.html
@@ -1,12 +1,13 @@
 {% load allauth %}
 {{ attrs.errors }}
-<p>
+<div class="mb-3">
     {% if attrs.type == "textarea" %}
-        <label for="{{ attrs.id }}">
+        <label for="{{ attrs.id }}" class="form-label">
             {% slot label %}
             {% endslot %}
         </label>
-        <textarea {% if attrs.required %}required{% endif %}
+        <textarea class="form-control"
+                  {% if attrs.required %}required{% endif %}
                   {% if attrs.rows %}rows="{{ attrs.rows }}"{% endif %}
                   {% if attrs.disabled %}disabled{% endif %}
                   {% if attrs.readonly %}readonly{% endif %}
@@ -14,14 +15,47 @@
                   {% if attrs.name %}name="{{ attrs.name }}"{% endif %}
                   {% if attrs.id %}id="{{ attrs.id }}"{% endif %}
                   {% if attrs.placeholder %}placeholder="{{ attrs.placeholder }}"{% endif %}>{% slot value %}{% endslot %}</textarea>
-    {% else %}
-        {% if attrs.type != "checkbox" and attrs.type != "radio" %}
-            <label for="{{ attrs.id }}">
+    {% elif attrs.type == "checkbox" %}
+        <div class="form-check">
+            <input class="form-check-input"
+                   {% if attrs.required %}required{% endif %}
+                   {% if attrs.disabled %}disabled{% endif %}
+                   {% if attrs.readonly %}readonly{% endif %}
+                   {% if attrs.checked %}checked{% endif %}
+                   {% if attrs.name %}name="{{ attrs.name }}"{% endif %}
+                   {% if attrs.id %}id="{{ attrs.id }}"{% endif %}
+                   {% if attrs.autocomplete %}autocomplete="{{ attrs.autocomplete }}"{% endif %}
+                   {% if attrs.value is not None %}value="{{ attrs.value }}"{% endif %}
+                   type="{{ attrs.type }}">
+            <label for="{{ attrs.id }}" class="form-check-label">
                 {% slot label %}
                 {% endslot %}
             </label>
-        {% endif %}
-        <input {% if attrs.required %}required{% endif %}
+        </div>
+    {% elif attrs.type == "radio" %}
+        <div class="form-check">
+            <input class="form-check-input"
+                   {% if attrs.required %}required{% endif %}
+                   {% if attrs.disabled %}disabled{% endif %}
+                   {% if attrs.readonly %}readonly{% endif %}
+                   {% if attrs.checked %}checked{% endif %}
+                   {% if attrs.name %}name="{{ attrs.name }}"{% endif %}
+                   {% if attrs.id %}id="{{ attrs.id }}"{% endif %}
+                   {% if attrs.autocomplete %}autocomplete="{{ attrs.autocomplete }}"{% endif %}
+                   {% if attrs.value is not None %}value="{{ attrs.value }}"{% endif %}
+                   type="{{ attrs.type }}">
+            <label for="{{ attrs.id }}" class="form-check-label">
+                {% slot label %}
+                {% endslot %}
+            </label>
+        </div>
+    {% else %}
+        <label for="{{ attrs.id }}" class="form-label">
+            {% slot label %}
+            {% endslot %}
+        </label>
+        <input class="form-control"
+               {% if attrs.required %}required{% endif %}
                {% if attrs.disabled %}disabled{% endif %}
                {% if attrs.readonly %}readonly{% endif %}
                {% if attrs.checked %}checked{% endif %}
@@ -31,17 +65,11 @@
                {% if attrs.autocomplete %}autocomplete="{{ attrs.autocomplete }}"{% endif %}
                {% if attrs.value is not None %}value="{{ attrs.value }}"{% endif %}
                type="{{ attrs.type }}">
-        {% if attrs.type == "checkbox" or attrs.type == "radio" %}
-            <label for="{{ attrs.id }}">
-                {% slot label %}
-                {% endslot %}
-            </label>
-        {% endif %}
     {% endif %}
     {% if slots.help_text %}
-        <span>
+        <div class="form-text">
             {% slot help_text %}
             {% endslot %}
-        </span>
+        </div>
     {% endif %}
-</p>
+</div>

--- a/gyrinx/core/templates/allauth/elements/fields.html
+++ b/gyrinx/core/templates/allauth/elements/fields.html
@@ -1,1 +1,18 @@
-{{ attrs.form.as_p }}
+{% load allauth allauth_bootstrap %}
+{% for field in attrs.form %}
+    <div class="mb-3">
+        {% if field|is_checkbox %}
+            <div class="form-check">
+                {{ field|add_bootstrap_class }}
+                <label for="{{ field.id_for_label }}" class="form-check-label">{{ field.label }}</label>
+            </div>
+        {% else %}
+            <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+            {{ field|add_bootstrap_class }}
+        {% endif %}
+        {% if field.help_text %}<div class="form-text">{{ field.help_text|safe }}</div>{% endif %}
+        {% if field.errors %}
+            {% for error in field.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        {% endif %}
+    </div>
+{% endfor %}

--- a/gyrinx/core/templates/allauth/elements/form.html
+++ b/gyrinx/core/templates/allauth/elements/form.html
@@ -1,7 +1,11 @@
 {% load allauth %}
-<form method="{{ attrs.method }}" action="{{ attrs.action }}">
+<form class="col-12 col-md-8 col-lg-6"
+      method="{{ attrs.method }}"
+      action="{{ attrs.action }}">
     {% slot body %}
     {% endslot %}
-    {% slot actions %}
-    {% endslot %}
+    <div class="hstack gap-3 mt-4">
+        {% slot actions %}
+        {% endslot %}
+    </div>
 </form>

--- a/gyrinx/core/templates/allauth/elements/panel.html
+++ b/gyrinx/core/templates/allauth/elements/panel.html
@@ -1,5 +1,5 @@
 {% load allauth %}
-<div class="card mb-3">
+<div class="card mb-3 col-12 col-md-8 col-lg-6">
     <div class="card-header">
         <h2 class="h5 mb-0">
             {% slot title %}

--- a/gyrinx/core/templates/allauth/elements/panel.html
+++ b/gyrinx/core/templates/allauth/elements/panel.html
@@ -1,14 +1,18 @@
 {% load allauth %}
-<section>
-    <h2>
-        {% slot title %}
+<div class="card mb-3">
+    <div class="card-header">
+        <h2 class="h5 mb-0">
+            {% slot title %}
+            {% endslot %}
+        </h2>
+    </div>
+    <div class="card-body">
+        {% slot body %}
         {% endslot %}
-    </h2>
-    {% slot body %}
-    {% endslot %}
-    {% if slots.actions %}
-        <ul>
-            {% for action in slots.actions %}<li>{{ action }}</li>{% endfor %}
-        </ul>
-    {% endif %}
-</section>
+        {% if slots.actions %}
+            <div class="list-group list-group-flush mt-3">
+                {% for action in slots.actions %}<div class="list-group-item">{{ action }}</div>{% endfor %}
+            </div>
+        {% endif %}
+    </div>
+</div>

--- a/gyrinx/core/templates/allauth/elements/table.html
+++ b/gyrinx/core/templates/allauth/elements/table.html
@@ -1,5 +1,5 @@
 {% load allauth %}
-<table>
+<table class="table table-striped">
     {% slot %}
     {% endslot %}
 </table>

--- a/gyrinx/core/templates/allauth/layouts/base.html
+++ b/gyrinx/core/templates/allauth/layouts/base.html
@@ -3,7 +3,7 @@
 {% block body %}
     <div class="container my-3 my-md-5">
         {% if user.is_authenticated %}
-            <div class="dropdown d-md-none mb-3 order-1">
+            <div class="dropdown d-lg-none mb-3 order-1">
                 <button class="btn btn-outline-secondary dropdown-toggle"
                         type="button"
                         data-bs-toggle="dropdown"
@@ -12,7 +12,7 @@
                     {% include "account/snippets/menu.html" with list_a_class="dropdown-item" %}
                 </ul>
             </div>
-            <ul class="d-none d-md-flex nav nav-tabs order-2">
+            <ul class="d-none d-lg-flex nav nav-tabs order-2">
                 {% include "account/snippets/menu.html" with list_item_class="nav-item" list_a_class="nav-link" %}
             </ul>
         {% endif %}

--- a/gyrinx/core/templatetags/allauth_bootstrap.py
+++ b/gyrinx/core/templatetags/allauth_bootstrap.py
@@ -1,0 +1,48 @@
+from django import template
+from django.forms import widgets
+
+register = template.Library()
+
+
+@register.filter
+def add_bootstrap_class(field):
+    """Add Bootstrap classes to form field widgets."""
+    widget = field.field.widget
+    css_classes = widget.attrs.get("class", "")
+
+    if isinstance(
+        widget,
+        (
+            widgets.TextInput,
+            widgets.EmailInput,
+            widgets.PasswordInput,
+            widgets.NumberInput,
+            widgets.URLInput,
+            widgets.DateInput,
+            widgets.DateTimeInput,
+            widgets.TimeInput,
+            widgets.Textarea,
+        ),
+    ):
+        css_classes = f"{css_classes} form-control".strip()
+    elif isinstance(widget, widgets.Select):
+        css_classes = f"{css_classes} form-select".strip()
+    elif isinstance(widget, (widgets.CheckboxInput, widgets.RadioSelect)):
+        css_classes = f"{css_classes} form-check-input".strip()
+
+    widget.attrs["class"] = css_classes
+    return field
+
+
+@register.filter
+def is_checkbox(field):
+    """Check if field is a checkbox."""
+    return isinstance(field.field.widget, widgets.CheckboxInput)
+
+
+@register.filter
+def add_label_class(field):
+    """Add Bootstrap label classes based on widget type."""
+    if isinstance(field.field.widget, widgets.CheckboxInput):
+        return "form-check-label"
+    return "form-label"

--- a/gyrinx/core/templatetags/allauth_bootstrap.py
+++ b/gyrinx/core/templatetags/allauth_bootstrap.py
@@ -25,10 +25,14 @@ def add_bootstrap_class(field):
         ),
     ):
         css_classes = f"{css_classes} form-control".strip()
-    elif isinstance(widget, widgets.Select):
+    elif isinstance(widget, (widgets.Select, widgets.SelectMultiple)):
         css_classes = f"{css_classes} form-select".strip()
     elif isinstance(widget, (widgets.CheckboxInput, widgets.RadioSelect)):
         css_classes = f"{css_classes} form-check-input".strip()
+
+    # Add is-invalid class if field has errors
+    if field.errors:
+        css_classes = f"{css_classes} is-invalid".strip()
 
     widget.attrs["class"] = css_classes
     return field
@@ -38,11 +42,3 @@ def add_bootstrap_class(field):
 def is_checkbox(field):
     """Check if field is a checkbox."""
     return isinstance(field.field.widget, widgets.CheckboxInput)
-
-
-@register.filter
-def add_label_class(field):
-    """Add Bootstrap label classes based on widget type."""
-    if isinstance(field.field.widget, widgets.CheckboxInput):
-        return "form-check-label"
-    return "form-label"


### PR DESCRIPTION
Fixes #290

This PR updates all account management forms to use Bootstrap 5 styling for consistency with the rest of the application.

## Changes
- Updated allauth element templates to use Bootstrap classes
- Added proper form controls, labels, and spacing
- Created custom template filter for dynamic Bootstrap class application
- Updated alerts, panels, and tables to use Bootstrap components

All account forms (login, signup, password management, email management, 2FA) now have consistent Bootstrap styling.

Generated with [Claude Code](https://claude.ai/code)