### PR TITLE
fix: pass campaign resources and assets to list template

### DIFF
--- a/gyrinx/core/templates/core/list.html
+++ b/gyrinx/core/templates/core/list.html
@@ -13,5 +13,5 @@
         {% url 'core:lists' as lists_url %}
         {% include "core/includes/back.html" with url=lists_url text="All Lists" %}
     {% endif %}
-    <div class="col-lg-12 px-0 vstack gap-5">{% include "core/includes/list.html" with list=list %}</div>
+    <div class="col-lg-12 px-0 vstack gap-5">{% include "core/includes/list.html" with list=list campaign_resources=campaign_resources held_assets=held_assets %}</div>
 {% endblock content %}


### PR DESCRIPTION
When viewing a campaign gang's detail page, the Assets & Resources box
was not showing assets because the held_assets and campaign_resources
context variables were not being passed through when including the
list template.

This fix ensures these variables are explicitly passed to the included
template so campaign assets and resources are properly displayed.

Fixes #291

Generated with [Claude Code](https://claude.ai/code)