### PR TITLE
feat: implement equipment reassignment between fighters

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -590,3 +590,19 @@ class EditListCreditsForm(forms.Form):
 
         # We'll do more validation in the view where we have access to the list
         return cleaned_data
+
+
+class EquipmentReassignForm(forms.Form):
+    """Form for reassigning equipment from one fighter to another."""
+
+    target_fighter = forms.ModelChoiceField(
+        queryset=ListFighter.objects.none(),
+        label="Reassign to",
+        widget=forms.Select(attrs={"class": "form-select"}),
+        help_text="Select the fighter to receive this equipment.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        fighters = kwargs.pop("fighters", ListFighter.objects.none())
+        super().__init__(*args, **kwargs)
+        self.fields["target_fighter"].queryset = fighters

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -84,6 +84,9 @@
                                                            class="link-secondary">Edit</a>
                                                         <span class="text-muted">·</span>
                                                     {% endif %}
+                                                    <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
+                                                       class="link-secondary">Reassign</a>
+                                                    <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
                                                        class="link-danger">Remove</a>
                                                 {% elif assign.kind == 'default' %}
@@ -176,6 +179,9 @@
                                                    class="link-secondary">Edit</a>
                                                 <span class="text-muted">·</span>
                                             {% endif %}
+                                            <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
+                                               class="link-secondary">Reassign</a>
+                                            <span class="text-muted">·</span>
                                             <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
                                                class="link-danger">Remove</a>
                                         {% elif assign.kind == 'default' %}

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -185,30 +185,53 @@
             {% if mode == 'edit' %}
                 <tr>
                     <td colspan="9" class="text-end">
-                        <div class="d-flex btn-group">
+                        <div class="d-flex">
                             {% if assign.kind == 'assigned' %}
-                                <a href="{% url 'core:list-fighter-weapon-accessories-edit' list.id fighter.id assign.id %}"
-                                   class="btn btn-outline-secondary btn-sm">
-                                    <i class="bi-crosshair"></i>
-                                    Accessories
-                                </a>
-                                {% if assign.upgrades_display|length > 0 %}
-                                    <a href="{% url 'core:list-fighter-weapon-upgrade-edit' list.id fighter.id assign.id %}"
+                                <div class="btn-group">
+                                    <a href="{% url 'core:list-fighter-weapon-accessories-edit' list.id fighter.id assign.id %}"
                                        class="btn btn-outline-secondary btn-sm">
-                                        <i class="bi-arrow-up-circle"></i>
-                                        <span class="d-none d-sm-inline">{{ assign.equipment.upgrade_stack_name }}</span>
+                                        <i class="bi-crosshair"></i>
+                                        Accessories
                                     </a>
-                                {% endif %}
-                                <a href="{% url 'core:list-fighter-weapon-cost-edit' list.id fighter.id assign.id %}"
-                                   class="btn btn-outline-secondary btn-sm col-2 col-sm-3 flex-grow-0">
-                                    <span class="d-none d-sm-inline"><i class="bi-pencil"></i> Cost</span>
-                                    <span class="d-inline d-sm-none fw-bold">¢</span>
-                                </a>
-                                <a href="{% url 'core:list-fighter-weapon-delete' list.id fighter.id assign.id %}"
-                                   class="btn btn-outline-danger btn-sm col-2 col-sm-3 flex-grow-0">
-                                    <i class="bi-trash"></i>
-                                    <span class="d-none d-sm-inline">Remove</span>
-                                </a>
+                                    {% if assign.upgrades_display|length > 0 %}
+                                        <a href="{% url 'core:list-fighter-weapon-upgrade-edit' list.id fighter.id assign.id %}"
+                                           class="btn btn-outline-secondary btn-sm">
+                                            <i class="bi-arrow-up-circle"></i>
+                                            <span class="d-none d-sm-inline">{{ assign.equipment.upgrade_stack_name }}</span>
+                                        </a>
+                                    {% endif %}
+                                    <div class="btn-group">
+                                        <button class="btn btn-outline-secondary btn-sm dropdown-toggle"
+                                                type="button"
+                                                data-bs-toggle="dropdown"
+                                                aria-expanded="false">
+                                            <i class="bi-three-dots"></i>
+                                        </button>
+                                        <ul class="dropdown-menu dropdown-menu-end">
+                                            <li>
+                                                <a href="{% url 'core:list-fighter-weapon-cost-edit' list.id fighter.id assign.id %}"
+                                                   class="dropdown-item">
+                                                    <i class="bi-pencil"></i> Cost
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a href="{% url 'core:list-fighter-weapon-reassign' list.id fighter.id assign.id %}"
+                                                   class="dropdown-item">
+                                                    <i class="bi-arrow-left-right"></i> Reassign
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <hr class="dropdown-divider">
+                                            </li>
+                                            <li>
+                                                <a href="{% url 'core:list-fighter-weapon-delete' list.id fighter.id assign.id %}"
+                                                   class="dropdown-item text-danger">
+                                                    <i class="bi-trash"></i> Remove
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
                             {% elif assign.kind == 'default' %}
                                 <a href="{% url 'core:list-fighter-weapons-default-convert' list.id fighter.id assign.id %}"
                                    class="btn btn-outline-secondary btn-sm">

--- a/gyrinx/core/templates/core/list_fighter_assign_reassign.html
+++ b/gyrinx/core/templates/core/list_fighter_assign_reassign.html
@@ -1,0 +1,30 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Reassign - {{ assign.content_equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url back_url list.id fighter.id as full_back_url %}
+    {% include "core/includes/back.html" with url=full_back_url %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">Reassign {{ assign.content_equipment.name }}</h1>
+        <p>
+            Currently assigned to: <strong>{{ fighter.name }}</strong>
+        </p>
+        <form method="post">
+            {% csrf_token %}
+            <div class="mb-3">
+                {{ form.target_fighter.label_tag }}
+                {{ form.target_fighter }}
+                {% if form.target_fighter.help_text %}<div class="form-text">{{ form.target_fighter.help_text }}</div>{% endif %}
+                {% if form.target_fighter.errors %}
+                    <div class="invalid-feedback d-block">{{ form.target_fighter.errors|first }}</div>
+                {% endif %}
+            </div>
+            <div class="mt-3">
+                <button type="submit" class="btn btn-primary">Reassign</button>
+                <a href="{{ full_back_url }}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -80,6 +80,15 @@ urlpatterns = [
         ),
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/gear/<assign_id>/reassign",
+        list.reassign_list_fighter_equipment,
+        name="list-fighter-gear-reassign",
+        kwargs=dict(
+            is_weapon=False,
+            back_name="core:list-fighter-gear-edit",
+        ),
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/gear/<assign_id>/upgrade/<upgrade_id>/delete",
         list.delete_list_fighter_gear_upgrade,
         name="list-fighter-gear-upgrade-delete",
@@ -149,6 +158,15 @@ urlpatterns = [
         kwargs=dict(
             back_name="core:list-fighter-weapons-edit",
             action_name="core:list-fighter-weapon-delete",
+        ),
+    ),
+    path(
+        "list/<id>/fighter/<fighter_id>/weapons/<assign_id>/reassign",
+        list.reassign_list_fighter_equipment,
+        name="list-fighter-weapon-reassign",
+        kwargs=dict(
+            is_weapon=True,
+            back_name="core:list-fighter-weapons-edit",
         ),
     ),
     path(


### PR DESCRIPTION
Closes #324

## Summary

Implements equipment reassignment functionality allowing users to move weapons and gear between fighters in their gang.

## Changes

- Refactored weapon edit menu to use dropdown layout with Cost, Reassign, and Remove inside
- Added reassign link to gear display (Edit · Reassign · Remove)
- Created reassignment views and forms for both weapons and gear
- Added validation to prevent reassigning default equipment
- Allows reassigning to any fighter including stash fighter

Generated with [Claude Code](https://claude.ai/code)