### PR TITLE
fix: sort weapons alphabetically in fighter cards

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -772,7 +772,10 @@ class ListFighter(AppBase):
         return self.skilline()
 
     def weapons(self):
-        return [e for e in self.assignments_cached if e.is_weapon_cached]
+        return sorted(
+            [e for e in self.assignments_cached if e.is_weapon_cached],
+            key=lambda e: e.name(),
+        )
 
     @cached_property
     def weapons_cached(self):


### PR DESCRIPTION
Fixes #142

Weapons now appear in alphabetical order on fighter cards by sorting them by name in the ListFighter.weapons() method.

Generated with [Claude Code](https://claude.ai/code)