### PR TITLE
fix: prevent duplication of linked fighters when cloning lists

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -239,8 +239,14 @@ class List(AppBase):
             **values,
         )
 
+        # Clone fighters, but skip linked fighters as they'll be created by equipment assignments
         for fighter in self.fighters():
-            fighter.clone(list=clone)
+            # Check if this fighter is linked to an equipment assignment using the related name
+            if (
+                not hasattr(fighter, "linked_fighter")
+                or not fighter.linked_fighter.exists()
+            ):
+                fighter.clone(list=clone)
 
         # Add a stash fighter if cloning for a campaign
         if for_campaign:

--- a/gyrinx/core/tests/test_clone_linked_equipment.py
+++ b/gyrinx/core/tests/test_clone_linked_equipment.py
@@ -1,0 +1,155 @@
+import pytest
+
+from gyrinx.content.models import (
+    ContentEquipmentCategory,
+    ContentEquipmentFighterProfile,
+)
+from gyrinx.core.models.list import ListFighterEquipmentAssignment
+from gyrinx.models import FighterCategoryChoices
+
+
+@pytest.mark.django_db
+def test_clone_list_with_linked_fighter(
+    user,
+    make_list,
+    make_content_house,
+    make_content_fighter,
+    make_list_fighter,
+    make_equipment,
+):
+    """Test that cloning a list with equipment that has linked fighters works correctly."""
+    # Create house and fighters
+    house = make_content_house("Example House")
+    owner_cf = make_content_fighter(
+        type="Owner",
+        category=FighterCategoryChoices.LEADER,
+        house=house,
+        base_cost=100,
+    )
+    beast_cf = make_content_fighter(
+        type="Beast",
+        category=FighterCategoryChoices.EXOTIC_BEAST,
+        house=house,
+        base_cost=20,  # This should be ignored when linked
+    )
+
+    # Create equipment that creates a linked fighter
+    beast_ce = make_equipment(
+        "Beast",
+        category=ContentEquipmentCategory.objects.get(name="Status Items"),
+        cost=50,
+    )
+
+    # Link the Beast Content Fighter to the Equipment
+    ContentEquipmentFighterProfile.objects.create(
+        equipment=beast_ce, content_fighter=beast_cf
+    )
+
+    # Create list and owner fighter
+    lst = make_list("Example List", content_house=house, owner=user)
+    owner_lf = make_list_fighter(lst, "Owner", content_fighter=owner_cf, owner=user)
+
+    # Assign the beast equipment to the owner
+    assign = ListFighterEquipmentAssignment(
+        list_fighter=owner_lf, content_equipment=beast_ce
+    )
+    assign.save()
+
+    # Verify setup
+    assert lst.fighters().count() == 2
+    assert assign.linked_fighter is not None
+    assert assign.linked_fighter.name == "Beast"
+    assert lst.cost_int() == 150  # 100 + 50, beast fighter cost ignored
+
+    # Clone the list
+    cloned_list = lst.clone(name="Cloned List")
+
+    # Verify clone results
+    assert cloned_list.fighters().count() == 2
+    cloned_fighters = list(cloned_list.fighters())
+
+    # Find the owner and beast fighters in the clone
+    cloned_owner = next(f for f in cloned_fighters if f.name == "Owner")
+    cloned_beast = next(f for f in cloned_fighters if f.name == "Beast")
+
+    # Verify the equipment assignment was cloned correctly
+    cloned_assignments = cloned_owner._direct_assignments()
+    assert cloned_assignments.count() == 1
+    cloned_assign = cloned_assignments.first()
+
+    # This is the key test - the cloned assignment should have a linked_fighter
+    assert cloned_assign.linked_fighter is not None
+    assert cloned_assign.linked_fighter == cloned_beast
+    assert cloned_assign.linked_fighter.name == "Beast"
+
+    # Verify cost is correct
+    assert cloned_list.cost_int() == 150
+
+
+@pytest.mark.django_db
+def test_clone_fighter_with_linked_equipment(
+    user,
+    make_list,
+    make_content_house,
+    make_content_fighter,
+    make_list_fighter,
+    make_equipment,
+):
+    """Test that cloning a single fighter with linked equipment works correctly."""
+    # Create house and fighter
+    house = make_content_house("Example House")
+    owner_cf = make_content_fighter(
+        type="Owner",
+        category=FighterCategoryChoices.LEADER,
+        house=house,
+        base_cost=100,
+    )
+    beast_cf = make_content_fighter(
+        type="Beast",
+        category=FighterCategoryChoices.EXOTIC_BEAST,
+        house=house,
+        base_cost=20,
+    )
+
+    # Create equipment that creates a linked fighter
+    beast_ce = make_equipment(
+        "Beast",
+        category=ContentEquipmentCategory.objects.get(name="Status Items"),
+        cost=50,
+    )
+
+    # Link the Beast Content Fighter to the Equipment
+    ContentEquipmentFighterProfile.objects.create(
+        equipment=beast_ce, content_fighter=beast_cf
+    )
+
+    # Create list and owner fighter
+    lst = make_list("Example List", content_house=house, owner=user)
+    owner_lf = make_list_fighter(lst, "Owner", content_fighter=owner_cf, owner=user)
+
+    # Assign the beast equipment to the owner
+    assign = ListFighterEquipmentAssignment(
+        list_fighter=owner_lf, content_equipment=beast_ce
+    )
+    assign.save()
+
+    # Verify setup
+    assert lst.fighters().count() == 2
+    assert assign.linked_fighter is not None
+
+    # Clone just the fighter
+    cloned_owner = owner_lf.clone(name="Cloned Owner")
+
+    # The clone should also have created a linked fighter
+    assert lst.fighters().count() == 4  # Original 2 + cloned 2
+
+    # Check the cloned assignment
+    cloned_assignments = cloned_owner._direct_assignments()
+    assert cloned_assignments.count() == 1
+    cloned_assign = cloned_assignments.first()
+
+    # The cloned assignment should have its own linked fighter
+    assert cloned_assign.linked_fighter is not None
+    assert cloned_assign.linked_fighter != assign.linked_fighter  # Different instances
+    assert cloned_assign.linked_fighter.name == "Beast"
+    assert cloned_assign.linked_fighter.list == lst


### PR DESCRIPTION
## Summary

This PR fixes an issue where linked fighters (like pets, exotic beasts, or vehicles) were being duplicated when cloning lists.

## Problem

When cloning a list that contains equipment with linked fighters:
- The linked fighters were being cloned as regular fighters
- Then the equipment assignment cloning would create them again
- This resulted in duplicate linked fighters in the cloned list

## Solution

Modified the `List.clone()` method to:
- Skip cloning fighters that have a `linked_fighter` relationship
- These linked fighters are automatically created when equipment assignments are cloned

## Testing

Added comprehensive tests to verify:
- List cloning with linked fighters works correctly
- Fighter cloning with linked equipment works correctly
- No duplicate fighters are created
- Costs are calculated correctly

Fixes #322

🤖 Generated with [Claude Code](https://claude.ai/code)