### PR TITLE
feat: implement equipment selling with dice rolls for stash fighters

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -609,3 +609,48 @@ class EquipmentReassignForm(forms.Form):
         self.fields["target_fighter"].label_from_instance = (
             lambda obj: obj.fully_qualified_name
         )
+
+
+class EquipmentSellSelectionForm(forms.Form):
+    """Form for selecting equipment sale options (manual price vs dice roll)."""
+
+    PRICE_CHOICES = [
+        ("dice", "Cost minus D6×10"),
+        ("manual", "Manual"),
+    ]
+
+    price_method = forms.ChoiceField(
+        choices=PRICE_CHOICES,
+        initial="dice",
+        widget=forms.RadioSelect(attrs={"class": "form-check-input"}),
+        label="Sale Price",
+    )
+    manual_price = forms.IntegerField(
+        required=False,
+        min_value=5,
+        widget=forms.NumberInput(attrs={"class": "form-control"}),
+        label="Manual Price",
+        help_text="Enter price in credits (minimum 5¢)",
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        price_method = cleaned_data.get("price_method")
+        manual_price = cleaned_data.get("manual_price")
+
+        if price_method == "manual" and not manual_price:
+            raise forms.ValidationError(
+                "Manual price is required when manual pricing is selected."
+            )
+
+        return cleaned_data
+
+
+class EquipmentSellForm(forms.Form):
+    """Form for confirming equipment sale with calculated prices."""
+
+    confirm = forms.BooleanField(
+        required=True,
+        widget=forms.HiddenInput(),
+        initial=True,
+    )

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -184,7 +184,7 @@
                                             <span class="text-muted">·</span>
                                             <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
                                                class="link-danger">Remove</a>
-                                            {% if fighter.is_stash and list.status == 'campaign' %}
+                                            {% if fighter.is_stash %}
                                                 <span class="text-muted">·</span>
                                                 <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
                                                    class="link-warning">Sell</a>

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -184,6 +184,11 @@
                                             <span class="text-muted">·</span>
                                             <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
                                                class="link-danger">Remove</a>
+                                            {% if fighter.is_stash and list.status == 'campaign' %}
+                                                <span class="text-muted">·</span>
+                                                <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
+                                                   class="link-warning">Sell</a>
+                                            {% endif %}
                                         {% elif assign.kind == 'default' %}
                                             <br>
                                             <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -75,7 +75,7 @@
                                                 {% endif %}
                                                 <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
                                                    class="link-secondary">Reassign</a>
-                                                {% if list.status == 'campaign' %}
+                                                {% if list.status == 'campaign_mode' %}
                                                     <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
                                                        class="link-warning">Sell</a>
@@ -118,7 +118,7 @@
                                         {% if profile.name %}
                                             <br>
                                             <i class="bi-dash"></i> {{ profile.name }} (+{{ profile.cost_display }})
-                                            {% if list.status == 'campaign' and list.owner_cached == user and not print %}
+                                            {% if list.status == 'campaign_mode' and list.owner_cached == user and not print %}
                                                 <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}&sell_profile={{ profile.id }}"
                                                    class="link-warning">Sell</a>
                                             {% endif %}
@@ -180,7 +180,7 @@
                                                             <i class="bi-arrow-left-right"></i> Reassign
                                                         </a>
                                                     </li>
-                                                    {% if list.status == 'campaign' %}
+                                                    {% if list.status == 'campaign_mode' %}
                                                         <li>
                                                             <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
                                                                class="dropdown-item text-warning">

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -28,9 +28,9 @@
                 <div class="hstack gap-2 align-items-center justify-content-between">
                     <h4 class="h6 mb-0">Trading Post</h4>
                     <div class="btn-group" role="group">
-                        <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
+                        <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}?filter=all"
                            class="btn btn-outline-primary btn-sm">Weapons</a>
-                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
+                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?filter=all"
                            class="btn btn-outline-primary btn-sm">Gear</a>
                     </div>
                 </div>
@@ -113,7 +113,7 @@
                             <td>
                                 {% include "core/includes/list_fighter_weapon_assign_name.html" with assign=assign %}
                                 {% comment %} Show weapon profile names {% endcomment %}
-                                {% if assign.weapon_profiles_cached|length > 1 %}
+                                {% if assign.weapon_profiles_cached|length > 0 %}
                                     {% for profile in assign.weapon_profiles_cached %}
                                         {% if profile.name %}
                                             <br>
@@ -160,6 +160,12 @@
                                                     <i class="bi-arrow-up-circle"></i> Upgrades
                                                 </a>
                                             {% endif %}
+                                            {% if list.status == 'campaign_mode' %}
+                                                <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
+                                                   class="btn btn-outline-secondary btn-sm">
+                                                    <i class="bi-coin"></i> Sell All
+                                                </a>
+                                            {% endif %}
                                             <div class="btn-group">
                                                 <button class="btn btn-outline-secondary btn-sm dropdown-toggle"
                                                         type="button"
@@ -180,14 +186,6 @@
                                                             <i class="bi-arrow-left-right"></i> Reassign
                                                         </a>
                                                     </li>
-                                                    {% if list.status == 'campaign_mode' %}
-                                                        <li>
-                                                            <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
-                                                               class="dropdown-item text-warning">
-                                                                <i class="bi-cash-coin"></i> Sell
-                                                            </a>
-                                                        </li>
-                                                    {% endif %}
                                                     <li>
                                                         <hr class="dropdown-divider">
                                                     </li>

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -75,6 +75,11 @@
                                                 {% endif %}
                                                 <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
                                                    class="link-secondary">Reassign</a>
+                                                {% if list.status == 'campaign' %}
+                                                    <span class="text-muted">·</span>
+                                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
+                                                       class="link-warning">Sell</a>
+                                                {% endif %}
                                                 <span class="text-muted">·</span>
                                                 <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
                                                    class="link-danger">Remove</a>
@@ -171,6 +176,14 @@
                                                             <i class="bi-arrow-left-right"></i> Reassign
                                                         </a>
                                                     </li>
+                                                    {% if list.status == 'campaign' %}
+                                                        <li>
+                                                            <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
+                                                               class="dropdown-item text-warning">
+                                                                <i class="bi-cash-coin"></i> Sell
+                                                            </a>
+                                                        </li>
+                                                    {% endif %}
                                                     <li>
                                                         <hr class="dropdown-divider">
                                                     </li>

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -118,6 +118,10 @@
                                         {% if profile.name %}
                                             <br>
                                             <i class="bi-dash"></i> {{ profile.name }} (+{{ profile.cost_display }})
+                                            {% if list.status == 'campaign' and list.owner_cached == user and not print %}
+                                                <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}&sell_profile={{ profile.id }}"
+                                                   class="link-warning">Sell</a>
+                                            {% endif %}
                                         {% endif %}
                                     {% endfor %}
                                 {% endif %}

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -178,6 +178,13 @@
                                 <i class="bi-plus"></i>
                                 Add {{ assign.base_name }}
                             </button>
+                            {% if fighter.is_stash and list.status == 'campaign' %}
+                                <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
+                                   class="btn btn-outline-warning btn-sm">
+                                    <i class="bi-cash-coin"></i>
+                                    Sell
+                                </a>
+                            {% endif %}
                         </div>
                     </td>
                 </tr>

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -112,8 +112,8 @@
                                 {% if not assign.has_total_cost_override %}
                                     {% if pd.cost_int != 0 %}({{ pd.cost_display }}){% endif %}
                                 {% endif %}
-                                {% if mode == 'edit' and fighter.is_stash and list.status == 'campaign' and list.owner_cached == user and assign.kind == 'assigned' %}
-                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}&sell_profile={{ pd.profile.id }}"
+                                {% if mode == 'edit' and fighter.is_stash and list.status == 'campaign_mode' and list.owner_cached == user and assign.kind == 'assigned' %}
+                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_profile={{ pd.profile.id }}"
                                        class="link-warning">Sell</a>
                                 {% endif %}
                             {% endif %}
@@ -182,7 +182,7 @@
                                 <i class="bi-plus"></i>
                                 Add {{ assign.base_name }}
                             </button>
-                            {% if fighter.is_stash and list.status == 'campaign' %}
+                            {% if fighter.is_stash and list.status == 'campaign_mode' %}
                                 <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
                                    class="btn btn-outline-warning btn-sm">
                                     <i class="bi-cash-coin"></i>
@@ -231,7 +231,7 @@
                                                     <i class="bi-arrow-left-right"></i> Reassign
                                                 </a>
                                             </li>
-                                            {% if fighter.is_stash and list.status == 'campaign' %}
+                                            {% if fighter.is_stash and list.status == 'campaign_mode' %}
                                                 <li>
                                                     <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
                                                        class="dropdown-item text-warning">

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -182,13 +182,6 @@
                                 <i class="bi-plus"></i>
                                 Add {{ assign.base_name }}
                             </button>
-                            {% if fighter.is_stash and list.status == 'campaign_mode' %}
-                                <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
-                                   class="btn btn-outline-warning btn-sm">
-                                    <i class="bi-cash-coin"></i>
-                                    Sell
-                                </a>
-                            {% endif %}
                         </div>
                     </td>
                 </tr>
@@ -211,6 +204,12 @@
                                             <span class="d-none d-sm-inline">{{ assign.equipment.upgrade_stack_name }}</span>
                                         </a>
                                     {% endif %}
+                                    {% if fighter.is_stash and list.status == 'campaign_mode' %}
+                                        <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
+                                           class="btn btn-outline-secondary btn-sm">
+                                            <i class="bi-coin"></i> Sell All
+                                        </a>
+                                    {% endif %}
                                     <div class="btn-group">
                                         <button class="btn btn-outline-secondary btn-sm dropdown-toggle"
                                                 type="button"
@@ -231,14 +230,6 @@
                                                     <i class="bi-arrow-left-right"></i> Reassign
                                                 </a>
                                             </li>
-                                            {% if fighter.is_stash and list.status == 'campaign_mode' %}
-                                                <li>
-                                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
-                                                       class="dropdown-item text-warning">
-                                                        <i class="bi-cash-coin"></i> Sell
-                                                    </a>
-                                                </li>
-                                            {% endif %}
                                             <li>
                                                 <hr class="dropdown-divider">
                                             </li>

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -233,7 +233,7 @@
                                             </li>
                                             {% if fighter.is_stash and list.status == 'campaign_mode' %}
                                                 <li>
-                                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
+                                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}"
                                                        class="dropdown-item text-warning">
                                                         <i class="bi-cash-coin"></i> Sell
                                                     </a>

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -220,6 +220,14 @@
                                                     <i class="bi-arrow-left-right"></i> Reassign
                                                 </a>
                                             </li>
+                                            {% if fighter.is_stash and list.status == 'campaign' %}
+                                                <li>
+                                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
+                                                       class="dropdown-item text-warning">
+                                                        <i class="bi-cash-coin"></i> Sell
+                                                    </a>
+                                                </li>
+                                            {% endif %}
                                             <li>
                                                 <hr class="dropdown-divider">
                                             </li>

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -112,6 +112,10 @@
                                 {% if not assign.has_total_cost_override %}
                                     {% if pd.cost_int != 0 %}({{ pd.cost_display }}){% endif %}
                                 {% endif %}
+                                {% if mode == 'edit' and fighter.is_stash and list.status == 'campaign' and list.owner_cached == user and assign.kind == 'assigned' %}
+                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}&sell_profile={{ pd.profile.id }}"
+                                       class="link-warning">Sell</a>
+                                {% endif %}
                             {% endif %}
                         </td>
                         {% include "core/includes/list_fighter_weapon_profile_statline.html" with profile=pd.profile %}

--- a/gyrinx/core/templates/core/list_fighter_equipment_sell.html
+++ b/gyrinx/core/templates/core/list_fighter_equipment_sell.html
@@ -180,6 +180,12 @@
                     <h3 class="h5 mb-0">Sale Results</h3>
                 </div>
             </div>
+            {% if sale_results.dice_rolls %}
+                <div class="alert alert-info hstack gap-3">
+                    <strong>Dice Rolls:</strong>
+                    {% for roll in sale_results.dice_rolls %}<i class="bi bi-dice-{{ roll }} fs-4"></i>{% endfor %}
+                </div>
+            {% endif %}
             <div class="table-responsive">
                 <table class="table">
                     <thead>
@@ -216,12 +222,6 @@
                     </tfoot>
                 </table>
             </div>
-            {% if sale_results.dice_rolls %}
-                <div class="hstack gap-3">
-                    <strong>Dice Rolls:</strong>
-                    {% for roll in sale_results.dice_rolls %}<i class="bi bi-dice-{{ roll }} fs-4"></i>{% endfor %}
-                </div>
-            {% endif %}
             <div class="alert alert-success">
                 <i class="bi bi-check-circle"></i>
                 {{ sale_results.total_credits }}¢ has been added to your gang's credits.

--- a/gyrinx/core/templates/core/list_fighter_equipment_sell.html
+++ b/gyrinx/core/templates/core/list_fighter_equipment_sell.html
@@ -37,7 +37,7 @@
                         <thead>
                             <tr>
                                 <th>Item</th>
-                                <th>Base Cost</th>
+                                <th>Cost</th>
                                 <th>Sale Price Method</th>
                             </tr>
                         </thead>
@@ -52,7 +52,7 @@
                                             </div>
                                         {% endif %}
                                     </td>
-                                    <td>{{ item.base_cost }}¢</td>
+                                    <td>{{ item.total_cost }}¢</td>
                                     <td>
                                         <div class="vstack gap-2">
                                             {% for radio in form.price_method %}
@@ -108,7 +108,7 @@
                     <thead>
                         <tr>
                             <th>Item</th>
-                            <th>Base Cost</th>
+                            <th>Cost</th>
                             <th>Sale Method</th>
                             <th>Sale Price</th>
                         </tr>
@@ -185,7 +185,7 @@
                     <thead>
                         <tr>
                             <th>Item</th>
-                            <th>Base Cost</th>
+                            <th>Cost</th>
                             <th>Dice Roll</th>
                             <th>Sale Price</th>
                         </tr>
@@ -194,7 +194,7 @@
                         {% for detail in sale_results.sale_details %}
                             <tr>
                                 <td>{{ detail.name }}</td>
-                                <td>{{ detail.base_cost }}¢</td>
+                                <td>{{ detail.total_cost }}¢</td>
                                 <td>
                                     {% if detail.dice_roll %}
                                         <i class="bi bi-dice-{{ detail.dice_roll }}"></i> {{ detail.dice_roll }}

--- a/gyrinx/core/templates/core/list_fighter_equipment_sell.html
+++ b/gyrinx/core/templates/core/list_fighter_equipment_sell.html
@@ -4,12 +4,17 @@
     Sell Equipment - {{ fighter.fully_qualified_name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
-    {% url "core:list-figher-gear-edit" list.id fighter.id as gear_edit_url %}
+    {% url "core:list-fighter-gear-edit" list.id fighter.id as gear_edit_url %}
+    {% url "core:list-fighter-weapons-edit" list.id fighter.id as weapons_edit_url %}
     <div class="col-12 col-md-8 col-lg-6 vstack gap-4">
         {% if step == "selection" %}
             <div class="vstack gap-3">
                 <div class="vstack gap-1">
-                    {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
+                    {% if assign.is_weapon %}
+                        {% include "core/includes/back.html" with url=weapons_edit_url text="Back to Weapons" %}
+                    {% else %}
+                        {% include "core/includes/back.html" with url=gear_edit_url text="Back to Gear" %}
+                    {% endif %}
                     <div class="progress mb-1"
                          role="progressbar"
                          aria-label="Step 1 of 3"
@@ -83,6 +88,7 @@
         {% elif step == "confirm" %}
             <div class="vstack gap-3">
                 <div class="vstack gap-1">
+                    {% include "core/includes/back_to_list.html" with url_name="core:list" back_text="Back to list" %}
                     <div class="progress mb-1"
                          role="progressbar"
                          aria-label="Step 2 of 3"
@@ -110,7 +116,14 @@
                     <tbody>
                         {% for item in sell_data %}
                             <tr>
-                                <td>{{ item.name }}</td>
+                                <td>
+                                    {{ item.name }}
+                                    {% if item.upgrades %}
+                                        <div class="text-muted small">
+                                            {% for upgrade in item.upgrades %}+ {{ upgrade.name }}{% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </td>
                                 <td>{{ item.base_cost }}¢</td>
                                 <td>
                                     {% if item.price_method == "dice" %}
@@ -140,7 +153,7 @@
                 {% csrf_token %}
                 <input type="hidden" name="step" value="confirm">
                 <div class="hstack gap-3">
-                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?{{ request.GET.urlencode }}"
+                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}{% querystring sell_assign=assign.id step=None %}"
                        class="icon-link">
                         <i class="bi-arrow-left"></i> Back
                     </a>
@@ -152,7 +165,7 @@
         {% elif step == "summary" %}
             <div class="vstack gap-3">
                 <div class="vstack gap-1">
-                    {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
+                    {% include "core/includes/back_to_list.html" with url_name="core:list" back_text="Back to list" %}
                     <div class="progress mb-1"
                          role="progressbar"
                          aria-label="Step 3 of 3"
@@ -195,25 +208,26 @@
                     </tbody>
                     <tfoot>
                         <tr>
-                            <th colspan="3">Total Credits Earned</th>
+                            <th colspan="3">
+                                <strong>Total</strong>
+                            </th>
                             <th>{{ sale_results.total_credits }}¢</th>
                         </tr>
                     </tfoot>
                 </table>
             </div>
             {% if sale_results.dice_rolls %}
-                <div>
+                <div class="hstack gap-3">
                     <strong>Dice Rolls:</strong>
                     {% for roll in sale_results.dice_rolls %}<i class="bi bi-dice-{{ roll }} fs-4"></i>{% endfor %}
                 </div>
             {% endif %}
-            <div class="border rounded p-2 text-success">
+            <div class="alert alert-success">
                 <i class="bi bi-check-circle"></i>
-                Equipment sold successfully! {{ sale_results.total_credits }}¢ has been added to your gang's credits.
+                {{ sale_results.total_credits }}¢ has been added to your gang's credits.
             </div>
             <div class="hstack gap-3">
-                <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
-                   class="btn btn-primary">Back to Equipment</a>
+                {% include "core/includes/back_to_list.html" with url_name="core:list" back_text="Back to list" %}
             </div>
         {% endif %}
     </div>

--- a/gyrinx/core/templates/core/list_fighter_equipment_sell.html
+++ b/gyrinx/core/templates/core/list_fighter_equipment_sell.html
@@ -4,11 +4,11 @@
     Sell Equipment - {{ fighter.fully_qualified_name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
+    {% url "core:list-figher-gear-edit" list.id fighter.id as gear_edit_url %}
     <div class="col-12 px-0 vstack gap-3">
         {% if step == "selection" %}
-            {% include "core/includes/back.html" with url="core:list-fighter-gear-edit" text="Back to Equipment" args=list.id,fighter.id %}
+            {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
             <h1 class="h3">Sell Equipment</h1>
-            
             <div class="card">
                 <div class="card-header">
                     <h2 class="h5 mb-0">Select Sale Price Method</h2>
@@ -17,7 +17,6 @@
                     <form method="post">
                         {% csrf_token %}
                         <input type="hidden" name="step" value="selection">
-                        
                         <div class="table-responsive">
                             <table class="table">
                                 <thead>
@@ -34,9 +33,7 @@
                                                 {{ item.name }}
                                                 {% if item.upgrades %}
                                                     <div class="text-muted small">
-                                                        {% for upgrade in item.upgrades %}
-                                                            + {{ upgrade.name }}
-                                                        {% endfor %}
+                                                        {% for upgrade in item.upgrades %}+ {{ upgrade.name }}{% endfor %}
                                                     </div>
                                                 {% endif %}
                                             </td>
@@ -46,20 +43,14 @@
                                                     {% for radio in form.price_method %}
                                                         <div class="form-check">
                                                             {{ radio.tag }}
-                                                            <label class="form-check-label" for="{{ radio.id_for_label }}">
-                                                                {{ radio.choice_label }}
-                                                            </label>
+                                                            <label class="form-check-label" for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
                                                         </div>
                                                     {% endfor %}
-                                                    <div class="manual-price-input" style="display: none;">
+                                                    <div class="manual-price-input">
                                                         {{ form.manual_price }}
-                                                        {% if form.manual_price.help_text %}
-                                                            <div class="form-text">{{ form.manual_price.help_text }}</div>
-                                                        {% endif %}
+                                                        {% if form.manual_price.help_text %}<div class="form-text">{{ form.manual_price.help_text }}</div>{% endif %}
                                                         {% if form.manual_price.errors %}
-                                                            <div class="invalid-feedback d-block">
-                                                                {{ form.manual_price.errors.0 }}
-                                                            </div>
+                                                            <div class="invalid-feedback d-block">{{ form.manual_price.errors.0 }}</div>
                                                         {% endif %}
                                                     </div>
                                                 </div>
@@ -69,18 +60,16 @@
                                 </tbody>
                             </table>
                         </div>
-                        
                         <div class="d-flex justify-content-end gap-2">
-                            <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}" class="btn btn-secondary">Cancel</a>
+                            <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
+                               class="btn btn-secondary">Cancel</a>
                             <button type="submit" class="btn btn-primary">Continue</button>
                         </div>
                     </form>
                 </div>
             </div>
-            
         {% elif step == "confirm" %}
             <h1 class="h3">Confirm Equipment Sale</h1>
-            
             <div class="card">
                 <div class="card-header">
                     <h2 class="h5 mb-0">Sale Summary</h2>
@@ -120,28 +109,25 @@
                             </tbody>
                         </table>
                     </div>
-                    
                     <div class="alert alert-info mt-3">
-                        <i class="bi bi-info-circle"></i> 
-                        Dice will be rolled automatically when you confirm the sale. Items sold with dice 
+                        <i class="bi bi-info-circle"></i>
+                        Dice will be rolled automatically when you confirm the sale. Items sold with dice
                         will receive their base cost minus the dice roll × 10 credits (minimum 5¢).
                     </div>
-                    
                     <form method="post">
                         {% csrf_token %}
                         <input type="hidden" name="step" value="confirm">
                         <div class="d-flex justify-content-end gap-2">
-                            <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?{{ request.GET.urlencode }}" class="btn btn-secondary">Back</a>
+                            <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?{{ request.GET.urlencode }}"
+                               class="btn btn-secondary">Back</a>
                             <button type="submit" class="btn btn-danger">Confirm Sale</button>
                         </div>
                     </form>
                 </div>
             </div>
-            
         {% elif step == "summary" %}
-            {% include "core/includes/back.html" with url="core:list-fighter-gear-edit" text="Back to Equipment" args=list.id,fighter.id %}
+            {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
             <h1 class="h3">Sale Complete</h1>
-            
             <div class="card">
                 <div class="card-header">
                     <h2 class="h5 mb-0">Sale Results</h2>
@@ -181,55 +167,22 @@
                             </tfoot>
                         </table>
                     </div>
-                    
                     {% if sale_results.dice_rolls %}
                         <div class="mt-3">
                             <strong>Dice Rolls:</strong>
-                            {% for roll in sale_results.dice_rolls %}
-                                <i class="bi bi-dice-{{ roll }} fs-4"></i>
-                            {% endfor %}
+                            {% for roll in sale_results.dice_rolls %}<i class="bi bi-dice-{{ roll }} fs-4"></i>{% endfor %}
                         </div>
                     {% endif %}
-                    
                     <div class="alert alert-success mt-3">
-                        <i class="bi bi-check-circle"></i> 
+                        <i class="bi bi-check-circle"></i>
                         Equipment sold successfully! {{ sale_results.total_credits }}¢ has been added to your gang's credits.
                     </div>
-                    
                     <div class="d-flex justify-content-end">
-                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}" class="btn btn-primary">Back to Equipment</a>
+                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
+                           class="btn btn-primary">Back to Equipment</a>
                     </div>
                 </div>
             </div>
         {% endif %}
     </div>
-    
-    <script>
-        // Toggle manual price input visibility based on radio selection
-        document.addEventListener('DOMContentLoaded', function() {
-            const radioButtons = document.querySelectorAll('input[type="radio"][name*="price_method"]');
-            
-            radioButtons.forEach(radio => {
-                radio.addEventListener('change', function() {
-                    const formGroup = this.closest('td');
-                    const manualInput = formGroup.querySelector('.manual-price-input');
-                    
-                    if (this.value === 'manual' && this.checked) {
-                        manualInput.style.display = 'block';
-                    } else if (this.value === 'dice' && this.checked) {
-                        manualInput.style.display = 'none';
-                    }
-                });
-                
-                // Check initial state
-                if (radio.checked) {
-                    const formGroup = radio.closest('td');
-                    const manualInput = formGroup.querySelector('.manual-price-input');
-                    if (radio.value === 'manual') {
-                        manualInput.style.display = 'block';
-                    }
-                }
-            });
-        });
-    </script>
 {% endblock content %}

--- a/gyrinx/core/templates/core/list_fighter_equipment_sell.html
+++ b/gyrinx/core/templates/core/list_fighter_equipment_sell.html
@@ -5,183 +5,215 @@
 {% endblock head_title %}
 {% block content %}
     {% url "core:list-figher-gear-edit" list.id fighter.id as gear_edit_url %}
-    <div class="col-12 px-0 vstack gap-3">
+    <div class="col-12 col-md-8 col-lg-6 vstack gap-4">
         {% if step == "selection" %}
-            {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
-            <h1 class="h3">Sell Equipment</h1>
-            <div class="card">
-                <div class="card-header">
-                    <h2 class="h5 mb-0">Select Sale Price Method</h2>
+            <div class="vstack gap-3">
+                <div class="vstack gap-1">
+                    {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
+                    <div class="progress mb-1"
+                         role="progressbar"
+                         aria-label="Step 1 of 3"
+                         aria-valuenow="33"
+                         aria-valuemin="0"
+                         aria-valuemax="100">
+                        {# djlint:off #}
+                        <div class="progress-bar" style="width: 33%">Step 1 of 3</div>
+                        {# djlint:on #}
+                    </div>
+                    <h2 class="mb-0">Sell Equipment</h2>
+                    <h3 class="h5 mb-0">Select Sale Price Method</h3>
                 </div>
-                <div class="card-body">
-                    <form method="post">
-                        {% csrf_token %}
-                        <input type="hidden" name="step" value="selection">
-                        <div class="table-responsive">
-                            <table class="table">
-                                <thead>
-                                    <tr>
-                                        <th>Item</th>
-                                        <th>Base Cost</th>
-                                        <th>Sale Price Method</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for item, form in forms %}
-                                        <tr>
-                                            <td>
-                                                {{ item.name }}
-                                                {% if item.upgrades %}
-                                                    <div class="text-muted small">
-                                                        {% for upgrade in item.upgrades %}+ {{ upgrade.name }}{% endfor %}
-                                                    </div>
-                                                {% endif %}
-                                            </td>
-                                            <td>{{ item.base_cost }}¢</td>
-                                            <td>
-                                                <div class="vstack gap-2">
-                                                    {% for radio in form.price_method %}
-                                                        <div class="form-check">
-                                                            {{ radio.tag }}
-                                                            <label class="form-check-label" for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
-                                                        </div>
-                                                    {% endfor %}
-                                                    <div class="manual-price-input">
-                                                        {{ form.manual_price }}
-                                                        {% if form.manual_price.help_text %}<div class="form-text">{{ form.manual_price.help_text }}</div>{% endif %}
-                                                        {% if form.manual_price.errors %}
-                                                            <div class="invalid-feedback d-block">{{ form.manual_price.errors.0 }}</div>
-                                                        {% endif %}
-                                                    </div>
+            </div>
+            <form method="post" class="vstack gap-3">
+                {% csrf_token %}
+                <input type="hidden" name="step" value="selection">
+                <div class="table-responsive">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Item</th>
+                                <th>Base Cost</th>
+                                <th>Sale Price Method</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for item, form in forms %}
+                                <tr>
+                                    <td>
+                                        {{ item.name }}
+                                        {% if item.upgrades %}
+                                            <div class="text-muted small">
+                                                {% for upgrade in item.upgrades %}+ {{ upgrade.name }}{% endfor %}
+                                            </div>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ item.base_cost }}¢</td>
+                                    <td>
+                                        <div class="vstack gap-2">
+                                            {% for radio in form.price_method %}
+                                                <div class="form-check">
+                                                    {{ radio.tag }}
+                                                    <label class="form-check-label" for="{{ radio.id_for_label }}">{{ radio.choice_label }}</label>
                                                 </div>
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
-                        <div class="d-flex justify-content-end gap-2">
-                            <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
-                               class="btn btn-secondary">Cancel</a>
-                            <button type="submit" class="btn btn-primary">Continue</button>
-                        </div>
-                    </form>
+                                            {% endfor %}
+                                            <div class="manual-price-input">
+                                                {{ form.manual_price }}
+                                                {% if form.manual_price.help_text %}<div class="form-text">{{ form.manual_price.help_text }}</div>{% endif %}
+                                                {% if form.manual_price.errors %}
+                                                    <div class="invalid-feedback d-block">{{ form.manual_price.errors.0 }}</div>
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
-            </div>
+                <div class="hstack gap-3">
+                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
+                       class="icon-link">
+                        <i class="bi-arrow-left"></i> Back
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        Continue <i class="bi-arrow-right"></i>
+                    </button>
+                </div>
+            </form>
         {% elif step == "confirm" %}
-            <h1 class="h3">Confirm Equipment Sale</h1>
-            <div class="card">
-                <div class="card-header">
-                    <h2 class="h5 mb-0">Sale Summary</h2>
-                </div>
-                <div class="card-body">
-                    <div class="table-responsive">
-                        <table class="table">
-                            <thead>
-                                <tr>
-                                    <th>Item</th>
-                                    <th>Base Cost</th>
-                                    <th>Sale Method</th>
-                                    <th>Sale Price</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for item in sell_data %}
-                                    <tr>
-                                        <td>{{ item.name }}</td>
-                                        <td>{{ item.base_cost }}¢</td>
-                                        <td>
-                                            {% if item.price_method == "dice" %}
-                                                Cost minus D6×10
-                                            {% else %}
-                                                Manual: {{ item.manual_price }}¢
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            {% if item.price_method == "dice" %}
-                                                <span class="text-muted">To be rolled...</span>
-                                            {% else %}
-                                                {{ item.manual_price }}¢
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+            <div class="vstack gap-3">
+                <div class="vstack gap-1">
+                    <div class="progress mb-1"
+                         role="progressbar"
+                         aria-label="Step 2 of 3"
+                         aria-valuenow="66"
+                         aria-valuemin="0"
+                         aria-valuemax="100">
+                        {# djlint:off #}
+                        <div class="progress-bar" style="width: 66%">Step 2 of 3</div>
+                        {# djlint:on #}
                     </div>
-                    <div class="alert alert-info mt-3">
-                        <i class="bi bi-info-circle"></i>
-                        Dice will be rolled automatically when you confirm the sale. Items sold with dice
-                        will receive their base cost minus the dice roll × 10 credits (minimum 5¢).
-                    </div>
-                    <form method="post">
-                        {% csrf_token %}
-                        <input type="hidden" name="step" value="confirm">
-                        <div class="d-flex justify-content-end gap-2">
-                            <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?{{ request.GET.urlencode }}"
-                               class="btn btn-secondary">Back</a>
-                            <button type="submit" class="btn btn-danger">Confirm Sale</button>
-                        </div>
-                    </form>
+                    <h2 class="mb-0">Confirm Equipment Sale</h2>
+                    <h3 class="h5 mb-0">Sale Summary</h3>
                 </div>
             </div>
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Item</th>
+                            <th>Base Cost</th>
+                            <th>Sale Method</th>
+                            <th>Sale Price</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in sell_data %}
+                            <tr>
+                                <td>{{ item.name }}</td>
+                                <td>{{ item.base_cost }}¢</td>
+                                <td>
+                                    {% if item.price_method == "dice" %}
+                                        Cost minus D6×10
+                                    {% else %}
+                                        Manual: {{ item.manual_price }}¢
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if item.price_method == "dice" %}
+                                        <span class="text-muted">To be rolled...</span>
+                                    {% else %}
+                                        {{ item.manual_price }}¢
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="border rounded p-2 text-secondary">
+                <i class="bi bi-info-circle"></i>
+                Dice will be rolled automatically when you confirm the sale. Items sold with dice
+                will receive their base cost minus the dice roll × 10 credits (minimum 5¢).
+            </div>
+            <form method="post" class="vstack gap-3">
+                {% csrf_token %}
+                <input type="hidden" name="step" value="confirm">
+                <div class="hstack gap-3">
+                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?{{ request.GET.urlencode }}"
+                       class="icon-link">
+                        <i class="bi-arrow-left"></i> Back
+                    </a>
+                    <button type="submit" class="btn btn-danger">
+                        <i class="bi-check-lg"></i> Confirm Sale
+                    </button>
+                </div>
+            </form>
         {% elif step == "summary" %}
-            {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
-            <h1 class="h3">Sale Complete</h1>
-            <div class="card">
-                <div class="card-header">
-                    <h2 class="h5 mb-0">Sale Results</h2>
+            <div class="vstack gap-3">
+                <div class="vstack gap-1">
+                    {% include "core/includes/back.html" with url=gear_edit_url text="Back to Equipment" %}
+                    <div class="progress mb-1"
+                         role="progressbar"
+                         aria-label="Step 3 of 3"
+                         aria-valuenow="100"
+                         aria-valuemin="0"
+                         aria-valuemax="100">
+                        {# djlint:off #}
+                        <div class="progress-bar" style="width: 100%">Step 3 of 3</div>
+                        {# djlint:on #}
+                    </div>
+                    <h2 class="mb-0">Sale Complete</h2>
+                    <h3 class="h5 mb-0">Sale Results</h3>
                 </div>
-                <div class="card-body">
-                    <div class="table-responsive">
-                        <table class="table">
-                            <thead>
-                                <tr>
-                                    <th>Item</th>
-                                    <th>Base Cost</th>
-                                    <th>Dice Roll</th>
-                                    <th>Sale Price</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for detail in sale_results.sale_details %}
-                                    <tr>
-                                        <td>{{ detail.name }}</td>
-                                        <td>{{ detail.base_cost }}¢</td>
-                                        <td>
-                                            {% if detail.dice_roll %}
-                                                <i class="bi bi-dice-{{ detail.dice_roll }}"></i> {{ detail.dice_roll }}
-                                            {% else %}
-                                                Manual
-                                            {% endif %}
-                                        </td>
-                                        <td>{{ detail.sale_price }}¢</td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                            <tfoot>
-                                <tr>
-                                    <th colspan="3">Total Credits Earned</th>
-                                    <th>{{ sale_results.total_credits }}¢</th>
-                                </tr>
-                            </tfoot>
-                        </table>
-                    </div>
-                    {% if sale_results.dice_rolls %}
-                        <div class="mt-3">
-                            <strong>Dice Rolls:</strong>
-                            {% for roll in sale_results.dice_rolls %}<i class="bi bi-dice-{{ roll }} fs-4"></i>{% endfor %}
-                        </div>
-                    {% endif %}
-                    <div class="alert alert-success mt-3">
-                        <i class="bi bi-check-circle"></i>
-                        Equipment sold successfully! {{ sale_results.total_credits }}¢ has been added to your gang's credits.
-                    </div>
-                    <div class="d-flex justify-content-end">
-                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
-                           class="btn btn-primary">Back to Equipment</a>
-                    </div>
+            </div>
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Item</th>
+                            <th>Base Cost</th>
+                            <th>Dice Roll</th>
+                            <th>Sale Price</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for detail in sale_results.sale_details %}
+                            <tr>
+                                <td>{{ detail.name }}</td>
+                                <td>{{ detail.base_cost }}¢</td>
+                                <td>
+                                    {% if detail.dice_roll %}
+                                        <i class="bi bi-dice-{{ detail.dice_roll }}"></i> {{ detail.dice_roll }}
+                                    {% else %}
+                                        Manual
+                                    {% endif %}
+                                </td>
+                                <td>{{ detail.sale_price }}¢</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <th colspan="3">Total Credits Earned</th>
+                            <th>{{ sale_results.total_credits }}¢</th>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+            {% if sale_results.dice_rolls %}
+                <div>
+                    <strong>Dice Rolls:</strong>
+                    {% for roll in sale_results.dice_rolls %}<i class="bi bi-dice-{{ roll }} fs-4"></i>{% endfor %}
                 </div>
+            {% endif %}
+            <div class="border rounded p-2 text-success">
+                <i class="bi bi-check-circle"></i>
+                Equipment sold successfully! {{ sale_results.total_credits }}¢ has been added to your gang's credits.
+            </div>
+            <div class="hstack gap-3">
+                <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
+                   class="btn btn-primary">Back to Equipment</a>
             </div>
         {% endif %}
     </div>

--- a/gyrinx/core/templates/core/list_fighter_equipment_sell.html
+++ b/gyrinx/core/templates/core/list_fighter_equipment_sell.html
@@ -1,0 +1,235 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Sell Equipment - {{ fighter.fully_qualified_name }} - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    <div class="col-12 px-0 vstack gap-3">
+        {% if step == "selection" %}
+            {% include "core/includes/back.html" with url="core:list-fighter-gear-edit" text="Back to Equipment" args=list.id,fighter.id %}
+            <h1 class="h3">Sell Equipment</h1>
+            
+            <div class="card">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Select Sale Price Method</h2>
+                </div>
+                <div class="card-body">
+                    <form method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="step" value="selection">
+                        
+                        <div class="table-responsive">
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th>Item</th>
+                                        <th>Base Cost</th>
+                                        <th>Sale Price Method</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for item, form in forms %}
+                                        <tr>
+                                            <td>
+                                                {{ item.name }}
+                                                {% if item.upgrades %}
+                                                    <div class="text-muted small">
+                                                        {% for upgrade in item.upgrades %}
+                                                            + {{ upgrade.name }}
+                                                        {% endfor %}
+                                                    </div>
+                                                {% endif %}
+                                            </td>
+                                            <td>{{ item.base_cost }}¢</td>
+                                            <td>
+                                                <div class="vstack gap-2">
+                                                    {% for radio in form.price_method %}
+                                                        <div class="form-check">
+                                                            {{ radio.tag }}
+                                                            <label class="form-check-label" for="{{ radio.id_for_label }}">
+                                                                {{ radio.choice_label }}
+                                                            </label>
+                                                        </div>
+                                                    {% endfor %}
+                                                    <div class="manual-price-input" style="display: none;">
+                                                        {{ form.manual_price }}
+                                                        {% if form.manual_price.help_text %}
+                                                            <div class="form-text">{{ form.manual_price.help_text }}</div>
+                                                        {% endif %}
+                                                        {% if form.manual_price.errors %}
+                                                            <div class="invalid-feedback d-block">
+                                                                {{ form.manual_price.errors.0 }}
+                                                            </div>
+                                                        {% endif %}
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        
+                        <div class="d-flex justify-content-end gap-2">
+                            <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}" class="btn btn-secondary">Cancel</a>
+                            <button type="submit" class="btn btn-primary">Continue</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            
+        {% elif step == "confirm" %}
+            <h1 class="h3">Confirm Equipment Sale</h1>
+            
+            <div class="card">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Sale Summary</h2>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Item</th>
+                                    <th>Base Cost</th>
+                                    <th>Sale Method</th>
+                                    <th>Sale Price</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for item in sell_data %}
+                                    <tr>
+                                        <td>{{ item.name }}</td>
+                                        <td>{{ item.base_cost }}¢</td>
+                                        <td>
+                                            {% if item.price_method == "dice" %}
+                                                Cost minus D6×10
+                                            {% else %}
+                                                Manual: {{ item.manual_price }}¢
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if item.price_method == "dice" %}
+                                                <span class="text-muted">To be rolled...</span>
+                                            {% else %}
+                                                {{ item.manual_price }}¢
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    
+                    <div class="alert alert-info mt-3">
+                        <i class="bi bi-info-circle"></i> 
+                        Dice will be rolled automatically when you confirm the sale. Items sold with dice 
+                        will receive their base cost minus the dice roll × 10 credits (minimum 5¢).
+                    </div>
+                    
+                    <form method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="step" value="confirm">
+                        <div class="d-flex justify-content-end gap-2">
+                            <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?{{ request.GET.urlencode }}" class="btn btn-secondary">Back</a>
+                            <button type="submit" class="btn btn-danger">Confirm Sale</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            
+        {% elif step == "summary" %}
+            {% include "core/includes/back.html" with url="core:list-fighter-gear-edit" text="Back to Equipment" args=list.id,fighter.id %}
+            <h1 class="h3">Sale Complete</h1>
+            
+            <div class="card">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Sale Results</h2>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Item</th>
+                                    <th>Base Cost</th>
+                                    <th>Dice Roll</th>
+                                    <th>Sale Price</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for detail in sale_results.sale_details %}
+                                    <tr>
+                                        <td>{{ detail.name }}</td>
+                                        <td>{{ detail.base_cost }}¢</td>
+                                        <td>
+                                            {% if detail.dice_roll %}
+                                                <i class="bi bi-dice-{{ detail.dice_roll }}"></i> {{ detail.dice_roll }}
+                                            {% else %}
+                                                Manual
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ detail.sale_price }}¢</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <th colspan="3">Total Credits Earned</th>
+                                    <th>{{ sale_results.total_credits }}¢</th>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                    
+                    {% if sale_results.dice_rolls %}
+                        <div class="mt-3">
+                            <strong>Dice Rolls:</strong>
+                            {% for roll in sale_results.dice_rolls %}
+                                <i class="bi bi-dice-{{ roll }} fs-4"></i>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                    
+                    <div class="alert alert-success mt-3">
+                        <i class="bi bi-check-circle"></i> 
+                        Equipment sold successfully! {{ sale_results.total_credits }}¢ has been added to your gang's credits.
+                    </div>
+                    
+                    <div class="d-flex justify-content-end">
+                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}" class="btn btn-primary">Back to Equipment</a>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    </div>
+    
+    <script>
+        // Toggle manual price input visibility based on radio selection
+        document.addEventListener('DOMContentLoaded', function() {
+            const radioButtons = document.querySelectorAll('input[type="radio"][name*="price_method"]');
+            
+            radioButtons.forEach(radio => {
+                radio.addEventListener('change', function() {
+                    const formGroup = this.closest('td');
+                    const manualInput = formGroup.querySelector('.manual-price-input');
+                    
+                    if (this.value === 'manual' && this.checked) {
+                        manualInput.style.display = 'block';
+                    } else if (this.value === 'dice' && this.checked) {
+                        manualInput.style.display = 'none';
+                    }
+                });
+                
+                // Check initial state
+                if (radio.checked) {
+                    const formGroup = radio.closest('td');
+                    const manualInput = formGroup.querySelector('.manual-price-input');
+                    if (radio.value === 'manual') {
+                        manualInput.style.display = 'block';
+                    }
+                }
+            });
+        });
+    </script>
+{% endblock content %}

--- a/gyrinx/core/tests/test_equipment_sell.py
+++ b/gyrinx/core/tests/test_equipment_sell.py
@@ -61,7 +61,7 @@ def make_stash_fighter(user, content_house):
             name="Gang Stash",
             content_fighter=stash_content,
             list=list_,
-            )
+        )
 
     return _make_stash_fighter
 
@@ -127,9 +127,7 @@ def test_sell_equipment_selection_form(
     url = reverse(
         "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
     )
-    response = client.get(
-        url + "?sell_assign=" + str(assignment.id)
-    )
+    response = client.get(url + "?sell_assign=" + str(assignment.id))
 
     assert response.status_code == 200
     assert "Select Sale Price Method" in response.content.decode()
@@ -328,12 +326,8 @@ def test_sell_accessories_individually(
 
     # Add weapon with accessories
     weapon = make_equipment("Test Weapon", cost=30)
-    accessory1 = ContentWeaponAccessory.objects.create(
-        name="Scope", cost=15
-    )
-    accessory2 = ContentWeaponAccessory.objects.create(
-        name="Laser", cost=10
-    )
+    accessory1 = ContentWeaponAccessory.objects.create(name="Scope", cost=15)
+    accessory2 = ContentWeaponAccessory.objects.create(name="Laser", cost=10)
 
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,

--- a/gyrinx/core/tests/test_equipment_sell.py
+++ b/gyrinx/core/tests/test_equipment_sell.py
@@ -27,7 +27,6 @@ def test_sell_equipment_requires_stash_fighter(
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=fighter,
         content_equipment=equipment,
-        owner=user,
     )
 
     # Try to access sell page
@@ -62,8 +61,7 @@ def make_stash_fighter(user, content_house):
             name="Gang Stash",
             content_fighter=stash_content,
             list=list_,
-            owner=user,
-        )
+            )
 
     return _make_stash_fighter
 
@@ -76,7 +74,7 @@ def test_sell_equipment_requires_campaign_mode(
     client.force_login(user)
 
     # Create non-campaign list with stash fighter
-    lst = make_list("Test List", status=List.GANG_MODE)
+    lst = make_list("Test List", status=List.LIST_BUILDING)
     stash = make_stash_fighter(lst)
 
     # Add equipment
@@ -84,7 +82,6 @@ def test_sell_equipment_requires_campaign_mode(
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,
         content_equipment=equipment,
-        owner=user,
     )
 
     # Try to access sell page
@@ -118,13 +115,11 @@ def test_sell_equipment_selection_form(
         name="Extended Mag",
         equipment=equipment,
         cost=10,
-        owner=user,
     )
 
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,
         content_equipment=equipment,
-        owner=user,
     )
     assignment.upgrades_field.add(upgrade)
 
@@ -133,7 +128,7 @@ def test_sell_equipment_selection_form(
         "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
     )
     response = client.get(
-        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id)
+        url + "?sell_assign=" + str(assignment.id)
     )
 
     assert response.status_code == 200
@@ -159,7 +154,6 @@ def test_sell_equipment_with_dice_roll(
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,
         content_equipment=equipment,
-        owner=user,
     )
 
     # Initial credits
@@ -170,7 +164,7 @@ def test_sell_equipment_with_dice_roll(
         "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
     )
     response = client.post(
-        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id),
+        url + "?sell_assign=" + str(assignment.id),
         {
             "step": "selection",
             "0-price_method": "dice",
@@ -223,7 +217,6 @@ def test_sell_equipment_with_manual_price(
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,
         content_equipment=equipment,
-        owner=user,
     )
 
     # Initial credits
@@ -234,7 +227,7 @@ def test_sell_equipment_with_manual_price(
         "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
     )
     response = client.post(
-        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id),
+        url + "?sell_assign=" + str(assignment.id),
         {
             "step": "selection",
             "0-price_method": "manual",
@@ -284,7 +277,6 @@ def test_sell_weapon_profiles_individually(
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,
         content_equipment=weapon,
-        owner=user,
     )
     assignment.weapon_profiles_field.add(profile1, profile2)
 
@@ -293,7 +285,7 @@ def test_sell_weapon_profiles_individually(
         "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
     )
     response = client.post(
-        url + f"?assign={assignment.id}&sell_profile={profile2.id}",
+        url + f"?sell_profile={profile2.id}",
         {
             "step": "selection",
             "0-price_method": "manual",
@@ -337,16 +329,15 @@ def test_sell_accessories_individually(
     # Add weapon with accessories
     weapon = make_equipment("Test Weapon", cost=30)
     accessory1 = ContentWeaponAccessory.objects.create(
-        name="Scope", cost=15, owner=user
+        name="Scope", cost=15
     )
     accessory2 = ContentWeaponAccessory.objects.create(
-        name="Laser", cost=10, owner=user
+        name="Laser", cost=10
     )
 
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,
         content_equipment=weapon,
-        owner=user,
     )
     assignment.weapon_accessories_field.add(accessory1, accessory2)
 
@@ -355,7 +346,7 @@ def test_sell_accessories_individually(
         "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
     )
     response = client.post(
-        url + f"?assign={assignment.id}&sell_accessory={accessory1.id}",
+        url + f"?sell_accessory={accessory1.id}",
         {
             "step": "selection",
             "0-price_method": "dice",
@@ -394,7 +385,6 @@ def test_sell_summary_page(client, user, make_list, make_stash_fighter, make_equ
     assignment = ListFighterEquipmentAssignment.objects.create(
         list_fighter=stash,
         content_equipment=equipment,
-        owner=user,
     )
 
     # Complete the sale flow
@@ -404,7 +394,7 @@ def test_sell_summary_page(client, user, make_list, make_stash_fighter, make_equ
 
     # Step 1: Selection
     response = client.post(
-        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id),
+        url + "?sell_assign=" + str(assignment.id),
         {
             "step": "selection",
             "0-price_method": "manual",

--- a/gyrinx/core/tests/test_equipment_sell.py
+++ b/gyrinx/core/tests/test_equipment_sell.py
@@ -1,0 +1,432 @@
+import pytest
+from django.urls import reverse
+
+from gyrinx.content.models import (
+    ContentEquipmentUpgrade,
+    ContentFighter,
+    ContentWeaponAccessory,
+)
+from gyrinx.core.models.campaign import Campaign, CampaignAction
+from gyrinx.core.models.list import List, ListFighter, ListFighterEquipmentAssignment
+
+
+@pytest.mark.django_db
+def test_sell_equipment_requires_stash_fighter(
+    client, user, make_list, make_list_fighter, make_equipment
+):
+    """Test that only stash fighters can sell equipment."""
+    client.force_login(user)
+
+    # Create a campaign list with regular fighter
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user)
+    lst = make_list("Test List", campaign=campaign, status=List.CAMPAIGN_MODE)
+    fighter = make_list_fighter(lst, "Regular Fighter")
+
+    # Add equipment
+    equipment = make_equipment("Test Gun", cost=50)
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=fighter,
+        content_equipment=equipment,
+        owner=user,
+    )
+
+    # Try to access sell page
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, fighter.id, assignment.id]
+    )
+    response = client.get(url)
+
+    # Should redirect with error message
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "core:list-fighter-gear-edit", args=[lst.id, fighter.id]
+    )
+
+
+@pytest.fixture
+def make_stash_fighter(user, content_house):
+    """Create a stash fighter for testing."""
+
+    def _make_stash_fighter(list_):
+        # Create stash content fighter
+        stash_content = ContentFighter.objects.create(
+            type="Stash",
+            category="STASH",
+            base_cost=0,
+            is_stash=True,
+            house=content_house,
+        )
+
+        # Create stash list fighter
+        return ListFighter.objects.create(
+            name="Gang Stash",
+            content_fighter=stash_content,
+            list=list_,
+            owner=user,
+        )
+
+    return _make_stash_fighter
+
+
+@pytest.mark.django_db
+def test_sell_equipment_requires_campaign_mode(
+    client, user, make_list, make_stash_fighter, make_equipment
+):
+    """Test that equipment can only be sold in campaign mode."""
+    client.force_login(user)
+
+    # Create non-campaign list with stash fighter
+    lst = make_list("Test List", status=List.GANG_MODE)
+    stash = make_stash_fighter(lst)
+
+    # Add equipment
+    equipment = make_equipment("Test Gun", cost=50)
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash,
+        content_equipment=equipment,
+        owner=user,
+    )
+
+    # Try to access sell page
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
+    )
+    response = client.get(url)
+
+    # Should redirect with error message
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "core:list-fighter-gear-edit", args=[lst.id, stash.id]
+    )
+
+
+@pytest.mark.django_db
+def test_sell_equipment_selection_form(
+    client, user, make_list, make_stash_fighter, make_equipment
+):
+    """Test the equipment sell selection form displays correctly."""
+    client.force_login(user)
+
+    # Create campaign list with stash fighter
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user)
+    lst = make_list("Test List", campaign=campaign, status=List.CAMPAIGN_MODE)
+    stash = make_stash_fighter(lst)
+
+    # Add equipment with upgrade
+    equipment = make_equipment("Test Gun", cost=50)
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        name="Extended Mag",
+        equipment=equipment,
+        cost=10,
+        owner=user,
+    )
+
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash,
+        content_equipment=equipment,
+        owner=user,
+    )
+    assignment.upgrades_field.add(upgrade)
+
+    # Access sell page
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
+    )
+    response = client.get(
+        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id)
+    )
+
+    assert response.status_code == 200
+    assert "Select Sale Price Method" in response.content.decode()
+    assert "Test Gun" in response.content.decode()
+    assert "60¢" in response.content.decode()  # 50 + 10 for upgrade
+
+
+@pytest.mark.django_db
+def test_sell_equipment_with_dice_roll(
+    client, user, make_list, make_stash_fighter, make_equipment
+):
+    """Test selling equipment with dice roll pricing."""
+    client.force_login(user)
+
+    # Create campaign list with stash fighter
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user)
+    lst = make_list("Test List", campaign=campaign, status=List.CAMPAIGN_MODE)
+    stash = make_stash_fighter(lst)
+
+    # Add equipment
+    equipment = make_equipment("Test Gun", cost=50)
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash,
+        content_equipment=equipment,
+        owner=user,
+    )
+
+    # Initial credits
+    initial_credits = lst.credits_current
+
+    # Submit selection form
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
+    )
+    response = client.post(
+        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id),
+        {
+            "step": "selection",
+            "0-price_method": "dice",
+        },
+    )
+
+    assert response.status_code == 302
+    assert "step=confirm" in response.url
+
+    # Confirm sale
+    response = client.post(
+        url,
+        {
+            "step": "confirm",
+        },
+        follow=True,
+    )
+
+    # Check that equipment was deleted
+    assert not ListFighterEquipmentAssignment.objects.filter(id=assignment.id).exists()
+
+    # Check credits were added
+    lst.refresh_from_db()
+    assert lst.credits_current > initial_credits
+    assert lst.credits_current <= initial_credits + 50  # Max possible with dice
+    assert lst.credits_current >= initial_credits + 5  # Min possible (5¢ minimum)
+
+    # Check campaign action was created
+    action = CampaignAction.objects.filter(campaign=campaign, list=lst).first()
+    assert action is not None
+    assert action.dice_count == 1
+    assert len(action.dice_results) == 1
+    assert "Sold equipment from stash" in action.description
+
+
+@pytest.mark.django_db
+def test_sell_equipment_with_manual_price(
+    client, user, make_list, make_stash_fighter, make_equipment
+):
+    """Test selling equipment with manual pricing."""
+    client.force_login(user)
+
+    # Create campaign list with stash fighter
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user)
+    lst = make_list("Test List", campaign=campaign, status=List.CAMPAIGN_MODE)
+    stash = make_stash_fighter(lst)
+
+    # Add equipment
+    equipment = make_equipment("Test Gun", cost=50)
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash,
+        content_equipment=equipment,
+        owner=user,
+    )
+
+    # Initial credits
+    initial_credits = lst.credits_current
+
+    # Submit selection form with manual price
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
+    )
+    response = client.post(
+        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id),
+        {
+            "step": "selection",
+            "0-price_method": "manual",
+            "0-manual_price": "25",
+        },
+    )
+
+    assert response.status_code == 302
+
+    # Confirm sale
+    response = client.post(
+        url,
+        {
+            "step": "confirm",
+        },
+        follow=True,
+    )
+
+    # Check credits were added exactly
+    lst.refresh_from_db()
+    assert lst.credits_current == initial_credits + 25
+
+    # Check campaign action
+    action = CampaignAction.objects.filter(campaign=campaign, list=lst).first()
+    assert action is not None
+    assert action.dice_count == 0  # No dice for manual price
+    assert "Test Gun (25¢)" in action.description
+
+
+@pytest.mark.django_db
+def test_sell_weapon_profiles_individually(
+    client, user, make_list, make_stash_fighter, make_equipment, make_weapon_profile
+):
+    """Test selling individual weapon profiles."""
+    client.force_login(user)
+
+    # Create campaign list with stash fighter
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user)
+    lst = make_list("Test List", campaign=campaign, status=List.CAMPAIGN_MODE)
+    stash = make_stash_fighter(lst)
+
+    # Add weapon with multiple profiles
+    weapon = make_equipment("Multi-weapon", cost=30)
+    profile1 = make_weapon_profile(weapon, name="Mode 1", cost=10)
+    profile2 = make_weapon_profile(weapon, name="Mode 2", cost=20)
+
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash,
+        content_equipment=weapon,
+        owner=user,
+    )
+    assignment.weapon_profiles_field.add(profile1, profile2)
+
+    # Sell only profile2
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
+    )
+    response = client.post(
+        url + f"?assign={assignment.id}&sell_profile={profile2.id}",
+        {
+            "step": "selection",
+            "0-price_method": "manual",
+            "0-manual_price": "15",
+        },
+    )
+
+    assert response.status_code == 302
+
+    # Confirm sale
+    response = client.post(
+        url,
+        {
+            "step": "confirm",
+        },
+        follow=True,
+    )
+
+    # Check that assignment still exists but profile2 is removed
+    assignment.refresh_from_db()
+    assert assignment.weapon_profiles_field.filter(id=profile1.id).exists()
+    assert not assignment.weapon_profiles_field.filter(id=profile2.id).exists()
+
+    # Check credits
+    lst.refresh_from_db()
+    assert lst.credits_earned == 15
+
+
+@pytest.mark.django_db
+def test_sell_accessories_individually(
+    client, user, make_list, make_stash_fighter, make_equipment
+):
+    """Test selling individual weapon accessories."""
+    client.force_login(user)
+
+    # Create campaign list with stash fighter
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user)
+    lst = make_list("Test List", campaign=campaign, status=List.CAMPAIGN_MODE)
+    stash = make_stash_fighter(lst)
+
+    # Add weapon with accessories
+    weapon = make_equipment("Test Weapon", cost=30)
+    accessory1 = ContentWeaponAccessory.objects.create(
+        name="Scope", cost=15, owner=user
+    )
+    accessory2 = ContentWeaponAccessory.objects.create(
+        name="Laser", cost=10, owner=user
+    )
+
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash,
+        content_equipment=weapon,
+        owner=user,
+    )
+    assignment.weapon_accessories_field.add(accessory1, accessory2)
+
+    # Sell only accessory1
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
+    )
+    response = client.post(
+        url + f"?assign={assignment.id}&sell_accessory={accessory1.id}",
+        {
+            "step": "selection",
+            "0-price_method": "dice",
+        },
+    )
+
+    assert response.status_code == 302
+
+    # Confirm sale
+    response = client.post(
+        url,
+        {
+            "step": "confirm",
+        },
+        follow=True,
+    )
+
+    # Check that assignment still exists but accessory1 is removed
+    assignment.refresh_from_db()
+    assert not assignment.weapon_accessories_field.filter(id=accessory1.id).exists()
+    assert assignment.weapon_accessories_field.filter(id=accessory2.id).exists()
+
+
+@pytest.mark.django_db
+def test_sell_summary_page(client, user, make_list, make_stash_fighter, make_equipment):
+    """Test the sale summary page shows correct information."""
+    client.force_login(user)
+
+    # Create campaign list with stash fighter
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user)
+    lst = make_list("Test List", campaign=campaign, status=List.CAMPAIGN_MODE)
+    stash = make_stash_fighter(lst)
+
+    # Add equipment
+    equipment = make_equipment("Test Gun", cost=50)
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash,
+        content_equipment=equipment,
+        owner=user,
+    )
+
+    # Complete the sale flow
+    url = reverse(
+        "core:list-fighter-equipment-sell", args=[lst.id, stash.id, assignment.id]
+    )
+
+    # Step 1: Selection
+    response = client.post(
+        url + "?assign=" + str(assignment.id) + "&sell_assign=" + str(assignment.id),
+        {
+            "step": "selection",
+            "0-price_method": "manual",
+            "0-manual_price": "30",
+        },
+    )
+
+    # Step 2: Confirm
+    response = client.post(
+        url,
+        {
+            "step": "confirm",
+        },
+    )
+
+    assert response.status_code == 302
+    assert "step=summary" in response.url
+
+    # Step 3: View summary
+    response = client.get(url + "?step=summary")
+
+    assert response.status_code == 200
+    assert "Sale Complete" in response.content.decode()
+    assert "30¢ has been added to your gang's credits" in response.content.decode()
+    assert "Test Gun" in response.content.decode()

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -89,6 +89,11 @@ urlpatterns = [
         ),
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/gear/<assign_id>/sell",
+        list.sell_list_fighter_equipment,
+        name="list-fighter-equipment-sell",
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/gear/<assign_id>/upgrade/<upgrade_id>/delete",
         list.delete_list_fighter_gear_upgrade,
         name="list-fighter-gear-upgrade-delete",

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -294,12 +294,12 @@ def edit_list_credits(request, id):
     """
     from django.contrib import messages
 
-    from gyrinx.core.forms.list import EditListCreditsForm
-    from gyrinx.core.models.campaign import CampaignAction
-
     # Allow both list owner and campaign owner to modify credits
     # Filter the queryset to include only lists owned by the user or by campaigns they own
     from django.db.models import Q
+
+    from gyrinx.core.forms.list import EditListCreditsForm
+    from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(
         List.objects.filter(Q(owner=request.user) | Q(campaign__owner=request.user)),
@@ -2924,7 +2924,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
 
     if sell_assign:
         # Selling entire assignment (equipment + upgrades)
-        base_cost = assignment.content_equipment.cost
+        base_cost = assignment.content_equipment.cost_int()
         if assignment.upgrade:
             base_cost += assignment.upgrade.cost
         for upgrade in assignment.upgrades_field.all():

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2944,6 +2944,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                 "upgrades": list(assignment.upgrades_field.all())
                 + ([assignment.upgrade] if assignment.upgrade else []),
                 "base_cost": base_cost,
+                "total_cost": base_cost,  # Total cost including upgrades
                 "assignment": assignment,
             }
         )
@@ -2955,6 +2956,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                     "type": "profile",
                     "name": profile.name,
                     "base_cost": profile.cost,
+                    "total_cost": profile.cost,  # No upgrades for profiles
                     "profile": profile,
                 }
             )
@@ -2966,6 +2968,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                     "type": "accessory",
                     "name": accessory.name,
                     "base_cost": accessory.cost,
+                    "total_cost": accessory.cost,  # No upgrades for accessories
                     "accessory": accessory,
                 }
             )
@@ -2979,6 +2982,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                         "type": "profile",
                         "name": profile.name,
                         "base_cost": profile.cost,
+                        "total_cost": profile.cost,  # No upgrades for profiles
                         "profile": profile,
                     }
                 )
@@ -2993,6 +2997,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                         "type": "accessory",
                         "name": accessory.name,
                         "base_cost": accessory.cost,
+                        "total_cost": accessory.cost,  # No upgrades for accessories
                         "accessory": accessory,
                     }
                 )
@@ -3020,6 +3025,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                             "name": item["name"],
                             "type": item["type"],
                             "base_cost": item["base_cost"],
+                            "total_cost": item.get("total_cost", item["base_cost"]),
                             "price_method": price_method,
                             "manual_price": manual_price,
                         }
@@ -3058,8 +3064,12 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                         dice_rolls.append(roll)
                         total_dice += 1
 
-                        # Calculate sale price: base cost - (roll × 10), minimum 5¢
-                        sale_price = max(5, item_data["base_cost"] - (roll * 10))
+                        # Calculate sale price: total cost - (roll × 10), minimum 5¢
+                        sale_price = max(
+                            5,
+                            item_data.get("total_cost", item_data["base_cost"])
+                            - (roll * 10),
+                        )
                     else:
                         # Use manual price
                         sale_price = item_data["manual_price"]
@@ -3069,6 +3079,9 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                         {
                             "name": item_data["name"],
                             "base_cost": item_data["base_cost"],
+                            "total_cost": item_data.get(
+                                "total_cost", item_data["base_cost"]
+                            ),
                             "sale_price": sale_price,
                             "dice_roll": roll
                             if item_data["price_method"] == "dice"
@@ -3109,7 +3122,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
                 for detail in sale_details:
                     if detail["dice_roll"]:
                         description_parts.append(
-                            f"{detail['name']} ({detail['base_cost']}¢ - {detail['dice_roll']}×10 = {detail['sale_price']}¢)"
+                            f"{detail['name']} ({detail['total_cost']}¢ - {detail['dice_roll']}×10 = {detail['sale_price']}¢)"
                         )
                     else:
                         description_parts.append(

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2932,10 +2932,12 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
     if step != "summary" and sell_assign:
         # Selling entire assignment (equipment + upgrades)
         base_cost = assignment.content_equipment.cost_int()
+        print(f"Base cost for {assignment.content_equipment.name}: {base_cost}")
         if assignment.upgrade:
-            base_cost += assignment.upgrade.cost
+            base_cost += assignment.upgrade.cost_int_cached
         for upgrade in assignment.upgrades_field.all():
-            base_cost += upgrade.cost
+            print(f"Adding upgrade cost: {upgrade.cost_int_cached} for {upgrade.name}")
+            base_cost += upgrade.cost_int_cached
 
         items_to_sell.append(
             {
@@ -2954,7 +2956,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
             items_to_sell.append(
                 {
                     "type": "profile",
-                    "name": profile.name,
+                    "name": f"- {profile.name}",
                     "base_cost": profile.cost,
                     "total_cost": profile.cost,  # No upgrades for profiles
                     "profile": profile,

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2895,7 +2895,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
-    
+
     # For summary step, assignment might not exist (already deleted)
     step = request.GET.get("step", "selection")
     if step == "summary":
@@ -3083,7 +3083,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
 
                 # Store assignment ID before potential deletion
                 assignment_id = assignment.id
-                
+
                 # Remove sold items
                 if request.session.get("sell_assign"):
                     # Delete entire assignment

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2894,7 +2894,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
     from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst)
 
     # For summary step, assignment might not exist (already deleted)
     step = request.GET.get("step", "selection")


### PR DESCRIPTION
Closes #325

This PR implements the equipment selling feature for stash fighters in campaign mode with dice roll mechanics.

## Features
- Three-step sell flow: selection, confirmation, summary
- Support for selling entire assignments or individual profiles/accessories
- Dice roll pricing: item cost minus D6×10 (minimum 5¢)
- Manual pricing option for each item
- Campaign actions created with dice roll tracking
- Only available for stash fighters in campaign mode

## Testing
- Comprehensive test coverage for all scenarios
- All tests passing
- Code formatted with ruff and npm fmt

Generated with [Claude Code](https://claude.ai/code)