### PR TITLE
fix: prevent stash fighters from being cloned when duplicating lists

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -239,13 +239,16 @@ class List(AppBase):
             **values,
         )
 
-        # Clone fighters, but skip linked fighters as they'll be created by equipment assignments
+        # Clone fighters, but skip linked fighters and stash fighters
         for fighter in self.fighters():
-            # Check if this fighter is linked to an equipment assignment using the related name
-            if (
-                not hasattr(fighter, "linked_fighter")
-                or not fighter.linked_fighter.exists()
-            ):
+            # Skip if this fighter is linked to an equipment assignment
+            is_linked = (
+                hasattr(fighter, "linked_fighter") and fighter.linked_fighter.exists()
+            )
+            # Skip if this is a stash fighter
+            is_stash = fighter.content_fighter.is_stash
+
+            if not is_linked and not is_stash:
                 fighter.clone(list=clone)
 
         # Add a stash fighter if cloning for a campaign


### PR DESCRIPTION
Fixes #348

## Summary

This PR fixes an issue where stash fighters were incorrectly duplicated when cloning a list.

## Changes

- Updated `List.clone()` method to filter out stash fighters in addition to linked fighters
- Added test to verify stash fighters are excluded from cloned lists

## Testing

- Added `test_list_clone_excludes_stash_fighter()` test
- All existing clone tests pass
- Linting checks pass

Generated with [Claude Code](https://claude.ai/code)