### PR TITLE
feat: implement fighter "dead" state in campaign mode

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -352,6 +352,10 @@ class ListFighterManager(models.Manager):
             )
             .order_by(
                 "list",
+                Case(
+                    When(injury_state="dead", then=1),
+                    default=0,
+                ),
                 "_category_order",
                 "_sort_key",
             )

--- a/gyrinx/core/templates/core/includes/fighter_card.html
+++ b/gyrinx/core/templates/core/includes/fighter_card.html
@@ -9,7 +9,7 @@
             {% endif %}
             <div class="card {{ card_classes }} {% flash fighter.id %}"
                  id="{{ fighter.id }}">
-                <div class="card-header p-2 {% if fighter.is_stash %}bg-secondary-subtle text-secondary-emphasis{% endif %}">
+                <div class="card-header p-2 {% if fighter.is_stash %}bg-secondary-subtle text-secondary-emphasis{% elif fighter.injury_state == 'dead' %}bg-danger-subtle{% endif %}">
                     <div class="vstack gap-1">
                         <div class="hstack">
                             <h3 class="h5 mb-0">{{ fighter.name }}</h3>
@@ -87,6 +87,12 @@
                                            class="btn btn-outline-danger btn-sm">
                                             <i class="bi-archive"></i> Archive
                                         </a>
+                                        {% if list.is_campaign_mode and fighter.injury_state != 'dead' %}
+                                            <a href="{% url 'core:list-fighter-kill' list.id fighter.id %}"
+                                               class="btn btn-outline-danger btn-sm">
+                                                <i class="bi-heartbreak"></i> Kill
+                                            </a>
+                                        {% endif %}
                                         <a href="{% url 'core:list-fighter-delete' list.id fighter.id %}"
                                            class="btn btn-outline-danger btn-sm">
                                             <i class="bi-trash"></i> Delete
@@ -381,15 +387,17 @@
                         </table>
                     {% endif %}
                     {% comment %} Wargear {% endcomment %}
-                    {% include "core/includes/list_fighter_weapons.html" with weapons=fighter.weapons_cached show_edit_link=False %}
-                    {% if not print %}
-                        {% if can_edit %}
-                            <div class="btn-group p-1">
-                                <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
-                                   class="btn btn-outline-primary btn-sm">
-                                    <i class="bi-plus-lg"></i> Add or edit weapons
-                                </a>
-                            </div>
+                    {% if fighter.injury_state != 'dead' %}
+                        {% include "core/includes/list_fighter_weapons.html" with weapons=fighter.weapons_cached show_edit_link=False %}
+                        {% if not print %}
+                            {% if can_edit %}
+                                <div class="btn-group p-1">
+                                    <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
+                                       class="btn btn-outline-primary btn-sm">
+                                        <i class="bi-plus-lg"></i> Add or edit weapons
+                                    </a>
+                                </div>
+                            {% endif %}
                         {% endif %}
                     {% endif %}
                 </div>
@@ -404,7 +412,7 @@
             {% endif %}
             <div class="card {{ card_classes }} {% flash fighter.id %}"
                  id="{{ fighter.id }}">
-                <div class="card-header p-2 {% if fighter.is_stash %}bg-secondary-subtle text-secondary-emphasis{% endif %}">
+                <div class="card-header p-2 {% if fighter.is_stash %}bg-secondary-subtle text-secondary-emphasis{% elif fighter.injury_state == 'dead' %}bg-danger-subtle{% endif %}">
                     <div class="vstack gap-1">
                         <div class="hstack">
                             <h3 class="h5 mb-0">{{ fighter.name }}</h3>
@@ -484,6 +492,12 @@
                                            class="btn btn-outline-danger btn-sm">
                                             <i class="bi-archive"></i> Archive
                                         </a>
+                                        {% if list.is_campaign_mode and fighter.injury_state != 'dead' %}
+                                            <a href="{% url 'core:list-fighter-kill' list.id fighter.id %}"
+                                               class="btn btn-outline-danger btn-sm">
+                                                <i class="bi-heartbreak"></i> Kill
+                                            </a>
+                                        {% endif %}
                                         <a href="{% url 'core:list-fighter-delete' list.id fighter.id %}"
                                            class="btn btn-outline-danger btn-sm">
                                             <i class="bi-trash"></i> Delete
@@ -775,15 +789,17 @@
                         </table>
                     {% endif %}
                     {% comment %} Wargear {% endcomment %}
-                    {% include "core/includes/list_fighter_weapons.html" with weapons=fighter.weapons_cached show_edit_link=False %}
-                    {% if not print %}
-                        {% if can_edit %}
-                            <div class="btn-group p-1">
-                                <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
-                                   class="btn btn-outline-primary btn-sm">
-                                    <i class="bi-plus-lg"></i> Add or edit weapons
-                                </a>
-                            </div>
+                    {% if fighter.injury_state != 'dead' %}
+                        {% include "core/includes/list_fighter_weapons.html" with weapons=fighter.weapons_cached show_edit_link=False %}
+                        {% if not print %}
+                            {% if can_edit %}
+                                <div class="btn-group p-1">
+                                    <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
+                                       class="btn btn-outline-primary btn-sm">
+                                        <i class="bi-plus-lg"></i> Add or edit weapons
+                                    </a>
+                                </div>
+                            {% endif %}
                         {% endif %}
                     {% endif %}
                 </div>

--- a/gyrinx/core/templates/core/list_fighter_kill.html
+++ b/gyrinx/core/templates/core/list_fighter_kill.html
@@ -1,0 +1,36 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Kill Fighter - {{ fighter.fully_qualified_name }} - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with text=list.name %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">Kill Fighter: {{ fighter.fully_qualified_name }}</h1>
+        <form action="{% url 'core:list-fighter-kill' list.id fighter.id %}"
+              method="post">
+            {% csrf_token %}
+            <div class="alert alert-danger">
+                <p class="mb-0">
+                    <strong>Warning:</strong> This action cannot be undone.
+                </p>
+            </div>
+            <p>
+                Are you sure you want to mark <strong>{{ fighter.name }}</strong> as dead?
+            </p>
+            <p>This will:</p>
+            <ul>
+                <li>Transfer all their equipment to the stash</li>
+                <li>Set their cost to 0 credits</li>
+                <li>Mark them as permanently dead</li>
+            </ul>
+            <p>Dead fighters will remain visible in your gang but will no longer contribute to your gang's total cost.</p>
+            <div class="mt-3">
+                <button type="submit" class="btn btn-danger">
+                    <i class="bi-heartbreak"></i> Kill Fighter
+                </button>
+                <a href="{% url 'core:list' list.id %}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_fighter_state_edit.py
+++ b/gyrinx/core/tests/test_fighter_state_edit.py
@@ -1,0 +1,224 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from gyrinx.content.models import ContentFighter
+from gyrinx.core.models.campaign import Campaign, CampaignAction
+from gyrinx.core.models.list import List, ListFighter
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_fighter_state_edit_requires_campaign_mode(client, user, content_house):
+    """Test that fighter state edit only works in campaign mode."""
+    # Create a list building mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.LIST_BUILDING,
+    )
+
+    # Create a content fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    # Create a list fighter
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    # Should redirect with error message
+    assert response.status_code == 302
+    assert response.url == reverse("core:list", args=[lst.id])
+
+
+@pytest.mark.django_db
+def test_fighter_state_edit_changes_state(client, user, content_house):
+    """Test that fighter state can be changed."""
+    # Create a campaign
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+    )
+
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+        campaign=campaign,
+    )
+
+    # Create a content fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    # Create a list fighter
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.ACTIVE,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+
+    # Change to recovery state
+    response = client.post(
+        url,
+        {
+            "fighter_state": ListFighter.RECOVERY,
+            "reason": "Test reason",
+        },
+    )
+
+    # Should redirect to injuries edit page
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "core:list-fighter-injuries-edit", args=[lst.id, fighter.id]
+    )
+
+    # Check state was changed
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.RECOVERY
+
+    # Check campaign action was created
+    action = CampaignAction.objects.last()
+    assert action.campaign == campaign
+    assert "State Change" in action.description
+    assert "Test reason" in action.description
+
+
+@pytest.mark.django_db
+def test_fighter_state_edit_dead_redirects_to_kill(client, user, content_house):
+    """Test that changing state to dead redirects to kill confirmation."""
+    # Create a campaign
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+    )
+
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+        campaign=campaign,
+    )
+
+    # Create a content fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    # Create a list fighter
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.RECOVERY,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+
+    # Try to change to dead state
+    response = client.post(
+        url,
+        {
+            "fighter_state": ListFighter.DEAD,
+            "reason": "Fatal injuries",
+        },
+    )
+
+    # Should redirect to kill confirmation page
+    assert response.status_code == 302
+    assert response.url == reverse("core:list-fighter-kill", args=[lst.id, fighter.id])
+
+    # Check state was NOT changed yet (kill view should handle it)
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.RECOVERY  # Still recovery
+
+    # Check no campaign action was created yet
+    assert CampaignAction.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_fighter_state_edit_no_change(client, user, content_house):
+    """Test that no change when state is the same."""
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+
+    # Create a content fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    # Create a list fighter
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.RECOVERY,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+
+    # Try to change to same state
+    response = client.post(
+        url,
+        {
+            "fighter_state": ListFighter.RECOVERY,
+            "reason": "No change",
+        },
+    )
+
+    # Should redirect to injuries edit page
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "core:list-fighter-injuries-edit", args=[lst.id, fighter.id]
+    )
+
+    # Check state was not changed
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.RECOVERY
+
+    # Check no campaign action was created
+    assert CampaignAction.objects.count() == 0

--- a/gyrinx/core/tests/test_kill_fighter.py
+++ b/gyrinx/core/tests/test_kill_fighter.py
@@ -1,0 +1,287 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from gyrinx.content.models import ContentEquipment, ContentFighter
+from gyrinx.core.models.list import List, ListFighter, ListFighterEquipmentAssignment
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_kill_fighter_url_exists(client, user, content_house):
+    """Test that the kill fighter URL exists and requires login."""
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+
+    # Create a content fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    # Create a list fighter
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+    )
+
+    # Test unauthenticated access
+    url = reverse("core:list-fighter-kill", args=[lst.id, fighter.id])
+    response = client.get(url)
+    assert response.status_code == 302  # Redirect to login
+
+    # Test authenticated access
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_kill_fighter_requires_campaign_mode(client, user, content_house):
+    """Test that killing fighters only works in campaign mode."""
+    # Create a list building mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.LIST_BUILDING,
+    )
+
+    # Create a content fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    # Create a list fighter
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-kill", args=[lst.id, fighter.id])
+    response = client.post(url)
+
+    # Should redirect with error message
+    assert response.status_code == 302
+    fighter.refresh_from_db()
+    assert fighter.injury_state != ListFighter.DEAD
+
+
+@pytest.mark.django_db
+def test_kill_fighter_cannot_kill_stash(client, user, content_house):
+    """Test that stash fighters cannot be killed."""
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+
+    # Create a stash fighter
+    stash_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Stash",
+        category="STASH",
+        base_cost=0,
+        is_stash=True,
+    )
+
+    # Create a list fighter
+    fighter = ListFighter.objects.create(
+        name="Stash",
+        content_fighter=stash_fighter,
+        list=lst,
+        owner=user,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-kill", args=[lst.id, fighter.id])
+    response = client.post(url)
+
+    # Should redirect with error message
+    assert response.status_code == 302
+    fighter.refresh_from_db()
+    assert fighter.injury_state != ListFighter.DEAD
+
+
+@pytest.mark.django_db
+def test_kill_fighter_transfers_equipment_to_stash(client, user, content_house):
+    """Test that killing a fighter transfers all equipment to stash."""
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+
+    # Create a stash fighter
+    stash_content = ContentFighter.objects.create(
+        house=content_house,
+        type="Stash",
+        category="STASH",
+        base_cost=0,
+        is_stash=True,
+    )
+    stash = ListFighter.objects.create(
+        name="Stash",
+        content_fighter=stash_content,
+        list=lst,
+        owner=user,
+    )
+
+    # Create a regular fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+    )
+
+    # Create some equipment
+    equipment = ContentEquipment.objects.create(
+        name="Lasgun",
+        cost=15,
+    )
+
+    # Assign equipment to fighter
+    ListFighterEquipmentAssignment.objects.create(
+        list_fighter=fighter,
+        content_equipment=equipment,
+        cost=15,
+        owner=user,
+    )
+
+    # Kill the fighter
+    client.force_login(user)
+    url = reverse("core:list-fighter-kill", args=[lst.id, fighter.id])
+    response = client.post(url)
+
+    assert response.status_code == 302
+
+    # Check fighter is dead
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.DEAD
+    assert fighter.cost_override == 0
+
+    # Check equipment was transferred to stash
+    assert not fighter.listfighterequipmentassignment_set.exists()
+    assert stash.listfighterequipmentassignment_set.count() == 1
+
+    stash_assignment = stash.listfighterequipmentassignment_set.first()
+    assert stash_assignment.content_equipment == equipment
+    assert stash_assignment.cost == 15
+
+
+@pytest.mark.django_db
+def test_kill_fighter_marks_as_dead_and_sets_cost_to_zero(client, user, content_house):
+    """Test that killing a fighter marks them as dead and sets cost to 0."""
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+
+    # Create a stash (required for equipment transfer)
+    stash_content = ContentFighter.objects.create(
+        house=content_house,
+        type="Stash",
+        category="STASH",
+        base_cost=0,
+        is_stash=True,
+    )
+    ListFighter.objects.create(
+        name="Stash",
+        content_fighter=stash_content,
+        list=lst,
+        owner=user,
+    )
+
+    # Create a fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Champion",
+        category="CHAMPION",
+        base_cost=100,
+    )
+    fighter = ListFighter.objects.create(
+        name="Test Champion",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+    )
+
+    # Kill the fighter
+    client.force_login(user)
+    url = reverse("core:list-fighter-kill", args=[lst.id, fighter.id])
+    response = client.post(url)
+
+    assert response.status_code == 302
+
+    # Check fighter state
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.DEAD
+    assert fighter.cost_override == 0
+
+    # Verify the fighter's cost is indeed 0
+    assert fighter.cost_int() == 0
+
+
+@pytest.mark.django_db
+def test_kill_fighter_confirmation_page(client, user, content_house):
+    """Test the kill fighter confirmation page displays correctly."""
+    # Create a campaign mode list
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+
+    # Create a fighter
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+    fighter = ListFighter.objects.create(
+        name="Doomed Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-kill", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert b"Kill Fighter: Doomed Fighter" in response.content
+    assert b"transfer all their equipment to the stash" in response.content
+    assert b"Set their cost to 0 credits" in response.content

--- a/gyrinx/core/tests/test_kill_fighter.py
+++ b/gyrinx/core/tests/test_kill_fighter.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from gyrinx.content.models import ContentEquipment, ContentFighter
-from gyrinx.core.models.list import List, ListFighter, ListFighterEquipmentAssignment
+from gyrinx.core.models.list import List, ListFighter
 
 User = get_user_model()
 
@@ -168,12 +168,7 @@ def test_kill_fighter_transfers_equipment_to_stash(client, user, content_house):
     )
 
     # Assign equipment to fighter
-    ListFighterEquipmentAssignment.objects.create(
-        list_fighter=fighter,
-        content_equipment=equipment,
-        cost=15,
-        owner=user,
-    )
+    fighter.assign(equipment)
 
     # Kill the fighter
     client.force_login(user)
@@ -193,7 +188,7 @@ def test_kill_fighter_transfers_equipment_to_stash(client, user, content_house):
 
     stash_assignment = stash.listfighterequipmentassignment_set.first()
     assert stash_assignment.content_equipment == equipment
-    assert stash_assignment.cost == 15
+    assert stash_assignment.cost_int() == 15
 
 
 @pytest.mark.django_db
@@ -283,5 +278,5 @@ def test_kill_fighter_confirmation_page(client, user, content_house):
 
     assert response.status_code == 200
     assert b"Kill Fighter: Doomed Fighter" in response.content
-    assert b"transfer all their equipment to the stash" in response.content
+    assert b"Transfer all their equipment to the stash" in response.content
     assert b"Set their cost to 0 credits" in response.content

--- a/gyrinx/core/tests/test_kill_fighter.py
+++ b/gyrinx/core/tests/test_kill_fighter.py
@@ -339,10 +339,7 @@ def test_kill_fighter_creates_campaign_action(client, user, content_house):
     )
 
     # Assign equipment to fighter
-    fighter.assign(
-        content_equipment=equipment,
-        from_default_assignment=False,
-    )
+    fighter.assign(equipment)
 
     client.force_login(user)
     url = reverse("core:list-fighter-kill", args=[lst.id, fighter.id])

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -130,6 +130,11 @@ urlpatterns = [
         name="list-fighter-archive",
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/kill",
+        list.kill_list_fighter,
+        name="list-fighter-kill",
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/delete",
         list.delete_list_fighter,
         name="list-fighter-delete",

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -1974,6 +1974,13 @@ def list_fighter_add_injury(request, id, fighter_id):
             messages.success(
                 request, f"Added injury '{injury.injury.name}' to {fighter.name}"
             )
+
+            # If fighter state is dead, redirect to kill confirmation
+            if form.cleaned_data["fighter_state"] == ListFighter.DEAD:
+                return HttpResponseRedirect(
+                    reverse("core:list-fighter-kill", args=(lst.id, fighter.id))
+                )
+
             return HttpResponseRedirect(
                 reverse("core:list-fighter-injuries-edit", args=(lst.id, fighter.id))
             )

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -1643,21 +1643,24 @@ def kill_list_fighter(request, id, fighter_id):
                 new_assignment = ListFighterEquipmentAssignment(
                     list_fighter=stash_fighter,
                     content_equipment=assignment.content_equipment,
-                    cost=assignment.cost,
-                    is_upgrade=assignment.is_upgrade,
+                    cost_override=assignment.cost_override,
+                    total_cost_override=assignment.total_cost_override,
                     upgrade=assignment.upgrade,
-                    owner=stash_fighter.owner,
+                    from_default_assignment=assignment.from_default_assignment,
                 )
                 new_assignment.save()
 
-                # Copy over any accessories or profile overrides
-                if assignment.accessories.exists():
-                    new_assignment.accessories.set(assignment.accessories.all())
-                if assignment.weapon_profile_override:
-                    new_assignment.weapon_profile_override = (
-                        assignment.weapon_profile_override
+                # Copy over any weapon profiles and accessories
+                if assignment.weapon_profiles_field.exists():
+                    new_assignment.weapon_profiles_field.set(
+                        assignment.weapon_profiles_field.all()
                     )
-                    new_assignment.save()
+                if assignment.weapon_accessories_field.exists():
+                    new_assignment.weapon_accessories_field.set(
+                        assignment.weapon_accessories_field.all()
+                    )
+                if assignment.upgrades_field.exists():
+                    new_assignment.upgrades_field.set(assignment.upgrades_field.all())
 
             # Delete all equipment assignments from the dead fighter
             equipment_assignments.delete()


### PR DESCRIPTION
Closes #233

## Summary

Implements a "dead" state for fighters in campaign mode that:
- Transfers all equipment to the stash
- Sets fighter cost to 0
- Shows dead fighters with special UI treatment
- Sorts dead fighters to the bottom

## Changes

- Added `kill_list_fighter` view with confirmation screen
- Added "Kill" button to fighter cards (only in campaign mode)
- Dead fighters display with danger background color
- Equipment sections hidden for dead fighters
- Updated fighter sorting to put dead fighters at bottom
- Added comprehensive test coverage

## Testing

- New test file: `test_kill_fighter.py` with 6 test cases
- Tests cover URL access, campaign mode restriction, stash protection, equipment transfer, and UI

Generated with [Claude Code](https://claude.ai/code)