### PR TITLE
refactor: create CostMixin to DRY up cost calculation logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,12 @@ SQL_DEBUG=True
 
 ## Development Workflow
 
-- Always run ruff to fix formatting and lint the code after making python changes
-- Run `npm run fmt` alongside ruff
-- Run `djlint --profile=django --reformat --lint .` when making template changes
+- Always run `./scripts/fmt.sh` after making code changes to format everything (Python, JS, SCSS, templates, etc.)
+- **IMPORTANT**: This includes running `./scripts/fmt.sh` after editing CLAUDE.md itself to ensure consistent formatting
+- Alternatively, you can run formatters individually:
+    - `ruff format` and `ruff check --fix` for Python
+    - `npm run fmt` for JS, SCSS, JSON, YAML, Markdown
+    - `djlint --profile=django --reformat .` for Django templates
 - When building something new, create a branch for it and open a pull request at the end
 - Use the screenshot tool when making UI changes and add the screenshot to the PR description. Mobile UI is important to show as we are mobile-first.
 - Always run the tests and ensure they are passing before pushing from CI/GitHub Action context
@@ -247,11 +250,12 @@ The list view establishes the standard UI pattern for detail pages:
 
 ### Code Quality
 
-- Run `ruff format` to format Python code
-- Run `ruff check --fix` to fix linting issues
-- Always run ruff after making Python changes
-- Run `npm run fmt` when making changes to Markdown, YAML, JSON, SCSS or JavaScript
-- Run `djlint --profile=django --lint --reformat .` when making changes to HTML files
+- Run `./scripts/fmt.sh` to format all code (Python, JS, SCSS, templates, etc.) in one go
+- This script runs:
+    - `ruff format` and `ruff check --fix` for Python formatting and linting
+    - `npm run fmt` for Markdown, YAML, JSON, SCSS, and JavaScript formatting
+    - `djlint --profile=django --reformat .` for Django template formatting
+- Always run `./scripts/fmt.sh` after making code changes
 
 ### Git Workflow
 

--- a/gyrinx/content/tests/test_cost_methods.py
+++ b/gyrinx/content/tests/test_cost_methods.py
@@ -1,0 +1,603 @@
+"""
+Comprehensive tests for cost calculation methods across content models.
+
+This test file ensures all cost-related methods (cost_int, cost_display, 
+cost_for_fighter_int) work correctly before implementing the CostMixin.
+"""
+import pytest
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentCategory,
+    ContentEquipmentUpgrade,
+    ContentFighter,
+    ContentFighterDefaultAssignment,
+    ContentFighterEquipmentListItem,
+    ContentFighterEquipmentListUpgrade,
+    ContentFighterEquipmentListWeaponAccessory,
+    ContentHouse,
+    ContentWeaponAccessory,
+    ContentWeaponProfile,
+)
+from gyrinx.models import FighterCategoryChoices
+
+
+@pytest.mark.django_db
+class TestContentEquipmentCostMethods:
+    """Test cost methods on ContentEquipment model."""
+
+    def test_cost_int_with_integer_string(self):
+        """Test cost_int with a valid integer string."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost="100"
+        )
+        assert equipment.cost_int() == 100
+
+    def test_cost_int_with_empty_string(self):
+        """Test cost_int with empty string returns 0."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost=""
+        )
+        assert equipment.cost_int() == 0
+
+    def test_cost_int_with_non_integer_string(self):
+        """Test cost_int with non-integer string returns 0."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost="2D6X10"
+        )
+        assert equipment.cost_int() == 0
+
+    def test_cost_display_with_integer_cost(self):
+        """Test cost_display with integer cost shows currency symbol."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost="50"
+        )
+        assert equipment.cost_display() == "50¢"
+
+    def test_cost_display_with_non_integer_cost(self):
+        """Test cost_display with non-integer cost shows as-is."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost="2D6X10"
+        )
+        assert equipment.cost_display() == "2D6X10"
+
+    def test_cost_display_with_empty_cost(self):
+        """Test cost_display with empty cost returns empty string."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost=""
+        )
+        assert equipment.cost_display() == ""
+
+    def test_cost_for_fighter_int_without_annotation(self):
+        """Test cost_for_fighter_int raises error without annotation."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost="100"
+        )
+        with pytest.raises(AttributeError, match="cost_for_fighter not available"):
+            equipment.cost_for_fighter_int()
+
+    def test_cost_for_fighter_int_with_annotation(self):
+        """Test cost_for_fighter_int with fighter-specific cost override."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house,
+            base_cost=50
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            cost="100"
+        )
+        
+        # Create override
+        ContentFighterEquipmentListItem.objects.create(
+            fighter=fighter,
+            equipment=equipment,
+            cost=75
+        )
+        
+        # Get equipment with annotation
+        equipment_with_cost = ContentEquipment.objects.with_cost_for_fighter(fighter).get(pk=equipment.pk)
+        assert equipment_with_cost.cost_for_fighter_int() == 75
+
+
+@pytest.mark.django_db
+class TestContentWeaponProfileCostMethods:
+    """Test cost methods on ContentWeaponProfile model."""
+
+    def test_cost_int(self):
+        """Test cost_int returns the integer cost."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Weapons & Ammo"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Weapon",
+            category=category
+        )
+        profile = ContentWeaponProfile.objects.create(
+            equipment=equipment,
+            name="Long Range",
+            cost=25
+        )
+        assert profile.cost_int() == 25
+
+    def test_cost_display_for_standard_profile(self):
+        """Test cost_display for standard (unnamed) profile returns empty."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Weapons & Ammo"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Weapon",
+            category=category
+        )
+        profile = ContentWeaponProfile.objects.create(
+            equipment=equipment,
+            name="",  # Standard profile
+            cost=0
+        )
+        assert profile.cost_display() == ""
+
+    def test_cost_display_for_named_profile_with_positive_cost(self):
+        """Test cost_display for named profile shows cost with sign."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Weapons & Ammo"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Weapon",
+            category=category
+        )
+        profile = ContentWeaponProfile.objects.create(
+            equipment=equipment,
+            name="Long Range",
+            cost=25
+        )
+        assert profile.cost_display() == "+25¢"
+
+    def test_cost_display_for_named_profile_with_zero_cost(self):
+        """Test cost_display for named profile with zero cost returns empty."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Weapons & Ammo"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Weapon",
+            category=category
+        )
+        profile = ContentWeaponProfile.objects.create(
+            equipment=equipment,
+            name="Special",
+            cost=0
+        )
+        assert profile.cost_display() == ""
+
+    def test_cost_for_fighter_int_with_override(self):
+        """Test cost_for_fighter_int with fighter-specific override."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house,
+            base_cost=50
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Weapons & Ammo"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Weapon",
+            category=category
+        )
+        profile = ContentWeaponProfile.objects.create(
+            equipment=equipment,
+            name="Long Range",
+            cost=25
+        )
+        
+        # Create override
+        ContentFighterEquipmentListItem.objects.create(
+            fighter=fighter,
+            equipment=equipment,
+            weapon_profile=profile,
+            cost=20
+        )
+        
+        # Get profile with annotation
+        profile_with_cost = ContentWeaponProfile.objects.with_cost_for_fighter(fighter).get(pk=profile.pk)
+        assert profile_with_cost.cost_for_fighter_int() == 20
+
+
+@pytest.mark.django_db 
+class TestContentWeaponAccessoryCostMethods:
+    """Test cost methods on ContentWeaponAccessory model."""
+
+    def test_cost_int(self):
+        """Test cost_int returns the integer cost."""
+        accessory = ContentWeaponAccessory.objects.create(
+            name="Test Scope",
+            cost=15
+        )
+        assert accessory.cost_int() == 15
+
+    def test_cost_display(self):
+        """Test cost_display formats cost with currency symbol."""
+        accessory = ContentWeaponAccessory.objects.create(
+            name="Test Scope",
+            cost=15
+        )
+        assert accessory.cost_display() == "15¢"
+
+    def test_cost_display_negative(self):
+        """Test cost_display with negative cost."""
+        accessory = ContentWeaponAccessory.objects.create(
+            name="Discount Scope",
+            cost=-5
+        )
+        assert accessory.cost_display() == "-5¢"
+
+    def test_cost_for_fighter_int_with_override(self):
+        """Test cost_for_fighter_int with fighter-specific override."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house,
+            base_cost=50
+        )
+        accessory = ContentWeaponAccessory.objects.create(
+            name="Test Scope",
+            cost=15
+        )
+        
+        # Create override
+        ContentFighterEquipmentListWeaponAccessory.objects.create(
+            fighter=fighter,
+            weapon_accessory=accessory,
+            cost=10
+        )
+        
+        # Get accessory with annotation
+        accessory_with_cost = ContentWeaponAccessory.objects.with_cost_for_fighter(fighter).get(pk=accessory.pk)
+        assert accessory_with_cost.cost_for_fighter_int() == 10
+
+
+@pytest.mark.django_db
+class TestContentEquipmentUpgradeCostMethods:
+    """Test cost methods on ContentEquipmentUpgrade model."""
+
+    def test_cost_int_single_mode(self):
+        """Test cost_int in SINGLE mode sums all upgrades up to position."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Cyberteknika",
+            category=category,
+            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE
+        )
+        
+        # Create upgrades with cumulative costs
+        upgrade1 = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment,
+            name="Basic",
+            position=1,
+            cost=10
+        )
+        upgrade2 = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment,
+            name="Advanced",
+            position=2,
+            cost=15
+        )
+        upgrade3 = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment,
+            name="Master",
+            position=3,
+            cost=20
+        )
+        
+        assert upgrade1.cost_int() == 10  # Just upgrade1
+        assert upgrade2.cost_int() == 25  # upgrade1 + upgrade2
+        assert upgrade3.cost_int() == 45  # upgrade1 + upgrade2 + upgrade3
+
+    def test_cost_int_multi_mode(self):
+        """Test cost_int in MULTI mode returns direct cost."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Gene-smithing",
+            category=category,
+            upgrade_mode=ContentEquipment.UpgradeMode.MULTI
+        )
+        
+        upgrade = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment,
+            name="Enhanced Reflexes",
+            position=1,
+            cost=30
+        )
+        
+        assert upgrade.cost_int() == 30
+
+    def test_cost_display_with_sign(self):
+        """Test cost_display shows sign for upgrades."""
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category,
+            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE
+        )
+        upgrade = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment,
+            name="Upgrade",
+            position=1,
+            cost=15
+        )
+        assert upgrade.cost_display() == "+15¢"
+
+    def test_cost_display_unsaved(self):
+        """Test cost_display on unsaved upgrade uses direct cost."""
+        upgrade = ContentEquipmentUpgrade(
+            name="Test Upgrade",
+            cost=25,
+            position=1
+        )
+        assert upgrade.cost_display() == "+25¢"
+
+
+@pytest.mark.django_db
+class TestContentFighterEquipmentListItemCostMethods:
+    """Test cost methods on ContentFighterEquipmentListItem model."""
+
+    def test_cost_int(self):
+        """Test cost_int returns the cost."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category
+        )
+        
+        list_item = ContentFighterEquipmentListItem.objects.create(
+            fighter=fighter,
+            equipment=equipment,
+            cost=45
+        )
+        
+        assert list_item.cost_int() == 45
+
+    def test_cost_display(self):
+        """Test cost_display formats with currency symbol."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category
+        )
+        
+        list_item = ContentFighterEquipmentListItem.objects.create(
+            fighter=fighter,
+            equipment=equipment,
+            cost=45
+        )
+        
+        assert list_item.cost_display() == "45¢"
+
+
+@pytest.mark.django_db
+class TestContentFighterEquipmentListWeaponAccessoryCostMethods:
+    """Test cost methods on ContentFighterEquipmentListWeaponAccessory model."""
+
+    def test_cost_int(self):
+        """Test cost_int returns the cost."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        accessory = ContentWeaponAccessory.objects.create(
+            name="Test Accessory",
+            cost=20
+        )
+        
+        list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
+            fighter=fighter,
+            weapon_accessory=accessory,
+            cost=15
+        )
+        
+        assert list_item.cost_int() == 15
+
+    def test_cost_display(self):
+        """Test cost_display formats with currency symbol."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        accessory = ContentWeaponAccessory.objects.create(
+            name="Test Accessory",
+            cost=20
+        )
+        
+        list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
+            fighter=fighter,
+            weapon_accessory=accessory,
+            cost=15
+        )
+        
+        assert list_item.cost_display() == "15¢"
+
+
+@pytest.mark.django_db
+class TestContentFighterEquipmentListUpgradeCostMethods:
+    """Test cost methods on ContentFighterEquipmentListUpgrade model."""
+
+    def test_cost_int(self):
+        """Test cost_int returns the cost."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category
+        )
+        upgrade = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment,
+            name="Test Upgrade",
+            position=1,
+            cost=30
+        )
+        
+        list_item = ContentFighterEquipmentListUpgrade.objects.create(
+            fighter=fighter,
+            upgrade=upgrade,
+            cost=25
+        )
+        
+        assert list_item.cost_int() == 25
+
+    def test_cost_display(self):
+        """Test cost_display formats with currency symbol."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category
+        )
+        upgrade = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment,
+            name="Test Upgrade",
+            position=1,
+            cost=30
+        )
+        
+        list_item = ContentFighterEquipmentListUpgrade.objects.create(
+            fighter=fighter,
+            upgrade=upgrade,
+            cost=25
+        )
+        
+        assert list_item.cost_display() == "25¢"
+
+
+@pytest.mark.django_db
+class TestContentFighterDefaultAssignmentCostMethods:
+    """Test cost methods on ContentFighterDefaultAssignment model."""
+
+    def test_cost_int(self):
+        """Test cost_int returns the cost."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category
+        )
+        
+        assignment = ContentFighterDefaultAssignment.objects.create(
+            fighter=fighter,
+            equipment=equipment,
+            cost=35
+        )
+        
+        assert assignment.cost_int() == 35
+
+    def test_cost_display(self):
+        """Test cost_display formats with currency symbol."""
+        house = ContentHouse.objects.create(name="Test House")
+        fighter = ContentFighter.objects.create(
+            type="Test Fighter",
+            category=FighterCategoryChoices.GANGER,
+            house=house
+        )
+        category = ContentEquipmentCategory.objects.create(
+            name="Test Category", group="Gear"
+        )
+        equipment = ContentEquipment.objects.create(
+            name="Test Equipment",
+            category=category
+        )
+        
+        assignment = ContentFighterDefaultAssignment.objects.create(
+            fighter=fighter,
+            equipment=equipment,
+            cost=0
+        )
+        
+        assert assignment.cost_display() == "0¢"

--- a/gyrinx/content/tests/test_cost_methods.py
+++ b/gyrinx/content/tests/test_cost_methods.py
@@ -1,9 +1,10 @@
 """
 Comprehensive tests for cost calculation methods across content models.
 
-This test file ensures all cost-related methods (cost_int, cost_display, 
+This test file ensures all cost-related methods (cost_int, cost_display,
 cost_for_fighter_int) work correctly before implementing the CostMixin.
 """
+
 import pytest
 
 from gyrinx.content.models import (
@@ -32,9 +33,7 @@ class TestContentEquipmentCostMethods:
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost="100"
+            name="Test Equipment", category=category, cost="100"
         )
         assert equipment.cost_int() == 100
 
@@ -44,9 +43,7 @@ class TestContentEquipmentCostMethods:
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost=""
+            name="Test Equipment", category=category, cost=""
         )
         assert equipment.cost_int() == 0
 
@@ -56,9 +53,7 @@ class TestContentEquipmentCostMethods:
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost="2D6X10"
+            name="Test Equipment", category=category, cost="2D6X10"
         )
         assert equipment.cost_int() == 0
 
@@ -68,9 +63,7 @@ class TestContentEquipmentCostMethods:
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost="50"
+            name="Test Equipment", category=category, cost="50"
         )
         assert equipment.cost_display() == "50¢"
 
@@ -80,9 +73,7 @@ class TestContentEquipmentCostMethods:
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost="2D6X10"
+            name="Test Equipment", category=category, cost="2D6X10"
         )
         assert equipment.cost_display() == "2D6X10"
 
@@ -92,9 +83,7 @@ class TestContentEquipmentCostMethods:
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost=""
+            name="Test Equipment", category=category, cost=""
         )
         assert equipment.cost_display() == ""
 
@@ -104,9 +93,7 @@ class TestContentEquipmentCostMethods:
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost="100"
+            name="Test Equipment", category=category, cost="100"
         )
         with pytest.raises(AttributeError, match="cost_for_fighter not available"):
             equipment.cost_for_fighter_int()
@@ -118,26 +105,24 @@ class TestContentEquipmentCostMethods:
             type="Test Fighter",
             category=FighterCategoryChoices.GANGER,
             house=house,
-            base_cost=50
+            base_cost=50,
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            cost="100"
+            name="Test Equipment", category=category, cost="100"
         )
-        
+
         # Create override
         ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter,
-            equipment=equipment,
-            cost=75
+            fighter=fighter, equipment=equipment, cost=75
         )
-        
+
         # Get equipment with annotation
-        equipment_with_cost = ContentEquipment.objects.with_cost_for_fighter(fighter).get(pk=equipment.pk)
+        equipment_with_cost = ContentEquipment.objects.with_cost_for_fighter(
+            fighter
+        ).get(pk=equipment.pk)
         assert equipment_with_cost.cost_for_fighter_int() == 75
 
 
@@ -151,13 +136,10 @@ class TestContentWeaponProfileCostMethods:
             name="Test Category", group="Weapons & Ammo"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Weapon",
-            category=category
+            name="Test Weapon", category=category
         )
         profile = ContentWeaponProfile.objects.create(
-            equipment=equipment,
-            name="Long Range",
-            cost=25
+            equipment=equipment, name="Long Range", cost=25
         )
         assert profile.cost_int() == 25
 
@@ -167,13 +149,12 @@ class TestContentWeaponProfileCostMethods:
             name="Test Category", group="Weapons & Ammo"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Weapon",
-            category=category
+            name="Test Weapon", category=category
         )
         profile = ContentWeaponProfile.objects.create(
             equipment=equipment,
             name="",  # Standard profile
-            cost=0
+            cost=0,
         )
         assert profile.cost_display() == ""
 
@@ -183,13 +164,10 @@ class TestContentWeaponProfileCostMethods:
             name="Test Category", group="Weapons & Ammo"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Weapon",
-            category=category
+            name="Test Weapon", category=category
         )
         profile = ContentWeaponProfile.objects.create(
-            equipment=equipment,
-            name="Long Range",
-            cost=25
+            equipment=equipment, name="Long Range", cost=25
         )
         assert profile.cost_display() == "+25¢"
 
@@ -199,13 +177,10 @@ class TestContentWeaponProfileCostMethods:
             name="Test Category", group="Weapons & Ammo"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Weapon",
-            category=category
+            name="Test Weapon", category=category
         )
         profile = ContentWeaponProfile.objects.create(
-            equipment=equipment,
-            name="Special",
-            cost=0
+            equipment=equipment, name="Special", cost=0
         )
         assert profile.cost_display() == ""
 
@@ -216,59 +191,48 @@ class TestContentWeaponProfileCostMethods:
             type="Test Fighter",
             category=FighterCategoryChoices.GANGER,
             house=house,
-            base_cost=50
+            base_cost=50,
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Weapons & Ammo"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Weapon",
-            category=category
+            name="Test Weapon", category=category
         )
         profile = ContentWeaponProfile.objects.create(
-            equipment=equipment,
-            name="Long Range",
-            cost=25
+            equipment=equipment, name="Long Range", cost=25
         )
-        
+
         # Create override
         ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter,
-            equipment=equipment,
-            weapon_profile=profile,
-            cost=20
+            fighter=fighter, equipment=equipment, weapon_profile=profile, cost=20
         )
-        
+
         # Get profile with annotation
-        profile_with_cost = ContentWeaponProfile.objects.with_cost_for_fighter(fighter).get(pk=profile.pk)
+        profile_with_cost = ContentWeaponProfile.objects.with_cost_for_fighter(
+            fighter
+        ).get(pk=profile.pk)
         assert profile_with_cost.cost_for_fighter_int() == 20
 
 
-@pytest.mark.django_db 
+@pytest.mark.django_db
 class TestContentWeaponAccessoryCostMethods:
     """Test cost methods on ContentWeaponAccessory model."""
 
     def test_cost_int(self):
         """Test cost_int returns the integer cost."""
-        accessory = ContentWeaponAccessory.objects.create(
-            name="Test Scope",
-            cost=15
-        )
+        accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
         assert accessory.cost_int() == 15
 
     def test_cost_display(self):
         """Test cost_display formats cost with currency symbol."""
-        accessory = ContentWeaponAccessory.objects.create(
-            name="Test Scope",
-            cost=15
-        )
+        accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
         assert accessory.cost_display() == "15¢"
 
     def test_cost_display_negative(self):
         """Test cost_display with negative cost."""
         accessory = ContentWeaponAccessory.objects.create(
-            name="Discount Scope",
-            cost=-5
+            name="Discount Scope", cost=-5
         )
         assert accessory.cost_display() == "-5¢"
 
@@ -279,22 +243,19 @@ class TestContentWeaponAccessoryCostMethods:
             type="Test Fighter",
             category=FighterCategoryChoices.GANGER,
             house=house,
-            base_cost=50
+            base_cost=50,
         )
-        accessory = ContentWeaponAccessory.objects.create(
-            name="Test Scope",
-            cost=15
-        )
-        
+        accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
+
         # Create override
         ContentFighterEquipmentListWeaponAccessory.objects.create(
-            fighter=fighter,
-            weapon_accessory=accessory,
-            cost=10
+            fighter=fighter, weapon_accessory=accessory, cost=10
         )
-        
+
         # Get accessory with annotation
-        accessory_with_cost = ContentWeaponAccessory.objects.with_cost_for_fighter(fighter).get(pk=accessory.pk)
+        accessory_with_cost = ContentWeaponAccessory.objects.with_cost_for_fighter(
+            fighter
+        ).get(pk=accessory.pk)
         assert accessory_with_cost.cost_for_fighter_int() == 10
 
 
@@ -310,29 +271,20 @@ class TestContentEquipmentUpgradeCostMethods:
         equipment = ContentEquipment.objects.create(
             name="Cyberteknika",
             category=category,
-            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE
+            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE,
         )
-        
+
         # Create upgrades with cumulative costs
         upgrade1 = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment,
-            name="Basic",
-            position=1,
-            cost=10
+            equipment=equipment, name="Basic", position=1, cost=10
         )
         upgrade2 = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment,
-            name="Advanced",
-            position=2,
-            cost=15
+            equipment=equipment, name="Advanced", position=2, cost=15
         )
         upgrade3 = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment,
-            name="Master",
-            position=3,
-            cost=20
+            equipment=equipment, name="Master", position=3, cost=20
         )
-        
+
         assert upgrade1.cost_int() == 10  # Just upgrade1
         assert upgrade2.cost_int() == 25  # upgrade1 + upgrade2
         assert upgrade3.cost_int() == 45  # upgrade1 + upgrade2 + upgrade3
@@ -345,16 +297,13 @@ class TestContentEquipmentUpgradeCostMethods:
         equipment = ContentEquipment.objects.create(
             name="Gene-smithing",
             category=category,
-            upgrade_mode=ContentEquipment.UpgradeMode.MULTI
+            upgrade_mode=ContentEquipment.UpgradeMode.MULTI,
         )
-        
+
         upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment,
-            name="Enhanced Reflexes",
-            position=1,
-            cost=30
+            equipment=equipment, name="Enhanced Reflexes", position=1, cost=30
         )
-        
+
         assert upgrade.cost_int() == 30
 
     def test_cost_display_with_sign(self):
@@ -365,23 +314,16 @@ class TestContentEquipmentUpgradeCostMethods:
         equipment = ContentEquipment.objects.create(
             name="Test Equipment",
             category=category,
-            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE
+            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE,
         )
         upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment,
-            name="Upgrade",
-            position=1,
-            cost=15
+            equipment=equipment, name="Upgrade", position=1, cost=15
         )
         assert upgrade.cost_display() == "+15¢"
 
     def test_cost_display_unsaved(self):
         """Test cost_display on unsaved upgrade uses direct cost."""
-        upgrade = ContentEquipmentUpgrade(
-            name="Test Upgrade",
-            cost=25,
-            position=1
-        )
+        upgrade = ContentEquipmentUpgrade(name="Test Upgrade", cost=25, position=1)
         assert upgrade.cost_display() == "+25¢"
 
 
@@ -393,48 +335,38 @@ class TestContentFighterEquipmentListItemCostMethods:
         """Test cost_int returns the cost."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category
+            name="Test Equipment", category=category
         )
-        
+
         list_item = ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter,
-            equipment=equipment,
-            cost=45
+            fighter=fighter, equipment=equipment, cost=45
         )
-        
+
         assert list_item.cost_int() == 45
 
     def test_cost_display(self):
         """Test cost_display formats with currency symbol."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category
+            name="Test Equipment", category=category
         )
-        
+
         list_item = ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter,
-            equipment=equipment,
-            cost=45
+            fighter=fighter, equipment=equipment, cost=45
         )
-        
+
         assert list_item.cost_display() == "45¢"
 
 
@@ -446,42 +378,32 @@ class TestContentFighterEquipmentListWeaponAccessoryCostMethods:
         """Test cost_int returns the cost."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         accessory = ContentWeaponAccessory.objects.create(
-            name="Test Accessory",
-            cost=20
+            name="Test Accessory", cost=20
         )
-        
+
         list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
-            fighter=fighter,
-            weapon_accessory=accessory,
-            cost=15
+            fighter=fighter, weapon_accessory=accessory, cost=15
         )
-        
+
         assert list_item.cost_int() == 15
 
     def test_cost_display(self):
         """Test cost_display formats with currency symbol."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         accessory = ContentWeaponAccessory.objects.create(
-            name="Test Accessory",
-            cost=20
+            name="Test Accessory", cost=20
         )
-        
+
         list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
-            fighter=fighter,
-            weapon_accessory=accessory,
-            cost=15
+            fighter=fighter, weapon_accessory=accessory, cost=15
         )
-        
+
         assert list_item.cost_display() == "15¢"
 
 
@@ -493,60 +415,44 @@ class TestContentFighterEquipmentListUpgradeCostMethods:
         """Test cost_int returns the cost."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category
+            name="Test Equipment", category=category
         )
         upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment,
-            name="Test Upgrade",
-            position=1,
-            cost=30
+            equipment=equipment, name="Test Upgrade", position=1, cost=30
         )
-        
+
         list_item = ContentFighterEquipmentListUpgrade.objects.create(
-            fighter=fighter,
-            upgrade=upgrade,
-            cost=25
+            fighter=fighter, upgrade=upgrade, cost=25
         )
-        
+
         assert list_item.cost_int() == 25
 
     def test_cost_display(self):
         """Test cost_display formats with currency symbol."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category
+            name="Test Equipment", category=category
         )
         upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment,
-            name="Test Upgrade",
-            position=1,
-            cost=30
+            equipment=equipment, name="Test Upgrade", position=1, cost=30
         )
-        
+
         list_item = ContentFighterEquipmentListUpgrade.objects.create(
-            fighter=fighter,
-            upgrade=upgrade,
-            cost=25
+            fighter=fighter, upgrade=upgrade, cost=25
         )
-        
+
         assert list_item.cost_display() == "25¢"
 
 
@@ -558,46 +464,36 @@ class TestContentFighterDefaultAssignmentCostMethods:
         """Test cost_int returns the cost."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category
+            name="Test Equipment", category=category
         )
-        
+
         assignment = ContentFighterDefaultAssignment.objects.create(
-            fighter=fighter,
-            equipment=equipment,
-            cost=35
+            fighter=fighter, equipment=equipment, cost=35
         )
-        
+
         assert assignment.cost_int() == 35
 
     def test_cost_display(self):
         """Test cost_display formats with currency symbol."""
         house = ContentHouse.objects.create(name="Test House")
         fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house
+            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
         )
         category = ContentEquipmentCategory.objects.create(
             name="Test Category", group="Gear"
         )
         equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category
+            name="Test Equipment", category=category
         )
-        
+
         assignment = ContentFighterDefaultAssignment.objects.create(
-            fighter=fighter,
-            equipment=equipment,
-            cost=0
+            fighter=fighter, equipment=equipment, cost=0
         )
-        
+
         assert assignment.cost_display() == "0¢"

--- a/gyrinx/content/tests/test_cost_methods.py
+++ b/gyrinx/content/tests/test_cost_methods.py
@@ -23,477 +23,519 @@ from gyrinx.content.models import (
 from gyrinx.models import FighterCategoryChoices
 
 
-@pytest.mark.django_db
-class TestContentEquipmentCostMethods:
-    """Test cost methods on ContentEquipment model."""
-
-    def test_cost_int_with_integer_string(self):
-        """Test cost_int with a valid integer string."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost="100"
-        )
-        assert equipment.cost_int() == 100
-
-    def test_cost_int_with_empty_string(self):
-        """Test cost_int with empty string returns 0."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost=""
-        )
-        assert equipment.cost_int() == 0
-
-    def test_cost_int_with_non_integer_string(self):
-        """Test cost_int with non-integer string returns 0."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost="2D6X10"
-        )
-        assert equipment.cost_int() == 0
-
-    def test_cost_display_with_integer_cost(self):
-        """Test cost_display with integer cost shows currency symbol."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost="50"
-        )
-        assert equipment.cost_display() == "50¢"
-
-    def test_cost_display_with_non_integer_cost(self):
-        """Test cost_display with non-integer cost shows as-is."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost="2D6X10"
-        )
-        assert equipment.cost_display() == "2D6X10"
-
-    def test_cost_display_with_empty_cost(self):
-        """Test cost_display with empty cost returns empty string."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost=""
-        )
-        assert equipment.cost_display() == ""
-
-    def test_cost_for_fighter_int_without_annotation(self):
-        """Test cost_for_fighter_int raises error without annotation."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost="100"
-        )
-        with pytest.raises(AttributeError, match="cost_for_fighter not available"):
-            equipment.cost_for_fighter_int()
-
-    def test_cost_for_fighter_int_with_annotation(self):
-        """Test cost_for_fighter_int with fighter-specific cost override."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house,
-            base_cost=50,
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category, cost="100"
-        )
-
-        # Create override
-        ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter, equipment=equipment, cost=75
-        )
-
-        # Get equipment with annotation
-        equipment_with_cost = ContentEquipment.objects.with_cost_for_fighter(
-            fighter
-        ).get(pk=equipment.pk)
-        assert equipment_with_cost.cost_for_fighter_int() == 75
+# ContentEquipment cost methods tests
 
 
 @pytest.mark.django_db
-class TestContentWeaponProfileCostMethods:
-    """Test cost methods on ContentWeaponProfile model."""
-
-    def test_cost_int(self):
-        """Test cost_int returns the integer cost."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Weapons & Ammo"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Weapon", category=category
-        )
-        profile = ContentWeaponProfile.objects.create(
-            equipment=equipment, name="Long Range", cost=25
-        )
-        assert profile.cost_int() == 25
-
-    def test_cost_display_for_standard_profile(self):
-        """Test cost_display for standard (unnamed) profile returns empty."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Weapons & Ammo"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Weapon", category=category
-        )
-        profile = ContentWeaponProfile.objects.create(
-            equipment=equipment,
-            name="",  # Standard profile
-            cost=0,
-        )
-        assert profile.cost_display() == ""
-
-    def test_cost_display_for_named_profile_with_positive_cost(self):
-        """Test cost_display for named profile shows cost with sign."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Weapons & Ammo"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Weapon", category=category
-        )
-        profile = ContentWeaponProfile.objects.create(
-            equipment=equipment, name="Long Range", cost=25
-        )
-        assert profile.cost_display() == "+25¢"
-
-    def test_cost_display_for_named_profile_with_zero_cost(self):
-        """Test cost_display for named profile with zero cost returns empty."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Weapons & Ammo"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Weapon", category=category
-        )
-        profile = ContentWeaponProfile.objects.create(
-            equipment=equipment, name="Special", cost=0
-        )
-        assert profile.cost_display() == ""
-
-    def test_cost_for_fighter_int_with_override(self):
-        """Test cost_for_fighter_int with fighter-specific override."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house,
-            base_cost=50,
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Weapons & Ammo"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Weapon", category=category
-        )
-        profile = ContentWeaponProfile.objects.create(
-            equipment=equipment, name="Long Range", cost=25
-        )
-
-        # Create override
-        ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter, equipment=equipment, weapon_profile=profile, cost=20
-        )
-
-        # Get profile with annotation
-        profile_with_cost = ContentWeaponProfile.objects.with_cost_for_fighter(
-            fighter
-        ).get(pk=profile.pk)
-        assert profile_with_cost.cost_for_fighter_int() == 20
+def test_content_equipment_cost_int_with_integer_string():
+    """Test cost_int with a valid integer string."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost="100"
+    )
+    assert equipment.cost_int() == 100
 
 
 @pytest.mark.django_db
-class TestContentWeaponAccessoryCostMethods:
-    """Test cost methods on ContentWeaponAccessory model."""
-
-    def test_cost_int(self):
-        """Test cost_int returns the integer cost."""
-        accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
-        assert accessory.cost_int() == 15
-
-    def test_cost_display(self):
-        """Test cost_display formats cost with currency symbol."""
-        accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
-        assert accessory.cost_display() == "15¢"
-
-    def test_cost_display_negative(self):
-        """Test cost_display with negative cost."""
-        accessory = ContentWeaponAccessory.objects.create(
-            name="Discount Scope", cost=-5
-        )
-        assert accessory.cost_display() == "-5¢"
-
-    def test_cost_for_fighter_int_with_override(self):
-        """Test cost_for_fighter_int with fighter-specific override."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter",
-            category=FighterCategoryChoices.GANGER,
-            house=house,
-            base_cost=50,
-        )
-        accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
-
-        # Create override
-        ContentFighterEquipmentListWeaponAccessory.objects.create(
-            fighter=fighter, weapon_accessory=accessory, cost=10
-        )
-
-        # Get accessory with annotation
-        accessory_with_cost = ContentWeaponAccessory.objects.with_cost_for_fighter(
-            fighter
-        ).get(pk=accessory.pk)
-        assert accessory_with_cost.cost_for_fighter_int() == 10
+def test_content_equipment_cost_int_with_empty_string():
+    """Test cost_int with empty string returns 0."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost=""
+    )
+    assert equipment.cost_int() == 0
 
 
 @pytest.mark.django_db
-class TestContentEquipmentUpgradeCostMethods:
-    """Test cost methods on ContentEquipmentUpgrade model."""
-
-    def test_cost_int_single_mode(self):
-        """Test cost_int in SINGLE mode sums all upgrades up to position."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Cyberteknika",
-            category=category,
-            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE,
-        )
-
-        # Create upgrades with cumulative costs
-        upgrade1 = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name="Basic", position=1, cost=10
-        )
-        upgrade2 = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name="Advanced", position=2, cost=15
-        )
-        upgrade3 = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name="Master", position=3, cost=20
-        )
-
-        assert upgrade1.cost_int() == 10  # Just upgrade1
-        assert upgrade2.cost_int() == 25  # upgrade1 + upgrade2
-        assert upgrade3.cost_int() == 45  # upgrade1 + upgrade2 + upgrade3
-
-    def test_cost_int_multi_mode(self):
-        """Test cost_int in MULTI mode returns direct cost."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Gene-smithing",
-            category=category,
-            upgrade_mode=ContentEquipment.UpgradeMode.MULTI,
-        )
-
-        upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name="Enhanced Reflexes", position=1, cost=30
-        )
-
-        assert upgrade.cost_int() == 30
-
-    def test_cost_display_with_sign(self):
-        """Test cost_display shows sign for upgrades."""
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment",
-            category=category,
-            upgrade_mode=ContentEquipment.UpgradeMode.SINGLE,
-        )
-        upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name="Upgrade", position=1, cost=15
-        )
-        assert upgrade.cost_display() == "+15¢"
-
-    def test_cost_display_unsaved(self):
-        """Test cost_display on unsaved upgrade uses direct cost."""
-        upgrade = ContentEquipmentUpgrade(name="Test Upgrade", cost=25, position=1)
-        assert upgrade.cost_display() == "+25¢"
+def test_content_equipment_cost_int_with_non_integer_string():
+    """Test cost_int with non-integer string returns 0."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost="2D6X10"
+    )
+    assert equipment.cost_int() == 0
 
 
 @pytest.mark.django_db
-class TestContentFighterEquipmentListItemCostMethods:
-    """Test cost methods on ContentFighterEquipmentListItem model."""
-
-    def test_cost_int(self):
-        """Test cost_int returns the cost."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category
-        )
-
-        list_item = ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter, equipment=equipment, cost=45
-        )
-
-        assert list_item.cost_int() == 45
-
-    def test_cost_display(self):
-        """Test cost_display formats with currency symbol."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category
-        )
-
-        list_item = ContentFighterEquipmentListItem.objects.create(
-            fighter=fighter, equipment=equipment, cost=45
-        )
-
-        assert list_item.cost_display() == "45¢"
+def test_content_equipment_cost_display_with_integer_cost():
+    """Test cost_display with integer cost shows currency symbol."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost="50"
+    )
+    assert equipment.cost_display() == "50¢"
 
 
 @pytest.mark.django_db
-class TestContentFighterEquipmentListWeaponAccessoryCostMethods:
-    """Test cost methods on ContentFighterEquipmentListWeaponAccessory model."""
-
-    def test_cost_int(self):
-        """Test cost_int returns the cost."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        accessory = ContentWeaponAccessory.objects.create(
-            name="Test Accessory", cost=20
-        )
-
-        list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
-            fighter=fighter, weapon_accessory=accessory, cost=15
-        )
-
-        assert list_item.cost_int() == 15
-
-    def test_cost_display(self):
-        """Test cost_display formats with currency symbol."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        accessory = ContentWeaponAccessory.objects.create(
-            name="Test Accessory", cost=20
-        )
-
-        list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
-            fighter=fighter, weapon_accessory=accessory, cost=15
-        )
-
-        assert list_item.cost_display() == "15¢"
+def test_content_equipment_cost_display_with_non_integer_cost():
+    """Test cost_display with non-integer cost shows as-is."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost="2D6X10"
+    )
+    assert equipment.cost_display() == "2D6X10"
 
 
 @pytest.mark.django_db
-class TestContentFighterEquipmentListUpgradeCostMethods:
-    """Test cost methods on ContentFighterEquipmentListUpgrade model."""
-
-    def test_cost_int(self):
-        """Test cost_int returns the cost."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category
-        )
-        upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name="Test Upgrade", position=1, cost=30
-        )
-
-        list_item = ContentFighterEquipmentListUpgrade.objects.create(
-            fighter=fighter, upgrade=upgrade, cost=25
-        )
-
-        assert list_item.cost_int() == 25
-
-    def test_cost_display(self):
-        """Test cost_display formats with currency symbol."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category
-        )
-        upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name="Test Upgrade", position=1, cost=30
-        )
-
-        list_item = ContentFighterEquipmentListUpgrade.objects.create(
-            fighter=fighter, upgrade=upgrade, cost=25
-        )
-
-        assert list_item.cost_display() == "25¢"
+def test_content_equipment_cost_display_with_empty_cost():
+    """Test cost_display with empty cost returns empty string."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost=""
+    )
+    assert equipment.cost_display() == ""
 
 
 @pytest.mark.django_db
-class TestContentFighterDefaultAssignmentCostMethods:
-    """Test cost methods on ContentFighterDefaultAssignment model."""
+def test_content_equipment_cost_for_fighter_int_without_annotation():
+    """Test cost_for_fighter_int raises error without annotation."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost="100"
+    )
+    with pytest.raises(AttributeError, match="cost_for_fighter not available"):
+        equipment.cost_for_fighter_int()
 
-    def test_cost_int(self):
-        """Test cost_int returns the cost."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category
-        )
 
-        assignment = ContentFighterDefaultAssignment.objects.create(
-            fighter=fighter, equipment=equipment, cost=35
-        )
+@pytest.mark.django_db
+def test_content_equipment_cost_for_fighter_int_with_annotation():
+    """Test cost_for_fighter_int with fighter-specific cost override."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter",
+        category=FighterCategoryChoices.GANGER,
+        house=house,
+        base_cost=50,
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category, cost="100"
+    )
 
-        assert assignment.cost_int() == 35
+    # Create override
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=fighter, equipment=equipment, cost=75
+    )
 
-    def test_cost_display(self):
-        """Test cost_display formats with currency symbol."""
-        house = ContentHouse.objects.create(name="Test House")
-        fighter = ContentFighter.objects.create(
-            type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
-        )
-        category = ContentEquipmentCategory.objects.create(
-            name="Test Category", group="Gear"
-        )
-        equipment = ContentEquipment.objects.create(
-            name="Test Equipment", category=category
-        )
+    # Get equipment with annotation
+    equipment_with_cost = ContentEquipment.objects.with_cost_for_fighter(
+        fighter
+    ).get(pk=equipment.pk)
+    assert equipment_with_cost.cost_for_fighter_int() == 75
 
-        assignment = ContentFighterDefaultAssignment.objects.create(
-            fighter=fighter, equipment=equipment, cost=0
-        )
 
-        assert assignment.cost_display() == "0¢"
+# ContentWeaponProfile cost methods tests
+
+
+@pytest.mark.django_db
+def test_content_weapon_profile_cost_int():
+    """Test cost_int returns the integer cost."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Weapons & Ammo"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Weapon", category=category
+    )
+    profile = ContentWeaponProfile.objects.create(
+        equipment=equipment, name="Long Range", cost=25
+    )
+    assert profile.cost_int() == 25
+
+
+@pytest.mark.django_db
+def test_content_weapon_profile_cost_display_for_standard_profile():
+    """Test cost_display for standard (unnamed) profile returns empty."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Weapons & Ammo"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Weapon", category=category
+    )
+    profile = ContentWeaponProfile.objects.create(
+        equipment=equipment,
+        name="",  # Standard profile
+        cost=0,
+    )
+    assert profile.cost_display() == ""
+
+
+@pytest.mark.django_db
+def test_content_weapon_profile_cost_display_for_named_profile_with_positive_cost():
+    """Test cost_display for named profile shows cost with sign."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Weapons & Ammo"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Weapon", category=category
+    )
+    profile = ContentWeaponProfile.objects.create(
+        equipment=equipment, name="Long Range", cost=25
+    )
+    assert profile.cost_display() == "+25¢"
+
+
+@pytest.mark.django_db
+def test_content_weapon_profile_cost_display_for_named_profile_with_zero_cost():
+    """Test cost_display for named profile with zero cost returns empty."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Weapons & Ammo"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Weapon", category=category
+    )
+    profile = ContentWeaponProfile.objects.create(
+        equipment=equipment, name="Special", cost=0
+    )
+    assert profile.cost_display() == ""
+
+
+@pytest.mark.django_db
+def test_content_weapon_profile_cost_for_fighter_int_with_override():
+    """Test cost_for_fighter_int with fighter-specific override."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter",
+        category=FighterCategoryChoices.GANGER,
+        house=house,
+        base_cost=50,
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Weapons & Ammo"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Weapon", category=category
+    )
+    profile = ContentWeaponProfile.objects.create(
+        equipment=equipment, name="Long Range", cost=25
+    )
+
+    # Create override
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=fighter, equipment=equipment, weapon_profile=profile, cost=20
+    )
+
+    # Get profile with annotation
+    profile_with_cost = ContentWeaponProfile.objects.with_cost_for_fighter(
+        fighter
+    ).get(pk=profile.pk)
+    assert profile_with_cost.cost_for_fighter_int() == 20
+
+
+# ContentWeaponAccessory cost methods tests
+
+
+@pytest.mark.django_db
+def test_content_weapon_accessory_cost_int():
+    """Test cost_int returns the integer cost."""
+    accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
+    assert accessory.cost_int() == 15
+
+
+@pytest.mark.django_db
+def test_content_weapon_accessory_cost_display():
+    """Test cost_display formats cost with currency symbol."""
+    accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
+    assert accessory.cost_display() == "15¢"
+
+
+@pytest.mark.django_db
+def test_content_weapon_accessory_cost_display_negative():
+    """Test cost_display with negative cost."""
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Discount Scope", cost=-5
+    )
+    assert accessory.cost_display() == "-5¢"
+
+
+@pytest.mark.django_db
+def test_content_weapon_accessory_cost_for_fighter_int_with_override():
+    """Test cost_for_fighter_int with fighter-specific override."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter",
+        category=FighterCategoryChoices.GANGER,
+        house=house,
+        base_cost=50,
+    )
+    accessory = ContentWeaponAccessory.objects.create(name="Test Scope", cost=15)
+
+    # Create override
+    ContentFighterEquipmentListWeaponAccessory.objects.create(
+        fighter=fighter, weapon_accessory=accessory, cost=10
+    )
+
+    # Get accessory with annotation
+    accessory_with_cost = ContentWeaponAccessory.objects.with_cost_for_fighter(
+        fighter
+    ).get(pk=accessory.pk)
+    assert accessory_with_cost.cost_for_fighter_int() == 10
+
+
+# ContentEquipmentUpgrade cost methods tests
+
+
+@pytest.mark.django_db
+def test_content_equipment_upgrade_cost_int_single_mode():
+    """Test cost_int in SINGLE mode sums all upgrades up to position."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Cyberteknika",
+        category=category,
+        upgrade_mode=ContentEquipment.UpgradeMode.SINGLE,
+    )
+
+    # Create upgrades with cumulative costs
+    upgrade1 = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Basic", position=1, cost=10
+    )
+    upgrade2 = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Advanced", position=2, cost=15
+    )
+    upgrade3 = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Master", position=3, cost=20
+    )
+
+    assert upgrade1.cost_int() == 10  # Just upgrade1
+    assert upgrade2.cost_int() == 25  # upgrade1 + upgrade2
+    assert upgrade3.cost_int() == 45  # upgrade1 + upgrade2 + upgrade3
+
+
+@pytest.mark.django_db
+def test_content_equipment_upgrade_cost_int_multi_mode():
+    """Test cost_int in MULTI mode returns direct cost."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Gene-smithing",
+        category=category,
+        upgrade_mode=ContentEquipment.UpgradeMode.MULTI,
+    )
+
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Enhanced Reflexes", position=1, cost=30
+    )
+
+    assert upgrade.cost_int() == 30
+
+
+@pytest.mark.django_db
+def test_content_equipment_upgrade_cost_display_with_sign():
+    """Test cost_display shows sign for upgrades."""
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment",
+        category=category,
+        upgrade_mode=ContentEquipment.UpgradeMode.SINGLE,
+    )
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Upgrade", position=1, cost=15
+    )
+    assert upgrade.cost_display() == "+15¢"
+
+
+@pytest.mark.django_db
+def test_content_equipment_upgrade_cost_display_unsaved():
+    """Test cost_display on unsaved upgrade uses direct cost."""
+    upgrade = ContentEquipmentUpgrade(name="Test Upgrade", cost=25, position=1)
+    assert upgrade.cost_display() == "+25¢"
+
+
+# ContentFighterEquipmentListItem cost methods tests
+
+
+@pytest.mark.django_db
+def test_content_fighter_equipment_list_item_cost_int():
+    """Test cost_int returns the cost."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category
+    )
+
+    list_item = ContentFighterEquipmentListItem.objects.create(
+        fighter=fighter, equipment=equipment, cost=45
+    )
+
+    assert list_item.cost_int() == 45
+
+
+@pytest.mark.django_db
+def test_content_fighter_equipment_list_item_cost_display():
+    """Test cost_display formats with currency symbol."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category
+    )
+
+    list_item = ContentFighterEquipmentListItem.objects.create(
+        fighter=fighter, equipment=equipment, cost=45
+    )
+
+    assert list_item.cost_display() == "45¢"
+
+
+# ContentFighterEquipmentListWeaponAccessory cost methods tests
+
+
+@pytest.mark.django_db
+def test_content_fighter_equipment_list_weapon_accessory_cost_int():
+    """Test cost_int returns the cost."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Test Accessory", cost=20
+    )
+
+    list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
+        fighter=fighter, weapon_accessory=accessory, cost=15
+    )
+
+    assert list_item.cost_int() == 15
+
+
+@pytest.mark.django_db
+def test_content_fighter_equipment_list_weapon_accessory_cost_display():
+    """Test cost_display formats with currency symbol."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Test Accessory", cost=20
+    )
+
+    list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
+        fighter=fighter, weapon_accessory=accessory, cost=15
+    )
+
+    assert list_item.cost_display() == "15¢"
+
+
+# ContentFighterEquipmentListUpgrade cost methods tests
+
+
+@pytest.mark.django_db
+def test_content_fighter_equipment_list_upgrade_cost_int():
+    """Test cost_int returns the cost."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category
+    )
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Test Upgrade", position=1, cost=30
+    )
+
+    list_item = ContentFighterEquipmentListUpgrade.objects.create(
+        fighter=fighter, upgrade=upgrade, cost=25
+    )
+
+    assert list_item.cost_int() == 25
+
+
+@pytest.mark.django_db
+def test_content_fighter_equipment_list_upgrade_cost_display():
+    """Test cost_display formats with currency symbol."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category
+    )
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Test Upgrade", position=1, cost=30
+    )
+
+    list_item = ContentFighterEquipmentListUpgrade.objects.create(
+        fighter=fighter, upgrade=upgrade, cost=25
+    )
+
+    assert list_item.cost_display() == "25¢"
+
+
+# ContentFighterDefaultAssignment cost methods tests
+
+
+@pytest.mark.django_db
+def test_content_fighter_default_assignment_cost_int():
+    """Test cost_int returns the cost."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category
+    )
+
+    assignment = ContentFighterDefaultAssignment.objects.create(
+        fighter=fighter, equipment=equipment, cost=35
+    )
+
+    assert assignment.cost_int() == 35
+
+
+@pytest.mark.django_db
+def test_content_fighter_default_assignment_cost_display():
+    """Test cost_display formats with currency symbol."""
+    house = ContentHouse.objects.create(name="Test House")
+    fighter = ContentFighter.objects.create(
+        type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
+    )
+    category = ContentEquipmentCategory.objects.create(
+        name="Test Category", group="Gear"
+    )
+    equipment = ContentEquipment.objects.create(
+        name="Test Equipment", category=category
+    )
+
+    assignment = ContentFighterDefaultAssignment.objects.create(
+        fighter=fighter, equipment=equipment, cost=0
+    )
+
+    assert assignment.cost_display() == "0¢"

--- a/gyrinx/content/tests/test_cost_methods.py
+++ b/gyrinx/content/tests/test_cost_methods.py
@@ -134,9 +134,9 @@ def test_content_equipment_cost_for_fighter_int_with_annotation():
     )
 
     # Get equipment with annotation
-    equipment_with_cost = ContentEquipment.objects.with_cost_for_fighter(
-        fighter
-    ).get(pk=equipment.pk)
+    equipment_with_cost = ContentEquipment.objects.with_cost_for_fighter(fighter).get(
+        pk=equipment.pk
+    )
     assert equipment_with_cost.cost_for_fighter_int() == 75
 
 
@@ -149,9 +149,7 @@ def test_content_weapon_profile_cost_int():
     category = ContentEquipmentCategory.objects.create(
         name="Test Category", group="Weapons & Ammo"
     )
-    equipment = ContentEquipment.objects.create(
-        name="Test Weapon", category=category
-    )
+    equipment = ContentEquipment.objects.create(name="Test Weapon", category=category)
     profile = ContentWeaponProfile.objects.create(
         equipment=equipment, name="Long Range", cost=25
     )
@@ -164,9 +162,7 @@ def test_content_weapon_profile_cost_display_for_standard_profile():
     category = ContentEquipmentCategory.objects.create(
         name="Test Category", group="Weapons & Ammo"
     )
-    equipment = ContentEquipment.objects.create(
-        name="Test Weapon", category=category
-    )
+    equipment = ContentEquipment.objects.create(name="Test Weapon", category=category)
     profile = ContentWeaponProfile.objects.create(
         equipment=equipment,
         name="",  # Standard profile
@@ -181,9 +177,7 @@ def test_content_weapon_profile_cost_display_for_named_profile_with_positive_cos
     category = ContentEquipmentCategory.objects.create(
         name="Test Category", group="Weapons & Ammo"
     )
-    equipment = ContentEquipment.objects.create(
-        name="Test Weapon", category=category
-    )
+    equipment = ContentEquipment.objects.create(name="Test Weapon", category=category)
     profile = ContentWeaponProfile.objects.create(
         equipment=equipment, name="Long Range", cost=25
     )
@@ -196,9 +190,7 @@ def test_content_weapon_profile_cost_display_for_named_profile_with_zero_cost():
     category = ContentEquipmentCategory.objects.create(
         name="Test Category", group="Weapons & Ammo"
     )
-    equipment = ContentEquipment.objects.create(
-        name="Test Weapon", category=category
-    )
+    equipment = ContentEquipment.objects.create(name="Test Weapon", category=category)
     profile = ContentWeaponProfile.objects.create(
         equipment=equipment, name="Special", cost=0
     )
@@ -218,9 +210,7 @@ def test_content_weapon_profile_cost_for_fighter_int_with_override():
     category = ContentEquipmentCategory.objects.create(
         name="Test Category", group="Weapons & Ammo"
     )
-    equipment = ContentEquipment.objects.create(
-        name="Test Weapon", category=category
-    )
+    equipment = ContentEquipment.objects.create(name="Test Weapon", category=category)
     profile = ContentWeaponProfile.objects.create(
         equipment=equipment, name="Long Range", cost=25
     )
@@ -231,9 +221,9 @@ def test_content_weapon_profile_cost_for_fighter_int_with_override():
     )
 
     # Get profile with annotation
-    profile_with_cost = ContentWeaponProfile.objects.with_cost_for_fighter(
-        fighter
-    ).get(pk=profile.pk)
+    profile_with_cost = ContentWeaponProfile.objects.with_cost_for_fighter(fighter).get(
+        pk=profile.pk
+    )
     assert profile_with_cost.cost_for_fighter_int() == 20
 
 
@@ -257,9 +247,7 @@ def test_content_weapon_accessory_cost_display():
 @pytest.mark.django_db
 def test_content_weapon_accessory_cost_display_negative():
     """Test cost_display with negative cost."""
-    accessory = ContentWeaponAccessory.objects.create(
-        name="Discount Scope", cost=-5
-    )
+    accessory = ContentWeaponAccessory.objects.create(name="Discount Scope", cost=-5)
     assert accessory.cost_display() == "-5¢"
 
 
@@ -416,9 +404,7 @@ def test_content_fighter_equipment_list_weapon_accessory_cost_int():
     fighter = ContentFighter.objects.create(
         type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
     )
-    accessory = ContentWeaponAccessory.objects.create(
-        name="Test Accessory", cost=20
-    )
+    accessory = ContentWeaponAccessory.objects.create(name="Test Accessory", cost=20)
 
     list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
         fighter=fighter, weapon_accessory=accessory, cost=15
@@ -434,9 +420,7 @@ def test_content_fighter_equipment_list_weapon_accessory_cost_display():
     fighter = ContentFighter.objects.create(
         type="Test Fighter", category=FighterCategoryChoices.GANGER, house=house
     )
-    accessory = ContentWeaponAccessory.objects.create(
-        name="Test Accessory", cost=20
-    )
+    accessory = ContentWeaponAccessory.objects.create(name="Test Accessory", cost=20)
 
     list_item = ContentFighterEquipmentListWeaponAccessory.objects.create(
         fighter=fighter, weapon_accessory=accessory, cost=15

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running all formatters..."
+
+# Run Python formatters
+echo "Running ruff..."
+ruff format .
+ruff check --fix .
+
+# Run npm formatters (includes prettier for JS, SCSS, JSON, YAML, Markdown)
+echo "Running npm fmt..."
+npm run fmt
+
+# Run Django template formatter
+echo "Running djlint..."
+djlint --profile=django --reformat .
+
+echo "All formatters completed!"


### PR DESCRIPTION
Closes #364

## Summary

Created a `CostMixin` to abstract repeated cost calculation logic across multiple models.

## Changes

- Added `CostMixin` and `FighterCostMixin` to `gyrinx/models.py`
- Refactored 8 content models to use the mixins
- Removed ~140 lines of duplicated cost calculation code
- Preserved special behavior for `ContentWeaponProfile` and `ContentEquipmentUpgrade`
- Added comprehensive tests for cost methods

## Test Plan

- [ ] Run existing tests to ensure no functionality is broken
- [ ] Run new `test_cost_methods.py` tests
- [ ] Manually verify cost display in the UI

Generated with [Claude Code](https://claude.ai/code)