### PR TITLE
feat: add captured fighters to Assets & Resources box on gang page

### DIFF
--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -104,9 +104,19 @@ body {
     position: relative;
 }
 
+// Links
+
 a[href="#"][data-bs-toggle="tooltip"] {
     cursor: help;
 }
+
+.link-sm {
+    @extend .link-underline-opacity-25;
+    @extend .link-underline-opacity-100-hover;
+    @extend .fs-7;
+}
+
+// Tables
 
 .table-group-divider {
     // This is a custom class to add a border between table groups. The !important
@@ -126,6 +136,8 @@ a[href="#"][data-bs-toggle="tooltip"] {
     }
 }
 
+// Forms
+
 fieldset legend {
     font-size: $font-size-base;
 }
@@ -134,20 +146,28 @@ label {
     margin-bottom: 0.25rem;
 }
 
+// Menu
+
 .dropdown-menu-mw {
     min-width: 25em;
     width: 100%;
     max-width: 35em;
 }
 
+// Spacing
+
 .mb-last-0 > :last-child {
     margin-bottom: 0 !important;
 }
+
+// Custom
 
 .errorlist {
     @extend .list-unstyled;
     color: var(--bs-danger);
 }
+
+// Flash
 
 @keyframes flash-warn {
     from {
@@ -162,6 +182,8 @@ label {
 .flash-warn td {
     animation: flash-warn 2s ease-in;
 }
+
+// Images
 
 img {
     max-width: 100%;

--- a/gyrinx/core/templates/core/includes/list_campaign_actions.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_actions.html
@@ -37,7 +37,7 @@
                 </table>
                 <div class="text-center">
                     <a href="{% url 'core:campaign-actions' list.campaign.id %}?gang={{ list.id }}"
-                       class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">
+                       class="link-secondary link-sm">
                         <i class="bi-list-ul" aria-hidden="true"></i> View all actions
                     </a>
                 </div>

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -52,9 +52,38 @@
                         </table>
                     </div>
                 {% endif %}
-                {% if not campaign_resources and not held_assets %}
+                {% if captured_fighters %}
                     <div class="col-12">
-                        <p class="text-muted fs-7 mb-0">No assets or resources held.</p>
+                        <h4 class="h6 mb-2 text-muted">Captured Fighters</h4>
+                        <table class="table table-sm mb-0 fs-7">
+                            <tbody>
+                                {% for capture in captured_fighters %}
+                                    <tr>
+                                        <td>
+                                            <strong>{{ capture.fighter.name }}</strong>
+                                            <span class="text-muted">({{ capture.fighter.list.name }})</span>
+                                        </td>
+                                        <td class="text-end">
+                                            <div class="btn-group" role="group">
+                                                <a href="{% url 'core:fighter-sell-to-guilders' list.campaign.id capture.fighter.id %}"
+                                                   class="btn btn-sm btn-outline-secondary">
+                                                    <i class="bi-cash-coin" aria-hidden="true"></i> Sell
+                                                </a>
+                                                <a href="{% url 'core:fighter-return-to-owner' list.campaign.id capture.fighter.id %}"
+                                                   class="btn btn-sm btn-outline-secondary">
+                                                    <i class="bi-arrow-return-left" aria-hidden="true"></i> Ransom
+                                                </a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+                {% if not campaign_resources and not held_assets and not captured_fighters %}
+                    <div class="col-12">
+                        <p class="text-muted fs-7 mb-0">No assets, resources, or captured fighters held.</p>
                     </div>
                 {% endif %}
             </div>

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -20,7 +20,7 @@
                                             {% endif %}
                                         </div>
                                         <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}"
-                                           class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7 ms-2">
+                                           class="icon-link link-secondary link-sm ms-2">
                                             <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
                                         </a>
                                     </div>
@@ -42,7 +42,7 @@
                                         </td>
                                         <td class="text-end">
                                             <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.id %}"
-                                               class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">
+                                               class="icon-link link-secondary link-sm">
                                                 <i class="bi-pencil-square" aria-hidden="true"></i> Modify
                                             </a>
                                         </td>
@@ -63,17 +63,12 @@
                                             <strong>{{ capture.fighter.name }}</strong>
                                             <span class="text-muted">({{ capture.fighter.list.name }})</span>
                                         </td>
-                                        <td class="text-end">
-                                            <div class="btn-group" role="group">
-                                                <a href="{% url 'core:fighter-sell-to-guilders' list.campaign.id capture.fighter.id %}"
-                                                   class="btn btn-sm btn-outline-secondary">
-                                                    <i class="bi-cash-coin" aria-hidden="true"></i> Sell
-                                                </a>
-                                                <a href="{% url 'core:fighter-return-to-owner' list.campaign.id capture.fighter.id %}"
-                                                   class="btn btn-sm btn-outline-secondary">
-                                                    <i class="bi-arrow-return-left" aria-hidden="true"></i> Ransom
-                                                </a>
-                                            </div>
+                                        <td class="text-end fs-7">
+                                            <a href="{% url 'core:fighter-sell-to-guilders' list.campaign.id capture.fighter.id %}"
+                                               class="link-secondary link-sm">Sell</a>
+                                            or
+                                            <a href="{% url 'core:fighter-return-to-owner' list.campaign.id capture.fighter.id %}"
+                                               class="link-secondary link-sm">Ransom</a>
                                         </td>
                                     </tr>
                                 {% endfor %}

--- a/gyrinx/core/tests/test_list_resources_assets.py
+++ b/gyrinx/core/tests/test_list_resources_assets.py
@@ -137,7 +137,9 @@ def test_list_view_no_resources_or_assets_shows_message(django_user_model):
     assert response.status_code == 200
 
     # Check that the empty message is shown
-    assert "No assets or resources held." in response.content.decode()
+    assert (
+        "No assets, resources, or captured fighters held." in response.content.decode()
+    )
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -148,6 +148,12 @@ class ListDetailView(generic.DetailView):
             held_assets = list_obj.held_assets.select_related("asset_type")
             context["held_assets"] = held_assets
 
+            # Get captured fighters held by this list
+            captured_fighters = list_obj.captured_fighters.filter(
+                sold_to_guilders=False
+            ).select_related("fighter", "fighter__list")
+            context["captured_fighters"] = captured_fighters
+
         return context
 
 


### PR DESCRIPTION
- Add captured_fighters to ListDetailView context when in campaign mode
- Display captured fighters in the Assets & Resources section
- Include sell to guilders and ransom/return actions for each captive
- Only show fighters not already sold to guilders

Fixes #392