### PR TITLE
fix: remove sell_assign parameter from weapon profile sell button

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -120,7 +120,7 @@
                                                 <br>
                                                 <i class="bi-dash"></i> {{ profile.name }} (+{{ profile.cost_display }})
                                                 {% if list.status == 'campaign_mode' and list.owner_cached == user and not print %}
-                                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_assign={{ assign.id }}&sell_profile={{ profile.id }}"
+                                                    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?sell_profile={{ profile.id }}"
                                                        class="link-warning">Sell</a>
                                                 {% endif %}
                                             {% endif %}


### PR DESCRIPTION
Fixes #401

When clicking the sell button next to a weapon profile, only the sell_profile parameter should be passed to show just the weapon profile in the sell flow, not the entire assignment.

Generated with [Claude Code](https://claude.ai/code)