### PR TITLE
feat: add gang attributes interface UI

### DIFF
--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -19,16 +19,16 @@ from django.utils.functional import cached_property
 from polymorphic.models import PolymorphicModel
 from simple_history.models import HistoricalRecords
 
+from gyrinx.core.models.base import AppBase
 from gyrinx.models import (
     Base,
     CostMixin,
-    FighterCostMixin,
     FighterCategoryChoices,
+    FighterCostMixin,
     QuerySetOf,
     equipment_category_group_choices,
     format_cost_display,
 )
-from gyrinx.core.models.base import AppBase
 
 ##
 ## Content Models
@@ -1896,7 +1896,7 @@ class ContentAttributeValue(Content):
     history = HistoricalRecords()
 
     def __str__(self):
-        return f"{self.attribute.name}: {self.name}"
+        return self.name
 
     class Meta:
         verbose_name = "Gang Attribute Value"

--- a/gyrinx/content/tests/test_attributes.py
+++ b/gyrinx/content/tests/test_attributes.py
@@ -52,7 +52,7 @@ def test_content_attribute_value_creation():
 
     assert value1.attribute == attribute
     assert value1.name == "Law Abiding"
-    assert str(value1) == "Alignment: Law Abiding"
+    assert str(value1) == "Law Abiding"
 
     assert attribute.values.count() == 2
     assert list(attribute.values.values_list("name", flat=True)) == [

--- a/gyrinx/core/forms/attribute.py
+++ b/gyrinx/core/forms/attribute.py
@@ -35,7 +35,7 @@ class ListAttributeForm(forms.Form):
                 widget=forms.RadioSelect,
                 required=False,
                 initial=current_assignments.first() if current_assignments else None,
-                label=f"Select {self.attribute.name}",
+                label="",
             )
         else:
             # Multi select - use checkboxes
@@ -44,7 +44,7 @@ class ListAttributeForm(forms.Form):
                 widget=forms.CheckboxSelectMultiple,
                 required=False,
                 initial=list(current_assignments),
-                label=f"Select {self.attribute.name} (multiple allowed)",
+                label="",
             )
 
     def clean(self):

--- a/gyrinx/core/forms/attribute.py
+++ b/gyrinx/core/forms/attribute.py
@@ -1,0 +1,108 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from gyrinx.content.models import ContentAttributeValue
+from gyrinx.core.models.list import ListAttributeAssignment
+
+
+class ListAttributeForm(forms.Form):
+    """Form for managing list attribute assignments."""
+
+    def __init__(self, *args, **kwargs):
+        self.list_obj = kwargs.pop("list_obj")
+        self.attribute = kwargs.pop("attribute")
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
+        # Get available values for this attribute
+        values = ContentAttributeValue.objects.filter(
+            attribute=self.attribute
+        ).order_by("name")
+
+        # Get current assignments
+        current_assignments = ListAttributeAssignment.objects.filter(
+            list=self.list_obj,
+            attribute_value__attribute=self.attribute,
+            archived=False,
+        ).values_list("attribute_value_id", flat=True)
+
+        if self.attribute.is_single_select:
+            # Single select - use radio buttons
+            self.fields["values"] = forms.ModelChoiceField(
+                queryset=values,
+                widget=forms.RadioSelect,
+                required=False,
+                initial=current_assignments.first() if current_assignments else None,
+                label=f"Select {self.attribute.name}",
+            )
+        else:
+            # Multi select - use checkboxes
+            self.fields["values"] = forms.ModelMultipleChoiceField(
+                queryset=values,
+                widget=forms.CheckboxSelectMultiple,
+                required=False,
+                initial=list(current_assignments),
+                label=f"Select {self.attribute.name} (multiple allowed)",
+            )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        # Check if list is archived
+        if self.list_obj.archived:
+            raise ValidationError("Cannot modify attributes for an archived list.")
+
+        return cleaned_data
+
+    def save(self):
+        """Save the attribute assignments."""
+        values = self.cleaned_data.get("values")
+
+        with transaction.atomic():
+            # Archive existing assignments for this attribute
+            ListAttributeAssignment.objects.filter(
+                list=self.list_obj,
+                attribute_value__attribute=self.attribute,
+                archived=False,
+            ).update(archived=True)
+
+            # Create new assignments
+            if values:
+                # Handle both single and multiple values
+                if self.attribute.is_single_select:
+                    values = [values] if values else []
+
+                for value in values:
+                    assignment, created = ListAttributeAssignment.objects.get_or_create(
+                        list=self.list_obj,
+                        attribute_value=value,
+                        defaults={"archived": False},
+                    )
+                    if not created and assignment.archived:
+                        assignment.archived = False
+                        assignment.save()
+
+            # Log campaign action if in campaign mode
+            if (
+                self.list_obj.is_campaign_mode
+                and self.list_obj.campaign
+                and self.request
+            ):
+                from gyrinx.core.models.campaign import CampaignAction
+
+                value_names = []
+                if values:
+                    if self.attribute.is_single_select:
+                        value_names = [values.name]
+                    else:
+                        value_names = [v.name for v in values]
+
+                action_text = f"Updated {self.attribute.name}: {', '.join(value_names) if value_names else 'None'}"
+
+                CampaignAction.objects.create(
+                    campaign=self.list_obj.campaign,
+                    list=self.list_obj,
+                    user=self.request.user,
+                    action=action_text,
+                )

--- a/gyrinx/core/forms/attribute.py
+++ b/gyrinx/core/forms/attribute.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from gyrinx.content.models import ContentAttributeValue
+from gyrinx.core.models.campaign import CampaignAction
 from gyrinx.core.models.list import ListAttributeAssignment
 
 
@@ -89,14 +90,10 @@ class ListAttributeForm(forms.Form):
                 and self.list_obj.campaign
                 and self.request
             ):
-                from gyrinx.core.models.campaign import CampaignAction
-
                 value_names = []
                 if values:
-                    if self.attribute.is_single_select:
-                        value_names = [values.name]
-                    else:
-                        value_names = [v.name for v in values]
+                    # values is always a list at this point due to line 75
+                    value_names = [v.name for v in values]
 
                 action_text = f"Updated {self.attribute.name}: {', '.join(value_names) if value_names else 'None'}"
 
@@ -104,5 +101,5 @@ class ListAttributeForm(forms.Form):
                     campaign=self.list_obj.campaign,
                     list=self.list_obj,
                     user=self.request.user,
-                    action=action_text,
+                    description=action_text,
                 )

--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -2645,6 +2645,7 @@ class ListAttributeAssignment(Base, Archived):
                     ListAttributeAssignment.objects.filter(
                         list=self.list,
                         attribute_value__attribute=attribute,
+                        archived=False,  # Only check active assignments
                     )
                     .exclude(pk=self.pk)
                     .exists()

--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -2633,7 +2633,7 @@ class ListAttributeAssignment(Base, Archived):
         unique_together = [["list", "attribute_value"]]
 
     def __str__(self):
-        return f"{self.list.name} - {self.attribute_value}"
+        return f"{self.list.name} - {self.attribute_value.attribute.name}: {self.attribute_value.name}"
 
     def clean(self):
         """Validate that single-select attributes only have one value per list."""

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -164,6 +164,7 @@
         {% if not print %}
             {% include "core/includes/list_campaign_actions.html" with list=list %}
             {% include "core/includes/list_campaign_resources_assets.html" with list=list campaign_resources=campaign_resources held_assets=held_assets %}
+            {% include "core/includes/list_attributes.html" with list=list attributes=attributes %}
         {% endif %}
         {% for fighter in list.fighters_cached %}
             {% if fighter.is_stash %}

--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -1,0 +1,42 @@
+{% load allauth custom_tags humanize %}
+<div class="card g-col-12 g-col-md-12 g-col-xl-6">
+    <div class="card-header p-2 bg-secondary-subtle text-secondary-emphasis">
+        <h3 class="h5 mb-0">Attributes</h3>
+    </div>
+    <div class="card-body p-2">
+        {% if attributes %}
+            <table class="table table-sm mb-0 fs-7">
+                <tbody>
+                    {% for attribute, assignments in attributes.items %}
+                        <tr>
+                            <td>{{ attribute.name }}</td>
+                            <td>
+                                {% if assignments %}
+                                    {{ assignments|join:", " }}
+                                {% else %}
+                                    <span class="text-muted">Not set</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-end">
+                                {% if list.owner_cached == user and not list.archived %}
+                                    <a href="{% url 'core:list-attribute-edit' list.id attribute.id %}"
+                                       class="icon-link link-secondary link-sm">
+                                        <i class="bi-{% if assignments %}pencil{% else %}plus{% endif %}"
+                                           aria-hidden="true"></i>
+                                        {% if assignments %}
+                                            Edit
+                                        {% else %}
+                                            Add
+                                        {% endif %}
+                                    </a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p class="text-muted fs-7 mb-0">No attributes available.</p>
+        {% endif %}
+    </div>
+</div>

--- a/gyrinx/core/templates/core/list_attribute_edit.html
+++ b/gyrinx/core/templates/core/list_attribute_edit.html
@@ -24,7 +24,7 @@
                             <button type="submit" class="btn btn-primary btn-sm">
                                 <i class="bi-check-lg"></i> Save
                             </button>
-                            <a href="{{ list_url }}" class="btn btn-secondary btn-sm">Cancel</a>
+                            {% include "core/includes/cancel.html" with url=list_url %}
                         </div>
                     </form>
                 </div>

--- a/gyrinx/core/templates/core/list_attribute_edit.html
+++ b/gyrinx/core/templates/core/list_attribute_edit.html
@@ -1,0 +1,34 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Edit {{ attribute.name }} - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:list' list.id as list_url %}
+    {% include "core/includes/back.html" with url=list_url text="Back to list" %}
+    <div class="row g-3 mb-3">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-body">
+                    <h2 class="h5">{{ attribute.name }}</h2>
+                    {% if attribute.is_single_select %}
+                        <p class="text-secondary">Select one option</p>
+                    {% else %}
+                        <p class="text-secondary">Select multiple options</p>
+                    {% endif %}
+                    <form method="post">
+                        {% csrf_token %}
+                        <div class="mb-3">{{ form.values }}</div>
+                        {% if form.errors %}<div class="alert alert-danger">{{ form.errors }}</div>{% endif %}
+                        <div class="hstack gap-2">
+                            <button type="submit" class="btn btn-primary btn-sm">
+                                <i class="bi-check-lg"></i> Save
+                            </button>
+                            <a href="{{ list_url }}" class="btn btn-secondary btn-sm">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_attribute_form.py
+++ b/gyrinx/core/tests/test_attribute_form.py
@@ -1,0 +1,338 @@
+"""Tests for ListAttributeForm."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from gyrinx.content.models import (
+    ContentAttribute,
+    ContentAttributeValue,
+    ContentHouse,
+)
+from gyrinx.core.forms.attribute import ListAttributeForm
+from gyrinx.core.models.campaign import Campaign, CampaignAction
+from gyrinx.core.models.list import List, ListAttributeAssignment
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user():
+    """Create a test user."""
+    return User.objects.create_user(username="testuser", password="testpass123")
+
+
+@pytest.fixture
+def house():
+    """Create a test house."""
+    return ContentHouse.objects.create(name="Test House")
+
+
+@pytest.fixture
+def list_obj(user, house):
+    """Create a test list."""
+    return List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=house,
+    )
+
+
+@pytest.fixture
+def campaign(user):
+    """Create a test campaign."""
+    return Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+    )
+
+
+@pytest.fixture
+def campaign_list(user, house, campaign):
+    """Create a test list in campaign mode."""
+    list_obj = List.objects.create(
+        name="Campaign List",
+        owner=user,
+        content_house=house,
+        status=List.CAMPAIGN_MODE,
+        campaign=campaign,
+    )
+    return list_obj
+
+
+@pytest.fixture
+def single_select_attribute():
+    """Create a single-select attribute."""
+    return ContentAttribute.objects.create(
+        name="Allegiance",
+        is_single_select=True,
+    )
+
+
+@pytest.fixture
+def multi_select_attribute():
+    """Create a multi-select attribute."""
+    return ContentAttribute.objects.create(
+        name="Traits",
+        is_single_select=False,
+    )
+
+
+@pytest.fixture
+def single_values(single_select_attribute):
+    """Create values for single-select attribute."""
+    return [
+        ContentAttributeValue.objects.create(
+            attribute=single_select_attribute,
+            name="Loyalist",
+        ),
+        ContentAttributeValue.objects.create(
+            attribute=single_select_attribute,
+            name="Outlaw",
+        ),
+    ]
+
+
+@pytest.fixture
+def multi_values(multi_select_attribute):
+    """Create values for multi-select attribute."""
+    return [
+        ContentAttributeValue.objects.create(
+            attribute=multi_select_attribute,
+            name="Fast",
+        ),
+        ContentAttributeValue.objects.create(
+            attribute=multi_select_attribute,
+            name="Tough",
+        ),
+        ContentAttributeValue.objects.create(
+            attribute=multi_select_attribute,
+            name="Sneaky",
+        ),
+    ]
+
+
+@pytest.mark.django_db
+def test_single_select_save(list_obj, single_select_attribute, single_values):
+    """Test saving a single-select attribute assignment."""
+    form = ListAttributeForm(
+        data={"values": single_values[0].pk},
+        list_obj=list_obj,
+        attribute=single_select_attribute,
+    )
+
+    assert form.is_valid()
+    form.save()
+
+    # Check that assignment was created
+    assignments = ListAttributeAssignment.objects.filter(
+        list=list_obj,
+        attribute_value__attribute=single_select_attribute,
+        archived=False,
+    )
+    assert assignments.count() == 1
+    assert assignments.first().attribute_value == single_values[0]
+
+
+@pytest.mark.django_db
+def test_single_select_update(list_obj, single_select_attribute, single_values):
+    """Test updating a single-select attribute assignment."""
+    # Create initial assignment
+    ListAttributeAssignment.objects.create(
+        list=list_obj,
+        attribute_value=single_values[0],
+        archived=False,
+    )
+
+    # Update to different value
+    form = ListAttributeForm(
+        data={"values": single_values[1].pk},
+        list_obj=list_obj,
+        attribute=single_select_attribute,
+    )
+
+    assert form.is_valid()
+    form.save()
+
+    # Check that old assignment is archived and new one created
+    assignments = ListAttributeAssignment.objects.filter(
+        list=list_obj,
+        attribute_value__attribute=single_select_attribute,
+    )
+    assert assignments.count() == 2
+
+    # Old assignment should be archived
+    old_assignment = assignments.get(attribute_value=single_values[0])
+    assert old_assignment.archived is True
+
+    # New assignment should be active
+    new_assignment = assignments.get(attribute_value=single_values[1])
+    assert new_assignment.archived is False
+
+
+@pytest.mark.django_db
+def test_multi_select_save(list_obj, multi_select_attribute, multi_values):
+    """Test saving multi-select attribute assignments."""
+    form = ListAttributeForm(
+        data={"values": [multi_values[0].pk, multi_values[2].pk]},
+        list_obj=list_obj,
+        attribute=multi_select_attribute,
+    )
+
+    assert form.is_valid()
+    form.save()
+
+    # Check that assignments were created
+    assignments = ListAttributeAssignment.objects.filter(
+        list=list_obj,
+        attribute_value__attribute=multi_select_attribute,
+        archived=False,
+    )
+    assert assignments.count() == 2
+    assigned_values = set(assignments.values_list("attribute_value", flat=True))
+    assert assigned_values == {multi_values[0].pk, multi_values[2].pk}
+
+
+@pytest.mark.django_db
+def test_campaign_action_single_select(
+    campaign_list, single_select_attribute, single_values, user
+):
+    """Test that campaign action is logged for single-select."""
+    request = RequestFactory().get("/")
+    request.user = user
+
+    form = ListAttributeForm(
+        data={"values": single_values[0].pk},
+        list_obj=campaign_list,
+        attribute=single_select_attribute,
+        request=request,
+    )
+
+    assert form.is_valid()
+    form.save()
+
+    # Check campaign action was created
+    action = CampaignAction.objects.get(
+        campaign=campaign_list.campaign,
+        list=campaign_list,
+    )
+    assert action.user == user
+    assert (
+        f"Updated {single_select_attribute.name}: {single_values[0].name}"
+        in action.description
+    )
+
+
+@pytest.mark.django_db
+def test_campaign_action_multi_select(
+    campaign_list, multi_select_attribute, multi_values, user
+):
+    """Test that campaign action is logged for multi-select."""
+    request = RequestFactory().get("/")
+    request.user = user
+
+    form = ListAttributeForm(
+        data={"values": [multi_values[0].pk, multi_values[1].pk]},
+        list_obj=campaign_list,
+        attribute=multi_select_attribute,
+        request=request,
+    )
+
+    assert form.is_valid()
+    form.save()
+
+    # Check campaign action was created
+    action = CampaignAction.objects.get(
+        campaign=campaign_list.campaign,
+        list=campaign_list,
+    )
+    assert action.user == user
+    assert f"Updated {multi_select_attribute.name}:" in action.description
+    assert multi_values[0].name in action.description
+    assert multi_values[1].name in action.description
+
+
+@pytest.mark.django_db
+def test_campaign_action_clear_values(
+    campaign_list, single_select_attribute, single_values, user
+):
+    """Test campaign action when clearing values."""
+    # First set a value
+    ListAttributeAssignment.objects.create(
+        list=campaign_list,
+        attribute_value=single_values[0],
+        archived=False,
+    )
+
+    request = RequestFactory().get("/")
+    request.user = user
+
+    # Clear the value
+    form = ListAttributeForm(
+        data={"values": ""},  # Empty selection
+        list_obj=campaign_list,
+        attribute=single_select_attribute,
+        request=request,
+    )
+
+    assert form.is_valid()
+    form.save()
+
+    # Check campaign action was created
+    action = CampaignAction.objects.get(
+        campaign=campaign_list.campaign,
+        list=campaign_list,
+    )
+    assert f"Updated {single_select_attribute.name}: None" in action.description
+
+
+@pytest.mark.django_db
+def test_archived_list_validation(list_obj, single_select_attribute, single_values):
+    """Test that form validation prevents modifying archived lists."""
+    list_obj.archived = True
+    list_obj.save()
+
+    form = ListAttributeForm(
+        data={"values": single_values[0].pk},
+        list_obj=list_obj,
+        attribute=single_select_attribute,
+    )
+
+    assert not form.is_valid()
+    assert "Cannot modify attributes for an archived list" in str(form.errors)
+
+
+@pytest.mark.django_db
+def test_reactivate_archived_assignment(
+    list_obj, single_select_attribute, single_values
+):
+    """Test that archived assignments are reactivated when re-selected."""
+    # Create an archived assignment
+    assignment = ListAttributeAssignment.objects.create(
+        list=list_obj,
+        attribute_value=single_values[0],
+        archived=True,
+    )
+
+    # Re-select the same value
+    form = ListAttributeForm(
+        data={"values": single_values[0].pk},
+        list_obj=list_obj,
+        attribute=single_select_attribute,
+    )
+
+    assert form.is_valid()
+    form.save()
+
+    # Check that the assignment was reactivated
+    assignment.refresh_from_db()
+    assert assignment.archived is False
+
+    # Should not create duplicate
+    assert (
+        ListAttributeAssignment.objects.filter(
+            list=list_obj,
+            attribute_value=single_values[0],
+        ).count()
+        == 1
+    )

--- a/gyrinx/core/tests/test_attribute_views.py
+++ b/gyrinx/core/tests/test_attribute_views.py
@@ -1,0 +1,172 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from gyrinx.content.models import ContentAttribute, ContentAttributeValue, ContentHouse
+from gyrinx.core.models.list import List, ListAttributeAssignment
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_list_view_shows_attributes(client):
+    """Test that attributes are displayed in the list view."""
+    # Create a user and list
+    user = User.objects.create_user(username="testuser", password="testpass")
+    client.login(username="testuser", password="testpass")
+    
+    # Create a house (required for list)
+    house = ContentHouse.objects.create(name="Test House")
+    
+    lst = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        content_house=house,
+        public=True,
+    )
+    
+    # Create an attribute and values
+    alignment = ContentAttribute.objects.create(
+        name="Alignment",
+        is_single_select=True,
+    )
+    
+    law_abiding = ContentAttributeValue.objects.create(
+        attribute=alignment,
+        name="Law Abiding",
+        description="Follows the rules",
+    )
+    
+    outlaw = ContentAttributeValue.objects.create(
+        attribute=alignment,
+        name="Outlaw",
+        description="Breaks the rules",
+    )
+    
+    # Assign an attribute to the list
+    ListAttributeAssignment.objects.create(
+        list=lst,
+        attribute_value=law_abiding,
+    )
+    
+    # Visit the list detail page
+    response = client.get(reverse("core:list", args=[lst.id]))
+    
+    assert response.status_code == 200
+    assert "Attributes" in response.content.decode()
+    assert "Alignment" in response.content.decode()
+    assert "Law Abiding" in response.content.decode()
+    assert "Edit" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_edit_attribute_form(client):
+    """Test the attribute edit form."""
+    # Create a user and list
+    user = User.objects.create_user(username="testuser", password="testpass")
+    client.login(username="testuser", password="testpass")
+    
+    # Create a house (required for list)
+    house = ContentHouse.objects.create(name="Test House")
+    
+    lst = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        content_house=house,
+        public=True,
+    )
+    
+    # Create an attribute and values
+    alignment = ContentAttribute.objects.create(
+        name="Alignment",
+        is_single_select=True,
+    )
+    
+    law_abiding = ContentAttributeValue.objects.create(
+        attribute=alignment,
+        name="Law Abiding",
+        description="Follows the rules",
+    )
+    
+    outlaw = ContentAttributeValue.objects.create(
+        attribute=alignment,
+        name="Outlaw", 
+        description="Breaks the rules",
+    )
+    
+    # Visit the attribute edit page
+    response = client.get(reverse("core:list-attribute-edit", args=[lst.id, alignment.id]))
+    
+    assert response.status_code == 200
+    assert "Alignment" in response.content.decode()
+    assert "Law Abiding" in response.content.decode()
+    assert "Outlaw" in response.content.decode()
+    
+    # Submit the form
+    response = client.post(
+        reverse("core:list-attribute-edit", args=[lst.id, alignment.id]),
+        {"values": outlaw.id},
+    )
+    
+    assert response.status_code == 302  # Redirect
+    
+    # Check that the assignment was created
+    assert ListAttributeAssignment.objects.filter(
+        list=lst, attribute_value=outlaw, archived=False
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_multi_select_attribute(client):
+    """Test multi-select attributes."""
+    # Create a user and list
+    user = User.objects.create_user(username="testuser", password="testpass")
+    client.login(username="testuser", password="testpass")
+    
+    # Create a house (required for list)
+    house = ContentHouse.objects.create(name="Test House")
+    
+    lst = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        content_house=house,
+        public=True,
+    )
+    
+    # Create a multi-select attribute
+    affiliation = ContentAttribute.objects.create(
+        name="Affiliation",
+        is_single_select=False,
+    )
+    
+    guild = ContentAttributeValue.objects.create(
+        attribute=affiliation,
+        name="Guilders",
+    )
+    
+    merchants = ContentAttributeValue.objects.create(
+        attribute=affiliation,
+        name="Merchants",
+    )
+    
+    # Submit the form with multiple values
+    response = client.post(
+        reverse("core:list-attribute-edit", args=[lst.id, affiliation.id]),
+        {"values": [guild.id, merchants.id]},
+    )
+    
+    assert response.status_code == 302  # Redirect
+    
+    # Check that both assignments were created
+    assert ListAttributeAssignment.objects.filter(
+        list=lst, attribute_value=guild, archived=False
+    ).exists()
+    assert ListAttributeAssignment.objects.filter(
+        list=lst, attribute_value=merchants, archived=False
+    ).exists()
+    
+    # Check list view shows comma-separated values
+    response = client.get(reverse("core:list", args=[lst.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Guilders, Merchants" in content or "Merchants, Guilders" in content

--- a/gyrinx/core/tests/test_attribute_views.py
+++ b/gyrinx/core/tests/test_attribute_views.py
@@ -14,44 +14,44 @@ def test_list_view_shows_attributes(client):
     # Create a user and list
     user = User.objects.create_user(username="testuser", password="testpass")
     client.login(username="testuser", password="testpass")
-    
+
     # Create a house (required for list)
     house = ContentHouse.objects.create(name="Test House")
-    
+
     lst = List.objects.create(
         name="Test Gang",
         owner=user,
         content_house=house,
         public=True,
     )
-    
+
     # Create an attribute and values
     alignment = ContentAttribute.objects.create(
         name="Alignment",
         is_single_select=True,
     )
-    
+
     law_abiding = ContentAttributeValue.objects.create(
         attribute=alignment,
         name="Law Abiding",
         description="Follows the rules",
     )
-    
-    outlaw = ContentAttributeValue.objects.create(
+
+    ContentAttributeValue.objects.create(
         attribute=alignment,
         name="Outlaw",
         description="Breaks the rules",
     )
-    
+
     # Assign an attribute to the list
     ListAttributeAssignment.objects.create(
         list=lst,
         attribute_value=law_abiding,
     )
-    
+
     # Visit the list detail page
     response = client.get(reverse("core:list", args=[lst.id]))
-    
+
     assert response.status_code == 200
     assert "Attributes" in response.content.decode()
     assert "Alignment" in response.content.decode()
@@ -65,51 +65,53 @@ def test_edit_attribute_form(client):
     # Create a user and list
     user = User.objects.create_user(username="testuser", password="testpass")
     client.login(username="testuser", password="testpass")
-    
+
     # Create a house (required for list)
     house = ContentHouse.objects.create(name="Test House")
-    
+
     lst = List.objects.create(
         name="Test Gang",
         owner=user,
         content_house=house,
         public=True,
     )
-    
+
     # Create an attribute and values
     alignment = ContentAttribute.objects.create(
         name="Alignment",
         is_single_select=True,
     )
-    
-    law_abiding = ContentAttributeValue.objects.create(
+
+    ContentAttributeValue.objects.create(
         attribute=alignment,
         name="Law Abiding",
         description="Follows the rules",
     )
-    
+
     outlaw = ContentAttributeValue.objects.create(
         attribute=alignment,
-        name="Outlaw", 
+        name="Outlaw",
         description="Breaks the rules",
     )
-    
+
     # Visit the attribute edit page
-    response = client.get(reverse("core:list-attribute-edit", args=[lst.id, alignment.id]))
-    
+    response = client.get(
+        reverse("core:list-attribute-edit", args=[lst.id, alignment.id])
+    )
+
     assert response.status_code == 200
     assert "Alignment" in response.content.decode()
     assert "Law Abiding" in response.content.decode()
     assert "Outlaw" in response.content.decode()
-    
+
     # Submit the form
     response = client.post(
         reverse("core:list-attribute-edit", args=[lst.id, alignment.id]),
         {"values": outlaw.id},
     )
-    
+
     assert response.status_code == 302  # Redirect
-    
+
     # Check that the assignment was created
     assert ListAttributeAssignment.objects.filter(
         list=lst, attribute_value=outlaw, archived=False
@@ -122,41 +124,41 @@ def test_multi_select_attribute(client):
     # Create a user and list
     user = User.objects.create_user(username="testuser", password="testpass")
     client.login(username="testuser", password="testpass")
-    
+
     # Create a house (required for list)
     house = ContentHouse.objects.create(name="Test House")
-    
+
     lst = List.objects.create(
         name="Test Gang",
         owner=user,
         content_house=house,
         public=True,
     )
-    
+
     # Create a multi-select attribute
     affiliation = ContentAttribute.objects.create(
         name="Affiliation",
         is_single_select=False,
     )
-    
+
     guild = ContentAttributeValue.objects.create(
         attribute=affiliation,
         name="Guilders",
     )
-    
+
     merchants = ContentAttributeValue.objects.create(
         attribute=affiliation,
         name="Merchants",
     )
-    
+
     # Submit the form with multiple values
     response = client.post(
         reverse("core:list-attribute-edit", args=[lst.id, affiliation.id]),
         {"values": [guild.id, merchants.id]},
     )
-    
+
     assert response.status_code == 302  # Redirect
-    
+
     # Check that both assignments were created
     assert ListAttributeAssignment.objects.filter(
         list=lst, attribute_value=guild, archived=False
@@ -164,7 +166,7 @@ def test_multi_select_attribute(client):
     assert ListAttributeAssignment.objects.filter(
         list=lst, attribute_value=merchants, archived=False
     ).exists()
-    
+
     # Check list view shows comma-separated values
     response = client.get(reverse("core:list", args=[lst.id]))
     assert response.status_code == 200

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -271,6 +271,11 @@ urlpatterns = [
     ),
     path("list/<id>/print", list.ListPrintView.as_view(), name="list-print"),
     path(
+        "list/<id>/attribute/<attribute_id>/edit",
+        list.edit_list_attribute,
+        name="list-attribute-edit",
+    ),
+    path(
         "list/<id>/campaign-clones",
         list.ListCampaignClonesView.as_view(),
         name="list-campaign-clones",

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -34,6 +34,7 @@ from gyrinx.core.forms.advancement import (
     SkillCategorySelectionForm,
     SkillSelectionForm,
 )
+from gyrinx.core.forms.attribute import ListAttributeForm
 from gyrinx.core.forms.list import (
     AddInjuryForm,
     CloneListFighterForm,
@@ -209,6 +210,22 @@ class ListDetailView(generic.DetailView):
                 sold_to_guilders=False
             ).select_related("fighter", "fighter__list")
             context["captured_fighters"] = captured_fighters
+
+        # Get attributes and their values for this list
+        from gyrinx.content.models import ContentAttribute
+        from gyrinx.core.models.list import ListAttributeAssignment
+
+        attributes = {}
+        for attribute in ContentAttribute.objects.all().order_by("name"):
+            assignments = ListAttributeAssignment.objects.filter(
+                list=list_obj, attribute_value__attribute=attribute, archived=False
+            ).select_related("attribute_value")
+
+            # Get the value names
+            value_names = [a.attribute_value.name for a in assignments]
+            attributes[attribute] = value_names
+
+        context["attributes"] = attributes
 
         return context
 
@@ -3551,3 +3568,40 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
         )
 
     return render(request, "core/list_fighter_equipment_sell.html", context)
+
+
+@login_required
+def edit_list_attribute(request: HttpRequest, id: uuid.UUID, attribute_id: uuid.UUID):
+    """
+    Edit attributes for a list.
+    """
+    lst = get_object_or_404(List, id=id, owner=request.user)
+
+    # Check if list is archived
+    if lst.archived:
+        messages.error(request, "Cannot modify attributes for an archived list.")
+        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+
+    # Get the attribute
+    from gyrinx.content.models import ContentAttribute
+
+    attribute = get_object_or_404(ContentAttribute, id=attribute_id)
+
+    if request.method == "POST":
+        form = ListAttributeForm(
+            request.POST, list_obj=lst, attribute=attribute, request=request
+        )
+        if form.is_valid():
+            form.save()
+            messages.success(request, f"{attribute.name} updated successfully.")
+            return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+    else:
+        form = ListAttributeForm(list_obj=lst, attribute=attribute, request=request)
+
+    context = {
+        "list": lst,
+        "attribute": attribute,
+        "form": form,
+    }
+
+    return render(request, "core/list_attribute_edit.html", context)


### PR DESCRIPTION
Closes #419

## Summary

This PR implements the UI for the gang attributes feature. Players can now view and manage attributes (Alignment, Alliance, Affiliation, etc.) for their gangs.

## Changes

- Add attributes card to list view showing all available attributes
- Create form for managing single/multi-select attribute assignments
- Add edit view with radio/checkbox selection based on attribute type
- Update list view to pass attributes data to template
- Create campaign actions when attributes change in campaign mode
- Add comprehensive tests for attribute functionality

## Screenshots

The attributes card appears in the list view grid alongside Actions and Assets & Resources cards.

Generated with [Claude Code](https://claude.ai/code)