### PR TITLE
fix: Replace bg-light with bg-body-secondary for theme compatibility

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_resource_modify.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resource_modify.html
@@ -29,7 +29,7 @@
                 {% endif %}
                 {% if form.modification.errors %}<div class="invalid-feedback d-block">{{ form.modification.errors }}</div>{% endif %}
             </div>
-            <div class="card bg-light d-none" id="preview-card">
+            <div class="card bg-body-secondary d-none" id="preview-card">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">New Amount</h6>
                     <p class="mb-0">

--- a/gyrinx/core/templates/core/list_archive.html
+++ b/gyrinx/core/templates/core/list_archive.html
@@ -21,7 +21,7 @@
         </h1>
         {% if not list.archived %}
             <p>Are you sure you want to archive this gang/list?</p>
-            <div class="border rounded p-3 bg-light">
+            <div class="border rounded p-3 bg-body-secondary">
                 <p class="mb-2">
                     <strong>What happens when you archive:</strong>
                 </p>
@@ -49,7 +49,7 @@
             {% endif %}
         {% else %}
             <p>Are you sure you want to unarchive this gang/list?</p>
-            <div class="border rounded p-3 bg-light">
+            <div class="border rounded p-3 bg-body-secondary">
                 <p class="mb-2">
                     <strong>What happens when you unarchive:</strong>
                 </p>


### PR DESCRIPTION
Closes #421

## Summary

Replaced all instances of Bootstrap's `bg-light` class with `bg-body-secondary` to ensure proper appearance in both light and dark themes.

- Updated 3 instances across 2 template files
- `bg-body-secondary` automatically adapts to the current color mode
- All tests pass

Generated with [Claude Code](https://claude.ai/code)