### PR TITLE
fix: Add success message when list is added to campaign

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_add_lists.html
+++ b/gyrinx/core/templates/core/campaign/campaign_add_lists.html
@@ -13,16 +13,6 @@
                 <p>{{ error_message }}</p>
             </div>
         {% endif %}
-        {% if added_list %}
-            <div class="alert alert-success" id="added">
-                <h4 class="alert-heading">Gang Added</h4>
-                <p>
-                    {% list_with_theme added_list "fw-bold" %}
-                    {% if added_list.content_house %}({{ added_list.content_house.name }}){% endif %}
-                    has been added to the campaign.
-                </p>
-            </div>
-        {% endif %}
         {% if show_confirmation and list_to_confirm %}
             <div class="alert alert-warning">
                 <h4 class="alert-heading">Confirm Add Gang to Active Campaign</h4>

--- a/gyrinx/core/tests/test_campaign_lists.py
+++ b/gyrinx/core/tests/test_campaign_lists.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib import messages
 from django.contrib.auth.models import User
 from django.test import Client
 from django.urls import reverse
@@ -131,13 +132,19 @@ def test_campaign_add_list_post():
 
     # Should redirect back to the same page
     assert response.status_code == 302
-    assert (
-        response.url
-        == reverse("core:campaign-add-lists", args=[campaign.id]) + "#added"
-    )
+    assert response.url == reverse("core:campaign-add-lists", args=[campaign.id])
 
     # List should be added to campaign
     assert list_to_add in campaign.lists.all()
+
+    # Check for success message
+    response = client.get(response.url)
+    messages_list = list(response.context["messages"])
+    assert len(messages_list) == 1
+    assert messages_list[0].level == messages.SUCCESS
+    assert f"{list_to_add.name} ({house.name}) has been added to the campaign." in str(
+        messages_list[0]
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Previously, users received no feedback when successfully adding a list to a campaign. This change uses Django's messages framework to display a success message, improving user experience.

- Modified campaign_add_lists view to use messages.success()
- Removed template-based success alert in favor of Django messages
- Updated test to verify success message is displayed
- Removed unused added_list context variable

Fixes #422

Generated with [Claude Code](https://claude.ai/code)