### PR TITLE
feat: add banner image to logged-in homescreen with updated text

### DIFF
--- a/gyrinx/core/templates/core/index.html
+++ b/gyrinx/core/templates/core/index.html
@@ -4,17 +4,19 @@
     Home
 {% endblock head_title %}
 {% block prebody %}
-    {% if not user.is_authenticated %}
-        <div id="hero"
-             class="hero"
-             style="background-image:linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.7)), url({% static 'core/img/content/93daeffd-9587-404a-b3e1-33eff4ce7398.jpg' %})">
-            <div class="container h-100 d-flex align-items-end py-4 z-1">
-                <h2 class="h1 fw-light text-light">
+    <div id="hero"
+         class="hero"
+         style="background-image:linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.7)), url({% static 'core/img/content/93daeffd-9587-404a-b3e1-33eff4ce7398.jpg' %})">
+        <div class="container h-100 d-flex align-items-end py-4 z-1">
+            <h2 class="h1 fw-light text-light">
+                {% if user.is_authenticated %}
+                    <strong>Welcome to Gyrinx's</strong> Necromunda tools.
+                {% else %}
                     <strong>Gyrinx</strong> is a new set of tools for the Necromunda community.
-                </h2>
-            </div>
+                {% endif %}
+            </h2>
         </div>
-    {% endif %}
+    </div>
 {% endblock prebody %}
 {% block content %}
     <div class="mb-5 pb-5">

--- a/gyrinx/core/templates/core/index.html
+++ b/gyrinx/core/templates/core/index.html
@@ -10,7 +10,8 @@
         <div class="container h-100 d-flex align-items-end py-4 z-1">
             <h2 class="h1 fw-light text-light">
                 {% if user.is_authenticated %}
-                    <strong>Welcome to Gyrinx's</strong> Necromunda tools.
+                    <strong>Welcome</strong> to Gyrinx's Necromunda tools, <a class="link-light link-underline-opacity-25 link-underline-opacity-100-hover"
+    href="{% url 'core:user' user.id %}">{{ user.username }}</a>.
                 {% else %}
                     <strong>Gyrinx</strong> is a new set of tools for the Necromunda community.
                 {% endif %}


### PR DESCRIPTION
This PR adds the banner image to the logged-in homescreen with updated text as requested.

## Changes
- Show banner for both authenticated and non-authenticated users
- Logged-in users see: "Welcome to Gyrinx's Necromunda tools."
- Logged-out users see: "Gyrinx is a new set of tools for the Necromunda community."

Fixes #432

Generated with [Claude Code](https://claude.ai/code)