### PR TITLE
feat: Add beta badge to topbar

### DIFF
--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -12,7 +12,7 @@
                      class="d-inline-block align-text-top">
                 <span class="fs-5 ms-1 fw-light">Gyrinx</span>
                 {% settings_value "SHOW_BETA_BADGE" as show_beta %}
-                {% if show_beta %}<span class="badge bg-warning text-dark ms-1">Beta</span>{% endif %}
+                {% if show_beta %}<span class="badge bg-warning text-dark ms-1 fw-normal">Beta</span>{% endif %}
             </a>
             <div class="hstack gap-2 gap-sm-1 me-sm-1">
                 {% if user.is_authenticated %}

--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -11,6 +11,8 @@
                      height="24"
                      class="d-inline-block align-text-top">
                 <span class="fs-5 ms-1 fw-light">Gyrinx</span>
+                {% settings_value "SHOW_BETA_BADGE" as show_beta %}
+                {% if show_beta %}<span class="badge bg-warning text-dark ms-1">Beta</span>{% endif %}
             </a>
             <div class="hstack gap-2 gap-sm-1 me-sm-1">
                 {% if user.is_authenticated %}

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -246,6 +246,9 @@ MFA_SUPPORTED_TYPES = ["totp"]  # Only support TOTP, not SMS or recovery codes i
 
 WAITING_LIST_ALLOW_SIGNUPS = os.getenv("WAITING_LIST_ALLOW_SIGNUPS", "False") == "True"
 
+# Beta badge
+SHOW_BETA_BADGE = os.getenv("SHOW_BETA_BADGE", "True") == "True"
+
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
Closes #431

Adds a "Beta" badge next to "Gyrinx" in the topbar using a Bootstrap warning badge. The badge is toggleable via the `SHOW_BETA_BADGE` environment variable.

Generated with [Claude Code](https://claude.ai/code)