### PR TITLE
fix: prevent users from using email addresses as usernames

### DIFF
--- a/gyrinx/core/forms/__init__.py
+++ b/gyrinx/core/forms/__init__.py
@@ -22,11 +22,12 @@ class SignupForm(SignupForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Update username field help text and add validation
+        print(self.fields.keys())
         if "username" in self.fields:
             self.fields["username"].help_text = (
                 "This is the name you'll use to log in to Gyrinx. "
                 "It can only contain letters, numbers, and underscores. "
-                "Please use a username, not an email address."
+                "Please pick a username, not an email address."
             )
             # Add validator to check for @ symbol
             from django.core import validators

--- a/gyrinx/core/forms/__init__.py
+++ b/gyrinx/core/forms/__init__.py
@@ -18,3 +18,23 @@ class LoginForm(LoginForm):
 
 class SignupForm(SignupForm):
     captcha = ReCaptchaField(widget=ReCaptchaV3(action="signup"))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Update username field help text and add validation
+        if "username" in self.fields:
+            self.fields["username"].help_text = (
+                "This is the name you'll use to log in to Gyrinx. "
+                "It can only contain letters, numbers, and underscores. "
+                "Please use a username, not an email address."
+            )
+            # Add validator to check for @ symbol
+            from django.core import validators
+
+            self.fields["username"].validators.insert(
+                0,
+                validators.RegexValidator(
+                    regex=r"^[^@]+$",
+                    message="Username cannot be an email address. Please choose a username without @ symbol.",
+                ),
+            )

--- a/gyrinx/pages/forms.py
+++ b/gyrinx/pages/forms.py
@@ -36,8 +36,12 @@ class JoinWaitingListForm(forms.ModelForm):
         widget=forms.TextInput(
             attrs={"placeholder": "lord_helmawr", "class": "form-control"}
         ),
-        help_text="This is the name you'll use to log in to Gyrinx. It can only contain letters, numbers, and underscores.",
+        help_text="This is the name you'll use to log in to Gyrinx. It can only contain letters, numbers, and underscores. Please use a username, not an email address.",
         validators=[
+            validators.RegexValidator(
+                regex=r"^[^@]+$",
+                message="Username cannot be an email address. Please choose a username without @ symbol.",
+            ),
             validators.RegexValidator(
                 regex=r"^[a-zA-Z0-9_]+$",
                 message="Username can only contain alphanumeric characters and underscores.",

--- a/gyrinx/pages/test_username_validation.py
+++ b/gyrinx/pages/test_username_validation.py
@@ -1,0 +1,77 @@
+"""Test username validation to prevent email addresses."""
+
+from django.test import TestCase
+from gyrinx.pages.forms import JoinWaitingListForm
+from gyrinx.core.forms import SignupForm
+
+
+class TestUsernameValidation(TestCase):
+    """Test that usernames cannot be email addresses."""
+
+    def test_waiting_list_form_rejects_email_as_username(self):
+        """Test that the waiting list form rejects email addresses as usernames."""
+        form_data = {
+            "email": "test@example.com",
+            "desired_username": "user@example.com",  # This should be rejected
+            "captcha": "dummy",  # ReCaptcha would be mocked in real tests
+        }
+        form = JoinWaitingListForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("desired_username", form.errors)
+        # Check that the error message mentions email/@ symbol
+        error_messages = form.errors["desired_username"]
+        self.assertTrue(
+            any("@" in msg or "email" in msg.lower() for msg in error_messages)
+        )
+
+    def test_waiting_list_form_accepts_valid_username(self):
+        """Test that the waiting list form accepts valid usernames."""
+        form_data = {
+            "email": "test@example.com",
+            "desired_username": "valid_username123",
+            "captcha": "dummy",
+        }
+        form = JoinWaitingListForm(data=form_data)
+        # Note: form might still be invalid due to captcha, but username should be valid
+        if not form.is_valid() and "desired_username" in form.errors:
+            self.fail(f"Valid username rejected: {form.errors['desired_username']}")
+
+    def test_signup_form_rejects_email_as_username(self):
+        """Test that the signup form rejects email addresses as usernames."""
+        form_data = {
+            "username": "user@example.com",  # This should be rejected
+            "email": "test@example.com",
+            "password1": "ComplexPassword123!",
+            "password2": "ComplexPassword123!",
+            "captcha": "dummy",
+        }
+        form = SignupForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("username", form.errors)
+        # Check that the error message mentions email/@ symbol
+        error_messages = form.errors["username"]
+        self.assertTrue(
+            any("@" in msg or "email" in msg.lower() for msg in error_messages)
+        )
+
+    def test_signup_form_accepts_valid_username(self):
+        """Test that the signup form accepts valid usernames."""
+        form_data = {
+            "username": "valid_username123",
+            "email": "test@example.com",
+            "password1": "ComplexPassword123!",
+            "password2": "ComplexPassword123!",
+            "captcha": "dummy",
+        }
+        form = SignupForm(data=form_data)
+        # Note: form might still be invalid due to captcha, but username should be valid
+        if not form.is_valid() and "username" in form.errors:
+            self.fail(f"Valid username rejected: {form.errors['username']}")
+
+    def test_username_help_text_mentions_no_email(self):
+        """Test that help text mentions not using email address."""
+        form = SignupForm()
+        if "username" in form.fields:
+            help_text = form.fields["username"].help_text
+            self.assertIn("email", help_text.lower())
+            self.assertIn("username", help_text.lower())


### PR DESCRIPTION
This PR implements validation to prevent users from using email addresses as usernames.

## Changes
- Update help text on username fields to indicate email addresses are not allowed
- Add validation to reject usernames containing @ symbol
- Update both waiting list and signup forms
- Add comprehensive tests for username validation

Closes #451

Generated with [Claude Code](https://claude.ai/code)