### PR TITLE
feat: add username change feature for users with '@' in username

### DIFF
--- a/gyrinx/core/forms/__init__.py
+++ b/gyrinx/core/forms/__init__.py
@@ -1,5 +1,7 @@
 from allauth.account.forms import LoginForm, ResetPasswordForm, SignupForm
 from django import forms
+from django.contrib.auth import get_user_model
+from django.core import validators
 from django_recaptcha.fields import ReCaptchaField, ReCaptchaV3
 
 
@@ -39,3 +41,58 @@ class SignupForm(SignupForm):
                     message="Username cannot be an email address. Please choose a username without @ symbol.",
                 ),
             )
+
+
+class UsernameChangeForm(forms.Form):
+    """Form for users to change their username (only for users with @ in username)."""
+
+    new_username = forms.CharField(
+        max_length=150,
+        label="New Username",
+        help_text=(
+            "Choose a new username. "
+            "It can only contain letters, numbers, and underscores. "
+            "Please pick a username, not an email address."
+        ),
+        validators=[
+            validators.RegexValidator(
+                regex=r"^[^@]+$",
+                message="Username cannot be an email address. Please choose a username without @ symbol.",
+            ),
+            validators.RegexValidator(
+                regex=r"^[a-zA-Z0-9_]+$",
+                message="Username can only contain letters, numbers, and underscores.",
+            ),
+        ],
+    )
+    captcha = ReCaptchaField(widget=ReCaptchaV3(action="change_username"))
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop("user", None)
+        super().__init__(*args, **kwargs)
+
+    def clean_new_username(self):
+        new_username = self.cleaned_data["new_username"]
+        User = get_user_model()
+
+        # Check if username is already taken
+        if (
+            User.objects.filter(username__iexact=new_username)
+            .exclude(pk=self.user.pk)
+            .exists()
+        ):
+            raise forms.ValidationError("This username is already taken.")
+
+        # Check against blacklist (matching settings configuration)
+        blacklist = ["admin", "superuser", "staff", "user", "gyrinx"]
+        if new_username.lower() in blacklist:
+            raise forms.ValidationError("This username is not allowed.")
+
+        return new_username
+
+    def save(self):
+        """Save the new username to the user."""
+        if self.user:
+            self.user.username = self.cleaned_data["new_username"]
+            self.user.save()
+            return self.user

--- a/gyrinx/core/forms/__init__.py
+++ b/gyrinx/core/forms/__init__.py
@@ -64,6 +64,7 @@ class UsernameChangeForm(forms.Form):
                 message="Username can only contain letters, numbers, and underscores.",
             ),
         ],
+        widget=forms.TextInput(attrs={"class": "form-control"}),
     )
     captcha = ReCaptchaField(widget=ReCaptchaV3(action="change_username"))
 

--- a/gyrinx/core/templates/account/snippets/menu.html
+++ b/gyrinx/core/templates/account/snippets/menu.html
@@ -9,6 +9,16 @@
            href="{{ account_home_url_ }}"><i class="bi-gear"></i> {{ user.username }}</a>
     </li>
 {% endif %}
+{% if '@' in user.username %}
+    {% url 'core:change-username' as change_username_url_ %}
+    {% if change_username_url_ %}
+        <li class="{{ list_item_class }}">
+            <a class="{{ list_a_class }} {% active_view 'core:change-username' %}"
+               {% active_aria 'core:change-username' %}
+               href="{{ change_username_url_ }}">{% trans "Change Username" %}</a>
+        </li>
+    {% endif %}
+{% endif %}
 {% url 'account_email' as email_url_ %}
 {% if email_url_ %}
     <li class="{{ list_item_class }}">

--- a/gyrinx/core/templates/core/change_username.html
+++ b/gyrinx/core/templates/core/change_username.html
@@ -7,13 +7,10 @@
     <div class="card">
         <div class="card-body">
             <h1 class="h3 mb-4">{% trans "Change Username" %}</h1>
-            <div class="alert alert-info mb-4">
-                <i class="bi-info-circle me-2"></i>
-                Your current username contains an '@' symbol. Please choose a new username that doesn't include '@'.
-            </div>
-            <p class="mb-4">
-                <strong>Current username:</strong> <code>{{ user.username }}</code>
+            <p>
+                Your current username contains an '@' symbol: <strong>{{ user.username }}</strong>
             </p>
+            <p>Please choose a new username that doesn't include '@'.</p>
             <form method="post" class="vstack gap-3">
                 {% csrf_token %}
                 <div>

--- a/gyrinx/core/templates/core/change_username.html
+++ b/gyrinx/core/templates/core/change_username.html
@@ -1,0 +1,40 @@
+{% extends "account/base_manage.html" %}
+{% load allauth i18n %}
+{% block head_title %}
+    {% trans "Change Username" %}
+{% endblock head_title %}
+{% block content %}
+    <div class="card">
+        <div class="card-body">
+            <h1 class="h3 mb-4">{% trans "Change Username" %}</h1>
+            <div class="alert alert-info mb-4">
+                <i class="bi-info-circle me-2"></i>
+                Your current username contains an '@' symbol. Please choose a new username that doesn't include '@'.
+            </div>
+            <p class="mb-4">
+                <strong>Current username:</strong> <code>{{ user.username }}</code>
+            </p>
+            <form method="post" class="vstack gap-3">
+                {% csrf_token %}
+                <div>
+                    <label for="{{ form.new_username.id_for_label }}" class="form-label">{{ form.new_username.label }}</label>
+                    {{ form.new_username }}
+                    {% if form.new_username.help_text %}<div class="form-text">{{ form.new_username.help_text }}</div>{% endif %}
+                    {% if form.new_username.errors %}
+                        <div class="invalid-feedback d-block">{{ form.new_username.errors.0 }}</div>
+                    {% endif %}
+                </div>
+                <div>
+                    {{ form.captcha }}
+                    {% if form.captcha.errors %}<div class="invalid-feedback d-block">{{ form.captcha.errors.0 }}</div>{% endif %}
+                </div>
+                <div class="hstack gap-2 mt-3">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi-check-circle"></i> {% trans "Change Username" %}
+                    </button>
+                    <a href="{% url 'core:account_home' %}" class="btn btn-link">{% trans "Cancel" %}</a>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/index.html
+++ b/gyrinx/core/templates/core/index.html
@@ -28,6 +28,17 @@
         {% if user.is_authenticated %}
             <div class="vstack gap-4">
                 {% include "core/includes/announcement_banner.html" %}
+                {% if '@' in user.username %}
+                    <div class="alert alert-warning d-flex align-items-center" role="alert">
+                        <i class="bi-exclamation-triangle me-2"></i>
+                        <div class="flex-grow-1">
+                            <strong>Update your username!</strong> Your current username contains an '@' symbol, which is no longer allowed.
+                            Please update it to continue using all features.
+                        </div>
+                        <a href="{% url 'core:change-username' %}"
+                           class="btn btn-warning btn-sm ms-3">Change Username</a>
+                    </div>
+                {% endif %}
                 <!-- Three column layout for desktop, stacked for mobile -->
                 <div class="row g-4">
                     <!-- Campaign gangs column -->

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -13,6 +13,11 @@ app_name = "core"
 urlpatterns = [
     path("", gyrinx.core.views.index, name="index"),
     path("accounts/", gyrinx.core.views.account_home, name="account_home"),
+    path(
+        "accounts/change-username/",
+        gyrinx.core.views.change_username,
+        name="change-username",
+    ),
     path("dice/", gyrinx.core.views.dice, name="dice"),
     path("lists/", list.ListsListView.as_view(), name="lists"),
     path("lists/new", list.new_list, name="lists-new"),


### PR DESCRIPTION
Add a feature that allows users whose username contains an '@' symbol to change their username.

This is accessible from the `/accounts/` page and linked via the account menu. A banner on the homepage invites eligible users to change their username.

Closes #456

Generated with [Claude Code](https://claude.ai/code)