### PR TITLE
Fix captured fighters display on campaign view

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -337,10 +337,8 @@
                             <i class="bi-person-lock"></i> View Captured
                         </a>
                     </div>
-                    <div class="card-body py-2 px-2 px-sm-3">
-                        <p class="text-muted mb-0">
-                            Track fighters captured during the campaign. Captured fighters can be sold to guilders or returned to their original gang.
-                        </p>
+                    <div class="card-body p-0">
+                        {% include "core/includes/campaign_captured_fighters.html" with campaign=campaign captured_fighters=captured_fighters %}
                     </div>
                 </div>
             {% endif %}

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -337,7 +337,7 @@
                             <i class="bi-person-lock"></i> View Captured
                         </a>
                     </div>
-                    <div class="card-body p-0">
+                    <div class="card-body p-0 px-sm-3 py-sm-2">
                         {% include "core/includes/campaign_captured_fighters.html" with campaign=campaign captured_fighters=captured_fighters %}
                     </div>
                 </div>

--- a/gyrinx/core/templates/core/includes/campaign_captured_fighters.html
+++ b/gyrinx/core/templates/core/includes/campaign_captured_fighters.html
@@ -1,0 +1,50 @@
+{% load custom_tags color_tags %}
+{% if captured_fighters %}
+    <table class="table table-sm mb-0">
+        <thead>
+            <tr>
+                <th>Fighter</th>
+                <th>Original Gang</th>
+                <th>Captured By</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for captured in captured_fighters|slice:":5" %}
+                <tr>
+                    <td>
+                        <strong>{{ captured.fighter.name }}</strong>
+                        <span class="text-secondary small d-block">{{ captured.fighter.content_fighter.type }}</span>
+                    </td>
+                    <td>
+                        <a href="{% url 'core:list' captured.fighter.list.id %}"
+                           class="link-underline-opacity-25 link-underline-opacity-100-hover">
+                            {% list_with_theme captured.fighter.list %}
+                        </a>
+                    </td>
+                    <td>
+                        <a href="{% url 'core:list' captured.capturing_list.id %}"
+                           class="link-underline-opacity-25 link-underline-opacity-100-hover">
+                            {% list_with_theme captured.capturing_list %}
+                        </a>
+                    </td>
+                    <td>
+                        {% if captured.sold_to_guilders %}
+                            <span class="badge bg-secondary">Sold</span>
+                        {% else %}
+                            <span class="badge bg-warning text-dark">Captured</span>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% if captured_fighters.count > 5 %}
+        <div class="text-center mt-2">
+            <a href="{% url 'core:campaign-captured-fighters' campaign.id %}"
+               class="btn btn-sm btn-link">View all {{ captured_fighters.count }} captured fighters →</a>
+        </div>
+    {% endif %}
+{% else %}
+    <p class="text-muted mb-0 text-center py-3">No fighters have been captured yet.</p>
+{% endif %}

--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -121,6 +121,22 @@ class CampaignDetailView(generic.DetailView):
         # Get resource types with their list resources
         context["resource_types"] = get_campaign_resource_types_with_resources(campaign)
 
+        # Get captured fighters for the campaign
+        if campaign.is_in_progress:
+            context["captured_fighters"] = (
+                CapturedFighter.objects.filter(
+                    models.Q(capturing_list__campaigns=campaign)
+                    | models.Q(fighter__list__campaigns=campaign)
+                )
+                .select_related(
+                    "fighter",
+                    "fighter__list",
+                    "fighter__content_fighter",
+                    "capturing_list",
+                )
+                .order_by("-captured_at")
+            )
+
         context["is_owner"] = user == campaign.owner
         return context
 


### PR DESCRIPTION
Fixes #466

## Summary

This PR fixes the captured fighters section on the campaign view to actually display captured fighters instead of just showing a description.

## Changes

- Created a reusable include template for displaying captured fighters
- Updated the campaign view to fetch captured fighters data
- Modified the campaign template to show the captured fighters table inline

## Result

The campaign view now shows up to 5 captured fighters directly on the page, with a link to view all if there are more.

Generated with [Claude Code](https://claude.ai/code)