### PR TITLE
feat: Add controls for stash fighter creation and display

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -15,6 +15,14 @@ from gyrinx.models import FighterCategoryChoices
 
 
 class NewListForm(forms.ModelForm):
+    show_stash = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Show Stash for this list",
+        help_text="If checked, a stash fighter will be created for this list.",
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
+    )
+
     class Meta:
         model = List
         fields = ["name", "content_house", "narrative", "public"]

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -136,10 +136,20 @@
                                 </li>
                                 {% if list.owner_cached == user %}
                                     <li>
-                                        <a href="{% url 'core:list-show-stash' list.id %}"
-                                           class="dropdown-item icon-link">
-                                            <i class="bi-plus-circle"></i> Show Stash
-                                        </a>
+                                        {% if has_stash_fighter %}
+                                            <a href="#"
+                                               class="dropdown-item icon-link disabled"
+                                               data-bs-toggle="tooltip"
+                                               data-bs-title="This list already has a stash fighter"
+                                               onclick="return false;">
+                                                <i class="bi-plus-circle"></i> Show Stash
+                                            </a>
+                                        {% else %}
+                                            <a href="{% url 'core:list-show-stash' list.id %}"
+                                               class="dropdown-item icon-link">
+                                                <i class="bi-plus-circle"></i> Show Stash
+                                            </a>
+                                        {% endif %}
                                     </li>
                                     <li>
                                         <a href="{% url 'core:list-archive' list.id %}"

--- a/gyrinx/core/templates/core/list.html
+++ b/gyrinx/core/templates/core/list.html
@@ -14,6 +14,6 @@
         {% include "core/includes/back.html" with url=lists_url text="All Lists" %}
     {% endif %}
     <div class="col-lg-12 px-0 vstack gap-5">
-        {% include "core/includes/list.html" with list=list campaign_resources=campaign_resources held_assets=held_assets %}
+        {% include "core/includes/list.html" with list=list campaign_resources=campaign_resources held_assets=held_assets has_stash_fighter=has_stash_fighter %}
     </div>
 {% endblock content %}


### PR DESCRIPTION
- Disable "Show stash" button for lists that already have a stash fighter
- Add tooltip explaining when button is disabled  
- Add checkbox to create list form to control stash fighter creation
- Only create stash fighter when checkbox is checked (default: true)
- Update tests to reflect new behavior

Fixes #481