### PR TITLE
fix: correct cost display in fighter cloning dropdown

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -98,7 +98,7 @@ class ContentFighterChoiceField(forms.ModelChoiceField):
 
     def label_from_instance(self, obj: ContentFighter):
         cost_for_house = (
-            obj.cost_for_house(self.content_house) if self.content_house else obj.cost
+            obj.cost_for_house(self.content_house) if self.content_house else obj.cost()
         )
         return f"{obj.name()} ({cost_for_house}¢)"
 
@@ -330,6 +330,8 @@ class CloneListFighterForm(forms.ModelForm):
         self.fields["content_fighter"] = ContentFighterChoiceField(
             queryset=self.fields["content_fighter"].queryset
         )
+        if inst:
+            self.fields["content_fighter"].content_house = inst.list.content_house
 
     class Meta:
         model = ListFighter


### PR DESCRIPTION
Fixes #480

## Summary
Fixed the display error when cloning fighters that was showing `<bound method ContentFighter.cost of ...>` instead of the actual cost value.

## Changes
- Changed `obj.cost` to `obj.cost()` in `ContentFighterChoiceField.label_from_instance`
- Added `content_house` property setting in `CloneListFighterForm` for proper cost calculation

## Test Plan
- Navigate to a fighter
- Click on 'clone'
- Click on the dropdown
- Verify that costs are displayed correctly (e.g., "100¢")

Generated with [Claude Code](https://claude.ai/code)