### PR TITLE
Add content data management process for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ screenshots/
 .claude/memory.local.json
 CLAUDE.local.md
 media/
+# Ignore the latest content data export file
+latest.json

--- a/README.md
+++ b/README.md
@@ -201,3 +201,19 @@ You can also enable SQL logging by setting the `SQL_DEBUG` variable:
 ```
 SQL_DEBUG=True
 ```
+
+## Content library for development
+
+To test Gyrinx locally, you are really limited unless you have the content library data available. This is because the content library is what provides the data for the Gyrinx application to work with.
+
+The content library is managed by the Gyrinx content team in production, and is what makes Gyrinx useful.
+
+Gyrinx uses a custom-ish data export/import process to manage content library data from production, so you can test locally.
+
+> [!NOTE]
+> This process is only available for trusted developers and admins.
+
+1. **Export**: Run the `gyrinx-dumpdata` Cloud Run job in production to export content to the `gyrinx-app-bootstrap-dump` bucket
+2. **Import**: Download `latest.json` from the bucket and use `manage loaddata_overwrite latest.json` to replace local content data
+
+This process ensures we have access to the latest production content library. See [docs/operations/content-data-management.md](docs/operations/content-data-management.md) for details.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,6 +65,20 @@ steps:
       - >-
         $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
     id: Push
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - tag
+      - >-
+        $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+      - >-
+        $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:latest
+    id: Tag Latest
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - >-
+        $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:latest
+    id: Push Latest
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
     args:
       - run
@@ -100,6 +114,8 @@ steps:
 images:
   - >-
     $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+  - >-
+    $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:latest
 options:
   substitutionOption: ALLOW_LOOSE
   logging: CLOUD_LOGGING_ONLY

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,6 +42,7 @@
 ## Operations
 
 * [Operational Overview](operations/operational-overview.md)
+* [Content Data Management](operations/content-data-management.md)
 * [Deployment](deployment.md)
 * [Runbook](runbook.md)
 

--- a/docs/operations/content-data-management.md
+++ b/docs/operations/content-data-management.md
@@ -1,0 +1,119 @@
+# Content Library Management
+
+This guide explains how to get the content library data from production into your local development environment using the custom-ish `dumpdata` and `loaddata_overwrite` process.
+
+> [!IMPORTANT]
+> This process is only available for trusted developers and admins who have been granted access to the production infrastructure.
+
+## Why You Need This
+
+Gyrinx is really limited without the content library data - it's what makes the application useful. The content library includes all the game data (fighters, equipment, weapons, skills, houses) that's managed by the Gyrinx content team in production.
+
+Without this data, you'll have an empty shell of an application that's pretty hard to test or develop against.
+
+## The Process
+
+### 1. Export from Production
+
+The export uses the `gyrinx-dumpdata` Cloud Run job in production:
+
+1. Access the Google Cloud Console (you need permissions)
+2. Navigate to Cloud Run → Jobs
+3. Find and run the `gyrinx-dumpdata` job
+4. The job exports all content data to `latest.json` in the `gyrinx-app-bootstrap-dump` bucket
+
+Or use the gcloud CLI:
+
+```bash
+# Trigger the dumpdata job
+gcloud run jobs execute gyrinx-dumpdata --region=europe-west2
+```
+
+### 2. Download the Export
+
+```bash
+# Download latest content from production (requires GCS access)
+gsutil cp gs://gyrinx-app-bootstrap-dump/latest.json .
+```
+
+### 3. Import Locally
+
+The `loaddata_overwrite` command replaces your local content with the production data:
+
+```bash
+# Check what will be changed first
+manage loaddata_overwrite latest.json --dry-run
+
+# Actually import the data
+manage loaddata_overwrite latest.json
+```
+
+## What loaddata_overwrite Does
+
+This custom command is different from Django's built-in `loaddata`:
+
+1. **Clears existing content** - Wipes all content models before importing (destructive!)
+2. **Handles foreign keys** - Temporarily disables constraints during import
+3. **Skips historical records** - Ignores django-simple-history tables
+4. **Actually works** - Django's loaddata would fail on duplicate keys
+
+The command lives at `gyrinx/core/management/commands/loaddata_overwrite.py`.
+
+## Common Tasks
+
+### Getting Started with Development
+
+When you first set up Gyrinx locally:
+
+```bash
+# Get the latest content library
+gsutil cp gs://gyrinx-app-bootstrap-dump/latest.json .
+
+# Import it
+manage loaddata_overwrite latest.json --verbose
+```
+
+### Debugging Production Content
+
+Need to investigate a content issue from production?
+
+```bash
+# Get fresh data
+gsutil cp gs://gyrinx-app-bootstrap-dump/latest.json .
+
+# Import with verbose output to see what's happening
+manage loaddata_overwrite latest.json --verbose
+
+# Poke around
+manage shell
+```
+
+## Warnings
+
+- **This deletes all your local content data** - The command wipes content models before importing
+- **Don't commit latest.json** - It's already in .gitignore, keep it that way
+- **Need access** - You must be a trusted developer with GCS permissions
+- **Big file** - The export can be large, depending on how much content exists
+
+## If Things Go Wrong
+
+### Import Failed?
+
+The database might be partially cleared. Just run the command again - it'll clear everything and start fresh.
+
+### No Access?
+
+If you can't access the GCS bucket or Cloud Run job, you'll need to ask an admin for:
+1. Access to the production GCP project
+2. Permissions for the `gyrinx-app-bootstrap-dump` bucket
+3. Ability to run the `gyrinx-dumpdata` Cloud Run job
+
+### Corrupted JSON?
+
+Re-download from the bucket. The export job creates valid JSON, so corruption usually happens during download.
+
+## Technical Details
+
+The command uses PostgreSQL's `TRUNCATE CASCADE` for fast deletion, but falls back to regular `DELETE` if that fails. Foreign key checks are disabled with `SET session_replication_role = 'replica'` during import.
+
+Historical models (from django-simple-history) are automatically detected and skipped - they're managed separately by the history system.

--- a/gyrinx/core/management/commands/loaddata_overwrite.py
+++ b/gyrinx/core/management/commands/loaddata_overwrite.py
@@ -1,0 +1,198 @@
+"""
+Django management command that loads fixture data and overwrites existing data.
+This command will delete existing objects and replace them with fixture data.
+"""
+
+import json
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
+from django.db import connection
+from django.apps import apps
+
+
+class Command(BaseCommand):
+    help = (
+        "Load fixture data and overwrite any existing objects with the same primary key"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "fixture_file", type=str, help="Path to the fixture file (JSON format)"
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be done without making changes",
+        )
+        parser.add_argument(
+            "--verbose", action="store_true", help="Show detailed progress"
+        )
+
+    def handle(self, *args, **options):
+        fixture_file = options["fixture_file"]
+        dry_run = options.get("dry_run", False)
+        verbose = options.get("verbose", False)
+
+        try:
+            with open(fixture_file, "r") as f:
+                fixture_data = json.load(f)
+        except FileNotFoundError:
+            raise CommandError(f"Fixture file '{fixture_file}' not found")
+        except json.JSONDecodeError as e:
+            raise CommandError(f"Invalid JSON in fixture file: {e}")
+
+        if dry_run:
+            self.stdout.write("DRY RUN - No changes will be made")
+
+        # Group objects by model
+        objects_by_model = {}
+        for obj_data in fixture_data:
+            model_label = obj_data["model"]
+            if model_label not in objects_by_model:
+                objects_by_model[model_label] = []
+            objects_by_model[model_label].append(obj_data)
+
+        # Separate historical models from regular models
+        historical_models = {}
+        regular_models = {}
+
+        for model_label, objects in objects_by_model.items():
+            if "historical" in model_label.lower():
+                historical_models[model_label] = objects
+            else:
+                regular_models[model_label] = objects
+
+        # Clear all data from regular models first (in reverse dependency order)
+        if not dry_run:
+            self.stdout.write("Clearing existing data...")
+            self._clear_all_models(regular_models, verbose)
+
+        # Process regular models
+        self._process_models(regular_models, dry_run, verbose)
+
+        # Then process historical models if needed
+        if historical_models:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Skipping {len(historical_models)} historical model types - these should be managed by django-simple-history"
+                )
+            )
+            if verbose:
+                for model_label in historical_models:
+                    self.stdout.write(f"  - {model_label}")
+
+        total_regular = sum(len(objs) for objs in regular_models.values())
+        total_historical = sum(len(objs) for objs in historical_models.values())
+
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"DRY RUN complete - would process {total_regular} objects (skipped {total_historical} historical records)"
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully processed {total_regular} objects from {fixture_file} (skipped {total_historical} historical records)"
+                )
+            )
+
+    def _process_models(self, models_dict, dry_run, verbose):
+        """Process a dictionary of models and their objects."""
+        if dry_run:
+            # In dry run mode, just count objects
+            for model_label, objects in models_dict.items():
+                if verbose:
+                    self.stdout.write(
+                        f"Would load {len(objects)} objects for {model_label}"
+                    )
+            return
+
+        # Create a temporary file with just the regular models
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            # Flatten all objects from regular models
+            all_objects = []
+            for objects in models_dict.values():
+                all_objects.extend(objects)
+
+            json.dump(all_objects, f, indent=2)
+            temp_file = f.name
+
+        try:
+            # Use Django's built-in loaddata which handles dependencies properly
+            if verbose:
+                self.stdout.write("Loading fixture data...")
+
+            # Disable foreign key checks temporarily for loading
+            with connection.cursor() as cursor:
+                cursor.execute("SET session_replication_role = 'replica';")
+
+            try:
+                # Load the data
+                call_command("loaddata", temp_file, verbosity=2 if verbose else 1)
+            finally:
+                # Re-enable foreign key checks
+                with connection.cursor() as cursor:
+                    cursor.execute("SET session_replication_role = 'origin';")
+
+        finally:
+            # Clean up temp file
+            import os
+
+            os.unlink(temp_file)
+
+    def _clear_all_models(self, models_dict, verbose):
+        """Clear all data from models before loading new data."""
+        # Get all model classes
+        model_classes = []
+        for model_label in models_dict.keys():
+            try:
+                app_label, model_name = model_label.split(".")
+                model = apps.get_model(app_label, model_name)
+                model_classes.append((model_label, model))
+            except (ValueError, LookupError):
+                continue
+
+        # Clear in reverse order to handle dependencies
+        for model_label, model in reversed(model_classes):
+            try:
+                count = model.objects.all().count()
+                if count > 0:
+                    with connection.cursor() as cursor:
+                        # Use TRUNCATE for faster deletion and to reset sequences
+                        cursor.execute(
+                            f'TRUNCATE TABLE "{model._meta.db_table}" CASCADE'
+                        )
+                    if verbose:
+                        self.stdout.write(f"Cleared {count} objects from {model_label}")
+            except Exception:
+                # Fallback to regular delete if TRUNCATE fails
+                try:
+                    count = model.objects.all().delete()[0]
+                    if verbose and count > 0:
+                        self.stdout.write(f"Deleted {count} objects from {model_label}")
+                except Exception as e2:
+                    if verbose:
+                        self.stdout.write(
+                            self.style.WARNING(f"Could not clear {model_label}: {e2}")
+                        )
+
+    def _extract_unique_fields(self, error, model):
+        """Try to extract field names from unique constraint error message."""
+        error_str = str(error)
+
+        # Common patterns for unique constraint field names
+        if "Key (" in error_str and ")=" in error_str:
+            # PostgreSQL format: Key (field_name)=(value)
+            start = error_str.find("Key (") + 5
+            end = error_str.find(")=", start)
+            if start > 4 and end > start:
+                field_name = error_str[start:end]
+                # Map database column to model field
+                for field in model._meta.fields:
+                    if field.column == field_name or field.name == field_name:
+                        return [field.name]
+
+        return None


### PR DESCRIPTION
- Add loaddata_overwrite management command to replace existing content with fixture data
- Update cloudbuild.yaml to tag images as "latest" in addition to commit SHA
- Document the dumpdata/loaddata process for syncing production content
- Add latest.json to .gitignore to prevent committing content exports

The loaddata_overwrite command provides advantages over Django's built-in loaddata:
- Clears existing data before importing (handles duplicates)
- Temporarily disables foreign key constraints during import
- Automatically skips historical models from django-simple-history
- Provides dry-run and verbose options for safer operations

🤖 Generated with [Claude Code](https://claude.ai/code)