### PR TITLE
fix: move variable definitions outside campaign mode check to fix UnboundLocalError

### DIFF
--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -3692,12 +3692,13 @@ def reassign_list_fighter_equipment(
                 assignment.list_fighter = target_fighter
                 assignment.save_with_user(user=request.user)
 
+                # Get names for logging and campaign action
+                equipment_name = assignment.content_equipment.name
+                from_fighter_name = fighter.name
+                to_fighter_name = target_fighter.name
+
                 # Create campaign action if in campaign mode
                 if lst.status == List.CAMPAIGN_MODE and lst.campaign:
-                    equipment_name = assignment.content_equipment.name
-                    from_fighter_name = fighter.name
-                    to_fighter_name = target_fighter.name
-
                     CampaignAction.objects.create(
                         user=request.user,
                         owner=request.user,


### PR DESCRIPTION
The variables equipment_name, from_fighter_name, and to_fighter_name were being
defined inside the campaign mode if block but used in the log_event call outside.
This caused an UnboundLocalError when reassigning equipment in non-campaign mode.

Moving these definitions outside the if block ensures they're always available
for logging, regardless of the list's campaign status.

Fixes #489

Generated with [Claude Code](https://claude.ai/code)