### PR TITLE
fix: preserve public/private state when cloning lists for campaigns

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -232,7 +232,6 @@ class List(AppBase):
             kwargs["status"] = self.CAMPAIGN_MODE
             kwargs["original_list"] = self
             kwargs["campaign"] = for_campaign
-            kwargs["public"] = False  # Campaign lists are always private
         else:
             # Regular clones get a suffix
             if not name:
@@ -242,7 +241,7 @@ class List(AppBase):
             owner = self.owner
 
         values = {
-            "public": self.public if for_campaign is None else False,
+            "public": self.public,
             "narrative": self.narrative,
             "theme_color": self.theme_color,
             **kwargs,

--- a/gyrinx/core/tests/test_clone.py
+++ b/gyrinx/core/tests/test_clone.py
@@ -138,3 +138,24 @@ def test_list_clone_excludes_stash_fighter(
     cloned_fighter = cloned_list.fighters().first()
     assert cloned_fighter.name == "Regular Fighter"
     assert not cloned_fighter.content_fighter.is_stash
+
+
+@pytest.mark.django_db
+def test_list_clone_for_campaign_preserves_public_state(make_list, make_campaign):
+    """Test that public/private state is preserved when cloning for campaigns."""
+    # Test with a public list
+    public_list = make_list("Public List", public=True)
+    campaign = make_campaign("Test Campaign")
+
+    public_clone = public_list.clone(for_campaign=campaign)
+    assert public_clone.public is True  # Should preserve public state
+    assert public_clone.campaign == campaign
+    assert public_clone.status == List.CAMPAIGN_MODE
+
+    # Test with a private list
+    private_list = make_list("Private List", public=False)
+
+    private_clone = private_list.clone(for_campaign=campaign)
+    assert private_clone.public is False  # Should preserve private state
+    assert private_clone.campaign == campaign
+    assert private_clone.status == List.CAMPAIGN_MODE


### PR DESCRIPTION
Fixes #502

## Summary
- Lists now maintain their public/private state when cloned into campaigns
- Previously all campaign lists were forced to be private

## Test plan
- Added test `test_list_clone_for_campaign_preserves_public_state` to verify the fix
- Run `pytest gyrinx/core/tests/test_clone.py::test_list_clone_for_campaign_preserves_public_state`

🤖 Generated with [Claude Code](https://claude.ai/code)