### PR TITLE
fix: prevent duplicate gang cloning in campaigns

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_add_lists.html
+++ b/gyrinx/core/templates/core/campaign/campaign_add_lists.html
@@ -8,9 +8,8 @@
     <div class="col-12 px-0 vstack gap-3">
         <h1 class="h3">Add Gangs to {{ campaign.name }}</h1>
         {% if error_message %}
-            <div class="alert alert-danger">
-                <h4 class="alert-heading">Error</h4>
-                <p>{{ error_message }}</p>
+            <div class="alert alert-danger mb-last-0">
+                <p>Error: {{ error_message }}</p>
             </div>
         {% endif %}
         {% if show_confirmation and list_to_confirm %}

--- a/gyrinx/core/tests/test_campaign.py
+++ b/gyrinx/core/tests/test_campaign.py
@@ -549,6 +549,165 @@ def test_campaign_action_list_filtering():
 
 
 @pytest.mark.django_db
+def test_campaign_prevents_duplicate_list_cloning():
+    """Test that campaigns prevent duplicate cloning of lists."""
+    # Create test users
+    user = User.objects.create_user(username="testuser", password="testpass")
+
+    # Create a campaign
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        public=True,
+        status=Campaign.PRE_CAMPAIGN,
+    )
+
+    # Create a house and list
+    house = ContentHouse.objects.create(name="Test House")
+    original_list = List.objects.create(
+        name="Original Gang",
+        owner=user,
+        content_house=house,
+        status=List.LIST_BUILDING,
+    )
+
+    # Add the list to the campaign
+    campaign.lists.add(original_list)
+
+    # Start the campaign (should clone the list)
+    assert campaign.start_campaign() is True
+
+    # Verify the campaign is now in progress
+    campaign.refresh_from_db()
+    assert campaign.status == Campaign.IN_PROGRESS
+
+    # Verify we have exactly one cloned list
+    assert campaign.lists.count() == 1
+    cloned_list = campaign.lists.first()
+    assert cloned_list.original_list == original_list
+    assert cloned_list.status == List.CAMPAIGN_MODE
+
+    # Test the has_clone_of_list method
+    assert campaign.has_clone_of_list(original_list) is True
+
+    # Create another list to test negative case
+    another_list = List.objects.create(
+        name="Another Gang",
+        owner=user,
+        content_house=house,
+        status=List.LIST_BUILDING,
+    )
+    assert campaign.has_clone_of_list(another_list) is False
+
+
+@pytest.mark.django_db
+def test_campaign_add_list_prevents_duplicates():
+    """Test that add_list_to_campaign prevents duplicate cloning."""
+    # Create test users
+    user = User.objects.create_user(username="testuser", password="testpass")
+
+    # Create a campaign already in progress
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        public=True,
+        status=Campaign.IN_PROGRESS,
+    )
+
+    # Create a house and list
+    house = ContentHouse.objects.create(name="Test House")
+    original_list = List.objects.create(
+        name="Original Gang",
+        owner=user,
+        content_house=house,
+        status=List.LIST_BUILDING,
+    )
+
+    # Add the list to the campaign (should clone it)
+    cloned_list1 = campaign.add_list_to_campaign(original_list)
+    assert cloned_list1.original_list == original_list
+    assert cloned_list1.status == List.CAMPAIGN_MODE
+    assert campaign.lists.count() == 1
+
+    # Try to add the same list again
+    cloned_list2 = campaign.add_list_to_campaign(original_list)
+
+    # Should return the existing clone, not create a new one
+    assert cloned_list2.id == cloned_list1.id
+    assert campaign.lists.count() == 1
+
+    # Verify the returned list is the same as the first clone
+    assert cloned_list2.original_list == original_list
+
+
+@pytest.mark.django_db
+def test_campaign_duplicate_prevention_with_transaction_rollback():
+    """Test that duplicate prevention works even with transaction rollback scenarios."""
+    # Create test users
+    user = User.objects.create_user(username="testuser", password="testpass")
+
+    # Create a campaign
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        public=True,
+        status=Campaign.PRE_CAMPAIGN,
+    )
+
+    # Create a house and lists
+    house = ContentHouse.objects.create(name="Test House")
+    list1 = List.objects.create(
+        name="Gang 1",
+        owner=user,
+        content_house=house,
+        status=List.LIST_BUILDING,
+    )
+    list2 = List.objects.create(
+        name="Gang 2",
+        owner=user,
+        content_house=house,
+        status=List.LIST_BUILDING,
+    )
+
+    # Add both lists to the campaign
+    campaign.lists.add(list1, list2)
+
+    # Start the campaign
+    assert campaign.start_campaign() is True
+
+    # Now we have clones of both lists
+    assert campaign.lists.count() == 2
+    clone1 = campaign.lists.get(original_list=list1)
+    clone2 = campaign.lists.get(original_list=list2)
+
+    # Simulate a scenario where someone tries to add the original lists again
+    # This might happen if the campaign status was reset due to an error
+    campaign.status = Campaign.PRE_CAMPAIGN
+    campaign.save()
+
+    # The clones still exist in the campaign
+    assert campaign.lists.filter(original_list=list1).exists()
+    assert campaign.lists.filter(original_list=list2).exists()
+
+    # Now add the original lists again (simulating retry after failure)
+    campaign.lists.add(list1, list2)
+
+    # Before starting, we have 4 lists (2 originals + 2 clones)
+    assert campaign.lists.count() == 4
+
+    # Start the campaign again - should not create duplicates
+    assert campaign.start_campaign() is True
+
+    # After starting, the originals are removed and we keep only the clones
+    campaign.refresh_from_db()
+    assert campaign.lists.count() == 2
+
+    # The clones should be the same ones
+    assert campaign.lists.get(original_list=list1).id == clone1.id
+    assert campaign.lists.get(original_list=list2).id == clone2.id
+
+
+@pytest.mark.django_db
 def test_campaign_action_list_timeframe_filtering():
     """Test that campaign action list view supports timeframe filtering."""
     client = Client()


### PR DESCRIPTION
Fixes #493

This PR prevents duplicate cloning of gangs into campaigns by:

- Adding duplicate detection before cloning lists
- Wrapping cloning operations in database transactions
- Re-adding existing clones when duplicates are detected

This prevents the issue where lists could be cloned multiple times into the same campaign if the campaign creation was interrupted or retried.

Generated with [Claude Code](https://claude.ai/code)