### PR TITLE
fix: configure Django error handlers to show proper 404 pages

### DIFF
--- a/gyrinx/pages/tests/test_error_handlers.py
+++ b/gyrinx/pages/tests/test_error_handlers.py
@@ -1,0 +1,29 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_404_handler():
+    """Test that 404 errors return the custom 404 page."""
+    client = Client()
+    response = client.get("/this-page-does-not-exist/")
+    assert response.status_code == 404
+    # Check that it's using our custom 404 template
+    assert "404.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+def test_direct_404_view():
+    """Test the direct 404 view."""
+    client = Client()
+    response = client.get(reverse("error_404"))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_direct_500_view():
+    """Test the direct 500 view."""
+    client = Client()
+    response = client.get(reverse("error_500"))
+    assert response.status_code == 500

--- a/gyrinx/pages/views.py
+++ b/gyrinx/pages/views.py
@@ -109,7 +109,7 @@ def join_the_waiting_list_success(request):
     )
 
 
-def error_404(request):
+def error_404(request, exception=None):
     return render(request, "404.html", status=404)
 
 

--- a/gyrinx/urls.py
+++ b/gyrinx/urls.py
@@ -50,3 +50,7 @@ urlpatterns = debug_toolbar_urls() + [
 # Serve media files in development
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# Custom error handlers
+handler404 = "gyrinx.pages.views.error_404"
+handler500 = "gyrinx.pages.views.error_500"


### PR DESCRIPTION
This PR fixes an issue where 404 errors were showing the 500 error page instead of the proper 404 page.

## Problem
The Django error handlers (`handler404` and `handler500`) were not configured in the URL configuration, causing Django to use its default behavior which resulted in 404 errors showing as 500 errors.

## Solution
- Added `handler404` and `handler500` to `urls.py`
- Updated the `error_404` view to accept the `exception` parameter that Django passes to 404 handlers
- Added unit tests to verify error handlers work correctly

Fixes #514

Generated with [Claude Code](https://claude.ai/code)