### PR TITLE
feat: add campaign archive functionality

### DIFF
--- a/gyrinx/core/models/battle.py
+++ b/gyrinx/core/models/battle.py
@@ -65,8 +65,11 @@ class Battle(AppBase):
         """
         Check if a user can edit this battle.
         Only the battle owner or campaign owner can edit.
+        Cannot edit if campaign is archived.
         """
         if not user or not user.is_authenticated:
+            return False
+        if self.campaign.archived:
             return False
         return user == self.owner or user == self.campaign.owner
 
@@ -74,8 +77,11 @@ class Battle(AppBase):
         """
         Check if a user can add notes to this battle.
         Participant gang owners can add notes.
+        Cannot add notes if campaign is archived.
         """
         if not user or not user.is_authenticated:
+            return False
+        if self.campaign.archived:
             return False
         if self.can_edit(user):
             return True

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -215,10 +215,12 @@
                                                     </td>
                                                     {% if is_owner %}
                                                         <td class="text-end pe-2 pe-sm-3">
-                                                            <a href="{% url 'core:campaign-asset-transfer' campaign.id asset.id %}"
-                                                               class="icon-link link-sm">
-                                                                <i class="bi-arrow-left-right"></i> Transfer
-                                                            </a>
+                                                            {% if not campaign.archived %}
+                                                                <a href="{% url 'core:campaign-asset-transfer' campaign.id asset.id %}"
+                                                                   class="icon-link link-sm">
+                                                                    <i class="bi-arrow-left-right"></i> Transfer
+                                                                </a>
+                                                            {% endif %}
                                                         </td>
                                                     {% endif %}
                                                 </tr>
@@ -278,10 +280,12 @@
                                                     </td>
                                                     <td class="text-end pe-2 pe-sm-3">
                                                         {% if is_owner or resource.list.owner == user %}
-                                                            <a href="{% url 'core:campaign-resource-modify' campaign.id resource.id %}"
-                                                               class="fs-7 icon-link">
-                                                                <i class="bi-pencil"></i> Modify
-                                                            </a>
+                                                            {% if not campaign.archived %}
+                                                                <a href="{% url 'core:campaign-resource-modify' campaign.id resource.id %}"
+                                                                   class="fs-7 icon-link">
+                                                                    <i class="bi-pencil"></i> Modify
+                                                                </a>
+                                                            {% endif %}
                                                         {% endif %}
                                                     </td>
                                                 </tr>

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -72,6 +72,27 @@
                                     <i class="bi-arrow-clockwise"></i> Reopen
                                 </a>
                             {% endif %}
+                            <div class="btn-group" role="group">
+                                <button type="button"
+                                        class="btn btn-secondary btn-sm dropdown-toggle"
+                                        data-bs-toggle="dropdown"
+                                        aria-expanded="false">
+                                    <i class="bi-three-dots"></i>
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end">
+                                    <li>
+                                        <a class="dropdown-item"
+                                           href="{% url 'core:campaign-archive' campaign.id %}">
+                                            <i class="bi-{% if campaign.archived %}box-arrow-up{% else %}box-arrow-in-down{% endif %}"></i>
+                                            {% if campaign.archived %}
+                                                Unarchive
+                                            {% else %}
+                                                Archive
+                                            {% endif %}
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
                         </nav>
                     {% endif %}
                 </div>

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -6,6 +6,23 @@
 {% block content %}
     {% url 'core:campaigns' as campaigns_url %}
     {% include "core/includes/back.html" with url=campaigns_url text="All Campaigns" %}
+    {% if campaign.archived %}
+        <div class="border rounded p-2 text-secondary mb-3">
+            <i class="bi-archive"></i>
+            This campaign has been archived by its owner.
+            {% if campaign.owner == request.user %}
+                <form action="{% url 'core:campaign-archive' campaign.id %}"
+                      method="post"
+                      class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit"
+                            name="archive"
+                            value="0"
+                            class="btn btn-sm btn-secondary">Unarchive</button>
+                </form>
+            {% endif %}
+        </div>
+    {% endif %}
     <div class="col-lg-12 px-0 vstack gap-3">
         <div class="vstack gap-0 mb-2">
             <div class="hstack gap-2 mb-2 align-items-start align-items-md-center">
@@ -116,7 +133,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center px-2 px-sm-3">
                     <h2 class="card-title h5 mb-0">Gangs</h2>
-                    {% if campaign.owner == user and not campaign.is_post_campaign %}
+                    {% if campaign.owner == user and not campaign.is_post_campaign and not campaign.archived %}
                         <a href="{% url 'core:campaign-add-lists' campaign.id %}"
                            class="btn btn-primary btn-sm">
                             <i class="bi-plus-circle"></i> Add Gangs
@@ -146,7 +163,7 @@
                     {% else %}
                         <div class="p-3 text-center text-muted">
                             No gangs have been added to this campaign yet.
-                            {% if campaign.owner == user and campaign.is_pre_campaign %}
+                            {% if campaign.owner == user and campaign.is_pre_campaign and not campaign.archived %}
                                 <br>
                                 <a href="{% url 'core:campaign-add-lists' campaign.id %}"
                                    class="btn btn-primary btn-sm mt-2">
@@ -294,7 +311,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center px-2 px-sm-3">
                     <h2 class="card-title h5 mb-0">Battle Reports</h2>
-                    {% if campaign.owner == user and campaign.is_in_progress %}
+                    {% if campaign.owner == user and campaign.is_in_progress and not campaign.archived %}
                         <a href="{% url 'core:battle-new' campaign.id %}"
                            class="btn btn-primary btn-sm">
                             <i class="bi-plus-circle"></i> New Battle
@@ -368,7 +385,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center px-2 px-sm-3">
                     <h2 class="card-title h5 mb-0">Action Log</h2>
                     <div class="hstack gap-2">
-                        {% if can_log_actions %}
+                        {% if can_log_actions and not campaign.archived %}
                             <a href="{% url 'core:campaign-action-new' campaign.id %}"
                                class="btn btn-primary btn-sm">
                                 <i class="bi-plus-circle"></i> Log Action

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -100,7 +100,7 @@
                                     <li>
                                         <a class="dropdown-item"
                                            href="{% url 'core:campaign-archive' campaign.id %}">
-                                            <i class="bi-{% if campaign.archived %}box-arrow-up{% else %}box-arrow-in-down{% endif %}"></i>
+                                            <i class="bi-{% if campaign.archived %}box-arrow-up{% else %}archive{% endif %}"></i>
                                             {% if campaign.archived %}
                                                 Unarchive
                                             {% else %}

--- a/gyrinx/core/templates/core/campaign/campaign_archive.html
+++ b/gyrinx/core/templates/core/campaign/campaign_archive.html
@@ -1,0 +1,60 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    {% if campaign.archived %}
+        Unarchive
+    {% else %}
+        Archive
+    {% endif %}
+    {{ campaign.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">
+            {% if campaign.archived %}
+                Unarchive
+            {% else %}
+                Archive
+            {% endif %}
+            {{ campaign.name }}
+        </h1>
+        {% if not campaign.archived %}
+            <p>Are you sure you want to archive this campaign?</p>
+            <div class="border rounded p-3 bg-body-secondary">
+                <p class="mb-2">
+                    <strong>What happens when you archive:</strong>
+                </p>
+                <ul class="mb-0">
+                    <li>The campaign will be hidden from the main campaigns page</li>
+                    <li>You'll still be able to view the campaign details</li>
+                    <li>Campaign participants can still access it directly</li>
+                    <li>You can unarchive it at any time</li>
+                </ul>
+            </div>
+        {% else %}
+            <p>Are you sure you want to unarchive this campaign?</p>
+            <div class="border rounded p-3 bg-body-secondary">
+                <p class="mb-2">
+                    <strong>What happens when you unarchive:</strong>
+                </p>
+                <ul class="mb-0">
+                    <li>The campaign will be visible on the main campaigns page again</li>
+                    <li>All functionality will be restored</li>
+                </ul>
+            </div>
+        {% endif %}
+        <form action="{% url 'core:campaign-archive' campaign.id %}" method="post">
+            {% csrf_token %}
+            <div class="mt-3">
+                {% if not campaign.archived %}
+                    <input type="hidden" name="archive" value="1">
+                    <button type="submit" class="btn btn-danger">Archive</button>
+                {% else %}
+                    <button type="submit" class="btn btn-primary">Unarchive</button>
+                {% endif %}
+                {% include "core/includes/cancel.html" %}
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -63,16 +63,18 @@
                                                         </span>
                                                     {% endif %}
                                                     {% if is_owner %}
-                                                        <div class="btn-group btn-group-sm flex-shrink-0 ms-auto">
-                                                            <a href="{% url 'core:campaign-asset-transfer' campaign.id asset.id %}"
-                                                               class="btn btn-outline-primary">
-                                                                <i class="bi-arrow-left-right"></i> Transfer
-                                                            </a>
-                                                            <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
-                                                               class="btn btn-outline-secondary">
-                                                                <i class="bi-pencil"></i> Edit
-                                                            </a>
-                                                        </div>
+                                                        {% if not campaign.archived %}
+                                                            <div class="btn-group btn-group-sm flex-shrink-0 ms-auto">
+                                                                <a href="{% url 'core:campaign-asset-transfer' campaign.id asset.id %}"
+                                                                   class="btn btn-outline-primary">
+                                                                    <i class="bi-arrow-left-right"></i> Transfer
+                                                                </a>
+                                                                <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
+                                                                   class="btn btn-outline-secondary">
+                                                                    <i class="bi-pencil"></i> Edit
+                                                                </a>
+                                                            </div>
+                                                        {% endif %}
                                                     {% endif %}
                                                 </div>
                                                 {% if asset.description %}<div class="small text-muted">{{ asset.description|safe }}</div>{% endif %}

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -59,10 +59,12 @@
                                                 </td>
                                                 <td class="text-end pe-3">
                                                     {% if is_owner or resource.list in user_lists %}
-                                                        <a href="{% url 'core:campaign-resource-modify' campaign.id resource.id %}"
-                                                           class="btn btn-outline-primary btn-sm">
-                                                            <i class="bi-pencil"></i> Modify
-                                                        </a>
+                                                        {% if not campaign.archived %}
+                                                            <a href="{% url 'core:campaign-resource-modify' campaign.id resource.id %}"
+                                                               class="btn btn-outline-primary btn-sm">
+                                                                <i class="bi-pencil"></i> Modify
+                                                            </a>
+                                                        {% endif %}
                                                     {% endif %}
                                                 </td>
                                             </tr>

--- a/gyrinx/core/tests/test_archived_campaign_buttons.py
+++ b/gyrinx/core/tests/test_archived_campaign_buttons.py
@@ -4,6 +4,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
 from django.urls import reverse
+from gyrinx.content.models import ContentHouse
 from gyrinx.core.models import (
     Campaign,
     Battle,
@@ -121,9 +122,11 @@ def test_archived_campaign_prevents_resource_modify():
         name="Reputation",
         default_amount=0,
     )
+    house = ContentHouse.objects.create(name="Test House")
     test_list = List.objects.create(
         name="Test Gang",
         owner=user,
+        content_house=house,
         status=List.CAMPAIGN_MODE,
     )
     test_list.campaigns.add(campaign)
@@ -183,9 +186,11 @@ def test_archived_campaign_hides_buttons_in_templates():
         name="Reputation",
         default_amount=0,
     )
+    house = ContentHouse.objects.create(name="Test House")
     test_list = List.objects.create(
         name="Test Gang",
         owner=user,
+        content_house=house,
         status=List.CAMPAIGN_MODE,
     )
     test_list.campaigns.add(campaign)

--- a/gyrinx/core/tests/test_archived_campaign_buttons.py
+++ b/gyrinx/core/tests/test_archived_campaign_buttons.py
@@ -1,0 +1,249 @@
+"""Test that archived campaigns have disabled buttons."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+from gyrinx.core.models import (
+    Campaign,
+    Battle,
+    CampaignAssetType,
+    CampaignAsset,
+    CampaignResourceType,
+    CampaignListResource,
+    List,
+)
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_archived_campaign_disables_log_action_button():
+    """Test that archived campaigns don't show the log action button."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+        archived=True,
+    )
+
+    client = Client()
+    client.login(username="testuser", password="testpass")
+
+    # Test on campaign detail page
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert response.status_code == 200
+    assert not response.context["can_log_actions"]
+
+    # Test on campaign actions page
+    response = client.get(reverse("core:campaign-actions", args=[campaign.id]))
+    assert response.status_code == 200
+    assert not response.context["can_log_actions"]
+
+
+@pytest.mark.django_db
+def test_archived_campaign_disables_battle_edit():
+    """Test that battles in archived campaigns can't be edited."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+        archived=True,
+    )
+    battle = Battle.objects.create(
+        campaign=campaign,
+        owner=user,
+        date="2025-01-01",
+        mission="Test Mission",
+    )
+
+    # Test that can_edit returns False for archived campaigns
+    assert not battle.can_edit(user)
+
+    # Test that can_add_notes returns False for archived campaigns
+    assert not battle.can_add_notes(user)
+
+
+@pytest.mark.django_db
+def test_archived_campaign_prevents_asset_transfer():
+    """Test that assets in archived campaigns can't be transferred."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+        archived=True,
+    )
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        owner=user,
+        name_singular="Territory",
+        name_plural="Territories",
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        owner=user,
+        name="Old Factory",
+    )
+
+    client = Client()
+    client.login(username="testuser", password="testpass")
+
+    # Try to access transfer page
+    response = client.get(
+        reverse("core:campaign-asset-transfer", args=[campaign.id, asset.id])
+    )
+    assert response.status_code == 302  # Should redirect
+
+    # Check that error message was added
+    response = client.get(reverse("core:campaign-assets", args=[campaign.id]))
+    messages = list(response.context["messages"])
+    assert any(
+        "Cannot transfer assets for archived campaigns" in str(m) for m in messages
+    )
+
+
+@pytest.mark.django_db
+def test_archived_campaign_prevents_resource_modify():
+    """Test that resources in archived campaigns can't be modified."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+        archived=True,
+    )
+    resource_type = CampaignResourceType.objects.create(
+        campaign=campaign,
+        owner=user,
+        name="Reputation",
+        default_amount=0,
+    )
+    test_list = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        status=List.CAMPAIGN_MODE,
+    )
+    test_list.campaigns.add(campaign)
+
+    resource = CampaignListResource.objects.create(
+        campaign=campaign,
+        resource_type=resource_type,
+        list=test_list,
+        amount=5,
+        owner=user,
+    )
+
+    client = Client()
+    client.login(username="testuser", password="testpass")
+
+    # Try to access modify page
+    response = client.get(
+        reverse("core:campaign-resource-modify", args=[campaign.id, resource.id])
+    )
+    assert response.status_code == 302  # Should redirect
+
+    # Check that error message was added
+    response = client.get(reverse("core:campaign-resources", args=[campaign.id]))
+    messages = list(response.context["messages"])
+    assert any(
+        "Cannot modify resources for archived campaigns" in str(m) for m in messages
+    )
+
+
+@pytest.mark.django_db
+def test_archived_campaign_hides_buttons_in_templates():
+    """Test that buttons are hidden in templates for archived campaigns."""
+    user = User.objects.create_user(username="testuser", password="testpass")
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+        archived=True,
+    )
+
+    # Create some test data
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        owner=user,
+        name_singular="Territory",
+        name_plural="Territories",
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        owner=user,
+        name="Old Factory",
+    )
+
+    resource_type = CampaignResourceType.objects.create(
+        campaign=campaign,
+        owner=user,
+        name="Reputation",
+        default_amount=0,
+    )
+    test_list = List.objects.create(
+        name="Test Gang",
+        owner=user,
+        status=List.CAMPAIGN_MODE,
+    )
+    test_list.campaigns.add(campaign)
+
+    resource = CampaignListResource.objects.create(
+        campaign=campaign,
+        resource_type=resource_type,
+        list=test_list,
+        amount=5,
+        owner=user,
+    )
+
+    client = Client()
+    client.login(username="testuser", password="testpass")
+
+    # Check campaign detail page
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Should not have Transfer link for assets
+    assert (
+        'href="'
+        + reverse("core:campaign-asset-transfer", args=[campaign.id, asset.id])
+        + '"'
+        not in content
+    )
+
+    # Should not have Modify link for resources
+    assert (
+        'href="'
+        + reverse("core:campaign-resource-modify", args=[campaign.id, resource.id])
+        + '"'
+        not in content
+    )
+
+    # Check assets page
+    response = client.get(reverse("core:campaign-assets", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Should not have Transfer button for assets
+    assert (
+        'href="'
+        + reverse("core:campaign-asset-transfer", args=[campaign.id, asset.id])
+        + '"'
+        not in content
+    )
+
+    # Check resources page
+    response = client.get(reverse("core:campaign-resources", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Should not have Modify button for resources
+    assert (
+        'href="'
+        + reverse("core:campaign-resource-modify", args=[campaign.id, resource.id])
+        + '"'
+        not in content
+    )

--- a/gyrinx/core/tests/test_campaign_archive.py
+++ b/gyrinx/core/tests/test_campaign_archive.py
@@ -1,0 +1,206 @@
+"""Tests for campaign archive functionality."""
+
+import pytest
+from django.contrib.messages import get_messages
+from django.urls import reverse
+
+from gyrinx.core.models import Campaign, CampaignAssetType, CampaignResourceType
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def pre_campaign(user):
+    """Create a pre-campaign for testing."""
+    return Campaign.objects.create(
+        name="Test Pre-Campaign",
+        owner=user,
+        status=Campaign.PRE_CAMPAIGN,
+    )
+
+
+@pytest.fixture
+def in_progress_campaign(user):
+    """Create an in-progress campaign for testing."""
+    return Campaign.objects.create(
+        name="Test In Progress Campaign",
+        owner=user,
+        status=Campaign.IN_PROGRESS,
+    )
+
+
+@pytest.fixture
+def archived_campaign(user):
+    """Create an archived campaign for testing."""
+    campaign = Campaign.objects.create(
+        name="Test Archived Campaign",
+        owner=user,
+        status=Campaign.PRE_CAMPAIGN,
+    )
+    campaign.archive()
+    return campaign
+
+
+def test_cannot_archive_in_progress_campaign(client, in_progress_campaign):
+    """Test that in-progress campaigns cannot be archived."""
+    client.force_login(in_progress_campaign.owner)
+
+    url = reverse("core:campaign-archive", args=[in_progress_campaign.id])
+    response = client.post(url, {"archive": "1"})
+
+    # Should redirect back to campaign detail page
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaign", args=[in_progress_campaign.id])
+
+    # Campaign should not be archived
+    in_progress_campaign.refresh_from_db()
+    assert not in_progress_campaign.archived
+
+    # Should have error message
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) == 1
+    assert "cannot archive" in messages[0].message.lower()
+    assert "in progress" in messages[0].message.lower()
+
+
+def test_can_archive_pre_campaign(client, pre_campaign):
+    """Test that pre-campaigns can be archived."""
+    client.force_login(pre_campaign.owner)
+
+    url = reverse("core:campaign-archive", args=[pre_campaign.id])
+    response = client.post(url, {"archive": "1"})
+
+    # Should redirect back to campaign detail page
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaign", args=[pre_campaign.id])
+
+    # Campaign should be archived
+    pre_campaign.refresh_from_db()
+    assert pre_campaign.archived
+
+    # Should have success message
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) == 1
+    assert "has been archived" in messages[0].message
+
+
+def test_campaign_detail_shows_archived_message(client, archived_campaign):
+    """Test that archived campaigns show an archived message."""
+    client.force_login(archived_campaign.owner)
+
+    url = reverse("core:campaign", args=[archived_campaign.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    assert b"This campaign has been archived by its owner" in response.content
+    assert b"Unarchive" in response.content
+
+
+def test_archived_campaign_hides_action_buttons(client, archived_campaign):
+    """Test that archived campaigns don't show action buttons."""
+    client.force_login(archived_campaign.owner)
+
+    url = reverse("core:campaign", args=[archived_campaign.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    # These buttons should not appear for archived campaigns
+    assert b"Add Gangs" not in response.content
+    assert b"New Battle" not in response.content
+    assert b"Log Action" not in response.content
+
+
+def test_cannot_create_asset_type_for_archived_campaign(client, archived_campaign):
+    """Test that asset types cannot be created for archived campaigns."""
+    client.force_login(archived_campaign.owner)
+
+    url = reverse("core:campaign-asset-type-new", args=[archived_campaign.id])
+    response = client.post(
+        url,
+        {
+            "name_singular": "Test Asset",
+            "name_plural": "Test Assets",
+            "is_transferable": True,
+        },
+    )
+
+    # Should redirect to campaign assets page
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaign-assets", args=[archived_campaign.id])
+
+    # No asset type should be created
+    assert not CampaignAssetType.objects.filter(campaign=archived_campaign).exists()
+
+    # Should have error message
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) == 1
+    assert (
+        "cannot create new asset types for archived campaigns"
+        in messages[0].message.lower()
+    )
+
+
+def test_cannot_create_resource_type_for_archived_campaign(client, archived_campaign):
+    """Test that resource types cannot be created for archived campaigns."""
+    client.force_login(archived_campaign.owner)
+
+    url = reverse("core:campaign-resource-type-new", args=[archived_campaign.id])
+    response = client.post(
+        url,
+        {
+            "name": "Test Resource",
+            "default_amount": 10,
+        },
+    )
+
+    # Should redirect to campaign resources page
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "core:campaign-resources", args=[archived_campaign.id]
+    )
+
+    # No resource type should be created
+    assert not CampaignResourceType.objects.filter(campaign=archived_campaign).exists()
+
+    # Should have error message
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) == 1
+    assert (
+        "cannot create new resource types for archived campaigns"
+        in messages[0].message.lower()
+    )
+
+
+def test_cannot_create_asset_for_archived_campaign(client, archived_campaign):
+    """Test that assets cannot be created for archived campaigns."""
+    # First create an asset type
+    asset_type = CampaignAssetType.objects.create(
+        campaign=archived_campaign,
+        owner=archived_campaign.owner,
+        name_singular="Test Asset",
+        name_plural="Test Assets",
+    )
+
+    client.force_login(archived_campaign.owner)
+
+    url = reverse("core:campaign-asset-new", args=[archived_campaign.id, asset_type.id])
+    response = client.post(
+        url,
+        {
+            "name": "Specific Asset",
+        },
+    )
+
+    # Should redirect to campaign assets page
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaign-assets", args=[archived_campaign.id])
+
+    # No asset should be created
+    assert not asset_type.assets.exists()
+
+    # Should have error message
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) == 1
+    assert (
+        "cannot create new assets for archived campaigns" in messages[0].message.lower()
+    )

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -328,6 +328,11 @@ urlpatterns = [
         campaign.reopen_campaign,
         name="campaign-reopen",
     ),
+    path(
+        "campaign/<id>/archive",
+        campaign.archive_campaign,
+        name="campaign-archive",
+    ),
     # Campaign Assets
     path(
         "campaign/<id>/assets",

--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -876,6 +876,14 @@ def archive_campaign(request, id):
 
                 campaign.archive()
 
+                CampaignAction.objects.create(
+                    user=request.user,
+                    owner=request.user,
+                    campaign=campaign,
+                    description=f"Campaign Archived: {campaign.name} has been archived",
+                    outcome="Campaign has been archived",
+                )
+
                 # Log the archive event
                 log_event(
                     user=request.user,
@@ -890,11 +898,19 @@ def archive_campaign(request, id):
             else:
                 campaign.unarchive()
 
+                CampaignAction.objects.create(
+                    user=request.user,
+                    owner=request.user,
+                    campaign=campaign,
+                    description=f"Campaign Unarchived: {campaign.name} has been unarchived",
+                    outcome="Campaign has been unarchived",
+                )
+
                 # Log the unarchive event
                 log_event(
                     user=request.user,
                     noun=EventNoun.CAMPAIGN,
-                    verb=EventVerb.UNARCHIVE,
+                    verb=EventVerb.RESTORE,
                     object=campaign,
                     request=request,
                     campaign_name=campaign.name,


### PR DESCRIPTION
Resolves #518

This PR adds the ability for campaign owners to archive campaigns, hiding them from the main campaigns page.

## Changes
- Add archive_campaign view to handle archiving/unarchiving campaigns
- Update campaign list view to filter out archived campaigns
- Add URL route for the archive functionality
- Create campaign archive confirmation template
- Add dropdown menu with archive option to campaign detail page

The archive feature allows campaign owners to hide test campaigns from the main campaigns page while still keeping them accessible.

Generated with [Claude Code](https://claude.ai/code)