### PR TITLE
fix: show equipment from both legacy and base fighters

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -548,6 +548,17 @@ class ListFighter(AppBase):
         return self.legacy_content_fighter or self.content_fighter
 
     @cached_property
+    def equipment_list_fighters(self):
+        """
+        Return a list of fighters whose equipment lists should be considered.
+        When a legacy fighter exists, returns both legacy and base fighters
+        to allow combining their equipment lists.
+        """
+        if self.legacy_content_fighter:
+            return [self.legacy_content_fighter, self.content_fighter]
+        return [self.content_fighter]
+
+    @cached_property
     def is_stash(self):
         """
         Returns True if this fighter is a stash fighter.
@@ -881,7 +892,8 @@ class ListFighter(AppBase):
                     # Check equipment list items for this fighter
                     equipment_list_items = (
                         ContentFighterEquipmentListItem.objects.filter(
-                            fighter=self.equipment_list_fighter, equipment__category=cat
+                            fighter__in=self.equipment_list_fighters,
+                            equipment__category=cat,
                         ).exists()
                     )
                     if equipment_list_items:
@@ -1477,11 +1489,12 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
         if hasattr(self.content_equipment, "cost_for_fighter"):
             return self.content_equipment.cost_for_fighter_int()
 
+        # Get all fighters whose equipment lists we should check
+        fighters = self.list_fighter.equipment_list_fighters
+
         overrides = ContentFighterEquipmentListItem.objects.filter(
-            # We use the "equipment list fighter" which, under the hood, picks between the
-            # "legacy" content fighter, if set, or the more typical content fighter. This is for
-            # Venators, which can have the Gang Legacy rule.
-            fighter=self._equipment_list_fighter,
+            # Check equipment lists from both legacy and base fighters
+            fighter__in=fighters,
             equipment=self.content_equipment,
             # None here is very important: it means we're looking for the base equipment cost.
             weapon_profile=None,
@@ -1489,10 +1502,14 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
         if not overrides.exists():
             return self.content_equipment.cost_int()
 
-        if overrides.count() > 1:
-            logger.warning(
-                f"Multiple overrides for {self.content_equipment} on {self.list_fighter}"
-            )
+        # If there are multiple overrides (from legacy and base), prefer legacy
+        if overrides.count() > 1 and self.list_fighter.legacy_content_fighter:
+            # Try to get the legacy override first
+            legacy_override = overrides.filter(
+                fighter=self.list_fighter.legacy_content_fighter
+            ).first()
+            if legacy_override:
+                return legacy_override.cost_int()
 
         override = overrides.first()
         return override.cost_int()
@@ -1550,17 +1567,28 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
             )
             return cost
 
-        try:
-            override = ContentFighterEquipmentListItem.objects.get(
-                # We use the "equipment list fighter" which, under the hood, picks between the
-                # "legacy" content fighter, if set, or the more typical content fighter. This is for
-                # Venators, which can have the Gang Legacy rule.
-                fighter=self._equipment_list_fighter,
-                equipment=self.content_equipment,
-                weapon_profile=profile.profile,
-            )
-            cost = override.cost_int()
-        except ContentFighterEquipmentListItem.DoesNotExist:
+        # Get all fighters whose equipment lists we should check
+        fighters = self.list_fighter.equipment_list_fighters
+
+        overrides = ContentFighterEquipmentListItem.objects.filter(
+            fighter__in=fighters,
+            equipment=self.content_equipment,
+            weapon_profile=profile.profile,
+        )
+
+        if overrides.exists():
+            # If there are multiple overrides (from legacy and base), prefer legacy
+            if overrides.count() > 1 and self.list_fighter.legacy_content_fighter:
+                legacy_override = overrides.filter(
+                    fighter=self.list_fighter.legacy_content_fighter
+                ).first()
+                if legacy_override:
+                    cost = legacy_override.cost_int()
+                else:
+                    cost = overrides.first().cost_int()
+            else:
+                cost = overrides.first().cost_int()
+        else:
             cost = profile.cost_int()
 
         self._profile_cost_with_override_for_profile_cache[profile.profile.id] = cost
@@ -1592,16 +1620,24 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
         if hasattr(accessory, "cost_for_fighter"):
             return accessory.cost_for_fighter_int()
 
-        try:
-            override = ContentFighterEquipmentListWeaponAccessory.objects.get(
-                # We use the "equipment list fighter" which, under the hood, picks between the
-                # "legacy" content fighter, if set, or the more typical content fighter. This is for
-                # Venators, which can have the Gang Legacy rule.
-                fighter=self._equipment_list_fighter,
-                weapon_accessory=accessory,
-            )
-            return override.cost_int()
-        except ContentFighterEquipmentListWeaponAccessory.DoesNotExist:
+        # Get all fighters whose equipment lists we should check
+        fighters = self.list_fighter.equipment_list_fighters
+
+        overrides = ContentFighterEquipmentListWeaponAccessory.objects.filter(
+            fighter__in=fighters,
+            weapon_accessory=accessory,
+        )
+
+        if overrides.exists():
+            # If there are multiple overrides (from legacy and base), prefer legacy
+            if overrides.count() > 1 and self.list_fighter.legacy_content_fighter:
+                legacy_override = overrides.filter(
+                    fighter=self.list_fighter.legacy_content_fighter
+                ).first()
+                if legacy_override:
+                    return legacy_override.cost_int()
+            return overrides.first().cost_int()
+        else:
             return accessory.cost_int()
 
     def accessory_cost_int(self, accessory):
@@ -1617,13 +1653,24 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
             if hasattr(upgrade, "cost_for_fighter"):
                 return upgrade.cost_for_fighter
 
-            try:
-                override = ContentFighterEquipmentListUpgrade.objects.get(
-                    fighter=self._equipment_list_fighter,
-                    upgrade=upgrade,
-                )
-                return override.cost_int()
-            except ContentFighterEquipmentListUpgrade.DoesNotExist:
+            # Get all fighters whose equipment lists we should check
+            fighters = self.list_fighter.equipment_list_fighters
+
+            overrides = ContentFighterEquipmentListUpgrade.objects.filter(
+                fighter__in=fighters,
+                upgrade=upgrade,
+            )
+
+            if overrides.exists():
+                # If there are multiple overrides (from legacy and base), prefer legacy
+                if overrides.count() > 1 and self.list_fighter.legacy_content_fighter:
+                    legacy_override = overrides.filter(
+                        fighter=self.list_fighter.legacy_content_fighter
+                    ).first()
+                    if legacy_override:
+                        return legacy_override.cost_int()
+                return overrides.first().cost_int()
+            else:
                 return upgrade.cost
 
         # For SINGLE mode, calculate cumulative cost with overrides
@@ -1632,16 +1679,30 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
             position__lte=upgrade.position
         ).order_by("position")
 
+        # Get all fighters whose equipment lists we should check
+        fighters = self.list_fighter.equipment_list_fighters
+
         cumulative_cost = 0
         for u in upgrades:
             # Check for fighter-specific override
-            try:
-                override = ContentFighterEquipmentListUpgrade.objects.get(
-                    fighter=self._equipment_list_fighter,
-                    upgrade=u,
-                )
-                cumulative_cost += override.cost_int()
-            except ContentFighterEquipmentListUpgrade.DoesNotExist:
+            overrides = ContentFighterEquipmentListUpgrade.objects.filter(
+                fighter__in=fighters,
+                upgrade=u,
+            )
+
+            if overrides.exists():
+                # If there are multiple overrides (from legacy and base), prefer legacy
+                if overrides.count() > 1 and self.list_fighter.legacy_content_fighter:
+                    legacy_override = overrides.filter(
+                        fighter=self.list_fighter.legacy_content_fighter
+                    ).first()
+                    if legacy_override:
+                        cumulative_cost += legacy_override.cost_int()
+                    else:
+                        cumulative_cost += overrides.first().cost_int()
+                else:
+                    cumulative_cost += overrides.first().cost_int()
+            else:
                 cumulative_cost += u.cost
 
         return cumulative_cost

--- a/gyrinx/core/tests/test_combined_equipment_lists.py
+++ b/gyrinx/core/tests/test_combined_equipment_lists.py
@@ -1,0 +1,263 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentCategory,
+    ContentFighter,
+    ContentFighterEquipmentListItem,
+    ContentHouse,
+)
+from gyrinx.core.models import List, ListFighter
+from django.contrib.auth import get_user_model
+from gyrinx.models import FighterCategoryChoices
+
+User = get_user_model()
+
+
+def make_content_house(name):
+    """Helper to create a content house."""
+    return ContentHouse.objects.create(name=name)
+
+
+def make_content_fighter(
+    type, category, house, base_cost, can_take_legacy=False, can_be_legacy=False
+):
+    """Helper to create a content fighter."""
+    return ContentFighter.objects.create(
+        type=type,
+        category=category,
+        house=house,
+        base_cost=base_cost,
+        can_take_legacy=can_take_legacy,
+        can_be_legacy=can_be_legacy,
+    )
+
+
+def make_equipment(name, category, cost):
+    """Helper to create equipment."""
+    return ContentEquipment.objects.create(
+        name=name,
+        category=category,
+        cost=cost,
+    )
+
+
+@pytest.mark.django_db
+def test_combined_equipment_lists_legacy_and_base():
+    """
+    Test that when a fighter has a legacy, equipment from both the legacy fighter
+    and base fighter equipment lists are available.
+
+    This tests the fix for issue #486 where Venator hunt leaders with gang legacy
+    were losing access to psyker upgrade options.
+    """
+    # Create houses
+    venator_house = make_content_house("House Venator")
+    legacy_house = make_content_house("Legacy House")
+
+    # Create fighters
+    hunt_leader = make_content_fighter(
+        type="Hunt Leader",
+        category=FighterCategoryChoices.LEADER,
+        house=venator_house,
+        base_cost=100,
+        can_take_legacy=True,
+    )
+
+    legacy_fighter = make_content_fighter(
+        type="Legacy Champion",
+        category=FighterCategoryChoices.CHAMPION,
+        house=legacy_house,
+        base_cost=100,
+        can_be_legacy=True,
+    )
+
+    # Create equipment category
+    options_category = ContentEquipmentCategory.objects.get_or_create(
+        name="Options", defaults={"visible_only_if_in_equipment_list": False}
+    )[0]
+
+    # Create equipment - psyker options on base fighter
+    non_sanctioned_psyker = make_equipment(
+        "Non-sanctioned Psyker",
+        category=options_category,
+        cost=30,
+    )
+    sanctioned_psyker = make_equipment(
+        "Sanctioned Psyker",
+        category=options_category,
+        cost=35,
+    )
+
+    # Create equipment - legacy equipment
+    legacy_gear = make_equipment(
+        "Legacy Gear",
+        category=options_category,
+        cost=50,
+    )
+
+    # Add psyker options to hunt leader's equipment list
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=hunt_leader,
+        equipment=non_sanctioned_psyker,
+        cost=30,
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=hunt_leader,
+        equipment=sanctioned_psyker,
+        cost=35,
+    )
+
+    # Add legacy gear to legacy fighter's equipment list
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=legacy_fighter,
+        equipment=legacy_gear,
+        cost=45,  # Discounted price
+    )
+
+    # Create list and fighter with legacy
+    lst = List.objects.create(name="Test Venator Gang", content_house=venator_house)
+    fighter = ListFighter.objects.create(
+        name="Hunt Leader with Legacy",
+        list=lst,
+        content_fighter=hunt_leader,
+        legacy_content_fighter=legacy_fighter,
+    )
+
+    # Test that equipment_list_fighters returns both fighters
+    assert len(fighter.equipment_list_fighters) == 2
+    assert legacy_fighter in fighter.equipment_list_fighters
+    assert hunt_leader in fighter.equipment_list_fighters
+
+    # Test that equipment from both lists is available
+    # First, verify the equipment is in the respective lists
+    hunt_leader_equipment = ContentFighterEquipmentListItem.objects.filter(
+        fighter=hunt_leader
+    ).values_list("equipment_id", flat=True)
+    assert non_sanctioned_psyker.id in hunt_leader_equipment
+    assert sanctioned_psyker.id in hunt_leader_equipment
+
+    legacy_equipment = ContentFighterEquipmentListItem.objects.filter(
+        fighter=legacy_fighter
+    ).values_list("equipment_id", flat=True)
+    assert legacy_gear.id in legacy_equipment
+
+    # Now test combined query
+    combined_equipment = ContentFighterEquipmentListItem.objects.filter(
+        fighter__in=fighter.equipment_list_fighters
+    ).values_list("equipment_id", flat=True)
+
+    # Should include equipment from both fighters
+    assert non_sanctioned_psyker.id in combined_equipment
+    assert sanctioned_psyker.id in combined_equipment
+    assert legacy_gear.id in combined_equipment
+
+    # Test cost precedence - if same equipment exists on both lists, legacy takes precedence
+    # Add the same psyker option to legacy fighter with different cost
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=legacy_fighter,
+        equipment=non_sanctioned_psyker,
+        cost=25,  # Cheaper on legacy
+    )
+
+    # When getting cost, should use legacy price
+    overrides = ContentFighterEquipmentListItem.objects.filter(
+        fighter__in=fighter.equipment_list_fighters,
+        equipment=non_sanctioned_psyker,
+        weapon_profile=None,
+    )
+
+    # Should find 2 overrides (one from each fighter)
+    assert overrides.count() == 2
+
+    # Legacy override should be preferred
+    legacy_override = overrides.filter(fighter=legacy_fighter).first()
+    assert legacy_override.cost == 25
+
+
+@pytest.mark.django_db
+def test_trading_post_shows_combined_equipment():
+    """
+    Test that the trading post view shows equipment from both legacy and base fighters.
+    """
+    # Setup similar to above
+    venator_house = make_content_house("House Venator")
+    legacy_house = make_content_house("Legacy House")
+
+    hunt_leader = make_content_fighter(
+        type="Hunt Leader",
+        category=FighterCategoryChoices.LEADER,
+        house=venator_house,
+        base_cost=100,
+        can_take_legacy=True,
+    )
+
+    legacy_fighter = make_content_fighter(
+        type="Legacy Champion",
+        category=FighterCategoryChoices.CHAMPION,
+        house=legacy_house,
+        base_cost=100,
+        can_be_legacy=True,
+    )
+
+    options_category = ContentEquipmentCategory.objects.get_or_create(
+        name="Options", defaults={"visible_only_if_in_equipment_list": False}
+    )[0]
+
+    # Equipment only on base fighter
+    base_only_equipment = make_equipment(
+        "Base Fighter Equipment",
+        category=options_category,
+        cost=20,
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=hunt_leader,
+        equipment=base_only_equipment,
+        cost=20,
+    )
+
+    # Equipment only on legacy fighter
+    legacy_only_equipment = make_equipment(
+        "Legacy Fighter Equipment",
+        category=options_category,
+        cost=30,
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=legacy_fighter,
+        equipment=legacy_only_equipment,
+        cost=30,
+    )
+
+    # Create user, list, and fighter
+    user = User.objects.create_user(username="testuser", password="testpass")
+    lst = List.objects.create(
+        name="Test Venator Gang",
+        content_house=venator_house,
+        owner=user,
+    )
+    fighter = ListFighter.objects.create(
+        name="Hunt Leader with Legacy",
+        list=lst,
+        content_fighter=hunt_leader,
+        legacy_content_fighter=legacy_fighter,
+        owner=user,
+    )
+
+    # Test through the view
+    client = Client()
+    client.force_login(user)
+
+    # Access trading post with equipment list filter
+    url = reverse(
+        "core:list_fighter_equipment_assign", args=[fighter.id, options_category.id]
+    )
+    response = client.get(url, {"filter": "equipment-list"})
+
+    assert response.status_code == 200
+
+    # Both equipment should be in the response context
+    equipment_ids = [eq.equipment.id for eq in response.context["equipment"]]
+    assert base_only_equipment.id in equipment_ids
+    assert legacy_only_equipment.id in equipment_ids

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -1468,7 +1468,7 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
         # show all equipment from the fighter's equipment list regardless of availability
         equipment = equipment.filter(
             id__in=ContentFighterEquipmentListItem.objects.filter(
-                fighter=fighter.equipment_list_fighter
+                fighter__in=fighter.equipment_list_fighters
             ).values("equipment_id")
         )
         # For profile filtering later, we need to know all rarities are allowed
@@ -1488,7 +1488,7 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
             # further filter to only show equipment from the fighter's equipment list
             equipment = equipment.filter(
                 id__in=ContentFighterEquipmentListItem.objects.filter(
-                    fighter=fighter.equipment_list_fighter
+                    fighter__in=fighter.equipment_list_fighters
                 ).values("equipment_id")
             )
 
@@ -1496,7 +1496,10 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
     assigns = []
     for item in equipment:
         if is_weapon:
-            profiles = item.profiles_for_fighter(fighter.equipment_list_fighter)
+            # Get profiles from all equipment list fighters (legacy and base)
+            profiles = []
+            for ef in fighter.equipment_list_fighters:
+                profiles.extend(item.profiles_for_fighter(ef))
 
             # Apply profile filtering based on availability
             profiles = [
@@ -1524,7 +1527,7 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
                 # Get weapon profiles that are specifically on the equipment list
                 equipment_list_profiles = (
                     ContentFighterEquipmentListItem.objects.filter(
-                        fighter=fighter.equipment_list_fighter,
+                        fighter__in=fighter.equipment_list_fighters,
                         equipment=item,
                         weapon_profile__isnull=False,
                     ).values_list("weapon_profile_id", flat=True)


### PR DESCRIPTION
## Summary

This PR fixes issue #486 where Venator hunt leaders with gang legacy were losing access to psyker upgrade options.

When a fighter has a legacy (e.g., Venator hunt leaders with gang legacy), the equipment list now shows items from both the legacy fighter and base fighter equipment lists. This ensures psyker upgrade options remain available.

## Changes
- Add `equipment_list_fighters` property that returns both fighters
- Update all equipment list queries to filter by both fighters
- Maintain legacy precedence for cost overrides
- Add tests to verify combined equipment lists work correctly

Fixes #486

Generated with [Claude Code](https://claude.ai/code)