### PR TITLE
fix: remove non-existent is_transferable attribute from CampaignAssetType log_event

### DIFF
--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -1096,7 +1096,6 @@ def campaign_asset_type_edit(request, id, type_id):
                 campaign_name=campaign.name,
                 asset_type_name=asset_type.name_singular,
                 asset_type_plural=asset_type.name_plural,
-                is_transferable=asset_type.is_transferable,
             )
 
             messages.success(request, "Asset type updated.")


### PR DESCRIPTION
## Summary

This PR fixes an AttributeError that was occurring when trying to edit a campaign asset type. The error was caused by attempting to access a non-existent `is_transferable` attribute on the CampaignAssetType model.

## Changes

- Removed the `is_transferable=asset_type.is_transferable` line from the `log_event` call in `campaign_asset_type_edit` function

## Testing

- Verified no other references to `is_transferable` exist in the codebase
- Code has been formatted with `./scripts/fmt.sh`

Fixes #530

Generated with [Claude Code](https://claude.ai/code)