### PR TITLE
fix: prevent campaign assets and resources from being assigned before campaign starts

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -285,7 +285,7 @@
                                 <thead>
                                     <tr>
                                         <th colspan="3"
-                                            class="px-2 px-sm-3 py-2 {% if not forloop.first %}pt-5{% endif %}">
+                                            class="px-2 px-sm-3 py-2 {% if not forloop.first %}pt-3{% endif %}">
                                             <h3 class="fs-6 mb-0 fst-italic">{{ resource_type.name }}</h3>
                                         </th>
                                     </tr>

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -51,20 +51,20 @@
                                         <div class="list-group-item">
                                             <div class="vstack gap-3">
                                                 <div class="mt-2 d-flex justify-content-between align-items-center">
-                                                    <h6 class="mb-0 me-2">{{ asset.name }}</h6>
+                                                    <h6 class="mb-0 me-2 flex-grow-1">{{ asset.name }}</h6>
                                                     {% if asset.holder %}
-                                                        <div class="d-flex align-items-center gap-1">
+                                                        <div class="flex-grow-1 d-flex align-items-center gap-1">
                                                             <i class="bi-person-check text-muted"></i>
                                                             {% list_with_theme asset.holder %}
                                                         </div>
                                                     {% else %}
-                                                        <span class="text-muted">
+                                                        <div class="flex-grow-1 text-muted">
                                                             <i class="bi-dash-circle"></i> Unowned
                                                             {% if campaign.is_pre_campaign %}
                                                                 <br>
                                                                 <small class="text-secondary">Campaign not started</small>
                                                             {% endif %}
-                                                        </span>
+                                                        </div>
                                                     {% endif %}
                                                     {% if is_owner %}
                                                         {% if not campaign.archived %}

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -60,6 +60,10 @@
                                                     {% else %}
                                                         <span class="text-muted">
                                                             <i class="bi-dash-circle"></i> Unowned
+                                                            {% if campaign.is_pre_campaign %}
+                                                                <br>
+                                                                <small class="text-secondary">Campaign not started</small>
+                                                            {% endif %}
                                                         </span>
                                                     {% endif %}
                                                     {% if is_owner %}

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -60,7 +60,7 @@
                                                 <td class="text-end pe-3">
                                                     {% if campaign.is_pre_campaign %}
                                                         <span class="text-muted">Campaign not started</span>
-                                                    {% elif is_owner or resource.list in user_lists %}
+                                                    {% elif not campaign.archived and is_owner or not campaign.archived and resource.list in user_lists %}
                                                         <a href="{% url 'core:campaign-resource-modify' campaign.id resource.id %}"
                                                            class="btn btn-outline-primary btn-sm">
                                                             <i class="bi-pencil"></i> Modify

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -58,13 +58,13 @@
                                                     <span class="badge bg-primary fs-6">{{ resource.amount }}</span>
                                                 </td>
                                                 <td class="text-end pe-3">
-                                                    {% if is_owner or resource.list in user_lists %}
-                                                        {% if not campaign.archived %}
-                                                            <a href="{% url 'core:campaign-resource-modify' campaign.id resource.id %}"
-                                                               class="btn btn-outline-primary btn-sm">
-                                                                <i class="bi-pencil"></i> Modify
-                                                            </a>
-                                                        {% endif %}
+                                                    {% if campaign.is_pre_campaign %}
+                                                        <span class="text-muted">Campaign not started</span>
+                                                    {% elif is_owner or resource.list in user_lists %}
+                                                        <a href="{% url 'core:campaign-resource-modify' campaign.id resource.id %}"
+                                                           class="btn btn-outline-primary btn-sm">
+                                                            <i class="bi-pencil"></i> Modify
+                                                        </a>
                                                     {% endif %}
                                                 </td>
                                             </tr>

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -19,10 +19,14 @@
                                                 <span class="text-muted">({{ asset.asset_type.name_singular }})</span>
                                             {% endif %}
                                         </div>
-                                        <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}"
-                                           class="icon-link link-secondary link-sm ms-2">
-                                            <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
-                                        </a>
+                                        {% if list.campaign.is_pre_campaign %}
+                                            <span class="text-muted small">Campaign not started</span>
+                                        {% else %}
+                                            <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}"
+                                               class="icon-link link-secondary link-sm ms-2">
+                                                <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
+                                            </a>
+                                        {% endif %}
                                     </div>
                                 </li>
                             {% endfor %}
@@ -38,13 +42,21 @@
                                     <tr>
                                         <td>{{ resource.resource_type.name }}</td>
                                         <td class="text-end">
-                                            <span class="badge bg-secondary">{{ resource.amount }}</span>
+                                            {% if list.campaign.is_pre_campaign %}
+                                                <span class="text-muted">0</span>
+                                            {% else %}
+                                                <span class="badge bg-secondary">{{ resource.amount }}</span>
+                                            {% endif %}
                                         </td>
                                         <td class="text-end">
-                                            <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.id %}"
-                                               class="icon-link link-secondary link-sm">
-                                                <i class="bi-pencil" aria-hidden="true"></i> Modify
-                                            </a>
+                                            {% if list.campaign.is_pre_campaign %}
+                                                <span class="text-muted small">Campaign not started</span>
+                                            {% else %}
+                                                <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.id %}"
+                                                   class="icon-link link-secondary link-sm">
+                                                    <i class="bi-pencil" aria-hidden="true"></i> Modify
+                                                </a>
+                                            {% endif %}
                                         </td>
                                     </tr>
                                 {% endfor %}

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -21,7 +21,7 @@
                                         </div>
                                         {% if list.campaign.is_pre_campaign %}
                                             <span class="text-muted small">Campaign not started</span>
-                                        {% else %}
+                                        {% elif not list.campaign.archived %}
                                             <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}"
                                                class="icon-link link-secondary link-sm ms-2">
                                                 <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
@@ -51,7 +51,7 @@
                                         <td class="text-end">
                                             {% if list.campaign.is_pre_campaign %}
                                                 <span class="text-muted small">Campaign not started</span>
-                                            {% else %}
+                                            {% elif not list.campaign.archived %}
                                                 <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.id %}"
                                                    class="icon-link link-secondary link-sm">
                                                     <i class="bi-pencil" aria-hidden="true"></i> Modify

--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -1381,6 +1381,13 @@ def campaign_asset_transfer(request, id, asset_id):
     campaign = get_object_or_404(Campaign, id=id, owner=request.user)
     asset = get_object_or_404(CampaignAsset, id=asset_id, asset_type__campaign=campaign)
 
+    # Check if campaign is archived
+    if campaign.archived:
+        messages.error(request, "Cannot transfer assets for archived campaigns.")
+        return HttpResponseRedirect(
+            reverse("core:campaign-assets", args=(campaign.id,))
+        )
+
     # Check if campaign has started
     if campaign.is_pre_campaign:
         messages.error(
@@ -1633,6 +1640,13 @@ def campaign_resource_modify(request, id, resource_id):
     # Check permissions - owner can modify any, list owner can modify their own
     if request.user != campaign.owner and request.user != resource.list.owner:
         messages.error(request, "You don't have permission to modify this resource.")
+        return HttpResponseRedirect(
+            reverse("core:campaign-resources", args=(campaign.id,))
+        )
+
+    # Check if campaign is archived
+    if campaign.archived:
+        messages.error(request, "Cannot modify resources for archived campaigns.")
         return HttpResponseRedirect(
             reverse("core:campaign-resources", args=(campaign.id,))
         )


### PR DESCRIPTION
This PR fixes issue #529 by preventing campaign assets and resources from being assigned or modified before the campaign starts.

## Changes

- Add validation in views to block asset assignment and resource modification before campaign starts
- Update templates to show "Campaign not started" messages instead of action links
- Display resources as greyed-out 0 when campaign hasn't started
- Prevents issue where assets assigned before campaign start don't transfer to cloned lists

Fixes #529

Generated with [Claude Code](https://claude.ai/code)