### PR TITLE
Use equipment list filter for EL categories

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -917,6 +917,9 @@ class ListFighter(AppBase):
                     "category": cat.name,
                     "id": cat.id,
                     "assignments": assignments,
+                    "filter": "equipment-list"
+                    if cat.visible_only_if_in_equipment_list
+                    else "all",
                 }
             )
 

--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -154,9 +154,9 @@
                             {% if not print %}
                                 {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                                     {% if line.assignments|length > 0 %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter=all&al=E&cat={{ line.id }}#search">Edit</a>
+                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Edit</a>
                                     {% else %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter=all&al=E&cat={{ line.id }}#search">Add {{ line.category|lower }}</a>
+                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Add {{ line.category|lower }}</a>
                                     {% endif %}
                                 {% endif %}
                             {% endif %}


### PR DESCRIPTION
Use the equipment-list filter when loading house-additional stuff that is restricted to the equipment list, such as Psyker-ness.

Fix #535.