### PR TITLE
Allow psyker disciplines on non-psyker fighters

### DIFF
--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -341,6 +341,12 @@ class ContentFighterAdmin(ContentAdmin, admin.ModelAdmin):
     actions = [copy_selected_to_house]
 
 
+@admin.register(ContentFighterPsykerDisciplineAssignment)
+class ContentFighterPsykerDisciplineAssignmentAdmin(ContentAdmin):
+    search_fields = ["fighter__type", "discipline__name"]
+    list_filter = ["fighter__type", "discipline__name"]
+
+
 @admin.register(ContentFighterHouseOverride)
 class ContentFighterHouseOverrideAdmin(ContentAdmin):
     search_fields = ["fighter__type", "house__name"]

--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -248,12 +248,14 @@ class ContentFighterPsykerDisciplineAssignment(Content):
         """
         Validation to ensure that a generic discipline cannot be assigned to a fighter.
         """
-        if not self.fighter.is_psyker:
-            raise ValidationError(
-                {
-                    "fighter": "Cannot assign a psyker discipline to a non-psyker fighter."
-                }
-            )
+        # This is removed because fighters can *become* psykers later in the game, if a rule
+        # is added via an updgrade or other means.
+        # if not self.fighter.is_psyker:
+        #     raise ValidationError(
+        #         {
+        #             "fighter": "Cannot assign a psyker discipline to a non-psyker fighter."
+        #         }
+        #     )
 
         if self.discipline.generic:
             raise ValidationError(

--- a/gyrinx/core/tests/test_psyker.py
+++ b/gyrinx/core/tests/test_psyker.py
@@ -48,13 +48,15 @@ def test_psyker(content_fighter, make_list, make_list_fighter):
     assign.delete()
 
     # You can't assign a discipline if the ContentFighter is not a psyker
-    assign = ContentFighterPsykerDisciplineAssignment.objects.create(
-        fighter=content_fighter,
-        discipline=chronomancy,
-    )
-    with pytest.raises(ValidationError):
-        assign.full_clean()
-    assign.delete()
+    # NOTE: You now can assign a discipline to a non-psyker fighter, because they can
+    # become psykers later in the game, if a rule is added via an upgrade or other means.
+    # assign = ContentFighterPsykerDisciplineAssignment.objects.create(
+    #     fighter=content_fighter,
+    #     discipline=chronomancy,
+    # )
+    # with pytest.raises(ValidationError):
+    #     assign.full_clean()
+    # assign.delete()
 
     lst = make_list("Test List")
     fighter = make_list_fighter(lst, "Test Fighter")


### PR DESCRIPTION
Fighters can become psykers later in the game, so we allow assigning psyker disciplines to non-psyker fighters.

Fix #543.