### PR TITLE
fix: handle fighters without houses in admin forms

### DIFF
--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -214,7 +214,9 @@ class ContentFighterEquipmentListItemAdminForm(forms.ModelForm):
             cost__gt=0,
         )
 
-        group_select(self, "fighter", key=lambda x: x.house.name)
+        group_select(
+            self, "fighter", key=lambda x: x.house.name if x.house else "No House"
+        )
         group_select(self, "equipment", key=lambda x: x.cat())
         group_select(self, "weapon_profile", key=lambda x: x.equipment.name)
 
@@ -231,7 +233,9 @@ class ContentFighterEquipmentListWeaponAccessoryAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        group_select(self, "fighter", key=lambda x: x.house.name)
+        group_select(
+            self, "fighter", key=lambda x: x.house.name if x.house else "No House"
+        )
 
 
 @admin.register(ContentFighterEquipmentListWeaponAccessory)
@@ -246,7 +250,9 @@ class ContentFighterEquipmentListUpgradeAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        group_select(self, "fighter", key=lambda x: x.house.name)
+        group_select(
+            self, "fighter", key=lambda x: x.house.name if x.house else "No House"
+        )
         group_select(self, "upgrade", key=lambda x: x.equipment.name)
 
 
@@ -280,7 +286,9 @@ class ContentFighterDefaultAssignmentAdminForm(forms.ModelForm):
             cost__gt=0,
         )
 
-        group_select(self, "fighter", key=lambda x: x.house.name)
+        group_select(
+            self, "fighter", key=lambda x: x.house.name if x.house else "No House"
+        )
         group_select(self, "equipment", key=lambda x: x.cat())
         group_select(self, "weapon_profiles_field", key=lambda x: x.equipment.name)
 
@@ -394,7 +402,9 @@ class ContentPsykerDisciplineAdmin(ContentAdmin):
 class ContentFighterPsykerPowerDefaultAssignmentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        group_select(self, "fighter", key=lambda x: x.house.name)
+        group_select(
+            self, "fighter", key=lambda x: x.house.name if x.house else "No House"
+        )
         group_select(self, "psyker_power", key=lambda x: x.discipline.name)
 
 


### PR DESCRIPTION
The admin forms were trying to access house.name without checking if a fighter has a house (which is nullable). This caused an AttributeError when trying to group fighters by house name.

Fixed by adding a check to display "No House" for fighters without a house assignment.

Fixes #548

Generated with [Claude Code](https://claude.ai/code)