### PR TITLE
fix: update list modified timestamp when related events are logged

### DIFF
--- a/gyrinx/core/signals.py
+++ b/gyrinx/core/signals.py
@@ -243,6 +243,14 @@ def update_list_modified_on_event(sender, instance, created, **kwargs):
         # Only process newly created events
         return
 
+    if type(instance) is not Event:
+        # Only handle Event instances, not other types
+        return
+
+    if instance.verb is EventVerb.VIEW:
+        # Skip view events, they don't modify the list
+        return
+
     # Check if the event has a list_id in its context
     if not instance.context or "list_id" not in instance.context:
         return

--- a/gyrinx/core/signals.py
+++ b/gyrinx/core/signals.py
@@ -26,9 +26,10 @@ from allauth.mfa.signals import (
 )
 from allauth.usersessions.signals import session_client_changed
 from django.contrib.auth.signals import user_logged_out
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from gyrinx.core.models.events import EventField, EventNoun, EventVerb, log_event
+from gyrinx.core.models.events import Event, EventField, EventNoun, EventVerb, log_event
 
 
 @receiver(user_logged_in)
@@ -227,3 +228,36 @@ def log_session_client_changed(sender, request, from_session, to_session, **kwar
         from_session=from_session,
         to_session=to_session,
     )
+
+
+@receiver(post_save, sender=Event)
+def update_list_modified_on_event(sender, instance, created, **kwargs):
+    """
+    Update the list's modified timestamp when an event is created
+    that references the list.
+
+    This ensures that the "last edited" time shown in the UI reflects
+    any changes to list-related objects, not just direct list updates.
+    """
+    if not created:
+        # Only process newly created events
+        return
+
+    # Check if the event has a list_id in its context
+    if not instance.context or "list_id" not in instance.context:
+        return
+
+    list_id = instance.context.get("list_id")
+    if not list_id:
+        return
+
+    # Import here to avoid circular imports
+    from gyrinx.core.models.list import List
+
+    try:
+        # Update the list's modified timestamp
+        # Using update() to avoid triggering save signals and history
+        List.objects.filter(id=list_id).update(modified=instance.created)
+    except List.DoesNotExist:
+        # List doesn't exist, nothing to do
+        pass

--- a/gyrinx/core/tests/test_event_list_update_signal.py
+++ b/gyrinx/core/tests/test_event_list_update_signal.py
@@ -1,0 +1,167 @@
+"""Test that Events with list_id update the list's modified timestamp."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from gyrinx.core.models.events import Event, EventNoun, EventVerb, log_event
+from gyrinx.core.models.list import List
+
+
+@pytest.mark.django_db
+def test_event_with_list_id_updates_list_modified(make_list):
+    """Test that creating an event with list_id updates the list's modified timestamp."""
+    # Create a list with an old modified timestamp
+    lst = make_list("Test List")
+
+    # Force the list to have an old modified timestamp
+    old_modified = timezone.now() - timedelta(hours=2)
+    List.objects.filter(id=lst.id).update(modified=old_modified)
+
+    # Refresh from DB to get the updated timestamp
+    lst.refresh_from_db()
+    assert lst.modified < timezone.now() - timedelta(hours=1)
+
+    # Create an event with list_id in context
+    event = Event.objects.create(
+        owner=lst.owner,
+        noun=EventNoun.LIST_FIGHTER,
+        verb=EventVerb.UPDATE,
+        context={
+            "list_id": str(lst.id),
+            "list_name": lst.name,
+            "fighter_name": "Test Fighter",
+        },
+    )
+
+    # Refresh the list from DB
+    lst.refresh_from_db()
+
+    # The list's modified timestamp should now match the event's created timestamp
+    assert lst.modified == event.created
+
+
+@pytest.mark.django_db
+def test_event_without_list_id_does_not_update_list(make_list):
+    """Test that events without list_id don't update any list."""
+    # Create a list
+    lst = make_list("Test List")
+
+    # Force the list to have an old modified timestamp
+    old_modified = timezone.now() - timedelta(hours=2)
+    List.objects.filter(id=lst.id).update(modified=old_modified)
+
+    # Create an event without list_id
+    Event.objects.create(
+        owner=lst.owner,
+        noun=EventNoun.USER,
+        verb=EventVerb.LOGIN,
+        context={"some_other_data": "value"},
+    )
+
+    # Refresh the list from DB
+    lst.refresh_from_db()
+
+    # The list's modified timestamp should not have changed
+    assert lst.modified < timezone.now() - timedelta(hours=1)
+
+
+@pytest.mark.django_db
+def test_event_with_empty_list_id_does_not_update_list(make_list):
+    """Test that events with empty list_id don't update any list."""
+    # Create a list
+    lst = make_list("Test List")
+
+    # Force the list to have an old modified timestamp
+    old_modified = timezone.now() - timedelta(hours=2)
+    List.objects.filter(id=lst.id).update(modified=old_modified)
+
+    # Create an event with empty list_id
+    Event.objects.create(
+        owner=lst.owner,
+        noun=EventNoun.LIST,
+        verb=EventVerb.UPDATE,
+        context={"list_id": "", "other_data": "value"},
+    )
+
+    # Refresh the list from DB
+    lst.refresh_from_db()
+
+    # The list's modified timestamp should not have changed
+    assert lst.modified < timezone.now() - timedelta(hours=1)
+
+
+@pytest.mark.django_db
+def test_event_with_nonexistent_list_id_does_not_error(user):
+    """Test that events with non-existent list_id don't cause errors."""
+
+    # Create an event with a non-existent list_id
+    # This should not raise an exception
+    Event.objects.create(
+        owner=user,
+        noun=EventNoun.LIST,
+        verb=EventVerb.UPDATE,
+        context={
+            "list_id": "00000000-0000-0000-0000-000000000000",
+            "list_name": "Non-existent List",
+        },
+    )
+    # Test passes if no exception is raised
+
+
+@pytest.mark.django_db
+def test_log_event_helper_updates_list_modified(make_list):
+    """Test that using the log_event helper also triggers list updates."""
+    # Create a list
+    lst = make_list("Test List")
+
+    # Force the list to have an old modified timestamp
+    old_modified = timezone.now() - timedelta(hours=2)
+    List.objects.filter(id=lst.id).update(modified=old_modified)
+
+    # Use log_event helper with list_id
+    log_event(
+        user=lst.owner,
+        noun=EventNoun.LIST_FIGHTER,
+        verb=EventVerb.CREATE,
+        request=None,
+        fighter_name="New Fighter",
+        list_id=str(lst.id),
+        list_name=lst.name,
+    )
+
+    # Refresh the list from DB
+    lst.refresh_from_db()
+
+    # The list's modified timestamp should be recent
+    assert lst.modified > timezone.now() - timedelta(seconds=5)
+
+
+@pytest.mark.django_db
+def test_updating_existing_event_does_not_update_list(make_list):
+    """Test that updating an existing event doesn't update the list's modified timestamp."""
+    # Create a list and event
+    lst = make_list("Test List")
+
+    # Create an event with list_id
+    event = Event.objects.create(
+        owner=lst.owner,
+        noun=EventNoun.LIST,
+        verb=EventVerb.UPDATE,
+        context={"list_id": str(lst.id), "list_name": lst.name},
+    )
+
+    # Force the list to have an old modified timestamp
+    old_modified = timezone.now() - timedelta(hours=2)
+    List.objects.filter(id=lst.id).update(modified=old_modified)
+
+    # Update the existing event
+    event.context["updated_field"] = "new_value"
+    event.save()
+
+    # Refresh the list from DB
+    lst.refresh_from_db()
+
+    # The list's modified timestamp should not have changed
+    assert lst.modified < timezone.now() - timedelta(hours=1)


### PR DESCRIPTION
Fixes #536

## Summary

This PR fixes the "last edited" feature for lists by implementing a signal handler that updates the list's modified timestamp whenever related events are logged.

## Changes

- Added signal handler in `gyrinx/core/signals.py` that listens for Event creation
- When an Event contains a `list_id` in its context JSON, the associated list's `modified` timestamp is updated
- Uses `update()` to avoid triggering additional save signals and history tracking
- Added comprehensive test coverage to verify the functionality

## Testing

Added `test_event_list_update_signal.py` with tests covering:
- Events with list_id update the list's timestamp
- Events without list_id don't affect lists
- Empty or non-existent list_id values are handled gracefully
- The `log_event` helper function triggers updates
- Updating existing events doesn't re-trigger list updates

Generated with [Claude Code](https://claude.ai/code)