### PR TITLE
feat: Display dot in fighter card if Info and Lore filled in

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -1141,6 +1141,14 @@ class ListFighter(AppBase):
             return False
         return True
 
+    def has_info_content(self):
+        """Check if the fighter has any content in the Info tab fields."""
+        return bool(self.image or self.save_roll or self.private_notes)
+
+    def has_lore_content(self):
+        """Check if the fighter has any content in the Lore tab."""
+        return bool(self.narrative)
+
     class Meta:
         verbose_name = "List Fighter"
         verbose_name_plural = "List Fighters"

--- a/gyrinx/core/templates/core/includes/fighter_card_content.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content.html
@@ -102,7 +102,10 @@
                                     type="button"
                                     role="tab"
                                     aria-controls="info-{{ fighter.id }}"
-                                    aria-selected="false">Info</button>
+                                    aria-selected="false">
+                                Info
+                                {% if fighter.has_info_content %}<i class="bi-dot"></i>{% endif %}
+                            </button>
                         </li>
                         <li class="nav-item" role="presentation">
                             <button class="nav-link fs-7 px-2 py-1"
@@ -112,7 +115,10 @@
                                     type="button"
                                     role="tab"
                                     aria-controls="lore-{{ fighter.id }}"
-                                    aria-selected="false">Lore</button>
+                                    aria-selected="false">
+                                Lore
+                                {% if fighter.has_lore_content %}<i class="bi-dot"></i>{% endif %}
+                            </button>
                         </li>
                     </ul>
                     {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}


### PR DESCRIPTION
Adds a visual indicator (dot icon) to fighter card tabs when Info and Lore have content, helping users quickly identify which tabs contain information.

Fixes #551

Generated with [Claude Code](https://claude.ai/code)