### PR TITLE
Fix AttributeError: Use advancement.advancement_type instead of params.advancement_type

### DIFF
--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -3476,7 +3476,7 @@ def list_fighter_advancement_confirm(request, id, fighter_id):
                 list_id=str(lst.id),
                 list_name=lst.name,
                 action="advancement_applied",
-                advancement_type=params.advancement_type,
+                advancement_type=advancement.advancement_type,
                 advancement_detail=stat_desc,
                 xp_cost=params.xp_cost,
                 cost_increase=params.cost_increase,


### PR DESCRIPTION
Fixes #562

The AdvancementFlowParams object has an advancement_choice attribute, not advancement_type.
The advancement_type is correctly set on the advancement object created earlier in the code.

## Changes
- Fixed AttributeError in list_fighter_advancement_confirm by using `advancement.advancement_type` instead of `params.advancement_type`

Generated with [Claude Code](https://claude.ai/code)