### PR TITLE
fix: Replace pagination links to prevent duplicate page params

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaigns.html
+++ b/gyrinx/core/templates/core/campaign/campaigns.html
@@ -66,7 +66,7 @@
                         {% if page_obj.has_previous %}
                             <li class="page-item">
                                 <a class="page-link"
-                                   href="?{% if request.GET %}{{ request.GET.urlencode }}&{% endif %}page={{ page_obj.previous_page_number }}">Previous</a>
+                                   href="?{% qt request page=page_obj.previous_page_number %}">Previous</a>
                             </li>
                         {% else %}
                             <li class="page-item disabled">
@@ -80,15 +80,14 @@
                                 </li>
                             {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
                                 <li class="page-item">
-                                    <a class="page-link"
-                                       href="?{% if request.GET %}{{ request.GET.urlencode }}&{% endif %}page={{ num }}">{{ num }}</a>
+                                    <a class="page-link" href="?{% qt request page=num %}">{{ num }}</a>
                                 </li>
                             {% endif %}
                         {% endfor %}
                         {% if page_obj.has_next %}
                             <li class="page-item">
                                 <a class="page-link"
-                                   href="?{% if request.GET %}{{ request.GET.urlencode }}&{% endif %}page={{ page_obj.next_page_number }}">Next</a>
+                                   href="?{% qt request page=page_obj.next_page_number %}">Next</a>
                             </li>
                         {% else %}
                             <li class="page-item disabled">

--- a/gyrinx/core/templates/core/list_fighter_advancement_other.html
+++ b/gyrinx/core/templates/core/list_fighter_advancement_other.html
@@ -46,7 +46,7 @@
             </div>
             <div class="d-flex gap-2">
                 <button type="submit" class="btn btn-primary">Continue</button>
-                <a href="{% url 'core:list-fighter-advancement-type' list.id fighter.id %}?{{ request.GET.urlencode }}"
+                <a href="{% url 'core:list-fighter-advancement-type' list.id fighter.id %}?{% qt request %}"
                    class="btn btn-secondary">Back</a>
             </div>
         </form>

--- a/gyrinx/core/templates/core/lists.html
+++ b/gyrinx/core/templates/core/lists.html
@@ -61,7 +61,7 @@
                         {% if page_obj.has_previous %}
                             <li class="page-item">
                                 <a class="page-link"
-                                   href="?{% if request.GET %}{{ request.GET.urlencode }}&{% endif %}page={{ page_obj.previous_page_number }}">Previous</a>
+                                   href="?{% qt request page=page_obj.previous_page_number %}">Previous</a>
                             </li>
                         {% else %}
                             <li class="page-item disabled">
@@ -75,15 +75,14 @@
                                 </li>
                             {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
                                 <li class="page-item">
-                                    <a class="page-link"
-                                       href="?{% if request.GET %}{{ request.GET.urlencode }}&{% endif %}page={{ num }}">{{ num }}</a>
+                                    <a class="page-link" href="?{% qt request page=num %}">{{ num }}</a>
                                 </li>
                             {% endif %}
                         {% endfor %}
                         {% if page_obj.has_next %}
                             <li class="page-item">
                                 <a class="page-link"
-                                   href="?{% if request.GET %}{{ request.GET.urlencode }}&{% endif %}page={{ page_obj.next_page_number }}">Next</a>
+                                   href="?{% qt request page=page_obj.next_page_number %}">Next</a>
                             </li>
                         {% else %}
                             <li class="page-item disabled">


### PR DESCRIPTION
Fixes #567

The pagination links were using `request.GET.urlencode` which appends parameters instead of replacing them, causing URLs like `?page=1&page=2&page=3`.

Updated all pagination links to use the `qt` template tag which properly replaces the page parameter while preserving other query parameters.

Generated with [Claude Code](https://claude.ai/code)