### PR TITLE
Ingest content dump without cascade

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -1361,7 +1361,7 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
         return f"{self.content_equipment_cached}"
 
     def __str__(self):
-        return f"{self.list_fighter} – {self.name()}"
+        return f"{self.list_fighter} – {self.base_name()}"
 
     # Profiles
 


### PR DESCRIPTION
1. Changed TRUNCATE ... CASCADE to plain TRUNCATE - This prevents SQL-level cascading to related tables
2. Wrapped the clear operation in foreign key disable/enable - Using PostgreSQL's session_replication_role
3. Changed fallback to use raw SQL DELETE - Avoids Django's ORM cascade behavior