### PR TITLE
feat: Add ability to remove campaign assets and resources

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_asset_type_remove.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_type_remove.html
@@ -1,0 +1,35 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Remove {{ asset_type.name_singular }} - {{ campaign.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:campaign-assets' campaign.id as campaign_assets_url %}
+    {% include "core/includes/back.html" with url=campaign_assets_url text="Back to Campaign Assets" %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">Remove {{ asset_type.name_plural }} from {{ campaign.name }}</h1>
+        <form action="{% url 'core:campaign-asset-type-remove' campaign.id asset_type.id %}"
+              method="post">
+            {% csrf_token %}
+            <div class="alert alert-warning" role="alert">
+                <h4 class="alert-heading">Are you sure?</h4>
+                <p class="mb-0">
+                    This will permanently remove the asset type <strong>{{ asset_type.name_plural }}</strong> from the campaign.
+                </p>
+                {% if assets_count > 0 %}
+                    <hr>
+                    <p class="mb-0">
+                        <i class="bi-exclamation-triangle-fill"></i>
+                        This will also delete <strong>{{ assets_count }} {{ asset_type.name_singular|lower }}{{ assets_count|pluralize }}</strong> currently in the campaign.
+                    </p>
+                {% endif %}
+            </div>
+            <div class="mt-3">
+                <button type="submit" class="btn btn-danger">
+                    <i class="bi-trash"></i> Remove Asset Type
+                </button>
+                <a href="{{ campaign_assets_url }}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -37,6 +37,10 @@
                                    class="btn btn-secondary btn-sm">
                                     <i class="bi-pencil"></i> Edit Type
                                 </a>
+                                <a href="{% url 'core:campaign-asset-type-remove' campaign.id asset_type.id %}"
+                                   class="btn btn-danger btn-sm">
+                                    <i class="bi-trash"></i> Remove Type
+                                </a>
                             </div>
                         {% endif %}
                     </div>

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -34,12 +34,12 @@
                                     <i class="bi-plus"></i> Add {{ asset_type.name_singular }}
                                 </a>
                                 <a href="{% url 'core:campaign-asset-type-edit' campaign.id asset_type.id %}"
-                                   class="btn btn-secondary btn-sm">
-                                    <i class="bi-pencil"></i> Edit Type
+                                   class="btn btn-outline-secondary btn-sm">
+                                    <i class="bi-pencil"></i> Edit
                                 </a>
                                 <a href="{% url 'core:campaign-asset-type-remove' campaign.id asset_type.id %}"
-                                   class="btn btn-danger btn-sm">
-                                    <i class="bi-trash"></i> Remove Type
+                                   class="btn btn-outline-danger btn-sm">
+                                    <i class="bi-trash"></i> Remove
                                 </a>
                             </div>
                         {% endif %}

--- a/gyrinx/core/templates/core/campaign/campaign_resource_type_remove.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resource_type_remove.html
@@ -1,0 +1,35 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Remove {{ resource_type.name }} - {{ campaign.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:campaign-resources' campaign.id as campaign_resources_url %}
+    {% include "core/includes/back.html" with url=campaign_resources_url text="Back to Campaign Resources" %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">Remove {{ resource_type.name }} from {{ campaign.name }}</h1>
+        <form action="{% url 'core:campaign-resource-type-remove' campaign.id resource_type.id %}"
+              method="post">
+            {% csrf_token %}
+            <div class="alert alert-warning" role="alert">
+                <h4 class="alert-heading">Are you sure?</h4>
+                <p class="mb-0">
+                    This will permanently remove the resource type <strong>{{ resource_type.name }}</strong> from the campaign.
+                </p>
+                {% if resources_count > 0 %}
+                    <hr>
+                    <p class="mb-0">
+                        <i class="bi-exclamation-triangle-fill"></i>
+                        This will also delete all <strong>{{ resources_count }} gang resource{{ resources_count|pluralize }}</strong> of this type.
+                    </p>
+                {% endif %}
+            </div>
+            <div class="mt-3">
+                <button type="submit" class="btn btn-danger">
+                    <i class="bi-trash"></i> Remove Resource Type
+                </button>
+                <a href="{{ campaign_resources_url }}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -28,10 +28,16 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h2 class="card-title h5 mb-0">{{ resource_type.name }}</h2>
                         {% if is_owner %}
-                            <a href="{% url 'core:campaign-resource-type-edit' campaign.id resource_type.id %}"
-                               class="btn btn-secondary btn-sm">
-                                <i class="bi-pencil"></i> Edit Type
-                            </a>
+                            <div class="btn-group">
+                                <a href="{% url 'core:campaign-resource-type-edit' campaign.id resource_type.id %}"
+                                   class="btn btn-secondary btn-sm">
+                                    <i class="bi-pencil"></i> Edit Type
+                                </a>
+                                <a href="{% url 'core:campaign-resource-type-remove' campaign.id resource_type.id %}"
+                                   class="btn btn-danger btn-sm">
+                                    <i class="bi-trash"></i> Remove Type
+                                </a>
+                            </div>
                         {% endif %}
                     </div>
                     {% if resource_type.description %}

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -30,12 +30,12 @@
                         {% if is_owner %}
                             <div class="btn-group">
                                 <a href="{% url 'core:campaign-resource-type-edit' campaign.id resource_type.id %}"
-                                   class="btn btn-secondary btn-sm">
-                                    <i class="bi-pencil"></i> Edit Type
+                                   class="btn btn-outline-secondary btn-sm">
+                                    <i class="bi-pencil"></i> Edit
                                 </a>
                                 <a href="{% url 'core:campaign-resource-type-remove' campaign.id resource_type.id %}"
-                                   class="btn btn-danger btn-sm">
-                                    <i class="bi-trash"></i> Remove Type
+                                   class="btn btn-outline-danger btn-sm">
+                                    <i class="bi-trash"></i> Remove
                                 </a>
                             </div>
                         {% endif %}

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -360,6 +360,11 @@ urlpatterns = [
         name="campaign-asset-type-edit",
     ),
     path(
+        "campaign/<id>/assets/type/<type_id>/remove",
+        campaign.campaign_asset_type_remove,
+        name="campaign-asset-type-remove",
+    ),
+    path(
         "campaign/<id>/assets/type/<type_id>/new",
         campaign.campaign_asset_new,
         name="campaign-asset-new",
@@ -389,6 +394,11 @@ urlpatterns = [
         "campaign/<id>/resources/type/<type_id>/edit",
         campaign.campaign_resource_type_edit,
         name="campaign-resource-type-edit",
+    ),
+    path(
+        "campaign/<id>/resources/type/<type_id>/remove",
+        campaign.campaign_resource_type_remove,
+        name="campaign-resource-type-remove",
     ),
     path(
         "campaign/<id>/resources/<resource_id>/modify",


### PR DESCRIPTION
## Description

This PR adds the ability for campaign owners to remove asset types and resource types from their campaigns. The implementation follows the same confirmation flow pattern as the existing "remove gang" functionality.

## Changes

- Added URL patterns for removing asset and resource types
- Implemented remove views with confirmation flow
- Added "Remove Type" buttons next to "Edit Type" buttons in templates
- Created confirmation templates for safe deletion
- Restricted removal to campaign owners only
- Prevented removal from archived campaigns

## Testing

- Syntax validation passed
- Templates created correctly
- Code formatted with fmt.sh

Fixes #573

Generated with [Claude Code](https://claude.ai/code)