### PR TITLE
fix: Add aria-label attributes to icon-only buttons and links

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -93,7 +93,8 @@
                                 <button type="button"
                                         class="btn btn-secondary btn-sm dropdown-toggle"
                                         data-bs-toggle="dropdown"
-                                        aria-expanded="false">
+                                        aria-expanded="false"
+                                        aria-label="More options">
                                     <i class="bi-three-dots"></i>
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-end">
@@ -164,7 +165,8 @@
                                             {% if not campaign.is_post_campaign %}
                                                 <a href="{% url 'core:campaign-remove-list' campaign.id list.id %}"
                                                    class="link-danger ms-2"
-                                                   title="Remove from campaign">
+                                                   title="Remove from campaign"
+                                                   aria-label="Remove from campaign">
                                                     <i class="bi-trash"></i>
                                                 </a>
                                             {% endif %}

--- a/gyrinx/core/templates/core/dice.html
+++ b/gyrinx/core/templates/core/dice.html
@@ -23,27 +23,32 @@
                         {% if group.dice_n > 1 %}
                             <a rel="nofollow"
                                class="btn btn-outline-secondary"
-                               href="?{% qt_nth request nth=forloop.counter0 d=group.dice_n|add:"-1"|max:"1" %}">
+                               href="?{% qt_nth request nth=forloop.counter0 d=group.dice_n|add:"-1"|max:"1" %}"
+                               aria-label="Remove one die">
                                 <i class="bi-dash-lg"></i>
                             </a>
                             <a rel="nofollow"
                                class="btn btn-outline-secondary"
                                href="?{% qt_nth request nth=forloop.counter0 d="1" %}">1</a>
                         {% else %}
-                            <a rel="nofollow" class="btn btn-outline-secondary disabled">
+                            <a rel="nofollow"
+                               class="btn btn-outline-secondary disabled"
+                               aria-label="Remove one die (disabled)">
                                 <i class="bi-dash-lg"></i>
                             </a>
                             <a rel="nofollow" class="btn btn-outline-secondary disabled">1</a>
                         {% endif %}
                         <a rel="nofollow"
                            class="btn btn-outline-primary"
-                           href="?{% qt_nth request nth=forloop.counter0 d=group.dice_n|add:"1" %}">
+                           href="?{% qt_nth request nth=forloop.counter0 d=group.dice_n|add:"1" %}"
+                           aria-label="Add one die">
                             <i class="bi-plus-lg"></i>
                         </a>
                         {% if forloop.counter0 > 0 %}
                             <a rel="nofollow"
                                class="ms-auto ms-md-0 btn btn-outline-danger"
-                               href="?{% qt_rm_nth request nth=forloop.counter0 d=1 fp=1 i=1 %}">
+                               href="?{% qt_rm_nth request nth=forloop.counter0 d=1 fp=1 i=1 %}"
+                               aria-label="Remove dice group">
                                 <i class="bi-x-lg"></i>
                             </a>
                         {% endif %}

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -109,7 +109,8 @@
                             <button type="button"
                                     class="btn btn-secondary btn-sm dropdown-toggle"
                                     data-bs-toggle="dropdown"
-                                    aria-expanded="false">
+                                    aria-expanded="false"
+                                    aria-label="More options">
                                 <i class="bi-three-dots-vertical"></i>
                             </button>
                             <ul class="dropdown-menu">

--- a/gyrinx/core/templates/core/lists.html
+++ b/gyrinx/core/templates/core/lists.html
@@ -47,7 +47,9 @@
                         </div>
                     </div>
                     <div class="ms-auto d-md-none">
-                        <a href="{% url 'core:list' list.id %}" class="p-3 stretched-link">
+                        <a href="{% url 'core:list' list.id %}"
+                           class="p-3 stretched-link"
+                           aria-label="View {{ list.name }} details">
                             <i class="bi-chevron-right"></i>
                         </a>
                     </div>


### PR DESCRIPTION
Fixes #366

This PR addresses accessibility issues in templates by adding aria-label attributes to icon-only buttons and links for better screen reader support.

## Changes
- Added aria-label to dropdown toggles with bi-three-dots icons
- Added aria-label to icon-only navigation links
- Added aria-label to dice control buttons
- Improved accessibility for screen reader users

Generated with [Claude Code](https://claude.ai/code)