### PR TITLE
Add support for GETs to patreon hook

### DIFF
--- a/gyrinx/api/views.py
+++ b/gyrinx/api/views.py
@@ -142,4 +142,17 @@ def hook_patreon(request):
 
         return HttpResponse(status=204)
 
+    if request.method == "GET":
+        # Handle GET requests if needed, e.g., for health checks
+        return HttpResponse(
+            json.dumps(
+                {
+                    "status": "ok",
+                    "message": "Patreon webhook is active and ready to receive events.",
+                }
+            ),
+            status=200,
+            content_type="application/json",
+        )
+
     return HttpResponse(status=400)


### PR DESCRIPTION
They seem to have decided to send GETs and then disable the endpoint when the GETs fail 🙄 