### PR TITLE
fix: improve equipment search UX when toggling equipment list filter

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -219,6 +219,89 @@ document.querySelectorAll("[data-gy-sync]").forEach((element) => {
     });
 });
 
+// Equipment list filter toggle functionality
+document.addEventListener("DOMContentLoaded", () => {
+    const filterSwitch = document.getElementById("filter-switch");
+    const illegalCheckbox = document.getElementById("al-i");
+
+    // Find the availability button by looking for a button containing "Availability" text
+    let availabilityButton = null;
+    const dropdownButtons = document.querySelectorAll(
+        ".btn-group button.dropdown-toggle",
+    );
+    dropdownButtons.forEach((button) => {
+        if (button.textContent.trim() === "Availability") {
+            availabilityButton = button;
+        }
+    });
+
+    if (filterSwitch && availabilityButton) {
+        filterSwitch.addEventListener("change", (event) => {
+            if (event.target.checked) {
+                // Equipment list is ON - disable availability
+                availabilityButton.classList.add("disabled");
+                availabilityButton.setAttribute("disabled", "");
+                availabilityButton.removeAttribute("data-bs-toggle");
+                availabilityButton.removeAttribute("aria-expanded");
+                availabilityButton.removeAttribute("data-bs-auto-close");
+
+                // Remove existing tooltip if any
+                const existingTooltip = bootstrap.Tooltip.getInstance(
+                    availabilityButton.parentElement,
+                );
+                if (existingTooltip) {
+                    existingTooltip.dispose();
+                }
+
+                // Add tooltip
+                availabilityButton.parentElement.setAttribute(
+                    "data-bs-toggle",
+                    "tooltip",
+                );
+                availabilityButton.parentElement.setAttribute(
+                    "data-bs-placement",
+                    "top",
+                );
+                availabilityButton.parentElement.setAttribute(
+                    "title",
+                    "Availability filters are disabled when Equipment List is toggled on. All equipment on the fighter's equipment list is shown regardless of availability.",
+                );
+                new bootstrap.Tooltip(availabilityButton.parentElement);
+            } else {
+                // Equipment list is OFF - enable availability
+                availabilityButton.classList.remove("disabled");
+                availabilityButton.removeAttribute("disabled");
+                availabilityButton.setAttribute("data-bs-toggle", "dropdown");
+                availabilityButton.setAttribute("aria-expanded", "false");
+                availabilityButton.setAttribute(
+                    "data-bs-auto-close",
+                    "outside",
+                );
+
+                // Remove tooltip
+                const tooltip = bootstrap.Tooltip.getInstance(
+                    availabilityButton.parentElement,
+                );
+                if (tooltip) {
+                    tooltip.dispose();
+                }
+                availabilityButton.parentElement.removeAttribute(
+                    "data-bs-toggle",
+                );
+                availabilityButton.parentElement.removeAttribute(
+                    "data-bs-placement",
+                );
+                availabilityButton.parentElement.removeAttribute("title");
+
+                // Check the illegal checkbox
+                if (illegalCheckbox && !illegalCheckbox.checked) {
+                    illegalCheckbox.checked = true;
+                }
+            }
+        });
+    }
+});
+
 // Add loading spinner to form submit buttons
 document.addEventListener("DOMContentLoaded", () => {
     const forms = document.querySelectorAll("form");

--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -224,16 +224,10 @@ document.addEventListener("DOMContentLoaded", () => {
     const filterSwitch = document.getElementById("filter-switch");
     const illegalCheckbox = document.getElementById("al-i");
 
-    // Find the availability button by looking for a button containing "Availability" text
-    let availabilityButton = null;
-    const dropdownButtons = document.querySelectorAll(
-        ".btn-group button.dropdown-toggle",
+    // Find the availability button by its ID
+    const availabilityButton = document.getElementById(
+        "availability-dropdown-button",
     );
-    dropdownButtons.forEach((button) => {
-        if (button.textContent.trim() === "Availability") {
-            availabilityButton = button;
-        }
-    });
 
     if (filterSwitch && availabilityButton) {
         filterSwitch.addEventListener("change", (event) => {

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -68,6 +68,7 @@
         <div class="btn-group"
              {% if is_equipment_list %} data-bs-toggle="tooltip" data-bs-placement="top" title="Availability filters are disabled when Equipment List is toggled on. All equipment on the fighter's equipment list is shown regardless of availability." {% endif %}>
             <button type="button"
+                    id="availability-dropdown-button"
                     class="btn btn-outline-primary btn-sm dropdown-toggle{% if is_equipment_list %} disabled{% endif %}"
                     {% if not is_equipment_list %} data-bs-toggle="dropdown" aria-expanded="false" data-bs-auto-close="outside" {% else %} disabled {% endif %}>
                 Availability

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -75,12 +75,6 @@
             </button>
             <div class="dropdown-menu shadow-sm p-2 fs-7 dropdown-menu-mw">
                 <div class="vstack gap-3">
-                    {% if is_equipment_list %}
-                        <div class="text-muted small">
-                            <i class="bi bi-info-circle"></i>
-                            Filters are disabled when Equipment List is toggled on. All equipment on the fighter's equipment list is shown regardless of availability.
-                        </div>
-                    {% endif %}
                     <div>
                         <label for="mal" class="form-label">Maximum Availability Level</label>
                         <div class="row gx-2 align-items-center">


### PR DESCRIPTION
Fixes #591

## Summary

Implemented two QoL improvements for equipment/weapon search:

1. **Immediate availability unlock** - When you untick "only equipment list", the availability dropdown now unlocks immediately without needing to click "Update"
2. **Auto-check "illegal"** - When you untick "only equipment list", the "illegal" checkbox is now automatically checked along with "common" and "rare"

## Technical Details

- Added JavaScript event listener for the equipment list toggle switch
- Dynamically enables/disables the availability dropdown and manages Bootstrap tooltips
- Automatically checks the "illegal" checkbox when equipment list is unchecked

Generated with [Claude Code](https://claude.ai/code)