### PR TITLE
fix: invert list fighter sort order for linked vehicles

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -365,9 +365,7 @@ class ListFighterManager(models.Manager):
                     # Linked fighters should be sorted next to their parent
                     When(
                         _is_linked=True,
-                        then=Concat(
-                            "linked_fighter__list_fighter__name", Value("-after")
-                        ),
+                        then=Concat(Value(" "), "linked_fighter__list_fighter__name"),
                     ),
                     default=F("name"),
                     output_field=models.CharField(),

--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -45,6 +45,7 @@ from gyrinx.content.models import (
     VirtualWeaponProfile,
 )
 from gyrinx.core.models.base import AppBase
+from gyrinx.models import FighterCategoryChoices
 from gyrinx.core.models.history_mixin import HistoryMixin
 from gyrinx.models import Archived, Base, QuerySetOf, format_cost_display
 
@@ -362,12 +363,20 @@ class ListFighterManager(models.Manager):
                     default=99,
                 ),
                 _sort_key=Case(
-                    # Linked fighters should be sorted next to their parent
+                    # If this is a beast linked to a fighter, sort after the owner
                     When(
                         _is_linked=True,
-                        then=Concat(Value(" "), "linked_fighter__list_fighter__name"),
+                        content_fighter__category=FighterCategoryChoices.EXOTIC_BEAST,
+                        then=Concat("linked_fighter__list_fighter__name", Value("~2")),
                     ),
-                    default=F("name"),
+                    # If this is a vehicle linked to a fighter, sort with the parent but come first
+                    When(
+                        _is_linked=True,
+                        content_fighter__category=FighterCategoryChoices.VEHICLE,
+                        then=Concat("linked_fighter__list_fighter__name", Value("~0")),
+                    ),
+                    # Default: regular fighters sort by their own name with a middle priority
+                    default=Concat(F("name"), Value("~1")),
                     output_field=models.CharField(),
                 ),
             )

--- a/gyrinx/core/tests/test_equipment_link.py
+++ b/gyrinx/core/tests/test_equipment_link.py
@@ -129,10 +129,193 @@ def test_list_ordering_with_link(
     assert lst.fighters().count() == 3
 
     assert [f.name for f in lst.fighters()] == [
-        "Beast",
         "Owner",
+        "Beast",
         "Another",
     ]
+
+
+@pytest.mark.django_db
+def test_comprehensive_sorting_with_vehicles_and_beasts(
+    user,
+    make_list,
+    make_content_house,
+    make_content_fighter,
+    make_list_fighter,
+    make_equipment,
+):
+    """Test all sorting scenarios for fighters linked to vehicles and beasts."""
+    house = make_content_house("Example House")
+
+    # Create content fighters
+    fighter_cf = make_content_fighter(
+        type="Fighter",
+        category=FighterCategoryChoices.GANGER,
+        house=house,
+        base_cost=100,
+    )
+    vehicle_cf = make_content_fighter(
+        type="Vehicle",
+        category=FighterCategoryChoices.VEHICLE,
+        house=house,
+        base_cost=200,
+    )
+    beast_cf = make_content_fighter(
+        type="Beast",
+        category=FighterCategoryChoices.EXOTIC_BEAST,
+        house=house,
+        base_cost=50,
+    )
+
+    # Create equipment
+    vehicle_ce = make_equipment(
+        "Vehicle Equipment",
+        category=ContentEquipmentCategory.objects.get(name="Status Items"),
+        cost=200,
+    )
+    beast_ce = make_equipment(
+        "Beast Equipment",
+        category=ContentEquipmentCategory.objects.get(name="Status Items"),
+        cost=50,
+    )
+
+    # Link equipment to content fighters
+    ContentEquipmentFighterProfile.objects.create(
+        equipment=vehicle_ce, content_fighter=vehicle_cf
+    )
+    ContentEquipmentFighterProfile.objects.create(
+        equipment=beast_ce, content_fighter=beast_cf
+    )
+
+    lst = make_list("Example List", content_house=house, owner=user)
+
+    # Scenario 1: Fighter linked to Beast should sort: Fighter, Beast
+    fighter1_lf = make_list_fighter(
+        lst, "Fighter1", content_fighter=fighter_cf, owner=user
+    )
+    assign1 = ListFighterEquipmentAssignment(
+        list_fighter=fighter1_lf, content_equipment=beast_ce
+    )
+    assign1.save()
+
+    # Scenario 2: Fighter linked to Vehicle should sort: Vehicle, Fighter
+    fighter2_lf = make_list_fighter(
+        lst, "Fighter2", content_fighter=fighter_cf, owner=user
+    )
+    assign2 = ListFighterEquipmentAssignment(
+        list_fighter=fighter2_lf, content_equipment=vehicle_ce
+    )
+    assign2.save()
+
+    # The vehicle is created automatically when we assign vehicle equipment
+
+    # Scenario 3: Fighter linked to Vehicle, where Fighter is also linked to Beast
+    # should sort: Vehicle, Fighter, Fighter's Beast
+    fighter3_lf = make_list_fighter(
+        lst, "Fighter3", content_fighter=fighter_cf, owner=user
+    )
+    assign3_vehicle = ListFighterEquipmentAssignment(
+        list_fighter=fighter3_lf, content_equipment=vehicle_ce
+    )
+    assign3_vehicle.save()
+    assign3_beast = ListFighterEquipmentAssignment(
+        list_fighter=fighter3_lf, content_equipment=beast_ce
+    )
+    assign3_beast.save()
+
+    # Scenario 4: Fighter linked to Vehicle, where Vehicle is also linked to Beast
+    # should sort: Vehicle, Fighter, Vehicle's Beast
+    fighter4_lf = make_list_fighter(
+        lst, "Fighter4", content_fighter=fighter_cf, owner=user
+    )
+    assign4 = ListFighterEquipmentAssignment(
+        list_fighter=fighter4_lf, content_equipment=vehicle_ce
+    )
+    assign4.save()
+
+    # Get the vehicle for fighter4
+    vehicle4_lf = ListFighter.objects.get(
+        list=lst,
+        content_fighter__category=FighterCategoryChoices.VEHICLE,
+        linked_fighter__list_fighter=fighter4_lf,
+    )
+
+    # Add beast to the vehicle
+    assign_vehicle_beast = ListFighterEquipmentAssignment(
+        list_fighter=vehicle4_lf, content_equipment=beast_ce
+    )
+    assign_vehicle_beast.save()
+
+    # Update names to be unique for better debugging
+    beast1 = ListFighter.objects.get(
+        list=lst,
+        content_fighter__category=FighterCategoryChoices.EXOTIC_BEAST,
+        linked_fighter__list_fighter=fighter1_lf,
+    )
+    beast1.name = "Beast1"
+    beast1.save()
+
+    vehicle2 = ListFighter.objects.get(
+        list=lst,
+        content_fighter__category=FighterCategoryChoices.VEHICLE,
+        linked_fighter__list_fighter=fighter2_lf,
+    )
+    vehicle2.name = "Vehicle2"
+    vehicle2.save()
+
+    vehicle3 = ListFighter.objects.get(
+        list=lst,
+        content_fighter__category=FighterCategoryChoices.VEHICLE,
+        linked_fighter__list_fighter=fighter3_lf,
+    )
+    vehicle3.name = "Vehicle3"
+    vehicle3.save()
+
+    beast3 = ListFighter.objects.get(
+        list=lst,
+        content_fighter__category=FighterCategoryChoices.EXOTIC_BEAST,
+        linked_fighter__list_fighter=fighter3_lf,
+    )
+    beast3.name = "Beast3"
+    beast3.save()
+
+    vehicle4_lf.name = "Vehicle4"
+    vehicle4_lf.save()
+
+    beast4 = ListFighter.objects.get(
+        list=lst,
+        content_fighter__category=FighterCategoryChoices.EXOTIC_BEAST,
+        linked_fighter__list_fighter=vehicle4_lf,
+    )
+    beast4.name = "Beast4"
+    beast4.save()
+
+    # Check the sorting
+    fighters = lst.fighters()
+    fighter_names = [f.name for f in fighters]
+
+    expected_order = [
+        # Scenario 1: Fighter, Beast
+        "Fighter1",
+        "Beast1",  # Fighter1's Beast
+        # Scenario 2: Vehicle, Fighter
+        "Vehicle2",  # Fighter2's Vehicle
+        "Fighter2",
+        # Scenario 3: Vehicle, Fighter, Fighter's Beast
+        "Vehicle3",  # Fighter3's Vehicle
+        "Fighter3",
+        "Beast3",  # Fighter3's Beast
+        # Scenario 4: Vehicle, Fighter, Vehicle's Beast
+        "Vehicle4",  # Fighter4's Vehicle
+        "Fighter4",
+        "Beast4",  # Vehicle4's Beast
+    ]
+
+    # Print for debugging
+    print(f"Actual order: {fighter_names}")
+    print(f"Expected order: {expected_order}")
+
+    assert fighter_names == expected_order
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_equipment_link.py
+++ b/gyrinx/core/tests/test_equipment_link.py
@@ -129,8 +129,8 @@ def test_list_ordering_with_link(
     assert lst.fighters().count() == 3
 
     assert [f.name for f in lst.fighters()] == [
-        "Owner",
         "Beast",
+        "Owner",
         "Another",
     ]
 


### PR DESCRIPTION
Linked fighters now appear before their owner instead of after.

Changed the sort key for linked fighters from appending "-after" to prepending a space character, which sorts before alphanumeric characters.

Fixes #593

Generated with [Claude Code](https://claude.ai/code)