### PR TITLE
fix: load custom_tag on advancement screen

### DIFF
--- a/gyrinx/core/templates/core/list_fighter_advancement_other.html
+++ b/gyrinx/core/templates/core/list_fighter_advancement_other.html
@@ -1,5 +1,5 @@
 {% extends "core/layouts/base.html" %}
-{% load allauth %}
+{% load allauth custom_tags %}
 {% block head_title %}
     New Advancement - {{ fighter.name }}
 {% endblock head_title %}


### PR DESCRIPTION
Fix #601 