### PR TITLE
fix: widen left column on fighter cards to fit "Advancements"

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -43,7 +43,7 @@
             {% if fighter.ruleline|length > 0 %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Rules</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% spaceless %}
                             {# djlint:off #}
                             {% for rule in fighter.ruleline %}<span>{% include "core/includes/rule.html" with rule=rule %}{% if not forloop.last %}<span>, </span>{% endif %}</span>{% endfor %}
@@ -56,7 +56,7 @@
             {% if list.is_campaign_mode %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">XP</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         <span class="badge text-bg-primary">{{ fighter.xp_current }} XP</span>
                         {% if not print and can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                             <a href="{% url 'core:list-fighter-xp-edit' list.id fighter.id %}">
@@ -74,7 +74,7 @@
                 {% if fighter.skilline_cached|length > 0 %}
                     <tr class="fs-7">
                         <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Skills</th>
-                        <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                        <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                             {% spaceless %}
                                 {% for skill in fighter.skilline_cached %}
                                     {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -96,7 +96,7 @@
                 {% else %}
                     <tr class="fs-7">
                         <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Skills</th>
-                        <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                        <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                             {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                                 <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Add skills</a>
                             {% else %}
@@ -109,7 +109,7 @@
             {% if fighter.is_psyker %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Powers</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% spaceless %}
                             {% for assign in fighter.powers_cached %}
                                 {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -135,7 +135,7 @@
                 {% for line in fighter.house_additional_gearline_display %}
                     <tr class="fs-7">
                         <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
-                        <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                        <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                             {% spaceless %}
                                 {% for assign in line.assignments %}
                                     {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -165,7 +165,7 @@
                             {{ line.category }}
                             {% if line.category_limit %}<span class="fw-normal">{{ line.category_limit }}</span>{% endif %}
                         </th>
-                        <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                        <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                             {% spaceless %}
                                 {% for assign in line.assignments %}
                                     {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -190,7 +190,7 @@
             {% if fighter.wargearline_cached|length > 0 %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% spaceless %}
                             {% for assign in fighter.wargear %}
                                 {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -210,7 +210,7 @@
             {% else %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                             <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
                         {% else %}
@@ -223,7 +223,7 @@
             {% if list.is_campaign_mode and fighter.injuries.exists %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Injuries</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% for injury in fighter.injuries.all %}
                             {% if not forloop.first %},{% endif %}
                             {{ injury.injury.name }}
@@ -236,7 +236,7 @@
             {% elif list.is_campaign_mode %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Injuries</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                             <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Add injuries</a>
                         {% else %}
@@ -249,7 +249,7 @@
             {% if list.is_campaign_mode %}
                 <tr class="fs-7">
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Advancements</th>
-                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% with advancement_count=fighter.advancements.count %}
                             {% if advancement_count == 0 %}
                                 {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}

--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -42,7 +42,7 @@
         <tbody class="table-group-divider">
             {% if fighter.ruleline|length > 0 %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Rules</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Rules</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% spaceless %}
                             {# djlint:off #}
@@ -55,7 +55,7 @@
             {% comment %} XP (only in campaign mode) {% endcomment %}
             {% if list.is_campaign_mode %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">XP</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">XP</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         <span class="badge text-bg-primary">{{ fighter.xp_current }} XP</span>
                         {% if not print and can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
@@ -73,7 +73,7 @@
             {% if not fighter.content_fighter.hide_skills %}
                 {% if fighter.skilline_cached|length > 0 %}
                     <tr class="fs-7">
-                        <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Skills</th>
+                        <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Skills</th>
                         <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                             {% spaceless %}
                                 {% for skill in fighter.skilline_cached %}
@@ -95,7 +95,7 @@
                     </tr>
                 {% else %}
                     <tr class="fs-7">
-                        <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Skills</th>
+                        <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Skills</th>
                         <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                             {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                                 <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Add skills</a>
@@ -108,7 +108,7 @@
             {% endif %}
             {% if fighter.is_psyker %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Powers</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Powers</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% spaceless %}
                             {% for assign in fighter.powers_cached %}
@@ -134,7 +134,7 @@
             {% if not fighter.content_fighter.hide_house_restricted_gear and fighter.has_house_additional_gear %}
                 {% for line in fighter.house_additional_gearline_display %}
                     <tr class="fs-7">
-                        <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ line.category }}</th>
+                        <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                         <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                             {% spaceless %}
                                 {% for assign in line.assignments %}
@@ -161,7 +161,7 @@
             {% if fighter.has_category_restricted_gear %}
                 {% for line in fighter.category_restricted_gearline_display %}
                     <tr class="fs-7">
-                        <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">
+                        <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">
                             {{ line.category }}
                             {% if line.category_limit %}<span class="fw-normal">{{ line.category_limit }}</span>{% endif %}
                         </th>
@@ -189,7 +189,7 @@
             {% endif %}
             {% if fighter.wargearline_cached|length > 0 %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Gear</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% spaceless %}
                             {% for assign in fighter.wargear %}
@@ -209,7 +209,7 @@
                 </tr>
             {% else %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Gear</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                             <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
@@ -222,7 +222,7 @@
             {% comment %} Injuries (only in campaign mode) {% endcomment %}
             {% if list.is_campaign_mode and fighter.injuries.exists %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Injuries</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Injuries</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% for injury in fighter.injuries.all %}
                             {% if not forloop.first %},{% endif %}
@@ -235,7 +235,7 @@
                 </tr>
             {% elif list.is_campaign_mode %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Injuries</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Injuries</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                             <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Add injuries</a>
@@ -248,7 +248,7 @@
             {% comment %} Advancements (only in campaign mode) {% endcomment %}
             {% if list.is_campaign_mode %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Advancements</th>
+                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Advancements</th>
                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% with advancement_count=fighter.advancements.count %}
                             {% if advancement_count == 0 %}

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -42,9 +42,9 @@
                                 {% for assign in line.assignments %}
                                     <tr class="fs-7">
                                         {% if forloop.first %}
-                                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ line.category }}</th>
+                                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                         {% else %}
-                                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}"></th>
+                                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}"></th>
                                         {% endif %}
                                         <td colspan="{% widthratio 75 100 fighter.statline|length %}"
                                             class="{% flash assign.id %}">
@@ -81,7 +81,7 @@
                                 {% empty %}
                                     {% if list.owner_cached == user and not print %}
                                         <tr class="fs-7">
-                                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ line.category }}</th>
+                                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                             <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
                                                     <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter=all&cat={{ line.id }}#search">Add {{ line.category }}</a>
@@ -97,7 +97,7 @@
                             <!-- House Additional Gearline -->
                             {% for line in fighter.house_additional_gearline_display %}
                                 <tr class="fs-7">
-                                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ line.category }}</th>
+                                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                                         {% for assign in line.assignments %}
                                             {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -133,9 +133,9 @@
                                 {% for assign in line.assignments %}
                                     <tr class="fs-7">
                                         {% if forloop.first %}
-                                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ line.category }}</th>
+                                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                         {% else %}
-                                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}"></th>
+                                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}"></th>
                                         {% endif %}
                                         <td colspan="{% widthratio 75 100 fighter.statline|length %}"
                                             class="{% flash assign.id %}">
@@ -172,7 +172,7 @@
                                 {% empty %}
                                     {% if list.owner_cached == user and not print %}
                                         <tr class="fs-7">
-                                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ line.category }}</th>
+                                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                             <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
                                                     <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
@@ -188,7 +188,7 @@
                             <!-- Category Restricted Gearline -->
                             {% for line in fighter.category_restricted_gearline_display %}
                                 <tr class="fs-7">
-                                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ line.category }}</th>
+                                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                     <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                                         {% for assign in line.assignments %}
                                             {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -223,9 +223,9 @@
                         {% for assign in fighter.wargear %}
                             <tr class="fs-7">
                                 {% if forloop.first %}
-                                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Gear</th>
+                                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                                 {% else %}
-                                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}"></th>
+                                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}"></th>
                                 {% endif %}
                                 <td colspan="{% widthratio 75 100 fighter.statline|length %}"
                                     class="{% flash assign.id %}">
@@ -276,7 +276,7 @@
                     {% else %}
                         <!-- Wargear -->
                         <tr class="fs-7">
-                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Gear</th>
+                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                             <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                                 {% spaceless %}
                                     {% for assign in fighter.wargear %}
@@ -298,7 +298,7 @@
                 {% else %}
                     {% if list.owner_cached == user and not print %}
                         <tr class="fs-7">
-                            <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Gear</th>
+                            <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                             <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                                 {% if gear_mode_default == "link" %}
                                     <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -46,7 +46,7 @@
                                         {% else %}
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}"></th>
                                         {% endif %}
-                                        <td colspan="{% widthratio 75 100 fighter.statline|length %}"
+                                        <td colspan="{% widthratio 66 100 fighter.statline|length %}"
                                             class="{% flash assign.id %}">
                                             {% if assign.is_from_default_assignment or assign.kind == "default" %}
                                                 <span bs-tooltip
@@ -82,7 +82,7 @@
                                     {% if list.owner_cached == user and not print %}
                                         <tr class="fs-7">
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
-                                            <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                                            <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
                                                     <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter=all&cat={{ line.id }}#search">Add {{ line.category }}</a>
                                                 {% else %}
@@ -98,7 +98,7 @@
                             {% for line in fighter.house_additional_gearline_display %}
                                 <tr class="fs-7">
                                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
-                                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                         {% for assign in line.assignments %}
                                             {% comment %} All this faff to avoid spaces {% endcomment %}
                                             {% spaceless %}
@@ -137,7 +137,7 @@
                                         {% else %}
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}"></th>
                                         {% endif %}
-                                        <td colspan="{% widthratio 75 100 fighter.statline|length %}"
+                                        <td colspan="{% widthratio 66 100 fighter.statline|length %}"
                                             class="{% flash assign.id %}">
                                             {% if assign.is_from_default_assignment or assign.kind == "default" %}
                                                 <span bs-tooltip
@@ -173,7 +173,7 @@
                                     {% if list.owner_cached == user and not print %}
                                         <tr class="fs-7">
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
-                                            <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                                            <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
                                                     <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
                                                 {% else %}
@@ -189,7 +189,7 @@
                             {% for line in fighter.category_restricted_gearline_display %}
                                 <tr class="fs-7">
                                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
-                                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                         {% for assign in line.assignments %}
                                             {% comment %} All this faff to avoid spaces {% endcomment %}
                                             {% spaceless %}
@@ -227,7 +227,7 @@
                                 {% else %}
                                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}"></th>
                                 {% endif %}
-                                <td colspan="{% widthratio 75 100 fighter.statline|length %}"
+                                <td colspan="{% widthratio 66 100 fighter.statline|length %}"
                                     class="{% flash assign.id %}">
                                     {% if assign.is_from_default_assignment or assign.kind == "default" %}
                                         <span bs-tooltip
@@ -277,7 +277,7 @@
                         <!-- Wargear -->
                         <tr class="fs-7">
                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
-                            <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                            <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                 {% spaceless %}
                                     {% for assign in fighter.wargear %}
                                         {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -299,7 +299,7 @@
                     {% if list.owner_cached == user and not print %}
                         <tr class="fs-7">
                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
-                            <td colspan="{% widthratio 75 100 fighter.statline|length %}">
+                            <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                 {% if gear_mode_default == "link" %}
                                     <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
                                 {% else %}


### PR DESCRIPTION
This PR updates the fighter card templates to widen the left column from 25% to 33%, providing more space for row headers. This prevents text overflow for longer words like "Advancements" on mobile views.

Fixes #611

Generated with [Claude Code](https://claude.ai/code)