### PR TITLE
fix: exclude stash fighter from about page navigation

### DIFF
--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -9,7 +9,7 @@
     </div>
     <nav class="nav card card-body flex-column mb-3 p-2">
         <a class="nav-link p-2 py-1" href="#about-list">Overview</a>
-        {% for fighter in list.fighters %}
+        {% for fighter in list.active_fighters %}
             {% if fighter.narrative %}
                 <a class="nav-link p-2 py-1" href="#about-{{ fighter.id }}">{{ fighter.name }}</a>
             {% endif %}


### PR DESCRIPTION
Fixes #610

## Summary
- Changed `list.fighters` to `list.active_fighters` in about page template
- Ensures stash fighters are excluded from the navigation menu
- Aligns navigation menu with main content area behavior

Generated with [Claude Code](https://claude.ai/code)