### PR TITLE
feat: add migration reset script and scripts documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
 * [Manual Testing Guide](manual-testing-guide.md)
 * [GCS CDN Setup](gcs-cdn-setup.md)
 * [Analytics Graph Configuration](how-to-guides/analytics-graph-configuration.md)
+* [Useful Scripts](useful-scripts.md)
 
 ## Technical Reference
 

--- a/docs/useful-scripts.md
+++ b/docs/useful-scripts.md
@@ -1,0 +1,61 @@
+# Useful Scripts
+
+This document provides an overview of commonly used scripts in the Gyrinx project.
+
+## Development Scripts
+
+### `scripts/fmt.sh`
+Formats all code in the project including Python, JavaScript, SCSS, and Django templates.
+```bash
+./scripts/fmt.sh
+```
+
+### `scripts/test.sh`
+Runs the full test suite using Docker for database services.
+```bash
+./scripts/test.sh
+```
+
+### `scripts/check_migrations.sh`
+Checks for any migration issues or conflicts.
+```bash
+./scripts/check_migrations.sh
+```
+
+## Database Scripts
+
+### `scripts/reset-migrations-to-main.sh`
+Safely resets Django migration state to match the main branch. Useful when switching between branches with different migration histories.
+```bash
+./scripts/reset-migrations-to-main.sh
+```
+
+## Quality Assurance Scripts
+
+### `scripts/fmt-check.sh`
+Checks if code formatting is correct without making changes.
+```bash
+./scripts/fmt-check.sh
+```
+
+## Management Commands
+
+These are Django management commands available through the `manage` command:
+
+### `manage setupenv`
+Sets up the development environment file (.env).
+```bash
+manage setupenv
+```
+
+### `manage ensuresuperuser`
+Ensures a superuser exists for development.
+```bash
+manage ensuresuperuser
+```
+
+### `manage loaddata_overwrite`
+Loads Django fixtures with overwrite capability.
+```bash
+manage loaddata_overwrite <fixture_name>
+```

--- a/scripts/reset-migrations-to-main.sh
+++ b/scripts/reset-migrations-to-main.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# reset-migrations-to-main.sh
+# Safely reset Django migration state to match main branch
+
+set -e
+
+# Check we're not on main
+current_branch=$(git branch --show-current)
+if [ "$current_branch" = "main" ]; then
+    echo "Already on main branch, nothing to do"
+    exit 0
+fi
+
+echo "Resetting migrations from '$current_branch' to 'main' state..."
+
+# Find apps with new migrations compared to main
+apps=$(git diff --name-only main HEAD | grep -E 'migrations/[0-9]+.*\.py$' | cut -d'/' -f2 | sort -u)
+
+if [ -z "$apps" ]; then
+    echo "No migration differences found between main and $current_branch"
+    exit 0
+fi
+
+echo "Found migrations in: $apps"
+echo
+
+# For each app, find the last migration that exists in main
+for app in $apps; do
+    echo "Processing $app..."
+
+    # Get the last migration in main for this app
+    last_migration=$(git ls-tree -r main --name-only | grep "/$app/migrations/[0-9]" | sort | tail -n 1 | sed 's/.*\///' | sed 's/\.py$//')
+
+    if [ -n "$last_migration" ]; then
+        echo "  → Resetting to migration: $last_migration"
+        manage migrate $app $last_migration
+    else
+        echo "  → No migrations found in main, skipping $app"
+    fi
+done
+
+echo
+echo "Migration state reset complete. You can now safely:"
+echo "  git checkout main"


### PR DESCRIPTION
## Summary
- Added a new script `reset-migrations-to-main.sh` to help developers reset migrations when encountering conflicts
- Created comprehensive documentation for all development scripts in `docs/useful-scripts.md`
- Updated the docs table of contents to include the new scripts documentation

## Purpose
This helps developers handle migration conflicts more efficiently by providing an automated way to reset migrations to the main branch state while preserving their model changes.

## Changes
- `scripts/reset-migrations-to-main.sh`: New script that automates the process of resetting migrations
- `docs/useful-scripts.md`: New documentation covering all development scripts with examples
- `docs/SUMMARY.md`: Added link to the new scripts documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>