### PR TITLE
feat: add admin action to show verification links

### DIFF
--- a/gyrinx/core/admin/auth.py
+++ b/gyrinx/core/admin/auth.py
@@ -6,6 +6,7 @@ from django.shortcuts import render
 from django.utils.translation import gettext as _
 from allauth.account.models import EmailAddress
 from allauth.account.internal.flows.email_verification import get_email_verification_url
+from allauth.account.admin import EmailAddressAdmin as AllauthEmailAddressAdmin
 
 from gyrinx.core.models.auth import UserProfile
 
@@ -265,11 +266,9 @@ except admin.sites.NotRegistered:
 
 
 @admin.register(EmailAddress)
-class EmailAddressAdmin(admin.ModelAdmin):
-    list_display = ["email", "user", "verified", "primary"]
-    list_filter = ["verified", "primary"]
-    search_fields = ["email", "user__username", "user__email"]
-    actions = [show_verification_links]
+class EmailAddressAdmin(AllauthEmailAddressAdmin):
+    # Extend allauth's EmailAddressAdmin to add our custom action
+    actions = AllauthEmailAddressAdmin.actions + [show_verification_links]
 
     def has_add_permission(self, request):
         # Disable manual addition of email addresses for security

--- a/gyrinx/core/templates/core/admin/show_verification_links.html
+++ b/gyrinx/core/templates/core/admin/show_verification_links.html
@@ -1,0 +1,68 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+        › <a href="{% url 'admin:account_emailaddress_changelist' %}">{% trans "Email addresses" %}</a>
+        › {% trans "Verification Links" %}
+    </div>
+{% endblock breadcrumbs %}
+{% block content %}
+    <h1>{% trans "Email Verification Links" %}</h1>
+    {% if verification_data %}
+        <p>{% trans "The following verification links have been generated:" %}</p>
+        <div class="mb-3">
+            <form method="post" action="">
+                {% csrf_token %}
+                <input type="hidden" name="download_csv" value="1">
+                {% for pk in selected %}<input type="hidden" name="_selected_action" value="{{ pk }}">{% endfor %}
+                <input type="hidden" name="action" value="show_verification_links">
+                <button type="submit" class="button">{% trans "Download as CSV" %}</button>
+            </form>
+        </div>
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>{% trans "Email Address" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Verification Link" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in verification_data %}
+                    <tr>
+                        <td>{{ item.email }}</td>
+                        <td>
+                            {% if item.already_verified %}
+                                <span class="text-success">{% trans "Already Verified" %}</span>
+                            {% else %}
+                                <span class="text-warning">{% trans "Unverified" %}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if item.verification_url %}
+                                <input type="text"
+                                       value="{{ item.verification_url }}"
+                                       readonly
+                                       class="form-control"
+                                       onclick="this.select();">
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <div class="mt-3">
+            <a href="{% url 'admin:account_emailaddress_changelist' %}"
+               class="button">{% trans "Back to Email Addresses" %}</a>
+        </div>
+    {% else %}
+        <p>{% trans "No email addresses were selected." %}</p>
+        <div class="mt-3">
+            <a href="{% url 'admin:account_emailaddress_changelist' %}"
+               class="button">{% trans "Back to Email Addresses" %}</a>
+        </div>
+    {% endif %}
+{% endblock content %}

--- a/gyrinx/core/tests/test_admin_auth.py
+++ b/gyrinx/core/tests/test_admin_auth.py
@@ -32,9 +32,9 @@ def test_show_verification_links_action():
     request.user = User.objects.create_superuser("admin", "admin@test.com", "password")
 
     # Set up messages framework
-    setattr(request, 'session', 'session')
+    setattr(request, "session", "session")
     messages_storage = FallbackStorage(request)
-    setattr(request, '_messages', messages_storage)
+    setattr(request, "_messages", messages_storage)
 
     # Execute the action
     queryset = EmailAddress.objects.filter(pk=email_address.pk)
@@ -65,9 +65,9 @@ def test_show_verification_links_skips_verified_emails():
     request.user = User.objects.create_superuser("admin", "admin@test.com", "password")
 
     # Set up messages framework
-    setattr(request, 'session', 'session')
+    setattr(request, "session", "session")
     messages_storage = FallbackStorage(request)
-    setattr(request, '_messages', messages_storage)
+    setattr(request, "_messages", messages_storage)
 
     # Execute the action
     queryset = EmailAddress.objects.filter(pk=email_address.pk)

--- a/gyrinx/core/tests/test_admin_auth.py
+++ b/gyrinx/core/tests/test_admin_auth.py
@@ -1,0 +1,91 @@
+import pytest
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.test import RequestFactory
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.fallback import FallbackStorage
+from allauth.account.models import EmailAddress
+
+from gyrinx.core.admin.auth import EmailAddressAdmin, show_verification_links
+
+
+@pytest.mark.django_db
+def test_email_address_admin_is_registered():
+    """Test that EmailAddress is registered in the admin."""
+    assert EmailAddress in admin.site._registry
+    assert isinstance(admin.site._registry[EmailAddress], EmailAddressAdmin)
+
+
+@pytest.mark.django_db
+def test_show_verification_links_action():
+    """Test the show_verification_links admin action."""
+    # Create a user and email address
+    user = User.objects.create_user(username="testuser", email="test@example.com")
+    email_address = EmailAddress.objects.create(
+        user=user, email="test@example.com", verified=False, primary=True
+    )
+
+    # Create admin and request
+    admin_instance = EmailAddressAdmin(EmailAddress, admin.site)
+    factory = RequestFactory()
+    request = factory.post("/admin/")
+    request.user = User.objects.create_superuser("admin", "admin@test.com", "password")
+
+    # Set up messages framework
+    setattr(request, 'session', 'session')
+    messages_storage = FallbackStorage(request)
+    setattr(request, '_messages', messages_storage)
+
+    # Execute the action
+    queryset = EmailAddress.objects.filter(pk=email_address.pk)
+    show_verification_links(admin_instance, request, queryset)
+
+    # Check that a success message with the verification link was added
+    messages = list(get_messages(request))
+    assert len(messages) == 1
+    assert "Verification link for test@example.com:" in str(messages[0])
+    assert "/accounts/confirm-email/" in str(
+        messages[0]
+    )  # Part of the verification URL
+
+
+@pytest.mark.django_db
+def test_show_verification_links_skips_verified_emails():
+    """Test that the action skips already verified emails."""
+    # Create a user and verified email address
+    user = User.objects.create_user(username="testuser", email="test@example.com")
+    email_address = EmailAddress.objects.create(
+        user=user, email="test@example.com", verified=True, primary=True
+    )
+
+    # Create admin and request
+    admin_instance = EmailAddressAdmin(EmailAddress, admin.site)
+    factory = RequestFactory()
+    request = factory.post("/admin/")
+    request.user = User.objects.create_superuser("admin", "admin@test.com", "password")
+
+    # Set up messages framework
+    setattr(request, 'session', 'session')
+    messages_storage = FallbackStorage(request)
+    setattr(request, '_messages', messages_storage)
+
+    # Execute the action
+    queryset = EmailAddress.objects.filter(pk=email_address.pk)
+    show_verification_links(admin_instance, request, queryset)
+
+    # Check that an info message was added saying email is already verified
+    messages = list(get_messages(request))
+    assert len(messages) == 2  # One info message per email, plus summary
+    assert "test@example.com is already verified" in str(messages[0])
+    assert "All selected email addresses are already verified" in str(messages[1])
+
+
+@pytest.mark.django_db
+def test_email_address_admin_prevents_manual_addition():
+    """Test that manual addition of email addresses is disabled."""
+    admin_instance = EmailAddressAdmin(EmailAddress, admin.site)
+    factory = RequestFactory()
+    request = factory.get("/admin/")
+    request.user = User.objects.create_superuser("admin", "admin@test.com", "password")
+
+    assert not admin_instance.has_add_permission(request)

--- a/gyrinx/core/tests/test_admin_auth.py
+++ b/gyrinx/core/tests/test_admin_auth.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory
 from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from allauth.account.models import EmailAddress
+from allauth.account.admin import EmailAddressAdmin as AllauthEmailAddressAdmin
 
 from gyrinx.core.admin.auth import EmailAddressAdmin, show_verification_links
 
@@ -14,6 +15,24 @@ def test_email_address_admin_is_registered():
     """Test that EmailAddress is registered in the admin."""
     assert EmailAddress in admin.site._registry
     assert isinstance(admin.site._registry[EmailAddress], EmailAddressAdmin)
+
+
+@pytest.mark.django_db
+def test_email_address_admin_inherits_from_allauth():
+    """Test that our EmailAddressAdmin inherits from allauth's EmailAddressAdmin."""
+    admin_instance = admin.site._registry[EmailAddress]
+    assert isinstance(admin_instance, AllauthEmailAddressAdmin)
+    # Check that the default allauth actions are preserved
+    action_names = []
+    for action in admin_instance.actions:
+        if hasattr(action, "__name__"):
+            action_names.append(action.__name__)
+        elif isinstance(action, str):
+            action_names.append(action)
+
+    assert "make_verified" in action_names
+    # Check that our custom action is added
+    assert "show_verification_links" in action_names
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR adds an admin action to show email verification links instead of sending emails automatically.

## Changes

- Add custom EmailAddress admin interface
- Implement "Show verification links" admin action
- Display verification URLs in admin messages
- Add comprehensive tests

Closes #622

Generated with [Claude Code](https://claude.ai/code)