### PR TITLE
fix: Sort mod-added traits to the end of weapon trait list

### DIFF
--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -2624,7 +2624,22 @@ class VirtualWeaponProfile:
 
     def traitline(self):
         # TODO: We need some kind of TraitDisplay thing
-        return sorted([trait.name for trait in self.traits])
+        # Get original traits from the profile
+        original_traits = list(self.profile.traits.all())
+
+        # Get the final trait list after modifications
+        final_traits = self.traits
+
+        # Separate traits into original (that weren't removed) and mod-added
+        original_trait_names = [
+            trait.name for trait in final_traits if trait in original_traits
+        ]
+        mod_added_trait_names = sorted(
+            [trait.name for trait in final_traits if trait not in original_traits]
+        )
+
+        # Return original traits first, then mod-added traits
+        return original_trait_names + mod_added_trait_names
 
     @cached_property
     def traitline_cached(self):

--- a/gyrinx/core/tests/test_assignments.py
+++ b/gyrinx/core/tests/test_assignments.py
@@ -327,8 +327,8 @@ def test_assign_accessory_stat_mod(
         ]
     ]
     assert modded_profile.traitline() == [
-        "Add Me",
         "Rapid Fire (1)",
+        "Add Me",
     ]
 
     modded_spike_profile = profiles[1]
@@ -392,8 +392,8 @@ def test_assign_accessory_stat_mod(
         ]
     ]
     assert modded_spike_profile.traitline() == [
-        "Add Me",
         "Rapid Fire (1)",
+        "Add Me",
     ]
 
 


### PR DESCRIPTION
Fixes #628

## Summary

Mod-added traits now correctly appear at the end of the weapon trait list after the default traits.

## Changes
- Modified `VirtualWeaponProfile.traitline()` to separate original traits from mod-added traits
- Original traits (that weren't removed) appear first in their original order
- Mod-added traits appear at the end, sorted alphabetically
- Updated tests to match the new expected behavior

Generated with [Claude Code](https://claude.ai/code)