### PR TITLE
feat: Add inline Fighter Statline to Content Fighter admin

### DIFF
--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -411,12 +411,29 @@ class ContentFighterForm(forms.ModelForm):
     pass
 
 
+class ContentStatlineInline(ContentStackedInline):
+    model = ContentStatline
+    extra = 0
+    max_num = 1
+    verbose_name = "Fighter Statline"
+    verbose_name_plural = "Fighter Statline"
+    fields = ["statline_type"]
+    can_delete = True
+
+    def has_add_permission(self, request, obj=None):
+        # Allow adding a statline if the fighter doesn't have one
+        if obj and hasattr(obj, "custom_statline"):
+            return False
+        return super().has_add_permission(request, obj)
+
+
 @admin.register(ContentFighter)
 class ContentFighterAdmin(ContentAdmin, admin.ModelAdmin):
     form = ContentFighterForm
     search_fields = ["type", "category", "house__name"]
     list_filter = ["category", "house", "psyker_disciplines__discipline"]
     inlines = [
+        ContentStatlineInline,
         # ContentFighterHouseOverrideInline,
         # ContentFighterEquipmentInline,
         # ContentFighterDefaultAssignmentInline,


### PR DESCRIPTION
Closes #629

## Summary

Added an inline Fighter Statline to the Content Fighter admin to improve the content ingestion workflow.

## Changes

- Created `ContentStatlineInline` class using `ContentStackedInline`
- Added the inline to `ContentFighterAdmin's` inlines list
- Configured inline with appropriate settings:
  - Shows statline_type field
  - Limits to one statline per fighter (max_num = 1)
  - Prevents adding a statline if fighter already has one
  - Allows deletion of existing statlines

This improvement allows editors to manage fighter statlines directly from the ContentFighter admin page without navigating to a separate admin.

Generated with [Claude Code](https://claude.ai/code)