### PR TITLE
feat: Add Vehicle flow for selecting vehicle and crew

### DIFF
--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -751,7 +751,16 @@ class ContentFighterQuerySet(models.QuerySet):
     Custom QuerySet for :model:`content.ContentFighter`.
     """
 
-    def available_for_house(self, house):
+    def available_for_house(
+        self,
+        house,
+        include=[],
+        exclude=[
+            FighterCategoryChoices.EXOTIC_BEAST,
+            FighterCategoryChoices.VEHICLE,
+            FighterCategoryChoices.STASH,
+        ],
+    ):
         """
         Returns fighters available for a specific house.
 
@@ -762,11 +771,15 @@ class ContentFighterQuerySet(models.QuerySet):
 
         Args:
             house: ContentHouse instance
+            include: List of fighter categories to include, which are removed from exclude
+            exclude: List of fighter categories to exclude, defaults to exotic beasts, vehicles, and stash
 
         Returns:
             QuerySet of ContentFighter objects
         """
         from gyrinx.models import FighterCategoryChoices
+
+        exclude = set(exclude) - set(include)
 
         # Check if the house can hire any fighter
         if house.can_hire_any:
@@ -779,13 +792,7 @@ class ContentFighterQuerySet(models.QuerySet):
             )
             return self.filter(
                 house__in=[house.id] + list(generic_houses),
-            ).exclude(
-                category__in=[
-                    FighterCategoryChoices.EXOTIC_BEAST,
-                    FighterCategoryChoices.VEHICLE,
-                    FighterCategoryChoices.STASH,
-                ]
-            )
+            ).exclude(category__in=exclude)
 
 
 class ContentFighter(Content):

--- a/gyrinx/core/forms/vehicle.py
+++ b/gyrinx/core/forms/vehicle.py
@@ -66,7 +66,8 @@ class VehicleSelectionForm(forms.Form):
         if list_instance:
             # Get equipment-fighter profiles for vehicles available to this list's house
             available_fighters = ContentFighter.objects.available_for_house(
-                list_instance.content_house
+                list_instance.content_house,
+                include=[FighterCategoryChoices.VEHICLE],
             )
             vehicle_equipment_ids = ContentEquipmentFighterProfile.objects.filter(
                 content_fighter__in=available_fighters,
@@ -125,6 +126,12 @@ class CrewSelectionForm(forms.Form):
         widget=forms.Select(attrs={"class": "form-select"}),
         label="Crew Type",
         help_text="Select the type of fighter to crew the vehicle.",
+    )
+
+    action = forms.CharField(
+        widget=forms.HiddenInput(),
+        initial="select_crew",
+        required=False,
     )
 
     def __init__(

--- a/gyrinx/core/forms/vehicle.py
+++ b/gyrinx/core/forms/vehicle.py
@@ -1,0 +1,170 @@
+"""Forms for vehicle addition flow."""
+
+from typing import Optional
+
+from django import forms
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentFighterProfile,
+    ContentFighter,
+    ContentHouse,
+)
+from gyrinx.core.forms.list import ContentFighterChoiceField, group_select
+from gyrinx.core.models.list import List
+from gyrinx.forms import fighter_group_key, group_sorter
+from gyrinx.models import FighterCategoryChoices
+
+
+class VehicleEquipmentChoiceField(forms.ModelChoiceField):
+    """Custom field that shows fighter info but submits equipment ID."""
+
+    content_house: ContentHouse | None = None
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", forms.Select(attrs={"class": "form-select"}))
+        kwargs.setdefault("label", "Select Vehicle")
+        super().__init__(*args, **kwargs)
+        # Store the equipment-to-fighter mapping
+        self._equipment_fighter_map = {}
+
+    def label_from_instance(self, obj: ContentEquipment):
+        # Get the associated fighter profile
+        profile = (
+            ContentEquipmentFighterProfile.objects.filter(equipment=obj)
+            .select_related("content_fighter")
+            .first()
+        )
+
+        if profile and profile.content_fighter:
+            fighter = profile.content_fighter
+            # Store the mapping for later use in grouping
+            self._equipment_fighter_map[obj.id] = fighter
+            cost_for_house = (
+                fighter.cost_for_house(self.content_house)
+                if self.content_house
+                else fighter.cost_int()
+            )
+            return f"{fighter.name()} ({cost_for_house}¢)"
+
+        # Fallback to equipment name if no fighter profile
+        return obj.name
+
+
+class VehicleSelectionForm(forms.Form):
+    """Form for selecting a vehicle (equipment with ContentEquipmentFighterProfile)."""
+
+    def __init__(self, *args, list_instance: Optional[List] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Create the field with custom choice field
+        self.fields["vehicle_equipment"] = VehicleEquipmentChoiceField(
+            queryset=ContentEquipment.objects.none(),
+            help_text="Choose the vehicle you want to add to your list.",
+        )
+
+        if list_instance:
+            # Get equipment-fighter profiles for vehicles available to this list's house
+            available_fighters = ContentFighter.objects.available_for_house(
+                list_instance.content_house
+            )
+            vehicle_equipment_ids = ContentEquipmentFighterProfile.objects.filter(
+                content_fighter__in=available_fighters,
+                content_fighter__category=FighterCategoryChoices.VEHICLE,
+            ).values_list("equipment_id", flat=True)
+
+            # Get equipment with prefetched fighter profiles
+            queryset = (
+                ContentEquipment.objects.filter(id__in=vehicle_equipment_ids)
+                .select_related("category")
+                .prefetch_related(
+                    "contentequipmentfighterprofile_set__content_fighter__house"
+                )
+            )
+
+            self.fields["vehicle_equipment"].queryset = queryset
+            self.fields["vehicle_equipment"].content_house = list_instance.content_house
+
+            # Group by fighter house using a custom key function
+            def equipment_group_key(equipment):
+                # Get the associated fighter
+                profile = (
+                    ContentEquipmentFighterProfile.objects.filter(equipment=equipment)
+                    .select_related("content_fighter__house")
+                    .first()
+                )
+
+                if (
+                    profile
+                    and profile.content_fighter
+                    and profile.content_fighter.house
+                ):
+                    return profile.content_fighter.house.name
+                return "Other"
+
+            group_select(
+                self,
+                "vehicle_equipment",
+                key=equipment_group_key,
+                sort_groups_by=group_sorter(list_instance.content_house.name),
+            )
+
+
+class CrewSelectionForm(forms.Form):
+    """Form for selecting a crew member for the vehicle."""
+
+    crew_name = forms.CharField(
+        max_length=255,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+        label="Crew Name",
+        help_text="Name for your crew member.",
+    )
+
+    crew_fighter = ContentFighterChoiceField(
+        queryset=ContentFighter.objects.none(),
+        widget=forms.Select(attrs={"class": "form-select"}),
+        label="Crew Type",
+        help_text="Select the type of fighter to crew the vehicle.",
+    )
+
+    def __init__(
+        self,
+        *args,
+        list_instance: Optional[List] = None,
+        vehicle_equipment=None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        if list_instance and vehicle_equipment:
+            # Get valid crew members for this vehicle
+            # For now, use the available_for_house method to get crew options
+            # This includes fighters from the house and generic houses, excluding exotic beasts and stash
+            queryset = ContentFighter.objects.available_for_house(
+                list_instance.content_house
+            )
+
+            # Exclude vehicles from being crew members
+            queryset = queryset.filter(category__in=[FighterCategoryChoices.CREW])
+
+            queryset = queryset.select_related("house").order_by("house__name", "type")
+
+            self.fields["crew_fighter"].queryset = queryset
+            self.fields["crew_fighter"].content_house = list_instance.content_house
+
+            group_select(
+                self,
+                "crew_fighter",
+                key=fighter_group_key,
+                sort_groups_by=group_sorter(list_instance.content_house.name),
+            )
+
+
+class VehicleConfirmationForm(forms.Form):
+    """Form for confirming vehicle and crew creation."""
+
+    confirm = forms.BooleanField(
+        required=True,
+        initial=True,
+        widget=forms.HiddenInput(),
+    )

--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -335,20 +335,18 @@ document.addEventListener("DOMContentLoaded", () => {
             );
 
             submitButtons.forEach((button) => {
-                // Store original content
-                const originalContent = button.innerHTML;
+                // Only modify the button if it is the one that was clicked
+                if (button.isSameNode(event.submitter)) {
+                    button.style.width = `${button.offsetWidth}px`;
+                    button.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>`;
+                }
 
-                // Create spinner SVG
-                const spinnerSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="16" height="16" style="display: inline-block; vertical-align: middle;"><circle fill="currentColor" stroke="currentColor" stroke-width="4" r="15" cx="40" cy="100"><animate attributeName="opacity" calcMode="spline" dur="2" values="1;0;1;" keySplines=".5 0 .5 1;.5 0 .5 1" repeatCount="indefinite" begin="-.4"></animate></circle><circle fill="currentColor" stroke="currentColor" stroke-width="4" r="15" cx="100" cy="100"><animate attributeName="opacity" calcMode="spline" dur="2" values="1;0;1;" keySplines=".5 0 .5 1;.5 0 .5 1" repeatCount="indefinite" begin="-.2"></animate></circle><circle fill="currentColor" stroke="currentColor" stroke-width="4" r="15" cx="160" cy="100"><animate attributeName="opacity" calcMode="spline" dur="2" values="1;0;1;" keySplines=".5 0 .5 1;.5 0 .5 1" repeatCount="indefinite" begin="0"></animate></circle></svg>`;
-
-                // Replace button content with spinner
-                button.innerHTML = spinnerSVG;
-
-                // Disable the button
-                button.disabled = true;
-
-                // Add a data attribute to prevent multiple submissions
-                button.setAttribute("data-submitting", "true");
+                // Disable all the buttons
+                // This is setTimeout to ensure it runs after the form submission starts so that any
+                // name/value attributes are still submitted.
+                setTimeout(() => {
+                    button.disabled = true;
+                }, 0);
             });
         });
     });

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -95,78 +95,85 @@
             </div>
             <div class="ms-sm-auto mt-2 mt-sm-0">
                 {% if not print %}
-                    <nav class="nav btn-group flex-nowrap">
+                    <div class="nav hstack gap-1 flex-nowrap">
                         {% if list.owner_cached == user and not list.archived %}
                             <a href="{% url 'core:list-fighter-new' list.id %}"
                                class="btn btn-primary btn-sm">
                                 <i class="bi-person-add"></i> Add fighter</a>
-                            <a href="{% url 'core:list-edit' list.id %}"
-                               class="btn btn-secondary btn-sm">
-                                <i class="bi-pencil"></i> Edit
-                            </a>
+                            <a href="{% url 'core:list-vehicle-new' list.id %}"
+                               class="btn btn-primary btn-sm">
+                                <i class="bi-truck"></i> Add vehicle</a>
                         {% endif %}
-                        <div class="btn-group" role="group">
-                            <button type="button"
-                                    class="btn btn-secondary btn-sm dropdown-toggle"
-                                    data-bs-toggle="dropdown"
-                                    aria-expanded="false"
-                                    aria-label="More options">
-                                <i class="bi-three-dots-vertical"></i>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li>
-                                    <a href="{% url 'core:list-print' list.id %}"
-                                       class="dropdown-item icon-link">
-                                        <i class="bi-printer"></i> Print
-                                    </a>
-                                </li>
-                                <li>
-                                    <button type="button"
-                                            class="dropdown-item icon-link"
-                                            data-bs-toggle="offcanvas"
-                                            data-bs-target="#embedOffcanvas"
-                                            aria-controls="embedOffcanvas">
-                                        <i class="bi-person-bounding-box"></i> Embed
-                                    </button>
-                                </li>
-                                <li>
-                                    <a href="{% url 'core:list-clone' list.id %}"
-                                       class="dropdown-item icon-link">
-                                        <i class="bi-copy"></i> Clone
-                                    </a>
-                                </li>
-                                {% if list.owner_cached == user %}
+                        <nav class="btn-group">
+                            {% if list.owner_cached == user and not list.archived %}
+                                <a href="{% url 'core:list-edit' list.id %}"
+                                   class="btn btn-secondary btn-sm">
+                                    <i class="bi-pencil"></i> Edit
+                                </a>
+                            {% endif %}
+                            <div class="btn-group" role="group">
+                                <button type="button"
+                                        class="btn btn-secondary btn-sm dropdown-toggle"
+                                        data-bs-toggle="dropdown"
+                                        aria-expanded="false"
+                                        aria-label="More options">
+                                    <i class="bi-three-dots-vertical"></i>
+                                </button>
+                                <ul class="dropdown-menu">
                                     <li>
-                                        {% if has_stash_fighter %}
-                                            <a href="#"
-                                               class="dropdown-item icon-link disabled"
-                                               data-bs-toggle="tooltip"
-                                               data-bs-title="This list already has a stash fighter"
-                                               onclick="return false;">
-                                                <i class="bi-plus-circle"></i> Show Stash
-                                            </a>
-                                        {% else %}
-                                            <a href="{% url 'core:list-show-stash' list.id %}"
-                                               class="dropdown-item icon-link">
-                                                <i class="bi-plus-circle"></i> Show Stash
-                                            </a>
-                                        {% endif %}
-                                    </li>
-                                    <li>
-                                        <a href="{% url 'core:list-archive' list.id %}"
+                                        <a href="{% url 'core:list-print' list.id %}"
                                            class="dropdown-item icon-link">
-                                            <i class="bi-archive"></i>
-                                            {% if list.archived %}
-                                                Unarchive
-                                            {% else %}
-                                                Archive
-                                            {% endif %}
+                                            <i class="bi-printer"></i> Print
                                         </a>
                                     </li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                    </nav>
+                                    <li>
+                                        <button type="button"
+                                                class="dropdown-item icon-link"
+                                                data-bs-toggle="offcanvas"
+                                                data-bs-target="#embedOffcanvas"
+                                                aria-controls="embedOffcanvas">
+                                            <i class="bi-person-bounding-box"></i> Embed
+                                        </button>
+                                    </li>
+                                    <li>
+                                        <a href="{% url 'core:list-clone' list.id %}"
+                                           class="dropdown-item icon-link">
+                                            <i class="bi-copy"></i> Clone
+                                        </a>
+                                    </li>
+                                    {% if list.owner_cached == user %}
+                                        <li>
+                                            {% if has_stash_fighter %}
+                                                <a href="#"
+                                                   class="dropdown-item icon-link disabled"
+                                                   data-bs-toggle="tooltip"
+                                                   data-bs-title="This list already has a stash fighter"
+                                                   onclick="return false;">
+                                                    <i class="bi-plus-circle"></i> Show Stash
+                                                </a>
+                                            {% else %}
+                                                <a href="{% url 'core:list-show-stash' list.id %}"
+                                                   class="dropdown-item icon-link">
+                                                    <i class="bi-plus-circle"></i> Show Stash
+                                                </a>
+                                            {% endif %}
+                                        </li>
+                                        <li>
+                                            <a href="{% url 'core:list-archive' list.id %}"
+                                               class="dropdown-item icon-link">
+                                                <i class="bi-archive"></i>
+                                                {% if list.archived %}
+                                                    Unarchive
+                                                {% else %}
+                                                    Archive
+                                                {% endif %}
+                                            </a>
+                                        </li>
+                                    {% endif %}
+                                </ul>
+                            </div>
+                        </nav>
+                    </div>
                 {% endif %}
             </div>
         </div>
@@ -220,6 +227,8 @@
                     {% if not print and list.owner_cached == user and not list.archived %}
                         <a href="{% url 'core:list-fighter-new' list.id %}"
                            class="btn btn-primary"><i class="bi-person-add"></i> Add a fighter</a>
+                        <a href="{% url 'core:list-vehicle-new' list.id %}"
+                           class="btn btn-primary"><i class="bi-truck"></i> Add a vehicle</a>
                     {% endif %}
                 </div>
             {% endif %}
@@ -236,6 +245,8 @@
                     {% if not print and list.owner_cached == user and not list.archived %}
                         <a href="{% url 'core:list-fighter-new' list.id %}"
                            class="btn btn-primary"><i class="bi-person-add"></i> Add a fighter</a>
+                        <a href="{% url 'core:list-vehicle-new' list.id %}"
+                           class="btn btn-primary"><i class="bi-truck"></i> Add a vehicle</a>
                     {% endif %}
                 </div>
             {% endfor %}

--- a/gyrinx/core/templates/core/vehicle_confirm.html
+++ b/gyrinx/core/templates/core/vehicle_confirm.html
@@ -1,0 +1,46 @@
+{% extends "core/layouts/base.html" %}
+{% block head_title %}
+    Confirm Vehicle - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    <div class="col-12 col-lg-8 col-xl-6">
+        {% url "core:list-vehicle-crew" list.id as back_url %}
+        {% include "core/includes/back.html" with url=back_url|add:"?"|add:request.GET.urlencode text="Back" %}
+        <h1 class="h2">Add Vehicle to {{ list.name }}</h1>
+        <div class="progress mb-3"
+             role="progressbar"
+             aria-label="Step 3 of 3"
+             aria-valuenow="100"
+             aria-valuemin="0"
+             aria-valuemax="100">
+            {# djlint:off #}
+                <div class="progress-bar" style="width: 100%">Step 3 of 3</div>
+            {# djlint:on #}
+        </div>
+        <p class="h4 mb-3">Confirm vehicle and crew</p>
+        <dl class="row my-3">
+            <dt class="col-sm-4">Vehicle</dt>
+            <dd class="col-sm-8">
+                <strong>{{ vehicle_equipment.name }}</strong> ({{ vehicle_equipment.cost }}¢)
+            </dd>
+            <dt class="col-sm-4">Crew</dt>
+            <dd class="col-sm-8">
+                <strong>{{ crew_name }}</strong> — {{ crew_fighter.type }} ({{ crew_cost }}¢)
+            </dd>
+            <dt class="col-sm-4">Total Cost</dt>
+            <dd class="col-sm-8">
+                <strong>{{ total_cost }}¢</strong>
+            </dd>
+        </dl>
+        <form method="post">
+            {% csrf_token %}
+            {{ form.confirm }}
+            <div class="hstack gap-3 align-items-center">
+                <button type="submit" class="btn btn-success">
+                    <i class="bi-check-circle"></i> Confirm and Add
+                </button>
+                <a href="{{ list.get_absolute_url }}" class="link-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/vehicle_confirm.html
+++ b/gyrinx/core/templates/core/vehicle_confirm.html
@@ -5,7 +5,7 @@
 {% block content %}
     <div class="col-12 col-lg-8 col-xl-6">
         {% url "core:list-vehicle-crew" list.id as back_url %}
-        {% include "core/includes/back.html" with url=back_url|add:"?"|add:request.GET.urlencode text="Back" %}
+        {% include "core/includes/back.html" %}
         <h1 class="h2">Add Vehicle to {{ list.name }}</h1>
         <div class="progress mb-3"
              role="progressbar"
@@ -18,29 +18,38 @@
             {# djlint:on #}
         </div>
         <p class="h4 mb-3">Confirm vehicle and crew</p>
-        <dl class="row my-3">
-            <dt class="col-sm-4">Vehicle</dt>
-            <dd class="col-sm-8">
-                <strong>{{ vehicle_equipment.name }}</strong> ({{ vehicle_equipment.cost }}¢)
-            </dd>
-            <dt class="col-sm-4">Crew</dt>
-            <dd class="col-sm-8">
-                <strong>{{ crew_name }}</strong> — {{ crew_fighter.type }} ({{ crew_cost }}¢)
-            </dd>
-            <dt class="col-sm-4">Total Cost</dt>
-            <dd class="col-sm-8">
-                <strong>{{ total_cost }}¢</strong>
-            </dd>
-        </dl>
-        <form method="post">
-            {% csrf_token %}
-            {{ form.confirm }}
-            <div class="hstack gap-3 align-items-center">
-                <button type="submit" class="btn btn-success">
-                    <i class="bi-check-circle"></i> Confirm and Add
-                </button>
-                <a href="{{ list.get_absolute_url }}" class="link-secondary">Cancel</a>
-            </div>
-        </form>
+        <div class="vstack gap-4">
+            <dl class="row my-3">
+                <dt class="col-sm-4">Vehicle</dt>
+                <dd class="col-sm-8">
+                    <strong>{{ vehicle_equipment.name }}</strong> ({{ vehicle_equipment.cost }}¢)
+                </dd>
+                {% if crew_fighter %}
+                    <dt class="col-sm-4">Crew</dt>
+                    <dd class="col-sm-8">
+                        <strong>{{ crew_name }}</strong> — {{ crew_fighter.type }} ({{ crew_cost }}¢)
+                    </dd>
+                {% else %}
+                    <dt class="col-sm-4 text-secondary">Crew</dt>
+                    <dd class="col-sm-8 text-secondary">
+                        Adding to stash, no crew selected.
+                    </dd>
+                {% endif %}
+                <dt class="col-sm-4 border-top pt-2 mt-1">Total Cost</dt>
+                <dd class="col-sm-8 border-top pt-2 mt-1">
+                    <strong>{{ total_cost }}¢</strong>
+                </dd>
+            </dl>
+            <form method="post">
+                {% csrf_token %}
+                {{ form.confirm }}
+                <div class="hstack gap-3 align-items-center">
+                    <button type="submit" class="btn btn-success">
+                        <i class="bi-check-circle"></i> Add Vehicle
+                    </button>
+                    <a href="{% url "core:list" list.id %}" class="link-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
     </div>
 {% endblock content %}

--- a/gyrinx/core/templates/core/vehicle_crew.html
+++ b/gyrinx/core/templates/core/vehicle_crew.html
@@ -18,26 +18,25 @@
             {# djlint:on #}
         </div>
         <p class="h4 mb-3">Select crew for {{ vehicle_equipment.name }} ({{ vehicle_equipment.cost }}¢)</p>
-        <div class="vstack gap-2">
-            <form method="post" class="vstack gap-3">
-                {% csrf_token %}
-                <div>
-                    <label for="{{ form.crew_name.id_for_label }}" class="form-label">{{ form.crew_name.label }}</label>
-                    {{ form.crew_name.errors }}
-                    {{ form.crew_name }}
-                </div>
-                <div>
-                    <label for="{{ form.crew_fighter.id_for_label }}" class="form-label">{{ form.crew_fighter.label }}</label>
-                    {{ form.crew_fighter.errors }}
-                    {{ form.crew_fighter }}
-                </div>
-                <div class="hstack gap-3 align-items-center">
-                    <button type="submit" class="btn btn-primary">
-                        Next <i class="bi-arrow-right"></i>
-                    </button>
-                    <a href="{{ list.get_absolute_url }}" class="link-secondary">Cancel</a>
-                </div>
-            </form>
-        </div>
+        <form method="post" class="vstack gap-4">
+            {% csrf_token %}
+            {{ form.action }}
+            <div>
+                <label for="{{ form.crew_name.id_for_label }}" class="form-label">{{ form.crew_name.label }}</label>
+                {{ form.crew_name.errors }}
+                {{ form.crew_name }}
+            </div>
+            <div>
+                <label for="{{ form.crew_fighter.id_for_label }}" class="form-label">{{ form.crew_fighter.label }}</label>
+                {{ form.crew_fighter.errors }}
+                {{ form.crew_fighter }}
+            </div>
+            <div class="hstack gap-3 align-items-center">
+                <button type="submit" class="btn btn-primary">
+                    Next <i class="bi-arrow-right"></i>
+                </button>
+                <a href="{% url "core:list" list.id %}" class="link-secondary">Cancel</a>
+            </div>
+        </form>
     </div>
 {% endblock content %}

--- a/gyrinx/core/templates/core/vehicle_crew.html
+++ b/gyrinx/core/templates/core/vehicle_crew.html
@@ -1,0 +1,43 @@
+{% extends "core/layouts/base.html" %}
+{% block head_title %}
+    Select Crew - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    <div class="col-12 col-lg-8 col-xl-6">
+        {% url "core:list-vehicle-select" list.id as back_url %}
+        {% include "core/includes/back.html" with url=back_url text="Back" %}
+        <h1 class="h2">Add Vehicle to {{ list.name }}</h1>
+        <div class="progress mb-3"
+             role="progressbar"
+             aria-label="Step 2 of 3"
+             aria-valuenow="66"
+             aria-valuemin="0"
+             aria-valuemax="100">
+            {# djlint:off #}
+                <div class="progress-bar" style="width: 66%">Step 2 of 3</div>
+            {# djlint:on #}
+        </div>
+        <p class="h4 mb-3">Select crew for {{ vehicle_equipment.name }} ({{ vehicle_equipment.cost }}¢)</p>
+        <div class="vstack gap-2">
+            <form method="post" class="vstack gap-3">
+                {% csrf_token %}
+                <div>
+                    <label for="{{ form.crew_name.id_for_label }}" class="form-label">{{ form.crew_name.label }}</label>
+                    {{ form.crew_name.errors }}
+                    {{ form.crew_name }}
+                </div>
+                <div>
+                    <label for="{{ form.crew_fighter.id_for_label }}" class="form-label">{{ form.crew_fighter.label }}</label>
+                    {{ form.crew_fighter.errors }}
+                    {{ form.crew_fighter }}
+                </div>
+                <div class="hstack gap-3 align-items-center">
+                    <button type="submit" class="btn btn-primary">
+                        Next <i class="bi-arrow-right"></i>
+                    </button>
+                    <a href="{{ list.get_absolute_url }}" class="link-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/vehicle_select.html
+++ b/gyrinx/core/templates/core/vehicle_select.html
@@ -1,0 +1,35 @@
+{% extends "core/layouts/base.html" %}
+{% block head_title %}
+    Select Vehicle - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    <div class="col-12 col-lg-8 col-xl-6">
+        {% include "core/includes/back.html" with url=list.get_absolute_url text="Back to List" %}
+        <h1 class="h2">Add Vehicle to {{ list.name }}</h1>
+        <div class="progress mb-3"
+             role="progressbar"
+             aria-label="Step 1 of 3"
+             aria-valuenow="33"
+             aria-valuemin="0"
+             aria-valuemax="100">
+            {# djlint:off #}
+                <div class="progress-bar" style="width: 33%">Step 1 of 3</div>
+            {# djlint:on #}
+        </div>
+        <p class="h4 mb-3">Select a vehicle</p>
+        <form method="post" class="vstack gap-3">
+            {% csrf_token %}
+            <div>
+                <label for="{{ form.vehicle_equipment.id_for_label }}" class="form-label">{{ form.vehicle_equipment.label }}</label>
+                {{ form.vehicle_equipment.errors }}
+                {{ form.vehicle_equipment }}
+            </div>
+            <div class="hstack gap-3 align-items-center">
+                <button type="submit" class="btn btn-primary">
+                    Next <i class="bi-arrow-right"></i>
+                </button>
+                <a href="{{ list.get_absolute_url }}" class="link-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/vehicle_select.html
+++ b/gyrinx/core/templates/core/vehicle_select.html
@@ -4,7 +4,8 @@
 {% endblock head_title %}
 {% block content %}
     <div class="col-12 col-lg-8 col-xl-6">
-        {% include "core/includes/back.html" with url=list.get_absolute_url text="Back to List" %}
+        {% url "core:list" list.id as back_url %}
+        {% include "core/includes/back.html" with url=back_url text="Back to List" %}
         <h1 class="h2">Add Vehicle to {{ list.name }}</h1>
         <div class="progress mb-3"
              role="progressbar"
@@ -17,7 +18,7 @@
             {# djlint:on #}
         </div>
         <p class="h4 mb-3">Select a vehicle</p>
-        <form method="post" class="vstack gap-3">
+        <form method="post" class="vstack gap-4">
             {% csrf_token %}
             <div>
                 <label for="{{ form.vehicle_equipment.id_for_label }}" class="form-label">{{ form.vehicle_equipment.label }}</label>
@@ -25,10 +26,20 @@
                 {{ form.vehicle_equipment }}
             </div>
             <div class="hstack gap-3 align-items-center">
-                <button type="submit" class="btn btn-primary">
-                    Next <i class="bi-arrow-right"></i>
+                <button type="submit"
+                        name="action"
+                        value="select_crew"
+                        class="btn btn-primary">
+                    Select Crew fighter <i class="bi-arrow-right"></i>
                 </button>
-                <a href="{{ list.get_absolute_url }}" class="link-secondary">Cancel</a>
+                or
+                <button type="submit"
+                        name="action"
+                        value="add_to_stash"
+                        class="btn btn-secondary">
+                    Add to Stash <i class="bi-arrow-right"></i>
+                </button>
+                <a href="{% url "core:list" list.id %}" class="link-secondary">Cancel</a>
             </div>
         </form>
     </div>

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 import gyrinx.core.views
 
-from .views import battle, campaign, list
+from .views import battle, campaign, list, vehicle
 
 # Name new URLs like this:
 # * Transaction pages: noun[-noun]-verb
@@ -29,6 +29,18 @@ urlpatterns = [
     path("list/<id>/credits", list.edit_list_credits, name="list-credits-edit"),
     path("list/<id>/clone", list.clone_list, name="list-clone"),
     path("list/<id>/fighters/new", list.new_list_fighter, name="list-fighter-new"),
+    path("list/<id>/vehicles/new", vehicle.new_vehicle, name="list-vehicle-new"),
+    path(
+        "list/<id>/vehicles/new/select",
+        vehicle.vehicle_select,
+        name="list-vehicle-select",
+    ),
+    path("list/<id>/vehicles/new/crew", vehicle.vehicle_crew, name="list-vehicle-crew"),
+    path(
+        "list/<id>/vehicles/new/confirm",
+        vehicle.vehicle_confirm,
+        name="list-vehicle-confirm",
+    ),
     path(
         "list/<id>/fighters/archived",
         list.ListArchivedFightersView.as_view(),

--- a/gyrinx/core/views/vehicle.py
+++ b/gyrinx/core/views/vehicle.py
@@ -1,0 +1,296 @@
+"""Views for vehicle addition flow."""
+
+import uuid
+from typing import Optional
+from urllib.parse import urlencode
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from pydantic import BaseModel, ValidationError
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentFighterProfile,
+    ContentFighter,
+)
+from gyrinx.core.forms.vehicle import (
+    CrewSelectionForm,
+    VehicleConfirmationForm,
+    VehicleSelectionForm,
+)
+from gyrinx.core.models.events import EventNoun, EventVerb, log_event
+from gyrinx.core.models.list import List, ListFighter, ListFighterEquipmentAssignment
+
+
+class VehicleFlowParams(BaseModel):
+    """Parameters for the vehicle addition flow."""
+
+    vehicle_equipment_id: Optional[uuid.UUID] = None
+    crew_name: str | None = None
+    crew_fighter_id: Optional[uuid.UUID] = None
+
+
+@login_required
+def new_vehicle(request, id):
+    """
+    Redirect to the start of the vehicle addition flow.
+    """
+    lst = get_object_or_404(List, id=id, owner=request.user)
+
+    # Check if list is archived
+    if lst.archived:
+        messages.error(request, "Cannot add vehicles to an archived list.")
+        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+
+    return redirect("core:list-vehicle-select", id=lst.id)
+
+
+@login_required
+def vehicle_select(request, id):
+    """
+    Step 1: Select a vehicle from available equipment with ContentEquipmentFighterProfile.
+    """
+    lst = get_object_or_404(List, id=id, owner=request.user)
+
+    # Check if list is archived
+    if lst.archived:
+        messages.error(request, "Cannot add vehicles to an archived list.")
+        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+
+    if request.method == "POST":
+        form = VehicleSelectionForm(request.POST, list_instance=lst)
+        if form.is_valid():
+            vehicle_equipment = form.cleaned_data["vehicle_equipment"]
+
+            # Build query params for next step
+            params = VehicleFlowParams(vehicle_equipment_id=vehicle_equipment.id)
+            query_string = urlencode(params.model_dump(exclude_none=True))
+
+            return HttpResponseRedirect(
+                reverse("core:list-vehicle-crew", args=(lst.id,)) + f"?{query_string}"
+            )
+    else:
+        form = VehicleSelectionForm(list_instance=lst)
+
+        # Log viewing the vehicle selection form
+        log_event(
+            user=request.user,
+            noun=EventNoun.LIST,
+            verb=EventVerb.VIEW,
+            object=lst,
+            request=request,
+            page="vehicle_select",
+        )
+
+    return render(
+        request,
+        "core/vehicle_select.html",
+        {
+            "form": form,
+            "list": lst,
+            "step": 1,
+            "total_steps": 3,
+        },
+    )
+
+
+@login_required
+def vehicle_crew(request, id):
+    """
+    Step 2: Select a crew member for the vehicle.
+    """
+    lst = get_object_or_404(List, id=id, owner=request.user)
+
+    # Check if list is archived
+    if lst.archived:
+        messages.error(request, "Cannot add vehicles to an archived list.")
+        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+
+    # Parse flow parameters
+    try:
+        params = VehicleFlowParams.model_validate(request.GET.dict())
+    except ValidationError:
+        messages.error(request, "Invalid flow parameters.")
+        return redirect("core:list-vehicle-select", id=lst.id)
+
+    if not params.vehicle_equipment_id:
+        messages.error(request, "Vehicle not selected.")
+        return redirect("core:list-vehicle-select", id=lst.id)
+
+    vehicle_equipment = get_object_or_404(
+        ContentEquipment, id=params.vehicle_equipment_id
+    )
+
+    if request.method == "POST":
+        form = CrewSelectionForm(
+            request.POST, list_instance=lst, vehicle_equipment=vehicle_equipment
+        )
+        if form.is_valid():
+            # Update params with crew info
+            params.crew_name = form.cleaned_data["crew_name"]
+            params.crew_fighter_id = form.cleaned_data["crew_fighter"].id
+
+            query_string = urlencode(params.model_dump(exclude_none=True))
+
+            return HttpResponseRedirect(
+                reverse("core:list-vehicle-confirm", args=(lst.id,))
+                + f"?{query_string}"
+            )
+    else:
+        form = CrewSelectionForm(list_instance=lst, vehicle_equipment=vehicle_equipment)
+
+        # Log viewing the crew selection form
+        log_event(
+            user=request.user,
+            noun=EventNoun.LIST,
+            verb=EventVerb.VIEW,
+            object=lst,
+            request=request,
+            page="vehicle_crew",
+            vehicle_equipment_id=str(vehicle_equipment.id),
+        )
+
+    return render(
+        request,
+        "core/vehicle_crew.html",
+        {
+            "form": form,
+            "list": lst,
+            "vehicle_equipment": vehicle_equipment,
+            "params": params,
+            "step": 2,
+            "total_steps": 3,
+        },
+    )
+
+
+@login_required
+def vehicle_confirm(request, id):
+    """
+    Step 3: Confirm vehicle and crew creation.
+    """
+    lst = get_object_or_404(List, id=id, owner=request.user)
+
+    # Check if list is archived
+    if lst.archived:
+        messages.error(request, "Cannot add vehicles to an archived list.")
+        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+
+    # Parse flow parameters
+    try:
+        params = VehicleFlowParams.model_validate(request.GET.dict())
+    except ValidationError:
+        messages.error(request, "Invalid flow parameters.")
+        return redirect("core:list-vehicle-select", id=lst.id)
+
+    if (
+        not params.vehicle_equipment_id
+        or not params.crew_fighter_id
+        or not params.crew_name
+    ):
+        messages.error(request, "Missing required information.")
+        return redirect("core:list-vehicle-select", id=lst.id)
+
+    vehicle_equipment = get_object_or_404(
+        ContentEquipment, id=params.vehicle_equipment_id
+    )
+    crew_fighter = get_object_or_404(ContentFighter, id=params.crew_fighter_id)
+
+    # Get the vehicle fighter profile
+    profile = (
+        ContentEquipmentFighterProfile.objects.filter(equipment=vehicle_equipment)
+        .select_related("content_fighter")
+        .first()
+    )
+
+    if not profile:
+        messages.error(request, "Invalid vehicle equipment.")
+        return redirect("core:list-vehicle-select", id=lst.id)
+
+    vehicle_fighter = profile.content_fighter
+
+    if request.method == "POST":
+        form = VehicleConfirmationForm(request.POST)
+        if form.is_valid():
+            with transaction.atomic():
+                # Create the crew member
+                crew = ListFighter.objects.create(
+                    list=lst,
+                    owner=lst.owner,
+                    name=params.crew_name,
+                    content_fighter=crew_fighter,
+                )
+
+                # Create the equipment assignment - this will trigger automatic vehicle creation
+                ListFighterEquipmentAssignment.objects.create(
+                    list_fighter=crew,
+                    content_equipment=vehicle_equipment,
+                )
+
+                # Log the vehicle addition
+                log_event(
+                    user=request.user,
+                    noun=EventNoun.LIST_FIGHTER,
+                    verb=EventVerb.CREATE,
+                    object=crew,
+                    request=request,
+                    fighter_name=crew.name,
+                    list_id=str(lst.id),
+                    list_name=lst.name,
+                    is_vehicle_crew=True,
+                    vehicle_equipment_id=str(vehicle_equipment.id),
+                    vehicle_equipment_name=vehicle_equipment.name,
+                )
+
+                messages.success(
+                    request,
+                    f"Vehicle '{vehicle_equipment.name}' and crew member '{crew.name}' added successfully!",
+                )
+
+                # Redirect to list with crew member highlighted
+                query_params = urlencode(dict(flash=crew.id))
+                return HttpResponseRedirect(
+                    reverse("core:list", args=(lst.id,))
+                    + f"?{query_params}"
+                    + f"#{str(crew.id)}"
+                )
+    else:
+        form = VehicleConfirmationForm()
+
+        # Log viewing the confirmation form
+        log_event(
+            user=request.user,
+            noun=EventNoun.LIST,
+            verb=EventVerb.VIEW,
+            object=lst,
+            request=request,
+            page="vehicle_confirm",
+        )
+
+    # Calculate total cost
+    vehicle_cost = vehicle_equipment.cost_int()
+    crew_cost = crew_fighter.cost_for_house(lst.content_house)
+    total_cost = vehicle_cost + crew_cost
+
+    return render(
+        request,
+        "core/vehicle_confirm.html",
+        {
+            "form": form,
+            "list": lst,
+            "vehicle_equipment": vehicle_equipment,
+            "vehicle_fighter": vehicle_fighter,
+            "crew_fighter": crew_fighter,
+            "crew_name": params.crew_name,
+            "params": params,
+            "vehicle_cost": vehicle_cost,
+            "crew_cost": crew_cost,
+            "total_cost": total_cost,
+            "step": 3,
+            "total_steps": 3,
+        },
+    )

--- a/gyrinx/forms.py
+++ b/gyrinx/forms.py
@@ -1,4 +1,7 @@
+from collections.abc import Callable
 from itertools import groupby
+
+from gyrinx.content.models import ContentFighter
 
 
 def group_select(form, field, key=lambda x: x, sort_groups_by=None):
@@ -45,3 +48,19 @@ def group_select(form, field, key=lambda x: x, sort_groups_by=None):
         ] + choices
     else:
         formfield.widget.choices = choices
+
+
+def fighter_group_key(fighter: ContentFighter):
+    # Group by house name
+    return fighter.house.name
+
+
+def group_sorter(priority_name: str) -> Callable[[str], tuple]:
+    def sort_groups_key(group_name):
+        # Sort groups: gang's own house first, then alphabetically
+        if group_name == priority_name:
+            return (0, group_name)  # Gang's house comes first
+        else:
+            return (1, group_name)  # Other houses alphabetically
+
+    return sort_groups_key

--- a/gyrinx/tests/test_forms.py
+++ b/gyrinx/tests/test_forms.py
@@ -1,0 +1,326 @@
+"""Tests for gyrinx.forms module."""
+
+import pytest
+from django import forms
+
+from gyrinx.content.models import ContentFighter, ContentHouse
+from gyrinx.forms import fighter_group_key, group_select, group_sorter
+from gyrinx.models import FighterCategoryChoices
+
+
+@pytest.mark.django_db
+def test_group_select_basic():
+    """Test basic group_select functionality with simple grouping."""
+    # Create test data
+    house1 = ContentHouse.objects.create(name="House Goliath")
+    house2 = ContentHouse.objects.create(name="House Escher")
+
+    fighter1 = ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house1
+    )
+    fighter2 = ContentFighter.objects.create(
+        type="Champion", category=FighterCategoryChoices.CHAMPION, house=house1
+    )
+    fighter3 = ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house2
+    )
+
+    # Create a form with a ModelChoiceField
+    class TestForm(forms.Form):
+        fighter = forms.ModelChoiceField(
+            queryset=ContentFighter.objects.all().order_by("house__name", "type")
+        )
+
+    form = TestForm()
+
+    # Apply group_select with house grouping
+    group_select(form, "fighter", key=lambda x: x.house.name)
+
+    # Check the choices are grouped correctly
+    choices = form.fields["fighter"].widget.choices
+
+    # Should have empty option plus two groups
+    assert len(choices) == 3
+    assert choices[0] == ("", "---------")
+
+    # Check House Escher group
+    assert choices[1][0] == "House Escher"
+    assert len(choices[1][1]) == 1
+    assert choices[1][1][0][0] == fighter3.id
+
+    # Check House Goliath group
+    assert choices[2][0] == "House Goliath"
+    assert len(choices[2][1]) == 2
+    assert {item[0] for item in choices[2][1]} == {fighter1.id, fighter2.id}
+
+
+@pytest.mark.django_db
+def test_group_select_with_sorting():
+    """Test group_select with custom sorting."""
+    house1 = ContentHouse.objects.create(name="House Goliath")
+    house2 = ContentHouse.objects.create(name="House Escher")
+    house3 = ContentHouse.objects.create(name="House Orlock")
+
+    ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house1
+    )
+    ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house2
+    )
+    ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house3
+    )
+
+    class TestForm(forms.Form):
+        fighter = forms.ModelChoiceField(queryset=ContentFighter.objects.all())
+
+    form = TestForm()
+
+    # Apply group_select with sorting - Goliath first
+    group_select(
+        form,
+        "fighter",
+        key=lambda x: x.house.name,
+        sort_groups_by=group_sorter("House Goliath"),
+    )
+
+    choices = form.fields["fighter"].widget.choices
+
+    # Check ordering - Goliath should be first after empty option
+    assert choices[1][0] == "House Goliath"
+    assert choices[2][0] == "House Escher"
+    assert choices[3][0] == "House Orlock"
+
+
+@pytest.mark.django_db
+def test_group_select_with_custom_label():
+    """Test group_select with custom label_from_instance."""
+    house = ContentHouse.objects.create(name="House Goliath")
+    ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house, base_cost=50
+    )
+
+    class CustomField(forms.ModelChoiceField):
+        def label_from_instance(self, obj):
+            return f"{obj.type} - {obj.base_cost}¢"
+
+    class TestForm(forms.Form):
+        pass
+
+    form = TestForm()
+    form.fields["fighter"] = CustomField(queryset=ContentFighter.objects.all())
+
+    group_select(form, "fighter", key=lambda x: x.house.name)
+
+    choices = form.fields["fighter"].widget.choices
+    assert choices[1][1][0][1] == "Ganger - 50¢"
+
+
+@pytest.mark.django_db
+def test_group_select_with_multiple_widget():
+    """Test group_select with a multiple select widget."""
+    house = ContentHouse.objects.create(name="House Goliath")
+    ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house
+    )
+
+    class TestForm(forms.Form):
+        fighters = forms.ModelMultipleChoiceField(
+            queryset=ContentFighter.objects.all(), widget=forms.CheckboxSelectMultiple()
+        )
+
+    form = TestForm()
+    group_select(form, "fighters", key=lambda x: x.house.name)
+
+    choices = form.fields["fighters"].widget.choices
+
+    # Multiple widgets should not have empty option
+    assert choices[0][0] == "House Goliath"
+    assert len(choices) == 1
+
+
+@pytest.mark.django_db
+def test_fighter_group_key():
+    """Test the fighter_group_key function."""
+    house = ContentHouse.objects.create(name="House Goliath")
+    fighter = ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house
+    )
+
+    assert fighter_group_key(fighter) == "House Goliath"
+
+
+def test_group_sorter():
+    """Test the group_sorter function."""
+    sorter = group_sorter("House Goliath")
+
+    # Priority house should sort first
+    assert sorter("House Goliath") == (0, "House Goliath")
+
+    # Other houses should sort after with alphabetical ordering
+    assert sorter("House Escher") == (1, "House Escher")
+    assert sorter("House Orlock") == (1, "House Orlock")
+
+    # Check actual sorting works correctly
+    groups = ["House Orlock", "House Goliath", "House Escher"]
+    sorted_groups = sorted(groups, key=sorter)
+
+    assert sorted_groups == ["House Goliath", "House Escher", "House Orlock"]
+
+
+@pytest.mark.django_db
+def test_group_select_merge_adjacent_groups():
+    """Test that group_select merges adjacent groups with same key after sorting."""
+    house1 = ContentHouse.objects.create(name="House Goliath")
+    house2 = ContentHouse.objects.create(name="House Escher")
+
+    # Create fighters that will be grouped the same after sorting
+    fighter1 = ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house1
+    )
+    fighter2 = ContentFighter.objects.create(
+        type="Champion", category=FighterCategoryChoices.CHAMPION, house=house1
+    )
+    fighter3 = ContentFighter.objects.create(
+        type="Leader", category=FighterCategoryChoices.LEADER, house=house2
+    )
+    fighter4 = ContentFighter.objects.create(
+        type="Specialist", category=FighterCategoryChoices.SPECIALIST, house=house2
+    )
+
+    class TestForm(forms.Form):
+        fighter = forms.ModelChoiceField(
+            # Order queryset in a way that will interleave houses
+            queryset=ContentFighter.objects.all().order_by("type")
+        )
+
+    form = TestForm()
+
+    # Group by house, but queryset order may interleave
+    group_select(
+        form,
+        "fighter",
+        key=lambda x: x.house.name,
+        sort_groups_by=lambda x: x,  # Sort alphabetically
+    )
+
+    choices = form.fields["fighter"].widget.choices
+
+    # Should have exactly 3 choices: empty + 2 house groups (not 4+ if not merged)
+    assert len(choices) == 3
+
+    # Check each group has correct fighters
+    escher_group = next(g for g in choices if g[0] == "House Escher")
+    goliath_group = next(g for g in choices if g[0] == "House Goliath")
+
+    escher_ids = {item[0] for item in escher_group[1]}
+    goliath_ids = {item[0] for item in goliath_group[1]}
+
+    assert escher_ids == {fighter3.id, fighter4.id}
+    assert goliath_ids == {fighter1.id, fighter2.id}
+
+
+@pytest.mark.django_db
+def test_group_select_empty_queryset():
+    """Test group_select with empty queryset."""
+
+    class TestForm(forms.Form):
+        fighter = forms.ModelChoiceField(queryset=ContentFighter.objects.none())
+
+    form = TestForm()
+    group_select(form, "fighter", key=lambda x: x.house.name)
+
+    choices = form.fields["fighter"].widget.choices
+
+    # Should only have empty option
+    assert len(choices) == 1
+    assert choices[0] == ("", "---------")
+
+
+@pytest.mark.django_db
+def test_group_select_no_grouping():
+    """Test group_select without grouping function (default behavior)."""
+    house = ContentHouse.objects.create(name="House Goliath")
+    fighter1 = ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house
+    )
+    fighter2 = ContentFighter.objects.create(
+        type="Champion", category=FighterCategoryChoices.CHAMPION, house=house
+    )
+
+    class TestForm(forms.Form):
+        fighter = forms.ModelChoiceField(
+            queryset=ContentFighter.objects.all().order_by("type")
+        )
+
+    form = TestForm()
+
+    # Apply without key function - each item becomes its own group
+    group_select(form, "fighter")
+
+    choices = form.fields["fighter"].widget.choices
+
+    # Should have empty option plus one group per fighter
+    assert len(choices) == 3
+    assert choices[0] == ("", "---------")
+
+    # Get the fighter IDs from choices to check both are present
+    choice_ids = {choices[1][1][0][0], choices[2][1][0][0]}
+    assert choice_ids == {fighter1.id, fighter2.id}
+
+    # Each should be its own group
+    assert len(choices[1][1]) == 1
+    assert len(choices[2][1]) == 1
+
+
+@pytest.mark.django_db
+def test_group_select_with_none_values():
+    """Test group_select handles None values in grouping."""
+    # Create fighter with no house (edge case)
+    fighter1 = ContentFighter.objects.create(
+        type="Mercenary", category=FighterCategoryChoices.GANGER, house=None
+    )
+
+    house = ContentHouse.objects.create(name="House Goliath")
+    ContentFighter.objects.create(
+        type="Ganger", category=FighterCategoryChoices.GANGER, house=house
+    )
+
+    class TestForm(forms.Form):
+        fighter = forms.ModelChoiceField(
+            queryset=ContentFighter.objects.all().order_by("type")
+        )
+
+    form = TestForm()
+
+    # Group by house name, handling None
+    group_select(form, "fighter", key=lambda x: x.house.name if x.house else "No House")
+
+    choices = form.fields["fighter"].widget.choices
+
+    # Should have empty option plus two groups
+    assert len(choices) == 3
+
+    # Find the "No House" group
+    no_house_group = next(g for g in choices if g[0] == "No House")
+    assert len(no_house_group[1]) == 1
+    assert no_house_group[1][0][0] == fighter1.id
+
+
+def test_group_sorter_edge_cases():
+    """Test group_sorter with edge cases."""
+    sorter = group_sorter("")
+
+    # Empty priority name
+    assert sorter("") == (0, "")
+    assert sorter("House Goliath") == (1, "House Goliath")
+
+    # Case sensitivity
+    sorter_case = group_sorter("house goliath")
+    assert sorter_case("house goliath") == (0, "house goliath")
+    assert sorter_case("House Goliath") == (1, "House Goliath")
+
+    # Special characters
+    sorter_special = group_sorter("House-Goliath")
+    assert sorter_special("House-Goliath") == (0, "House-Goliath")
+    assert sorter_special("House Goliath") == (1, "House Goliath")


### PR DESCRIPTION
Implements #631

This PR adds the "Add Vehicle" flow that allows users to:
1. Select a vehicle from available equipment with ContentEquipmentFighterProfile
2. Name and select a crew member for the vehicle
3. Confirm the selection with cost breakdown

The vehicle is automatically created via the existing equipment assignment system.