### PR TITLE
Add 'all' availability option to equipment filtering

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -286,11 +286,30 @@ document.addEventListener("DOMContentLoaded", () => {
                     "data-bs-placement",
                 );
                 availabilityButton.parentElement.removeAttribute("title");
+            }
+        });
+    }
+});
 
-                // Check the illegal checkbox
-                if (illegalCheckbox && !illegalCheckbox.checked) {
-                    illegalCheckbox.checked = true;
-                }
+// Handle "all" link in availability dropdown
+document.addEventListener("DOMContentLoaded", () => {
+    const allLink = document.getElementById("availability-all-link");
+    if (allLink) {
+        allLink.addEventListener("click", (event) => {
+            event.preventDefault();
+
+            // Check all availability checkboxes
+            const checkboxes = document.querySelectorAll(
+                'input[name="al"][type="checkbox"]',
+            );
+            checkboxes.forEach((checkbox) => {
+                checkbox.checked = true;
+            });
+
+            // Submit the search form to apply the changes
+            const searchForm = document.getElementById("search");
+            if (searchForm) {
+                searchForm.submit();
             }
         });
     }

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -102,7 +102,11 @@
                         </div>
                     </div>
                     <div>
-                        <label for="al" class="form-label">Availability</label>
+                        <label for="al" class="form-label">
+                            Availability
+                            •
+                            <a href="#" id="availability-all-link" class="ms-auto">all</a>
+                        </label>
                         {% qt_contains request "al" "C" as al_contains_c %}
                         <div class="form-check mb-0">
                             <input class="form-check-input"

--- a/gyrinx/core/templates/core/list_fighter_gear_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_gear_edit.html
@@ -120,6 +120,21 @@
                     {% if request.GET.q %}
                         <a href="?{% qt_rm request "q" "flash" %}">Clear your search</a>.
                     {% endif %}
+                    {% comment %}Check if not all availability filters are selected{% endcomment %}
+                    {% qt_contains request "al" "C" as has_c %}
+                    {% qt_contains request "al" "R" as has_r %}
+                    {% qt_contains request "al" "I" as has_i %}
+                    {% qt_contains request "al" "E" as has_e %}
+                    {% qt_contains request "al" "U" as has_u %}
+                    {% if request.GET.filter == "all" and not has_c and not has_r and not has_i and not has_e and not has_u %}
+                        {# If no explicit al params, check defaults #}
+                        {% if request.GET.al %}
+                            <a href="?filter=all&al=C&al=R&al=I&al=E&al=U#search">Show equipment with any availability</a>.
+                        {% endif %}
+                    {% elif request.GET.filter == "all" and not has_i and not has_e and not has_u %}
+                        {# Some filters missing #}
+                        <a href="?filter=all&al=C&al=R&al=I&al=E&al=U#search">Show equipment with any availability</a>.
+                    {% endif %}
                 </div>
             {% endfor %}
         </div>

--- a/gyrinx/core/templates/core/list_fighter_weapons_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_weapons_edit.html
@@ -40,6 +40,21 @@
                     {% if request.GET.q %}
                         <a href="?{% qt_rm request "q" "flash" %}">Clear your search</a>.
                     {% endif %}
+                    {% comment %}Check if not all availability filters are selected{% endcomment %}
+                    {% qt_contains request "al" "C" as has_c %}
+                    {% qt_contains request "al" "R" as has_r %}
+                    {% qt_contains request "al" "I" as has_i %}
+                    {% qt_contains request "al" "E" as has_e %}
+                    {% qt_contains request "al" "U" as has_u %}
+                    {% if request.GET.filter == "all" and not has_c and not has_r and not has_i and not has_e and not has_u %}
+                        {# If no explicit al params, check defaults #}
+                        {% if request.GET.al %}
+                            <a href="?filter=all&al=C&al=R&al=I&al=E&al=U#search">Show equipment with any availability</a>.
+                        {% endif %}
+                    {% elif request.GET.filter == "all" and not has_i and not has_e and not has_u %}
+                        {# Some filters missing #}
+                        <a href="?filter=all&al=C&al=R&al=I&al=E&al=U#search">Show equipment with any availability</a>.
+                    {% endif %}
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
Fixes #647

## Summary
- Add 'all' link to Availability dropdown that checks all availability boxes
- Remove automatic checking of illegal checkbox when switching modes (fixes bug)
- Add message suggesting to show all availabilities when search returns no results
- Works in both gear and weapons edit views

Generated with [Claude Code](https://claude.ai/code)