### PR TITLE
fix: Remove non-existent action_type field reference in campaign_action_outcome

### DIFF
--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -700,7 +700,6 @@ def campaign_action_outcome(request, id, action_id):
                 request=request,
                 campaign_id=str(campaign.id),
                 campaign_name=campaign.name,
-                action_type=action.action_type,
                 outcome=action.outcome,
             )
 


### PR DESCRIPTION
The CampaignAction model doesn't have an action_type field, causing AttributeError.
Removed the invalid field reference from the log_event call.

Fixes #650

Generated with [Claude Code](https://claude.ai/code)