### PR TITLE
feat: Add copy action for default assignments to other fighters

### DIFF
--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -374,6 +374,7 @@ class ContentFighterDefaultAssignmentAdminForm(forms.ModelForm):
 class ContentFighterDefaultAssignmentAdmin(ContentAdmin, admin.ModelAdmin):
     search_fields = ["fighter__type", "equipment__name", "weapon_profiles_field__name"]
     form = ContentFighterDefaultAssignmentAdminForm
+    actions = [copy_selected_to_fighter]
 
 
 class ContentFighterEquipmentInline(ContentTabularInline):


### PR DESCRIPTION
Fixes #653

This PR adds the `copy_selected_to_fighter` action to the `ContentFighterDefaultAssignmentAdmin`, allowing default assignments to be copied to other fighters in the Django admin backend.

This provides similar functionality to how equipment list items can already be copied between fighters.

Generated with [Claude Code](https://claude.ai/code)