### PR TITLE
fix: add grid-auto-flow: row dense to fighter card grids

### DIFF
--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -323,3 +323,8 @@ $em-sizes: (
         background-color: var(--bs-secondary-bg-subtle);
     }
 }
+
+// Fighter card grids
+.auto-flow-dense {
+    grid-auto-flow: row dense;
+}

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -171,7 +171,7 @@
             </div>
         </div>
     </div>
-    <div class="grid {% if print %}gap-2{% endif %}">
+    <div class="grid auto-flow-dense {% if print %}gap-2{% endif %}">
         {% if not print %}
             {% include "core/includes/list_campaign_actions.html" with list=list %}
             {% include "core/includes/list_campaign_resources_assets.html" with list=list campaign_resources=campaign_resources held_assets=held_assets %}

--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -37,7 +37,7 @@
             <div class="text-muted fst-italic">No narrative added yet.</div>
         {% endif %}
     </div>
-    <div class="grid">
+    <div class="grid auto-flow-dense">
         {% for fighter in list.active_fighters %}
             {% if fighter.narrative %}
                 <div class="g-col-12 g-col-md-6" id="about-{{ fighter.id }}">


### PR DESCRIPTION
Adds CSS grid-auto-flow: row dense to all .grid elements to ensure fighter cards reflow around each other properly.

Fix #655 