### PR TITLE
fix: toggle filter checkboxes now auto-submit forms

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -353,3 +353,34 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     });
 });
+
+// Auto-submit filter forms when toggle checkboxes are changed
+document.addEventListener("DOMContentLoaded", () => {
+    // List of toggle checkbox IDs that should trigger auto-submit
+    const autoSubmitCheckboxIds = [
+        // Lists filter
+        "your-lists",
+        "archived",
+        // Campaigns filter
+        "my-campaigns",
+        "participating",
+        // Fighter gear filter
+        "filter-switch",
+        // Note: We're using the same ID for both fighter gear and skills filter
+        // so this will handle both
+    ];
+
+    autoSubmitCheckboxIds.forEach((checkboxId) => {
+        const checkbox = document.getElementById(checkboxId);
+        if (checkbox && checkbox.type === "checkbox") {
+            checkbox.addEventListener("change", (event) => {
+                // Find the form this checkbox belongs to
+                const form = event.target.form || event.target.closest("form");
+                if (form) {
+                    // Submit the form
+                    form.submit();
+                }
+            });
+        }
+    });
+});

--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -354,33 +354,34 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
-// Auto-submit filter forms when toggle checkboxes are changed
+// Auto-submit forms when elements with data-gy-toggle-submit are changed
 document.addEventListener("DOMContentLoaded", () => {
-    // List of toggle checkbox IDs that should trigger auto-submit
-    const autoSubmitCheckboxIds = [
-        // Lists filter
-        "your-lists",
-        "archived",
-        // Campaigns filter
-        "my-campaigns",
-        "participating",
-        // Fighter gear filter
-        "filter-switch",
-        // Note: We're using the same ID for both fighter gear and skills filter
-        // so this will handle both
-    ];
+    // Find all elements with data-gy-toggle-submit attribute
+    const autoSubmitElements = document.querySelectorAll(
+        "[data-gy-toggle-submit]",
+    );
 
-    autoSubmitCheckboxIds.forEach((checkboxId) => {
-        const checkbox = document.getElementById(checkboxId);
-        if (checkbox && checkbox.type === "checkbox") {
-            checkbox.addEventListener("change", (event) => {
-                // Find the form this checkbox belongs to
-                const form = event.target.form || event.target.closest("form");
-                if (form) {
-                    // Submit the form
-                    form.submit();
-                }
-            });
-        }
+    autoSubmitElements.forEach((element) => {
+        element.addEventListener("change", (event) => {
+            const formIdentifier = element.getAttribute(
+                "data-gy-toggle-submit",
+            );
+            let form;
+
+            if (formIdentifier) {
+                // If a value is provided, find the form by that identifier
+                form =
+                    document.getElementById(formIdentifier) ||
+                    document.querySelector(formIdentifier);
+            } else {
+                // If no value provided, find the parent form
+                form = event.target.form || event.target.closest("form");
+            }
+
+            if (form) {
+                // Submit the form
+                form.submit();
+            }
+        });
     });
 });

--- a/gyrinx/core/templates/core/includes/campaigns_filter.html
+++ b/gyrinx/core/templates/core/includes/campaigns_filter.html
@@ -48,7 +48,41 @@
                 </div>
             </div>
         </div>
-        <div class="g-col-12 g-col-xl-6 align-items-center hstack gap-3 flex-wrap">
+        <div class="g-col-12 align-items-center hstack gap-3 flex-wrap">
+            {# Status filter dropdown #}
+            <div class="btn-group">
+                <button type="button"
+                        class="btn btn-outline-primary btn-sm dropdown-toggle"
+                        data-bs-toggle="dropdown"
+                        aria-expanded="false"
+                        data-bs-auto-close="outside">Status</button>
+                <div class="dropdown-menu shadow-sm p-2 fs-7 dropdown-menu-mw">
+                    {% for status_value, status_label in status_choices %}
+                        {% qt_contains request "status" status_value as status_contains %}
+                        <div class="form-check mb-0">
+                            <input class="form-check-input"
+                                   type="checkbox"
+                                   role="switch"
+                                   id="status-{{ status_value }}"
+                                   name="status"
+                                   value="{{ status_value }}"
+                                   {% if status_contains or not request.GET.status %}checked{% endif %}>
+                            <label class="form-check-label" for="status-{{ status_value }}">{{ status_label }}</label>
+                            •
+                            <a class="ms-auto" href="?{% qt request status=status_value %}#search">only</a>
+                        </div>
+                    {% endfor %}
+                    <div class="btn-group align-items-center">
+                        <button class="btn btn-link icon-link btn-sm" type="submit">
+                            <i class="bi-arrow-clockwise"></i>
+                            Update
+                        </button>
+                        •
+                        <a class="btn btn-link text-secondary icon-link btn-sm"
+                           href="?{% qt request status="all" %}#search">Reset</a>
+                    </div>
+                </div>
+            </div>
             {# My Campaigns toggle #}
             <div class="form-check form-switch mb-0">
                 {# Hidden field to ensure 0 is sent when unchecked #}
@@ -83,40 +117,6 @@
                        value="1"
                        {% if request.GET.archived == "1" %}checked{% endif %}>
                 <label class="form-check-label fs-7 mb-0" for="archived">Archived Only</label>
-            </div>
-            {# Status filter dropdown #}
-            <div class="btn-group">
-                <button type="button"
-                        class="btn btn-outline-primary btn-sm dropdown-toggle"
-                        data-bs-toggle="dropdown"
-                        aria-expanded="false"
-                        data-bs-auto-close="outside">Status</button>
-                <div class="dropdown-menu shadow-sm p-2 fs-7 dropdown-menu-mw">
-                    {% for status_value, status_label in status_choices %}
-                        {% qt_contains request "status" status_value as status_contains %}
-                        <div class="form-check mb-0">
-                            <input class="form-check-input"
-                                   type="checkbox"
-                                   role="switch"
-                                   id="status-{{ status_value }}"
-                                   name="status"
-                                   value="{{ status_value }}"
-                                   {% if status_contains or not request.GET.status %}checked{% endif %}>
-                            <label class="form-check-label" for="status-{{ status_value }}">{{ status_label }}</label>
-                            •
-                            <a class="ms-auto" href="?{% qt request status=status_value %}#search">only</a>
-                        </div>
-                    {% endfor %}
-                    <div class="btn-group align-items-center">
-                        <button class="btn btn-link icon-link btn-sm" type="submit">
-                            <i class="bi-arrow-clockwise"></i>
-                            Update
-                        </button>
-                        •
-                        <a class="btn btn-link text-secondary icon-link btn-sm"
-                           href="?{% qt request status="all" %}#search">Reset</a>
-                    </div>
-                </div>
             </div>
             <div class="ms-auto btn-group align-items-center">
                 <button class="btn btn-link icon-link btn-sm"

--- a/gyrinx/core/templates/core/includes/campaigns_filter.html
+++ b/gyrinx/core/templates/core/includes/campaigns_filter.html
@@ -15,6 +15,7 @@
             <span class="input-group-text">
                 <i class="bi-search"></i>
             </span>
+            <input type="hidden" name="cb" value="{% cachebuster %}">
             <input class="form-control"
                    type="search"
                    placeholder="Search"
@@ -31,6 +32,7 @@
           action="{{ action }}#search"
           class="grid g-col-12">
         <input type="hidden" name="flash" value="search">
+        <input type="hidden" name="cb" value="{% cachebuster %}">
         {# Search and filters row #}
         <div class="g-col-12 g-col-xl-6">
             <div class="hstack gap-2 align-items-end">
@@ -121,7 +123,7 @@
                        {% if request.GET.archived == "1" %}checked{% endif %}>
                 <label class="form-check-label fs-7 mb-0" for="archived">Archived Only</label>
             </div>
-            <div class="ms-auto btn-group align-items-center">
+            <div class="btn-group align-items-center">
                 <button class="btn btn-link icon-link btn-sm"
                         type="submit"
                         id="update-filters">
@@ -130,7 +132,7 @@
                 </button>
                 •
                 <a class="btn btn-link text-secondary icon-link btn-sm"
-                   href="{{ action }}">Clear</a>
+                   href="{{ action }}">Reset</a>
             </div>
         </div>
     </form>

--- a/gyrinx/core/templates/core/includes/campaigns_filter.html
+++ b/gyrinx/core/templates/core/includes/campaigns_filter.html
@@ -93,6 +93,7 @@
                        id="my-campaigns"
                        name="my"
                        value="1"
+                       data-gy-toggle-submit
                        {% if request.GET.my == "1" or request.GET.my is None %}checked{% endif %}>
                 <label class="form-check-label fs-7 mb-0" for="my-campaigns">My Campaigns Only</label>
             </div>
@@ -104,6 +105,7 @@
                        id="participating"
                        name="participating"
                        value="1"
+                       data-gy-toggle-submit
                        {% if request.GET.participating == "1" %}checked{% endif %}>
                 <label class="form-check-label fs-7 mb-0" for="participating">Participating Only</label>
             </div>
@@ -115,6 +117,7 @@
                        id="archived"
                        name="archived"
                        value="1"
+                       data-gy-toggle-submit
                        {% if request.GET.archived == "1" %}checked{% endif %}>
                 <label class="form-check-label fs-7 mb-0" for="archived">Archived Only</label>
             </div>

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -27,7 +27,7 @@
         </div>
     </form>
 </div>
-<div class="g-col-12 g-col-xl-6 align-items-center hstack gap-3 flex-wrap">
+<div class="g-col-12 align-items-center hstack gap-3 flex-wrap">
     <div class="btn-group">
         <div class="btn-group">
             <button type="button"

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -7,6 +7,7 @@
           action="{{ action }}{{ querystring }}#search"
           class="g-col-12 g-col-md-6 hstack gap-2 align-items-end">
         <input type="hidden" name="flash" value="search">
+        <input type="hidden" name="cb" value="{% cachebuster %}">
         <div class="input-group">
             <span class="input-group-text">
                 <i class="bi-search"></i>
@@ -21,7 +22,7 @@
         <div class="btn-group">
             <button class="btn btn-primary" type="submit">Search</button>
             {% if request.GET.q %}
-                <a href="?{% qt_rm request "q" "flash" %}#search"
+                <a href="?cb={% cachebuster %}&{% qt_rm request "q" "flash" %}#search"
                    class="btn btn-outline-secondary">Clear</a>
             {% endif %}
         </div>
@@ -61,7 +62,7 @@
                     </button>
                     •
                     <a class="btn btn-link text-secondary icon-link btn-sm"
-                       href="?{% qt request cat="all" %}#search">Reset</a>
+                       href="?cb={% cachebuster %}&{% qt request cat="all" %}#search">Reset</a>
                 </div>
             </div>
         </div>
@@ -184,7 +185,7 @@
                             </button>
                             •
                             <a class="btn btn-link text-secondary icon-link btn-sm"
-                               href="?{% qt_rm request "al" "mal" %}#search">Reset</a>
+                               href="?cb={% cachebuster %}&{% qt_rm request "al" "mal" %}#search">Reset</a>
                         </div>
                     </div>
                 </div>
@@ -205,7 +206,7 @@
                {% if not request.GET.filter or request.GET.filter == "equipment-list" %}checked{% endif %}>
         <label class="form-check-label fs-7 mb-0" for="filter-switch">Only Equipment List</label>
     </div>
-    <div class="ms-auto btn-group align-items-center">
+    <div class="btn-group align-items-center">
         <button class="btn btn-link icon-link btn-sm"
                 type="submit"
                 form="search"
@@ -214,6 +215,7 @@
             Update
         </button>
         •
-        <a class="btn btn-link text-secondary icon-link btn-sm" href="?#search">Reset</a>
+        <a class="btn btn-link text-secondary icon-link btn-sm"
+           href="?cb={% cachebuster %}&#search">Reset</a>
     </div>
 </div>

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -201,6 +201,7 @@
                id="filter-switch"
                name="filter"
                value="equipment-list"
+               data-gy-toggle-submit="search"
                {% if not request.GET.filter or request.GET.filter == "equipment-list" %}checked{% endif %}>
         <label class="form-check-label fs-7 mb-0" for="filter-switch">Only Equipment List</label>
     </div>

--- a/gyrinx/core/templates/core/includes/fighter_skills_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_skills_filter.html
@@ -32,6 +32,7 @@
                    id="filter-switch"
                    name="filter"
                    value="primary-secondary"
+                   data-gy-toggle-submit="search-skills"
                    {% if not request.GET.filter or request.GET.filter == "primary-secondary" %}checked{% endif %}>
             <label class="form-check-label" for="filter-switch">Primary/Secondary Only</label>
         </div>

--- a/gyrinx/core/templates/core/includes/lists_filter.html
+++ b/gyrinx/core/templates/core/includes/lists_filter.html
@@ -15,6 +15,7 @@
             <span class="input-group-text">
                 <i class="bi-search"></i>
             </span>
+            <input type="hidden" name="cb" value="{% cachebuster %}">
             <input class="form-control"
                    type="search"
                    placeholder="Search"
@@ -31,6 +32,7 @@
           action="{{ action }}#search"
           class="grid g-col-12">
         <input type="hidden" name="flash" value="search">
+        <input type="hidden" name="cb" value="{% cachebuster %}">
         {# Search and filters row #}
         <div class="g-col-12 g-col-xl-6">
             <div class="hstack gap-2 align-items-end">
@@ -49,32 +51,6 @@
             </div>
         </div>
         <div class="g-col-12 align-items-center hstack gap-3 flex-wrap">
-            {# Your Lists toggle #}
-            <div class="form-check form-switch mb-0">
-                {# Hidden field to ensure 0 is sent when unchecked #}
-                <input type="hidden" name="my" value="0">
-                <input class="form-check-input"
-                       type="checkbox"
-                       role="switch"
-                       id="your-lists"
-                       name="my"
-                       value="1"
-                       data-gy-toggle-submit
-                       {% if request.GET.my == "1" or not request.GET and request.user.is_authenticated %}checked{% endif %}>
-                <label class="form-check-label fs-7 mb-0" for="your-lists">Your Lists Only</label>
-            </div>
-            {# Archived toggle #}
-            <div class="form-check form-switch mb-0">
-                <input class="form-check-input"
-                       type="checkbox"
-                       role="switch"
-                       id="archived"
-                       name="archived"
-                       value="1"
-                       data-gy-toggle-submit
-                       {% if request.GET.archived == "1" %}checked{% endif %}>
-                <label class="form-check-label fs-7 mb-0" for="archived">Archived Only</label>
-            </div>
             {# Type filter dropdown #}
             <div class="btn-group">
                 <button type="button"
@@ -157,7 +133,33 @@
                     </div>
                 </div>
             </div>
-            <div class="ms-auto btn-group align-items-center">
+            {# Your Lists toggle #}
+            <div class="form-check form-switch mb-0">
+                {# Hidden field to ensure 0 is sent when unchecked #}
+                <input type="hidden" name="my" value="0">
+                <input class="form-check-input"
+                       type="checkbox"
+                       role="switch"
+                       id="your-lists"
+                       name="my"
+                       value="1"
+                       data-gy-toggle-submit
+                       {% if request.GET.my == "1" or not request.GET and request.user.is_authenticated %}checked{% endif %}>
+                <label class="form-check-label fs-7 mb-0" for="your-lists">Your Lists Only</label>
+            </div>
+            {# Archived toggle #}
+            <div class="form-check form-switch mb-0">
+                <input class="form-check-input"
+                       type="checkbox"
+                       role="switch"
+                       id="archived"
+                       name="archived"
+                       value="1"
+                       data-gy-toggle-submit
+                       {% if request.GET.archived == "1" %}checked{% endif %}>
+                <label class="form-check-label fs-7 mb-0" for="archived">Archived Only</label>
+            </div>
+            <div class="btn-group align-items-center">
                 <button class="btn btn-link icon-link btn-sm"
                         type="submit"
                         id="update-filters">
@@ -166,7 +168,7 @@
                 </button>
                 •
                 <a class="btn btn-link text-secondary icon-link btn-sm"
-                   href="{{ action }}">Clear</a>
+                   href="{{ action }}">Reset</a>
             </div>
         </div>
     </form>

--- a/gyrinx/core/templates/core/includes/lists_filter.html
+++ b/gyrinx/core/templates/core/includes/lists_filter.html
@@ -48,7 +48,7 @@
                 </div>
             </div>
         </div>
-        <div class="g-col-12 g-col-xl-6 align-items-center hstack gap-3 flex-wrap">
+        <div class="g-col-12 align-items-center hstack gap-3 flex-wrap">
             {# Your Lists toggle #}
             <div class="form-check form-switch mb-0">
                 {# Hidden field to ensure 0 is sent when unchecked #}

--- a/gyrinx/core/templates/core/includes/lists_filter.html
+++ b/gyrinx/core/templates/core/includes/lists_filter.html
@@ -59,6 +59,7 @@
                        id="your-lists"
                        name="my"
                        value="1"
+                       data-gy-toggle-submit
                        {% if request.GET.my == "1" or not request.GET and request.user.is_authenticated %}checked{% endif %}>
                 <label class="form-check-label fs-7 mb-0" for="your-lists">Your Lists Only</label>
             </div>
@@ -70,6 +71,7 @@
                        id="archived"
                        name="archived"
                        value="1"
+                       data-gy-toggle-submit
                        {% if request.GET.archived == "1" %}checked{% endif %}>
                 <label class="form-check-label fs-7 mb-0" for="archived">Archived Only</label>
             </div>

--- a/gyrinx/core/templatetags/custom_tags.py
+++ b/gyrinx/core/templatetags/custom_tags.py
@@ -252,3 +252,13 @@ def random_404_message():
         "Someone might have been at it with a data-thief.",
     ]
     return random.choice(messages)  # nosec
+
+
+@register.simple_tag
+def cachebuster():
+    """
+    Generate a cachebuster string.
+
+    This is used to force browsers to reload forms even if other params don't change.
+    """
+    return hex(int(random.random() * 1e8))[2:]  # nosec


### PR DESCRIPTION
Fixes #656

## Summary

This PR makes filter checkboxes auto-submit their forms when toggled, removing the need for users to click "Update" manually.

## Changes

- Added JavaScript to auto-submit forms when toggle checkboxes are changed
- Moved Status dropdown before toggle buttons in campaigns filter
- Adjusted grid layout so filters always flow over two lines
- Applies to lists, campaigns, fighter gear, and fighter skills filters

Generated with [Claude Code](https://claude.ai/code)