### PR TITLE
Rename 'Remove' to 'Delete' for equipment actions

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -69,11 +69,11 @@
                                                        class="link-secondary">Reassign</a>
                                                     <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Remove</a>
+                                                       class="link-danger">Delete</a>
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Remove</a>
+                                                       class="link-danger">Delete</a>
                                                 {% endif %}
                                             {% endif %}
                                         </td>
@@ -160,11 +160,11 @@
                                                        class="link-secondary">Reassign</a>
                                                     <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Remove</a>
+                                                       class="link-danger">Delete</a>
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Remove</a>
+                                                       class="link-danger">Delete</a>
                                                 {% endif %}
                                             {% endif %}
                                         </td>
@@ -258,7 +258,7 @@
                                                class="link-secondary">Reassign</a>
                                             <span class="text-muted">·</span>
                                             <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
-                                               class="link-danger">Remove</a>
+                                               class="link-danger">Delete</a>
                                             {% if fighter.is_stash %}
                                                 <span class="text-muted">·</span>
                                                 <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
@@ -267,7 +267,7 @@
                                         {% elif assign.kind == 'default' %}
                                             <br>
                                             <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
-                                               class="link-danger">Remove</a>
+                                               class="link-danger">Delete</a>
                                         {% endif %}
                                     {% endif %}
                                 </td>

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -87,11 +87,11 @@
                                                     {% endif %}
                                                     <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Remove</a>
+                                                       class="link-danger">Delete</a>
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Remove</a>
+                                                       class="link-danger">Delete</a>
                                                 {% endif %}
                                             {% endif %}
                                         </div>
@@ -197,7 +197,7 @@
                                                         <li>
                                                             <a href="{% url 'core:list-fighter-weapon-delete' list.id fighter.id assign.id %}"
                                                                class="dropdown-item text-danger">
-                                                                <i class="bi-trash"></i> Remove
+                                                                <i class="bi-trash"></i> Delete
                                                             </a>
                                                         </li>
                                                     </ul>
@@ -220,7 +220,7 @@
                                                         <li>
                                                             <a href="{% url 'core:list-fighter-weapons-default-disable' list.id fighter.id assign.id %}"
                                                                class="dropdown-item text-danger">
-                                                                <i class="bi-trash"></i> Remove
+                                                                <i class="bi-trash"></i> Delete
                                                             </a>
                                                         </li>
                                                     </ul>

--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -142,7 +142,7 @@
                             {% endif %}
                             {% if mode == 'edit' and assign.kind == 'assigned' %}
                                 <a href="{% url 'core:list-fighter-weapon-accessory-delete' list.id fighter.id assign.id ad.accessory.id %}"
-                                   class="ms-auto link-danger">Remove</a>
+                                   class="ms-auto link-danger">Delete</a>
                             {% endif %}
                         </td>
                     </tr>
@@ -167,7 +167,7 @@
                         {% endif %}
                         {% if mode == 'edit' and assign.kind == 'assigned' %}
                             <a href="{% url 'core:list-fighter-gear-upgrade-delete' list.id fighter.id assign.id assign.active_upgrade_cached.id %}"
-                               class="ms-auto link-danger">Remove</a>
+                               class="ms-auto link-danger">Delete</a>
                         {% endif %}
                     </td>
                 </tr>
@@ -236,7 +236,7 @@
                                             <li>
                                                 <a href="{% url 'core:list-fighter-weapon-delete' list.id fighter.id assign.id %}"
                                                    class="dropdown-item text-danger">
-                                                    <i class="bi-trash"></i> Remove
+                                                    <i class="bi-trash"></i> Delete
                                                 </a>
                                             </li>
                                         </ul>
@@ -260,7 +260,7 @@
                                             <li>
                                                 <a href="{% url 'core:list-fighter-weapons-default-disable' list.id fighter.id assign.id %}"
                                                    class="dropdown-item text-danger">
-                                                    <i class="bi-trash"></i> Remove
+                                                    <i class="bi-trash"></i> Delete
                                                 </a>
                                             </li>
                                         </ul>

--- a/gyrinx/core/templates/core/list_fighter_assign_convert.html
+++ b/gyrinx/core/templates/core/list_fighter_assign_convert.html
@@ -13,7 +13,7 @@
             {% csrf_token %}
             <p>Are you sure you want to enable modification of this {{ assign.equipment.name }}?</p>
             <div class="alert alert-warning" role="alert">
-                Watch out! If you later remove this equipment, the default assignment <strong>not</strong> be restored.
+                Watch out! If you later delete this equipment, the default assignment will <strong>not</strong> be restored.
             </div>
             <div class="mt-3">
                 <input type="hidden" name="convert" value="1">

--- a/gyrinx/core/templates/core/list_fighter_assign_delete_confirm.html
+++ b/gyrinx/core/templates/core/list_fighter_assign_delete_confirm.html
@@ -1,20 +1,34 @@
 {% extends "core/layouts/base.html" %}
 {% load allauth custom_tags %}
 {% block head_title %}
-    Remove - {{ assign.content_equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
+    Delete - {{ assign.content_equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
     {% url back_url list.id fighter.id as full_back_url %}
     {% include "core/includes/back.html" with url=full_back_url %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
-        <h1 class="h3">Remove from {{ fighter.fully_qualified_name }}</h1>
+        <h1 class="h3">Delete from {{ fighter.fully_qualified_name }}</h1>
         <form action="{% url action_url list.id fighter.id assign.id %}"
               method="post">
             {% csrf_token %}
-            <p>Are you sure you want to remove the {{ assign.content_equipment.name }} from {{ fighter.name }}?</p>
+            <p>Are you sure you want to delete the {{ assign.content_equipment.name }} from {{ fighter.name }}?</p>
+            {% if assign.content_equipment.category.name == "Vehicles" or assign.content_equipment.category.parent and assign.content_equipment.category.parent.name == "Vehicles" %}
+                <div class="alert alert-warning" role="alert">
+                    <i class="bi bi-exclamation-triangle-fill me-2"></i>
+                    <strong>Warning:</strong> This will delete the vehicle's entire profile. Are you sure you wish to proceed?
+                    <br>
+                    <br>
+                    <strong>Note:</strong> If you want to instead move the vehicle to another fighter or to your stash, use the Reassign option.
+                </div>
+            {% else %}
+                <div class="alert alert-info" role="alert">
+                    <i class="bi bi-info-circle-fill me-2"></i>
+                    <strong>Tip:</strong> If you want to move this equipment to another fighter or to your stash instead of deleting it, use the Reassign option.
+                </div>
+            {% endif %}
             <div class="mt-3">
                 <input type="hidden" name="remove" value="1">
-                <button type="submit" class="btn btn-danger">Remove</button>
+                <button type="submit" class="btn btn-danger">Delete</button>
                 <a href="{{ full_back_url }}" class="btn btn-link">Cancel</a>
             </div>
         </form>

--- a/gyrinx/core/templates/core/list_fighter_assign_disable.html
+++ b/gyrinx/core/templates/core/list_fighter_assign_disable.html
@@ -1,20 +1,20 @@
 {% extends "core/layouts/base.html" %}
 {% load allauth custom_tags %}
 {% block head_title %}
-    Remove - {{ assign.equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
+    Delete - {{ assign.equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
     {% url back_url list.id fighter.id as full_back_url %}
     {% include "core/includes/back.html" with url=full_back_url %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
-        <h1 class="h3">Remove default assignment from {{ fighter.fully_qualified_name }}</h1>
+        <h1 class="h3">Delete default assignment from {{ fighter.fully_qualified_name }}</h1>
         <form action="{% url action_url list.id fighter.id assign.id %}"
               method="post">
             {% csrf_token %}
-            <p>Are you sure you want to remove the default {{ assign.equipment.name }} assignment from {{ fighter.name }}?</p>
+            <p>Are you sure you want to delete the default {{ assign.equipment.name }} assignment from {{ fighter.name }}?</p>
             <div class="mt-3">
                 <input type="hidden" name="remove" value="1">
-                <button type="submit" class="btn btn-danger">Remove</button>
+                <button type="submit" class="btn btn-danger">Delete</button>
                 <a href="{{ full_back_url }}" class="btn btn-link">Cancel</a>
             </div>
         </form>

--- a/gyrinx/core/templates/core/list_fighter_assign_upgrade_delete_confirm.html
+++ b/gyrinx/core/templates/core/list_fighter_assign_upgrade_delete_confirm.html
@@ -1,24 +1,24 @@
 {% extends "core/layouts/base.html" %}
 {% load allauth custom_tags %}
 {% block head_title %}
-    Remove - {{ upgrade.name }} - {{ assign.content_equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
+    Delete - {{ upgrade.name }} - {{ assign.content_equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
     {% url back_url list.id fighter.id as full_back_url %}
     {% include "core/includes/back.html" with url=full_back_url %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <h1 class="h3">
-            Remove {{ upgrade.name }} {{ assign.content_equipment.upgrade_stack_name }} from {{ assign.content_equipment.name }} for {{ fighter.fully_qualified_name }}
+            Delete {{ upgrade.name }} {{ assign.content_equipment.upgrade_stack_name }} from {{ assign.content_equipment.name }} for {{ fighter.fully_qualified_name }}
         </h1>
         <form action="{% url action_url list.id fighter.id assign.id upgrade.id %}"
               method="post">
             {% csrf_token %}
             <p>
-                Are you sure you want to remove the {{ upgrade.name }} {{ assign.content_equipment.upgrade_stack_name }} from the {{ assign.content_equipment.name }} assigned to {{ fighter.name }}?
+                Are you sure you want to delete the {{ upgrade.name }} {{ assign.content_equipment.upgrade_stack_name }} from the {{ assign.content_equipment.name }} assigned to {{ fighter.name }}?
             </p>
             <div class="mt-3">
                 <input type="hidden" name="remove" value="1">
-                <button type="submit" class="btn btn-danger">Remove</button>
+                <button type="submit" class="btn btn-danger">Delete</button>
                 <a href="{{ full_back_url }}" class="btn btn-link">Cancel</a>
             </div>
         </form>

--- a/gyrinx/core/templates/core/list_fighter_weapons_accessory_delete.html
+++ b/gyrinx/core/templates/core/list_fighter_weapons_accessory_delete.html
@@ -1,23 +1,23 @@
 {% extends "core/layouts/base.html" %}
 {% load allauth custom_tags %}
 {% block head_title %}
-    Remove - {{ accessory.name }} from {{ assign.content_equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
+    Delete - {{ accessory.name }} from {{ assign.content_equipment.name }} - {{ fighter.fully_qualified_name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
     {% include "core/includes/back.html" with text="Weapons: "|add:fighter.name %}
     <div class="col-lg-12 px-0 vstack gap-3">
         <h1 class="h3">
-            Remove: {{ accessory.name }} from the {{ assign.content_equipment.name }} assigned to {{ fighter.fully_qualified_name }}
+            Delete: {{ accessory.name }} from the {{ assign.content_equipment.name }} assigned to {{ fighter.fully_qualified_name }}
         </h1>
         <form action="{% url 'core:list-fighter-weapon-accessory-delete' list.id fighter.id assign.id accessory.id %}"
               method="post">
             {% csrf_token %}
             <p>
-                Are you sure you want to remove the {{ accessory.name }} from the {{ assign.content_equipment.name }} assigned to {{ fighter.name }}?
+                Are you sure you want to delete the {{ accessory.name }} from the {{ assign.content_equipment.name }} assigned to {{ fighter.name }}?
             </p>
             <div class="mt-3">
                 <input type="hidden" name="remove" value="1">
-                <button type="submit" class="btn btn-danger">Remove</button>
+                <button type="submit" class="btn btn-danger">Delete</button>
                 <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
                    class="btn btn-link">Cancel</a>
             </div>


### PR DESCRIPTION
Fixes #669

## Changes

- Changed all 'Remove' buttons to 'Delete' in equipment management UI
- Added gentle warning messages on delete confirmation pages
- Special warning for vehicles about entire profile deletion
- Info tip about using Reassign option instead of deleting
- Updated all related confirmation page titles and headings

Generated with [Claude Code](https://claude.ai/code)