### PR TITLE
feat: Allow XP and advancements outside of campaigns

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -1289,6 +1289,8 @@ class ListFighter(AppBase):
             "cool_override": self.cool_override,
             "willpower_override": self.willpower_override,
             "intelligence_override": self.intelligence_override,
+            "xp_current": self.xp_current,
+            "xp_total": self.xp_total,
             **kwargs,
         }
 
@@ -1335,6 +1337,14 @@ class ListFighter(AppBase):
                 list_fighter=clone,
                 psyker_power=power_assignment.psyker_power,
             )
+
+        # Clone advancements
+        for advancement in self.advancements.all():
+            # Use Django model instance copying
+            advancement.pk = None  # Clear primary key
+            advancement.fighter = clone  # Set to the new fighter
+            advancement.campaign_action = None  # Clear campaign action reference
+            advancement.save()
 
         return clone
 

--- a/gyrinx/core/templates/core/list_fighter_advancement_dice_choice.html
+++ b/gyrinx/core/templates/core/list_fighter_advancement_dice_choice.html
@@ -26,10 +26,12 @@
             {% if form.non_field_errors %}<div class="alert alert-danger mb-last-0">{{ form.non_field_errors }}</div>{% endif %}
             <p>You can choose to roll 2D6 for your advancement.</p>
             {{ form.roll_dice }}
-            <div class="alert alert-info">
-                <i class="bi-info-circle"></i>
-                The roll will <em>immediately</em> be added to the campaign action log.
-            </div>
+            {% if is_campaign_mode %}
+                <div class="alert alert-info">
+                    <i class="bi-info-circle"></i>
+                    The roll will <em>immediately</em> be added to the campaign action log.
+                </div>
+            {% endif %}
             <div class="hstack gap-3">
                 <button type="submit" class="btn btn-primary">Roll 2D6</button>
                 <a href="{% url 'core:list-fighter-advancement-type' list.id fighter.id %}"

--- a/gyrinx/core/tests/test_advancements.py
+++ b/gyrinx/core/tests/test_advancements.py
@@ -160,8 +160,8 @@ def test_advancement_list_view(client, user, fighter_with_xp):
 
 
 @pytest.mark.django_db
-def test_advancement_start_requires_campaign_mode(client, user, house, content_fighter):
-    """Test that advancement requires campaign mode."""
+def test_advancement_start_works_in_any_mode(client, user, house, content_fighter):
+    """Test that advancement works in any list mode."""
     client.login(username="testuser", password="password")
 
     # Create a non-campaign list
@@ -175,13 +175,16 @@ def test_advancement_start_requires_campaign_mode(client, user, house, content_f
         name="Test Fighter",
         content_fighter=content_fighter,
         list=lst,
+        owner=user,
     )
 
     url = reverse("core:list-fighter-advancement-start", args=[lst.id, fighter.id])
     response = client.get(url)
 
-    assert response.status_code == 302  # Redirect
-    assert response.url == reverse("core:list", args=[lst.id])
+    assert response.status_code == 302  # Redirect to dice choice
+    assert response.url == reverse(
+        "core:list-fighter-advancement-dice-choice", args=[lst.id, fighter.id]
+    )
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_xp_tracking.py
+++ b/gyrinx/core/tests/test_xp_tracking.py
@@ -150,8 +150,8 @@ def test_edit_fighter_xp_view_requires_ownership(list_with_fighter):
 
 
 @pytest.mark.django_db
-def test_edit_fighter_xp_view_requires_campaign_mode():
-    """Test that edit_fighter_xp view requires campaign mode."""
+def test_edit_fighter_xp_view_works_in_any_mode():
+    """Test that edit_fighter_xp view works in any list mode."""
     # Create a list in basic mode
     owner = User.objects.create_user(username="testuser", password="password")
     house = ContentHouse.objects.create(name="House")
@@ -192,8 +192,7 @@ def test_edit_fighter_xp_view_requires_campaign_mode():
 
     url = reverse("core:list-fighter-xp-edit", args=[list_obj.id, fighter.id])
     response = client.get(url)
-    assert response.status_code == 302
-    assert response.url == reverse("core:list", args=[list_obj.id])
+    assert response.status_code == 200  # Should work now
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #680

## Summary
- Removed campaign mode restriction from XP editing and advancement flows
- Campaign actions still created when in campaign mode
- Updated UI to conditionally show campaign action message
- Fixed fighter clone to copy XP and advancements
- Updated tests to reflect new behavior

🤖 Generated with [Claude Code](https://claude.ai/code)