### PR TITLE
fix: handle InterfaceError in site_banner context processor

### DIFF
--- a/gyrinx/core/context_processors.py
+++ b/gyrinx/core/context_processors.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db import DatabaseError, OperationalError
+from django.db.utils import InterfaceError
 
 from gyrinx.core.models import Banner
 
@@ -22,7 +23,7 @@ def site_banner(request):
     except Banner.DoesNotExist:
         # This is expected when no banner exists
         pass
-    except (DatabaseError, OperationalError):
+    except (DatabaseError, OperationalError, InterfaceError):
         # Database-related errors should be logged but not break the page
         logger.exception("Database error while fetching site banner")
         pass


### PR DESCRIPTION
## Summary

Add InterfaceError to the exception handling in the site_banner context processor to prevent "connection already closed" errors from breaking page rendering in production.

## Changes
- Added `InterfaceError` import from `django.db.utils`
- Updated exception handling to catch `InterfaceError` along with `DatabaseError` and `OperationalError`

This ensures database connection issues are logged but don't break page rendering.

Fixes #702

Generated with [Claude Code](https://claude.ai/code)