### PR TITLE
Fix validation error when cloning lists with archived single-select attributes

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -333,7 +333,9 @@ class List(AppBase):
                     assignment.clone(list_fighter=new_stash)
 
         # Clone attributes
-        for attribute_assignment in self.listattributeassignment_set.all():
+        for attribute_assignment in self.listattributeassignment_set.filter(
+            archived=False
+        ):
             ListAttributeAssignment.objects.create(
                 list=clone,
                 attribute_value=attribute_assignment.attribute_value,


### PR DESCRIPTION
Fixes #701

Only clone non-archived attribute assignments to prevent validation errors
when a list has multiple assignments for single-select attributes (some archived).

Generated with [Claude Code](https://claude.ai/code)