### PR TITLE
Show empty fighter narrative box even when logged out

### DIFF
--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -67,6 +67,13 @@
                     </div>
                     <div class="text-muted fst-italic">No narrative added yet.</div>
                 </div>
+            {% else %}
+                <div class="g-col-12 g-col-md-6" id="about-{{ fighter.id }}">
+                    <div class="hstack">
+                        <h3 class="h4">{{ fighter.fully_qualified_name }}</h3>
+                    </div>
+                    <div class="text-muted fst-italic">No narrative added yet.</div>
+                </div>
             {% endif %}
             {% include "core/includes/fighter_card.html" with fighter=fighter list=list print=True classes="g-col-12 g-col-md-6" %}
         {% empty %}


### PR DESCRIPTION
This ensures consistent layout between logged in and logged out states on the About pages. Previously, empty narrative boxes were only shown to the list owner.

Fixes #612

Generated with [Claude Code](https://claude.ai/code)