### PR TITLE
fix: reduce fighter name minimum length from 3 to 1 character

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -78,7 +78,7 @@ class List(AppBase):
 
     help_text = "A List is a reusable collection of fighters."
     name = models.CharField(
-        max_length=255, validators=[validators.MinLengthValidator(3)]
+        max_length=255, validators=[validators.MinLengthValidator(1)]
     )
     content_house = models.ForeignKey(
         ContentHouse, on_delete=models.CASCADE, null=False, blank=False
@@ -484,7 +484,7 @@ class ListFighter(AppBase):
 
     help_text = "A ListFighter is a member of a List, linked to a Content Fighter archetype to give base stats and equipment."
     name = models.CharField(
-        max_length=255, validators=[validators.MinLengthValidator(3)]
+        max_length=255, validators=[validators.MinLengthValidator(1)]
     )
     content_fighter = models.ForeignKey(
         ContentFighter, on_delete=models.CASCADE, null=False, blank=False

--- a/gyrinx/core/tests/test_models_core.py
+++ b/gyrinx/core/tests/test_models_core.py
@@ -39,11 +39,13 @@ def test_basic_list(content_house):
 
 @pytest.mark.django_db
 def test_list_name_min_length(content_house):
-    with pytest.raises(
-        ValidationError, match="Ensure this value has at least 3 characters"
-    ):
-        lst = List(name="Te", content_house=content_house)
-        lst.full_clean()  # This will trigger the validation
+    # Test that 1 character names are now allowed
+    lst = List.objects.create(name="A", content_house=content_house)
+    assert lst.name == "A"
+
+    # Test that 2 character names still work
+    lst2 = List.objects.create(name="AB", content_house=content_house)
+    assert lst2.name == "AB"
 
 
 @pytest.mark.django_db
@@ -61,11 +63,16 @@ def test_basic_list_fighter(content_house, content_fighter):
 def test_fighter_name_min_length(user, content_house, content_fighter):
     lst = List.objects.create(name="Test List", content_house=content_house)
 
-    with pytest.raises(
-        ValidationError, match="Ensure this value has at least 3 characters"
-    ):
+    # Test that 1 character names are now allowed
+    fighter = ListFighter(
+        name="B", list=lst, content_fighter=content_fighter, owner=user
+    )
+    fighter.full_clean()  # This should not raise any validation error
+
+    # Test that empty names still fail (due to blank=False)
+    with pytest.raises(ValidationError, match="This field cannot be blank"):
         fighter = ListFighter(
-            name="Te", list=lst, content_fighter=content_fighter, owner=user
+            name="", list=lst, content_fighter=content_fighter, owner=user
         )
         fighter.full_clean()  # This will trigger the validation
 


### PR DESCRIPTION
Updated List and ListFighter models to allow single character names by changing MinLengthValidator from 3 to 1. Updated tests to verify the new behavior.

Fixes #707

Generated with [Claude Code](https://claude.ai/code)