### PR TITLE
fix: allow deselection of single-select gang attributes

### DIFF
--- a/gyrinx/core/forms/attribute.py
+++ b/gyrinx/core/forms/attribute.py
@@ -30,13 +30,18 @@ class ListAttributeForm(forms.Form):
 
         if self.attribute.is_single_select:
             # Single select - use radio buttons
+            # Note: empty_label doesn't work with RadioSelect, so we manually add None option
             self.fields["values"] = forms.ModelChoiceField(
                 queryset=values,
                 widget=forms.RadioSelect,
                 required=False,
                 initial=current_assignments.first() if current_assignments else None,
                 label="",
-                empty_label="None",
+                empty_label=None,
+            )
+            # Manually add a "None" option at the beginning of choices
+            self.fields["values"].choices = [("", "None")] + list(
+                self.fields["values"].choices
             )
         else:
             # Multi select - use checkboxes

--- a/gyrinx/core/forms/attribute.py
+++ b/gyrinx/core/forms/attribute.py
@@ -36,6 +36,7 @@ class ListAttributeForm(forms.Form):
                 required=False,
                 initial=current_assignments.first() if current_assignments else None,
                 label="",
+                empty_label="None",
             )
         else:
             # Multi select - use checkboxes


### PR DESCRIPTION
Fixes #709

## Summary

This PR adds a "None" option to single-select gang attributes, allowing users to deselect previously selected values.

## Changes

- Added `empty_label="None"` to the `ModelChoiceField` for single-select attributes in `ListAttributeForm`
- This provides a UI way to clear single-select attribute assignments

## Test Plan

- All existing tests pass, including `test_campaign_action_clear_values` which specifically tests deselection behavior
- Manual testing: Create a list, select a single-select attribute value, save, then select "None" and save again

Generated with [Claude Code](https://claude.ai/code)