### PR TITLE
fix: apply fs-7 font size to fighter statlines to prevent overflow

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -31,7 +31,7 @@
         <thead>
             <tr>
                 {% for stat in fighter.statline %}
-                    <th class="text-center border-bottom {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
+                    <th class="text-center border-bottom fs-7 {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
                         scope="col">{{ stat.name }}</th>
                 {% endfor %}
             </tr>

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -24,7 +24,7 @@
             {% if not fighter.is_stash %}
                 <thead>
                     {% for stat in fighter.statline %}
-                        <th class="text-center border-bottom {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
+                        <th class="text-center border-bottom fs-7 {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
                             scope="col">{{ stat.name }}</th>
                     {% endfor %}
                 </thead>

--- a/gyrinx/core/templates/core/includes/fighter_card_weapon_menu.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_weapon_menu.html
@@ -1,7 +1,7 @@
 {% load custom_tags %}
 <tr>
     <td colspan="9" class="text-end">
-        <div class="d-flex">
+        <div class="d-flex flex-wrap">
             <i class="bi-arrow-90deg-up text-secondary me-2"></i>
             {% if assign.kind == 'assigned' %}
                 <a href="{% url 'core:list-fighter-weapon-accessories-edit' list.id fighter.id assign.id %}"

--- a/gyrinx/core/templates/core/includes/list_fighter_statline.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_statline.html
@@ -1,5 +1,5 @@
 {% for stat in fighter.statline %}
-    <td class="text-center {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}">
+    <td class="text-center fs-7 {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}">
         {% if stat.modded %}
             <span bs-tooltip
                   data-bs-toggle="tooltip"

--- a/gyrinx/core/templates/core/includes/list_fighter_weapon_profile_statline.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapon_profile_statline.html
@@ -1,5 +1,5 @@
 {% for stat in profile.statline %}
-    <td class="text-center {{ stat.classes }}">
+    <td class="text-center fs-7 {{ stat.classes }}">
         {% if stat.modded %}
             <span bs-tooltip
                   data-bs-toggle="tooltip"


### PR DESCRIPTION
Fixes double-digit stats disappearing on smaller screens by applying
the fs-7 (smaller) font size class to stat headers and values.

This ensures stats fit properly even on screens under 1400px width.

Fixes #726

Generated with [Claude Code](https://claude.ai/code)