### PR TITLE
fix: Allow non-owners to view and print list configurations

### DIFF
--- a/gyrinx/core/templates/core/print_config/index.html
+++ b/gyrinx/core/templates/core/print_config/index.html
@@ -8,11 +8,13 @@
     <div class="col-12 px-0 vstack gap-3">
         <div class="d-flex justify-content-between align-items-center">
             <h1 class="h3">Print Configurations</h1>
-            <a href="{% url 'core:print-config-create' list.id %}"
-               class="btn btn-primary btn-sm">
-                <i class="bi-plus"></i>
-                New Configuration
-            </a>
+            {% if is_owner %}
+                <a href="{% url 'core:print-config-create' list.id %}"
+                   class="btn btn-primary btn-sm">
+                    <i class="bi-plus"></i>
+                    New Configuration
+                </a>
+            {% endif %}
         </div>
         <p class="text-muted">
             Manage print configurations for <strong>{{ list.name }}</strong>.
@@ -52,16 +54,18 @@
                             <td class="text-muted">{{ config.card_summary }}</td>
                             <td class="text-end">
                                 <div class="btn-group" role="group">
-                                    <a href="{% url 'core:print-config-edit' list.id config.id %}"
-                                       class="btn btn-outline-secondary btn-sm">
-                                        <i class="bi-pencil"></i>
-                                        Edit
-                                    </a>
-                                    <a href="{% url 'core:print-config-delete' list.id config.id %}"
-                                       class="btn btn-outline-danger btn-sm">
-                                        <i class="bi-trash"></i>
-                                        Delete
-                                    </a>
+                                    {% if is_owner %}
+                                        <a href="{% url 'core:print-config-edit' list.id config.id %}"
+                                           class="btn btn-outline-secondary btn-sm">
+                                            <i class="bi-pencil"></i>
+                                            Edit
+                                        </a>
+                                        <a href="{% url 'core:print-config-delete' list.id config.id %}"
+                                           class="btn btn-outline-danger btn-sm">
+                                            <i class="bi-trash"></i>
+                                            Delete
+                                        </a>
+                                    {% endif %}
                                     <a href="{% url 'core:print-config-print' list.id config.id %}"
                                        class="btn btn-primary btn-sm">
                                         <i class="bi-printer"></i>

--- a/gyrinx/core/views/print_config.py
+++ b/gyrinx/core/views/print_config.py
@@ -38,7 +38,8 @@ class PrintConfigIndexView(generic.ListView):
             list_id = kwargs["list_id"]
             return redirect("core:list-print", id=list_id)
 
-        self.list = get_object_or_404(List, id=kwargs["list_id"], owner=request.user)
+        # Allow any authenticated user to view print configurations
+        self.list = get_object_or_404(List, id=kwargs["list_id"])
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
@@ -49,6 +50,7 @@ class PrintConfigIndexView(generic.ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["list"] = self.list
+        context["is_owner"] = self.request.user == self.list.owner
         return context
 
 
@@ -195,7 +197,8 @@ def print_config_delete(request, list_id, config_id):
 @login_required
 def print_config_print(request, list_id, config_id=None):
     """Redirect to the print view with the specified configuration."""
-    list_obj = get_object_or_404(List, id=list_id, owner=request.user)
+    # Allow any authenticated user to print
+    list_obj = get_object_or_404(List, id=list_id)
 
     if config_id:
         # Verify the config exists and belongs to this list


### PR DESCRIPTION
Fixes #743

This PR allows non-owners to access print options for lists they don't own, which is important when people need to print other people's lists due to variable printer access.

## Changes

- Remove owner check from `PrintConfigIndexView.dispatch()`
- Allow any authenticated user to use `print_config_print` view
- Add `is_owner` context variable to template
- Hide new/edit/delete buttons for non-owners in template

Non-owners can now:
- ✅ View all print configurations for a list
- ✅ Click the print button on any configuration
- ❌ Cannot create new configurations (button hidden)
- ❌ Cannot edit or delete configurations (buttons hidden)

Generated with [Claude Code](https://claude.ai/code)