### PR TITLE
fix: Add queryset optimization to FlatPageVisibilityAdmin to avoid N+1 queries

### DIFF
--- a/gyrinx/pages/admin.py
+++ b/gyrinx/pages/admin.py
@@ -83,3 +83,8 @@ class FlatPageVisibilityAdmin(admin.ModelAdmin):
     search_fields = ("page__title", "groups__name")
     ordering = ("page__title",)
     actions = None
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        # Prefetch groups to avoid N+1 queries
+        return qs.prefetch_related("groups").select_related("page")


### PR DESCRIPTION
## Summary

Implemented queryset optimization for FlatPageVisibilityAdmin to resolve N+1 query issue.

## Changes

- Added `get_queryset` method with `prefetch_related('groups')` and `select_related('page')`
- This reduces database queries from N+1 to just 3 queries
- Performance improvement is significant when displaying many visibility rules

Fixes #751

Generated with [Claude Code](https://claude.ai/code)