### PR TITLE
fix: remove unsafe filter from help_text in form field template

### DIFF
--- a/gyrinx/core/forms/__init__.py
+++ b/gyrinx/core/forms/__init__.py
@@ -2,6 +2,7 @@ from allauth.account.forms import LoginForm, ResetPasswordForm, SignupForm
 from django import forms
 from django.contrib.auth import get_user_model
 from django.core import validators
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django_recaptcha.fields import ReCaptchaField, ReCaptchaV3
 
@@ -36,7 +37,9 @@ class SignupForm(SignupForm):
     tos_agreement = forms.BooleanField(
         required=True,
         label="Agree to the Terms of Use",
-        help_text='By signing up, you acknowledge that you have read and agree to be bound by our <a href="/terms/" target="_blank">Terms of Use</a>',
+        help_text=mark_safe(  # nosec B308 - HTML content required for TOS link
+            'By signing up, you acknowledge that you have read and agree to be bound by our <a href="/terms/" target="_blank">Terms of Use</a>'
+        ),
         error_messages={
             "required": "You must agree to the Terms of Use to create an account."
         },

--- a/gyrinx/templates/django/forms/field.html
+++ b/gyrinx/templates/django/forms/field.html
@@ -8,6 +8,6 @@
     {{ field }}
     {% if field.help_text %}
         <div class="helptext form-text"
-             {% if field.auto_id %}id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</div>
+             {% if field.auto_id %}id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text }}</div>
     {% endif %}
     {% if field.use_fieldset %}</fieldset>{% endif %}


### PR DESCRIPTION
Removed the |safe filter from field.help_text to prevent potential XSS vulnerabilities.
Django's auto-escaping will now handle the help text safely by default.
If HTML formatting is needed in specific help texts, they should use mark_safe()
explicitly in the form definition.

Fixes #757

Generated with [Claude Code](https://claude.ai/code)