### PR TITLE
Add select_related/prefetch_related to fighter queries

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -476,7 +476,17 @@ class ListFighterQuerySet(models.QuerySet):
     Custom QuerySet for :model:`content.ListFighter`.
     """
 
-    pass
+    def with_related_data(self):
+        """
+        Optimize queries by selecting related content_fighter and list,
+        and prefetching injuries and equipment assignments.
+
+        This is the standard optimization pattern used throughout views
+        to reduce N+1 query issues.
+        """
+        return self.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        )
 
 
 class ListFighter(AppBase):
@@ -1559,6 +1569,26 @@ def update_list_cost_cache(sender, instance: ListFighter, **kwargs):
     instance.list.update_cost_cache()
 
 
+class ListFighterEquipmentAssignmentQuerySet(models.QuerySet):
+    """
+    Custom QuerySet for :model:`content.ListFighterEquipmentAssignment`.
+    """
+
+    def with_related_data(self):
+        """
+        Optimize queries by selecting related content_equipment and list_fighter,
+        and prefetching weapon profiles, accessories, and upgrades.
+
+        This is the standard optimization pattern used throughout views
+        to reduce N+1 query issues.
+        """
+        return self.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        )
+
+
 class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
     """A ListFighterEquipmentAssignment is a link between a ListFighter and an Equipment."""
 
@@ -2133,6 +2163,8 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
                         "upgrade": f"Upgrade {upgrade} is not for equipment {self.content_equipment}"
                     }
                 )
+
+    objects = ListFighterEquipmentAssignmentQuerySet.as_manager()
 
     class Meta:
         verbose_name = "Fighter Equipment Assignment"

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -907,9 +907,7 @@ def edit_list_fighter(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -974,9 +972,7 @@ def clone_list_fighter(request: HttpRequest, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
     )
@@ -1048,9 +1044,7 @@ def edit_list_fighter_skills(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -1173,9 +1167,7 @@ def add_list_fighter_skill(request, id, fighter_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -1219,9 +1211,7 @@ def remove_list_fighter_skill(request, id, fighter_id, skill_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -1273,9 +1263,7 @@ def edit_list_fighter_powers(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -1475,9 +1463,7 @@ def edit_list_fighter_narrative(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -1550,9 +1536,7 @@ def edit_list_fighter_info(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -1633,9 +1617,7 @@ def list_fighter_stats_edit(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -1742,9 +1724,7 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -2088,19 +2068,13 @@ def edit_list_fighter_assign_cost(
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
     )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment.objects.select_related(
-            "content_equipment", "list_fighter"
-        ).prefetch_related(
-            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
-        ),
+        ListFighterEquipmentAssignment.objects.with_related_data(),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2171,19 +2145,13 @@ def delete_list_fighter_assign(
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
     )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment.objects.select_related(
-            "content_equipment", "list_fighter"
-        ).prefetch_related(
-            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
-        ),
+        ListFighterEquipmentAssignment.objects.with_related_data(),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2246,19 +2214,13 @@ def delete_list_fighter_gear_upgrade(
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
     )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment.objects.select_related(
-            "content_equipment", "list_fighter"
-        ).prefetch_related(
-            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
-        ),
+        ListFighterEquipmentAssignment.objects.with_related_data(),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2335,19 +2297,13 @@ def edit_list_fighter_weapon_accessories(request, id, fighter_id, assign_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
     )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment.objects.select_related(
-            "content_equipment", "list_fighter"
-        ).prefetch_related(
-            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
-        ),
+        ListFighterEquipmentAssignment.objects.with_related_data(),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2490,19 +2446,13 @@ def delete_list_fighter_weapon_accessory(
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
     )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment.objects.select_related(
-            "content_equipment", "list_fighter"
-        ).prefetch_related(
-            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
-        ),
+        ListFighterEquipmentAssignment.objects.with_related_data(),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2574,19 +2524,13 @@ def edit_list_fighter_weapon_upgrade(
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
     )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment.objects.select_related(
-            "content_equipment", "list_fighter"
-        ).prefetch_related(
-            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
-        ),
+        ListFighterEquipmentAssignment.objects.with_related_data(),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2640,9 +2584,7 @@ def disable_list_fighter_default_assign(
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -2696,9 +2638,7 @@ def convert_list_fighter_default_assign(
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -2743,9 +2683,7 @@ def archive_list_fighter(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -2812,9 +2750,7 @@ def kill_list_fighter(request, id, fighter_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -2931,9 +2867,7 @@ def delete_list_fighter(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -2980,9 +2914,7 @@ def embed_list_fighter(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -3055,9 +2987,7 @@ def list_fighter_injuries_edit(request, id, fighter_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -3104,9 +3034,7 @@ def list_fighter_state_edit(request, id, fighter_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -3205,9 +3133,7 @@ def mark_fighter_captured(request, id, fighter_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -3353,9 +3279,7 @@ def list_fighter_add_injury(request, id, fighter_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -3473,9 +3397,7 @@ def list_fighter_remove_injury(request, id, fighter_id, injury_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -4450,19 +4372,13 @@ def reassign_list_fighter_equipment(
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
     )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment.objects.select_related(
-            "content_equipment", "list_fighter"
-        ).prefetch_related(
-            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
-        ),
+        ListFighterEquipmentAssignment.objects.with_related_data(),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -4570,9 +4486,7 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
     )
@@ -5014,9 +4928,7 @@ def edit_list_fighter_rules(request, id, fighter_id):
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -5106,9 +5018,7 @@ def toggle_list_fighter_rule(request, id, fighter_id, rule_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -5161,9 +5071,7 @@ def add_list_fighter_rule(request, id, fighter_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,
@@ -5209,9 +5117,7 @@ def remove_list_fighter_rule(request, id, fighter_id, rule_id):
 
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
-        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
-            "injuries", "listfighterequipmentassignment_set"
-        ),
+        ListFighter.objects.with_related_data(),
         id=fighter_id,
         list=lst,
         owner=lst.owner,

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -3487,6 +3487,9 @@ def list_fighter_remove_injury(request, id, fighter_id, injury_id):
             injury_name = injury.injury.name
             injury.delete()
 
+            # Clear the prefetch cache to get accurate count
+            fighter._prefetched_objects_cache = {}
+
             # If fighter has no more injuries, reset state to active
             if fighter.injuries.count() == 0:
                 fighter.injury_state = ListFighter.ACTIVE

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -906,7 +906,14 @@ def edit_list_fighter(request, id, fighter_id):
     :template:`core/list_fighter_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     error_message = None
     if request.method == "POST":
@@ -966,7 +973,13 @@ def clone_list_fighter(request: HttpRequest, id, fighter_id):
     :template:`core/list_fighter_clone.html`
     """
     lst = get_object_or_404(List, id=id)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+    )
 
     error_message = None
     if request.method == "POST":
@@ -1034,7 +1047,14 @@ def edit_list_fighter_skills(request, id, fighter_id):
     :template:`core/list_fighter_skills_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Get query parameters
     search_query = request.GET.get("q", "").strip()
@@ -1152,7 +1172,14 @@ def add_list_fighter_skill(request, id, fighter_id):
         raise Http404()
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     skill_id = request.POST.get("skill_id")
     if skill_id:
@@ -1191,7 +1218,14 @@ def remove_list_fighter_skill(request, id, fighter_id, skill_id):
         raise Http404()
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     skill = get_object_or_404(ContentSkill, id=skill_id)
     fighter.skills.remove(skill)
@@ -1238,7 +1272,14 @@ def edit_list_fighter_powers(request, id, fighter_id):
     :template:`core/list_fighter_psyker_powers_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     error_message = None
     if request.method == "POST":
@@ -1433,7 +1474,14 @@ def edit_list_fighter_narrative(request, id, fighter_id):
     :template:`core/list_fighter_narrative_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Get the return URL from query params, with fallback to default
     default_url = (
@@ -1501,7 +1549,14 @@ def edit_list_fighter_info(request, id, fighter_id):
     :template:`core/list_fighter_info_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Get the return URL from query params, with fallback to default
     default_url = (
@@ -1577,7 +1632,14 @@ def list_fighter_stats_edit(request, id, fighter_id):
     :template:`core/list_fighter_stats_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Get the return URL from query params, with fallback to default
     default_url = reverse("core:list-fighter-edit", args=(lst.id, fighter.id))
@@ -1679,7 +1741,14 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
     :template:`core/list_fighter_weapons_edit.html` or :template:`core/list_fighter_gear_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     view_name = (
         "core:list-fighter-weapons-edit" if is_weapon else "core:list-fighter-gear-edit"
     )
@@ -2018,9 +2087,20 @@ def edit_list_fighter_assign_cost(
     :template:`core/list_fighter_assign_cost_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignment.objects.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        ),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2090,9 +2170,20 @@ def delete_list_fighter_assign(
     :template:`core/list_fighter_assign_delete_confirm.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignment.objects.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        ),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2154,9 +2245,20 @@ def delete_list_fighter_gear_upgrade(
     :template:`core/list_fighter_assign_upgrade_delete_confirm.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignment.objects.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        ),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2232,9 +2334,20 @@ def edit_list_fighter_weapon_accessories(request, id, fighter_id, assign_id):
 
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignment.objects.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        ),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2376,9 +2489,20 @@ def delete_list_fighter_weapon_accessory(
     :template:`core/list_fighter_weapons_accessory_delete.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignment.objects.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        ),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2449,9 +2573,20 @@ def edit_list_fighter_weapon_upgrade(
     :template:`core/list_fighter_assign_upgrade_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignment.objects.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        ),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -2504,7 +2639,14 @@ def disable_list_fighter_default_assign(
     :template:`core/list_fighter_assign_disable.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
         ContentFighterDefaultAssignment,
         pk=assign_id,
@@ -2553,7 +2695,14 @@ def convert_list_fighter_default_assign(
     :template:`core/list_fighter_assign_convert.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
         ContentFighterDefaultAssignment,
         pk=assign_id,
@@ -2593,7 +2742,14 @@ def archive_list_fighter(request, id, fighter_id):
     :template:`core/list_fighter_archive.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     if request.method == "POST":
         if request.POST.get("archive") == "1":
@@ -2655,7 +2811,14 @@ def kill_list_fighter(request, id, fighter_id):
     from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Only allow killing fighters in campaign mode
     if not lst.is_campaign_mode:
@@ -2767,7 +2930,14 @@ def delete_list_fighter(request, id, fighter_id):
     :template:`core/list_fighter_delete.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     if request.method == "POST":
         # Log the fighter delete event before deletion
@@ -2809,7 +2979,14 @@ def embed_list_fighter(request, id, fighter_id):
     :template:`core/list_fighter_embed.html`
     """
     lst = get_object_or_404(List, id=id)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Log the embed view event
     log_event(
@@ -2877,7 +3054,14 @@ def list_fighter_injuries_edit(request, id, fighter_id):
     from django.contrib import messages
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Check campaign mode
     if lst.status != List.CAMPAIGN_MODE:
@@ -2919,7 +3103,14 @@ def list_fighter_state_edit(request, id, fighter_id):
     from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Check campaign mode
     if lst.status != List.CAMPAIGN_MODE:
@@ -3013,7 +3204,14 @@ def mark_fighter_captured(request, id, fighter_id):
     from gyrinx.core.models.list import CapturedFighter
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Check campaign mode
     if lst.status != List.CAMPAIGN_MODE:
@@ -3154,7 +3352,14 @@ def list_fighter_add_injury(request, id, fighter_id):
     from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Check campaign mode
     if lst.status != List.CAMPAIGN_MODE:
@@ -3267,7 +3472,14 @@ def list_fighter_remove_injury(request, id, fighter_id, injury_id):
     from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     injury = get_object_or_404(ListFighterInjury, id=injury_id, fighter=fighter)
 
     if request.method == "POST":
@@ -4234,9 +4446,20 @@ def reassign_list_fighter_equipment(
     from gyrinx.core.forms.list import EquipmentReassignForm
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     assignment = get_object_or_404(
-        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignment.objects.select_related(
+            "content_equipment", "list_fighter"
+        ).prefetch_related(
+            "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+        ),
         pk=assign_id,
         list_fighter=fighter,
     )
@@ -4343,7 +4566,13 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
     from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+    )
 
     # For summary step, assignment might not exist (already deleted)
     step = request.GET.get("step", "selection")
@@ -4351,7 +4580,11 @@ def sell_list_fighter_equipment(request, id, fighter_id, assign_id):
         assignment = None
     else:
         assignment = get_object_or_404(
-            ListFighterEquipmentAssignment,
+            ListFighterEquipmentAssignment.objects.select_related(
+                "content_equipment", "list_fighter"
+            ).prefetch_related(
+                "weapon_profiles_field", "weapon_accessories_field", "upgrades_field"
+            ),
             pk=assign_id,
             list_fighter=fighter,
         )
@@ -4777,7 +5010,14 @@ def edit_list_fighter_rules(request, id, fighter_id):
     :template:`core/list_fighter_rules_edit.html`
     """
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Get query parameters
     search_query = request.GET.get("q", "").strip()
@@ -4862,7 +5102,14 @@ def toggle_list_fighter_rule(request, id, fighter_id, rule_id):
         raise Http404()
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
     rule = get_object_or_404(ContentRule, id=rule_id)
 
     # Ensure this is a default rule for the fighter
@@ -4910,7 +5157,14 @@ def add_list_fighter_rule(request, id, fighter_id):
         raise Http404()
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     rule_id = request.POST.get("rule_id")
     if rule_id and is_valid_uuid(rule_id):
@@ -4951,7 +5205,14 @@ def remove_list_fighter_rule(request, id, fighter_id, rule_id):
         raise Http404()
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter", "list").prefetch_related(
+            "injuries", "listfighterequipmentassignment_set"
+        ),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     rule = get_object_or_404(ContentRule, id=rule_id)
     fighter.custom_rules.remove(rule)


### PR DESCRIPTION
Optimize database queries by adding select_related() and prefetch_related()
to all ListFighter and ListFighterEquipmentAssignment queries in views.

- Add select_related('content_fighter', 'list') to ListFighter queries
- Add prefetch_related('injuries', 'listfighterequipmentassignment_set')
- Add similar optimizations to ListFighterEquipmentAssignment queries

This reduces N+1 query issues when accessing related objects in templates.

Fixes #758

Generated with [Claude Code](https://claude.ai/code)