### PR TITLE
feat: Move print button out of dropdown menu

### DIFF
--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -98,26 +98,25 @@
                     <div class="nav hstack gap-1 flex-nowrap">
                         {% if list.owner_cached == user and not list.archived %}
                             <a href="{% url 'core:list-fighter-new' list.id %}"
-                               class="btn btn-primary btn-sm">
+                               class="btn btn-primary btn-sm"
+                               title="Add a fighter to this list">
                                 <i class="bi-person-add"></i> Add fighter</a>
                             <a href="{% url 'core:list-vehicle-new' list.id %}"
-                               class="btn btn-primary btn-sm">
+                               class="btn btn-primary btn-sm"
+                               title="Add a vehicle to this list">
                                 <i class="bi-truck"></i> Add vehicle</a>
                         {% endif %}
                         <a href="{% url 'core:print-config-index' list.id %}"
                            class="btn btn-secondary btn-sm d-none d-sm-inline-flex"
                            title="Print">
-                            <i class="bi-printer"></i> Print
-                        </a>
-                        <a href="{% url 'core:print-config-index' list.id %}"
-                           class="btn btn-secondary btn-sm d-inline-flex d-sm-none"
-                           title="Print">
                             <i class="bi-printer"></i>
+                            <span class="visually-hidden">Print</span>
                         </a>
                         <nav class="btn-group">
                             {% if list.owner_cached == user and not list.archived %}
                                 <a href="{% url 'core:list-edit' list.id %}"
-                                   class="btn btn-secondary btn-sm">
+                                   class="btn btn-secondary btn-sm"
+                                   title="Edit this list">
                                     <i class="bi-pencil"></i> Edit
                                 </a>
                             {% endif %}
@@ -130,6 +129,12 @@
                                     <i class="bi-three-dots-vertical"></i>
                                 </button>
                                 <ul class="dropdown-menu">
+                                    <li>
+                                        <a href="{% url 'core:print-config-index' list.id %}"
+                                           class="dropdown-item icon-link">
+                                            <i class="bi-printer"></i> Print
+                                        </a>
+                                    </li>
                                     <li>
                                         <button type="button"
                                                 class="dropdown-item icon-link"

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -104,6 +104,16 @@
                                class="btn btn-primary btn-sm">
                                 <i class="bi-truck"></i> Add vehicle</a>
                         {% endif %}
+                        <a href="{% url 'core:print-config-index' list.id %}"
+                           class="btn btn-secondary btn-sm d-none d-sm-inline-flex"
+                           title="Print">
+                            <i class="bi-printer"></i> Print
+                        </a>
+                        <a href="{% url 'core:print-config-index' list.id %}"
+                           class="btn btn-secondary btn-sm d-inline-flex d-sm-none"
+                           title="Print">
+                            <i class="bi-printer"></i>
+                        </a>
                         <nav class="btn-group">
                             {% if list.owner_cached == user and not list.archived %}
                                 <a href="{% url 'core:list-edit' list.id %}"
@@ -120,12 +130,6 @@
                                     <i class="bi-three-dots-vertical"></i>
                                 </button>
                                 <ul class="dropdown-menu">
-                                    <li>
-                                        <a href="{% url 'core:print-config-index' list.id %}"
-                                           class="dropdown-item icon-link">
-                                            <i class="bi-printer"></i> Print
-                                        </a>
-                                    </li>
                                     <li>
                                         <button type="button"
                                                 class="dropdown-item icon-link"

--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -1,5 +1,5 @@
 {% load allauth custom_tags humanize %}
-<div class="card g-col-12 {% if print %}g-col-sm-6 g-col-md-4 g-col-xl-3{% else %}g-col-md-12 g-col-lg-6 {% endif %}">
+<div class="card g-col-12 {% if print %}g-col-sm-6 g-col-md-4 g-col-xl-3{% else %}g-col-md-12 g-col-lg-6 g-col-xl-4{% endif %}">
     <div class="card-header p-2 bg-secondary-subtle text-secondary-emphasis">
         <h3 class="h5 mb-0">Attributes</h3>
     </div>


### PR DESCRIPTION
Closes #771

## Summary

- Move print button out of dropdown to improve visibility
- Place alongside "Add Vehicle" button with secondary styling
- Add responsive design: icon+text on desktop, icon-only on mobile

## Test plan

- [x] Visit a list page
- [x] Verify print button appears alongside "Add Vehicle"
- [x] Check responsive behavior on mobile (icon only)
- [x] Ensure print button is no longer in dropdown

🤖 Generated with [Claude Code](https://claude.ai/code)