### PR TITLE
Fix N+1 query in list_fighter_state_edit view

### DIFF
--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2919,7 +2919,12 @@ def list_fighter_state_edit(request, id, fighter_id):
     from gyrinx.core.models.campaign import CampaignAction
 
     lst = get_object_or_404(List, id=id, owner=request.user)
-    fighter = get_object_or_404(ListFighter, id=fighter_id, list=lst, owner=lst.owner)
+    fighter = get_object_or_404(
+        ListFighter.objects.select_related("content_fighter"),
+        id=fighter_id,
+        list=lst,
+        owner=lst.owner,
+    )
 
     # Check campaign mode
     if lst.status != List.CAMPAIGN_MODE:


### PR DESCRIPTION
Fix N+1 query problem in the `list_fighter_state_edit` view by adding `select_related('content_fighter')` to eagerly load the related content_fighter object.

This prevents potential N+1 queries when accessing the content_fighter relationship.

Fixes #756

Generated with [Claude Code](https://claude.ai/code)