### PR TITLE
Fix AttributeError: convert set to queryset for skill categories

### DIFF
--- a/gyrinx/core/forms/advancement.py
+++ b/gyrinx/core/forms/advancement.py
@@ -223,16 +223,14 @@ class SkillCategorySelectionForm(forms.Form):
             if "primary" in skill_type:
                 categories = fighter.get_primary_skill_categories()
                 # Convert set to queryset
-                category_ids = [cat.id for cat in categories]
                 self.fields["category"].queryset = ContentSkillCategory.objects.filter(
-                    id__in=category_ids
+                    id__in=categories
                 )
             elif "secondary" in skill_type:
                 categories = fighter.get_secondary_skill_categories()
                 # Convert set to queryset
-                category_ids = [cat.id for cat in categories]
                 self.fields["category"].queryset = ContentSkillCategory.objects.filter(
-                    id__in=category_ids
+                    id__in=categories
                 )
             else:
                 # For "any" skill type, show all categories

--- a/gyrinx/core/forms/advancement.py
+++ b/gyrinx/core/forms/advancement.py
@@ -222,13 +222,21 @@ class SkillCategorySelectionForm(forms.Form):
         if fighter and skill_type:
             if "primary" in skill_type:
                 categories = fighter.get_primary_skill_categories()
+                # Convert set to queryset
+                category_ids = [cat.id for cat in categories]
+                self.fields["category"].queryset = ContentSkillCategory.objects.filter(
+                    id__in=category_ids
+                )
             elif "secondary" in skill_type:
                 categories = fighter.get_secondary_skill_categories()
+                # Convert set to queryset
+                category_ids = [cat.id for cat in categories]
+                self.fields["category"].queryset = ContentSkillCategory.objects.filter(
+                    id__in=category_ids
+                )
             else:
                 # For "any" skill type, show all categories
-                categories = ContentSkillCategory.objects.all()
-
-            self.fields["category"].queryset = categories
+                self.fields["category"].queryset = ContentSkillCategory.objects.all()
 
 
 class RandomSkillForm(forms.Form):


### PR DESCRIPTION
The get_primary_skill_categories() and get_secondary_skill_categories() methods return sets, but Django form fields expect querysets. Convert the sets to querysets using filter(id__in=...) before assigning to the form field.

Fixes #789

Generated with [Claude Code](https://claude.ai/code)