### PR TITLE
fix: replace HTTP_REFERER with safe_referer template tag

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_new.html
+++ b/gyrinx/core/templates/core/campaign/campaign_new.html
@@ -15,7 +15,7 @@
             {{ form }}
             <div class="mt-3">
                 <button type="submit" class="btn btn-primary">Create</button>
-                <a href="{{ request.META.HTTP_REFERER|escape }}" class="btn btn-link">Cancel</a>
+                <a href="{% safe_referer '/campaigns/' %}" class="btn btn-link">Cancel</a>
             </div>
         </form>
     </div>

--- a/gyrinx/core/templates/core/includes/back.html
+++ b/gyrinx/core/templates/core/includes/back.html
@@ -1,8 +1,9 @@
+{% load custom_tags %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item active" aria-current="page">
             <i class="bi-chevron-left"></i>
-            <a href="{% if url %}{{ url }}{% else %}{{ request.META.HTTP_REFERER|escape }}{% endif %}">
+            <a href="{% if url %}{{ url }}{% else %}{% safe_referer "/" %}{% endif %}">
                 {% if text %}
                     {{ text }}
                 {% else %}

--- a/gyrinx/core/templates/core/includes/cancel.html
+++ b/gyrinx/core/templates/core/includes/cancel.html
@@ -1,4 +1,5 @@
-<a href="{% if url %}{{ url }}{% else %}{{ request.META.HTTP_REFERER|escape }}{% endif %}"
+{% load custom_tags %}
+<a href="{% if url %}{{ url }}{% else %}{% safe_referer "/" %}{% endif %}"
    class="btn btn-link">
     {% if text %}
         {{ text }}

--- a/gyrinx/core/templates/core/list_fighter_new.html
+++ b/gyrinx/core/templates/core/list_fighter_new.html
@@ -14,7 +14,7 @@
             {{ form }}
             <div class="mt-3">
                 <button type="submit" class="btn btn-primary">Add</button>
-                <a href="{{ request.META.HTTP_REFERER|escape }}" class="btn btn-link">Cancel</a>
+                <a href="{% safe_referer list.get_absolute_url %}" class="btn btn-link">Cancel</a>
             </div>
         </form>
     </div>

--- a/gyrinx/core/templates/core/list_new.html
+++ b/gyrinx/core/templates/core/list_new.html
@@ -15,7 +15,7 @@
             {{ form }}
             <div class="mt-3">
                 <button type="submit" class="btn btn-primary">Create</button>
-                <a href="{{ request.META.HTTP_REFERER|escape }}" class="btn btn-link">Cancel</a>
+                <a href="{% safe_referer '/lists/' %}" class="btn btn-link">Cancel</a>
             </div>
         </form>
     </div>

--- a/gyrinx/templates/404.html
+++ b/gyrinx/templates/404.html
@@ -11,7 +11,7 @@
                 <h2 class="mb-4">Page Not Found</h2>
                 <p data-test-id="the-joke" class="text-secondary mb-4">{% random_404_message %}</p>
                 <div class="hstack gap-3 justify-content-center align-items-center">
-                    <a href="{{ request.META.HTTP_REFERER|escape }}" class="icon-link">
+                    <a href="{% safe_referer '/' %}" class="icon-link">
                         <i class="bi-chevron-left"></i>Back</a>
                     or
                     <a href="{% url 'core:index' %}" class="btn btn-primary">


### PR DESCRIPTION
Fixes #780

## Summary
Implemented an app-wide fix for the open redirect vulnerability by creating a custom `safe_referer` template tag that validates HTTP_REFERER headers.

## Changes
- Created `safe_referer` custom template tag in `custom_tags.py`
- Updated all templates to use the new tag instead of direct HTTP_REFERER access
- Uses Django's `url_has_allowed_host_and_scheme` for secure validation
- Provides appropriate fallback URLs for each context

Generated with [Claude Code](https://claude.ai/code)