### PR TITLE
fix: prevent duplicate CampaignAssetType name_singular within same campaign

### DIFF
--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -1177,7 +1177,7 @@ def campaign_asset_type_new(request, id):
         return redirect("core:campaign-assets", campaign.id)
 
     if request.method == "POST":
-        form = CampaignAssetTypeForm(request.POST)
+        form = CampaignAssetTypeForm(request.POST, campaign=campaign)
         if form.is_valid():
             asset_type = form.save(commit=False)
             asset_type.campaign = campaign
@@ -1204,7 +1204,7 @@ def campaign_asset_type_new(request, id):
                 reverse("core:campaign-assets", args=(campaign.id,))
             )
     else:
-        form = CampaignAssetTypeForm()
+        form = CampaignAssetTypeForm(campaign=campaign)
 
     return render(
         request,


### PR DESCRIPTION
Fix for issue #792 - django.db.utils.IntegrityError when editing CampaignAssetType

This PR adds form validation to prevent duplicate name_singular values within the same campaign, which was causing an IntegrityError when editing an asset type without changing its name.

The fix:
- Adds clean_name_singular method to validate uniqueness
- Excludes current instance when editing to avoid false positives
- Passes campaign parameter during form initialization
- Provides user-friendly error message

Fixes #792

Generated with [Claude Code](https://claude.ai/code)