### PR TITLE
fix: convert skill category model instances to IDs before filtering

### DIFF
--- a/gyrinx/core/forms/advancement.py
+++ b/gyrinx/core/forms/advancement.py
@@ -222,15 +222,17 @@ class SkillCategorySelectionForm(forms.Form):
         if fighter and skill_type:
             if "primary" in skill_type:
                 categories = fighter.get_primary_skill_categories()
-                # Convert set to queryset
+                # Convert set of model instances to list of IDs
+                category_ids = [cat.id for cat in categories]
                 self.fields["category"].queryset = ContentSkillCategory.objects.filter(
-                    id__in=categories
+                    id__in=category_ids
                 )
             elif "secondary" in skill_type:
                 categories = fighter.get_secondary_skill_categories()
-                # Convert set to queryset
+                # Convert set of model instances to list of IDs
+                category_ids = [cat.id for cat in categories]
                 self.fields["category"].queryset = ContentSkillCategory.objects.filter(
-                    id__in=categories
+                    id__in=category_ids
                 )
             else:
                 # For "any" skill type, show all categories


### PR DESCRIPTION
Fixes #802

The SkillCategorySelectionForm was passing ContentSkillCategory model instances directly to filter(id__in=categories), causing Django to convert them to their string representations instead of using their UUIDs. This resulted in the ValidationError: "Savant" is not a valid UUID.

Fixed by extracting the IDs from the model instances before passing to the filter.

Generated with [Claude Code](https://claude.ai/code)