### PR TITLE
fix: Show 'None' for empty vehicle upgrade slots on fighter cards

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -147,6 +147,9 @@
                                         {% if not assign.has_total_cost_override %}
                                             {% if assign.active_upgrade_cost_int != 0 %}({{ assign.active_upgrade_cost_display }}){% endif %}
                                         {% endif %}
+                                    {% elif assign.upgrades_display|length > 0 and list.owner_cached != user %}
+                                        <br>
+                                        <i class="bi-dash"></i> <i class="bi-arrow-up-circle"></i> {{ assign.equipment.upgrade_stack_name }}: <span class="text-muted fst-italic">None</span>
                                     {% endif %}
                                 </td>
                             </tr>

--- a/gyrinx/core/templates/core/includes/list_fighter_weapon_rows.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapon_rows.html
@@ -123,4 +123,13 @@
             {% endif %}
         </td>
     </tr>
+{% elif assign.upgrades_display|length > 0 and mode != 'add' and mode != 'edit' %}
+    <tr>
+        <td colspan="9">
+            <i class="bi-dash"></i>
+            <i class="bi-arrow-up-circle"></i>
+            {{ assign.equipment.upgrade_stack_name }}:
+            <span class="text-muted fst-italic">None</span>
+        </td>
+    </tr>
 {% endif %}


### PR DESCRIPTION
When equipment (including vehicles) has available upgrades but none are selected, non-owning users now see 'None' in italics, consistent with other empty sections on fighter cards.

Fixes #807

Generated with [Claude Code](https://claude.ai/code)