### PR TITLE
fix: Show 'None' for empty house additional and category restricted gear lines

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -156,6 +156,8 @@
                                     {% include "core/includes/gear_assign_name.html" with assign=assign forloop=forloop %}
                                     {% if assign.cost_int != 0 %}<span>&nbsp;({{ assign.cost_display }})</span>{% endif %}
                                     {% if not forloop.last %}<span>,&nbsp;</span>{% endif %}
+                                {% empty %}
+                                    {% if not can_edit %}<span class="text-muted fst-italic">None</span>{% endif %}
                                 {% endfor %}
                             {% endspaceless %}
                             {% if not print %}
@@ -186,6 +188,8 @@
                                     {% include "core/includes/gear_assign_name.html" with assign=assign forloop=forloop %}
                                     {% if assign.cost_int != 0 %}<span>&nbsp;({{ assign.cost_display }})</span>{% endif %}
                                     {% if not forloop.last %}<span>,&nbsp;</span>{% endif %}
+                                {% empty %}
+                                    {% if not can_edit %}<span class="text-muted fst-italic">None</span>{% endif %}
                                 {% endfor %}
                             {% endspaceless %}
                             {% if not print %}

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -106,6 +106,8 @@
                                                 {% if assign.cost_int != 0 %}<span>&nbsp;({{ assign.cost_display }})</span>{% endif %}
                                                 {% if not forloop.last %}<span>,</span>{% endif %}
                                             {% endspaceless %}
+                                        {% empty %}
+                                            {% if list.owner_cached != user or print %}<span class="text-muted fst-italic">None</span>{% endif %}
                                         {% endfor %}
                                         {% if list.owner_cached == user and not print %}
                                             {% if line.assignments|length > 0 %}
@@ -197,6 +199,8 @@
                                                 {% if assign.cost_int != 0 %}<span>&nbsp;({{ assign.cost_display }})</span>{% endif %}
                                                 {% if not forloop.last %}<span>,</span>{% endif %}
                                             {% endspaceless %}
+                                        {% empty %}
+                                            {% if list.owner_cached != user or print %}<span class="text-muted fst-italic">None</span>{% endif %}
                                         {% endfor %}
                                         {% if list.owner_cached == user and not print %}
                                             {% if line.assignments|length > 0 %}


### PR DESCRIPTION
When equipment sections for house_additional_gearline_display and category_restricted_gearline_display are empty, non-owning users now see 'None' in italics, consistent with other empty sections on fighter cards.

Fixes #807

Generated with [Claude Code](https://claude.ai/code)