### PR TITLE
fix: Add transaction handling to copy_selected_to_fighter admin action

### DIFF
--- a/gyrinx/content/actions.py
+++ b/gyrinx/content/actions.py
@@ -14,11 +14,12 @@ def copy_selected_to_fighter(self, request, queryset):
 
     if request.POST.get("post"):
         try:
-            for fighter_id in request.POST.getlist("to_fighters"):
-                for item in queryset:
-                    item.pk = None
-                    item.fighter_id = fighter_id
-                    item.save()
+            with transaction.atomic():
+                for fighter_id in request.POST.getlist("to_fighters"):
+                    for item in queryset:
+                        item.pk = None
+                        item.fighter_id = fighter_id
+                        item.save()
         except Exception as e:
             self.message_user(
                 request,


### PR DESCRIPTION
Fixes #816

## Summary
Add transaction handling to `copy_selected_to_fighter` admin action to ensure atomicity and prevent partial data copies if an error occurs during the operation.

## Changes
- Wrapped the copy operation in `transaction.atomic()` to ensure all-or-nothing behavior
- Matches the existing pattern used in `copy_selected_to_house` function

## Testing
- All 756 tests pass successfully
- Code formatted with `./scripts/fmt.sh`

Generated with [Claude Code](https://claude.ai/code)