### PR TITLE
fix: use equipment_list_fighter house for injury filtering

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -530,7 +530,7 @@ class AddInjuryForm(forms.Form):
         # Filter injuries based on fighter category if fighter is provided
         if fighter:
             fighter_category = fighter.content_fighter.category
-            fighter_house = fighter.list.content_house
+            fighter_house = fighter.equipment_list_fighter.house
 
             # Build query for injury groups available to this fighter
             # Start with groups that have no category restrictions or include this category


### PR DESCRIPTION
Fixes #824

## Summary

Fixed AddInjuryForm to use the fighter's `equipment_list_fighter` house instead of the list house when filtering available injuries. This ensures correct house is used when applying injuries, especially when there is a legacy fighter.

## Changes

- Updated `AddInjuryForm` to use `fighter.equipment_list_fighter.house` for injury filtering
- Added comprehensive test case to verify the fix works correctly

## Test Plan

- ✅ Run `pytest gyrinx/core/tests/test_injury_forms.py` - all tests pass
- ✅ Specifically test `test_add_injury_form_uses_equipment_list_fighter_house` which verifies:
  - Fighters with legacy use the legacy fighter's house for injury filtering
  - Fighters without legacy use their normal house

🤖 Generated with [Claude Code](https://claude.ai/code)