### PR TITLE
fix: use @cached_property for Battle.name to avoid repeated DB queries

### DIFF
--- a/gyrinx/core/models/battle.py
+++ b/gyrinx/core/models/battle.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.db import models
+from django.utils.functional import cached_property
 from simple_history.models import HistoricalRecords
 
 from gyrinx.core.models.base import AppBase
@@ -49,7 +50,7 @@ class Battle(AppBase):
     def __str__(self):
         return self.name
 
-    @property
+    @cached_property
     def name(self):
         """Computed name for the battle."""
         battle_number = (


### PR DESCRIPTION
The Battle model's name property was performing multiple database queries every time it was accessed. By using Django's @cached_property decorator, the value is now computed once and cached for the lifetime of the instance, significantly improving performance on pages that display battle names.

Fixes #829

Generated with [Claude Code](https://claude.ai/code)