### PR TITLE
feat: add upgrade support for gear items

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -213,6 +213,7 @@
                             {% for assign in fighter.wargear %}
                                 {% comment %} All this faff to avoid spaces {% endcomment %}
                                 <span>{{ assign.name }}</span>
+                                {% include "core/includes/gear_upgrades_display.html" with assign=assign %}
                                 {% if assign.cost_int != 0 %}<span>&nbsp;({{ assign.cost_display }})</span>{% endif %}
                                 {% if not forloop.last %}<span>,&nbsp;</span>{% endif %}
                             {% endfor %}
@@ -297,6 +298,7 @@
                             {% for assign in fighter.wargear %}
                                 {% comment %} All this faff to avoid spaces {% endcomment %}
                                 <span>{{ assign.name }}</span>
+                                {% include "core/includes/gear_upgrades_display.html" with assign=assign %}
                                 {% if assign.cost_int != 0 %}<span>&nbsp;({{ assign.cost_display }})</span>{% endif %}
                                 {% if not forloop.last %}<span>,</span>{% endif %}
                             {% endfor %}

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -59,17 +59,7 @@
                                             {% if assign.cost_int != 0 %}({{ assign.cost_display }}){% endif %}
                                             {% if list.owner_cached == user and not print %}
                                                 {% if assign.kind == 'assigned' and not assign.is_linked %}
-                                                    <br>
-                                                    {% if not assign.is_from_default_assignment %}
-                                                        <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
-                                                           class="link-secondary">Edit</a>
-                                                        <span class="text-muted">·</span>
-                                                    {% endif %}
-                                                    <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
-                                                       class="link-secondary">Reassign</a>
-                                                    <span class="text-muted">·</span>
-                                                    <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Delete</a>
+                                                    {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
@@ -152,17 +142,7 @@
                                             {% if assign.cost_int != 0 %}({{ assign.cost_display }}){% endif %}
                                             {% if list.owner_cached == user and not print %}
                                                 {% if assign.kind == 'assigned' and not assign.is_linked %}
-                                                    <br>
-                                                    {% if not assign.is_from_default_assignment %}
-                                                        <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
-                                                           class="link-secondary">Edit</a>
-                                                        <span class="text-muted">·</span>
-                                                    {% endif %}
-                                                    <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
-                                                       class="link-secondary">Reassign</a>
-                                                    <span class="text-muted">·</span>
-                                                    <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Delete</a>
+                                                    {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
@@ -246,28 +226,13 @@
                                                   title="This gear is assigned via the {{ assign.linked_parent.name }} and cannot be removed directly.">
                                             {% endif %}
                                             {{ assign.name }}
-                                            {% for up in assign.active_upgrades_display %}({{ up.name }}){% endfor %}
+                                            {% include "core/includes/gear_upgrades_display.html" with assign=assign %}
                                             {% if assign.is_from_default_assignment or assign.kind == "default" %}</span>{% endif %}
                                         {% if assign.is_linked %}</span>{% endif %}
                                     {% if assign.cost_int != 0 %}({{ assign.cost_display }}){% endif %}
                                     {% if list.owner_cached == user and not print %}
                                         {% if assign.kind == 'assigned' and not assign.is_linked %}
-                                            <br>
-                                            {% if not assign.is_from_default_assignment %}
-                                                <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
-                                                   class="link-secondary">Edit</a>
-                                                <span class="text-muted">·</span>
-                                            {% endif %}
-                                            <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
-                                               class="link-secondary">Reassign</a>
-                                            <span class="text-muted">·</span>
-                                            <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
-                                               class="link-danger">Delete</a>
-                                            {% if fighter.is_stash %}
-                                                <span class="text-muted">·</span>
-                                                <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
-                                                   class="link-warning">Sell</a>
-                                            {% endif %}
+                                            {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                         {% elif assign.kind == 'default' %}
                                             <br>
                                             <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
@@ -286,6 +251,7 @@
                                     {% for assign in fighter.wargear %}
                                         {% comment %} All this faff to avoid spaces {% endcomment %}
                                         <span>{{ assign.name }}</span>
+                                        {% include "core/includes/gear_upgrades_display.html" with assign=assign %}
                                         {% if assign.cost_int != 0 %}<span>&nbsp;({{ assign.cost_display }})</span>{% endif %}
                                         {% if not forloop.last %}<span>,</span>{% endif %}
                                     {% endfor %}

--- a/gyrinx/core/templates/core/includes/fighter_card_gear_menu.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear_menu.html
@@ -1,0 +1,24 @@
+{% load custom_tags %}
+<br>
+{% if not assign.is_from_default_assignment %}
+    <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
+       class="link-secondary">Edit</a>
+    <span class="text-muted">·</span>
+{% endif %}
+{% if assign.upgrades_display|length > 0 %}
+    <a href="{% url 'core:list-fighter-gear-upgrade-edit' list.id fighter.id assign.id %}"
+       class="link-secondary">
+        <i class="bi-arrow-90deg-up text-secondary me-2"></i>{{ assign.equipment.upgrade_stack_name }}
+    </a>
+    <span class="text-muted">·</span>
+{% endif %}
+<a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
+   class="link-secondary">Reassign</a>
+<span class="text-muted">·</span>
+<a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
+   class="link-danger">Delete</a>
+{% if fighter.is_stash %}
+    <span class="text-muted">·</span>
+    <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
+       class="link-warning">Sell</a>
+{% endif %}

--- a/gyrinx/core/templates/core/includes/gear_upgrades_display.html
+++ b/gyrinx/core/templates/core/includes/gear_upgrades_display.html
@@ -1,0 +1,7 @@
+{% if assign.active_upgrades_display %}
+    {% for up in assign.active_upgrades_display %}
+        <span class="text-nowrap">
+            <i class="bi-arrow-up-circle text-secondary"></i> {{ assign.equipment.upgrade_stack_name }}: {{ up.name }}
+        </span>
+    {% endfor %}
+{% endif %}

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -152,6 +152,15 @@ urlpatterns = [
         name="list-fighter-equipment-sell",
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/gear/<assign_id>/upgrade",
+        list.edit_list_fighter_weapon_upgrade,
+        name="list-fighter-gear-upgrade-edit",
+        kwargs=dict(
+            back_name="core:list-fighter-gear-edit",
+            action_name="core:list-fighter-gear-upgrade-edit",
+        ),
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/gear/<assign_id>/upgrade/<upgrade_id>/delete",
         list.delete_list_fighter_gear_upgrade,
         name="list-fighter-gear-upgrade-delete",

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2759,9 +2759,7 @@ def edit_list_fighter_weapon_upgrade(
         )
         if form.is_valid():
             form.save()
-            return HttpResponseRedirect(
-                reverse("core:list-fighter-weapons-edit", args=(lst.id, fighter.id))
-            )
+            return HttpResponseRedirect(reverse(back_name, args=(lst.id, fighter.id)))
     else:
         form = ListFighterEquipmentAssignmentUpgradeForm(instance=assignment)
 


### PR DESCRIPTION
Fixes #467

## Summary

This PR adds support for gear upgrades, making them visible and editable like weapon upgrades.

## Changes

- Created gear menu template similar to weapon menu with upgrade option
- Added URL route for gear upgrade editing
- Updated fighter card templates to consistently display gear upgrades
- Created shared template for displaying upgrades with icon
- Modified weapon upgrade view to use configurable back_name parameter

## Testing

- Code has been formatted using `./scripts/fmt.sh`
- All pre-commit hooks pass

Generated with [Claude Code](https://claude.ai/code)