### PR TITLE
fix: optimize Equipment List Extensions system for better performance

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -3629,6 +3629,15 @@ class ListAttributeAssignment(Base, Archived):
 
     history = HistoricalRecords()
 
+    def delete(self, *args, **kwargs):
+        """Clear expansion caches when list attributes are deleted."""
+        super().delete(*args, **kwargs)
+        # Invalidate expansion caches
+        import time
+        from django.core.cache import cache
+
+        cache.set("expansion_cache_version", time.time(), None)
+
     class Meta:
         verbose_name = "List Attribute Assignment"
         verbose_name_plural = "List Attribute Assignments"
@@ -3658,9 +3667,14 @@ class ListAttributeAssignment(Base, Archived):
                     )
 
     def save(self, *args, **kwargs):
-        """Override save to call full_clean() for validation."""
+        """Override save to call full_clean() for validation and clear expansion caches."""
         self.full_clean()
         super().save(*args, **kwargs)
+        # Invalidate expansion caches since attributes affect expansion rules
+        import time
+        from django.core.cache import cache
+
+        cache.set("expansion_cache_version", time.time(), None)
 
 
 class CapturedFighter(AppBase):


### PR DESCRIPTION
Fixes #873

## Summary

- Added caching to expansion rule evaluations to avoid recomputing for every equipment item
- Introduced optimized query method using JOINs instead of subqueries for better database performance
- Implemented cache invalidation when expansions, items, or list attributes change
- Reduced N+1 query problems by prefetching related data and using bulk operations
- Added cache versioning to ensure clean cache invalidation

The changes significantly reduce the number of database queries and Python computations when loading the list view with equipment extensions enabled.

## Test Plan

- [ ] Verify list view loads faster with extensions enabled
- [ ] Test that expansion rules still apply correctly
- [ ] Confirm equipment costs are calculated correctly
- [ ] Test cache invalidation when modifying expansions
- [ ] Verify no regressions in equipment selection

Generated with [Claude Code](https://claude.ai/code)