### PR TITLE
perf: optimize list views with cached properties and reduced queries

### DIFF
--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -697,7 +697,7 @@ class ContentEquipment(FighterCostMixin, Content):
         """
         if hasattr(self, "has_weapon_profiles"):
             return self.has_weapon_profiles
-        return ContentWeaponProfile.objects.filter(equipment=self).exists()
+        return self.contentweaponprofile_set.exists()
 
     @cached_property
     def is_weapon_cached(self):

--- a/gyrinx/core/templates/core/campaign/campaign_actions.html
+++ b/gyrinx/core/templates/core/campaign/campaign_actions.html
@@ -61,7 +61,7 @@
                                     <option value="{{ list.id }}"
                                             {% if request.GET.gang == list.id|stringformat:"s" %}selected{% endif %}>
                                         {{ list.name }}
-                                        {% if list.content_house %}({{ list.content_house.name }}){% endif %}
+                                        {% if list.content_house %}({{ list.content_house_name }}){% endif %}
                                         - {{ list.owner.username }}
                                     </option>
                                 {% endfor %}

--- a/gyrinx/core/templates/core/campaign/campaign_add_lists.html
+++ b/gyrinx/core/templates/core/campaign/campaign_add_lists.html
@@ -124,7 +124,7 @@
                                     <div class="col">
                                         <h6 class="mb-1">
                                             <strong>{% list_with_theme list %}</strong>
-                                            {% if list.content_house %}• {{ list.content_house.name }}{% endif %}
+                                            {% if list.content_house %}• {{ list.content_house_name }}{% endif %}
                                         </h6>
                                         <p class="mb-0 text-muted small">
                                             {% if list.owner == request.user %}

--- a/gyrinx/core/templates/core/campaign/includes/list_row.html
+++ b/gyrinx/core/templates/core/campaign/includes/list_row.html
@@ -1,7 +1,7 @@
 {% load allauth custom_tags color_tags %}
 <h6 class="mb-1">
     <strong>{% list_with_theme list %}</strong>
-    {% if list.content_house %}• {{ list.content_house.name }}{% endif %}
+    {% if list.content_house %}• {{ list.content_house_name }}{% endif %}
 </h6>
 <p class="mb-0 text-muted small">
     <i class="bi-person"></i> {{ list.owner.username }}

--- a/gyrinx/core/templates/core/includes/fighter_card_content.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content.html
@@ -54,7 +54,7 @@
                 <div class="hstack gap-2">
                     <div>
                         {% if not print %}
-                            {% ref list.content_house.name fighter.content_fighter_cached.type value=fighter.content_fighter_cached.type %}
+                            {% ref list.content_house_name fighter.content_fighter_cached.type value=fighter.content_fighter_cached.type %}
                             {% if fighter.category_override %}
                                 (<span class="tooltipped"
       data-bs-toggle="tooltip"

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -15,7 +15,7 @@
             <div class="d-flex flex-column flex-md-row flex-grow-1 align-items-start align-items-md-center gap-2">
                 <h2 class="mb-0">{% list_with_theme list %}</h2>
                 <div class="ms-md-auto">
-                    {{ list.content_house.name }}
+                    {{ list.content_house_name }}
                     {% if list.is_campaign_mode %}<span class="badge bg-success">In Campaign</span>{% endif %}
                 </div>
                 <div class="h5 mb-0">
@@ -262,24 +262,6 @@
                     {% endif %}
                 </div>
             {% endif %}
-        {% else %}
-            {% for fighter in list.fighters_cached %}
-                {% if fighter.is_stash %}
-                    {% include "core/includes/fighter_card_stash.html" with fighter=fighter list=list print=print %}
-                {% else %}
-                    {% include "core/includes/fighter_card.html" with fighter=fighter list=list print=print %}
-                {% endif %}
-            {% empty %}
-                <div class="g-col-12 py-2 hstack gap-2 align-items-center">
-                    This List is empty.
-                    {% if not print and list.owner_cached == user and not list.archived %}
-                        <a href="{% url 'core:list-fighter-new' list.id %}"
-                           class="btn btn-primary"><i class="bi-person-add"></i> Add a fighter</a>
-                        <a href="{% url 'core:list-vehicle-new' list.id %}"
-                           class="btn btn-primary"><i class="bi-truck"></i> Add a vehicle</a>
-                    {% endif %}
-                </div>
-            {% endfor %}
         {% endif %}
     </div>
     <div class="offcanvas offcanvas-end"
@@ -302,7 +284,7 @@
                 <p>
                     Add <code>?theme=light</code> or <code>?theme=dark</code> to the URL to force a particular theme.
                 </p>
-                {% for fighter in list.fighters_cached %}
+                {% for fighter in fighters_minimal %}
                     <li class="list-group-item vstack gap-2">
                         <h3 class="h6 mb-0">{{ fighter.name }}</h3>
                         {% url 'core:list-fighter-embed' list.id fighter.id as embed_url %}

--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -2,7 +2,7 @@
 <div>
     <div class="vstack gap-1 mb-2">
         <h2>{{ list.name }}</h2>
-        <div>{{ list.content_house.name }}</div>
+        <div>{{ list.content_house_name }}</div>
         <div class="text-secondary">
             <i class="bi-person"></i> {{ list.owner_cached }}
         </div>

--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -7,12 +7,12 @@
         {% if attributes %}
             <table class="table table-sm mb-0 fs-7">
                 <tbody>
-                    {% for attribute, assignments in attributes.items %}
+                    {% for attribute in attributes %}
                         <tr>
                             <td>{{ attribute.name }}</td>
                             <td>
-                                {% if assignments %}
-                                    {{ assignments|join:", " }}
+                                {% if attribute.assignments %}
+                                    {{ attribute.assignments|join:", " }}
                                 {% else %}
                                     <span class="text-muted">Not set</span>
                                 {% endif %}
@@ -22,9 +22,9 @@
                                     {% if list.owner_cached == user and not list.archived %}
                                         <a href="{% url 'core:list-attribute-edit' list.id attribute.id %}"
                                            class="icon-link link-secondary link-sm">
-                                            <i class="bi-{% if assignments %}pencil{% else %}plus{% endif %}"
+                                            <i class="bi-{% if attribute.assignments %}pencil{% else %}plus{% endif %}"
                                                aria-hidden="true"></i>
-                                            {% if assignments %}
+                                            {% if attribute.assignments %}
                                                 Edit
                                             {% else %}
                                                 Add

--- a/gyrinx/core/templates/core/index.html
+++ b/gyrinx/core/templates/core/index.html
@@ -151,7 +151,7 @@
                                             <a href="{% url 'core:list' list.id %}">{% list_with_theme list %}</a>
                                         </h3>
                                         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
-                                            <div>{{ list.content_house.name }}</div>
+                                            <div>{{ list.content_house_name }}</div>
                                             <div class="badge text-bg-primary">{{ list.cost_display }}</div>
                                         </div>
                                         {% load tz %}

--- a/gyrinx/core/templates/core/list_print.html
+++ b/gyrinx/core/templates/core/list_print.html
@@ -1,7 +1,7 @@
 {% extends "core/layouts/base_print.html" %}
 {% load allauth custom_tags %}
 {% block head_title %}
-    {{ list.name }} | {{ list.content_house.name }}
+    {{ list.name }} | {{ list.content_house_name }}
 {% endblock head_title %}
 {% block content %}
     <div id="content" class="p-2">

--- a/gyrinx/core/templates/core/lists.html
+++ b/gyrinx/core/templates/core/lists.html
@@ -29,7 +29,7 @@
                             </div>
                         </div>
                         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
-                            <div>{{ list.content_house.name }}</div>
+                            <div>{{ list.content_house_name }}</div>
                             <div class="badge text-bg-primary">{{ list.cost_int_display }}</div>
                             {% if list.status == list.CAMPAIGN_MODE %}
                                 <div class="badge text-bg-success">

--- a/gyrinx/core/templates/core/user.html
+++ b/gyrinx/core/templates/core/user.html
@@ -38,7 +38,7 @@
                             </div>
                         </div>
                         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
-                            <div>{{ list.content_house.name }}</div>
+                            <div>{{ list.content_house_name }}</div>
                             <div class="badge text-bg-primary">{{ list.cost_int_cached }}</div>
                         </div>
                     </div>


### PR DESCRIPTION
- Add cached properties to List model for frequently accessed data (content_house_name, fighters_minimal_cached)
- Optimize ListFighterQuerySet with comprehensive prefetching to reduce N+1 queries
- Add ListQuerySet.with_related_data() for optimized list fetching
- Replace object access with cached properties in templates to avoid repeated queries
- Refactor get_list_attributes() to use values() queries instead of object access
- Use prefetched data in ListDetailView to minimize database hits

🤖 Generated with [Claude Code](https://claude.ai/code)