### PR TITLE
fix: remove sign-out button from base layout

### DIFF
--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -104,7 +104,6 @@
                             <i class="bi-gear"></i>
                             {{ user.username }}
                         </a>
-                        <a href="{% url 'account_logout' %}" class="btn btn-danger">Sign Out</a>
                     {% else %}
                         <a href="{% url 'account_login' %}" class="btn btn-outline-light">Sign In</a>
                         {% url 'account_signup' as signup_url_ %}


### PR DESCRIPTION
Fixes #878

## Summary
Removes the sign-out button from the base layout so it no longer appears on every screen.

Users can still sign out from their account settings page.

Generated with [Claude Code](https://claude.ai/code)