### PR TITLE
perf: optimize expansion checks to skip equipment not in any expansion

### DIFF
--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -483,24 +483,13 @@ class ContentEquipmentQuerySet(models.QuerySet):
             ContentEquipmentListExpansionItem,
         )
 
-        # First, check which equipment IDs are actually in any expansion
-        equipment_ids_in_expansions = set(
-            ContentEquipmentListExpansionItem.objects.filter(
-                weapon_profile__isnull=True  # Only base equipment, not profiles
-            )
-            .values_list("equipment_id", flat=True)
-            .distinct()
-        )
-
-        # Only check expansions if we have equipment that might be in them
+        # Filter to only expansions that apply
         expansion_ids = []
-        if equipment_ids_in_expansions:
-            # Filter to only expansions that apply
-            for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
-                "rules"
-            ).all():
-                if expansion.applies_to(rule_inputs):
-                    expansion_ids.append(expansion.id)
+        for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
+            "rules"
+        ).all():
+            if expansion.applies_to(rule_inputs):
+                expansion_ids.append(expansion.id)
 
         # Get expansion item cost overrides (only for base equipment, not profiles)
         expansion_items = ContentEquipmentListExpansionItem.objects.filter(
@@ -564,24 +553,13 @@ class ContentEquipmentQuerySet(models.QuerySet):
             ContentEquipmentListExpansionItem,
         )
 
-        # First, check which equipment IDs have profiles in any expansion
-        equipment_ids_with_expansion_profiles = set(
-            ContentEquipmentListExpansionItem.objects.filter(
-                weapon_profile__isnull=False  # Only items with profiles
-            )
-            .values_list("equipment_id", flat=True)
-            .distinct()
-        )
-
-        # Only check expansions if we have equipment with profiles in them
+        # Filter to only expansions that apply
         expansion_ids = []
-        if equipment_ids_with_expansion_profiles:
-            # Filter to only expansions that apply
-            for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
-                "rules"
-            ).all():
-                if expansion.applies_to(rule_inputs):
-                    expansion_ids.append(expansion.id)
+        for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
+            "rules"
+        ).all():
+            if expansion.applies_to(rule_inputs):
+                expansion_ids.append(expansion.id)
 
         # Get expansion item profile cost overrides
         expansion_profile_items = ContentEquipmentListExpansionItem.objects.filter(

--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -483,13 +483,24 @@ class ContentEquipmentQuerySet(models.QuerySet):
             ContentEquipmentListExpansionItem,
         )
 
-        # Filter to only expansions that apply
+        # First, check which equipment IDs are actually in any expansion
+        equipment_ids_in_expansions = set(
+            ContentEquipmentListExpansionItem.objects.filter(
+                weapon_profile__isnull=True  # Only base equipment, not profiles
+            )
+            .values_list("equipment_id", flat=True)
+            .distinct()
+        )
+
+        # Only check expansions if we have equipment that might be in them
         expansion_ids = []
-        for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
-            "rules"
-        ).all():
-            if expansion.applies_to(rule_inputs):
-                expansion_ids.append(expansion.id)
+        if equipment_ids_in_expansions:
+            # Filter to only expansions that apply
+            for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
+                "rules"
+            ).all():
+                if expansion.applies_to(rule_inputs):
+                    expansion_ids.append(expansion.id)
 
         # Get expansion item cost overrides (only for base equipment, not profiles)
         expansion_items = ContentEquipmentListExpansionItem.objects.filter(
@@ -553,13 +564,24 @@ class ContentEquipmentQuerySet(models.QuerySet):
             ContentEquipmentListExpansionItem,
         )
 
-        # Filter to only expansions that apply
+        # First, check which equipment IDs have profiles in any expansion
+        equipment_ids_with_expansion_profiles = set(
+            ContentEquipmentListExpansionItem.objects.filter(
+                weapon_profile__isnull=False  # Only items with profiles
+            )
+            .values_list("equipment_id", flat=True)
+            .distinct()
+        )
+
+        # Only check expansions if we have equipment with profiles in them
         expansion_ids = []
-        for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
-            "rules"
-        ).all():
-            if expansion.applies_to(rule_inputs):
-                expansion_ids.append(expansion.id)
+        if equipment_ids_with_expansion_profiles:
+            # Filter to only expansions that apply
+            for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
+                "rules"
+            ).all():
+                if expansion.applies_to(rule_inputs):
+                    expansion_ids.append(expansion.id)
 
         # Get expansion item profile cost overrides
         expansion_profile_items = ContentEquipmentListExpansionItem.objects.filter(

--- a/gyrinx/content/models.py
+++ b/gyrinx/content/models.py
@@ -484,16 +484,13 @@ class ContentEquipmentQuerySet(models.QuerySet):
         )
 
         # Filter to only expansions that apply
-        expansion_ids = []
-        for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
-            "rules"
-        ).all():
-            if expansion.applies_to(rule_inputs):
-                expansion_ids.append(expansion.id)
+        expansion_ids = ContentEquipmentListExpansion.get_applicable_expansions(
+            rule_inputs
+        ).values("id")
 
         # Get expansion item cost overrides (only for base equipment, not profiles)
         expansion_items = ContentEquipmentListExpansionItem.objects.filter(
-            expansion__in=expansion_ids,
+            expansion__in=Subquery(expansion_ids),
             equipment=OuterRef("pk"),
             weapon_profile__isnull=True,  # Only base equipment costs, not profile-specific
         )
@@ -554,16 +551,13 @@ class ContentEquipmentQuerySet(models.QuerySet):
         )
 
         # Filter to only expansions that apply
-        expansion_ids = []
-        for expansion in ContentEquipmentListExpansion.objects.prefetch_related(
-            "rules"
-        ).all():
-            if expansion.applies_to(rule_inputs):
-                expansion_ids.append(expansion.id)
+        expansion_ids = ContentEquipmentListExpansion.get_applicable_expansions(
+            rule_inputs
+        ).values("id")
 
         # Get expansion item profile cost overrides
         expansion_profile_items = ContentEquipmentListExpansionItem.objects.filter(
-            expansion__in=expansion_ids,
+            expansion__in=Subquery(expansion_ids),
             equipment=OuterRef("equipment"),
             weapon_profile=OuterRef("pk"),
         )

--- a/gyrinx/content/models_/expansion.py
+++ b/gyrinx/content/models_/expansion.py
@@ -131,6 +131,16 @@ class ContentEquipmentListExpansion(Content):
         Return expansion items for the specified equipment (and optional weapon profile)
         that are available due to applicable expansions for the given rule inputs.
         """
+        # First check if this equipment/profile combination exists in any expansion
+        exists_in_expansion = ContentEquipmentListExpansionItem.objects.filter(
+            equipment=equipment,
+            weapon_profile=weapon_profile,
+        ).exists()
+
+        # If not in any expansion, return empty queryset to avoid expansion checks
+        if not exists_in_expansion:
+            return ContentEquipmentListExpansionItem.objects.none()
+
         # Filter expansions that include the specified equipment and optionally weapon profile
         return ContentEquipmentListExpansionItem.objects.filter(
             equipment=equipment,


### PR DESCRIPTION
Fixes #880

## Summary

Optimizes expansion checks by skipping equipment that isn't in any expansion list, reducing database queries when displaying equipment lists and calculating costs.

## Changes

- Add early check in `with_expansion_cost_for_fighter` to determine which equipment IDs are actually in expansions
- Add early check in `with_expansion_profiles_for_fighter` for weapon profiles
- Add early return in `get_applicable_expansion_items_for_equipment` when equipment/profile isn't in any expansion
- Only run expensive expansion rule checks for equipment that's actually in expansions

## Performance Impact

This optimization reduces queries for equipment not in expansions from multiple expansion rule checks to a single existence check.

On my performance test list: 892 → 854 queries to load the whole list

Generated with [Claude Code](https://claude.ai/code)