### PR TITLE
fix: update category override help text to include special rules

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -218,7 +218,7 @@ class ListFighterForm(forms.ModelForm):
         help_texts = {
             "name": "The name you use to identify this {term_singular}. This may be public.",
             "legacy_content_fighter": "The Gang Legacy for this fighter.",
-            "category_override": "Override the {term_singular}'s category without changing their type.",
+            "category_override": "Override the {term_singular}'s category without changing their type or special rules.",
             "cost_override": "Only change this if you want to override the default base cost of the {term_singular}.",
         }
         widgets = {


### PR DESCRIPTION
Updated the help text for the category_override field on the add fighter page to clarify that it doesn't change the fighter's type or special rules.

Fixes #891

Generated with [Claude Code](https://claude.ai/code)