### PR TITLE
Fixup CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Before contributing, read our [Code of Conduct](./CODE-OF-CONDUCT.md) — by joi
 #### **Did you find a bug?**
 
 - **Do not open up a GitHub issue if the bug is a security vulnerability
-  in Gyrinx**, and instead [email hello@gyrinx.app](mailto:hello@gyrinx.app).
+  in Gyrinx**, and instead [email hello@gyrinx.app](mailto:hello@gyrinx.app) or submit a [Security Advisory](https://github.com/gyrinx-app/gyrinx/security/advisories/new).
 
 - **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/gyrinx-app/gyrinx/issues).
 
@@ -23,20 +23,22 @@ Before contributing, read our [Code of Conduct](./CODE-OF-CONDUCT.md) — by joi
 
 #### **Did you write a patch that fixes a bug?**
 
-- Open a new GitHub pull request with the patch.
+Thanks for fixing the bug!
 
+- Open a new GitHub pull request with the patch.
 - Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+- Ideally, include tests that cover the change.
 
 #### **Do you intend to add a new feature or change an existing one?**
 
-- Suggest your change in the [#core](https://discord.com/channels/1337524316987985963/1337860878782955590) channel on [our Discord](https://discord.gg/jamrJPYC) and start writing code.
+- Join [our Discord](https://discord.gg/NjMVRSEMAz)
+- Suggest your change in the `💡-ideas` channel
+- Start writing code
 
-- Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
+Ideally, don't open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
 
 #### **Do you have questions about the source code or content?**
 
-- Ask any question about Gyrinx code & internals on the [#core](https://discord.com/channels/1337524316987985963/1337860878782955590) channel.
-
-- For questions about content, head to the [#content](https://discord.com/channels/1337524316987985963/1337526710911897651) channel.
+Ask away on [our Discord](https://discord.gg/NjMVRSEMAz)
 
 Thanks! :heart:


### PR DESCRIPTION
- Use same Discord link as the website
- Improve some wording and remove out-of-date info
- Add link to the security advisory page

Fix #898