### PR TITLE
fix: Cleanup equipment category groups

### DIFF
--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -13,7 +13,7 @@ from polymorphic.admin import (
 
 from gyrinx.content.actions import copy_selected_to_fighter, copy_selected_to_house
 from gyrinx.forms import group_select
-from gyrinx.models import equipment_category_choices
+from gyrinx.models import equipment_category_groups
 
 from .models import (
     ContentAttribute,
@@ -267,7 +267,7 @@ class ContentEquipmentAdminForm(forms.ModelForm):
                         group=group,
                         then=i,
                     )
-                    for i, group in enumerate(equipment_category_choices.keys())
+                    for i, group in enumerate(equipment_category_groups)
                 ],
                 default=99,
             ),

--- a/gyrinx/models.py
+++ b/gyrinx/models.py
@@ -161,81 +161,13 @@ class FighterCategoryChoices(models.TextChoices):
     GANG_TERRAIN = "GANG_TERRAIN", "Gang Terrain"
 
 
-class EquipmentCategoryChoices(models.TextChoices):
-    AMMO = "AMMO", "Ammo"
-    ARMOR = "ARMOR", "Armor"
-    BASIC_WEAPONS = "BASIC_WEAPONS", "Basic Weapons"
-    BIONICS = "BIONICS", "Bionics"
-    BODY_UPGRADES = "BODY_UPGRADES", "Body Upgrades"
-    BOOBY_TRAPS = "BOOBY_TRAPS", "Booby Traps"
-    CHEM_ALCHEMY_ELIXIRS = "CHEM_ALCHEMY_ELIXIRS", "Chem-alchemy Elixirs"
-    CHEMS = "CHEMS", "Chems"
-    CLOSE_COMBAT = "CLOSE_COMBAT", "Close Combat Weapons"
-    CYBERTEKNIKA = "CYBERTEKNIKA", "Cyberteknika"
-    DRIVE_UPGRADES = "DRIVE_UPGRADES", "Drive Upgrades"
-    ENGINE_UPGRADES = "ENGINE_UPGRADES", "Engine Upgrades"
-    EQUIPMENT = "EQUIPMENT", "Personal Equipment"
-    FIELD_ARMOUR = "FIELD_ARMOUR", "Field Armour"
-    GANG_EQUIPMENT = "GANG_EQUIPMENT", "Gang Equipment"
-    GANG_TERRAIN = "GANG_TERRAIN", "Gang Terrain"
-    GENE_SMITHING = "GENE_SMITHING", "Gene-smithing"
-    GRENADES = "GRENADES", "Grenades"
-    HARDPOINT_UPGRADES = "HARDPOINT_UPGRADES", "Hardpoint Upgrades"
-    HEAVY_WEAPONS = "HEAVY_WEAPONS", "Heavy Weapons"
-    MOUNTS = "MOUNTS", "Mounts"
-    OPTIONS = "OPTIONS", "Options"
-    PISTOLS = "PISTOLS", "Pistols"
-    POWER_PACK_WEAPONS = "POWER_PACK_WEAPONS", "Power Pack Weapons"
-    RELICS = "RELICS", "Relics"
-    SPECIAL_WEAPONS = "SPECIAL_WEAPONS", "Special Weapons"
-    STATUS_ITEMS = "STATUS_ITEMS", "Status Items"
-    VEHICLE_EQUIPMENT = "VEHICLE_EQUIPMENT", "Vehicle Wargear"
-    VEHICLES = "VEHICLES", "Vehicles"
-
-
-equipment_category_choices = {
-    "Gear": {
-        "ARMOR": "Armor",
-        "BIONICS": "Bionics",
-        "BODY_UPGRADES": "Body Upgrades",
-        "BOOBY_TRAPS": "Booby Traps",
-        "CHEM_ALCHEMY_ELIXIRS": "Chem-alchemy Elixirs",
-        "CHEMS": "Chems",
-        "CYBERTEKNIKA": "Cyberteknika",
-        "EQUIPMENT": "Personal Equipment",
-        "FIELD_ARMOUR": "Field Armour",
-        "GANG_EQUIPMENT": "Gang Equipment",
-        "GANG_TERRAIN": "Gang Terrain",
-        "GENE_SMITHING": "Gene-smithing",
-        "RELICS": "Relics",
-        "STATUS_ITEMS": "Status Items",
-    },
-    "Vehicle & Mount": {
-        "DRIVE_UPGRADES": "Drive Upgrades",
-        "ENGINE_UPGRADES": "Engine Upgrades",
-        "HARDPOINT_UPGRADES": "Hardpoint Upgrades",
-        "MOUNTS": "Mounts",
-        "VEHICLE_EQUIPMENT": "Vehicle Wargear",
-        "VEHICLES": "Vehicles",
-    },
-    "Weapons & Ammo": {
-        "AMMO": "Ammo",
-        "BASIC_WEAPONS": "Basic Weapons",
-        "CLOSE_COMBAT": "Close Combat Weapons",
-        "GRENADES": "Grenades",
-        "HEAVY_WEAPONS": "Heavy Weapons",
-        "PISTOLS": "Pistols",
-        "POWER_PACK_WEAPONS": "Power Pack Weapons",
-        "SPECIAL_WEAPONS": "Special Weapons",
-    },
-    "Other": {"OPTIONS": "Options"},
-}
-equipment_category_choices_flat = {
-    key: value
-    for subcategories in equipment_category_choices.values()
-    for key, value in subcategories.items()
-}
-equipment_category_group_choices = [(x, x) for x in equipment_category_choices.keys()]
+equipment_category_groups = [
+    "Gear",
+    "Vehicle & Mount",
+    "Weapons & Ammo",
+    "Other",
+]
+equipment_category_group_choices = [(x, x) for x in equipment_category_groups]
 
 
 T = TypeVar("T")


### PR DESCRIPTION
There was some legacy code hanging around from before we made equipment categories into a Content model. This cleans that up.