### PR TITLE
Small initial print fixes

### DIFF
--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -328,3 +328,9 @@ $em-sizes: (
 .auto-flow-dense {
     grid-auto-flow: row dense;
 }
+
+// Print
+
+.break-inside-avoid {
+    break-inside: avoid;
+}

--- a/gyrinx/core/templates/core/includes/fighter_card_content.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content.html
@@ -15,7 +15,7 @@
     {% firstof classes 'g-col-12 g-col-md-6 g-col-xl-4' as card_classes %}
     {% firstof body_classes 'p-0 p-sm-2' as body_classes_ %}
 {% endif %}
-<div class="card {{ card_classes }} {% flash fighter.id %}"
+<div class="card {{ card_classes }} break-inside-avoid {% flash fighter.id %}"
      id="{{ fighter.id }}">
     <div class="card-header p-2 {% if fighter.is_dead %}bg-danger-subtle{% elif fighter.is_captured or fighter.is_sold_to_guilders %}bg-warning-subtle{% endif %}">
         <div class="vstack gap-1">

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -4,7 +4,8 @@
 {% else %}
     {% firstof classes 'g-col-12 g-col-md-6 g-col-xl-4' as card_classes %}
 {% endif %}
-<div class="card {{ card_classes }}" id="{{ fighter.id }}">
+<div class="card {{ card_classes }} break-inside-avoid"
+     id="{{ fighter.id }}">
     <div class="card-header p-2">
         <div class="vstack gap-1">
             <div class="hstack align-items-center">

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -221,7 +221,7 @@
             {% endif %}
         {% endif %}
         {% if print %}
-            {% firstof 'g-col-12 g-col-xl-6 g-col-lg-6' as inner_grid_layout_classes %}
+            {% firstof 'g-col-12 g-col-xl-6 g-col-lg-8' as inner_grid_layout_classes %}
         {% else %}
             {% firstof 'g-col-12 g-col-xl-8' as inner_grid_layout_classes %}
         {% endif %}
@@ -230,7 +230,7 @@
             {% if fighter_groups %}
                 {% for group in fighter_groups %}
                     {% if group.list|length > 1 %}
-                        <div class="{{ inner_grid_layout_classes }}">
+                        <div class="{{ inner_grid_layout_classes }} break-inside-avoid">
                             <div class="grid h-100 gap-2 gap-md-0 border rounded p-2 bg-secondary-subtle">
                                 {% for fighter in group.list %}
                                     {% if fighter.is_stash %}

--- a/gyrinx/core/templates/core/list_print.html
+++ b/gyrinx/core/templates/core/list_print.html
@@ -7,7 +7,8 @@
     <div id="content" class="p-2">
         <div class="col px-0 vstack gap-5">
             {% include "core/includes/list.html" with list=list print=True print_config=print_config %}
-            <div id="qr" class="card card-body gap-2 align-items-center">
+            <div id="qr"
+                 class="card card-body col-12 col-md-6 col-xl-4 gap-2 mx-auto align-items-center break-inside-avoid">
                 {% url 'core:list-print' list.id as list_url %}
                 {% fullurl list_url as full_list_url %}
                 <div id="qr-code" class="col-4 col-sm-3 col-md-2">{% qr_svg full_list_url %}</div>


### PR DESCRIPTION
- Add break-inside-avoid class to relevant elements
- Improve grouped fighter column widths

This already makes the layout a bit better for printing.

Addresses #919