### PR TITLE
fix: hide Advancements and XP rows in print view

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -51,7 +51,7 @@
             </tr>
         {% endif %}
         {% comment %} XP{% endcomment %}
-        {% if not fighter.is_vehicle %}
+        {% if not fighter.is_vehicle and not print %}
             <tr class="fs-7">
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">XP</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
@@ -248,7 +248,7 @@
             </tr>
         {% endif %}
         {% comment %} Advancements {% endcomment %}
-        {% if not fighter.is_vehicle %}
+        {% if not fighter.is_vehicle and not print %}
             <tr class="fs-7">
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Advancements</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">


### PR DESCRIPTION
Fixes #926

- Added conditional check for 'not print' to both XP and Advancements rows
- Both sections are now hidden in print view and when print=True is passed to sub-templates

Generated with [Claude Code](https://claude.ai/code)