### PR TITLE
feat: add 'Modify from default' option for gear assignments

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -62,6 +62,10 @@
                                                     {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
+                                                    <i class="bi-arrow-90deg-up text-secondary me-2"></i>
+                                                    <a href="{% url 'core:list-fighter-gear-default-convert' list.id fighter.id assign.id %}"
+                                                       class="link-secondary">Modify from default</a>
+                                                    <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
                                                        class="link-danger">Delete</a>
                                                 {% endif %}
@@ -145,6 +149,10 @@
                                                     {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
+                                                    <i class="bi-arrow-90deg-up text-secondary me-2"></i>
+                                                    <a href="{% url 'core:list-fighter-gear-default-convert' list.id fighter.id assign.id %}"
+                                                       class="link-secondary">Modify from default</a>
+                                                    <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
                                                        class="link-danger">Delete</a>
                                                 {% endif %}

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -61,13 +61,7 @@
                                                 {% if assign.kind == 'assigned' and not assign.is_linked %}
                                                     {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                                 {% elif assign.kind == 'default' %}
-                                                    <br>
-                                                    <i class="bi-arrow-90deg-up text-secondary me-2"></i>
-                                                    <a href="{% url 'core:list-fighter-gear-default-convert' list.id fighter.id assign.id %}"
-                                                       class="link-secondary">Modify from default</a>
-                                                    <span class="text-muted">·</span>
-                                                    <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Delete</a>
+                                                    {% include "core/includes/fighter_card_gear_default_menu.html" %}
                                                 {% endif %}
                                             {% endif %}
                                         </td>
@@ -148,13 +142,7 @@
                                                 {% if assign.kind == 'assigned' and not assign.is_linked %}
                                                     {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                                 {% elif assign.kind == 'default' %}
-                                                    <br>
-                                                    <i class="bi-arrow-90deg-up text-secondary me-2"></i>
-                                                    <a href="{% url 'core:list-fighter-gear-default-convert' list.id fighter.id assign.id %}"
-                                                       class="link-secondary">Modify from default</a>
-                                                    <span class="text-muted">·</span>
-                                                    <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
-                                                       class="link-danger">Delete</a>
+                                                    {% include "core/includes/fighter_card_gear_default_menu.html" %}
                                                 {% endif %}
                                             {% endif %}
                                         </td>
@@ -241,9 +229,7 @@
                                         {% if assign.kind == 'assigned' and not assign.is_linked %}
                                             {% include "core/includes/fighter_card_gear_menu.html" with assign=assign %}
                                         {% elif assign.kind == 'default' %}
-                                            <br>
-                                            <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
-                                               class="link-danger">Delete</a>
+                                            {% include "core/includes/fighter_card_gear_default_menu.html" %}
                                         {% endif %}
                                     {% endif %}
                                 </td>

--- a/gyrinx/core/templates/core/includes/fighter_card_gear_default_menu.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear_default_menu.html
@@ -1,0 +1,8 @@
+{% load custom_tags %}
+<br>
+<i class="bi-arrow-90deg-up text-secondary me-1"></i>
+<a href="{% url 'core:list-fighter-gear-default-convert' list.id fighter.id assign.id %}"
+   class="link-secondary">Modify from default</a>
+{% dot %}
+<a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
+   class="link-danger">Delete</a>

--- a/gyrinx/core/templates/core/includes/fighter_card_gear_menu.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear_menu.html
@@ -1,23 +1,23 @@
 {% load custom_tags %}
 <br>
-<i class="bi-arrow-90deg-up text-secondary me-2"></i>
+<i class="bi-arrow-90deg-up text-secondary me-1"></i>
 {% if not assign.is_from_default_assignment %}
     <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
        class="link-secondary">Edit</a>
-    <span class="text-muted">·</span>
+    {% dot %}
 {% endif %}
 {% if assign.upgrades_display|length > 0 %}
     <a href="{% url 'core:list-fighter-gear-upgrade-edit' list.id fighter.id assign.id %}"
        class="link-secondary">{{ assign.equipment.upgrade_stack_name_display }}</a>
-    <span class="text-muted">·</span>
+    {% dot %}
 {% endif %}
 <a href="{% url 'core:list-fighter-gear-reassign' list.id fighter.id assign.id %}"
    class="link-secondary">Reassign</a>
-<span class="text-muted">·</span>
+{% dot %}
 <a href="{% url 'core:list-fighter-gear-delete' list.id fighter.id assign.id %}"
    class="link-danger">Delete</a>
 {% if fighter.is_stash %}
-    <span class="text-muted">·</span>
+    {% dot %}
     <a href="{% url 'core:list-fighter-equipment-sell' list.id fighter.id assign.id %}?assign={{ assign.id }}&sell_assign={{ assign.id }}"
        class="link-warning">Sell</a>
 {% endif %}

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -74,7 +74,7 @@
                                             {% if list.owner_cached == user and not print %}
                                                 {% if assign.kind == 'assigned' and not assign.is_linked %}
                                                     <br>
-                                                    <i class="bi-arrow-90deg-up text-secondary me-2"></i>
+                                                    <i class="bi-arrow-90deg-up text-secondary me-1"></i>
                                                     {% if not assign.is_from_default_assignment %}
                                                         <a href="{% url 'core:list-fighter-gear-cost-edit' list.id fighter.id assign.id %}"
                                                            class="link-secondary">Edit</a>
@@ -92,7 +92,7 @@
                                                        class="link-danger">Delete</a>
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
-                                                    <i class="bi-arrow-90deg-up text-secondary me-2"></i>
+                                                    <i class="bi-arrow-90deg-up text-secondary me-1"></i>
                                                     <a href="{% url 'core:list-fighter-gear-default-convert' list.id fighter.id assign.id %}"
                                                        class="link-secondary">Modify from default</a>
                                                     <span class="text-muted">·</span>

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -92,6 +92,10 @@
                                                        class="link-danger">Delete</a>
                                                 {% elif assign.kind == 'default' %}
                                                     <br>
+                                                    <i class="bi-arrow-90deg-up text-secondary me-2"></i>
+                                                    <a href="{% url 'core:list-fighter-gear-default-convert' list.id fighter.id assign.id %}"
+                                                       class="link-secondary">Modify from default</a>
+                                                    <span class="text-muted">·</span>
                                                     <a href="{% url 'core:list-fighter-gear-default-disable' list.id fighter.id assign.id %}"
                                                        class="link-danger">Delete</a>
                                                 {% endif %}

--- a/gyrinx/core/templates/core/includes/fighter_card_weapon_menu.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_weapon_menu.html
@@ -2,7 +2,7 @@
 <tr>
     <td colspan="9" class="text-end">
         <div class="d-flex flex-wrap">
-            <i class="bi-arrow-90deg-up text-secondary me-2"></i>
+            <i class="bi-arrow-90deg-up text-secondary me-1"></i>
             {% if assign.kind == 'assigned' %}
                 <a href="{% url 'core:list-fighter-weapon-edit' list.id fighter.id assign.id %}"
                    class="link-secondary">Edit</a>

--- a/gyrinx/core/templates/core/includes/list_common_header.html
+++ b/gyrinx/core/templates/core/includes/list_common_header.html
@@ -1,0 +1,13 @@
+{% load allauth custom_tags color_tags %}
+<div class="hstack gap-2 mb-2 align-items-start align-items-md-center break-inside-avoid">
+    <div class="d-flex flex-column flex-md-row flex-grow-1 align-items-start align-items-md-center gap-2">
+        <h2 class="mb-0">{% list_with_theme list %}</h2>
+        <div class="ms-md-auto">{{ list.content_house_name }}</div>
+        <div class="h5 mb-0 btn-group">
+            {% if list.is_campaign_mode %}<div class="btn btn-success">In Campaign</div>{% endif %}
+            <div class="btn btn-secondary">Rating: {{ list.cost_int_cached }}¢</div>
+            <div class="btn btn-secondary">Credits: {{ list.credits_current }}¢</div>
+            <div class="btn btn-secondary">Wealth: {{ list.credits_current|add:list.cost_int_cached }}¢</div>
+        </div>
+    </div>
+</div>

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -196,6 +196,15 @@ urlpatterns = [
         ),
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/gear/<assign_id>/convert",
+        list.convert_list_fighter_default_assign,
+        name="list-fighter-gear-default-convert",
+        kwargs=dict(
+            back_name="core:list-fighter-gear-edit",
+            action_name="core:list-fighter-gear-default-convert",
+        ),
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/weapons/<assign_id>/disable",
         list.disable_list_fighter_default_assign,
         name="list-fighter-weapons-default-disable",


### PR DESCRIPTION
Fixes #932. Fixes #921.

## Summary

Added the missing "Modify from default" menu option for gear assignments to match the functionality that already exists for weapons. This allows users to convert default gear assignments into direct assignments that can be modified.

## Changes

- Added `list-fighter-gear-default-convert` URL pattern
- Updated gear templates to show "Modify from default" link for default assignments
- Uses existing `convert_list_fighter_default_assign` view function

Generated with [Claude Code](https://claude.ai/code)