### PR TITLE
fix: check list.campaign instead of list.is_campaign_mode in common header

### DIFF
--- a/gyrinx/core/templates/core/includes/list_common_header.html
+++ b/gyrinx/core/templates/core/includes/list_common_header.html
@@ -21,7 +21,7 @@
         </div>
         <div class="ms-md-auto fs-7 vstack align-items-start align-items-md-end justify-content-center">
             <div>{{ list.content_house_name }}</div>
-            {% if list.is_campaign_mode %}
+            {% if list.campaign %}
                 <div>
                     {% if print %}
                         <i class="bi-award"></i> {{ list.campaign.name }}


### PR DESCRIPTION
Fixes #949

## Summary

Fixed the issue where lists in campaign mode without an associated campaign would cause a `NoReverseMatch` error when rendering the common header template.

## Changes

- Updated `list_common_header.html` to check `list.campaign` instead of `list.is_campaign_mode`
- Added test case `test_list_with_campaign_mode_but_no_campaign` to prevent regression

The fix ensures that the campaign information is only shown when a list actually has a campaign associated with it, not just when it's in campaign mode status.

Generated with [Claude Code](https://claude.ai/code)