### PR TITLE
fix: hide edit weapons button from non-list owners

### DIFF
--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -20,7 +20,7 @@
         <tr>
             <th scope="col">
                 Weapons
-                {% if not print %}
+                {% if not print and list.owner_cached == user %}
                     {% if mode == "gear" %}
                         <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}{% querystring %}"
                            class="fw-normal">Edit weapons</a>


### PR DESCRIPTION
Fixes #948

## Problem
The "Edit" button next to "Weapons" was visible to all users viewing a list, not just the list owner.

## Solution
Added ownership check (`list.owner_cached == user`) to match the permission pattern used throughout the rest of the template.

Generated with [Claude Code](https://claude.ai/code)