### PR TITLE
fix: hide stash credits edit button for list building campaigns

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -20,7 +20,7 @@
             <div class="hstack gap-3 align-items-center justify-content-between px-1">
                 <h4 class="h6 mb-0">Stash Credits</h4>
                 <div class="hstack gap-2 align-items-center">
-                    {% if list.owner_cached == user and not print %}
+                    {% if list.owner_cached == user and not print and not list.is_list_building %}
                         <a href="{% url 'core:list-credits-edit' list.id %}" class="fs-7 linked">Edit</a>
                     {% endif %}
                     <span class="badge bg-primary fs-7">{{ list.credits_current|default:"0" }}¢</span>


### PR DESCRIPTION
The edit button for stash credits was showing for list building campaigns which would cause an error when clicked. Added check for list.is_list_building to prevent the button from being shown in list building mode.

Fixes #943

Generated with [Claude Code](https://claude.ai/code)