### PR TITLE
ci: disable code review workflow for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # We can't run this on dependabot-generated PRs because GitHub secrets are not available
+    # You _can_ amend and force-push dependabot PRs back up to force this to run.
+    if: |
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Skip automated code review on dependabot-generated pull requests since GitHub secrets are not available to these PRs for security reasons.