### PR TITLE
Increase relative fighter stat block font size on print view, and related tweaks. 

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -10,19 +10,19 @@
 {% endcomment %}
 {% comment %} Stats {% endcomment %}
 <table class="table table-sm table-borderless table-fixed mb-0">
+    {% comment %} Statline {% endcomment %}
     <thead>
         <tr>
             {% for stat in fighter.statline %}
-                <th class="text-center border-bottom {% if print %}fs-10{% else %}fs-7{% endif %} {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
+                <th class="text-center border-bottom {% if print %}fs-5{% else %}fs-7{% endif %} {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
                     scope="col">{{ stat.name }}</th>
             {% endfor %}
         </tr>
     </thead>
     <tbody>
-        <tr class="table-nowrap">
-            {% include "core/includes/list_fighter_statline.html" with fighter=fighter, print=print %}
-        </tr>
+        <tr class="table-nowrap">{% include "core/includes/list_fighter_statline.html" with fighter=fighter print=print %}</tr>
     </tbody>
+    {% comment %} Details {% endcomment %}
     <tbody class="table-group-divider">
         {% if fighter.ruleline|length > 0 %}
             <tr class="fs-7">
@@ -52,7 +52,7 @@
                 </td>
             </tr>
         {% endif %}
-        {% comment %} XP{% endcomment %}
+        {% comment %} XP {% endcomment %}
         {% if not fighter.is_vehicle and not print %}
             <tr class="fs-7">
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">XP</th>

--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -13,13 +13,15 @@
     <thead>
         <tr>
             {% for stat in fighter.statline %}
-                <th class="text-center border-bottom fs-7 {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
+                <th class="text-center border-bottom {% if print %}fs-10{% else %}fs-7{% endif %} {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}"
                     scope="col">{{ stat.name }}</th>
             {% endfor %}
         </tr>
     </thead>
     <tbody>
-        <tr class="table-nowrap">{% include "core/includes/list_fighter_statline.html" with fighter=fighter %}</tr>
+        <tr class="table-nowrap">
+            {% include "core/includes/list_fighter_statline.html" with fighter=fighter, print=print %}
+        </tr>
     </tbody>
     <tbody class="table-group-divider">
         {% if fighter.ruleline|length > 0 %}

--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -24,6 +24,7 @@
     </tbody>
     {% comment %} Details {% endcomment %}
     <tbody class="table-group-divider">
+        {% comment %} Rules {% endcomment %}
         {% if fighter.ruleline|length > 0 %}
             <tr class="fs-7">
                 <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Rules</th>

--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -26,8 +26,8 @@
     <tbody class="table-group-divider">
         {% if fighter.ruleline|length > 0 %}
             <tr class="fs-7">
-                <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Rules</th>
-                <td colspan="{% widthratio 66 100 fighter.statline|length %}">
+                <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Rules</th>
+                <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                     {% spaceless %}
                         {# djlint:off #}
                             {% for rule in fighter.ruleline %}<span>{% include "core/includes/rule.html" with rule=rule %}{% if not forloop.last %}<span>, </span>{% endif %}</span>{% endfor %}
@@ -70,11 +70,12 @@
                 </td>
             </tr>
         {% endif %}
+        {% comment %} Skills {% endcomment %}
         {% if not fighter.content_fighter.hide_skills %}
             {% if fighter.skilline_cached|length > 0 %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Skills</th>
-                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
+                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Skills</th>
+                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% spaceless %}
                             {% for skill in fighter.skilline_cached %}
                                 {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -106,11 +107,12 @@
                 </tr>
             {% endif %}
         {% endif %}
+        {% comment %} Psychic powers {% endcomment %}
         {% if fighter.is_psyker %}
             {% if fighter.powers_cached|length > 0 %}
                 <tr class="fs-7">
-                    <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Powers</th>
-                    <td colspan="{% widthratio 66 100 fighter.statline|length %}">
+                    <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Powers</th>
+                    <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                         {% spaceless %}
                             {% for assign in fighter.powers_cached %}
                                 {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -138,6 +140,7 @@
                 </tr>
             {% endif %}
         {% endif %}
+        {% comment %} Gear {% endcomment %}
         {% if not fighter.content_fighter.hide_house_restricted_gear and fighter.has_house_additional_gear %}
             {% for line in fighter.house_additional_gearline_display %}
                 {% if line.assignments|length > 0 or not print %}
@@ -204,8 +207,8 @@
         {% endif %}
         {% if fighter.wargearline_cached|length > 0 %}
             <tr class="fs-7">
-                <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
-                <td colspan="{% widthratio 66 100 fighter.statline|length %}">
+                <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Gear</th>
+                <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                     {% spaceless %}
                         {% for assign in fighter.wargear %}
                             {% comment %} All this faff to avoid spaces {% endcomment %}
@@ -224,8 +227,8 @@
             </tr>
         {% else %}
             <tr class="fs-7">
-                <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
-                <td colspan="{% widthratio 66 100 fighter.statline|length %}">
+                <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">Gear</th>
+                <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                     {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                         <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
                     {% else %}
@@ -237,8 +240,8 @@
         {% comment %} Injuries (only in campaign mode) {% endcomment %}
         {% if list.is_campaign_mode and fighter.injuries.exists %}
             <tr class="fs-7">
-                <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ fighter.term_injury_plural }}</th>
-                <td colspan="{% widthratio 66 100 fighter.statline|length %}">
+                <th scope="row" colspan="{% widthratio 25 100 fighter.statline|length %}">{{ fighter.term_injury_plural }}</th>
+                <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                     {% for injury in fighter.injuries.all %}
                         {% if not forloop.first %},{% endif %}
                         {{ injury.injury.name }}

--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -30,7 +30,9 @@
                 <td colspan="{% widthratio 75 100 fighter.statline|length %}">
                     {% spaceless %}
                         {# djlint:off #}
-                            {% for rule in fighter.ruleline %}<span>{% include "core/includes/rule.html" with rule=rule %}{% if not forloop.last %}<span>, </span>{% endif %}</span>{% endfor %}
+                        {% for rule in fighter.ruleline %}
+                            {% include "core/includes/rule.html" with rule=rule %}{% if not forloop.last %}<span>,&nbsp;</span>{% endif %}
+                        {% endfor %}
                         {# djlint:on #}
                     {% endspaceless %}
                     {% if not print %}

--- a/gyrinx/core/templates/core/includes/list_fighter_statline.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_statline.html
@@ -1,5 +1,5 @@
 {% for stat in fighter.statline %}
-    <td class="text-center {% if print %}fs-10{% else %}fs-7{% endif %} {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}">
+    <td class="text-center {% if print %}fs-5{% else %}fs-7{% endif %} {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}">
         {% if stat.modded %}
             <span bs-tooltip
                   data-bs-toggle="tooltip"

--- a/gyrinx/core/templates/core/includes/list_fighter_statline.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_statline.html
@@ -1,5 +1,5 @@
 {% for stat in fighter.statline %}
-    <td class="text-center fs-7 {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}">
+    <td class="text-center {% if print %}fs-10{% else %}fs-7{% endif %} {% if stat.highlight %}bg-warning-subtle{% endif %} {{ stat.classes }}">
         {% if stat.modded %}
             <span bs-tooltip
                   data-bs-toggle="tooltip"

--- a/gyrinx/core/templates/core/includes/rule.html
+++ b/gyrinx/core/templates/core/includes/rule.html
@@ -9,5 +9,7 @@
         {% ref rule.value value=rule.value %}<!-- ! -->
     {% endif %}
 {% else %}
-    {{ rule.value }}
+    {% spaceless %}
+        <span>{{ rule.value }}</span>
+    {% endspaceless %}
 {% endif %}


### PR DESCRIPTION
Resolves 936.

- Font size in the fighter card stat block increased, making it easier to read (print view only).
- More space given for content in fighter detail block at expense of row label, to fit more items in (print view only).
- Removed gap between item and comma in "Rules" list.

Before:
<img width="818" height="381" alt="image" src="https://github.com/user-attachments/assets/43a05590-e539-4d4b-bd76-603aba991e93" />


After:
<img width="818" height="381" alt="image" src="https://github.com/user-attachments/assets/0d794bce-6e6a-4bf8-8056-237c58a726db" />

Did not change table padding, as this is already as low as is possible without customising bootstrap styles further. 