### PR TITLE
Fix TypeError in validate_advancement_choice

### DIFF
--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -4099,7 +4099,7 @@ class AdvancementFlowParams(AdvancementBaseParams):
     @classmethod
     def validate_advancement_choice(cls, value: str) -> str:
         if value not in AdvancementTypeForm.all_advancement_choices().keys():
-            raise ValidationError("Invalid advancement type choice.")
+            raise ValueError("Invalid advancement type choice.")
         return value
 
     def is_stat_advancement(self) -> bool:


### PR DESCRIPTION
Fixes #981

Changed ValidationError to ValueError in Pydantic field validator.
In Pydantic v2, field validators should raise ValueError instead of
ValidationError to avoid the TypeError.

Generated with [Claude Code](https://claude.ai/code)