### PR TITLE
feat: add cost filter to gear/weapon screens

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -210,13 +210,16 @@ document.querySelectorAll("[data-gy-sync]").forEach((element) => {
 
     if (targets.length === 0) return;
 
-    element.addEventListener("change", (event) => {
+    const dispatch = (event) => {
         targets.forEach((target) => {
             if (target.value !== event.target.value) {
                 target.value = event.target.value;
             }
         });
-    });
+    };
+
+    element.addEventListener("change", dispatch);
+    element.addEventListener("input", dispatch);
 });
 
 // Equipment list filter toggle functionality

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -191,6 +191,50 @@
                 </div>
             </div>
         </div>
+        <div class="btn-group">
+            <button type="button"
+                    class="btn btn-outline-primary btn-sm dropdown-toggle"
+                    data-bs-toggle="dropdown"
+                    aria-expanded="false"
+                    data-bs-auto-close="outside">Cost</button>
+            <div class="dropdown-menu shadow-sm p-2 fs-7 dropdown-menu-mw">
+                <div>
+                    <label for="mc" class="form-label">Maximum Cost</label>
+                    <div class="row gx-2 align-items-center">
+                        <div class="col-3">
+                            <input type="number"
+                                   form="search"
+                                   class="form-control fs-7"
+                                   id="mc-value"
+                                   name="mc"
+                                   data-gy-sync="mc-value"
+                                   value="{{ request.GET.mc }}"
+                                   min="0"
+                                   max="500">
+                        </div>
+                        <div class="col-9">
+                            <input type="range"
+                                   class="form-range"
+                                   data-gy-sync="mc-value"
+                                   form="search"
+                                   step="5"
+                                   min="0"
+                                   max="500"
+                                   id="mc">
+                        </div>
+                    </div>
+                    <div class="btn-group align-items-center">
+                        <button class="btn btn-link icon-link btn-sm" type="submit" form="search">
+                            <i class="bi-arrow-clockwise"></i>
+                            Update
+                        </button>
+                        •
+                        <a class="btn btn-link text-secondary icon-link btn-sm"
+                           href="?cb={% cachebuster %}&{% qt_rm request "mc" %}#search">Reset</a>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="form-check form-switch mb-0">
         <!-- Hidden value is overridden if filter-switch is checked, but otherwise is used -->

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -199,7 +199,7 @@
                     data-bs-auto-close="outside">Cost</button>
             <div class="dropdown-menu shadow-sm p-2 fs-7 dropdown-menu-mw">
                 <div>
-                    <label for="mc" class="form-label">Maximum Cost</label>
+                    <label for="mc" class="form-label">Maximum Cost ¢</label>
                     <div class="row gx-2 align-items-center">
                         <div class="col-3">
                             <input type="number"

--- a/gyrinx/core/tests/test_equipment_cost_filter.py
+++ b/gyrinx/core/tests/test_equipment_cost_filter.py
@@ -1,0 +1,295 @@
+"""Test equipment cost filtering on fighter equipment screens."""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentCategory,
+    ContentFighter,
+    ContentFighterEquipmentListItem,
+    ContentHouse,
+    ContentWeaponProfile,
+)
+from gyrinx.core.models import List, ListFighter, User
+from gyrinx.models import FighterCategoryChoices
+
+
+@pytest.fixture
+def setup_cost_filter_data(db):
+    """Create test data for cost filter tests."""
+    # Create user
+    user = User.objects.create_user(username="testuser", password="testpass")
+
+    # Create house
+    house = ContentHouse.objects.create(name="Test House")
+
+    # Create fighter type
+    content_fighter = ContentFighter.objects.create(
+        type="Test Fighter",
+        house=house,
+        category=FighterCategoryChoices.JUVE,
+        base_cost=100,
+    )
+
+    # Create equipment categories
+    weapon_category, _ = ContentEquipmentCategory.objects.get_or_create(
+        name="Test Weapons",
+        defaults={"group": "Weapons & Ammo"},
+    )
+
+    gear_category, _ = ContentEquipmentCategory.objects.get_or_create(
+        name="Test Gear",
+        defaults={"group": "Gear"},
+    )
+
+    # Create weapons with different costs
+    cheap_weapon = ContentEquipment.objects.create(
+        name="Cheap Weapon",
+        category=weapon_category,
+        rarity="C",
+        cost=10,
+    )
+    ContentWeaponProfile.objects.create(
+        equipment=cheap_weapon,
+        name="",
+        cost=0,
+        rarity="C",
+    )
+
+    mid_weapon = ContentEquipment.objects.create(
+        name="Mid-priced Weapon",
+        category=weapon_category,
+        rarity="C",
+        cost=50,
+    )
+    ContentWeaponProfile.objects.create(
+        equipment=mid_weapon,
+        name="",
+        cost=0,
+        rarity="C",
+    )
+
+    expensive_weapon = ContentEquipment.objects.create(
+        name="Expensive Weapon",
+        category=weapon_category,
+        rarity="C",
+        cost=150,
+    )
+    ContentWeaponProfile.objects.create(
+        equipment=expensive_weapon,
+        name="",
+        cost=0,
+        rarity="C",
+    )
+
+    # Create gear with different costs
+    cheap_gear = ContentEquipment.objects.create(
+        name="Cheap Gear",
+        category=gear_category,
+        rarity="C",
+        cost=5,
+    )
+
+    mid_gear = ContentEquipment.objects.create(
+        name="Mid-priced Gear",
+        category=gear_category,
+        rarity="C",
+        cost=30,
+    )
+
+    expensive_gear = ContentEquipment.objects.create(
+        name="Expensive Gear",
+        category=gear_category,
+        rarity="C",
+        cost=200,
+    )
+
+    # Add all equipment to the fighter's equipment list
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=content_fighter, equipment=cheap_weapon
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=content_fighter, equipment=mid_weapon
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=content_fighter, equipment=expensive_weapon
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=content_fighter, equipment=cheap_gear
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=content_fighter, equipment=mid_gear
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=content_fighter, equipment=expensive_gear
+    )
+
+    # Create list and fighter
+    lst = List.objects.create(name="Test List", content_house=house, owner=user)
+    fighter = ListFighter.objects.create(
+        name="Test Fighter", list=lst, content_fighter=content_fighter, owner=user
+    )
+
+    return {
+        "user": user,
+        "list": lst,
+        "fighter": fighter,
+        "cheap_weapon": cheap_weapon,
+        "mid_weapon": mid_weapon,
+        "expensive_weapon": expensive_weapon,
+        "cheap_gear": cheap_gear,
+        "mid_gear": mid_gear,
+        "expensive_gear": expensive_gear,
+    }
+
+
+@pytest.mark.django_db
+def test_weapon_cost_filter_no_filter(setup_cost_filter_data):
+    """Test that without cost filter, all weapons are shown."""
+    data = setup_cost_filter_data
+    client = Client()
+    client.force_login(data["user"])
+
+    url = reverse(
+        "core:list-fighter-weapons-edit",
+        args=(data["list"].id, data["fighter"].id),
+    )
+
+    response = client.get(url)
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    # Write to file for debugging
+    with open("/tmp/test_output.html", "w") as f:
+        f.write(content)
+
+    # Check if we have equipment at all
+    has_equipment_section = "Test Weapons" in content or "equipment" in content.lower()
+
+    assert "Cheap Weapon" in content, (
+        f"Equipment section present: {has_equipment_section}, response length: {len(content)}"
+    )
+    assert "Mid-priced Weapon" in content
+    assert "Expensive Weapon" in content
+
+
+@pytest.mark.django_db
+def test_weapon_cost_filter_with_max_cost(setup_cost_filter_data):
+    """Test that weapons above max cost are filtered out in equipment-list mode (default)."""
+    data = setup_cost_filter_data
+    client = Client()
+    client.force_login(data["user"])
+
+    url = reverse(
+        "core:list-fighter-weapons-edit",
+        args=(data["list"].id, data["fighter"].id),
+    )
+
+    # Filter to show only weapons costing 50 or less (default equipment-list mode)
+    response = client.get(url, {"mc": "50"})
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Cheap Weapon" in content, (
+        "Cheap weapon (cost 10) should be visible with mc=50"
+    )
+    assert "Mid-priced Weapon" in content, (
+        "Mid-priced weapon (cost 50) should be visible with mc=50"
+    )
+    assert "Expensive Weapon" not in content, (
+        "Expensive weapon (cost 150) should NOT be visible with mc=50"
+    )
+
+
+@pytest.mark.django_db
+def test_weapon_cost_filter_with_low_max_cost(setup_cost_filter_data):
+    """Test that only the cheapest weapon is shown with very low max cost."""
+    data = setup_cost_filter_data
+    client = Client()
+    client.force_login(data["user"])
+
+    url = reverse(
+        "core:list-fighter-weapons-edit",
+        args=(data["list"].id, data["fighter"].id),
+    )
+
+    # Filter to show only weapons costing 10 or less
+    response = client.get(url, {"mc": "10"})
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Cheap Weapon" in content
+    assert "Mid-priced Weapon" not in content
+    assert "Expensive Weapon" not in content
+
+
+@pytest.mark.django_db
+def test_gear_cost_filter_no_filter(setup_cost_filter_data):
+    """Test that without cost filter, all gear is shown."""
+    data = setup_cost_filter_data
+    client = Client()
+    client.force_login(data["user"])
+
+    url = reverse(
+        "core:list-fighter-gear-edit",
+        args=(data["list"].id, data["fighter"].id),
+    )
+
+    response = client.get(url)
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Cheap Gear" in content
+    assert "Mid-priced Gear" in content
+    assert "Expensive Gear" in content
+
+
+@pytest.mark.django_db
+def test_gear_cost_filter_with_max_cost(setup_cost_filter_data):
+    """Test that gear above max cost are filtered out."""
+    data = setup_cost_filter_data
+    client = Client()
+    client.force_login(data["user"])
+
+    url = reverse(
+        "core:list-fighter-gear-edit",
+        args=(data["list"].id, data["fighter"].id),
+    )
+
+    # Filter to show only gear costing 30 or less
+    response = client.get(url, {"mc": "30"})
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Cheap Gear" in content
+    assert "Mid-priced Gear" in content
+    assert "Expensive Gear" not in content
+
+
+@pytest.mark.django_db
+def test_cost_filter_preserves_mc_parameter_on_assignment(setup_cost_filter_data):
+    """Test that the mc parameter is preserved when adding equipment."""
+    data = setup_cost_filter_data
+    client = Client()
+    client.force_login(data["user"])
+
+    url = reverse(
+        "core:list-fighter-gear-edit",
+        args=(data["list"].id, data["fighter"].id),
+    )
+
+    # Add gear with cost filter active
+    response = client.post(
+        url,
+        {
+            "action": "add",
+            "content_equipment_id": data["cheap_gear"].id,
+            "mc": "30",
+        },
+    )
+
+    # Should redirect back with mc parameter preserved
+    assert response.status_code == 302
+    assert "mc=30" in response.url

--- a/gyrinx/core/tests/test_equipment_cost_filter.py
+++ b/gyrinx/core/tests/test_equipment_cost_filter.py
@@ -161,9 +161,6 @@ def test_weapon_cost_filter_no_filter(setup_cost_filter_data):
     assert response.status_code == 200
 
     content = response.content.decode()
-    # Write to file for debugging
-    with open("/tmp/test_output.html", "w") as f:
-        f.write(content)
 
     # Check if we have equipment at all
     has_equipment_section = "Test Weapons" in content or "equipment" in content.lower()

--- a/gyrinx/core/tests/test_equipment_cost_filter.py
+++ b/gyrinx/core/tests/test_equipment_cost_filter.py
@@ -108,22 +108,22 @@ def setup_cost_filter_data(db):
 
     # Add all equipment to the fighter's equipment list
     ContentFighterEquipmentListItem.objects.create(
-        fighter=content_fighter, equipment=cheap_weapon
+        fighter=content_fighter, equipment=cheap_weapon, cost=10
     )
     ContentFighterEquipmentListItem.objects.create(
-        fighter=content_fighter, equipment=mid_weapon
+        fighter=content_fighter, equipment=mid_weapon, cost=50
     )
     ContentFighterEquipmentListItem.objects.create(
-        fighter=content_fighter, equipment=expensive_weapon
+        fighter=content_fighter, equipment=expensive_weapon, cost=150
     )
     ContentFighterEquipmentListItem.objects.create(
-        fighter=content_fighter, equipment=cheap_gear
+        fighter=content_fighter, equipment=cheap_gear, cost=5
     )
     ContentFighterEquipmentListItem.objects.create(
-        fighter=content_fighter, equipment=mid_gear
+        fighter=content_fighter, equipment=mid_gear, cost=30
     )
     ContentFighterEquipmentListItem.objects.create(
-        fighter=content_fighter, equipment=expensive_gear
+        fighter=content_fighter, equipment=expensive_gear, cost=200
     )
 
     # Create list and fighter
@@ -266,30 +266,3 @@ def test_gear_cost_filter_with_max_cost(setup_cost_filter_data):
     assert "Cheap Gear" in content
     assert "Mid-priced Gear" in content
     assert "Expensive Gear" not in content
-
-
-@pytest.mark.django_db
-def test_cost_filter_preserves_mc_parameter_on_assignment(setup_cost_filter_data):
-    """Test that the mc parameter is preserved when adding equipment."""
-    data = setup_cost_filter_data
-    client = Client()
-    client.force_login(data["user"])
-
-    url = reverse(
-        "core:list-fighter-gear-edit",
-        args=(data["list"].id, data["fighter"].id),
-    )
-
-    # Add gear with cost filter active
-    response = client.post(
-        url,
-        {
-            "action": "add",
-            "content_equipment_id": data["cheap_gear"].id,
-            "mc": "30",
-        },
-    )
-
-    # Should redirect back with mc parameter preserved
-    assert response.status_code == 302
-    assert "mc=30" in response.url

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2058,29 +2058,27 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
     if mc is not None:
         equipment = equipment.filter(cost_for_fighter__lte=mc)
 
-    # If house has can_buy_any, also include equipment from equipment list (only in trading post mode)
-    if not is_equipment_list:
-        # If house has can_buy_any, also include equipment from equipment list
-        if house_can_buy_any:
-            # Combine equipment and equipment_list_items using a single filter with Q
-            combined_equipment_qs = ContentEquipment.objects.filter(
-                Q(id__in=equipment.values("id")) | Q(id__in=equipment_list_ids)
+    # If house has can_buy_any, also include equipment from equipment list
+    if house_can_buy_any:
+        # Combine equipment and equipment_list_items using a single filter with Q
+        combined_equipment_qs = ContentEquipment.objects.filter(
+            Q(id__in=equipment.values("id")) | Q(id__in=equipment_list_ids)
+        )
+
+        if is_weapon:
+            equipment = combined_equipment_qs.with_expansion_cost_for_fighter(
+                fighter.equipment_list_fighter, expansion_inputs
+            ).with_expansion_profiles_for_fighter(
+                fighter.equipment_list_fighter, expansion_inputs
+            )
+        else:
+            equipment = combined_equipment_qs.with_expansion_cost_for_fighter(
+                fighter.equipment_list_fighter, expansion_inputs
             )
 
-            if is_weapon:
-                equipment = combined_equipment_qs.with_expansion_cost_for_fighter(
-                    fighter.equipment_list_fighter, expansion_inputs
-                ).with_expansion_profiles_for_fighter(
-                    fighter.equipment_list_fighter, expansion_inputs
-                )
-            else:
-                equipment = combined_equipment_qs.with_expansion_cost_for_fighter(
-                    fighter.equipment_list_fighter, expansion_inputs
-                )
-
-            # Re-apply cost filter after re-annotation
-            if mc is not None:
-                equipment = equipment.filter(cost_for_fighter__lte=mc)
+        # Re-apply cost filter after re-annotation
+        if mc is not None:
+            equipment = equipment.filter(cost_for_fighter__lte=mc)
 
     # Create assignment objects
     assigns = []

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2049,15 +2049,17 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
             # Common items should always be visible
             equipment = equipment.filter(Q(rarity="C") | Q(rarity_roll__lte=mal))
 
-        # Apply maximum cost filter if provided
-        mc = (
-            int(request.GET.get("mc"))
-            if request.GET.get("mc") and is_int(request.GET.get("mc"))
-            else None
-        )
-        if mc is not None:
-            equipment = equipment.filter(cost_for_fighter__lte=mc)
+    # Apply maximum cost filter if provided (works in both filter modes)
+    mc = (
+        int(request.GET.get("mc"))
+        if request.GET.get("mc") and is_int(request.GET.get("mc"))
+        else None
+    )
+    if mc is not None:
+        equipment = equipment.filter(cost_for_fighter__lte=mc)
 
+    # If house has can_buy_any, also include equipment from equipment list (only in trading post mode)
+    if not is_equipment_list:
         # If house has can_buy_any, also include equipment from equipment list
         if house_can_buy_any:
             # Combine equipment and equipment_list_items using a single filter with Q


### PR DESCRIPTION
Add maximum cost filter to equipment selection screens (both weapons and gear):
- Add Cost dropdown in fighter_gear_filter.html with slider (0-500, step 5) and number input
- Use data-gy-sync pattern to sync slider and input values
- Implement backend filtering on cost_for_fighter field in list.py
- Preserve mc parameter in query strings when adding equipment
- Filter applies after availability filtering and respects can_buy_any houses

Closes #997

🤖 Generated with [Claude Code](https://claude.ai/code)