### PR TITLE
Simplify fighter card edit links to just say "Edit"

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -33,7 +33,7 @@
                     {% endspaceless %}
                     {% if not print %}
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                            <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Edit rules</a>
+                            <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Edit</a>
                         {% endif %}
                     {% endif %}
                 </td>
@@ -43,7 +43,7 @@
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Rules</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                     {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Add rules</a>
+                        <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Edit</a>
                     {% else %}
                         <span class="text-muted fst-italic">None</span>
                     {% endif %}
@@ -57,13 +57,7 @@
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                     <span class="badge text-bg-primary">{{ fighter.xp_current }} XP</span>
                     {% if not print and can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-xp-edit' list.id fighter.id %}">
-                            {% if fighter.xp_current == 0 %}
-                                Add XP
-                            {% else %}
-                                Edit XP
-                            {% endif %}
-                        </a>
+                        <a href="{% url 'core:list-fighter-xp-edit' list.id fighter.id %}">Edit</a>
                     {% endif %}
                 </td>
             </tr>
@@ -86,7 +80,7 @@
                         {% endspaceless %}
                         {% if not print %}
                             {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Edit skills</a>
+                                <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Edit</a>
                             {% endif %}
                         {% endif %}
                     </td>
@@ -96,7 +90,7 @@
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Skills</th>
                     <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                            <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Add skills</a>
+                            <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Edit</a>
                         {% else %}
                             <span class="text-muted fst-italic">None</span>
                         {% endif %}
@@ -118,7 +112,7 @@
                         {% endspaceless %}
                         {% if not print %}
                             {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Edit powers</a>
+                                <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Edit</a>
                             {% endif %}
                         {% endif %}
                     </td>
@@ -128,7 +122,7 @@
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Powers</th>
                     <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                            <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Add powers</a>
+                            <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Edit</a>
                         {% else %}
                             <span class="text-muted fst-italic">None</span>
                         {% endif %}
@@ -154,11 +148,7 @@
                             {% endspaceless %}
                             {% if not print %}
                                 {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                    {% if line.assignments|length > 0 %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Edit</a>
-                                    {% else %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Add {{ line.category|lower }}</a>
-                                    {% endif %}
+                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Edit</a>
                                 {% endif %}
                             {% endif %}
                         </td>
@@ -188,11 +178,7 @@
                             {% endspaceless %}
                             {% if not print %}
                                 {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                    {% if line.assignments|length > 0 %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Edit</a>
-                                    {% else %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category|lower }}</a>
-                                    {% endif %}
+                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Edit</a>
                                 {% endif %}
                             {% endif %}
                         </td>
@@ -215,7 +201,7 @@
                     {% if not print %}
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                             <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
-                               class="d-inline-block">Edit gear</a>
+                               class="d-inline-block">Edit</a>
                         {% endif %}
                     {% endif %}
                 </td>
@@ -225,7 +211,7 @@
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                     {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
+                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Edit</a>
                     {% else %}
                         <span class="text-muted fst-italic">None</span>
                     {% endif %}
@@ -242,7 +228,7 @@
                         {{ injury.injury.name }}
                     {% endfor %}
                     {% if not print and can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Edit {{ fighter.term_injury_plural|lower }}</a>
+                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Edit</a>
                     {% endif %}
                 </td>
             </tr>
@@ -251,7 +237,7 @@
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ fighter.term_injury_plural }}</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                     {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Add {{ fighter.term_injury_plural|lower }}</a>
+                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Edit</a>
                     {% else %}
                         <span class="text-muted fst-italic">None</span>
                     {% endif %}
@@ -266,7 +252,7 @@
                     {% with advancement_count=fighter.advancements.count %}
                         {% if advancement_count == 0 %}
                             {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                <a href="{% url 'core:list-fighter-advancements' list.id fighter.id %}">Add advancements</a>
+                                <a href="{% url 'core:list-fighter-advancements' list.id fighter.id %}">Edit</a>
                             {% else %}
                                 <span class="text-muted fst-italic">None</span>
                             {% endif %}
@@ -289,7 +275,7 @@
         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
             <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}"
                class="fs-7 icon-link mt-1">
-                <i class="bi-plus-lg"></i> Add or edit weapons
+                <i class="bi-plus-lg"></i> Edit
             </a>
         {% endif %}
     {% endif %}

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -72,7 +72,7 @@
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                             <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Edit</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -104,7 +104,7 @@
                                                 {% endif %}
                                             {% else %}
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Edit</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -153,7 +153,7 @@
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                             <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Edit</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -185,7 +185,7 @@
                                                 {% endif %}
                                             {% else %}
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Edit</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -259,7 +259,7 @@
                                 {% if not print and gear_mode_default == "link" %}
                                     {% if list.owner_cached == user %}
                                         <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
-                                           class="d-inline-block">Edit gear</a>
+                                           class="d-inline-block">Edit</a>
                                     {% endif %}
                                 {% endif %}
                             </td>
@@ -271,7 +271,7 @@
                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                             <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                 {% if gear_mode_default == "link" %}
-                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
+                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Edit</a>
                                 {% else %}
                                     <span class="text-secondary">{{ fighter.proximal_demonstrative }} has no gear.</span>
                                 {% endif %}
@@ -290,7 +290,7 @@
         <div class="card-footer p-2 fs-7">
             {% if list.owner_cached == user and not print %}
                 <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}{% querystring %}"
-                   class="fw-normal">Edit weapons</a>
+                   class="fw-normal">Edit</a>
             {% endif %}
         </div>
     {% endif %}


### PR DESCRIPTION
Changed all fighter card edit/add links to consistently say "Edit" instead of combining category names with "edit/add" actions. This simplifies the UI and reduces confusion.

Fixes #995

Generated with [Claude Code](https://claude.ai/code)