### PR TITLE
Simplify fighter card link text

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -38,7 +38,7 @@
                     {% endspaceless %}
                     {% if not print %}
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                            <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Edit rules</a>
+                            <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Edit</a>
                         {% endif %}
                     {% endif %}
                 </td>
@@ -48,7 +48,7 @@
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Rules</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                     {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Add rules</a>
+                        <a href="{% url 'core:list-fighter-rules-edit' list.id fighter.id %}">Add</a>
                     {% else %}
                         <span class="text-muted fst-italic">None</span>
                     {% endif %}
@@ -92,7 +92,7 @@
                         {% endspaceless %}
                         {% if not print %}
                             {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Edit skills</a>
+                                <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Edit</a>
                             {% endif %}
                         {% endif %}
                     </td>
@@ -102,7 +102,7 @@
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Skills</th>
                     <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                            <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Add skills</a>
+                            <a href="{% url 'core:list-fighter-skills-edit' list.id fighter.id %}">Add</a>
                         {% else %}
                             <span class="text-muted fst-italic">None</span>
                         {% endif %}
@@ -125,7 +125,7 @@
                         {% endspaceless %}
                         {% if not print %}
                             {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Edit powers</a>
+                                <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Edit</a>
                             {% endif %}
                         {% endif %}
                     </td>
@@ -135,7 +135,7 @@
                     <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Powers</th>
                     <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                            <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Add powers</a>
+                            <a href="{% url 'core:list-fighter-powers-edit' list.id fighter.id %}">Add</a>
                         {% else %}
                             <span class="text-muted fst-italic">None</span>
                         {% endif %}
@@ -165,7 +165,7 @@
                                     {% if line.assignments|length > 0 %}
                                         <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Edit</a>
                                     {% else %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Add {{ line.category|lower }}</a>
+                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Add</a>
                                     {% endif %}
                                 {% endif %}
                             {% endif %}
@@ -199,7 +199,7 @@
                                     {% if line.assignments|length > 0 %}
                                         <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Edit</a>
                                     {% else %}
-                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category|lower }}</a>
+                                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add</a>
                                     {% endif %}
                                 {% endif %}
                             {% endif %}
@@ -223,7 +223,7 @@
                     {% if not print %}
                         {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
                             <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
-                               class="d-inline-block">Edit gear</a>
+                               class="d-inline-block">Edit</a>
                         {% endif %}
                     {% endif %}
                 </td>
@@ -233,7 +233,7 @@
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                     {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
+                        <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add</a>
                     {% else %}
                         <span class="text-muted fst-italic">None</span>
                     {% endif %}
@@ -250,7 +250,7 @@
                         {{ injury.injury.name }}
                     {% endfor %}
                     {% if not print and can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Edit {{ fighter.term_injury_plural|lower }}</a>
+                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Edit</a>
                     {% endif %}
                 </td>
             </tr>
@@ -259,7 +259,7 @@
                 <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ fighter.term_injury_plural }}</th>
                 <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                     {% if can_edit and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Add {{ fighter.term_injury_plural|lower }}</a>
+                        <a href="{% url 'core:list-fighter-injuries-edit' list.id fighter.id %}">Add</a>
                     {% else %}
                         <span class="text-muted fst-italic">None</span>
                     {% endif %}
@@ -274,7 +274,7 @@
                     {% with advancement_count=fighter.advancements.count %}
                         {% if advancement_count == 0 %}
                             {% if can_edit and not print and not fighter.is_captured and not fighter.is_sold_to_guilders %}
-                                <a href="{% url 'core:list-fighter-advancements' list.id fighter.id %}">Add advancements</a>
+                                <a href="{% url 'core:list-fighter-advancements' list.id fighter.id %}">Add</a>
                             {% else %}
                                 <span class="text-muted fst-italic">None</span>
                             {% endif %}

--- a/gyrinx/core/templates/core/includes/fighter_card_gear.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_gear.html
@@ -72,7 +72,7 @@
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                             <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -104,7 +104,7 @@
                                                 {% endif %}
                                             {% else %}
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&al=E&cat={{ line.id }}#search">Add</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -153,7 +153,7 @@
                                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">{{ line.category }}</th>
                                             <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -185,7 +185,7 @@
                                                 {% endif %}
                                             {% else %}
                                                 {% if gear_mode_default == "link" %}
-                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add {{ line.category }}</a>
+                                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}?flash=search&filter={{ line.filter }}&cat={{ line.id }}#search">Add</a>
                                                 {% else %}
                                                     <span class="text-secondary">None</span>
                                                 {% endif %}
@@ -259,7 +259,7 @@
                                 {% if not print and gear_mode_default == "link" %}
                                     {% if list.owner_cached == user %}
                                         <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}"
-                                           class="d-inline-block">Edit gear</a>
+                                           class="d-inline-block">Edit</a>
                                     {% endif %}
                                 {% endif %}
                             </td>
@@ -271,7 +271,7 @@
                             <th scope="row" colspan="{% widthratio 33 100 fighter.statline|length %}">Gear</th>
                             <td colspan="{% widthratio 66 100 fighter.statline|length %}">
                                 {% if gear_mode_default == "link" %}
-                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add gear</a>
+                                    <a href="{% url 'core:list-fighter-gear-edit' list.id fighter.id %}">Add</a>
                                 {% else %}
                                     <span class="text-secondary">{{ fighter.proximal_demonstrative }} has no gear.</span>
                                 {% endif %}
@@ -290,7 +290,7 @@
         <div class="card-footer p-2 fs-7">
             {% if list.owner_cached == user and not print %}
                 <a href="{% url 'core:list-fighter-weapons-edit' list.id fighter.id %}{% querystring %}"
-                   class="fw-normal">Edit weapons</a>
+                   class="fw-normal">Edit</a>
             {% endif %}
         </div>
     {% endif %}


### PR DESCRIPTION
Changed most fighter card edit links to simply say "Edit" instead of "Edit [category]". Empty state links now say "Add" instead of "Add [category]". XP links remain as "Add XP" and "Edit XP" as requested.

This simplifies the UI by reducing unnecessarily complicated link text while maintaining clarity.

Fixes #995

🤖 Generated with [Claude Code](https://claude.ai/code)