### PR TITLE
fix: remove PII and secrets from email confirmation logging

### DIFF
--- a/gyrinx/core/signals.py
+++ b/gyrinx/core/signals.py
@@ -99,11 +99,10 @@ def log_email_confirmed(request, email_address, **kwargs):
 def log_email_confirmation_sent(request, confirmation, signup, **kwargs):
     """Log when an email confirmation is sent."""
     log_event(
-        user=None,
+        user=confirmation.email_address.user,
         noun=EventNoun.USER,
         verb=EventVerb.CONFIRM,
         request=request,
-        confirmation=confirmation,
         signup=signup,
     )
 


### PR DESCRIPTION
Fixes #1017

## Summary

- Changed user from None to confirmation.email_address.user
- Removed confirmation object from context (contained email and key)
- Kept signup boolean flag (safe to log)

This ensures we properly populate user_id and username while avoiding logging of personally identifiable information (email) and secrets (confirmation key).

🤖 Generated with [Claude Code](https://claude.ai/code)