### PR TITLE
feat: Implement "View all battles" page for campaigns

### DIFF
--- a/.claude/notes/issue-1015-view-all-battles.md
+++ b/.claude/notes/issue-1015-view-all-battles.md
@@ -1,0 +1,56 @@
+# Issue #1015: View all X battles implementation
+
+## Overview
+
+Implement the "View all battles" link functionality for campaigns that currently points to "#".
+
+## Tasks
+
+- [x] Create .claude/notes directory and todo file
+- [ ] Extract battle summary card into reusable include
+- [ ] Create URL pattern for campaign battles list (`campaign/<id>/battles`)
+- [ ] Create view for battles list
+- [ ] Create template for battles list
+- [ ] Update campaign.html link to use new URL
+- [ ] Run formatting
+- [ ] Run tests
+- [ ] Commit and push changes
+
+## Implementation Details
+
+### Battle Summary Card
+
+Extract from `campaign.html` lines 302-323 into `core/includes/battle_summary_card.html`
+
+### URL Pattern
+
+Add to `urls.py` around line 530 (after resources, before individual battle paths):
+
+```python
+path(
+    "campaign/<id>/battles",
+    campaign.campaign_battles,
+    name="campaign-battles",
+),
+```
+
+### View
+
+Add to `views/campaign.py`:
+
+- Function or class to list all battles for a campaign
+- Reuse same prefetching as campaign overview (lines 185-188)
+- No limit on battles returned
+
+### Template
+
+Create `core/templates/core/campaign/campaign_battles.html`:
+
+- Extend base layout
+- Display all battles using the extracted include
+- Similar structure to campaign overview
+
+### Link Update
+
+In `campaign.html` line 327:
+Change `href="#"` to `href="{% url 'core:campaign-battles' campaign.id %}"`

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -299,32 +299,12 @@
                     {% if recent_battles %}
                         <div class="list-group list-group-flush">
                             {% for battle in recent_battles %}
-                                <a href="{% url 'core:battle' battle.id %}"
-                                   class="list-group-item list-group-item-action px-2 px-sm-3">
-                                    <div class="d-flex w-100 justify-content-between">
-                                        <div>
-                                            <h6 class="mb-1">
-                                                <strong>{{ battle.mission }}</strong>
-                                                <span class="text-muted">• {{ battle.date|date:"M d, Y" }}</span>
-                                            </h6>
-                                            <p class="mb-0 text-muted small">
-                                                {% for participant in battle.participants.all %}
-                                                    {{ participant.name }}
-                                                    {% if participant in battle.winners.all %}<i class="bi-trophy-fill text-warning"></i>{% endif %}
-                                                    {% if not forloop.last %},{% endif %}
-                                                {% endfor %}
-                                            </p>
-                                        </div>
-                                        <small class="text-muted">
-                                            <i class="bi-file-text"></i>
-                                            {{ battle.notes.count }} report{{ battle.notes.count|pluralize }}
-                                        </small>
-                                    </div>
-                                </a>
+                                {% include "core/includes/battle_summary_card.html" %}
                             {% endfor %}
                             {% if campaign.battles.count > 5 %}
                                 <div class="list-group-item text-center">
-                                    <a href="#" class="text-decoration-none">View all {{ campaign.battles.count }} battles →</a>
+                                    <a href="{% url 'core:campaign-battles' campaign.id %}"
+                                       class="text-decoration-none">View all {{ campaign.battles.count }} battles →</a>
                                 </div>
                             {% endif %}
                         </div>

--- a/gyrinx/core/templates/core/campaign/campaign_battles.html
+++ b/gyrinx/core/templates/core/campaign/campaign_battles.html
@@ -1,0 +1,29 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags color_tags %}
+{% block head_title %}
+    Battles - {{ campaign.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with url=campaign.get_absolute_url text="Back to Campaign" %}
+    <div class="col-lg-12 px-0 vstack gap-3">
+        <div class="vstack gap-0 mb-2">
+            <div class="hstack gap-2 mb-2 align-items-start align-items-md-center">
+                <div class="d-flex flex-column flex-md-row flex-grow-1 align-items-start align-items-md-center gap-2">
+                    <h1 class="mb-0">Battles</h1>
+                </div>
+            </div>
+            <div class="text-secondary">{{ campaign.name }}</div>
+        </div>
+        {% if battles %}
+            <div class="list-group list-group-flush">
+                {% for battle in battles %}
+                    {% include "core/includes/battle_summary_card.html" %}
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="border rounded p-2">
+                <i class="bi-info-circle"></i> No battles have been recorded in this campaign yet.
+            </div>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/includes/battle_summary_card.html
+++ b/gyrinx/core/templates/core/includes/battle_summary_card.html
@@ -1,0 +1,22 @@
+<a href="{% url 'core:battle' battle.id %}"
+   class="list-group-item list-group-item-action px-2 px-sm-3">
+    <div class="d-flex w-100 justify-content-between">
+        <div>
+            <h6 class="mb-1">
+                <strong>{{ battle.mission }}</strong>
+                <span class="text-muted">• {{ battle.date|date:"M d, Y" }}</span>
+            </h6>
+            <p class="mb-0 text-muted small">
+                {% for participant in battle.participants.all %}
+                    {{ participant.name }}
+                    {% if participant in battle.winners.all %}<i class="bi-trophy-fill text-warning"></i>{% endif %}
+                    {% if not forloop.last %},{% endif %}
+                {% endfor %}
+            </p>
+        </div>
+        <small class="text-muted">
+            <i class="bi-file-text"></i>
+            {{ battle.notes.count }} report{{ battle.notes.count|pluralize }}
+        </small>
+    </div>
+</a>

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -529,6 +529,11 @@ urlpatterns = [
     ),
     # Battles
     path(
+        "campaign/<id>/battles",
+        campaign.campaign_battles,
+        name="campaign-battles",
+    ),
+    path(
         "battle/<id>",
         battle.BattleDetailView.as_view(),
         name="battle",

--- a/gyrinx/core/views/campaign.py
+++ b/gyrinx/core/views/campaign.py
@@ -2401,3 +2401,45 @@ def fighter_release(request, id, fighter_id):
             "captured_fighter": captured_fighter,
         },
     )
+
+
+def campaign_battles(request, id):
+    """
+    View all battles in a campaign.
+
+    **Context**
+
+    ``campaign``
+        The :model:`core.Campaign` whose battles are being viewed.
+    ``battles``
+        QuerySet of :model:`core.Battle` objects for this campaign.
+
+    **Template**
+
+    :template:`core/campaign/campaign_battles.html`
+    """
+    campaign = get_object_or_404(Campaign.objects.prefetch_related("lists"), id=id)
+
+    user_owns_list = any(
+        list.owner_id == request.user.id for list in campaign.lists.all()
+    )
+    if campaign.owner != request.user and not user_owns_list:
+        messages.error(
+            request, "You don't have permission to view this campaign's battles."
+        )
+        return HttpResponseRedirect(reverse("core:campaign", args=(campaign.id,)))
+
+    battles = (
+        campaign.battles.select_related("owner")
+        .prefetch_related("participants", "winners")
+        .order_by("-date", "-created")
+    )
+
+    return render(
+        request,
+        "core/campaign/campaign_battles.html",
+        {
+            "campaign": campaign,
+            "battles": battles,
+        },
+    )


### PR DESCRIPTION
Implements the "View all battles" link functionality for campaigns.

## Changes
- Created reusable battle_summary_card.html include
- Added campaign/<id>/battles URL pattern
- Added campaign_battles view with proper permissions
- Created campaign_battles.html template
- Updated campaign.html to use include and link to new page

Fixes #1015

🤖 Generated with [Claude Code](https://claude.ai/code)