### PR TITLE
fix: Configure TinyMCE to store UTF-8 characters instead of HTML entities

### DIFF
--- a/gyrinx/core/widgets.py
+++ b/gyrinx/core/widgets.py
@@ -54,6 +54,8 @@ TINYMCE_UPLOAD_CONFIG = {
     "plugins": "autoresize autosave code emoticons fullscreen help image link lists quickbars textpattern visualblocks",
     "toolbar": "undo redo | blocks | bold italic underline link image | numlist bullist align | code",
     "menubar": "edit view insert format table tools help",
+    # Character encoding configuration
+    "entity_encoding": "raw",  # Store UTF-8 characters instead of HTML entities
     # Image upload configuration
     "automatic_uploads": True,
     "images_upload_credentials": True,


### PR DESCRIPTION
Add entity_encoding: 'raw' to TinyMCE configuration to ensure that accented and special characters are stored as UTF-8 in the database rather than as HTML entities.

This resolves the issue where TinyMCE was inconsistently encoding some characters as UTF-8 and others as HTML entities.

Fixes #1028

Generated with [Claude Code](https://claude.ai/code)