### PR TITLE
Fix credit spending for equipment, accessories, and upgrades

### DIFF
--- a/gyrinx/core/tests/test_campaign_equipment_credit_spending.py
+++ b/gyrinx/core/tests/test_campaign_equipment_credit_spending.py
@@ -195,7 +195,7 @@ def test_add_weapon_insufficient_credits(
     response = client.post(
         reverse(
             "core:list-fighter-weapons-edit",
-            args=(campaign_list_low_credits.id, fighter_in_campaign.id),
+            args=(campaign_list_low_credits.id, fighter_in_low_credit_campaign.id),
         ),
         {
             "content_equipment": expensive_weapon.id,
@@ -306,7 +306,11 @@ def test_add_accessory_insufficient_credits(
     response = client.post(
         reverse(
             "core:list-fighter-weapon-accessories-edit",
-            args=(campaign_list_low_credits.id, fighter_in_campaign.id, assignment.id),
+            args=(
+                campaign_list_low_credits.id,
+                fighter_in_low_credit_campaign.id,
+                assignment.id,
+            ),
         ),
         {
             "accessory_id": expensive_accessory.id,
@@ -425,7 +429,11 @@ def test_add_weapon_profile_insufficient_credits(
     response = client.post(
         reverse(
             "core:list-fighter-weapon-edit",
-            args=(campaign_list_low_credits.id, fighter_in_campaign.id, assignment.id),
+            args=(
+                campaign_list_low_credits.id,
+                fighter_in_low_credit_campaign.id,
+                assignment.id,
+            ),
         ),
         {
             "profile_id": expensive_profile.id,
@@ -551,10 +559,8 @@ def test_add_equipment_upgrade_insufficient_credits(
             "core:list-fighter-weapon-upgrade-edit",
             args=(
                 campaign_list_low_credits.id,
-                fighter_in_campaign.id,
+                fighter_in_low_credit_campaign.id,
                 assignment.id,
-                "core:list-fighter-weapons-edit",
-                "core:list-fighter-weapon-upgrade-edit",
             ),
         ),
         {

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -1868,7 +1868,7 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
                 except DjangoValidationError as e:
                     # Not enough credits - delete the assignment and show error
                     assign.delete()
-                    error_message = str(e.message)
+                    error_message = str(e)
                     messages.error(request, error_message)
                     # Continue to render the form below
             else:
@@ -2511,7 +2511,7 @@ def edit_list_fighter_weapon_accessories(request, id, fighter_id, assign_id):
                         outcome=f"Credits remaining: {lst.credits_current}¢",
                     )
             except DjangoValidationError as e:
-                error_message = str(e.message)
+                error_message = str(e)
                 messages.error(request, error_message)
                 # Continue to render the form below
         else:
@@ -2696,7 +2696,7 @@ def edit_single_weapon(request, id, fighter_id, assign_id):
                         outcome=f"Credits remaining: {lst.credits_current}¢",
                     )
             except DjangoValidationError as e:
-                error_message = str(e.message)
+                error_message = str(e)
                 messages.error(request, error_message)
                 # Continue to render the form below
         else:
@@ -3002,7 +3002,7 @@ def edit_list_fighter_weapon_upgrade(
                             outcome=f"Credits remaining: {lst.credits_current}¢",
                         )
                 except DjangoValidationError as e:
-                    error_message = str(e.message)
+                    error_message = str(e)
                     messages.error(request, error_message)
                     # Re-render form with error
             else:


### PR DESCRIPTION
Fixes #1016

This PR implements proper credit spending for weapons, gear, accessories, weapon profiles, and equipment upgrades in campaign mode.

## Changes
- Modified `edit_list_fighter_equipment` to use `spend_credits()` instead of manual deduction
- Added credit spending to `edit_list_fighter_weapon_accessories`
- Added credit spending to `edit_single_weapon` (profiles)
- Added credit spending to `edit_list_fighter_weapon_upgrade`
- All operations wrapped in `transaction.atomic()`
- Error handling uses `messages.error()`
- Creates `CampaignAction` records for audit trail

## Testing
- Added 8 passing tests in `test_campaign_equipment_credit_spending.py`
- Tests cover both campaign mode and list-building mode

Generated with [Claude Code](https://claude.ai/code)