### PR TITLE
feat: Add Claude Code hooks for automated formatting, testing, and migration checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/fmt.sh",
+            "description": "Auto-format code after editing files"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "filePattern": "**/models*.py",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/check_migrations.sh",
+            "description": "Check for missing migrations after editing model files"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'echo \"\\n=== Running Pre-Push Checks ===\\n\" && echo \"1. Running tests...\" && pytest -n auto --tb=short || { echo \"\\n⚠️  TESTS FAILED - Please fix before pushing\"; exit 1; } && echo \"\\n2. Checking for CSS files in git...\" && if git diff --cached --name-only | grep -q \"\\.css$\"; then echo \"\\n⚠️  WARNING: CSS files should not be committed (auto-generated from SCSS)\"; git diff --cached --name-only | grep \"\\.css$\"; fi && echo \"\\n3. Checking git status...\" && git status && echo \"\\n✅ All checks passed! Remember to commit and push your changes.\" && echo \"\\n📋 Critical workflow: Format ✓ | Test ✓ | Commit → Push\"'",
+            "description": "Run tests and checks before finishing session"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Implemented top 3 most valuable hooks based on repo workflows:

1. PostToolUse hook (confidence: 0.95)
   - Auto-format code after editing with ./scripts/fmt.sh
   - Ensures code formatting consistency without manual intervention

2. Stop hook (confidence: 0.90)
   - Run pytest -n auto before finishing sessions
   - Check for uncommitted CSS files (shouldn't be committed)
   - Display git status and remind to commit/push

3. PostToolUse hook for models (confidence: 0.85)
   - Check for missing migrations after editing model files
   - Runs ./scripts/check_migrations.sh automatically

These hooks align with the critical workflow documented in CLAUDE.md: Format → Test → Fix → Commit → Push

🤖 Generated with [Claude Code](https://claude.com/claude-code)