### PR TITLE
Temporarily disable Dependabot pip updates due to pip-tools incompatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,21 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      minor-and-patch:
-        update-types:
-          - "patch"
-          - "minor"
-      major:
-        update-types:
-          - "major"
+  # Temporarily disabled due to Dependabot issue with pip-tools/pip 25.3 incompatibility
+  # See: https://github.com/jazzband/pip-tools/issues/2252
+  # Re-enable once GitHub fixes their internal pip-tools version
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   groups:
+  #     minor-and-patch:
+  #       update-types:
+  #         - "patch"
+  #         - "minor"
+  #     major:
+  #       update-types:
+  #         - "major"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
Dependabot's internal "submit-pypi" job is failing with: AttributeError: 'InstallRequirement' object has no attribute 'use_pep517'

This is caused by pip-tools 7.5.1 being incompatible with pip 25.3+. The issue is tracked at: https://github.com/jazzband/pip-tools/issues/2252

Re-enable once GitHub updates their internal pip-tools version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)