### PR TITLE
Allow exotic beasts to roll dice for advancements

### DIFF
--- a/gyrinx/core/templates/core/list_fighter_advancement_dice_choice.html
+++ b/gyrinx/core/templates/core/list_fighter_advancement_dice_choice.html
@@ -45,7 +45,7 @@
             {% else %}
                 <div class="alert alert-warning">
                     <i class="bi-exclamation-triangle"></i>
-                    Only Gangers can roll for advancements. {{ fighter.name }} is a {{ fighter_category }} and must spend XP to choose advancements.
+                    Only Gangers and Exotic Beasts can roll for advancements. {{ fighter.name }} is a {{ fighter_category }} and must spend XP to choose advancements.
                 </div>
                 <nav class="hstack gap-3" aria-label="Form navigation">
                     <button type="submit"
@@ -54,13 +54,13 @@
                             disabled
                             data-bs-toggle="tooltip"
                             data-bs-placement="top"
-                            title="Only Gangers can roll for advancements">
+                            title="Only Gangers and Exotic Beasts can roll for advancements">
                         <i class="bi-dice-6"></i> Roll 2D6
                     </button>
                     <a href="{% url 'core:list-fighter-advancement-type' list.id fighter.id %}"
                        class="btn btn-success"
                        aria-describedby="spend-help">Spend XP</a>
-                    <span id="roll-help" class="visually-hidden">Roll 2D6 dice for a random advancement (disabled for non-Gangers)</span>
+                    <span id="roll-help" class="visually-hidden">Roll 2D6 dice for a random advancement (disabled for non-Gangers and non-Exotic Beasts)</span>
                     <span id="spend-help" class="visually-hidden">Spend XP to choose your advancement</span>
                 </nav>
             {% endif %}

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -3986,8 +3986,12 @@ class ListCampaignClonesView(generic.DetailView):
 
 # Fighter Advancement Views
 def can_fighter_roll_dice_for_advancement(fighter):
-    """Check if a fighter can roll dice for advancement (only GANGERs can)."""
-    return fighter.get_category() == FighterCategoryChoices.GANGER.value
+    """Check if a fighter can roll dice for advancement (GANGERs and EXOTIC_BEASTs can)."""
+    category = fighter.get_category()
+    return category in [
+        FighterCategoryChoices.GANGER.value,
+        FighterCategoryChoices.EXOTIC_BEAST.value,
+    ]
 
 
 @login_required


### PR DESCRIPTION
Updates the advancement system to allow exotic beasts to roll dice for advancements, matching the RAW.

Fixes #1074

🤖 Generated with [Claude Code](https://claude.ai/code)