### PR TITLE
Make fighter status badges clickable to status update pages

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content.html
@@ -34,7 +34,7 @@
                     {% endif %}
                 {% endif %}
                 {% if fighter.is_captured %}
-                    {% if list.campaign and not print %}
+                    {% if can_edit and list.campaign and not print %}
                         <a href="{% url 'core:campaign-captured-fighters' list.campaign.id %}"
                            class="badge ms-2 bg-warning text-dark text-decoration-none"
                            data-bs-toggle="tooltip"
@@ -45,7 +45,7 @@
                               data-bs-title="Captured by {{ fighter.capture_info.capturing_list.name }}">Captured</span>
                     {% endif %}
                 {% elif fighter.is_sold_to_guilders %}
-                    {% if list.campaign and not print %}
+                    {% if can_edit and list.campaign and not print %}
                         <a href="{% url 'core:campaign-captured-fighters' list.campaign.id %}"
                            class="badge ms-2 bg-secondary text-decoration-none">Sold to Guilders</a>
                     {% else %}


### PR DESCRIPTION
Clicking on fighter status flags now takes you to the correct page to change that status.

- Injury status badges (injured/dead/recovery) now link to fighter state edit page
- Captured badge links to campaign captured fighters page
- Sold to Guilders badge links to campaign captured fighters page
- Badges remain non-clickable in print mode or when user cannot edit

Fixes #987

Generated with [Claude Code](https://claude.ai/code)