### PR TITLE
Fix TransactionManagementError by removing refresh_from_db call

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -588,7 +588,8 @@ class List(AppBase):
                     **track_args,
                     error=str(e),
                 )
-                self.refresh_from_db()
+                # Don't refresh_from_db() here - causes TransactionManagementError when
+                # called within an atomic transaction after an error
                 return la
 
             track(


### PR DESCRIPTION
Removed the `refresh_from_db()` call in the exception handler of `List.create_action()` method. This call was causing a TransactionManagementError when the method was called within an atomic transaction (like in `delete_list_fighter_assign`).

The `refresh_from_db()` call was unnecessary as we're immediately returning the `ListAction` object and not using the refreshed state.

Fixes #1096

Generated with [Claude Code](https://claude.ai/code)