### PR TITLE
Add Value column to stat overrides table

### DIFF
--- a/gyrinx/core/templates/core/list_fighter_stats_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_stats_edit.html
@@ -25,6 +25,13 @@
                                     <th>Stat</th>
                                     <th>Short</th>
                                     <th>Base Value</th>
+                                    <th>
+                                        Value
+                                        <i class="bi bi-info-circle"
+                                           data-bs-toggle="tooltip"
+                                           data-bs-placement="top"
+                                           data-bs-title="Stat value after modifications and before the override"></i>
+                                    </th>
                                     <th>Override</th>
                                 </tr>
                             </thead>
@@ -40,6 +47,9 @@
                                             {% endif %}
                                         </td>
                                         <td class="text-muted">{{ field.field.base_value }}</td>
+                                        <td class="{% if field.field.modified_value != field.field.base_value %}{% else %}text-muted{% endif %}">
+                                            {{ field.field.modified_value }}
+                                        </td>
                                         <td>
                                             {{ field }}
                                             {% if field.errors %}<div class="invalid-feedback d-block">{{ field.errors.0 }}</div>{% endif %}
@@ -59,3 +69,12 @@
         </form>
     </div>
 {% endblock content %}
+{% block extra_body %}
+    <script>
+        // Initialize Bootstrap tooltips
+        document.addEventListener('DOMContentLoaded', function() {
+            const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+            const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+        });
+    </script>
+{% endblock extra_body %}


### PR DESCRIPTION
Fixes #1114

Adds a new "Value" column to the stat override table that shows the stat value after equipment/skill modifications but before user overrides.

This helps users see what their base stat is, what it becomes after mods, and what override they've set (if any).

## Changes

- Split `ListFighter.statline` into `statline` and `statline_before_overrides`
- Updated form to calculate modified values using `statline_before_overrides`
- Added Value column to template with Bootstrap tooltip
- Value shows as muted when unchanged, normal when modified

🤖 Generated with [Claude Code](https://claude.ai/code)