### PR TITLE
fix: grant write permissions to Claude workflow and add main branch protection

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,8 +30,9 @@ jobs:
         env:
           REF: ${{ github.ref }}
           BASE_REF: ${{ github.base_ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          if [ "$REF" = "refs/heads/main" ] || [ "$BASE_REF" = "main" ]; then
+          if [ "$REF" = "refs/heads/main" ] || [ "$BASE_REF" = "main" ] || [ "$PR_BASE_REF" = "main" ]; then
             echo "::error::This workflow cannot run on or target the main branch directly"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Change `contents: read` → `contents: write` to allow pushing commits
- Change `pull-requests: read` → `pull-requests: write` to allow creating PRs
- Add early guard step to prevent workflow from running on or targeting main branch

This fixes the permission denied error when Claude tries to push commits in the GitHub Actions workflow.

## Test plan

- [ ] Verify workflow can push commits on feature branches
- [ ] Verify workflow fails early if triggered on main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)