### PR TITLE
fix: restore project_id for trace correlation in StructuredLogHandler

### DIFF
--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -7,8 +7,11 @@ from .storage_settings import configure_gcs_storage
 # Configure Django logging for production using StructuredLogHandler
 # This writes JSON to stdout, which Cloud Run captures and sends to Cloud Logging
 # Note: RequestMiddleware in settings.py handles trace correlation
+# The project_id is required for proper trace correlation formatting
+GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT", os.getenv("GCP_PROJECT_ID", ""))
 LOGGING["handlers"]["structured_console"] = {
     "class": "google.cloud.logging_v2.handlers.StructuredLogHandler",
+    "project_id": GCP_PROJECT_ID,
 }
 
 # Update loggers to use structured logging with propagate: False to prevent duplicates


### PR DESCRIPTION
## Summary

- Restores `project_id` parameter to `StructuredLogHandler` that was accidentally removed in PR #1128
- Without `project_id`, trace IDs cannot be formatted correctly, breaking trace correlation in Cloud Logging
- Uses `GOOGLE_CLOUD_PROJECT` environment variable (set automatically by Cloud Run) instead of creating a client

## Test plan

- [ ] Deploy to production
- [ ] Trigger a request and check Cloud Logging
- [ ] Verify logs now have `logging.googleapis.com/trace` field populated
- [ ] Verify clicking the triangle (▶) icon on request logs shows nested application logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)