### PR TITLE
feat: add OpenTelemetry tracing with Cloud Trace integration

### DIFF
--- a/.claude/notes/tracing-spans-pattern.md
+++ b/.claude/notes/tracing-spans-pattern.md
@@ -1,0 +1,71 @@
+# OpenTelemetry Tracing for Cloud Trace
+
+## Setup
+
+Dependencies added to `requirements.txt`:
+```
+opentelemetry-sdk>=1.28.0
+opentelemetry-exporter-gcp-trace>=1.8.0
+opentelemetry-instrumentation-django>=0.49b0
+```
+
+Tracing is initialized in `gyrinx/wsgi.py` and `gyrinx/asgi.py` via import of `gyrinx.tracing`.
+
+## Usage
+
+### Context Manager
+
+```python
+from gyrinx.tracing import span
+
+def process_list(list_obj):
+    with span("process_list", list_id=str(list_obj.id)):
+        for fighter in list_obj.fighters.all():
+            with span("process_fighter", fighter_id=str(fighter.id)):
+                calculate_fighter_cost(fighter)
+```
+
+### Decorator
+
+```python
+from gyrinx.tracing import traced
+
+@traced("calculate_cost")
+def calculate_fighter_cost(fighter):
+    return fighter.calculate_cost()
+
+# With default attributes
+@traced("cache_operation", cache_type="list_cost")
+def update_cache(key, value):
+    cache.set(key, value)
+```
+
+### Check if Enabled
+
+```python
+from gyrinx.tracing import is_tracing_enabled
+
+if is_tracing_enabled():
+    # Do something tracing-specific
+    pass
+```
+
+## How It Works
+
+1. **Automatic enablement** - Tracing is only enabled when `GOOGLE_CLOUD_PROJECT` env var is set (automatic on Cloud Run)
+2. **Django auto-instrumentation** - All HTTP requests automatically get spans
+3. **Trace context propagation** - Custom spans appear as children of the Cloud Run request span via `X-Cloud-Trace-Context` header
+4. **Exception recording** - Exceptions are automatically recorded on spans and marked as errors
+5. **Zero overhead when disabled** - `span()` and `@traced()` are no-ops in development
+
+## Viewing Traces
+
+1. Go to GCP Console > Cloud Trace
+2. Find traces by time range or trace ID
+3. Click to see span hierarchy and timing
+
+## References
+
+- [Cloud Trace Python Setup](https://cloud.google.com/trace/docs/setup/python-ot)
+- [OpenTelemetry Python](https://opentelemetry.io/docs/languages/python/)
+- [Django Instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
 - [History Tracking](developing-gyrinx/history-tracking.md)
 - [Group-Based Features](developing-gyrinx/group-based-features.md)
 - [Deployment Environment Variables](deployment-environment-variables.md)
+- [Logging and Tracing Reference](logging-and-tracing-reference.md)
 - [Security Baseline](security-baseline.md)
 - [Statlines](technical-reference/statlines.md)
 

--- a/docs/logging-and-tracing-reference.md
+++ b/docs/logging-and-tracing-reference.md
@@ -1,0 +1,397 @@
+# Logging and Tracing Reference
+
+This reference documents the logging and tracing systems used in Gyrinx for production observability and debugging.
+
+## Logging System
+
+### Configuration
+
+Gyrinx uses Python's standard logging module with environment-specific handlers.
+
+#### Development Configuration
+
+Location: `gyrinx/settings.py` (lines 305-347)
+
+```python
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
+            "style": "{",
+        },
+        "simple": {
+            "format": "{levelname} {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "null": {
+            "class": "logging.NullHandler",
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        "django.security.DisallowedHost": {
+            "handlers": ["null"],
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+        "gyrinx": {
+            "handlers": ["console"],
+            "level": "INFO",  # Configurable via GYRINX_LOG_LEVEL
+            "propagate": False,
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",  # Configurable via GYRINX_LOG_LEVEL
+    },
+}
+```
+
+#### Production Configuration
+
+Location: `gyrinx/settings_prod.py`
+
+In production, the logging handler is replaced with `google.cloud.logging_v2.handlers.StructuredLogHandler`, which outputs JSON to stdout. Cloud Run captures this output and sends it to Cloud Logging.
+
+```python
+GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT", os.getenv("GCP_PROJECT_ID", ""))
+
+LOGGING["handlers"]["structured_console"] = {
+    "class": "google.cloud.logging_v2.handlers.StructuredLogHandler",
+    "project_id": GCP_PROJECT_ID,
+}
+
+LOGGING["loggers"]["django.request"]["handlers"] = ["structured_console"]
+LOGGING["loggers"]["gyrinx"]["handlers"] = ["structured_console"]
+LOGGING["root"]["handlers"] = ["structured_console"]
+```
+
+### Trace Correlation
+
+The `RequestMiddleware` from `google.cloud.logging_v2.handlers.middleware` correlates log entries with Cloud Trace spans. This middleware must be placed early in the middleware stack to capture request context.
+
+Location: `gyrinx/settings.py` (line 127)
+
+```python
+MIDDLEWARE = [
+    "google.cloud.sqlcommenter.django.middleware.SqlCommenter",
+    "google.cloud.logging_v2.handlers.middleware.RequestMiddleware",
+    # ... other middleware
+]
+```
+
+The `project_id` parameter in `StructuredLogHandler` is required for proper trace ID formatting in Cloud Logging.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GYRINX_LOG_LEVEL` | Log level for `gyrinx` logger and root logger | `INFO` |
+| `GOOGLE_CLOUD_PROJECT` | GCP project ID for trace correlation | None |
+| `GCP_PROJECT_ID` | Fallback for GCP project ID | None |
+
+### Logger Names
+
+| Logger | Purpose |
+|--------|---------|
+| `gyrinx` | Application-level logging |
+| `gyrinx.tracker` | Structured event tracking |
+| `gyrinx.tracing` | OpenTelemetry tracing status |
+| `django.request` | HTTP request errors |
+| `django.security.DisallowedHost` | Suppressed (null handler) |
+
+---
+
+## Structured Event Tracking
+
+The `gyrinx.tracker` module provides structured event logging for metrics and analytics.
+
+### Module Location
+
+`gyrinx/tracker.py`
+
+### track()
+
+Emit a structured log event.
+
+```python
+def track(
+    event: str,
+    n: int = 1,
+    value: Optional[float] = None,
+    **labels: Any
+) -> None
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `event` | `str` | Event name (e.g., `stat_config_fallback_used`) |
+| `n` | `int` | Count increment. Default: `1` |
+| `value` | `Optional[float]` | Numeric value for distributions |
+| `**labels` | `Any` | Arbitrary key-value metadata |
+
+#### Return Value
+
+None
+
+#### Behavior
+
+- In production: Outputs JSON via `StructuredLogHandler` for Cloud Logging
+- In development: Logs JSON string to console via `gyrinx.tracker` logger
+- Non-serializable label values are converted: objects with `id` attribute or `UUID` instances become strings; other non-serializable values are dropped with a debug log
+
+#### Output Format
+
+```json
+{
+    "event": "stat_config_fallback_used",
+    "n": 1,
+    "labels": {
+        "stat_name": "ammo",
+        "model_type": "ContentModStatApply"
+    }
+}
+```
+
+#### Examples
+
+```python
+from gyrinx.tracker import track
+
+# Simple event
+track("user_login")
+
+# Event with count
+track("api_call", n=5)
+
+# Event with distribution value
+track("response_time", value=123.45)
+
+# Event with labels
+track("stat_config_fallback_used", stat_name="ammo", model_type="ContentModStatApply")
+
+# Event with model object (ID extracted automatically)
+track("fighter_created", fighter=fighter_instance)
+```
+
+---
+
+## Tracing System (OpenTelemetry)
+
+The `gyrinx.tracing` module provides OpenTelemetry tracing integration with Google Cloud Trace.
+
+### Module Location
+
+`gyrinx/tracing.py`
+
+### Initialization
+
+Tracing is initialized automatically when the module is imported. The module is imported in `gyrinx/wsgi.py` and `gyrinx/asgi.py` before Django loads:
+
+```python
+import gyrinx.tracing  # noqa: F401, E402
+```
+
+### Configuration
+
+| Condition | Result |
+|-----------|--------|
+| `GOOGLE_CLOUD_PROJECT` set | Tracing enabled |
+| `GOOGLE_CLOUD_PROJECT` not set | Tracing disabled (all functions become no-ops) |
+
+### Dependencies
+
+Required packages for tracing:
+
+```
+opentelemetry-sdk>=1.28.0
+opentelemetry-exporter-gcp-trace>=1.8.0
+opentelemetry-instrumentation-django>=0.49b0
+```
+
+### span()
+
+Create a custom span as a context manager.
+
+```python
+@contextmanager
+def span(
+    name: str,
+    *,
+    record_exception: bool = True,
+    **attributes: Any
+) -> Generator[Optional[Any], None, None]
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Span name (e.g., `database_query`, `process_fighter`) |
+| `record_exception` | `bool` | Record exceptions on span before re-raising. Default: `True` |
+| `**attributes` | `Any` | Key-value attributes to attach to span. Values are converted to strings. |
+
+#### Yields
+
+The span object, or `None` if tracing is disabled.
+
+#### Behavior
+
+- When tracing is enabled: Creates a span, attaches attributes, records exceptions if `record_exception=True`
+- When tracing is disabled: Yields `None` immediately with no overhead
+
+#### Examples
+
+```python
+from gyrinx.tracing import span
+
+# Basic span
+with span("calculate_list_cost", list_id=str(lst.id)):
+    total = sum(fighter.cost for fighter in lst.fighters.all())
+
+# Nested spans
+def process_list(list_obj):
+    with span("process_list", list_id=str(list_obj.id)):
+        for fighter in list_obj.fighters.all():
+            with span("process_fighter", fighter_id=str(fighter.id)):
+                calculate_fighter_cost(fighter)
+
+# Exception handling (automatic)
+with span("risky_operation"):
+    raise ValueError("Something went wrong")  # Recorded on span, then re-raised
+```
+
+---
+
+### traced()
+
+Decorator to automatically trace a function.
+
+```python
+def traced(
+    name: Optional[str] = None,
+    **default_attributes: Any
+) -> Callable
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `Optional[str]` | Span name. Default: function name |
+| `**default_attributes` | `Any` | Default attributes to add to every span |
+
+#### Returns
+
+Decorated function with tracing.
+
+#### Examples
+
+```python
+from gyrinx.tracing import traced
+
+# Basic usage (span name = function name)
+@traced()
+def calculate_fighter_cost(fighter):
+    return fighter.calculate_cost()
+
+# Custom span name
+@traced("process_advancement")
+def apply_stat_advancement(fighter, stat):
+    return fighter.apply_advancement(stat)
+
+# With default attributes
+@traced("cache_operation", cache_type="list_cost")
+def update_cache(key, value):
+    cache.set(key, value)
+```
+
+---
+
+### is_tracing_enabled()
+
+Check if tracing is currently enabled.
+
+```python
+def is_tracing_enabled() -> bool
+```
+
+#### Returns
+
+`True` if tracing is enabled and initialized, `False` otherwise.
+
+#### Example
+
+```python
+from gyrinx.tracing import is_tracing_enabled
+
+if is_tracing_enabled():
+    # Perform tracing-specific logic
+    pass
+```
+
+---
+
+## Automatic Instrumentation
+
+### Django Request Spans
+
+When tracing is enabled, `DjangoInstrumentor` automatically creates spans for all HTTP requests. These appear in Cloud Trace as the root span for each request.
+
+### Trace Context Propagation
+
+The `X-Cloud-Trace-Context` header is automatically parsed by OpenTelemetry's Django instrumentation. Custom spans created with `span()` or `@traced()` appear as children of the request span in Cloud Trace.
+
+Header format: `TRACE_ID/SPAN_ID;o=TRACE_TRUE`
+
+---
+
+## Cloud Logging Queries
+
+Query events in Cloud Logging:
+
+```
+resource.type="cloud_run_revision"
+jsonPayload.event="stat_config_fallback_used"
+```
+
+Filter by labels:
+
+```
+resource.type="cloud_run_revision"
+jsonPayload.event="api_call"
+jsonPayload.labels.endpoint="/api/v1/fighters"
+```
+
+---
+
+## File Locations
+
+| File | Purpose |
+|------|---------|
+| `gyrinx/settings.py` | Base logging configuration |
+| `gyrinx/settings_prod.py` | Production logging with StructuredLogHandler |
+| `gyrinx/tracker.py` | Structured event tracking module |
+| `gyrinx/tracing.py` | OpenTelemetry tracing module |
+| `gyrinx/wsgi.py` | Tracing initialization for WSGI |
+| `gyrinx/asgi.py` | Tracing initialization for ASGI |
+
+---
+
+## Related Documentation
+
+- [Tracking and Metrics](tracking.md) - Usage guide for event tracking
+- [Operational Overview](operations/operational-overview.md) - Infrastructure and monitoring

--- a/gyrinx/asgi.py
+++ b/gyrinx/asgi.py
@@ -13,4 +13,8 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gyrinx.settings")
 
+# Initialize OpenTelemetry tracing before Django loads
+# This ensures trace context propagation is configured for all requests
+import gyrinx.tracing  # noqa: F401, E402
+
 application = get_asgi_application()

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -7,8 +7,11 @@ from .storage_settings import configure_gcs_storage
 # Configure Django logging for production using StructuredLogHandler
 # This writes JSON to stdout, which Cloud Run captures and sends to Cloud Logging
 # Note: RequestMiddleware in settings.py handles trace correlation
+# The project_id is required for proper trace correlation formatting
+GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT", os.getenv("GCP_PROJECT_ID", ""))
 LOGGING["handlers"]["structured_console"] = {
     "class": "google.cloud.logging_v2.handlers.StructuredLogHandler",
+    "project_id": GCP_PROJECT_ID,
 }
 
 # Update loggers to use structured logging with propagate: False to prevent duplicates

--- a/gyrinx/tests/test_tracing.py
+++ b/gyrinx/tests/test_tracing.py
@@ -1,0 +1,99 @@
+"""Tests for OpenTelemetry tracing utilities."""
+
+import pytest
+
+from gyrinx import tracing
+
+
+def test_span_context_manager_works_when_disabled():
+    """span() should work as a no-op when tracing is disabled."""
+    # In tests, GOOGLE_CLOUD_PROJECT is not set, so tracing is disabled
+    with tracing.span("test_operation", test_key="test_value") as span_obj:
+        result = 1 + 1
+
+    assert result == 2
+    assert span_obj is None  # No-op returns None
+
+
+def test_span_propagates_exceptions():
+    """span() should re-raise exceptions."""
+    with pytest.raises(ValueError, match="Test error"):
+        with tracing.span("failing_operation"):
+            raise ValueError("Test error")
+
+
+def test_traced_decorator_works():
+    """@traced should work as a function decorator."""
+
+    @tracing.traced("test_function")
+    def sample_function(x, y):
+        return x + y
+
+    result = sample_function(2, 3)
+    assert result == 5
+
+
+def test_traced_decorator_with_attributes():
+    """@traced should support default attributes."""
+
+    @tracing.traced("cache_op", cache_type="list_cost")
+    def cache_operation(key, value):
+        return f"{key}={value}"
+
+    result = cache_operation("test_key", "test_value")
+    assert result == "test_key=test_value"
+
+
+def test_traced_uses_function_name_by_default():
+    """@traced should use function name if no name provided."""
+
+    @tracing.traced()
+    def my_custom_function():
+        return "ok"
+
+    result = my_custom_function()
+    assert result == "ok"
+
+
+def test_traced_preserves_function_metadata():
+    """@traced should preserve function name and docstring."""
+
+    @tracing.traced()
+    def documented_function():
+        """This is a docstring."""
+        return True
+
+    assert documented_function.__name__ == "documented_function"
+    assert documented_function.__doc__ == "This is a docstring."
+
+
+def test_is_tracing_enabled():
+    """is_tracing_enabled() should return False when not configured."""
+    # In tests, GOOGLE_CLOUD_PROJECT is not set
+    assert tracing.is_tracing_enabled() is False
+
+
+def test_nested_spans_work():
+    """Nested spans should work correctly."""
+    results = []
+
+    with tracing.span("outer") as outer_span:
+        results.append("outer_start")
+        with tracing.span("inner") as inner_span:
+            results.append("inner")
+        results.append("outer_end")
+
+    assert results == ["outer_start", "inner", "outer_end"]
+    assert outer_span is None
+    assert inner_span is None
+
+
+def test_traced_decorator_propagates_exceptions():
+    """@traced should propagate exceptions."""
+
+    @tracing.traced("failing_function")
+    def failing_function():
+        raise RuntimeError("Function failed")
+
+    with pytest.raises(RuntimeError, match="Function failed"):
+        failing_function()

--- a/gyrinx/tracing.py
+++ b/gyrinx/tracing.py
@@ -1,0 +1,177 @@
+"""
+OpenTelemetry tracing utilities for Google Cloud Run.
+
+This module provides tracing capabilities that integrate with Google Cloud Trace.
+Tracing is only enabled when the GOOGLE_CLOUD_PROJECT environment variable is set.
+
+Typical usage:
+
+    # Context manager for custom spans
+    from gyrinx.tracing import span
+
+    with span("database_query", query_type="select"):
+        results = Model.objects.filter(...)
+
+    # Decorator for tracing functions
+    from gyrinx.tracing import traced
+
+    @traced("process_fighter_stats")
+    def calculate_stats(fighter):
+        return fighter.get_stats()
+
+Error handling is automatic - exceptions are recorded on spans and re-raised.
+"""
+
+import logging
+import os
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any, Callable, Generator, Optional
+
+logger = logging.getLogger(__name__)
+
+# Module-level state
+_tracing_enabled = False
+_tracer = None
+_initialized = False
+
+
+def _init_tracing() -> None:
+    """Initialize OpenTelemetry tracing if GOOGLE_CLOUD_PROJECT is set.
+
+    This configures:
+    1. Google Cloud Trace exporter
+    2. Django auto-instrumentation (automatic request spans)
+    3. Trace context propagation from X-Cloud-Trace-Context header
+
+    Called automatically on module import.
+    """
+    global _tracing_enabled, _tracer, _initialized
+
+    if _initialized:
+        return
+
+    _initialized = True
+
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+    if not project_id:
+        logger.debug("OpenTelemetry tracing disabled - GOOGLE_CLOUD_PROJECT not set")
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+        from opentelemetry.instrumentation.django import DjangoInstrumentor
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        # Create tracer provider
+        provider = TracerProvider()
+
+        # Add Cloud Trace exporter with batch processing
+        exporter = CloudTraceSpanExporter(project_id=project_id)
+        processor = BatchSpanProcessor(exporter)
+        provider.add_span_processor(processor)
+
+        # Set as global tracer provider
+        trace.set_tracer_provider(provider)
+
+        # Auto-instrument Django (adds automatic request spans)
+        # This also handles X-Cloud-Trace-Context propagation
+        DjangoInstrumentor().instrument()
+
+        # Get tracer for manual spans
+        _tracer = trace.get_tracer("gyrinx.tracing")
+        _tracing_enabled = True
+
+        logger.info(f"OpenTelemetry tracing enabled for project: {project_id}")
+
+    except ImportError as e:
+        logger.warning(f"OpenTelemetry packages not installed: {e}")
+    except Exception as e:
+        logger.error(f"Failed to initialize OpenTelemetry tracing: {e}", exc_info=True)
+
+
+@contextmanager
+def span(
+    name: str, *, record_exception: bool = True, **attributes: Any
+) -> Generator[Optional[Any], None, None]:
+    """Create a custom span as a context manager.
+
+    Args:
+        name: Span name (e.g., "database_query", "process_fighter")
+        record_exception: If True, record exceptions on the span before re-raising
+        **attributes: Key-value attributes to attach to span
+
+    Yields:
+        The span object (or None if tracing disabled)
+
+    Example:
+        with span("calculate_list_cost", list_id=str(lst.id)):
+            total = sum(fighter.cost for fighter in lst.fighters.all())
+    """
+    if not _tracing_enabled or _tracer is None:
+        yield None
+        return
+
+    with _tracer.start_as_current_span(name) as current_span:
+        # Add attributes
+        for key, value in attributes.items():
+            current_span.set_attribute(key, str(value))
+
+        try:
+            yield current_span
+        except Exception as e:
+            if record_exception:
+                from opentelemetry.trace import Status, StatusCode
+
+                current_span.record_exception(e)
+                current_span.set_status(Status(StatusCode.ERROR))
+            raise
+
+
+def traced(name: Optional[str] = None, **default_attributes: Any) -> Callable:
+    """Decorator to automatically trace a function.
+
+    Args:
+        name: Optional span name (defaults to function name)
+        **default_attributes: Default attributes to add to span
+
+    Returns:
+        Decorated function
+
+    Example:
+        @traced("process_advancement")
+        def apply_stat_advancement(fighter, stat):
+            return fighter.apply_advancement(stat)
+
+        # With default attributes
+        @traced("cache_operation", cache_type="list_cost")
+        def update_cache(key, value):
+            cache.set(key, value)
+    """
+
+    def decorator(func: Callable) -> Callable:
+        span_name = name or func.__name__
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with span(span_name, **default_attributes):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def is_tracing_enabled() -> bool:
+    """Check if tracing is currently enabled.
+
+    Returns:
+        True if tracing is enabled and initialized, False otherwise.
+    """
+    return _tracing_enabled
+
+
+# Initialize tracing on module import
+_init_tracing()

--- a/gyrinx/wsgi.py
+++ b/gyrinx/wsgi.py
@@ -13,4 +13,8 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gyrinx.settings")
 
+# Initialize OpenTelemetry tracing before Django loads
+# This ensures trace context propagation is configured for all requests
+import gyrinx.tracing  # noqa: F401, E402
+
 application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,11 @@ jsonschema==4.25.1
 jupyter==1.1.1
 nbstripout==0.8.2
 nodeenv==1.9.1
+opentelemetry-exporter-gcp-trace>=1.8.0
+opentelemetry-instrumentation-django>=0.49b0
+
+# OpenTelemetry - Cloud Trace integration
+opentelemetry-sdk>=1.28.0
 Pillow==12.0.0
 playwright==1.56.0
 pre-commit==4.5.0


### PR DESCRIPTION
## Summary

- Adds `gyrinx/tracing.py` module with `span()` context manager and `@traced()` decorator for custom spans
- Initializes OpenTelemetry in `wsgi.py` and `asgi.py` before Django loads
- Auto-instruments Django requests via `opentelemetry-instrumentation-django`
- Propagates trace context from Cloud Run's `X-Cloud-Trace-Context` header so custom spans appear as children of request spans
- Gracefully degrades to no-op when `GOOGLE_CLOUD_PROJECT` is not set (zero overhead in development)
- Adds reference documentation for logging and tracing systems

## Usage

```python
from gyrinx.tracing import span, traced

# Context manager
with span("calculate_cost", list_id=str(lst.id)):
    total = sum(f.cost for f in lst.fighters.all())

# Decorator
@traced("process_advancement")
def apply_advancement(fighter, stat):
    return fighter.apply_stat(stat)
```

## Test plan

- [x] All 9 tracing tests pass
- [ ] Deploy to Cloud Run
- [ ] Verify spans appear in Cloud Trace console
- [ ] Verify custom spans are children of request spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)