### PR TITLE
Add debug page for viewing list actions

### DIFF
--- a/gyrinx/core/templates/core/debug/list_actions.html
+++ b/gyrinx/core/templates/core/debug/list_actions.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="description" content="Debug endpoint for list actions">
+        <meta name="keywords" content="debug, list actions">
+        <title>List Actions - {{ list.name }}</title>
+        <style>
+        body { font-family: system-ui, sans-serif; max-width: 1000px; margin: 2rem auto; padding: 0 1rem; }
+        h1 { margin-bottom: 0.5rem; }
+        .back { margin-bottom: 1rem; }
+        .back a { color: #0066cc; text-decoration: none; }
+        .back a:hover { text-decoration: underline; }
+        .description { color: #666; margin-bottom: 1.5rem; }
+        .count { background: #eee; padding: 0.125rem 0.5rem; border-radius: 4px; font-size: 0.875rem; }
+        table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+        th, td { padding: 0.5rem; text-align: left; border-bottom: 1px solid #ddd; }
+        th { background: #f5f5f5; font-weight: 600; }
+        tr:hover { background: #fafafa; }
+        .timestamp { white-space: nowrap; color: #666; }
+        .action-type { font-weight: 500; }
+        .user { color: #666; }
+        .description-cell { max-width: 300px; }
+        .delta { font-family: monospace; }
+        .delta-positive { color: #28a745; }
+        .delta-negative { color: #dc3545; }
+        .delta-zero { color: #999; }
+        .before-after { font-family: monospace; font-size: 0.75rem; color: #666; }
+        .empty { padding: 2rem; background: #f5f5f5; border-radius: 4px; text-align: center; }
+        </style>
+    </head>
+    <body>
+        <div class="back">
+            <a href="{% url 'core:list' list.id %}">← Back to {{ list.name }}</a>
+        </div>
+        <h1>
+            List Actions <span class="count">{{ actions|length }}</span>
+        </h1>
+        <p class="description">
+            Debug view showing all actions for <strong>{{ list.name }}</strong>, sorted newest first.
+        </p>
+        {% if actions %}
+            <table>
+                <thead>
+                    <tr>
+                        <th>Timestamp</th>
+                        <th>Type</th>
+                        <th>User</th>
+                        <th>Description</th>
+                        <th>Rating</th>
+                        <th>Credits</th>
+                        <th>Stash</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for action in actions %}
+                        <tr>
+                            <td class="timestamp">{{ action.created|date:"Y-m-d H:i:s" }}</td>
+                            <td class="action-type">{{ action.action_type }}</td>
+                            <td class="user">{{ action.user|default:"-" }}</td>
+                            <td class="description-cell">{{ action.description|default:"-" }}</td>
+                            <td>
+                                <span class="delta {% if action.rating_delta > 0 %}delta-positive{% elif action.rating_delta < 0 %}delta-negative{% else %}delta-zero{% endif %}">
+                                    {% if action.rating_delta >= 0 %}+{% endif %}
+                                    {{ action.rating_delta }}
+                                </span>
+                                <div class="before-after">{{ action.rating_before }} → {{ action.rating_after }}</div>
+                            </td>
+                            <td>
+                                <span class="delta {% if action.credits_delta > 0 %}delta-positive{% elif action.credits_delta < 0 %}delta-negative{% else %}delta-zero{% endif %}">
+                                    {% if action.credits_delta >= 0 %}+{% endif %}
+                                    {{ action.credits_delta }}
+                                </span>
+                                <div class="before-after">{{ action.credits_before }} → {{ action.credits_after }}</div>
+                            </td>
+                            <td>
+                                <span class="delta {% if action.stash_delta > 0 %}delta-positive{% elif action.stash_delta < 0 %}delta-negative{% else %}delta-zero{% endif %}">
+                                    {% if action.stash_delta >= 0 %}+{% endif %}
+                                    {{ action.stash_delta }}
+                                </span>
+                                <div class="before-after">{{ action.stash_before }} → {{ action.stash_after }}</div>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div class="empty">
+                <p>No actions recorded for this list.</p>
+            </div>
+        {% endif %}
+    </body>
+</html>

--- a/gyrinx/core/templates/core/includes/list_common_header.html
+++ b/gyrinx/core/templates/core/includes/list_common_header.html
@@ -101,15 +101,19 @@
 {% if gyrinx_debug %}
     <div class="bg-warning-subtle border border-warning rounded px-2 py-1 mb-2 fs-7 font-monospace d-flex align-items-center gap-3">
         <span class="text-warning-emphasis fw-bold">DEBUG</span>
-        <span bs-tooltip
-              data-bs-toggle="tooltip"
-              title="{% if list.latest_action %}{{ list.latest_action.action_type }}: {{ list.latest_action.description }}{% else %}No actions recorded{% endif %}">
-            {% if list.latest_action %}
-                <i class="bi-flag-fill text-success"></i> Has actions
-            {% else %}
+        {% if list.latest_action %}
+            <a href="{% url 'debug_list_actions' list.id %}"
+               class="text-decoration-none"
+               bs-tooltip
+               data-bs-toggle="tooltip"
+               title="{{ list.latest_action.action_type }}: {{ list.latest_action.description }}">
+                <i class="bi-flag-fill text-success"></i> <span class="text-body">Has actions</span>
+            </a>
+        {% else %}
+            <span bs-tooltip data-bs-toggle="tooltip" title="No actions recorded">
                 <i class="bi-flag text-secondary"></i> No actions
-            {% endif %}
-        </span>
+            </span>
+        {% endif %}
         <span class="text-muted">|</span>
         <span>R: {{ list.rating_current }}¢ · C: {{ list.credits_current }}¢ · S: {{ list.stash_current }}¢ · W: {{ list.wealth_current }}¢</span>
     </div>

--- a/gyrinx/core/views/debug.py
+++ b/gyrinx/core/views/debug.py
@@ -1,13 +1,15 @@
 """Debug-only views for development utilities.
 
-These views are only available when DEBUG=True.
+These views are only available when DEBUG=True or GYRINX_DEBUG=True.
 """
 
 from pathlib import Path
 
 from django.conf import settings
 from django.http import Http404, HttpResponse
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
+
+from gyrinx.core.models import List
 
 # Test plans directory relative to project root
 TEST_PLANS_DIR = Path(settings.BASE_DIR) / ".claude" / "test-plans"
@@ -60,3 +62,18 @@ def debug_test_plan_detail(request, filename):
     file_path = plans[filename]["path"]
     content = file_path.read_text(encoding="utf-8")
     return HttpResponse(content, content_type="text/plain; charset=utf-8")
+
+
+def debug_list_actions(request, list_id):
+    """Display all actions for a list, sorted newest first."""
+    if not settings.GYRINX_DEBUG:
+        raise Http404("Debug views are only available when GYRINX_DEBUG is enabled")
+
+    lst = get_object_or_404(List, id=list_id)
+    actions = lst.actions.select_related("user", "list_fighter").order_by("-created")
+
+    return render(
+        request,
+        "core/debug/list_actions.html",
+        {"list": lst, "actions": actions},
+    )

--- a/gyrinx/urls.py
+++ b/gyrinx/urls.py
@@ -40,6 +40,11 @@ _debug_urls = [
         debug_views.debug_test_plan_detail,
         name="debug_test_plan_detail",
     ),
+    path(
+        "_debug/list/<uuid:list_id>/actions/",
+        debug_views.debug_list_actions,
+        name="debug_list_actions",
+    ),
 ]
 
 urlpatterns = (


### PR DESCRIPTION
## Summary
- Add clickable "Has actions" flag in the debug toolbar that links to a new debug page
- New debug page displays all ListAction records for a list, sorted newest first
- Shows timestamp, action type, user, description, and cost deltas with before/after values

## Test plan
- [x] Set `GYRINX_DEBUG=True` in `.env`
- [x] Navigate to a list that has actions recorded
- [x] Verify the "Has actions" flag in the debug toolbar is now clickable
- [x] Click the link and verify the debug actions page displays correctly
- [x] Verify actions are sorted with newest first
- [x] Verify "No actions" state is not clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)