### PR TITLE
feat: implement kill/resurrect handlers and refactor clone handler

### DIFF
--- a/gyrinx/core/handlers/fighter/__init__.py
+++ b/gyrinx/core/handlers/fighter/__init__.py
@@ -10,16 +10,25 @@ from gyrinx.core.handlers.fighter.edit import (
     handle_fighter_edit,
 )
 from gyrinx.core.handlers.fighter.hire_clone import (
+    FighterCloneParams,
     FighterCloneResult,
     FighterHireResult,
     handle_fighter_clone,
     handle_fighter_hire,
+)
+from gyrinx.core.handlers.fighter.kill import (
+    FighterKillResult,
+    handle_fighter_kill,
 )
 from gyrinx.core.handlers.fighter.removal import (
     FighterArchiveResult,
     FighterDeletionResult,
     handle_fighter_archive_toggle,
     handle_fighter_deletion,
+)
+from gyrinx.core.handlers.fighter.resurrect import (
+    FighterResurrectResult,
+    handle_fighter_resurrect,
 )
 from gyrinx.core.handlers.fighter.vehicle import (
     VehiclePurchaseResult,
@@ -30,10 +39,13 @@ __all__ = [
     "FieldChange",
     "FighterAdvancementResult",
     "FighterArchiveResult",
+    "FighterCloneParams",
     "FighterCloneResult",
     "FighterDeletionResult",
     "FighterEditResult",
     "FighterHireResult",
+    "FighterKillResult",
+    "FighterResurrectResult",
     "VehiclePurchaseResult",
     "handle_fighter_advancement",
     "handle_fighter_archive_toggle",
@@ -41,5 +53,7 @@ __all__ = [
     "handle_fighter_deletion",
     "handle_fighter_edit",
     "handle_fighter_hire",
+    "handle_fighter_kill",
+    "handle_fighter_resurrect",
     "handle_vehicle_purchase",
 ]

--- a/gyrinx/core/handlers/fighter/kill.py
+++ b/gyrinx/core/handlers/fighter/kill.py
@@ -1,0 +1,169 @@
+"""Handler for fighter kill operations in campaign mode."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from django.db import transaction
+
+from gyrinx.core.models.action import ListAction, ListActionType
+from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.list import (
+    List,
+    ListFighter,
+    ListFighterEquipmentAssignment,
+)
+
+
+@dataclass
+class FighterKillResult:
+    """Result of killing a fighter in campaign mode."""
+
+    fighter: ListFighter
+    fighter_cost_before: int
+    equipment_count: int
+    list_action: Optional[ListAction]
+    campaign_action: Optional[CampaignAction]
+    description: str
+
+
+@transaction.atomic
+def handle_fighter_kill(
+    *,
+    user,
+    lst: List,
+    fighter: ListFighter,
+) -> FighterKillResult:
+    """
+    Handle fighter death in campaign mode.
+
+    This handler performs the following operations atomically:
+    1. Captures before values for ListAction
+    2. Finds stash fighter
+    3. Transfers ALL equipment to stash (creates new assignments)
+    4. Deletes original equipment assignments
+    5. Marks fighter as DEAD
+    6. Sets fighter cost_override = 0
+    7. Creates UPDATE_FIGHTER ListAction for death
+    8. Creates CampaignAction if in campaign
+
+    The fighter's cost goes from X to 0, reducing rating by X.
+    Equipment transfers from fighter to stash don't change overall wealth,
+    but equipment is preserved in the stash for potential re-use.
+
+    Args:
+        user: User performing the kill
+        lst: List containing the fighter
+        fighter: Fighter being killed (must not be stash, must be campaign mode)
+
+    Returns:
+        FighterKillResult with all operation details
+
+    Raises:
+        ValueError: If fighter is stash or list is not in campaign mode
+    """
+    # Validate preconditions
+    if not lst.is_campaign_mode:
+        raise ValueError("Fighters can only be killed in campaign mode")
+
+    if fighter.is_stash:
+        raise ValueError("Cannot kill the stash")
+
+    # Capture BEFORE values for ListAction
+    rating_before = lst.rating_current
+    stash_before = lst.stash_current
+    credits_before = lst.credits_current
+
+    # Calculate fighter cost before death (includes equipment)
+    fighter_cost_before = fighter.cost_int()
+
+    # Find the stash fighter for this list
+    stash_fighter = lst.listfighter_set.filter(content_fighter__is_stash=True).first()
+
+    # Transfer equipment to stash
+    equipment_count = 0
+    equipment_cost = 0
+    if stash_fighter:
+        equipment_assignments = fighter.listfighterequipmentassignment_set.all()
+        equipment_count = equipment_assignments.count()
+        # Calculate equipment cost before we delete assignments
+        equipment_cost = sum(a.cost_int() for a in equipment_assignments)
+
+        for assignment in equipment_assignments:
+            # Create new assignment for stash with same equipment
+            new_assignment = ListFighterEquipmentAssignment(
+                list_fighter=stash_fighter,
+                content_equipment=assignment.content_equipment,
+                cost_override=assignment.cost_override,
+                total_cost_override=assignment.total_cost_override,
+                from_default_assignment=assignment.from_default_assignment,
+            )
+            new_assignment.save()
+
+            # Copy over M2M relationships
+            if assignment.weapon_profiles_field.exists():
+                new_assignment.weapon_profiles_field.set(
+                    assignment.weapon_profiles_field.all()
+                )
+            if assignment.weapon_accessories_field.exists():
+                new_assignment.weapon_accessories_field.set(
+                    assignment.weapon_accessories_field.all()
+                )
+            if assignment.upgrades_field.exists():
+                new_assignment.upgrades_field.set(assignment.upgrades_field.all())
+
+        # Delete all equipment assignments from the dead fighter
+        equipment_assignments.delete()
+
+    # Mark fighter as dead and set cost to 0
+    fighter.injury_state = ListFighter.DEAD
+    fighter.cost_override = 0
+    fighter.save()
+
+    # Build description
+    equipment_desc = (
+        " All equipment transferred to stash."
+        if equipment_count > 0
+        else " No equipment to transfer."
+    )
+    description = f"{fighter.name} was killed ({fighter_cost_before}¢).{equipment_desc}"
+
+    # Create UPDATE_FIGHTER ListAction for death
+    # Rating decreases by fighter's full cost (base + equipment)
+    # Stash increases by equipment value (transferred there)
+    # Net wealth change = -fighter_base_cost (equipment preserved in stash)
+    list_action = lst.create_action(
+        user=user,
+        action_type=ListActionType.UPDATE_FIGHTER,
+        subject_app="core",
+        subject_type="ListFighter",
+        subject_id=fighter.id,
+        description=description,
+        list_fighter=fighter,
+        rating_delta=-fighter_cost_before,
+        stash_delta=equipment_cost,
+        credits_delta=0,
+        rating_before=rating_before,
+        stash_before=stash_before,
+        credits_before=credits_before,
+    )
+
+    # Create CampaignAction if this list is part of a campaign
+    campaign_action = None
+    if lst.campaign:
+        campaign_action = CampaignAction.objects.create(
+            user=user,
+            owner=user,
+            campaign=lst.campaign,
+            list=lst,
+            description=f"Death: {fighter.name} was killed",
+            outcome=f"{fighter.name} is permanently dead.{equipment_desc}",
+        )
+
+    return FighterKillResult(
+        fighter=fighter,
+        fighter_cost_before=fighter_cost_before,
+        equipment_count=equipment_count,
+        list_action=list_action,
+        campaign_action=campaign_action,
+        description=description,
+    )

--- a/gyrinx/core/handlers/fighter/resurrect.py
+++ b/gyrinx/core/handlers/fighter/resurrect.py
@@ -1,0 +1,120 @@
+"""Handler for fighter resurrection operations in campaign mode."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from django.db import transaction
+
+from gyrinx.core.models.action import ListAction, ListActionType
+from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.list import ListFighter
+
+
+@dataclass
+class FighterResurrectResult:
+    """Result of resurrecting a dead fighter."""
+
+    fighter: ListFighter
+    restored_cost: int
+    list_action: Optional[ListAction]
+    campaign_action: Optional[CampaignAction]
+    description: str
+
+
+@transaction.atomic
+def handle_fighter_resurrect(
+    *,
+    user,
+    fighter: ListFighter,
+) -> FighterResurrectResult:
+    """
+    Resurrect a dead fighter, restoring their cost to the list rating.
+
+    This handler performs the following operations atomically:
+    1. Captures before values from the list
+    2. Calculates the cost that will be restored
+    3. Sets injury_state to ACTIVE
+    4. Clears cost_override (restores original cost)
+    5. Saves the fighter
+    6. Creates UPDATE_FIGHTER ListAction to track rating increase
+    7. Creates CampaignAction if in campaign
+
+    Note: Equipment is NOT restored - it remains in the stash and must be
+    manually re-equipped by the user.
+
+    Args:
+        user: The user performing the resurrection
+        fighter: The dead fighter to resurrect (must have injury_state=DEAD)
+
+    Returns:
+        FighterResurrectResult with fighter, restored cost, and actions
+
+    Raises:
+        ValueError: If fighter is not dead, is stash, or list not in campaign mode
+    """
+    lst = fighter.list
+
+    # Validate preconditions
+    if not lst.is_campaign_mode:
+        raise ValueError("Fighters can only be resurrected in campaign mode")
+
+    if fighter.is_stash:
+        raise ValueError("Cannot resurrect the stash")
+
+    if fighter.injury_state != ListFighter.DEAD:
+        raise ValueError("Only dead fighters can be resurrected")
+
+    # Capture before values for ListAction
+    rating_before = lst.rating_current
+    stash_before = lst.stash_current
+    credits_before = lst.credits_current
+
+    # Calculate what the cost WILL BE after we clear cost_override
+    # Dead fighters have cost_override=0, so we need the original base cost
+    restored_cost = fighter._base_cost_before_override()
+
+    # Apply mutations
+    fighter.injury_state = ListFighter.ACTIVE
+    fighter.cost_override = None  # Restores original cost
+    fighter.save()
+
+    # Build description
+    description = f"{fighter.name} resurrected (rating +{restored_cost}¢)"
+
+    # Create UPDATE_FIGHTER ListAction
+    # The fighter's cost goes from 0 to restored_cost
+    list_action = lst.create_action(
+        user=user,
+        action_type=ListActionType.UPDATE_FIGHTER,
+        subject_app="core",
+        subject_type="ListFighter",
+        subject_id=fighter.id,
+        description=description,
+        list_fighter=fighter,
+        rating_delta=restored_cost,
+        stash_delta=0,
+        credits_delta=0,
+        rating_before=rating_before,
+        stash_before=stash_before,
+        credits_before=credits_before,
+    )
+
+    # Create CampaignAction if this list is part of a campaign
+    campaign_action = None
+    if lst.campaign:
+        campaign_action = CampaignAction.objects.create(
+            user=user,
+            owner=user,
+            campaign=lst.campaign,
+            list=lst,
+            description=f"Resurrection: {fighter.name} is no longer dead",
+            outcome=f"{fighter.name} has been returned to the active roster.",
+        )
+
+    return FighterResurrectResult(
+        fighter=fighter,
+        restored_cost=restored_cost,
+        list_action=list_action,
+        campaign_action=campaign_action,
+        description=description,
+    )

--- a/gyrinx/core/templates/core/list_fighter_kill.html
+++ b/gyrinx/core/templates/core/list_fighter_kill.html
@@ -16,10 +16,10 @@
             <p>This will:</p>
             <ul>
                 <li>Transfer all their equipment to the stash</li>
-                <li>Set their cost to 0 credits</li>
+                <li>Set their rating to 0¢</li>
                 <li>Mark them as permanently dead</li>
             </ul>
-            <p>Dead fighters will remain visible in your gang but will no longer contribute to your gang's total cost.</p>
+            <p>Dead fighters will remain visible but will no longer contribute to your gang's rating.</p>
             <div class="mt-3">
                 <button type="submit" class="btn btn-danger">
                     <i class="bi-heartbreak"></i> Kill Fighter

--- a/gyrinx/core/templates/core/list_fighter_resurrect.html
+++ b/gyrinx/core/templates/core/list_fighter_resurrect.html
@@ -15,8 +15,8 @@
             </p>
             <p>This will:</p>
             <ul>
-                <li>Return them to the gang roster;</li>
-                <li>Set their cost back to its original value, minus equipment.</li>
+                <li>Return them to the gang roster</li>
+                <li>Set their rating back to its original value, minus equipment</li>
             </ul>
             <div class="alert alert-primary">
                 <p class="mb-0">

--- a/gyrinx/core/tests/test_resurrect_fighter.py
+++ b/gyrinx/core/tests/test_resurrect_fighter.py
@@ -251,9 +251,6 @@ def test_resurrect_fighter_confirmation_page(client, user, content_house):
 
     assert response.status_code == 200
     assert b"Resurrect Fighter - Deceased Fighter" in response.content
-    assert b"Are you sure you want to resurrect" in response.content
-    assert b"Return them to the gang roster" in response.content
-    assert b"Set their cost back to its original value" in response.content
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -76,12 +76,15 @@ from gyrinx.core.handlers.equipment import (
     handle_weapon_profile_purchase,
 )
 from gyrinx.core.handlers.fighter import (
+    FighterCloneParams,
     handle_fighter_advancement,
     handle_fighter_archive_toggle,
     handle_fighter_clone,
     handle_fighter_deletion,
     handle_fighter_edit,
     handle_fighter_hire,
+    handle_fighter_kill,
+    handle_fighter_resurrect,
 )
 from gyrinx.core.handlers.list import handle_list_clone, handle_list_creation
 from gyrinx.core.models.campaign import CampaignAction
@@ -1060,31 +1063,28 @@ def clone_list_fighter(request: HttpRequest, id, fighter_id):
         form = CloneListFighterForm(request.POST, fighter=fighter, user=request.user)
         if form.is_valid():
             try:
-                # Prepare clone kwargs
-                clone_kwargs = {
-                    "name": form.cleaned_data["name"],
-                    "content_fighter": form.cleaned_data["content_fighter"],
-                    "list": form.cleaned_data["list"],
-                }
-
+                # Prepare clone params
                 # Handle category_override based on checkbox
                 # If fighter has an override and checkbox is checked, preserve it
                 # Otherwise, clear it
+                category_override = None
                 if fighter.category_override and form.cleaned_data.get(
                     "clone_category_override", False
                 ):
-                    clone_kwargs["category_override"] = fighter.category_override
-                else:
-                    clone_kwargs["category_override"] = None
+                    category_override = fighter.category_override
 
-                new_fighter = fighter.clone(**clone_kwargs)
-                new_fighter.save()
+                clone_params = FighterCloneParams(
+                    name=form.cleaned_data["name"],
+                    content_fighter=form.cleaned_data["content_fighter"],
+                    target_list=form.cleaned_data["list"],
+                    category_override=category_override,
+                )
 
-                # Handle the clone operation (creates ListAction and handles credits)
-                handle_fighter_clone(
+                # Handle the clone operation (clones fighter, creates ListAction, handles credits)
+                result = handle_fighter_clone(
                     user=request.user,
                     source_fighter=fighter,
-                    new_fighter=new_fighter,
+                    clone_params=clone_params,
                 )
 
                 # Log the fighter clone event
@@ -1092,20 +1092,20 @@ def clone_list_fighter(request: HttpRequest, id, fighter_id):
                     user=request.user,
                     noun=EventNoun.LIST_FIGHTER,
                     verb=EventVerb.CLONE,
-                    object=new_fighter,
+                    object=result.fighter,
                     request=request,
-                    fighter_name=new_fighter.name,
-                    list_id=str(new_fighter.list.id),
-                    list_name=new_fighter.list.name,
+                    fighter_name=result.fighter.name,
+                    list_id=str(result.fighter.list.id),
+                    list_name=result.fighter.list.name,
                     source_fighter_id=str(fighter.id),
                     source_fighter_name=fighter.name,
                 )
 
-                query_params = urlencode(dict(flash=new_fighter.id))
+                query_params = urlencode(dict(flash=result.fighter.id))
                 return HttpResponseRedirect(
-                    reverse("core:list", args=(new_fighter.list.id,))
+                    reverse("core:list", args=(result.fighter.list.id,))
                     + f"?{query_params}"
-                    + f"#{str(new_fighter.id)}"
+                    + f"#{str(result.fighter.id)}"
                 )
             except DjangoValidationError as e:
                 error_message = str(e)
@@ -3247,8 +3247,6 @@ def kill_list_fighter(request, id, fighter_id):
 
     :template:`core/list_fighter_kill.html`
     """
-    from gyrinx.core.models.campaign import CampaignAction
-
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
         ListFighter.objects.with_related_data(),
@@ -3268,76 +3266,27 @@ def kill_list_fighter(request, id, fighter_id):
         return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
 
     if request.method == "POST":
-        with transaction.atomic():
-            # Find the stash fighter for this list
-            stash_fighter = lst.listfighter_set.filter(
-                content_fighter__is_stash=True
-            ).first()
-
-            if stash_fighter:
-                # Transfer all equipment to stash
-                equipment_assignments = fighter.listfighterequipmentassignment_set.all()
-                for assignment in equipment_assignments:
-                    # Create new assignment for stash with same equipment
-                    new_assignment = ListFighterEquipmentAssignment(
-                        list_fighter=stash_fighter,
-                        content_equipment=assignment.content_equipment,
-                        cost_override=assignment.cost_override,
-                        total_cost_override=assignment.total_cost_override,
-                        from_default_assignment=assignment.from_default_assignment,
-                    )
-                    new_assignment.save()
-
-                    # Copy over any weapon profiles and accessories
-                    if assignment.weapon_profiles_field.exists():
-                        new_assignment.weapon_profiles_field.set(
-                            assignment.weapon_profiles_field.all()
-                        )
-                    if assignment.weapon_accessories_field.exists():
-                        new_assignment.weapon_accessories_field.set(
-                            assignment.weapon_accessories_field.all()
-                        )
-                    if assignment.upgrades_field.exists():
-                        new_assignment.upgrades_field.set(
-                            assignment.upgrades_field.all()
-                        )
-
-                # Delete all equipment assignments from the dead fighter
-                equipment_assignments.delete()
-
-            # Mark fighter as dead and set cost to 0
-            fighter.injury_state = ListFighter.DEAD
-            fighter.cost_override = 0
-            fighter.save()
-
-            # Log the fighter kill event
-            log_event(
-                user=request.user,
-                noun=EventNoun.LIST_FIGHTER,
-                verb=EventVerb.DELETE,
-                object=fighter,
-                request=request,
-                fighter_name=fighter.name,
-                list_id=str(lst.id),
-                list_name=lst.name,
-                action="killed",
-            )
-
-            # Log the kill in campaign action if this list is part of a campaign
-            if lst.campaign:
-                CampaignAction.objects.create(
-                    user=request.user,
-                    owner=request.user,
-                    campaign=lst.campaign,
-                    list=lst,
-                    description=f"Death: {fighter.name} was killed",
-                    outcome=f"{fighter.name} is permanently dead. All equipment transferred to stash.",
-                )
-
-        messages.success(
-            request,
-            f"{fighter.name} has been killed. Their equipment has been transferred to the stash.",
+        # Handle fighter death (transfers equipment, creates ListAction and CampaignAction)
+        result = handle_fighter_kill(
+            user=request.user,
+            lst=lst,
+            fighter=fighter,
         )
+
+        # Log the fighter kill event
+        log_event(
+            user=request.user,
+            noun=EventNoun.LIST_FIGHTER,
+            verb=EventVerb.DELETE,
+            object=fighter,
+            request=request,
+            fighter_name=fighter.name,
+            list_id=str(lst.id),
+            list_name=lst.name,
+            action="killed",
+        )
+
+        messages.success(request, result.description)
         return HttpResponseRedirect(
             reverse("core:list", args=(lst.id,)) + f"#{str(fighter.id)}"
         )
@@ -3367,8 +3316,6 @@ def resurrect_list_fighter(request, id, fighter_id):
 
     :template:`core/list_fighter_resurrect.html`
     """
-    from gyrinx.core.models.campaign import CampaignAction
-
     lst = get_object_or_404(List, id=id, owner=request.user)
     fighter = get_object_or_404(
         ListFighter.objects.with_related_data(),
@@ -3387,14 +3334,15 @@ def resurrect_list_fighter(request, id, fighter_id):
         return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
 
     if request.method == "POST":
-        if not fighter.injury_state == ListFighter.DEAD:
+        if fighter.injury_state != ListFighter.DEAD:
             messages.error(request, "Only dead fighters can be resurrected.")
             return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
 
-        # Mark fighter as alive and set cost to original value
-        fighter.injury_state = ListFighter.ACTIVE
-        fighter.cost_override = None
-        fighter.save()
+        # Handle resurrection (restores cost, creates ListAction and CampaignAction)
+        handle_fighter_resurrect(
+            user=request.user,
+            fighter=fighter,
+        )
 
         # Log the resurrection event
         log_event(
@@ -3408,17 +3356,6 @@ def resurrect_list_fighter(request, id, fighter_id):
             list_name=lst.name,
             action="resurrected",
         )
-
-        # Log the resurrection campaign action
-        if lst.campaign:
-            CampaignAction.objects.create(
-                user=request.user,
-                owner=request.user,
-                campaign=lst.campaign,
-                list=lst,
-                description=f"Resurrection: {fighter.name} is no longer dead",
-                outcome=f"{fighter.name} has been returned to the active roster.",
-            )
 
         messages.success(
             request,


### PR DESCRIPTION
- Add handle_fighter_kill handler that atomically transfers equipment to stash, marks fighter as DEAD, and creates ListAction with proper stash_delta to track equipment value moving to stash
- Add handle_fighter_resurrect handler that restores fighter to ACTIVE state and creates ListAction tracking rating increase
- Refactor handle_fighter_clone to perform clone inside handler with new FighterCloneParams dataclass for typed parameters
- Update views to use new handlers instead of inline logic
- Update templates to use consistent "rating" terminology

Closes #1152, #1155