### PR TITLE
feat: add TRACING_MODE setting with off/console/gcp options

### DIFF
--- a/gyrinx/conftest.py
+++ b/gyrinx/conftest.py
@@ -43,6 +43,9 @@ def django_test_settings():
     # Disable GYRINX_DEBUG to avoid debug UI elements in test output
     settings.GYRINX_DEBUG = False
 
+    # Disable tracing in tests to avoid loading GCP dependencies
+    settings.TRACING_MODE = "off"
+
     # Use faster password hasher for tests (MD5 instead of PBKDF2)
     settings.PASSWORD_HASHERS = [
         "django.contrib.auth.hashers.MD5PasswordHasher",

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -440,3 +440,7 @@ SQLCOMMENTER_WITH_CONTROLLER = True
 SQLCOMMENTER_WITH_FRAMEWORK = True
 SQLCOMMENTER_WITH_ROUTE = True
 SQLCOMMENTER_WITH_APP_NAME = True
+
+# Tracing configuration
+# Options: "off" (no-op), "console" (print to stdout), "gcp" (Google Cloud Trace)
+TRACING_MODE = os.getenv("TRACING_MODE", "off")

--- a/gyrinx/settings_dev.py
+++ b/gyrinx/settings_dev.py
@@ -10,6 +10,9 @@ from .settings import *  # noqa: F403
 from .settings import BASE_DIR, STORAGES
 from .settings import LOGGING as BASE_LOGGING
 
+# Use console tracing in development
+TRACING_MODE = "console"
+
 logger = logging.getLogger(__name__)
 
 DEBUG = True

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -4,6 +4,9 @@ from .settings import *  # noqa: F403
 from .settings import LOGGING, STORAGES
 from .storage_settings import configure_gcs_storage
 
+# Use GCP tracing in production
+TRACING_MODE = "gcp"
+
 # GCP Project ID - required for trace correlation in logging
 # Uses env var with hardcoded fallback (same approach as storage_settings.py)
 GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT") or "windy-ellipse-440618-p9"


### PR DESCRIPTION
Replace DEBUG-based tracing detection with explicit TRACING_MODE setting:
- "off": No-op, disables all tracing (default, used in tests)
- "console": Print traces to stdout (used in development)
- "gcp": Export traces to Google Cloud Trace (used in production)

Fixes #1154

🤖 Generated with [Claude Code](https://claude.ai/claude-code)