### PR TITLE
Fix AttributeError when session not available in ASGI context

### DIFF
--- a/gyrinx/core/context_processors.py
+++ b/gyrinx/core/context_processors.py
@@ -53,8 +53,13 @@ def site_banner(request):
 
     # Only show banner if user hasn't dismissed it
     if live_banner:
-        dismissed_banners = request.session.get("dismissed_banners", [])
-        if str(live_banner.id) not in dismissed_banners:
+        # Check if session is available (may not be in ASGI error handling contexts)
+        if hasattr(request, "session"):
+            dismissed_banners = request.session.get("dismissed_banners", [])
+            if str(live_banner.id) not in dismissed_banners:
+                context["banner"] = live_banner
+        else:
+            # Show banner if we can't check dismissed status
             context["banner"] = live_banner
 
     return context


### PR DESCRIPTION
Fix AttributeError: 'ASGIRequest' object has no attribute 'session'

Adds a `hasattr` check before accessing `request.session` in the `site_banner` context processor. In ASGI contexts during exception handling, the session middleware may not have been applied yet.

Fixes #1173

Generated with [Claude Code](https://claude.ai/code)