### PR TITLE
feat: add facts_with_fallback() for migration-period cache optimization

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_add_lists.html
+++ b/gyrinx/core/templates/core/campaign/campaign_add_lists.html
@@ -123,7 +123,7 @@
                                 <div class="row align-items-center">
                                     <div class="col">
                                         <h6 class="mb-1">
-                                            <strong>{% list_with_theme list %}</strong>
+                                            <a href="{% url 'core:list' list.id %}" target="_blank" rel="noopener"><strong>{% list_with_theme list %}</strong></a>
                                             {% if list.content_house %}• {{ list.content_house_name }}{% endif %}
                                         </h6>
                                         <p class="mb-0 text-muted small">
@@ -132,7 +132,9 @@
                                             {% else %}
                                                 By {{ list.owner.username }}
                                             {% endif %}
-                                            • {{ list.cost_int_cached }}¢
+                                            {% with facts=list.facts_with_fallback %}
+                                                • R: {% credits facts.rating %} Cr: {% credits facts.credits %} St: {% credits facts.stash %} W: {% credits facts.wealth %}
+                                            {% endwith %}
                                         </p>
                                     </div>
                                     <div class="col-auto">

--- a/gyrinx/core/templates/core/campaign/includes/list_row.html
+++ b/gyrinx/core/templates/core/campaign/includes/list_row.html
@@ -5,5 +5,7 @@
 </h6>
 <p class="mb-0 text-muted small">
     <i class="bi-person"></i> {{ list.owner.username }}
-    • {{ list.cost_int_cached }}¢
+    {% with facts=list.facts_with_fallback %}
+        • R: {% credits facts.rating %} Cr: {% credits facts.credits %} St: {% credits facts.stash %} W: {% credits facts.wealth %}
+    {% endwith %}
 </p>

--- a/gyrinx/core/templates/core/index.html
+++ b/gyrinx/core/templates/core/index.html
@@ -59,7 +59,7 @@
                                         </h3>
                                         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
                                             <div>{{ gang.content_house.name }}</div>
-                                            <div class="badge text-bg-primary">{{ gang.cost_display }}</div>
+                                            <div class="badge text-bg-primary">{% credits gang.facts_with_fallback.wealth %}</div>
                                         </div>
                                         <div class="small">
                                             <i class="bi-award"
@@ -152,7 +152,7 @@
                                         </h3>
                                         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
                                             <div>{{ list.content_house_name }}</div>
-                                            <div class="badge text-bg-primary">{{ list.cost_display }}</div>
+                                            <div class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</div>
                                         </div>
                                         {% load tz %}
                                         <div class="text-muted small">Last edit: {{ list.modified|timesince }} ago</div>

--- a/gyrinx/core/templates/core/lists.html
+++ b/gyrinx/core/templates/core/lists.html
@@ -30,7 +30,7 @@
                         </div>
                         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
                             <div>{{ list.content_house_name }}</div>
-                            <div class="badge text-bg-primary">{{ list.cost_int_display }}</div>
+                            <div class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</div>
                             {% if list.status == list.CAMPAIGN_MODE %}
                                 <div class="badge text-bg-success">
                                     <i class="bi-award"></i> Campaign: {{ list.campaign.name }}

--- a/gyrinx/core/templates/core/user.html
+++ b/gyrinx/core/templates/core/user.html
@@ -39,7 +39,7 @@
                         </div>
                         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
                             <div>{{ list.content_house_name }}</div>
-                            <div class="badge text-bg-primary">{{ list.cost_int_cached }}</div>
+                            <div class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</div>
                         </div>
                     </div>
                     <div class="ms-auto d-md-none">

--- a/gyrinx/core/templatetags/custom_tags.py
+++ b/gyrinx/core/templatetags/custom_tags.py
@@ -18,6 +18,7 @@ from django.utils.safestring import mark_safe
 
 from gyrinx.content.models import ContentPageRef
 from gyrinx.core import url
+from gyrinx.models import format_cost_display
 
 register = template.Library()
 
@@ -314,6 +315,22 @@ def cachebuster():
 @register.simple_tag
 def dot():
     return mark_safe("&nbsp;·&nbsp;")
+
+
+@register.simple_tag
+def credits(value, show_sign=False):
+    """
+    Format an integer cost value with the credits symbol.
+
+    Args:
+        value: Integer cost value
+        show_sign: If True, show '+' for positive values (default: False)
+
+    Usage:
+        {% credits list.facts_with_fallback.wealth %}
+        {% credits delta show_sign=True %}
+    """
+    return format_cost_display(value, show_sign=show_sign)
 
 
 @register.simple_tag(takes_context=True)

--- a/gyrinx/core/tests/test_tags.py
+++ b/gyrinx/core/tests/test_tags.py
@@ -1,7 +1,7 @@
 import pytest
 from django.template.context import make_context as django_make_context
 
-from gyrinx.core.templatetags.custom_tags import is_active
+from gyrinx.core.templatetags.custom_tags import credits, is_active
 
 
 @pytest.fixture
@@ -15,3 +15,34 @@ def make_context(rf):
 def test_is_active(make_context):
     context = make_context("/")
     assert is_active(context, "core:index")
+
+
+def test_credits_basic_formatting():
+    """Test basic credits formatting."""
+    assert credits(100) == "100¢"
+    assert credits(0) == "0¢"
+    assert credits(1500) == "1500¢"
+
+
+def test_credits_negative_values():
+    """Test credits formatting with negative values."""
+    assert credits(-50) == "-50¢"
+    assert credits(-100) == "-100¢"
+
+
+def test_credits_show_sign_positive():
+    """Test credits formatting with show_sign=True for positive values."""
+    assert credits(100, show_sign=True) == "+100¢"
+    assert credits(50, show_sign=True) == "+50¢"
+
+
+def test_credits_show_sign_negative():
+    """Test credits formatting with show_sign=True for negative values."""
+    # Negative values should show minus sign regardless of show_sign
+    assert credits(-100, show_sign=True) == "-100¢"
+
+
+def test_credits_show_sign_zero():
+    """Test credits formatting with show_sign=True for zero."""
+    # Zero gets a + sign when show_sign=True (matches format_cost_display behavior)
+    assert credits(0, show_sign=True) == "+0¢"


### PR DESCRIPTION
Add List.facts_with_fallback() method that uses cached values when clean, falling back to calculation when dirty. Emits track("facts_fallback") for monitoring rollout progress.

Update multi-list views (homepage, user page, lists search, campaign pages) to use facts_with_fallback() via new credits template tag:
- Show R: Cr: St: W: breakdown on campaign pages instead of just wealth
- Link gang names to detail pages on campaign add-lists page
- Add credits template tag with show_sign parameter