### PR TITLE
fix: prevent negative rating_current in facts_from_db methods

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -521,7 +521,9 @@ class List(AppBase):
 
         # Optionally update cache
         if update:
-            self.rating_current = rating
+            # Use max(0, rating) to prevent PositiveIntegerField constraint violation
+            # (cost_int can return negative values via cost overrides)
+            self.rating_current = max(0, rating)
             self.stash_current = stash
             self.dirty = False
             self.save(update_fields=["rating_current", "stash_current", "dirty"])
@@ -1967,7 +1969,9 @@ class ListFighter(AppBase):
 
         # Optionally update cache
         if update:
-            self.rating_current = rating
+            # Use max(0, rating) to prevent PositiveIntegerField constraint violation
+            # (cost_int can return negative values via cost overrides)
+            self.rating_current = max(0, rating)
             self.dirty = False
             self.save(update_fields=["rating_current", "dirty"])
 
@@ -3561,7 +3565,9 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
 
         # Optionally update cache
         if update:
-            self.rating_current = rating
+            # Use max(0, rating) to prevent PositiveIntegerField constraint violation
+            # (cost_int can return negative values via cost overrides)
+            self.rating_current = max(0, rating)
             self.dirty = False
             self.save(update_fields=["rating_current", "dirty"])
 


### PR DESCRIPTION
## Summary
- Fix IntegrityError when `rating_current` goes negative via cost overrides
- Use `max(0, rating)` in all three `facts_from_db()` methods to prevent `PositiveIntegerField` constraint violations

## Root Cause
`cost_int()` can return negative values because `cost_override` and `total_cost_override` are `IntegerField` (allow negatives), but `rating_current` is a `PositiveIntegerField` (enforces >= 0 at DB level).

## Test Plan
- [x] All existing tests pass (1382 passed)
- [x] `facts`-related tests pass (43 passed)

Fixes #1205