### PR TITLE
feat: make PubSubBackend.enqueue() fire-and-forget for low latency

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -429,8 +429,7 @@ class List(AppBase):
         # Fallback to calculation (original behavior)
         track("facts_fallback", list_id=str(self.pk))
 
-        # Optionally enqueue a background refresh
-        # Disabled by default because Pub/Sub publish is synchronous and blocks page loads
+        # Enqueue a background refresh (fire-and-forget, doesn't block page loads)
         if settings.FEATURE_FACTS_FALLBACK_ENQUEUE:
             try:
                 refresh_list_facts.enqueue(list_id=str(self.pk))

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -81,9 +81,9 @@ FEATURE_LIST_ACTION_CREATE_INITIAL = (
 )
 
 # Enable background task enqueue in facts_with_fallback
-# Disabled by default because the synchronous Pub/Sub publish blocks page loads
+# Uses fire-and-forget publishing so it doesn't block page loads
 FEATURE_FACTS_FALLBACK_ENQUEUE = (
-    os.getenv("FEATURE_FACTS_FALLBACK_ENQUEUE", "") == "True"
+    os.getenv("FEATURE_FACTS_FALLBACK_ENQUEUE", "True") == "True"
 )
 
 # Gyrinx debug mode - shows debug info in templates (not the same as Django DEBUG)


### PR DESCRIPTION
## Summary

- Make `PubSubBackend.enqueue()` return immediately using fire-and-forget publishing
- Use `future.add_done_callback()` instead of blocking `future.result(timeout=10)`
- Track publish success/failure via `track()` in the callback
- Enable `FEATURE_FACTS_FALLBACK_ENQUEUE` by default now that it doesn't block page loads

## Problem

The lists page was extremely slow in production because `facts_with_fallback()` called `refresh_list_facts.enqueue()` for each dirty list, and each enqueue blocked for up to 10 seconds waiting for Pub/Sub confirmation.

## Test plan

- [x] All 1407 tests pass
- [ ] Verify lists page loads quickly in production with multiple dirty lists
- [ ] Monitor `task_published` and `task_publish_failed` events in logs