### PR TITLE
fix: use parent spanId for request logs to nest under Cloud Run traces

### DIFF
--- a/gyrinx/logging_filter.py
+++ b/gyrinx/logging_filter.py
@@ -1,0 +1,155 @@
+"""Custom CloudLoggingFilter that handles parent/child spanId correctly.
+
+This module provides a trace-aware logging filter and handler that fixes the spanId
+mismatch between Cloud Run request logs and application logs.
+
+Problem:
+- Cloud Run request logs use parent spanId from X-Cloud-Trace-Context header
+- App logs were using child spanId from OpenTelemetry DjangoInstrumentor
+- This caused app logs to not nest under request logs in Cloud Logging
+
+Solution:
+- For request-level logs: use parent spanId (nests under Cloud Run logs)
+- For custom span logs: use child spanId (correlates with Cloud Trace spans)
+
+Detection is based on span.kind:
+- SpanKind.SERVER = Root request span (created by DjangoInstrumentor)
+- SpanKind.INTERNAL = Custom/nested span (created by application code)
+"""
+
+import logging
+from typing import Optional, Tuple
+
+from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
+from google.cloud.logging_v2.handlers.structured_log import StructuredLogHandler
+from google.cloud.logging_v2.handlers._helpers import get_request_data_from_django
+
+try:
+    import opentelemetry.trace
+    from opentelemetry.trace import format_span_id, format_trace_id
+
+    HAS_OPENTELEMETRY = True
+except ImportError:
+    HAS_OPENTELEMETRY = False
+
+
+class TraceAwareCloudLoggingFilter(CloudLoggingFilter):
+    """
+    CloudLoggingFilter that uses parent spanId for request-level logs
+    and child spanId for custom span logs.
+
+    This fixes the spanId mismatch where:
+    - Cloud Run request logs have parent spanId from X-Cloud-Trace-Context
+    - App logs had child spanId from OpenTelemetry DjangoInstrumentor
+
+    Now:
+    - Request-level logs use parent spanId (nests under Cloud Run logs)
+    - Custom span logs use child spanId (correlates with Cloud Trace spans)
+    """
+
+    def filter(self, record):
+        # Get HTTP request data and header-based trace context
+        http_request, header_trace_id, header_span_id, header_sampled = (
+            get_request_data_from_django()
+        )
+
+        # Get OpenTelemetry span context
+        otel_trace_id, otel_span_id, otel_sampled, is_custom_span = (
+            self._get_otel_context()
+        )
+
+        # Determine which spanId to use
+        if otel_trace_id and header_span_id:
+            # We have both OTel and header context
+            # Use child spanId only if we're in a custom span
+            if is_custom_span:
+                span_id = otel_span_id  # Correlate with custom span in Cloud Trace
+            else:
+                span_id = header_span_id  # Nest under Cloud Run request log
+            trace_id = otel_trace_id
+            sampled = otel_sampled
+        elif otel_trace_id:
+            # Only OTel context (rare - no incoming header)
+            span_id = otel_span_id
+            trace_id = otel_trace_id
+            sampled = otel_sampled
+        else:
+            # Only header context (OTel not active)
+            span_id = header_span_id
+            trace_id = header_trace_id
+            sampled = header_sampled
+
+        # Format trace path if we have project
+        if trace_id and self.project:
+            trace_id = f"projects/{self.project}/traces/{trace_id}"
+
+        # Set record attributes (same pattern as CloudLoggingFilter)
+        # Manual overrides via extra= take precedence
+        record._resource = getattr(record, "resource", None)
+        record._trace = getattr(record, "trace", trace_id) or None
+        record._span_id = getattr(record, "span_id", span_id) or None
+        record._trace_sampled = bool(getattr(record, "trace_sampled", sampled))
+        record._http_request = getattr(record, "http_request", http_request)
+        record._source_location = CloudLoggingFilter._infer_source_location(record)
+
+        # Handle labels (from parent class logic)
+        user_labels = getattr(record, "labels", {})
+        record._labels = {**self.default_labels, **user_labels} or None
+
+        return True
+
+    def _get_otel_context(self) -> Tuple[Optional[str], Optional[str], bool, bool]:
+        """Get trace context from current OpenTelemetry span.
+
+        Returns:
+            Tuple of (trace_id, span_id, sampled, is_custom_span)
+        """
+        if not HAS_OPENTELEMETRY:
+            return None, None, False, False
+
+        span = opentelemetry.trace.get_current_span()
+        if span == opentelemetry.trace.span.INVALID_SPAN:
+            return None, None, False, False
+
+        context = span.get_span_context()
+        trace_id = format_trace_id(context.trace_id)
+        span_id = format_span_id(context.span_id)
+        sampled = context.trace_flags.sampled
+
+        # Detect if this is a custom span vs root request span
+        # DjangoInstrumentor sets SERVER for root requests, INTERNAL for nested
+        is_custom_span = (
+            getattr(span, "kind", None) != opentelemetry.trace.SpanKind.SERVER
+        )
+
+        return trace_id, span_id, sampled, is_custom_span
+
+
+class TraceAwareStructuredLogHandler(StructuredLogHandler):
+    """StructuredLogHandler that uses our custom TraceAwareCloudLoggingFilter.
+
+    This handler is a drop-in replacement for StructuredLogHandler that properly
+    handles the parent/child spanId correlation for Cloud Logging.
+    """
+
+    def __init__(
+        self,
+        *,
+        labels=None,
+        stream=None,
+        project_id=None,
+        json_encoder_cls=None,
+        **kwargs,
+    ):
+        # Call StreamHandler init directly to skip StructuredLogHandler's filter setup
+        logging.StreamHandler.__init__(self, stream=stream)
+        self.project_id = project_id
+
+        # Use our custom filter instead of default CloudLoggingFilter
+        log_filter = TraceAwareCloudLoggingFilter(
+            project=project_id, default_labels=labels
+        )
+        self.addFilter(log_filter)
+
+        # Store json encoder class (used by StructuredLogHandler.emit)
+        self._json_encoder_cls = json_encoder_cls

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -16,7 +16,7 @@ GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT") or "windy-ellipse-440618-p9"
 # Note: RequestMiddleware in settings.py handles trace correlation
 # The project_id is required for proper trace correlation formatting
 LOGGING["handlers"]["structured_console"] = {
-    "class": "google.cloud.logging_v2.handlers.StructuredLogHandler",
+    "class": "gyrinx.logging_filter.TraceAwareStructuredLogHandler",
     "project_id": GCP_PROJECT_ID,
 }
 

--- a/gyrinx/tests/test_logging_filter.py
+++ b/gyrinx/tests/test_logging_filter.py
@@ -1,0 +1,317 @@
+"""Tests for TraceAwareCloudLoggingFilter."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gyrinx.logging_filter import (
+    TraceAwareCloudLoggingFilter,
+    TraceAwareStructuredLogHandler,
+)
+
+
+class TestTraceAwareCloudLoggingFilter:
+    """Tests for TraceAwareCloudLoggingFilter."""
+
+    @pytest.fixture
+    def filter_instance(self):
+        """Create a filter instance with a test project."""
+        return TraceAwareCloudLoggingFilter(
+            project="test-project", default_labels={"env": "test"}
+        )
+
+    @pytest.fixture
+    def log_record(self):
+        """Create a basic log record."""
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="/test/path.py",
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        return record
+
+    def test_request_level_log_uses_header_span_id(self, filter_instance, log_record):
+        """Request-level logs should use parent spanId from header."""
+        header_span_id = "abc123header"
+        header_trace_id = "trace123"
+        otel_span_id = "def456otel"
+
+        # Mock Django request data to return header context
+        with patch("gyrinx.logging_filter.get_request_data_from_django") as mock_django:
+            mock_django.return_value = (
+                {"method": "GET"},  # http_request
+                header_trace_id,  # trace_id
+                header_span_id,  # span_id
+                True,  # sampled
+            )
+
+            # Mock OpenTelemetry context with SERVER span kind (root request)
+            with patch.object(filter_instance, "_get_otel_context") as mock_otel:
+                mock_otel.return_value = (
+                    header_trace_id,  # trace_id (same as header)
+                    otel_span_id,  # span_id (different - child)
+                    True,  # sampled
+                    False,  # is_custom_span = False (SERVER span)
+                )
+
+                result = filter_instance.filter(log_record)
+
+                assert result is True
+                # Should use header span_id (parent) for request-level logs
+                assert log_record._span_id == header_span_id
+                assert (
+                    log_record._trace
+                    == f"projects/test-project/traces/{header_trace_id}"
+                )
+                assert log_record._trace_sampled is True
+
+    def test_custom_span_log_uses_otel_span_id(self, filter_instance, log_record):
+        """Custom span logs should use child spanId from OpenTelemetry."""
+        header_span_id = "abc123header"
+        header_trace_id = "trace123"
+        otel_span_id = "def456otel"
+
+        with patch("gyrinx.logging_filter.get_request_data_from_django") as mock_django:
+            mock_django.return_value = (
+                {"method": "GET"},
+                header_trace_id,
+                header_span_id,
+                True,
+            )
+
+            with patch.object(filter_instance, "_get_otel_context") as mock_otel:
+                mock_otel.return_value = (
+                    header_trace_id,
+                    otel_span_id,
+                    True,
+                    True,  # is_custom_span = True (INTERNAL span)
+                )
+
+                result = filter_instance.filter(log_record)
+
+                assert result is True
+                # Should use OTel span_id (child) for custom span logs
+                assert log_record._span_id == otel_span_id
+
+    def test_fallback_to_header_when_no_otel_context(self, filter_instance, log_record):
+        """Falls back to header when OpenTelemetry context is not available."""
+        header_span_id = "abc123header"
+        header_trace_id = "trace123"
+
+        with patch("gyrinx.logging_filter.get_request_data_from_django") as mock_django:
+            mock_django.return_value = (
+                {"method": "GET"},
+                header_trace_id,
+                header_span_id,
+                True,
+            )
+
+            with patch.object(filter_instance, "_get_otel_context") as mock_otel:
+                # No OTel context
+                mock_otel.return_value = (None, None, False, False)
+
+                result = filter_instance.filter(log_record)
+
+                assert result is True
+                assert log_record._span_id == header_span_id
+                assert (
+                    log_record._trace
+                    == f"projects/test-project/traces/{header_trace_id}"
+                )
+
+    def test_fallback_to_otel_when_no_header(self, filter_instance, log_record):
+        """Falls back to OTel when no header context available."""
+        otel_span_id = "def456otel"
+        otel_trace_id = "trace456"
+
+        with patch("gyrinx.logging_filter.get_request_data_from_django") as mock_django:
+            # No header context
+            mock_django.return_value = (None, None, None, False)
+
+            with patch.object(filter_instance, "_get_otel_context") as mock_otel:
+                mock_otel.return_value = (
+                    otel_trace_id,
+                    otel_span_id,
+                    True,
+                    False,
+                )
+
+                result = filter_instance.filter(log_record)
+
+                assert result is True
+                assert log_record._span_id == otel_span_id
+                assert (
+                    log_record._trace == f"projects/test-project/traces/{otel_trace_id}"
+                )
+
+    def test_manual_override_via_extra(self, filter_instance, log_record):
+        """Manual override via extra= parameter takes precedence."""
+        header_span_id = "abc123header"
+        override_span_id = "override123"
+        override_trace = "projects/test-project/traces/override_trace"
+
+        # Set manual overrides on record (simulating extra= parameter)
+        log_record.span_id = override_span_id
+        log_record.trace = override_trace
+
+        with patch("gyrinx.logging_filter.get_request_data_from_django") as mock_django:
+            mock_django.return_value = (
+                {"method": "GET"},
+                "trace123",
+                header_span_id,
+                True,
+            )
+
+            with patch.object(filter_instance, "_get_otel_context") as mock_otel:
+                mock_otel.return_value = ("trace123", "otel456", True, False)
+
+                result = filter_instance.filter(log_record)
+
+                assert result is True
+                # Manual overrides should be used
+                assert log_record._span_id == override_span_id
+                assert log_record._trace == override_trace
+
+    def test_labels_are_merged(self, filter_instance, log_record):
+        """Default labels and user labels should be merged."""
+        log_record.labels = {"user_label": "value"}
+
+        with patch("gyrinx.logging_filter.get_request_data_from_django") as mock_django:
+            mock_django.return_value = (None, None, None, False)
+
+            with patch.object(filter_instance, "_get_otel_context") as mock_otel:
+                mock_otel.return_value = (None, None, False, False)
+
+                filter_instance.filter(log_record)
+
+                # Should have both default and user labels
+                assert log_record._labels == {"env": "test", "user_label": "value"}
+
+    def test_no_context_available(self, filter_instance, log_record):
+        """Handles case where no context is available at all."""
+        with patch("gyrinx.logging_filter.get_request_data_from_django") as mock_django:
+            mock_django.return_value = (None, None, None, False)
+
+            with patch.object(filter_instance, "_get_otel_context") as mock_otel:
+                mock_otel.return_value = (None, None, False, False)
+
+                result = filter_instance.filter(log_record)
+
+                assert result is True
+                assert log_record._span_id is None
+                assert log_record._trace is None
+                assert log_record._trace_sampled is False
+
+
+class TestGetOtelContext:
+    """Tests for _get_otel_context method."""
+
+    @pytest.fixture
+    def filter_instance(self):
+        return TraceAwareCloudLoggingFilter(project="test-project")
+
+    def test_returns_none_when_no_opentelemetry(self, filter_instance):
+        """Returns None values when OpenTelemetry is not available."""
+        with patch("gyrinx.logging_filter.HAS_OPENTELEMETRY", False):
+            result = filter_instance._get_otel_context()
+            assert result == (None, None, False, False)
+
+    def test_returns_none_for_invalid_span(self, filter_instance):
+        """Returns None values for invalid span."""
+        with patch("gyrinx.logging_filter.opentelemetry.trace") as mock_trace:
+            mock_trace.get_current_span.return_value = mock_trace.span.INVALID_SPAN
+            result = filter_instance._get_otel_context()
+            assert result == (None, None, False, False)
+
+    def test_detects_server_span_as_not_custom(self, filter_instance):
+        """SERVER span kind should not be detected as custom span."""
+        with patch("gyrinx.logging_filter.opentelemetry") as mock_otel:
+            mock_span = MagicMock()
+            mock_span.kind = mock_otel.trace.SpanKind.SERVER
+            mock_context = MagicMock()
+            mock_context.trace_id = 12345
+            mock_context.span_id = 67890
+            mock_context.trace_flags.sampled = True
+            mock_span.get_span_context.return_value = mock_context
+
+            mock_otel.trace.get_current_span.return_value = mock_span
+            mock_otel.trace.span.INVALID_SPAN = MagicMock()
+            mock_otel.trace.format_trace_id.return_value = "trace123"
+            mock_otel.trace.format_span_id.return_value = "span456"
+
+            with patch(
+                "gyrinx.logging_filter.format_trace_id", return_value="trace123"
+            ):
+                with patch(
+                    "gyrinx.logging_filter.format_span_id", return_value="span456"
+                ):
+                    result = filter_instance._get_otel_context()
+
+                    # is_custom_span should be False for SERVER spans
+                    assert result[3] is False
+
+    def test_detects_internal_span_as_custom(self, filter_instance):
+        """INTERNAL span kind should be detected as custom span."""
+        with patch("gyrinx.logging_filter.opentelemetry") as mock_otel:
+            mock_span = MagicMock()
+            mock_span.kind = mock_otel.trace.SpanKind.INTERNAL
+            mock_context = MagicMock()
+            mock_context.trace_id = 12345
+            mock_context.span_id = 67890
+            mock_context.trace_flags.sampled = True
+            mock_span.get_span_context.return_value = mock_context
+
+            mock_otel.trace.get_current_span.return_value = mock_span
+            mock_otel.trace.span.INVALID_SPAN = MagicMock()
+            mock_otel.trace.SpanKind.SERVER = "SERVER"
+
+            with patch(
+                "gyrinx.logging_filter.format_trace_id", return_value="trace123"
+            ):
+                with patch(
+                    "gyrinx.logging_filter.format_span_id", return_value="span456"
+                ):
+                    result = filter_instance._get_otel_context()
+
+                    # is_custom_span should be True for INTERNAL spans
+                    assert result[3] is True
+
+
+class TestTraceAwareStructuredLogHandler:
+    """Tests for TraceAwareStructuredLogHandler."""
+
+    def test_uses_custom_filter(self):
+        """Handler should use TraceAwareCloudLoggingFilter."""
+        handler = TraceAwareStructuredLogHandler(
+            project_id="test-project", labels={"env": "test"}
+        )
+
+        # Should have exactly one filter of our custom type
+        custom_filters = [
+            f for f in handler.filters if isinstance(f, TraceAwareCloudLoggingFilter)
+        ]
+        assert len(custom_filters) == 1
+
+        # Check filter configuration
+        custom_filter = custom_filters[0]
+        assert custom_filter.project == "test-project"
+        assert custom_filter.default_labels == {"env": "test"}
+
+    def test_stores_project_id(self):
+        """Handler should store project_id attribute."""
+        handler = TraceAwareStructuredLogHandler(project_id="my-project")
+        assert handler.project_id == "my-project"
+
+    def test_stores_json_encoder(self):
+        """Handler should store json_encoder_cls attribute."""
+        import json
+
+        handler = TraceAwareStructuredLogHandler(
+            project_id="test", json_encoder_cls=json.JSONEncoder
+        )
+        assert handler._json_encoder_cls == json.JSONEncoder

--- a/gyrinx/tracing.py
+++ b/gyrinx/tracing.py
@@ -121,7 +121,6 @@ def _init_tracing() -> None:
     try:
         from opentelemetry import trace
         from opentelemetry.instrumentation.django import DjangoInstrumentor
-        from opentelemetry.instrumentation.logging import LoggingInstrumentor
         from opentelemetry.propagate import set_global_textmap
         from opentelemetry.propagators.cloud_trace_propagator import (
             CloudTraceFormatPropagator,
@@ -147,9 +146,9 @@ def _init_tracing() -> None:
         # Auto-instrument Django (adds automatic request spans)
         DjangoInstrumentor().instrument()
 
-        # Auto-instrument logging (injects trace context into log records)
-        # This ensures StructuredLogHandler uses OpenTelemetry span IDs
-        LoggingInstrumentor().instrument(set_logging_format=False)
+        # Note: We don't use LoggingInstrumentor here because our custom
+        # TraceAwareCloudLoggingFilter in logging_filter.py handles trace context
+        # injection with proper parent/child spanId handling.
 
         # Get tracer for manual spans
         _tracer = trace.get_tracer("gyrinx.tracing")


### PR DESCRIPTION
Custom TraceAwareCloudLoggingFilter fixes spanId mismatch where app logs were detached from parent HTTP requests in Cloud Logging.

- Request-level logs use parent spanId (nests under Cloud Run logs)
- Custom span logs use child spanId (correlates with Cloud Trace spans)
- Detection via span.kind: SERVER = root request, INTERNAL = custom span
- Removed LoggingInstrumentor (custom filter handles trace context)