### PR TITLE
docs: add task framework documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Analytics Graph Configuration](how-to-guides/analytics-graph-configuration.md)
 - [Tracking and Metrics](tracking.md)
 - [Useful Scripts](useful-scripts.md)
+- [Task Framework](how-to-guides/task-framework.md)
 
 ## Technical Reference
 
@@ -36,11 +37,7 @@
 - [Logging and Tracing Reference](logging-and-tracing-reference.md)
 - [Security Baseline](security-baseline.md)
 - [Statlines](technical-reference/statlines.md)
-- [Task Framework Reference](tasks/reference.md)
-
-## How-To Guides: Tasks
-
-- [Task Framework How-To Guides](tasks/how-to.md)
+- [Task Framework](technical-reference/task-framework.md)
 
 ## Explanation
 
@@ -52,7 +49,7 @@
 - [Integration Testing](integration_testing.md)
 - [Test Performance Improvements](test-performance-improvements.md)
 - [Changelog Management](developing-gyrinx/changelog-management.md)
-- [Task Framework Architecture](tasks/architecture.md)
+- [Task Framework Architecture](explanation/task-framework.md)
 
 ## Operations
 

--- a/docs/technical-reference/task-framework.md
+++ b/docs/technical-reference/task-framework.md
@@ -192,21 +192,7 @@ The `PubSubBackend` has the following capability flags:
 
 | Capability | Supported | Notes |
 |------------|-----------|-------|
-| `supports_defer` | No | Would require Pub/Sub scheduled delivery |
-| `supports_async_task` | No | Would require async Pub/Sub client |
-| `supports_get_result` | No | Would require result storage (database/Cloud Storage) |
-| `supports_priority` | No | Would require separate topics per priority |
-
-## File Locations
-
-| File | Purpose |
-|------|---------|
-| `gyrinx/tasks/__init__.py` | Package exports (`TaskRoute`) |
-| `gyrinx/tasks/route.py` | `TaskRoute` dataclass definition |
-| `gyrinx/tasks/registry.py` | Task registration (add tasks here) |
-| `gyrinx/tasks/backend.py` | `PubSubBackend` implementation |
-| `gyrinx/tasks/views.py` | Push handler view |
-| `gyrinx/tasks/provisioning.py` | Auto-provisioning logic |
-| `gyrinx/tasks/apps.py` | Django app config (triggers provisioning) |
-| `gyrinx/tasks/urls.py` | URL routing |
-| `gyrinx/core/tasks.py` | Task function implementations |
+| `supports_defer` | No | To implement, use Pub/Sub scheduled delivery |
+| `supports_async_task` | No | To implement, use async Pub/Sub client |
+| `supports_get_result` | No | To implement, use result storage (database/Cloud Storage) |
+| `supports_priority` | No | Unclear |


### PR DESCRIPTION
- Add comprehensive documentation for the background task infrastructure following the Diataxis framework
- Reference doc covers TaskRoute configuration, environment variables, response codes, and naming conventions
- How-to guides cover creating tasks, scheduling, kill switches, retry config, and idempotency patterns
- Architecture doc explains why Pub/Sub, message flow, provisioning strategy, and security model