### PR TITLE
fix: use theme-responsive background class in asset type editors

### DIFF
--- a/gyrinx/core/templates/core/campaign/includes/property_schema_editor.html
+++ b/gyrinx/core/templates/core/campaign/includes/property_schema_editor.html
@@ -24,7 +24,7 @@ Requires: form with property_schema_json field
     {% endif %}
 </div>
 <template id="property-row-template">
-    <div class="property-row d-flex flex-column gap-2 p-2 border rounded bg-light">
+    <div class="property-row d-flex flex-column gap-2 p-2 border rounded bg-body-tertiary">
         <div class="d-flex flex-column flex-sm-row gap-2">
             <div class="flex-grow-1">
                 <input type="text"

--- a/gyrinx/core/templates/core/campaign/includes/sub_asset_schema_editor.html
+++ b/gyrinx/core/templates/core/campaign/includes/sub_asset_schema_editor.html
@@ -24,7 +24,7 @@ Requires: form with sub_asset_schema_json field
     {% endif %}
 </div>
 <template id="sub-asset-type-template">
-    <div class="sub-asset-type-entry p-3 border rounded bg-light">
+    <div class="sub-asset-type-entry p-3 border rounded bg-body-tertiary">
         <div class="d-flex justify-content-between align-items-start mb-2">
             <strong class="sub-asset-type-title">New Sub-Asset Type</strong>
             <button type="button"


### PR DESCRIPTION
Fixes #1240

Replace `bg-light` with `bg-body-tertiary` in property_schema_editor.html and sub_asset_schema_editor.html to fix dark mode display issues.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)