### PR TITLE
fix: ensure consistent rating display across all views

### DIFF
--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -120,6 +120,10 @@ def get_clean_list_or_404(model_or_queryset, *args, **kwargs):
     If the list is marked as dirty (e.g., due to content cost changes),
     this function will refresh the cached facts before returning.
 
+    When passed the List model class directly, this function automatically
+    applies the with_latest_actions() prefetch to enable the facts system
+    for consistent rating display across all views.
+
     Args:
         model_or_queryset: A model class (List) or queryset to filter
         *args, **kwargs: Additional arguments passed to get_object_or_404
@@ -131,6 +135,11 @@ def get_clean_list_or_404(model_or_queryset, *args, **kwargs):
         get_clean_list_or_404(List, id=id, owner=request.user)
         get_clean_list_or_404(List.objects.filter(...), id=id)
     """
+    # If passed the List model directly, apply with_latest_actions() prefetch
+    # to enable can_use_facts for consistent rating display
+    if model_or_queryset is List:
+        model_or_queryset = List.objects.with_latest_actions()
+
     obj = get_object_or_404(model_or_queryset, *args, **kwargs)
 
     if obj.dirty:


### PR DESCRIPTION
Fixed the rating display discrepancy between the gang summary page and weapon customise pages.

- Modified `get_clean_list_or_404` to automatically apply `with_latest_actions()` prefetch when passed the `List` model class
- Added tests to verify the fix

Fixes #1232

🤖 Generated with [Claude Code](https://claude.ai/claude-code)