### PR TITLE
fix: apply microcopy guidelines to campaign copy templates

### DIFF
--- a/gyrinx/core/templates/CLAUDE.md
+++ b/gyrinx/core/templates/CLAUDE.md
@@ -1,0 +1,38 @@
+# Templates
+
+## Microcopy Guidelines
+
+### Casing
+
+Use sentence case for UI text. Title case proper nouns only.
+
+**Proper nouns (title case):**
+
+- Campaign
+- Action
+- Asset
+- Gang
+- Fighter
+- Territory
+- Resource
+
+**Linking words (lowercase):**
+
+- from, to, and, or, the, a, an, in, on, for, with
+
+### Examples
+
+| Correct | Incorrect |
+|---------|-----------|
+| Copy from another Campaign | Copy From Another Campaign |
+| Add a Gang to this Campaign | Add A Gang To This Campaign |
+| Assets and Resources | Assets And Resources |
+| Copy to Campaign | Copy To Campaign |
+| Create new Asset | Create New Asset |
+
+### Button Labels
+
+- Use action verbs: "Add", "Create", "Copy", "Remove"
+- Keep labels concise: "Next", "Cancel", "Save"
+- Arrow icons go after text for forward actions: "Next →"
+- Arrow icons go before text for back actions: "← Back"

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -96,7 +96,7 @@
                 {% elif user.is_authenticated %}
                     <a href="{% url 'core:campaign-copy-out' campaign.id %}"
                        class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover small ms-md-auto">
-                        <i class="bi-box-arrow-up"></i> Copy from this campaign
+                        <i class="bi-box-arrow-up"></i> Copy from this Campaign
                     </a>
                 {% endif %}
             </div>
@@ -231,7 +231,7 @@
                 <p class="text-muted small mb-0">
                     No asset types defined yet.
                     {% if campaign.owner == user and not campaign.archived %}
-                        <a href="{% url 'core:campaign-copy-in' campaign.id %}">Copy from another campaign</a>
+                        <a href="{% url 'core:campaign-copy-in' campaign.id %}">Copy from another Campaign</a>
                         or <a href="{% url 'core:campaign-asset-type-new' campaign.id %}">add an asset type →</a>
                     {% elif campaign.owner == user %}
                         <a href="{% url 'core:campaign-assets' campaign.id %}">Manage Assets →</a>
@@ -296,7 +296,7 @@
                 <p class="text-muted small mb-0">
                     No resource types defined yet.
                     {% if campaign.owner == user and not campaign.archived %}
-                        <a href="{% url 'core:campaign-copy-in' campaign.id %}">Copy from another campaign</a>
+                        <a href="{% url 'core:campaign-copy-in' campaign.id %}">Copy from another Campaign</a>
                         or <a href="{% url 'core:campaign-resource-type-new' campaign.id %}">add a resource type →</a>
                     {% elif campaign.owner == user %}
                         <a href="{% url 'core:campaign-resources' campaign.id %}">Manage Resources →</a>

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -21,7 +21,7 @@
                         {% if not campaign.archived %}
                             <a href="{% url 'core:campaign-copy-in' campaign.id %}"
                                class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">
-                                <i class="bi-box-arrow-in-down"></i> Copy from Campaign
+                                <i class="bi-box-arrow-in-down"></i> Copy from another Campaign
                             </a>
                         {% endif %}
                     </div>

--- a/gyrinx/core/templates/core/campaign/campaign_copy_from.html
+++ b/gyrinx/core/templates/core/campaign/campaign_copy_from.html
@@ -7,9 +7,10 @@
     {% include "core/includes/back.html" with url=campaign.get_absolute_url text="Back to Campaign" %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-4">
         <div>
-            <h1 class="mb-2">Copy From Another Campaign</h1>
+            <h1 class="mb-2">Copy from another Campaign</h1>
+            <h3 class="mb-2 text-muted">{{ campaign.name }}</h3>
             <p class="text-muted mb-0">
-                Copy asset types, assets, and resource types from another campaign to <strong>{{ campaign.name }}</strong>.
+                Copy asset types, assets, and resource types to <strong>{{ campaign.name }}</strong>.
             </p>
         </div>
         {% if show_confirmation %}

--- a/gyrinx/core/templates/core/campaign/campaign_copy_to.html
+++ b/gyrinx/core/templates/core/campaign/campaign_copy_to.html
@@ -6,9 +6,9 @@
     {% include "core/includes/back.html" with url=campaign.get_absolute_url text="Back to Campaign" %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-4">
         <div>
-            <h1 class="mb-2">Copy To Another Campaign</h1>
+            <h1 class="mb-2">Copy to another Campaign</h1>
             <p class="text-muted mb-0">
-                Copy asset types, assets, and resource types from <strong>{{ campaign.name }}</strong> to another campaign.
+                Copy asset types, assets, and resource types from <strong>{{ campaign.name }}</strong> to another Campaign.
             </p>
         </div>
         {% if show_confirmation %}

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -16,7 +16,7 @@
                         {% if not campaign.archived %}
                             <a href="{% url 'core:campaign-copy-in' campaign.id %}"
                                class="icon-link link-secondary link-underline-opacity-25 link-underline-opacity-100-hover small">
-                                <i class="bi-box-arrow-in-down"></i> Copy from Campaign
+                                <i class="bi-box-arrow-in-down"></i> Copy from another Campaign
                             </a>
                         {% endif %}
                         <a href="{% url 'core:campaign-resource-type-new' campaign.id %}"

--- a/gyrinx/core/tests/test_campaign_copy.py
+++ b/gyrinx/core/tests/test_campaign_copy.py
@@ -466,7 +466,7 @@ def test_campaign_copy_to_view_shows_form_when_content_exists(
     response = client.get(reverse("core:campaign-copy-out", args=[source.id]))
 
     assert response.status_code == 200
-    assert b"Copy To Another Campaign" in response.content
+    assert b"Copy to another Campaign" in response.content
 
 
 @pytest.mark.django_db
@@ -489,7 +489,7 @@ def test_campaign_copy_from_view_shows_form_when_other_campaigns_exist(
     response = client.get(reverse("core:campaign-copy-in", args=[target.id]))
 
     assert response.status_code == 200
-    assert b"Copy From Another Campaign" in response.content
+    assert b"Copy from another Campaign" in response.content
 
 
 # --- Model Tests ---


### PR DESCRIPTION
Update UI text to use sentence case with proper nouns (Campaign, Asset, Resource, Gang) title-cased per the new microcopy guidelines.

Changes:
- "Copy from this campaign" → "Copy from this Campaign"
- "Copy from another campaign" → "Copy from another Campaign"
- "Copy from Campaign" → "Copy from another Campaign"
- "to another campaign" → "to another Campaign"

Also update tests to match the new sentence case heading text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)