### PR TITLE
fix: UI audit fixes for vehicles, links, and cursor styles

### DIFF
--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -101,6 +101,11 @@ $font-sizes: map-merge($font-sizes, $custom-font-sizes);
     cursor: help;
 }
 
+// Links with tooltips should show pointer cursor
+a[data-bs-toggle="tooltip"] {
+    cursor: pointer;
+}
+
 .linked {
     @extend .link-underline-opacity-25;
     @extend .link-underline-opacity-100-hover;

--- a/gyrinx/core/templates/core/campaign/campaign_captured_fighters.html
+++ b/gyrinx/core/templates/core/campaign/campaign_captured_fighters.html
@@ -1,5 +1,9 @@
 {% extends "core/layouts/base.html" %}
 {% load allauth custom_tags color_tags %}
+{% comment %}
+    Captured Fighters screen for a campaign.
+    Displays all captured fighters with links to their original gang and capturing gang.
+{% endcomment %}
 {% block head_title %}
     Captured Fighters - {{ campaign.name }}
 {% endblock head_title %}
@@ -31,12 +35,21 @@
                         {% for captured in captured_fighters %}
                             <tr>
                                 <td>
-                                    <strong>{{ captured.fighter.name }}</strong>
+                                    <a href="{% url 'core:list' captured.fighter.list.id %}#{{ captured.fighter.id }}"
+                                       class="link-underline-opacity-25 link-underline-opacity-100-hover">
+                                        <strong>{{ captured.fighter.name }}</strong>
+                                    </a>
                                     <br>
                                     <small class="text-secondary">{{ captured.fighter.content_fighter.type }}</small>
                                 </td>
-                                <td>{{ captured.fighter.list.name }}</td>
-                                <td>{{ captured.capturing_list.name }}</td>
+                                <td>
+                                    <a href="{% url 'core:list' captured.fighter.list.id %}"
+                                       class="link-underline-opacity-25 link-underline-opacity-100-hover">{% list_with_theme captured.fighter.list %}</a>
+                                </td>
+                                <td>
+                                    <a href="{% url 'core:list' captured.capturing_list.id %}"
+                                       class="link-underline-opacity-25 link-underline-opacity-100-hover">{% list_with_theme captured.capturing_list %}</a>
+                                </td>
                                 <td>
                                     {% if captured.sold_to_guilders %}
                                         <span class="badge bg-secondary">Sold to Guilders</span>

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -1,5 +1,5 @@
 {% extends "core/layouts/base.html" %}
-{% load allauth custom_tags %}
+{% load allauth custom_tags color_tags %}
 {% block head_title %}
     Campaign Resources - {{ campaign.name }}
 {% endblock head_title %}
@@ -62,7 +62,7 @@
                                     <tr>
                                         <td class="ps-0">
                                             <a href="{% url 'core:list' resource.list.id %}"
-                                               class="link-underline-opacity-25 link-underline-opacity-100-hover">{{ resource.list.name }}</a>
+                                               class="link-underline-opacity-25 link-underline-opacity-100-hover">{% list_with_theme resource.list %}</a>
                                         </td>
                                         <td class="text-end">{{ resource.amount }}</td>
                                         <td class="text-end pe-0">

--- a/gyrinx/core/templates/core/includes/fighter_card_content.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content.html
@@ -33,10 +33,10 @@
                         </span>
                     {% endif %}
                 {% endif %}
-                {% if fighter.is_captured %}
+                {% if fighter.is_captured and not fighter.is_vehicle %}
                     {% if can_edit and list.campaign and not print %}
                         <a href="{% url 'core:campaign-captured-fighters' list.campaign.id %}"
-                           class="badge ms-2 bg-warning text-dark text-decoration-none"
+                           class="badge ms-2 bg-warning text-dark text-decoration-none captured-badge-link"
                            data-bs-toggle="tooltip"
                            data-bs-title="Captured by {{ fighter.capture_info.capturing_list.name }}">Captured</a>
                     {% else %}
@@ -44,7 +44,7 @@
                               data-bs-toggle="tooltip"
                               data-bs-title="Captured by {{ fighter.capture_info.capturing_list.name }}">Captured</span>
                     {% endif %}
-                {% elif fighter.is_sold_to_guilders %}
+                {% elif fighter.is_sold_to_guilders and not fighter.is_vehicle %}
                     {% if can_edit and list.campaign and not print %}
                         <a href="{% url 'core:campaign-captured-fighters' list.campaign.id %}"
                            class="badge ms-2 bg-secondary text-decoration-none">Sold to Guilders</a>
@@ -159,7 +159,7 @@
                             </button>
                             <ul class="dropdown-menu">
                                 {% if fighter.is_child_fighter %}
-                                    {% if list.is_campaign_mode and fighter.injury_state != 'dead' and not fighter.is_captured and not fighter.is_sold_to_guilders %}
+                                    {% if list.is_campaign_mode and fighter.injury_state != 'dead' and not fighter.is_captured and not fighter.is_sold_to_guilders and not fighter.is_vehicle %}
                                         <li>
                                             <a class="dropdown-item"
                                                href="{% url 'core:list-fighter-mark-captured' list.id fighter.id %}"><i class="bi-exclamation-triangle"></i> Mark Captured</a>
@@ -169,22 +169,19 @@
                                         </li>
                                     {% endif %}
                                     <li>
-                                        <a class="dropdown-item disabled"
-                                           href="#"
-                                           tabindex="-1"
-                                           aria-disabled="true"><i class="bi-copy"></i> Clone</a>
+                                        <span class="dropdown-item text-muted"
+                                              data-bs-toggle="tooltip"
+                                              data-bs-title="Child fighters are managed through their crew"><i class="bi-copy"></i> Clone</span>
                                     </li>
                                     <li>
-                                        <a class="dropdown-item disabled"
-                                           href="#"
-                                           tabindex="-1"
-                                           aria-disabled="true"><i class="bi-archive"></i> Archive</a>
+                                        <span class="dropdown-item text-muted"
+                                              data-bs-toggle="tooltip"
+                                              data-bs-title="Child fighters are managed through their crew"><i class="bi-archive"></i> Archive</span>
                                     </li>
                                     <li>
-                                        <a class="dropdown-item disabled"
-                                           href="#"
-                                           tabindex="-1"
-                                           aria-disabled="true"><i class="bi-trash"></i> Delete</a>
+                                        <span class="dropdown-item text-muted"
+                                              data-bs-toggle="tooltip"
+                                              data-bs-title="Child fighters are managed through their crew"><i class="bi-trash"></i> Delete</span>
                                     </li>
                                 {% else %}
                                     {% if list.is_campaign_mode %}

--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -4,7 +4,9 @@
         <h2>{{ list.name }}</h2>
         <div>{{ list.content_house_name }}</div>
         <div class="text-secondary">
-            <i class="bi-person"></i> {{ list.owner_cached }}
+            <i class="bi-person"></i>
+            <a href="{% url 'core:user' list.owner_cached.username %}"
+               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{{ list.owner_cached }}</a>
         </div>
     </div>
     <nav class="nav card card-body flex-column mb-3 p-2">


### PR DESCRIPTION
## Summary

Fixes several UI issues from the UI audit:

- Hide captured/sold status badges for vehicles (can't be captured)
- Hide "Mark Captured" option for vehicles in dropdown menu
- Replace disabled Clone/Archive/Delete links with spans + tooltips
- Add list_with_theme to campaign resources for gang color tags
- Add links to fighter name and gang names on captured fighters screen
- Make username a link to user profile on list about page
- Fix cursor: use pointer for clickable links with tooltips

Fixes #1257

🤖 Generated with [Claude Code](https://claude.ai/claude-code)