### PR TITLE
feat: Add confirmation dialog for restore fighter action

### DIFF
--- a/gyrinx/core/templates/core/list_archived_fighters.html
+++ b/gyrinx/core/templates/core/list_archived_fighters.html
@@ -21,12 +21,8 @@
                             <td>{{ fighter.fully_qualified_name }}</td>
                             {% if not fighter.source_assignment.exists %}
                                 <td>
-                                    <form action="{% url 'core:list-fighter-archive' list.id fighter.id %}"
-                                          method="post">
-                                        {% csrf_token %}
-                                        <input type="hidden" name="archive" value="0">
-                                        <button type="submit" class="btn btn-link">Restore</button>
-                                    </form>
+                                    <a href="{% url 'core:list-fighter-restore' list.id fighter.id %}"
+                                       class="btn btn-link">Restore</a>
                                 </td>
                             {% else %}
                                 <td>

--- a/gyrinx/core/templates/core/list_fighter_restore_confirm.html
+++ b/gyrinx/core/templates/core/list_fighter_restore_confirm.html
@@ -1,0 +1,37 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Restore Fighter - {{ fighter.fully_qualified_name }} - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with text="Archived Fighters" %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">Restore Fighter: {{ fighter.fully_qualified_name }}</h1>
+        <form action="{% url 'core:list-fighter-restore' list.id fighter.id %}"
+              method="post">
+            {% csrf_token %}
+            <p>
+                Are you sure you want to restore <strong>{{ fighter.name }}</strong>?
+            </p>
+            <p>This will:</p>
+            <ul>
+                <li>Return them to the active gang roster</li>
+                <li>Add {{ fighter_cost }}¢ back to your gang rating</li>
+            </ul>
+            {% if list.is_campaign_mode %}
+                <div class="alert alert-primary">
+                    <p class="mb-0">
+                        <strong>Note:</strong> Restoring this fighter will increase your gang rating by {{ fighter_cost }}¢.
+                    </p>
+                </div>
+            {% endif %}
+            <div class="mt-3">
+                <button type="submit" class="btn btn-success">
+                    <i class="bi-arrow-counterclockwise"></i> Restore Fighter
+                </button>
+                <a href="{% url 'core:list-archived-fighters' list.id %}"
+                   class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_restore_fighter.py
+++ b/gyrinx/core/tests/test_restore_fighter.py
@@ -1,0 +1,314 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from gyrinx.content.models import ContentFighter
+from gyrinx.core.models.list import List, ListFighter
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_restore_fighter_url_requires_login(client, user, content_house):
+    """Test that the restore fighter URL requires login."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert "/login/" in response.url
+
+
+@pytest.mark.django_db
+def test_restore_fighter_url_exists_for_logged_in_user(client, user, content_house):
+    """Test that the restore fighter URL exists for logged in user."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_restore_fighter_only_works_for_archived_fighters(client, user, content_house):
+    """Test that restore only works for archived fighters."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    # Create a non-archived fighter
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=False,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    # Should return 404 for non-archived fighter
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_restore_fighter_requires_ownership(client, user, content_house):
+    """Test that only the owner can restore their fighter."""
+    other_user = User.objects.create_user(username="otheruser", password="testpass")
+
+    lst = List.objects.create(
+        name="Test List",
+        owner=other_user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=other_user,
+        archived=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_restore_fighter_confirmation_page(client, user, content_house):
+    """Test that the restore fighter confirmation page displays correctly."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Archived Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Restore Fighter" in content
+    assert "Archived Fighter" in content
+    assert "Are you sure you want to restore" in content
+    assert "Return them to the active gang roster" in content
+    assert "Cancel" in content
+
+
+@pytest.mark.django_db
+def test_restore_fighter_post_restores_fighter(client, user, content_house):
+    """Test that POST restores the fighter."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Archived Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.post(url)
+
+    assert response.status_code == 302
+    assert response.url == f"{reverse('core:list', args=[lst.id])}#{fighter.id}"
+
+    fighter.refresh_from_db()
+    assert fighter.archived is False
+
+
+@pytest.mark.django_db
+def test_restore_fighter_shows_cost_info(client, user, content_house):
+    """Test that the confirmation page shows cost information."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=75,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Archived Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Check that the cost is mentioned (75 credits)
+    assert "75" in content
+
+
+@pytest.mark.django_db
+def test_restore_fighter_shows_campaign_mode_info(client, user, content_house):
+    """Test that campaign mode lists show additional info."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Archived Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Check for the campaign mode note
+    assert "gang rating" in content.lower()
+
+
+@pytest.mark.django_db
+def test_archived_fighters_page_links_to_restore(client, user, content_house):
+    """Test that the archived fighters page links to the restore confirmation."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    fighter = ListFighter.objects.create(
+        name="Archived Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-archived-fighters", args=[lst.id])
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Check that the restore link is present
+    restore_url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
+    assert restore_url in content
+    assert "Restore" in content

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -229,6 +229,11 @@ urlpatterns = [
         name="list-fighter-archive",
     ),
     path(
+        "list/<id>/fighter/<fighter_id>/restore",
+        list.restore_list_fighter,
+        name="list-fighter-restore",
+    ),
+    path(
         "list/<id>/fighter/<fighter_id>/kill",
         list.kill_list_fighter,
         name="list-fighter-kill",


### PR DESCRIPTION
Adds a confirmation page for the restore fighter action, following the existing confirmation page pattern used throughout the codebase.

Closes #1256

Generated with [Claude Code](https://claude.ai/code)