### PR TITLE
Add background styling to gang page section headers

### DIFF
--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -1,6 +1,8 @@
 {% load allauth custom_tags humanize %}
 <div class="g-col-12 {% if print %}g-col-sm-6 g-col-md-3 g-col-xl-2{% else %}g-col-md-12 g-col-lg-6 g-col-xl-4{% endif %}">
-    <h3 class="h5 mb-2">Attributes</h3>
+    <div class="bg-body-secondary rounded px-2 py-1 mb-2">
+        <h3 class="h5 mb-0">Attributes</h3>
+    </div>
     {% if list.all_attributes %}
         <table class="table table-sm table-borderless mb-0 fs-7">
             <tbody>

--- a/gyrinx/core/templates/core/includes/list_campaign_actions.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_actions.html
@@ -1,8 +1,8 @@
 {% load allauth custom_tags humanize color_tags %}
 {% if list.is_campaign_mode and list.campaign %}
     <div class="g-col-12 {% if print %}g-col-sm-6 g-col-md-3 g-col-xl-2{% else %}g-col-md-12 g-col-lg-6 g-col-xl-4{% endif %}">
-        <div class="hstack gap-2 align-items-center">
-            <h3 class="h5 mb-1 flex-grow-1">Actions</h3>
+        <div class="bg-body-secondary rounded px-2 py-1 mb-1 hstack gap-2 align-items-center">
+            <h3 class="h5 mb-0 flex-grow-1">Actions</h3>
             {% if not list.campaign.archived %}
                 <a href="{% url 'core:campaign-action-new' list.campaign.id %}{% querystring gang=list.id return_url=request.get_full_path %}"
                    class="icon-link small">

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -1,7 +1,9 @@
 {% load allauth custom_tags humanize %}
 {% if list.is_campaign_mode and list.campaign %}
     <div class="g-col-12 {% if print %}g-col-sm-6 g-col-md-3 g-col-xl-2{% else %}g-col-md-12 g-col-lg-6 g-col-xl-4{% endif %}">
-        <h3 class="h5 mb-2">Assets & Resources</h3>
+        <div class="bg-body-secondary rounded px-2 py-1 mb-2">
+            <h3 class="h5 mb-0">Assets & Resources</h3>
+        </div>
         <div class="vstack gap-3">
             {% if held_assets %}
                 <div>


### PR DESCRIPTION
## Summary
- Add bg-body-secondary background to Assets & Resources, Attributes, and Actions headers on gang pages
- Matches the styling pattern used on campaign pages
- Uses theme-change-friendly Bootstrap classes

Fixes #1243

🤖 Generated with [Claude Code](https://claude.ai/claude-code)