### PR TITLE
fix: exclude archived gangs from home page campaign list

### DIFF
--- a/gyrinx/core/views/__init__.py
+++ b/gyrinx/core/views/__init__.py
@@ -90,6 +90,7 @@ def index(request):
                 List.objects.filter(
                     owner=request.user,
                     status=List.CAMPAIGN_MODE,
+                    archived=False,
                     campaign__status=Campaign.IN_PROGRESS,
                     campaign__archived=False,
                 )


### PR DESCRIPTION
Fixes #1276

The campaign_gangs query on the home page was checking if the campaign was archived but not if the gang (List) itself was archived. Added `archived=False` filter to fix this.

🤖 Generated with [Claude Code](https://claude.ai/code)