### PR TITLE
fix: Preserve equipment filter params when adding equipment

### DIFF
--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -12,6 +12,10 @@
             {% comment %} Propagate the query params {% endcomment %}
             {% if request.GET.filter %}<input type="hidden" name="filter" value="{{ request.GET.filter }}">{% endif %}
             {% if request.GET.q %}<input type="hidden" name="q" value="{{ request.GET.q }}">{% endif %}
+            {% for al_val in request.GET.al %}<input type="hidden" name="al" value="{{ al_val }}">{% endfor %}
+            {% if request.GET.mal %}<input type="hidden" name="mal" value="{{ request.GET.mal }}">{% endif %}
+            {% for cat_val in request.GET.cat %}<input type="hidden" name="cat" value="{{ cat_val }}">{% endfor %}
+            {% if request.GET.mc %}<input type="hidden" name="mc" value="{{ request.GET.mc }}">{% endif %}
         </form>
     {% endfor %}
 {% endif %}

--- a/gyrinx/core/templates/core/list_fighter_gear_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_gear_edit.html
@@ -40,6 +40,10 @@
                                 {% comment %} Propagate the query params {% endcomment %}
                                 {% if request.GET.filter %}<input type="hidden" name="filter" value="{{ request.GET.filter }}">{% endif %}
                                 {% if request.GET.q %}<input type="hidden" name="q" value="{{ request.GET.q }}">{% endif %}
+                                {% for al_val in request.GET.al %}<input type="hidden" name="al" value="{{ al_val }}">{% endfor %}
+                                {% if request.GET.mal %}<input type="hidden" name="mal" value="{{ request.GET.mal }}">{% endif %}
+                                {% for cat_val in request.GET.cat %}<input type="hidden" name="cat" value="{{ cat_val }}">{% endfor %}
+                                {% if request.GET.mc %}<input type="hidden" name="mc" value="{{ request.GET.mc }}">{% endif %}
                                 <div class="vstack gap-1">
                                     <div class="hstack">
                                         <h4 class="h6 mb-0">

--- a/gyrinx/core/views/list.py
+++ b/gyrinx/core/views/list.py
@@ -2000,8 +2000,8 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
                 if request.POST.get("q"):
                     query_dict["q"] = request.POST.get("q")
 
-                # From GET - category and availability filters
-                cat_list = request.GET.getlist("cat")
+                # From POST - category and availability filters (forms submit via POST)
+                cat_list = request.POST.getlist("cat")
                 if cat_list:
                     # For lists, we need to use QueryDict to properly encode them
                     from django.http import QueryDict
@@ -2011,26 +2011,45 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
                         qd[k] = v
                     qd.setlist("cat", cat_list)
 
-                    al_list = request.GET.getlist("al")
+                    al_list = request.POST.getlist("al")
                     if al_list:
                         qd.setlist("al", al_list)
 
-                    mal = request.GET.get("mal")
+                    mal = request.POST.get("mal")
                     if mal:
                         qd["mal"] = mal
 
-                    mc = request.GET.get("mc")
+                    mc = request.POST.get("mc")
                     if mc:
                         qd["mc"] = mc
 
                     query_params = qd.urlencode()
                 else:
-                    # No lists, use simple approach
-                    if request.GET.get("mal"):
-                        query_dict["mal"] = request.GET.get("mal")
-                    if request.GET.get("mc"):
-                        query_dict["mc"] = request.GET.get("mc")
-                    query_params = make_query_params_str(**query_dict)
+                    # No lists, use simple approach - also check for al list
+                    from django.http import QueryDict
+
+                    al_list = request.POST.getlist("al")
+                    if al_list:
+                        qd = QueryDict(mutable=True)
+                        for k, v in query_dict.items():
+                            qd[k] = v
+                        qd.setlist("al", al_list)
+
+                        mal = request.POST.get("mal")
+                        if mal:
+                            qd["mal"] = mal
+
+                        mc = request.POST.get("mc")
+                        if mc:
+                            qd["mc"] = mc
+
+                        query_params = qd.urlencode()
+                    else:
+                        if request.POST.get("mal"):
+                            query_dict["mal"] = request.POST.get("mal")
+                        if request.POST.get("mc"):
+                            query_dict["mc"] = request.POST.get("mc")
+                        query_params = make_query_params_str(**query_dict)
                 return HttpResponseRedirect(
                     reverse(view_name, args=(lst.id, fighter.id))
                     + f"?{query_params}"


### PR DESCRIPTION
Fixes #1273

The filter parameters (al, mal, cat, mc) were getting lost when adding equipment via POST. Now templates include all filter params as hidden inputs, and the view reads from POST data when handling equipment additions.

Generated with [Claude Code](https://claude.ai/claude-code)