### PR TITLE
Add email detection warning to login page

### DIFF
--- a/gyrinx/core/templates/account/login.html
+++ b/gyrinx/core/templates/account/login.html
@@ -18,7 +18,9 @@
                 {% csrf_token %}
                 {% element fields form=form unlabeled=True %}
                 {% endelement %}
-                <div id="email-warning" class="form-text text-warning mb-3 d-none">
+                <div id="email-warning"
+                     class="form-text text-warning mb-3 d-none"
+                     role="alert">
                     <i class="bi bi-info-circle"></i>
                     {% trans "It looks like you've entered an email address. Please use your username to sign in." %}
                 </div>


### PR DESCRIPTION
When users enter what looks like an email address in the username field, show a helpful warning message guiding them to use their username instead.

Closes #1284

Generated with [Claude Code](https://claude.ai/code)