### PR TITLE
fix: Validate UUID category parameters for weapon equipment

### DIFF
--- a/gyrinx/core/views/fighter/equipment.py
+++ b/gyrinx/core/views/fighter/equipment.py
@@ -272,15 +272,9 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
         equipment = equipment.exclude(category_id__in=restricted_category_ids)
 
     # Filter by category if specified
-    cats = (
-        [
-            cat
-            for cat in request.GET.getlist("cat", list())
-            if cat and is_valid_uuid(cat)
-        ]
-        if not is_weapon
-        else request.GET.getlist("cat", list())
-    )
+    cats = [
+        cat for cat in request.GET.getlist("cat", list()) if cat and is_valid_uuid(cat)
+    ]
 
     if cats and "all" not in cats:
         equipment = equipment.filter(category_id__in=cats)


### PR DESCRIPTION
Fixes #1287

Apply UUID validation to category filter parameters consistently for both weapons and non-weapons. Previously, when filtering equipment by category for weapons, the code skipped UUID validation, allowing invalid UUIDs like "7" to reach the database filter and cause a 500 error.

Generated with [Claude Code](https://claude.ai/claude-code)