### PR TITLE
fix: Only trigger claude.yml workflow on @claude-bot mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'tgvashworth') ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'tgvashworth') ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.login == 'tgvashworth') ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.login == 'tgvashworth')
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude-bot') && github.event.comment.user.login == 'tgvashworth') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude-bot') && github.event.comment.user.login == 'tgvashworth') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude-bot') && github.event.review.user.login == 'tgvashworth') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude-bot') || contains(github.event.issue.title, '@claude-bot')) && github.event.issue.user.login == 'tgvashworth')
     runs-on: [gyrinx-ubuntu-2]
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Previously the workflow used contains(..., '@claude') which would also match @claude-triage, causing unintended workflow runs.