### PR TITLE
fix: Preserve multi-value filter params when adding equipment

### DIFF
--- a/gyrinx/core/templates/core/includes/list_fighter_weapons.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapons.html
@@ -12,9 +12,11 @@
             {% comment %} Propagate the query params {% endcomment %}
             {% if request.GET.filter %}<input type="hidden" name="filter" value="{{ request.GET.filter }}">{% endif %}
             {% if request.GET.q %}<input type="hidden" name="q" value="{{ request.GET.q }}">{% endif %}
-            {% for al_val in request.GET.al %}<input type="hidden" name="al" value="{{ al_val }}">{% endfor %}
+            {% qt_getlist request "al" as al_values %}
+            {% for al_val in al_values %}<input type="hidden" name="al" value="{{ al_val }}">{% endfor %}
             {% if request.GET.mal %}<input type="hidden" name="mal" value="{{ request.GET.mal }}">{% endif %}
-            {% for cat_val in request.GET.cat %}<input type="hidden" name="cat" value="{{ cat_val }}">{% endfor %}
+            {% qt_getlist request "cat" as cat_values %}
+            {% for cat_val in cat_values %}<input type="hidden" name="cat" value="{{ cat_val }}">{% endfor %}
             {% if request.GET.mc %}<input type="hidden" name="mc" value="{{ request.GET.mc }}">{% endif %}
         </form>
     {% endfor %}

--- a/gyrinx/core/templates/core/list_fighter_gear_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_gear_edit.html
@@ -40,9 +40,11 @@
                                 {% comment %} Propagate the query params {% endcomment %}
                                 {% if request.GET.filter %}<input type="hidden" name="filter" value="{{ request.GET.filter }}">{% endif %}
                                 {% if request.GET.q %}<input type="hidden" name="q" value="{{ request.GET.q }}">{% endif %}
-                                {% for al_val in request.GET.al %}<input type="hidden" name="al" value="{{ al_val }}">{% endfor %}
+                                {% qt_getlist request "al" as al_values %}
+                                {% for al_val in al_values %}<input type="hidden" name="al" value="{{ al_val }}">{% endfor %}
                                 {% if request.GET.mal %}<input type="hidden" name="mal" value="{{ request.GET.mal }}">{% endif %}
-                                {% for cat_val in request.GET.cat %}<input type="hidden" name="cat" value="{{ cat_val }}">{% endfor %}
+                                {% qt_getlist request "cat" as cat_values %}
+                                {% for cat_val in cat_values %}<input type="hidden" name="cat" value="{{ cat_val }}">{% endfor %}
                                 {% if request.GET.mc %}<input type="hidden" name="mc" value="{{ request.GET.mc }}">{% endif %}
                                 <div class="vstack gap-1">
                                     <div class="hstack">

--- a/gyrinx/core/templatetags/custom_tags.py
+++ b/gyrinx/core/templatetags/custom_tags.py
@@ -150,6 +150,22 @@ def qt_rm(request, *args):
 
 
 @register.simple_tag
+def qt_getlist(request, key):
+    """
+    Get all values for a query parameter key as a list.
+
+    Use this to properly iterate over multi-value query params (like cat, al).
+    Unlike request.GET.key (which returns only the last value as a string),
+    this uses getlist() to get all values.
+
+    Usage:
+        {% qt_getlist request "cat" as cat_values %}
+        {% for val in cat_values %}<input type="hidden" name="cat" value="{{ val }}">{% endfor %}
+    """
+    return request.GET.getlist(key)
+
+
+@register.simple_tag
 def qt_contains(request, key, value):
     value = str(value)
     return key in request.GET and value in request.GET.getlist(key, list)


### PR DESCRIPTION
## Summary

- Added `qt_getlist` template tag that properly calls `getlist()` on QueryDict
- Fixed weapons and gear templates to use the new tag for `al` and `cat` params
- Fixes bug where iterating over `request.GET.cat` iterated over characters of the last value instead of all values

## Test plan

- [x] Apply filters on weapons page (categories, availability levels)
- [x] Add a weapon
- [x] Verify the redirect URL preserves all filter values correctly
- [x] Repeat for gear page