### PR TITLE
feat: add All/None option to filter dropdowns

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -299,207 +299,57 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 });
 
-// Handle "all" and "none" links in availability dropdown
-document.addEventListener("DOMContentLoaded", () => {
-    const allLink = document.getElementById("availability-all-link");
-    if (allLink) {
-        allLink.addEventListener("click", (event) => {
-            event.preventDefault();
+// Generic handler for "All/None" filter links in dropdown menus
+function setupFilterLinks(config) {
+    const { prefix, param, allValues } = config;
 
-            // Build query string with all availability options
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
+    document.addEventListener("DOMContentLoaded", () => {
+        const allLink = document.getElementById(`${prefix}-all-link`);
+        if (allLink) {
+            allLink.addEventListener("click", (event) => {
+                event.preventDefault();
+                const url = new URL(window.location.href);
+                const params = new URLSearchParams(url.search);
+                params.delete(param);
 
-            // Remove existing availability parameters
-            params.delete("al");
+                if (Array.isArray(allValues)) {
+                    allValues.forEach((v) => params.append(param, v));
+                } else {
+                    params.set(param, allValues);
+                }
 
-            // Add all availability parameters
-            params.append("al", "C");
-            params.append("al", "R");
-            params.append("al", "I");
-            params.append("al", "E");
-            params.append("al", "U");
+                window.location.href = `${url.pathname}?${params.toString()}#search`;
+            });
+        }
 
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
+        const noneLink = document.getElementById(`${prefix}-none-link`);
+        if (noneLink) {
+            noneLink.addEventListener("click", (event) => {
+                event.preventDefault();
+                const url = new URL(window.location.href);
+                const params = new URLSearchParams(url.search);
+                params.delete(param);
+                params.append(param, "");
+                window.location.href = `${url.pathname}?${params.toString()}#search`;
+            });
+        }
+    });
+}
 
-    const noneLink = document.getElementById("availability-none-link");
-    if (noneLink) {
-        noneLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with no availability options
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing availability parameters and add empty marker
-            params.delete("al");
-            params.append("al", "");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
+// Configure all filter dropdowns with All/None links
+setupFilterLinks({
+    prefix: "availability",
+    param: "al",
+    allValues: ["C", "R", "I", "E", "U"],
 });
-
-// Handle "all" and "none" links in category dropdown
-document.addEventListener("DOMContentLoaded", () => {
-    const allLink = document.getElementById("category-all-link");
-    if (allLink) {
-        allLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with all categories selected (reset to default)
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing category parameters and set to all
-            params.delete("cat");
-            params.set("cat", "all");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
-
-    const noneLink = document.getElementById("category-none-link");
-    if (noneLink) {
-        noneLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with no categories selected
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing category parameters and add empty marker
-            params.delete("cat");
-            params.append("cat", "");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
+setupFilterLinks({ prefix: "category", param: "cat", allValues: "all" });
+setupFilterLinks({
+    prefix: "type",
+    param: "type",
+    allValues: ["list", "gang"],
 });
-
-// Handle "all" and "none" links in type dropdown (Lists & Gangs page)
-document.addEventListener("DOMContentLoaded", () => {
-    const allLink = document.getElementById("type-all-link");
-    if (allLink) {
-        allLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with all types selected
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing type parameters and add all types
-            params.delete("type");
-            params.append("type", "list");
-            params.append("type", "gang");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
-
-    const noneLink = document.getElementById("type-none-link");
-    if (noneLink) {
-        noneLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with no types selected
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing type parameters and add empty marker
-            params.delete("type");
-            params.append("type", "");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
-});
-
-// Handle "all" and "none" links in house dropdown (Lists & Gangs page)
-document.addEventListener("DOMContentLoaded", () => {
-    const allLink = document.getElementById("house-all-link");
-    if (allLink) {
-        allLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with all houses selected (reset to default)
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing house parameters and set to all
-            params.delete("house");
-            params.set("house", "all");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
-
-    const noneLink = document.getElementById("house-none-link");
-    if (noneLink) {
-        noneLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with no houses selected
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing house parameters and add empty marker
-            params.delete("house");
-            params.append("house", "");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
-});
-
-// Handle "all" and "none" links in status dropdown (Campaigns page)
-document.addEventListener("DOMContentLoaded", () => {
-    const allLink = document.getElementById("status-all-link");
-    if (allLink) {
-        allLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with all statuses selected (reset to default)
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing status parameters and set to all
-            params.delete("status");
-            params.set("status", "all");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
-
-    const noneLink = document.getElementById("status-none-link");
-    if (noneLink) {
-        noneLink.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            // Build query string with no statuses selected
-            const url = new URL(window.location.href);
-            const params = new URLSearchParams(url.search);
-
-            // Remove existing status parameters and add empty marker
-            params.delete("status");
-            params.append("status", "");
-
-            // Navigate to the new URL with updated query string
-            window.location.href = `${url.pathname}?${params.toString()}#search`;
-        });
-    }
-});
+setupFilterLinks({ prefix: "house", param: "house", allValues: "all" });
+setupFilterLinks({ prefix: "status", param: "status", allValues: "all" });
 
 // Add loading spinner to form submit buttons
 document.addEventListener("DOMContentLoaded", () => {

--- a/gyrinx/core/templates/core/includes/campaigns_filter.html
+++ b/gyrinx/core/templates/core/includes/campaigns_filter.html
@@ -64,6 +64,7 @@
                         /
                         <a href="#" id="status-none-link">None</a>
                     </label>
+                    {% qt_has_key request "status" as status_key_exists %}
                     {% for status_value, status_label in status_choices %}
                         {% qt_contains request "status" status_value as status_contains %}
                         <div class="form-check mb-0">
@@ -73,7 +74,7 @@
                                    id="status-{{ status_value }}"
                                    name="status"
                                    value="{{ status_value }}"
-                                   {% if status_contains or not request.GET.status %}checked{% endif %}>
+                                   {% if status_contains or not status_key_exists %}checked{% endif %}>
                             <label class="form-check-label" for="status-{{ status_value }}">{{ status_label }}</label>
                             •
                             <a class="ms-auto" href="?{% qt request status=status_value %}#search">only</a>

--- a/gyrinx/core/templates/core/includes/fighter_gear_filter.html
+++ b/gyrinx/core/templates/core/includes/fighter_gear_filter.html
@@ -42,6 +42,7 @@
                     /
                     <a href="#" id="category-none-link">None</a>
                 </label>
+                {% qt_has_key request "cat" as cat_key_exists %}
                 {% for cat in categories %}
                     {% qt_contains request "cat" cat.id as contains_id %}
                     <div class="form-check mb-0">
@@ -52,7 +53,7 @@
                                id="cat-{{ cat.id }}"
                                name="cat"
                                value="{{ cat.id }}"
-                               {% if contains_id or request.GET.cat == "" or request.GET.cat == "all" or not request.GET.cat %}checked{% endif %}>
+                               {% if contains_id or request.GET.cat == "all" or not cat_key_exists %}checked{% endif %}>
                         <label class="form-check-label" for="cat-{{ cat.id }}">{{ cat.name }}</label>
                         •
                         <a class="ms-auto" href="?{% qt request cat=cat.id %}#search">only</a>
@@ -115,6 +116,7 @@
                             /
                             <a href="#" id="availability-none-link">None</a>
                         </label>
+                        {% qt_has_key request "al" as al_key_exists %}
                         {% qt_contains request "al" "C" as al_contains_c %}
                         <div class="form-check mb-0">
                             <input class="form-check-input"
@@ -124,7 +126,7 @@
                                    id="al-c"
                                    name="al"
                                    value="C"
-                                   {% if not request.GET.al or al_contains_c %}checked{% endif %}>
+                                   {% if al_contains_c or not al_key_exists %}checked{% endif %}>
                             <label class="form-check-label" for="al-c">Common (C)</label>
                             •
                             <a class="ms-auto" href="?{% qt request al="C" %}#search">only</a>
@@ -138,7 +140,7 @@
                                    id="al-r"
                                    name="al"
                                    value="R"
-                                   {% if not request.GET.al or al_contains_r %}checked{% endif %}>
+                                   {% if al_contains_r or not al_key_exists %}checked{% endif %}>
                             <label class="form-check-label" for="al-r">Rare (R)</label>
                             •
                             <a class="ms-auto" href="?{% qt request al="R" %}#search">only</a>

--- a/gyrinx/core/templates/core/includes/lists_filter.html
+++ b/gyrinx/core/templates/core/includes/lists_filter.html
@@ -64,6 +64,7 @@
                         /
                         <a href="#" id="type-none-link">None</a>
                     </label>
+                    {% qt_has_key request "type" as type_key_exists %}
                     {% qt_contains request "type" "list" as type_contains_list %}
                     {% qt_contains request "type" "gang" as type_contains_gang %}
                     <div class="form-check mb-0">
@@ -73,7 +74,7 @@
                                id="type-lists"
                                name="type"
                                value="list"
-                               {% if type_contains_list or not request.GET.type %}checked{% endif %}>
+                               {% if type_contains_list or not type_key_exists %}checked{% endif %}>
                         <label class="form-check-label" for="type-lists">Lists (List Building)</label>
                         •
                         <a class="ms-auto" href="?{% qt request type="list" %}#search">only</a>
@@ -85,7 +86,7 @@
                                id="type-gangs"
                                name="type"
                                value="gang"
-                               {% if type_contains_gang or not request.GET.type %}checked{% endif %}>
+                               {% if type_contains_gang or not type_key_exists %}checked{% endif %}>
                         <label class="form-check-label" for="type-gangs">Gangs (Campaign)</label>
                         •
                         <a class="ms-auto" href="?{% qt request type="gang" %}#search">only</a>
@@ -114,6 +115,7 @@
                         /
                         <a href="#" id="house-none-link">None</a>
                     </label>
+                    {% qt_has_key request "house" as house_key_exists %}
                     {% for house in houses %}
                         {% qt_contains request "house" house.id as contains_id %}
                         <div class="form-check mb-0">
@@ -124,7 +126,7 @@
                                    id="house-{{ house.id }}"
                                    name="house"
                                    value="{{ house.id }}"
-                                   {% if contains_id or request.GET.house == "" or request.GET.house == "all" or not request.GET.house %}checked{% endif %}>
+                                   {% if contains_id or request.GET.house == "all" or not house_key_exists %}checked{% endif %}>
                             <label class="form-check-label" for="house-{{ house.id }}">{{ house.name }}</label>
                             •
                             <a class="ms-auto" href="?{% qt request house=house.id %}#search">only</a>

--- a/gyrinx/core/templatetags/custom_tags.py
+++ b/gyrinx/core/templatetags/custom_tags.py
@@ -171,6 +171,12 @@ def qt_contains(request, key, value):
     return key in request.GET and value in request.GET.getlist(key, list)
 
 
+@register.simple_tag
+def qt_has_key(request, key):
+    """Check if a query parameter key exists in the request (even if empty)."""
+    return key in request.GET
+
+
 @register.filter(name="min")
 def fmin(value, arg):
     return min(int(value), int(arg))

--- a/gyrinx/core/views/campaign/views.py
+++ b/gyrinx/core/views/campaign/views.py
@@ -57,9 +57,14 @@ class Campaigns(generic.ListView):
             queryset = queryset.filter(archived=False)
 
         # Apply status filter
-        status_filters = self.request.GET.getlist("status")
+        status_filters_raw = self.request.GET.getlist("status")
+        # Filter out empty strings and "all" marker
+        status_filters = [s for s in status_filters_raw if s and s != "all"]
         if status_filters:
             queryset = queryset.filter(status__in=status_filters)
+        elif status_filters_raw:
+            # Had values but all filtered out (e.g. empty string for "None") - show nothing
+            queryset = queryset.none()
 
         # Apply search filter
         search_query = self.request.GET.get("q")

--- a/gyrinx/core/views/fighter/equipment.py
+++ b/gyrinx/core/views/fighter/equipment.py
@@ -340,8 +340,19 @@ def edit_list_fighter_equipment(request, id, fighter_id, is_weapon=False):
             )
     else:
         # Apply availability filters (either explicit or default)
-        als = request.GET.getlist("al", ["C", "R"])
-        equipment = equipment.filter(rarity__in=set(als))
+        # Note: `als` is also used later for profile filtering, so we must always set it
+        als_raw = request.GET.getlist("al")
+        als = [a for a in als_raw if a]
+        if als:
+            equipment = equipment.filter(rarity__in=set(als))
+        elif als_raw:
+            # Had values but all filtered out (e.g. empty string for "None") - show nothing
+            equipment = equipment.none()
+            als = []  # No profiles should match either
+        else:
+            # No parameter at all - use defaults
+            als = ["C", "R"]
+            equipment = equipment.filter(rarity__in=set(als))
 
         # Still need profiles for weapons when not in equipment list mode
         if is_weapon:


### PR DESCRIPTION
Add consistent All/None select links to filter dropdowns across the app:

- Availability dropdown in weapons/gear menu (add None button next to existing All)
- Category dropdown in weapons/gear menu
- Type dropdown on Lists & Gangs page
- House dropdown on Lists & Gangs page
- Status dropdown on Campaigns page

Fixes #1274

Generated with [Claude Code](https://claude.ai/code)