### PR TITLE
fix: optimize ListAction admin page with select_related and autocomplete

### DIFF
--- a/gyrinx/core/admin/action.py
+++ b/gyrinx/core/admin/action.py
@@ -15,7 +15,19 @@ class ListActionAdmin(BaseAdmin):
         "created",
     ]
     search_fields = ["list__id", "list__name", "owner__username", "description"]
+    list_select_related = [
+        "list",
+        "owner",
+        "list_fighter",
+        "list_fighter_equipment_assignment",
+    ]
     list_filter = ["action_type", "subject_type", "created"]
+    autocomplete_fields = [
+        "owner",
+        "list",
+        "list_fighter",
+        "list_fighter_equipment_assignment",
+    ]
     fields = [
         "list",
         "action_type",


### PR DESCRIPTION
Fixes #1318

Add `list_select_related` to prefetch related objects and `autocomplete_fields` to avoid loading all objects in form dropdowns.

Generated with [Claude Code](https://claude.ai/code)