### PR TITLE
Add list ID to search fields in ListAction admin

### DIFF
--- a/gyrinx/core/admin/action.py
+++ b/gyrinx/core/admin/action.py
@@ -14,7 +14,7 @@ class ListActionAdmin(BaseAdmin):
         "owner",
         "created",
     ]
-    search_fields = ["list__name", "owner__username", "description"]
+    search_fields = ["list__id", "list__name", "owner__username", "description"]
     list_filter = ["action_type", "subject_type", "created"]
     fields = [
         "list",


### PR DESCRIPTION
Add ability to search by list ID in addition to list name in the ListAction admin view, making it easier to filter actions by the associated list.

Closes #1316

Generated with [Claude Code](https://claude.ai/code)