### PR TITLE
Add staff-only debug link to list dropdown menu

### DIFF
--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -164,6 +164,20 @@
                                                 </a>
                                             </li>
                                         {% endif %}
+                                        {% if request.user.is_staff %}
+                                            <li>
+                                                <hr class="dropdown-divider">
+                                            </li>
+                                            <li>
+                                                <h6 class="dropdown-header text-uppercase small">Internal</h6>
+                                            </li>
+                                            <li>
+                                                <a href="{% url 'debug_list_actions' list.id %}"
+                                                   class="dropdown-item icon-link">
+                                                    <i class="bi-flag"></i> Actions
+                                                </a>
+                                            </li>
+                                        {% endif %}
                                     </ul>
                                 </div>
                             </nav>


### PR DESCRIPTION
Add a new 'Internal' section to the list dropdown menu that is only visible to staff users. The section contains a link to the list actions debug endpoint.

Closes #1323

Generated with [Claude Code](https://claude.ai/claude-code)