### PR TITLE
feat: Add owner search fields to ListAdmin

### DIFF
--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -56,7 +56,13 @@ class ListAdmin(BaseAdmin):
     readonly_fields = ["original_list", "campaign"]
     list_display = ["name", "content_house", "owner", "status", "public"]
     list_filter = ["status", "public", "content_house"]
-    search_fields = ["name", "content_house__name", "campaign__name"]
+    search_fields = [
+        "name",
+        "content_house__name",
+        "campaign__name",
+        "owner__username",
+        "owner__email",
+    ]
 
     inlines = [ListFighterInline, ListAttributeAssignmentInline]
 


### PR DESCRIPTION
Closes #1322

Adds `owner__username` and `owner__email` to `search_fields` in `ListAdmin`, enabling admins to search lists by owner's username or email in the admin view.

Generated with [Claude Code](https://claude.ai/claude-code)