### PR TITLE
fix: Guard field access in ListFighterForm to prevent KeyError

### DIFF
--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -65,13 +65,15 @@ class ListFighterForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if hasattr(self.instance, "list"):
-            self.fields["disabled_default_assignments"].queryset = self.fields[
-                "disabled_default_assignments"
-            ].queryset.filter(fighter=self.instance.content_fighter)
+            if "disabled_default_assignments" in self.fields:
+                self.fields["disabled_default_assignments"].queryset = self.fields[
+                    "disabled_default_assignments"
+                ].queryset.filter(fighter=self.instance.content_fighter)
 
-            self.fields["disabled_pskyer_default_powers"].queryset = self.fields[
-                "disabled_pskyer_default_powers"
-            ].queryset.filter(fighter=self.instance.content_fighter)
+            if "disabled_pskyer_default_powers" in self.fields:
+                self.fields["disabled_pskyer_default_powers"].queryset = self.fields[
+                    "disabled_pskyer_default_powers"
+                ].queryset.filter(fighter=self.instance.content_fighter)
 
         if hasattr(self.instance, "content_fighter"):
             if not self.instance.content_fighter.can_take_legacy:


### PR DESCRIPTION
Added existence checks before accessing `disabled_default_assignments` and `disabled_pskyer_default_powers` fields in the admin form's `__init__` method. This prevents a `KeyError` when the form is instantiated without these fields available.

Fixes #1324

🤖 Generated with [Claude Code](https://claude.ai/code)