### PR TITLE
fix: preserve upgrades on converted default assignments when cloning

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -3196,12 +3196,21 @@ class ListFighter(AppBase):
         )
 
         if include_equipment:
-            # Copy equipment assignments that weren't converted from default assignments
+            # Copy equipment assignments, including those converted from default assignments
             for assignment in self._direct_assignments():
+                # Clone the assignment, preserving from_default_assignment if present
+                # This ensures upgrades and other customizations are preserved
+                cloned_assignment = assignment.clone(
+                    list_fighter=target_fighter,
+                    preserve_from_default_assignment=True,
+                )
+
+                # If this assignment was converted from a default, disable the default
+                # on the target fighter to match the original state
                 if assignment.from_default_assignment is not None:
-                    # Skip assignments that were converted from default assignments
-                    continue
-                cloned_assignment = assignment.clone(list_fighter=target_fighter)
+                    target_fighter.disabled_default_assignments.add(
+                        assignment.from_default_assignment
+                    )
 
                 # Handle nested linked fighters recursively
                 if assignment.child_fighter:
@@ -3309,18 +3318,26 @@ class ListFighter(AppBase):
             self.disabled_pskyer_default_powers.all()
         )
 
-        # Don't clone equipment assignments that were converted from default assignments
-        # or assignments that were auto-created from equipment-equipment links
+        # Clone equipment assignments, including those converted from default assignments
+        # to preserve upgrades and other customizations
         for assignment in self._direct_assignments():
-            if assignment.from_default_assignment is not None:
-                # Skip assignments that were converted from default assignments
-                # The clone will get these as default assignments instead
-                continue
             if assignment.linked_equipment_parent is not None:
                 # Skip assignments that were auto-created from equipment-equipment links
                 # The clone will get these via the signal when the parent equipment is cloned
                 continue
-            cloned_assignment = assignment.clone(list_fighter=clone)
+
+            # Clone the assignment, preserving from_default_assignment if present
+            cloned_assignment = assignment.clone(
+                list_fighter=clone,
+                preserve_from_default_assignment=True,
+            )
+
+            # If this assignment was converted from a default, disable the default
+            # on the clone to match the original state
+            if assignment.from_default_assignment is not None:
+                clone.disabled_default_assignments.add(
+                    assignment.from_default_assignment
+                )
 
             # If the original assignment has a linked fighter (e.g., vehicle, exotic beast),
             # we need to copy all attributes from that linked fighter to the new linked fighter
@@ -4283,8 +4300,15 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
     #  Behaviour
 
     @traced("list_fighter_equipment_assignment_clone")
-    def clone(self, list_fighter=None):
-        """Clone the assignment, creating a new assignment with the same weapon profiles."""
+    def clone(self, list_fighter=None, preserve_from_default_assignment=False):
+        """Clone the assignment, creating a new assignment with the same weapon profiles.
+
+        Args:
+            list_fighter: The ListFighter to associate the clone with.
+            preserve_from_default_assignment: If True, preserve the from_default_assignment
+                field on the clone. This is used when cloning fighters to preserve
+                upgrades on assignments that were converted from default assignments.
+        """
         if not list_fighter:
             list_fighter = self.list_fighter
 
@@ -4292,6 +4316,10 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
             list_fighter=list_fighter,
             content_equipment=self.content_equipment,
         )
+
+        # Preserve from_default_assignment if requested
+        if preserve_from_default_assignment and self.from_default_assignment:
+            clone.from_default_assignment = self.from_default_assignment
 
         for profile in self.weapon_profiles_field.all():
             clone.weapon_profiles_field.add(profile)
@@ -4301,6 +4329,9 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
 
         for upgrade in self.upgrades_field.all():
             clone.upgrades_field.add(upgrade)
+
+        if self.cost_override is not None:
+            clone.cost_override = self.cost_override
 
         if self.total_cost_override is not None:
             clone.total_cost_override = self.total_cost_override

--- a/gyrinx/core/tests/test_assignments.py
+++ b/gyrinx/core/tests/test_assignments.py
@@ -887,10 +887,11 @@ def test_fighter_clone_default_assignment_conversion_to_full(
     assert assignment.weapon_profiles()[1] == spoon_spike_profile
     assert assignment.weapon_accessories()[0] == spoon_scope
     assert assignment.cost_int() == 0
-    # Note this! The assignment is default and not "from" default
-    # assignment.
-    assert assignment.kind() == "default"
-    assert not assignment.is_from_default_assignment()
+    # After the fix for issue #1331, cloning now preserves the converted assignment
+    # instead of reverting to a default assignment. This ensures that any
+    # customizations (upgrades, profiles, accessories) are preserved on the clone.
+    assert assignment.kind() == "assigned"
+    assert assignment.is_from_default_assignment()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #1331

## Summary
- When cloning a fighter with equipment converted from a default assignment, preserve the direct assignment with all its upgrades
- Also copies cost_override field to maintain correct pricing

## Test Plan
- [x] Clone a fighter with a converted default assignment that has upgrades
- [x] Verify upgrades appear on the cloned fighter
- [x] Clone a list with such fighters and verify the same

Generated with [Claude Code](https://claude.ai/claude-code)