### PR TITLE
fix: Add LoginRequiredMixin to ListArchivedFightersView

### DIFF
--- a/gyrinx/core/views/fighter/crud.py
+++ b/gyrinx/core/views/fighter/crud.py
@@ -3,6 +3,7 @@
 from urllib.parse import urlencode
 
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -653,7 +654,7 @@ def embed_list_fighter(request, id, fighter_id):
     )
 
 
-class ListArchivedFightersView(generic.ListView):
+class ListArchivedFightersView(LoginRequiredMixin, generic.ListView):
     """
     Display a page with archived :model:`core.ListFighter` objects within a given :model:`core.List`.
 


### PR DESCRIPTION
Fixes TypeError when unauthenticated users access /list/<id>/fighters/archived.

The view was using `owner=self.request.user` in `get_queryset` without authentication, causing an error when `AnonymousUser` was passed to the query.

Fixes #1341

Generated with [Claude Code](https://claude.ai/claude-code)