### PR TITLE
Fix weekly summary workflow for scheduled runs with bot actors

### DIFF
--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           fetch-depth: 0 # Need full history for git log
 
+      # Workaround for anthropics/claude-code-action#900: the action's
+      # checkHumanActor calls the GitHub API before checking allowed_bots,
+      # which 404s for bot actors like github-merge-queue[bot]. Override
+      # GITHUB_ACTOR so the action sees a real user.
+      - name: Fix actor for scheduled runs
+        if: github.event_name == 'schedule' && contains(github.actor, '[bot]')
+        run: echo "GITHUB_ACTOR=${{ github.repository_owner }}" >> "$GITHUB_ENV"
+
       - name: Get date range
         id: dates
         run: |
@@ -52,7 +60,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Allow scheduled runs which may have github-merge-queue[bot] as the actor
+          # Belt-and-suspenders: also declare the bot as allowed in case the
+          # GITHUB_ACTOR override above is removed once the upstream bug is fixed.
           allowed_bots: "github-merge-queue[bot]"
 
           claude_args: |


### PR DESCRIPTION
## Summary
This PR fixes the weekly summary workflow to handle scheduled runs that may have bot actors (like `github-merge-queue[bot]`), which were causing failures in the Claude Code action.

## Changes
- Added a workaround step that overrides `GITHUB_ACTOR` with the repository owner for scheduled runs with bot actors
  - This addresses an upstream issue (anthropics/claude-code-action#900) where the action's `checkHumanActor` call fails with a 404 when the actor is a bot
- Updated the `allowed_bots` configuration comment to clarify this is a belt-and-suspenders approach
  - The `allowed_bots` declaration remains as a safeguard in case the `GITHUB_ACTOR` override is removed once the upstream bug is fixed

## Implementation Details
- The fix uses a conditional step that only runs for scheduled events (`github.event_name == 'schedule'`) where the actor contains `[bot]`
- The `GITHUB_ACTOR` environment variable is set to the repository owner, allowing the action to see a real user instead of a bot
- This is a temporary workaround pending a fix in the upstream Claude Code action

https://claude.ai/code/session_018V4KpfeWGgDpXA5hEWNueq