### PR TITLE
Add line break to lists & campaigns page title

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaigns.html
+++ b/gyrinx/core/templates/core/campaign/campaigns.html
@@ -10,6 +10,7 @@
             <p class="fs-5 col-12 col-md-6 mb-0">
                 Browse and manage campaigns.
                 {% if user.is_authenticated %}
+                    <br>
                     <a href="{% url 'core:campaigns-new' %}">Create a new Campaign</a>.
                 {% endif %}
             </p>

--- a/gyrinx/core/templates/core/lists.html
+++ b/gyrinx/core/templates/core/lists.html
@@ -8,7 +8,9 @@
         <div>
             <h1 class="mb-1">Lists & Gangs</h1>
             <p class="fs-5 col-12 col-md-6 mb-0">
-                Browse and manage your Lists & Campaign Gangs. <a href="{% url 'core:lists-new' %}">Create a new List</a>.
+                Browse and manage your Lists & Campaign Gangs.
+                <br>
+                <a href="{% url 'core:lists-new' %}">Create a new List</a>.
             </p>
         </div>
         <div class="grid">


### PR DESCRIPTION
## Summary
Updated the Lists & Gangs page description to improve layout and readability by adding a line break before the "Create a new List" link. Also applied to Campaigns.

## Changes
- Added `<br>` tag between the descriptive text and the "Create a new List" link in the Lists & Gangs template
- This separates the introductory text from the call-to-action link for better visual hierarchy

## Details
The change improves the user interface by ensuring the "Create a new List" link appears on its own line, making it more prominent and easier to locate. This is a minor UI/UX improvement to the core lists management page.

https://claude.ai/code/session_01DeLEAEXjHyqiaWiref1A4V