### PR TITLE
fix: install gh from binary tarball instead of apt

### DIFF
--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -28,11 +28,18 @@ if ! command -v gh &>/dev/null; then
   # download only needs github.com + objects.githubusercontent.com, both
   # on the allow-list.
   GH_VERSION="2.67.0"
-  curl -LsSf "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+  # Map kernel arch to the naming convention used by gh release tarballs.
+  case "$(uname -m)" in
+    x86_64)  GH_ARCH="amd64" ;;
+    aarch64) GH_ARCH="arm64" ;;
+    *)       GH_ARCH="$(uname -m)" ;;
+  esac
+  GH_TARBALL="gh_${GH_VERSION}_linux_${GH_ARCH}"
+  curl -LsSf "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}.tar.gz" \
     -o /tmp/gh.tar.gz
   tar -xzf /tmp/gh.tar.gz -C /tmp
-  sudo install /tmp/"gh_${GH_VERSION}_linux_amd64"/bin/gh /usr/local/bin/gh
-  rm -rf /tmp/gh.tar.gz /tmp/"gh_${GH_VERSION}_linux_amd64"
+  sudo install /tmp/"${GH_TARBALL}"/bin/gh /usr/local/bin/gh
+  rm -rf /tmp/gh.tar.gz /tmp/"${GH_TARBALL}"
   echo "gh installed: $(gh --version | head -1)"
 else
   echo "gh already installed: $(gh --version | head -1)"


### PR DESCRIPTION
## Summary
- Replace apt-based `gh` installation with a direct binary download from GitHub releases
- The web environment has limited network access — `apt-get update` fails because it tries to resolve all configured apt sources (deadsnakes PPA, ondrej/php PPA, etc.) which are unreachable
- Direct tarball download only needs `github.com` and `objects.githubusercontent.com`, both on the allow-list

## Test plan
- [ ] Start a Claude Code on the Web session against this repo and verify the SessionStart hook completes without gh installation errors
- [ ] Verify `gh --version` works in the web session after setup

https://claude.ai/code/session_0131BTgXSfsLD7ViUNMJyPaf