### PR TITLE
fix: return 400 instead of 500 for RequestDataTooBig exception

### DIFF
--- a/gyrinx/core/middleware.py
+++ b/gyrinx/core/middleware.py
@@ -1,0 +1,57 @@
+"""
+Custom middleware for the Gyrinx application.
+"""
+
+from django.core.exceptions import RequestDataTooBig
+from django.http import HttpResponse
+from django.shortcuts import render
+from django.template import TemplateDoesNotExist, TemplateSyntaxError
+
+
+class RequestSizeExceptionMiddleware:
+    """
+    Middleware to catch RequestDataTooBig exceptions and return a 400 response.
+
+    This ensures that overly large requests are properly handled as client errors
+    (400 Bad Request) instead of server errors (500 Internal Server Error).
+
+    The issue is that Django's default exception handling doesn't always properly
+    convert RequestDataTooBig (a SuspiciousOperation) to a 400 response,
+    especially when the exception is raised during middleware processing
+    (like CSRF middleware) before the view is called.
+
+    See: https://github.com/gyrinx-app/gyrinx/issues/1097
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        """
+        Process exceptions raised during request handling.
+
+        If the exception is RequestDataTooBig, return a 400 Bad Request response
+        instead of letting it bubble up as a 500 error.
+        """
+        if isinstance(exception, RequestDataTooBig):
+            context = {
+                "error_code": 400,
+                "error_message": "Request Too Large",
+                "error_description": (
+                    "The request body is too large. "
+                    "Please reduce the size of your upload."
+                ),
+            }
+            try:
+                return render(request, "errors/error.html", context, status=400)
+            except (TemplateDoesNotExist, TemplateSyntaxError):
+                # Fallback to simple response if template rendering fails
+                return HttpResponse(
+                    "400 Bad Request: The request body is too large.",
+                    status=400,
+                    content_type="text/plain",
+                )
+        return None

--- a/gyrinx/core/tests/test_request_data_too_big.py
+++ b/gyrinx/core/tests/test_request_data_too_big.py
@@ -1,0 +1,143 @@
+"""
+Tests for RequestDataTooBig exception handling.
+
+This test verifies that when a request body exceeds DATA_UPLOAD_MAX_MEMORY_SIZE,
+the server returns a 400 Bad Request (not a 500 Internal Server Error).
+
+Issue: https://github.com/gyrinx-app/gyrinx/issues/1097
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.core.exceptions import RequestDataTooBig
+from django.http import HttpRequest, HttpResponse
+from django.template import TemplateDoesNotExist
+from django.test import RequestFactory, override_settings
+
+from gyrinx.core.middleware import RequestSizeExceptionMiddleware
+
+
+def test_request_size_exception_middleware_catches_exception():
+    """
+    Test that RequestSizeExceptionMiddleware catches RequestDataTooBig
+    and returns a 400 response.
+    """
+    middleware = RequestSizeExceptionMiddleware(lambda r: HttpResponse("OK"))
+
+    request = HttpRequest()
+    request.method = "POST"
+
+    exception = RequestDataTooBig("Request body exceeded settings.")
+
+    with patch(
+        "gyrinx.core.middleware.render", return_value=HttpResponse("Error", status=400)
+    ):
+        response = middleware.process_exception(request, exception)
+
+    assert response is not None, "Middleware should return a response"
+    assert response.status_code == 400, f"Expected 400 but got {response.status_code}"
+
+
+def test_request_size_exception_middleware_fallback():
+    """
+    Test that the middleware falls back to a plain text response
+    when template rendering fails.
+    """
+    middleware = RequestSizeExceptionMiddleware(lambda r: HttpResponse("OK"))
+
+    request = HttpRequest()
+    request.method = "POST"
+
+    exception = RequestDataTooBig("Request body exceeded settings.")
+
+    with patch(
+        "gyrinx.core.middleware.render",
+        side_effect=TemplateDoesNotExist("errors/error.html"),
+    ):
+        response = middleware.process_exception(request, exception)
+
+    assert response is not None, "Middleware should return a fallback response"
+    assert response.status_code == 400, f"Expected 400 but got {response.status_code}"
+    assert response["Content-Type"] == "text/plain"
+
+
+def test_request_size_exception_middleware_ignores_other_exceptions():
+    """
+    Test that RequestSizeExceptionMiddleware ignores other exceptions.
+    """
+    middleware = RequestSizeExceptionMiddleware(lambda r: HttpResponse("OK"))
+
+    request = HttpRequest()
+    request.method = "POST"
+
+    exception = ValueError("Some other error")
+
+    response = middleware.process_exception(request, exception)
+
+    assert response is None, "Middleware should not handle other exceptions"
+
+
+def test_request_data_too_big_exception_behavior():
+    """
+    Test that RequestDataTooBig is a SuspiciousOperation exception.
+
+    This verifies the exception hierarchy that our middleware relies on.
+    """
+    from django.core.exceptions import SuspiciousOperation
+
+    with override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=100):
+        try:
+            raise RequestDataTooBig("Request body exceeded settings.")
+        except RequestDataTooBig as e:
+            assert isinstance(e, SuspiciousOperation), (
+                "RequestDataTooBig should be a SuspiciousOperation"
+            )
+
+
+@pytest.mark.django_db
+def test_full_middleware_chain_returns_400():
+    """
+    Test the middleware with a real Django request through the full
+    process_exception flow, verifying template rendering works.
+    """
+    factory = RequestFactory()
+    request = factory.post("/upload", data={"field": "x" * 200})
+
+    # Simulate what Django does: view raises, middleware process_exception is called
+    def get_response(r):
+        raise RequestDataTooBig("Request body exceeded settings.")
+
+    middleware = RequestSizeExceptionMiddleware(get_response)
+    exception = RequestDataTooBig("Request body exceeded settings.")
+
+    response = middleware.process_exception(request, exception)
+
+    assert response is not None, "Middleware should return a response"
+    assert response.status_code == 400
+    assert b"Request Too Large" in response.content
+
+
+@pytest.mark.django_db
+def test_middleware_call_wraps_downstream_exceptions():
+    """
+    Test that the middleware's __call__ properly propagates requests
+    and that process_exception handles RequestDataTooBig from views.
+    """
+    factory = RequestFactory()
+    request = factory.get("/")
+
+    # Normal request flows through
+    middleware = RequestSizeExceptionMiddleware(
+        lambda r: HttpResponse("OK", status=200)
+    )
+    response = middleware(request)
+    assert response.status_code == 200
+
+    # process_exception returns 400 for RequestDataTooBig
+    exception = RequestDataTooBig("Request body exceeded settings.")
+    with patch(
+        "gyrinx.core.middleware.render", return_value=HttpResponse("Error", status=400)
+    ):
+        response = middleware.process_exception(request, exception)
+    assert response.status_code == 400

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -150,6 +150,8 @@ MIDDLEWARE = [
     "google.cloud.logging_v2.handlers.middleware.RequestMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    # Catch RequestDataTooBig early and return 400 instead of 500
+    "gyrinx.core.middleware.RequestSizeExceptionMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
## Summary

- Adds `RequestSizeExceptionMiddleware` to catch `RequestDataTooBig` exceptions and return 400 Bad Request responses instead of 500 Internal Server Error
- Middleware is positioned early in the stack (after WhiteNoise, before CSRF) to intercept exceptions before they propagate
- Addresses all Copilot review feedback from #1127

## Changes from #1127

- Narrowed `except Exception:` to `except (TemplateDoesNotExist, TemplateSyntaxError):` to avoid masking unexpected errors
- Moved all imports to top of test file per PEP 8
- Fixed redundant `csrf_exempt` application in test
- Fixed module docstring pluralization
- Added proper mocking in unit tests to isolate template rendering
- Added explicit test for the fallback plain text response path

Closes #1097
Supersedes #1127

## Test plan

- [x] Unit tests pass for middleware exception handling (mocked render)
- [x] Unit test covers fallback to plain text when template fails
- [x] Unit test verifies middleware ignores non-RequestDataTooBig exceptions
- [x] Unit test verifies RequestDataTooBig is a SuspiciousOperation
- [ ] Integration tests with full middleware stack (require database, run in CI)

https://claude.ai/code/session_0138XuH6p8fPEHLLE1baDPHh