### PR TITLE
fix: remove hardcoded SendGrid email defaults

### DIFF
--- a/gyrinx/settings_dev.py
+++ b/gyrinx/settings_dev.py
@@ -43,10 +43,10 @@ USE_REAL_EMAIL_IN_DEV = os.getenv("USE_REAL_EMAIL_IN_DEV", "False").lower() == "
 if USE_REAL_EMAIL_IN_DEV:
     # Email configuration - all values from environment variables
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.sendgrid.net")
+    EMAIL_HOST = os.getenv("EMAIL_HOST")
     EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
     EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True").lower() == "true"
-    EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "apikey")
+    EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
     EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 
 

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -33,10 +33,10 @@ DEBUG = False
 CSRF_COOKIE_SECURE = True
 # Email configuration - all values from environment variables
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.sendgrid.net")
+EMAIL_HOST = os.getenv("EMAIL_HOST")
 EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True").lower() == "true"
-EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "apikey")
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 
 # This is handled by the load balancer


### PR DESCRIPTION
Set `EMAIL_HOST` and `EMAIL_HOST_USER` defaults to empty strings in both settings_prod.py and settings_dev.py. This allows email configuration to be fully controlled via environment variables without falling back to SendGrid.

Fixes #1375

Generated with [Claude Code](https://claude.ai/code)