### PR TITLE
Fix duplicate startup logs

### DIFF
--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -334,6 +334,10 @@ LOGGING = {
             "handlers": ["null"],
             "propagate": False,
         },
+        "django.utils.autoreload": {
+            "handlers": ["null"],
+            "propagate": False,
+        },
         "django.request": {
             "handlers": ["console"],
             "level": "ERROR",


### PR DESCRIPTION
This PR addresses duplicate startup logs in Django's autoreloader.

- **Prevent duplicate tracing initialization**: Modified `gyrinx/tracing.py` to skip `_init_tracing()` in Django's autoreloader parent process. Django's StatReloader spawns two processes (parent watcher and child server), causing startup messages to appear twice. The fix checks for the `RUN_MAIN` environment variable to ensure initialization only happens in the child process or when not running the development server.

- **Add django.utils.autoreload logger configuration**: Added a new logger entry in `gyrinx/settings.py` to suppress verbose autoreloader logs by routing them to the null handler, reducing noise in development output.

## Implementation Details

The autoreloader fix uses a conditional guard:
```python
if os.environ.get("RUN_MAIN") == "true" or "runserver" not in sys.argv:
    _init_tracing()
```

This ensures tracing initialization occurs in the child process (where `RUN_MAIN=true`) or in non-development contexts, preventing duplicate initialization logs during development.

https://claude.ai/code/session_01HC13KFH7HnKoj6MziFgQky