### PR TITLE
Add migration conflict detection to CI and pre-commit

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -73,6 +73,11 @@ jobs:
           source .venv/bin/activate && \
           npm run fmt-check
 
+      - name: Check for migration conflicts
+        run: |
+          source .venv/bin/activate && \
+          ./scripts/check_migration_conflicts.sh
+
       - name: Check Jupyter notebooks are stripped
         run: |
           source .venv/bin/activate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,15 @@ repos:
 
   - repo: local
     hooks:
+      - id: check-migration-conflicts
+        name: Check for migration conflicts
+        entry: ./scripts/check_migration_conflicts.sh
+        language: script
+        pass_filenames: false
+        always_run: true
+
+  - repo: local
+    hooks:
       - id: markdownlint
         name: markdownlint
         entry: npx markdownlint-cli2 --fix

--- a/gyrinx/core/management/commands/check_migration_conflicts.py
+++ b/gyrinx/core/management/commands/check_migration_conflicts.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db.migrations.loader import MigrationLoader
+
+
+class Command(BaseCommand):
+    help = "Check for conflicting migrations (multiple leaf nodes per app)."
+
+    def handle(self, *args, **options):
+        loader = MigrationLoader(None, ignore_no_migrations=True)
+        conflicts = loader.detect_conflicts()
+
+        if not conflicts:
+            self.stdout.write("No migration conflicts detected.")
+            return
+
+        messages = []
+        for app_label, migration_names in sorted(conflicts.items()):
+            names = ", ".join(sorted(migration_names))
+            messages.append(f"  {app_label}: {names}")
+
+        raise CommandError(
+            "Conflicting migrations detected!\n" + "\n".join(messages) + "\n\n"
+            "These migrations branch from the same parent and need a "
+            "merge migration.\n"
+            "Run: manage makemigrations --merge"
+        )

--- a/scripts/check_migration_conflicts.sh
+++ b/scripts/check_migration_conflicts.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Check for conflicting Django migrations using Django's own
+# MigrationLoader.detect_conflicts().
+#
+# This catches the real problem: multiple leaf nodes in a single app's
+# migration graph (i.e. two migrations that both claim to follow the
+# same parent, requiring a merge migration).  This is strictly better
+# than checking for duplicate numeric prefixes, because two PRs can
+# create migrations with *different* numbers that still conflict.
+#
+# Requires Django to be importable (run inside the virtualenv or CI
+# after `pip install`).
+
+set -euo pipefail
+
+python scripts/manage.py check_migration_conflicts


### PR DESCRIPTION
## Summary

- Add a Django management command (`check_migration_conflicts`) that uses `MigrationLoader.detect_conflicts()` to detect migration branches (multiple leaf nodes per app)
- Add a shell wrapper script and integrate it into CI (format-check workflow) and pre-commit hooks
- This catches the real problem: two PRs creating migrations that branch from the same parent, even if they have different numbers

## Test plan

- [x] Script runs locally and reports "No migration conflicts detected"
- [x] Pre-commit hook passes
- [ ] CI workflow runs successfully on PR