### PR TITLE
Update Claude model from opus-4-5 to opus-4-6 across workflows

### DIFF
--- a/.github/workflows/claude-code-improvement.yml
+++ b/.github/workflows/claude-code-improvement.yml
@@ -72,7 +72,7 @@ jobs:
 
           # Claude configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model claude-opus-4-6
             --allowedTools "Edit,View,Replace,Write,Create,BatchTool,GlobTool,GrepTool,NotebookEditCell,Bash,mcp__*"
             --system-prompt "The repo is gyrinx-app/gyrinx.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,7 +43,7 @@ jobs:
 
           # Claude configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model claude-opus-4-6
             --allowedTools "Bash(./scripts/fmt.sh:*),Bash(./scripts/check_migrations.sh:*),Bash(python -m pytest:*),Bash(pytest:*)"
 
           # Automated PR review prompt

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -51,7 +51,7 @@ jobs:
 
           # Allowed tools: gh CLI for issue management, file reading for codebase context, web access for documentation
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model claude-opus-4-6
             --allowedTools "Bash(gh issue:*),Bash(gh label:*),Bash(gh search:*),Bash(rg:*),Bash(grep:*),Bash(find:*),Bash(ls:*),Bash(cat:*),View,GlobTool,GrepTool,WebFetch,WebSearch"
 
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,7 +105,7 @@ jobs:
 
           # Claude configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model claude-opus-4-6
             --allowedTools Bash
             --system-prompt "IMPORTANT: Before running any Python code, tests, or linting tools, you MUST first run:
             pip install --editable .


### PR DESCRIPTION
## Summary
Updates all GitHub Actions workflows to use the latest Claude model `claude-opus-4-6` instead of the previous `claude-opus-4-5-20251101` version.

## Changes
- **claude-code-improvement.yml**: Updated model specification in Claude configuration
- **claude-code-review.yml**: Updated model specification in Claude configuration
- **claude-issue-triage.yml**: Updated model specification in Claude configuration
- **claude.yml**: Updated model specification in Claude configuration

## Details
This change standardizes the Claude model across all four automation workflows to use the newer `claude-opus-4-6` model. This ensures consistent behavior and access to the latest model improvements across:
- Automated code improvement tasks
- Automated PR code reviews
- Automated issue triage
- General Claude automation tasks

The model update maintains all existing tool permissions and system prompts without modification.

https://claude.ai/code/session_01APZK8pdfbLGsn3r82TFcxo