### PR TITLE
fix: Strip HTML from campaign summaries in list views

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_copy_from.html
+++ b/gyrinx/core/templates/core/campaign/campaign_copy_from.html
@@ -109,7 +109,7 @@
                                 <div class="border rounded p-3">
                                     <h6 class="mb-1">{{ source_campaign.name }}</h6>
                                     {% if source_campaign.summary %}
-                                        <div class="text-muted small mb-0 mb-last-0">{{ source_campaign.summary|safe_rich_text|safe }}</div>
+                                        <div class="text-muted small mb-0 mb-last-0">{{ source_campaign.summary|plain_text_truncate:150 }}</div>
                                     {% endif %}
                                 </div>
                             {% else %}
@@ -139,7 +139,9 @@
                                             <div class="d-flex justify-content-between align-items-start gap-3">
                                                 <div>
                                                     <h6 class="mb-1">{{ tc.name }}</h6>
-                                                    {% if tc.summary %}<div class="text-muted small mb-0 mb-last-0">{{ tc.summary|safe_rich_text|safe }}</div>{% endif %}
+                                                    {% if tc.summary %}
+                                                        <div class="text-muted small mb-0 mb-last-0">{{ tc.summary|plain_text_truncate:150 }}</div>
+                                                    {% endif %}
                                                 </div>
                                                 <button type="button"
                                                         class="btn btn-sm btn-outline-primary flex-shrink-0"

--- a/gyrinx/core/templates/core/campaign/campaigns.html
+++ b/gyrinx/core/templates/core/campaign/campaigns.html
@@ -36,7 +36,7 @@
                                 {% endif %}
                             </div>
                         </div>
-                        <div class="mb-last-0 text-secondary">{{ campaign.summary|safe_rich_text|safe }}</div>
+                        <div class="mb-last-0 text-secondary">{{ campaign.summary|plain_text_truncate:150 }}</div>
                         <div class="hstack column-gap-2 row-gap-1 flex-wrap fs-7 text-secondary">
                             {% if campaign.archived %}
                                 <div>

--- a/gyrinx/core/tests/test_campaign.py
+++ b/gyrinx/core/tests/test_campaign.py
@@ -329,8 +329,13 @@ def test_campaign_automatically_creates_reputation_resource():
 
 
 @pytest.mark.django_db
-def test_campaign_list_view_html_content():
-    """Test that HTML content is displayed in campaign list view."""
+def test_campaign_list_view_shows_plain_text_summary():
+    """Test that HTML content is stripped to plain text in campaign list view.
+
+    Campaign summaries in list views should show plain text, not HTML,
+    to prevent large images and complex formatting from cluttering the list.
+    Full HTML is still shown on the campaign detail page.
+    """
     client = Client()
 
     # Create a test user
@@ -354,9 +359,11 @@ def test_campaign_list_view_html_content():
     # The campaign should be listed
     assert "HTML Summary Test" in content
 
-    # HTML should be rendered (using |safe filter)
-    assert "<strong>Bold</strong>" in content
-    assert "<em>italic</em>" in content
+    # HTML should be stripped to plain text in list view
+    assert "Bold and italic summary" in content
+    # HTML tags should NOT be rendered in the summary
+    assert "<strong>Bold</strong>" not in content
+    assert "<em>italic</em>" not in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- Adds a `plain_text_truncate` template filter that strips all HTML tags and truncates text for list view previews
- Campaign summaries in list views now show plain text instead of full HTML (including images)
- Full rich text is still shown on campaign detail pages

Closes #1384

## Test plan

- [ ] Visit /campaigns/ and verify summaries show plain text, not HTML
- [ ] Create a campaign with images in the summary and verify they don't appear in list view
- [ ] Visit a campaign detail page and verify full rich text still renders

🤖 Generated with [Claude Code](https://claude.ai/claude-code)