### PR TITLE
feat: Pack history tracking and activity feed

### DIFF
--- a/gyrinx/core/models/pack.py
+++ b/gyrinx/core/models/pack.py
@@ -2,6 +2,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.urls import reverse
 from simple_history.models import HistoricalRecords
 
 from .base import AppBase
@@ -37,6 +38,9 @@ class CustomContentPack(AppBase):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse("core:pack", args=(self.id,))
 
 
 class CustomContentPackItem(AppBase):

--- a/gyrinx/core/templates/core/includes/pack_activity_item.html
+++ b/gyrinx/core/templates/core/includes/pack_activity_item.html
@@ -1,0 +1,42 @@
+{% comment %}
+    Pack activity item - displays a single history record.
+    - activity: History record (HistoricalCustomContentPack or HistoricalCustomContentPackItem)
+{% endcomment %}
+<div class="list-group-item px-0">
+    <small class="text-muted hstack w-100 justify-content-between">
+        <div class="flex-grow-1">
+            {% if activity.history_user %}
+                <strong><i class="bi-person"></i> {{ activity.history_user.username }}</strong>
+            {% else %}
+                <strong><i class="bi-person"></i> System</strong>
+            {% endif %}
+            •
+            {% if activity.is_pack_record %}
+                {% if activity.history_type == "+" %}
+                    Created pack
+                {% elif activity.history_type == "~" %}
+                    Updated pack
+                {% elif activity.history_type == "-" %}
+                    Deleted pack
+                {% endif %}
+            {% else %}
+                {% if activity.history_type == "+" %}
+                    Added item
+                {% elif activity.history_type == "~" %}
+                    Updated item
+                {% elif activity.history_type == "-" %}
+                    Removed item
+                {% endif %}
+            {% endif %}
+        </div>
+        <div class="ms-auto">
+            <em>{{ activity.history_date|timesince }} ago</em>
+        </div>
+    </small>
+    {% if not activity.is_pack_record %}<p class="mb-0">{{ activity.item_description }}</p>{% endif %}
+    {% if activity.changes %}
+        <ul class="mb-0 small text-muted">
+            {% for change in activity.changes %}<li>{{ change }}</li>{% endfor %}
+        </ul>
+    {% endif %}
+</div>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -57,5 +57,30 @@
                 {% endif %}
             </section>
         {% endfor %}
+        <!-- Activity -->
+        <section>
+            <div class="d-flex justify-content-between align-items-center mb-3 bg-body-secondary rounded px-2 py-1">
+                <h2 class="h5 mb-0">
+                    <i class="bi-clock-history"></i> Activity
+                </h2>
+                {% if total_activity_count > 0 %}
+                    <a href="{% url 'core:pack-activity' pack.id %}"
+                       class="link-primary link-underline-opacity-25 link-underline-opacity-100-hover small">View all →</a>
+                {% endif %}
+            </div>
+            {% if recent_activities %}
+                <div class="list-group list-group-flush">
+                    {% for activity in recent_activities %}
+                        {% include "core/includes/pack_activity_item.html" with activity=activity %}
+                    {% endfor %}
+                </div>
+                {% if total_activity_count > 5 %}
+                    <a href="{% url 'core:pack-activity' pack.id %}"
+                       class="small mt-2 d-inline-block">View all {{ total_activity_count }} activities →</a>
+                {% endif %}
+            {% else %}
+                <p class="text-muted small mb-0">No activity yet.</p>
+            {% endif %}
+        </section>
     </div>
 {% endblock content %}

--- a/gyrinx/core/templates/core/pack/pack_activity.html
+++ b/gyrinx/core/templates/core/pack/pack_activity.html
@@ -1,0 +1,42 @@
+{% extends "core/layouts/base.html" %}
+{% load allauth custom_tags %}
+{% block head_title %}
+    Activity - {{ pack.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with url=pack.get_absolute_url text="Back to Content Pack" %}
+    <div class="col-12 col-xl-8 px-0 vstack gap-3">
+        <div>
+            <h1 class="h3 mb-0">Activity</h1>
+            <h2 class="h5 text-muted">{{ pack.name }}</h2>
+        </div>
+        {% if activities %}
+            <div class="list-group list-group-flush">
+                {% for activity in activities %}
+                    {% include "core/includes/pack_activity_item.html" with activity=activity %}
+                {% endfor %}
+            </div>
+            {% if is_paginated %}
+                <nav aria-label="Page navigation">
+                    <ul class="pagination justify-content-center">
+                        {% if page_obj.has_previous %}
+                            <li class="page-item">
+                                <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                            </li>
+                        {% endif %}
+                        <li class="page-item active">
+                            <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                        </li>
+                        {% if page_obj.has_next %}
+                            <li class="page-item">
+                                <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                            </li>
+                        {% endif %}
+                    </ul>
+                </nav>
+            {% endif %}
+        {% else %}
+            <p class="text-muted">No activity yet.</p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1,7 +1,9 @@
 import pytest
 from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
 
-from gyrinx.core.models.pack import CustomContentPack
+from gyrinx.content.models.house import ContentHouse
+from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 
 
 @pytest.fixture
@@ -308,3 +310,219 @@ def test_pack_edit_success(client, group_user, pack):
     assert response.status_code == 302
     pack.refresh_from_db()
     assert pack.name == "Updated Pack"
+
+
+# --- History tracking ---
+
+
+@pytest.mark.django_db
+def test_pack_create_records_history(client, group_user):
+    """Test that creating a pack via view creates a history record with the correct user."""
+    client.force_login(group_user)
+    response = client.post(
+        "/packs/new/",
+        {"name": "History Test Pack", "summary": "Testing history", "description": ""},
+    )
+    assert response.status_code == 302
+
+    pack = CustomContentPack.objects.get(name="History Test Pack")
+    history = pack.history.all()
+
+    assert history.count() == 1
+    assert history[0].history_type == "+"
+    assert history[0].history_user == group_user
+    assert history[0].name == "History Test Pack"
+
+
+@pytest.mark.django_db
+def test_pack_edit_records_history(client, group_user, pack):
+    """Test that editing a pack via view creates a history record with the correct user."""
+    client.force_login(group_user)
+    initial_count = pack.history.count()
+
+    response = client.post(
+        f"/pack/{pack.id}/edit/",
+        {
+            "name": "Updated History Pack",
+            "summary": "Updated summary",
+            "description": "Updated desc",
+        },
+    )
+    assert response.status_code == 302
+
+    pack.refresh_from_db()
+    history = pack.history.all()
+
+    assert history.count() == initial_count + 1
+    assert history[0].history_type == "~"
+    assert history[0].history_user == group_user
+    assert history[0].name == "Updated History Pack"
+
+
+@pytest.mark.django_db
+def test_pack_edit_no_change_still_records_history(client, group_user, pack):
+    """Test that submitting the edit form without changes still creates a history record."""
+    client.force_login(group_user)
+    initial_count = pack.history.count()
+
+    response = client.post(
+        f"/pack/{pack.id}/edit/",
+        {
+            "name": pack.name,
+            "summary": pack.summary,
+            "description": pack.description,
+        },
+    )
+    assert response.status_code == 302
+
+    history = pack.history.all()
+    assert history.count() == initial_count + 1
+    assert history[0].history_user == group_user
+
+
+@pytest.mark.django_db
+def test_pack_item_history_tracked(group_user):
+    """Test that pack item creation records history."""
+    pack = CustomContentPack.objects.create(name="Item History Pack", owner=group_user)
+    house = ContentHouse.objects.all_content().create(name="History House")
+    ct = ContentType.objects.get_for_model(ContentHouse)
+
+    item = CustomContentPackItem(
+        pack=pack, content_type=ct, object_id=house.pk, owner=group_user
+    )
+    item.save_with_user(user=group_user)
+
+    history = item.history.all()
+    assert history.count() == 1
+    assert history[0].history_type == "+"
+    assert history[0].history_user == group_user
+
+
+# --- Activity views ---
+
+
+@pytest.mark.django_db
+def test_pack_detail_shows_activity_section(client, group_user, pack):
+    """Test that the pack detail page includes an activity section."""
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    assert b"Activity" in response.content
+
+
+@pytest.mark.django_db
+def test_pack_detail_shows_recent_activity(client, group_user, pack):
+    """Test that the pack detail page shows recent history records."""
+    client.force_login(group_user)
+    # Edit the pack to create an update history record
+    client.post(
+        f"/pack/{pack.id}/edit/",
+        {"name": "Activity Test", "summary": "", "description": ""},
+    )
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    assert b"Updated" in response.content
+    assert b"pack" in response.content
+
+
+@pytest.mark.django_db
+def test_pack_activity_page_loads(client, group_user, pack):
+    """Test that the pack activity page loads."""
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}/activity/")
+    assert response.status_code == 200
+    assert b"Activity" in response.content
+
+
+@pytest.mark.django_db
+def test_pack_activity_page_requires_group(client, pack, make_user):
+    """Test that the activity page requires group membership."""
+    non_member = make_user("nonmember", "password")
+    client.force_login(non_member)
+    response = client.get(f"/pack/{pack.id}/activity/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_pack_activity_page_respects_visibility(
+    client, group_user, custom_content_group, make_user
+):
+    """Test that the activity page respects pack visibility rules."""
+    unlisted = CustomContentPack.objects.create(
+        name="Secret Pack", listed=False, owner=group_user
+    )
+    other_user = make_user("other", "password")
+    other_user.groups.add(custom_content_group)
+    client.force_login(other_user)
+    response = client.get(f"/pack/{unlisted.id}/activity/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_pack_activity_includes_item_history(client, group_user, pack):
+    """Test that the activity page shows both pack and item history records."""
+    house = ContentHouse.objects.all_content().create(name="Activity House")
+    ct = ContentType.objects.get_for_model(ContentHouse)
+    item = CustomContentPackItem(
+        pack=pack, content_type=ct, object_id=house.pk, owner=group_user
+    )
+    item.save_with_user(user=group_user)
+
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}/activity/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Should show pack creation and item addition with resolved name
+    assert "Created pack" in content
+    assert "Added item" in content
+    assert "Activity House (House)" in content
+
+
+@pytest.mark.django_db
+def test_pack_activity_shows_field_changes(client, group_user, pack):
+    """Test that update records show which fields changed."""
+    client.force_login(group_user)
+    # Edit the pack to change name and listed flag
+    client.post(
+        f"/pack/{pack.id}/edit/",
+        {
+            "name": "Renamed Pack",
+            "summary": pack.summary,
+            "description": pack.description,
+            "listed": "",  # unchecked = False
+        },
+    )
+    response = client.get(f"/pack/{pack.id}/activity/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Name set to Renamed Pack" in content
+    assert "Listed set to no" in content
+
+
+@pytest.mark.django_db
+def test_pack_activity_textfield_changes_say_updated(client, group_user, pack):
+    """Test that TextField changes show 'updated' without the value."""
+    client.force_login(group_user)
+    client.post(
+        f"/pack/{pack.id}/edit/",
+        {
+            "name": pack.name,
+            "summary": "Brand new summary",
+            "description": pack.description,
+        },
+    )
+    response = client.get(f"/pack/{pack.id}/activity/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Summary updated" in content
+    # Should NOT contain the actual text content
+    assert "Brand new summary" not in content
+
+
+@pytest.mark.django_db
+def test_pack_activity_shows_view_all_link(client, group_user, pack):
+    """Test that the detail page shows a 'View all' link when activity exists."""
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    assert f"/pack/{pack.id}/activity/".encode() in response.content

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -661,6 +661,11 @@ urlpatterns = [
     path("packs/new/", pack_views.new_pack, name="packs-new"),
     path("pack/<id>", pack_views.PackDetailView.as_view(), name="pack"),
     path("pack/<id>/edit/", pack_views.edit_pack, name="pack-edit"),
+    path(
+        "pack/<id>/activity/",
+        pack_views.PackActivityView.as_view(),
+        name="pack-activity",
+    ),
     # TinyMCE upload
     path(
         "tinymce/upload/",

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -1,10 +1,12 @@
 """Pack list, detail, and CRUD views."""
 
+import itertools
 from collections import defaultdict
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.search import SearchQuery, SearchVector
+from django.core.paginator import Paginator
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -12,7 +14,7 @@ from django.views import generic
 
 from gyrinx.content.models.house import ContentHouse
 from gyrinx.core.forms.pack import PackForm
-from gyrinx.core.models.pack import CustomContentPack
+from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 from gyrinx.core.views.auth import (
     GroupMembershipRequiredMixin,
     group_membership_required,
@@ -28,6 +30,159 @@ SUPPORTED_CONTENT_TYPES = [
         "bi-house-door",
     ),
 ]
+
+
+# Fields to exclude from change diffs (internal/inherited fields).
+_SKIP_FIELDS = {
+    "id",
+    "created",
+    "modified",
+    "owner",
+    "archived",
+    "archived_at",
+    "object_id",
+    "content_type",
+    "pack",
+}
+
+# Human-readable labels for model fields.
+_FIELD_LABELS = {
+    "name": "Name",
+    "summary": "Summary",
+    "description": "Description",
+    "listed": "Listed",
+}
+
+
+class _ActivityRecord:
+    """Wraps a SimpleHistory record with display helpers for templates."""
+
+    __slots__ = ("_record", "is_pack_record", "item_description", "changes")
+
+    def __init__(self, record, is_pack_record, item_description="", changes=None):
+        self._record = record
+        self.is_pack_record = is_pack_record
+        self.item_description = item_description
+        self.changes = changes or []
+
+    def __getattr__(self, name):
+        return getattr(self._record, name)
+
+
+def _format_change(field_name, new_value, field_obj):
+    """Format a single field change for display.
+
+    For TextFields (summary, description), just say "updated".
+    For BooleanFields, show the new value as a readable string.
+    For CharFields, show the new value.
+    """
+    from django.db import models
+
+    label = _FIELD_LABELS.get(field_name, field_name.replace("_", " ").title())
+
+    if isinstance(field_obj, models.TextField):
+        return f"{label} updated"
+    elif isinstance(field_obj, models.BooleanField):
+        return f"{label} set to {'yes' if new_value else 'no'}"
+    else:
+        return f"{label} set to {new_value}"
+
+
+def _compute_changes(record):
+    """Compute a list of human-readable change descriptions for a history record."""
+    if record.history_type != "~":
+        return []
+
+    prev = record.prev_record
+    if prev is None:
+        return []
+
+    delta = record.diff_against(prev)
+    changes = []
+
+    # Build a field lookup from the original model
+    model_class = record.instance_type
+    field_map = {f.name: f for f in model_class._meta.fields}
+
+    for change in delta.changes:
+        if change.field in _SKIP_FIELDS:
+            continue
+        field_obj = field_map.get(change.field)
+        if field_obj is None:
+            continue
+        changes.append(_format_change(change.field, change.new, field_obj))
+
+    return changes
+
+
+def _resolve_item_description(record):
+    """Resolve a pack item history record to a human-readable description.
+
+    Attempts to load the content object to get its name. Falls back to
+    the content type name if the object no longer exists.
+    """
+    ct_name = record.content_type.name.title() if record.content_type else "item"
+    if record.object_id and record.content_type:
+        model_class = record.content_type.model_class()
+        if model_class:
+            manager = model_class._default_manager
+            qs = (
+                manager.all_content()
+                if hasattr(manager, "all_content")
+                else manager.all()
+            )
+            try:
+                obj = qs.get(pk=record.object_id)
+                return f"{obj} ({ct_name})"
+            except model_class.DoesNotExist:
+                pass
+    return ct_name
+
+
+def _get_pack_activity(pack, limit=None):
+    """Get unified activity history for a pack and its items.
+
+    Returns a sorted list of _ActivityRecord wrappers, ordered by
+    history_date descending. Update records with no meaningful field
+    changes are excluded.
+    """
+    pack_history = pack.history.select_related("history_user").all()
+    item_history = (
+        CustomContentPackItem.history.filter(pack_id=pack.id)
+        .select_related("history_user", "content_type")
+        .all()
+    )
+
+    pack_records = []
+    for r in pack_history:
+        changes = _compute_changes(r)
+        if r.history_type == "~" and not changes:
+            continue
+        pack_records.append(_ActivityRecord(r, is_pack_record=True, changes=changes))
+
+    item_records = []
+    for r in item_history:
+        changes = _compute_changes(r)
+        if r.history_type == "~" and not changes:
+            continue
+        item_records.append(
+            _ActivityRecord(
+                r,
+                is_pack_record=False,
+                item_description=_resolve_item_description(r),
+                changes=changes,
+            )
+        )
+
+    combined = sorted(
+        itertools.chain(pack_records, item_records),
+        key=lambda h: h.history_date,
+        reverse=True,
+    )
+
+    if limit:
+        return combined[:limit]
+    return combined
 
 
 class PacksView(GroupMembershipRequiredMixin, generic.ListView):
@@ -107,6 +262,9 @@ class PackDetailView(GroupMembershipRequiredMixin, generic.DetailView):
             )
 
         context["content_sections"] = content_sections
+        all_activities = _get_pack_activity(pack)
+        context["recent_activities"] = all_activities[:5]
+        context["total_activity_count"] = len(all_activities)
 
         return context
 
@@ -157,3 +315,34 @@ def edit_pack(request, id):
         "core/pack/pack_edit.html",
         {"form": form, "pack": pack, "error_message": error_message},
     )
+
+
+class PackActivityView(GroupMembershipRequiredMixin, generic.TemplateView):
+    """Display full activity history for a pack."""
+
+    template_name = "core/pack/pack_activity.html"
+    required_groups = ["Custom Content"]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        pack = get_object_or_404(
+            CustomContentPack.objects.select_related("owner"),
+            id=self.kwargs["id"],
+        )
+
+        user = self.request.user
+        if not pack.listed and (not user.is_authenticated or user != pack.owner):
+            raise Http404
+
+        all_activity = _get_pack_activity(pack)
+        paginator = Paginator(all_activity, 50)
+        page_number = self.request.GET.get("page")
+        page_obj = paginator.get_page(page_number)
+
+        context["pack"] = pack
+        context["activities"] = page_obj
+        context["page_obj"] = page_obj
+        context["is_paginated"] = page_obj.has_other_pages()
+        context["is_owner"] = user.is_authenticated and user == pack.owner
+
+        return context


### PR DESCRIPTION
## Summary

Closes #1310

- Add comprehensive test suite (13 new tests) verifying SimpleHistory records are created with correct user attribution when packs are created/edited via views
- Add unified activity feed on pack detail page (last 5 entries) with dedicated paginated activity page at `/pack/<id>/activity/`
- Show field-level change details on update records — TextField changes say "updated", CharField/BooleanField show the new value

## Test plan

- [x] Verify pack creation via UI creates history with correct user
- [x] Verify pack edit via UI creates history with correct user
- [x] Verify activity section appears on pack detail page
- [x] Verify "View all" link goes to full activity page
- [x] Verify field changes shown as bullet points on update entries
- [x] Verify unlisted pack activity page returns 404 for non-owners
- [x] Verify non-group-members cannot access activity page