### PR TITLE
fix: upgrade Django to 6.0.2 (CVE-2026-1312)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.14.3
 bleach==6.3.0
 click==8.3.1
 daphne==4.2.1
-Django==6.0.1
+Django==6.0.2
 django-allauth==65.14.0
 django-csp==4.0
 django-debug-toolbar==6.2.0


### PR DESCRIPTION
## Summary

- Upgrades Django from 6.0.1 to 6.0.2 to fix a high-severity SQL injection vulnerability (CVE-2026-1312, GHSA-6426-9fv3-65x8)
- Resolves Dependabot alert 60

## Test plan

- [x] Full test suite passes (1669 passed, 13 skipped)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)