### PR TITLE
docs: add comprehensive content library documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,6 +42,23 @@
 - [State Machine](technical-reference/state-machine.md)
 - [Prefetching Strategy](technical-reference/prefetching-strategy.md)
 
+## Content Library
+
+- [Content Library Overview](content-library/README.md)
+- [Houses & Factions](content-library/houses-and-factions.md)
+- [Fighters & Fighter Types](content-library/fighters.md)
+- [Stats & Statlines](content-library/stats-and-statlines.md)
+- [Skills, Rules & Psyker Powers](content-library/skills-rules-and-psyker-powers.md)
+- [Equipment & Weapons](content-library/equipment-and-weapons.md)
+- [Equipment Availability & Restrictions](content-library/equipment-availability.md)
+- [Equipment List Expansions](content-library/equipment-list-expansions.md)
+- [Modifiers](content-library/modifiers.md)
+- [Injuries](content-library/injuries.md)
+- [Gang Attributes](content-library/gang-attributes.md)
+- [Advancements](content-library/advancements.md)
+- [Content Packs](content-library/content-packs.md)
+- [Reference Library](content-library/reference-library.md)
+
 ## Explanation
 
 - [Technology Choices](explanation/technology-choices.md)

--- a/docs/content-library/README.md
+++ b/docs/content-library/README.md
@@ -1,0 +1,35 @@
+# Content Library
+
+The content library is the game data that powers Gyrinx. It contains all the fighter types, equipment, weapons, skills, rules, and other definitions from Necromunda that users draw from when building their lists. Everything in the content library is managed through the Django admin interface.
+
+When a user creates a list and adds fighters to it, they're selecting from templates defined in the content library. The content library defines *what's available*; users create their own instances of that content in their lists.
+
+## How this section is organised
+
+Each document covers a distinct area of the content library, including the models involved, how they appear in the admin, how they affect the user-facing application, and common administrative tasks.
+
+| Document | What it covers |
+|----------|---------------|
+| [Houses & Factions](houses-and-factions.md) | Gang factions, the `generic` and `legacy` flags, house-specific cost overrides |
+| [Fighters & Fighter Types](fighters.md) | Fighter archetypes, categories, default equipment loadouts, category terminology |
+| [Stats & Statlines](stats-and-statlines.md) | Stat definitions, statline types, the legacy vs custom statline system |
+| [Skills, Rules & Psyker Powers](skills-rules-and-psyker-powers.md) | Skill trees, special rules, psyker disciplines and powers |
+| [Equipment & Weapons](equipment-and-weapons.md) | Equipment items, weapon profiles, traits, accessories, upgrades, rarity |
+| [Equipment Availability & Restrictions](equipment-availability.md) | Fighter-specific equipment lists, category restrictions, availability presets |
+| [Equipment List Expansions](equipment-list-expansions.md) | Conditional equipment unlocked by attributes, house, or fighter category |
+| [Modifiers](modifiers.md) | The polymorphic modifier system that changes stats, traits, rules, and skills |
+| [Injuries](injuries.md) | Injury groups, outcomes, and how injuries affect fighters during campaigns |
+| [Gang Attributes](gang-attributes.md) | List-level attributes (Alignment, Alliance, Affiliation) and their effects |
+| [Advancements](advancements.md) | Equipment advancements fighters can purchase with XP during campaigns |
+| [Content Packs](content-packs.md) | User-created custom content collections and the pack filtering system |
+| [Reference Library](reference-library.md) | Book and page references used for in-app tooltips |
+
+## Key ideas
+
+**Content vs user data.** The content library (`ContentFighter`, `ContentEquipment`, etc.) defines templates. User data (`ListFighter`, `ListFighterEquipmentAssignment`, etc.) holds the instances users create from those templates. Content is managed by admins; user data is created by users through the application.
+
+**Cost propagation.** When you change a cost in the content library, the system automatically marks affected user data for recalculation. See [Equipment & Weapons](equipment-and-weapons.md) for details on how this works.
+
+**Modifiers.** Equipment, upgrades, accessories, and injuries can all carry modifiers that change fighter stats, weapon stats, traits, rules, skills, and more. The [Modifiers](modifiers.md) documentation explains the full system.
+
+**Pack filtering.** Content that belongs to a custom content pack is hidden from normal queries by default. The [Content Packs](content-packs.md) documentation explains how this works.

--- a/docs/content-library/advancements.md
+++ b/docs/content-library/advancements.md
@@ -1,0 +1,179 @@
+# Advancements
+
+## Overview
+
+Advancements represent how fighters grow and improve over the course of a Necromunda campaign. When a fighter earns enough experience points (XP), their player can spend those points to improve characteristics, learn new skills, or acquire new equipment. The advancement system in Gyrinx manages the equipment-based advancement options that content administrators configure through the content library. In this context, a list represents a user's collection of fighters (called a "gang" in Necromunda).
+
+The content library models covered here -- `ContentAdvancementEquipment` and `ContentAdvancementAssignment` -- specifically handle equipment advancements. These define what equipment a fighter can gain by spending XP, along with the costs, restrictions, and selection methods. Characteristic increases and skill advancements are configured elsewhere through the stat and skill systems, with their XP costs and rating increases defined in the application code rather than the content library.
+
+When a user purchases an equipment advancement for one of their fighters, the system deducts the XP cost, increases the fighter's rating by the configured amount, and creates the corresponding equipment assignment on the fighter automatically. This directly affects the fighter's value and the list's overall gang rating.
+
+## Key Concepts
+
+**Equipment Advancement** (`ContentAdvancementEquipment`): A named advancement option that defines what equipment a fighter can gain, how much it costs in XP, and how it affects the fighter's rating. Each equipment advancement can offer multiple specific equipment options through its assignments.
+
+**Advancement Assignment** (`ContentAdvancementAssignment`): A specific piece of equipment (optionally with upgrades) that a fighter receives when they take a particular equipment advancement. An equipment advancement can have many assignments, representing the pool of options a fighter selects from.
+
+**Chosen vs Random Selection**: Each equipment advancement can allow the player to choose their equipment (`enable_chosen`) or have it randomly selected (`enable_random`), or both. This mirrors the tabletop game's advancement tables where some results let you pick and others are rolled randomly.
+
+**XP Cost**: The experience points a fighter must spend to purchase the advancement. This is deducted from the fighter's current XP balance.
+
+**Cost Increase**: The credit value added to the fighter's rating when they take the advancement. This affects the list's total gang rating, which is used for balancing campaigns.
+
+## Models
+
+### `ContentAdvancementEquipment`
+
+This model defines a named equipment advancement that fighters can purchase with XP. It controls the cost, selection method, and which fighters are eligible.
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (255) | The name of the advancement, displayed to users in the advancement selection form. For example, "Legendary Name" or "Gang Equipment". |
+| `xp_cost` | PositiveIntegerField | The XP cost to purchase this advancement. Deducted from the fighter's `xp_current` when applied. |
+| `cost_increase` | IntegerField (default: 0) | The credit increase applied to the fighter's rating when this advancement is taken. This value propagates up to the list's `rating_current`. |
+| `enable_random` | BooleanField (default: False) | When enabled, the advancement appears as a "Random [Name]" option. The system randomly selects one assignment from the pool, filtering out options the fighter already has. |
+| `enable_chosen` | BooleanField (default: False) | When enabled, the advancement appears as a "Chosen [Name]" option. The player picks which assignment they want from the available pool. |
+| `restricted_to_houses` | ManyToManyField to `ContentHouse` (blank) | If any houses are selected, only fighters belonging to those houses can take this advancement. When left empty, the advancement is available to all houses. |
+| `restricted_to_fighter_categories` | JSONField (default: []) | A list of fighter category strings (e.g., `["GANGER", "CHAMPION"]`) that can take this advancement. When empty, all fighter categories are eligible. Uses the `FighterCategoryChoices` values: `LEADER`, `CHAMPION`, `GANGER`, `JUVE`, `CREW`, `EXOTIC_BEAST`, `SPECIALIST`, and others. |
+
+#### Validation Rules
+
+- At least one of `enable_random` or `enable_chosen` must be set to `True`. The model's `clean()` method enforces this, and the admin form will display an error if neither is enabled.
+
+#### Relationships
+
+- Has many `ContentAdvancementAssignment` records through the `assignments` reverse relation.
+- References `ContentHouse` through `restricted_to_houses` for house-based filtering.
+
+#### Admin Configuration
+
+The admin interface for `ContentAdvancementEquipment` is organized into three fieldset sections:
+
+1. **Main fields** -- `name`, `xp_cost`, and `cost_increase`.
+2. **Assignment Selection** -- The `enable_chosen` and `enable_random` checkboxes, with an inline form below for adding `ContentAdvancementAssignment` records directly.
+3. **Restrictions** (collapsed by default) -- `restricted_to_houses` (shown as a horizontal filter widget) and `restricted_to_fighter_categories` (shown as checkboxes).
+
+The list view shows columns for `name`, `xp_cost`, `cost_increase`, `enable_chosen`, `enable_random`, an "Assignment Options" count, and a "Restrictions" summary. You can filter the list by `enable_chosen`, `enable_random`, and `restricted_to_houses`. The search box matches against the `name` field.
+
+### `ContentAdvancementAssignment`
+
+This model represents a specific equipment configuration that a fighter can gain through an advancement. Each assignment links a base equipment item and optionally includes upgrades.
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `advancement` | ForeignKey to `ContentAdvancementEquipment` (nullable) | The equipment advancement this assignment belongs to. Links back to the parent advancement that offers this option. |
+| `equipment` | ForeignKey to `ContentEquipment` | The base equipment item the fighter receives. This is the core piece of gear granted by the advancement. |
+| `upgrades_field` | ManyToManyField to `ContentEquipmentUpgrade` (blank) | Optional upgrades that come pre-attached to the equipment. When the advancement is applied, both the equipment and these upgrades are added to the fighter's equipment assignment. |
+
+#### Display
+
+The string representation of an assignment shows the equipment name followed by any upgrade names in parentheses. For example, an assignment with a "Lasgun" and a "Hotshot Pack" upgrade would display as "Lasgun (Hotshot Pack)".
+
+#### Relationships
+
+- Belongs to a `ContentAdvancementEquipment` through the `advancement` foreign key.
+- References `ContentEquipment` for the base equipment item. See [Equipment & Weapons](equipment-and-weapons.md) for details on the equipment models.
+- References `ContentEquipmentUpgrade` for any pre-configured upgrades. See [Equipment & Weapons](equipment-and-weapons.md) for details on the equipment models.
+
+#### Admin Configuration
+
+The admin list view shows columns for `equipment`, an upgrade count, and the parent `advancement`. You can search by equipment name or advancement name, and filter by equipment category or advancement.
+
+The upgrades field uses a horizontal filter widget, and when editing an assignment inline from its parent advancement, the upgrades are filtered to only show upgrades available for the selected equipment.
+
+Assignments can also be managed inline when editing a `ContentAdvancementEquipment` record. The inline form shows `equipment` (with autocomplete) and `upgrades_field` (with horizontal filter), and you can add multiple assignments at once.
+
+## How It Works in the Application
+
+### The Advancement Flow
+
+When a user wants to advance a fighter, they go through a multi-step process:
+
+1. **Dice choice** (campaign mode only) -- Gangers and Exotic Beasts can optionally roll 2d6 to determine their advancement type. The dice result maps to a specific characteristic increase. Other fighter categories skip this step.
+
+2. **Advancement type selection** -- The user sees all available advancement options grouped into three sections: characteristic increases (from the fighter's statline), equipment advancements (from `ContentAdvancementEquipment` records), and skill/other options. Equipment advancements appear as "Chosen [Name]" or "Random [Name]" depending on their configuration. The XP cost and rating increase are pre-filled based on the selected option.
+
+3. **Selection** (for chosen equipment and skills only) -- If the user selected a "Chosen" equipment advancement, they pick a specific assignment from the available pool. Assignments whose upgrades the fighter already has are automatically filtered out. For random equipment advancements, this step is skipped.
+
+4. **Confirmation** -- The user confirms the advancement. For random equipment, the system selects a random assignment at this point. The advancement is then applied: XP is deducted, the fighter's rating increases, and the equipment (with any upgrades) is added to the fighter.
+
+### Availability Filtering
+
+Equipment advancements are filtered based on the fighter attempting to advance:
+
+- **House restrictions**: If `restricted_to_houses` is set, the fighter's list must belong to one of those houses.
+- **Fighter category restrictions**: If `restricted_to_fighter_categories` is set, the fighter's category must be in the list.
+- **Duplicate filtering**: When selecting an assignment, the system excludes assignments whose upgrades the fighter already has on existing equipment. This prevents a fighter from gaining duplicate upgrades.
+
+### Effect on Fighter Cost and Rating
+
+When an equipment advancement is applied:
+
+- The `xp_cost` is subtracted from the fighter's `xp_current` field.
+- The `cost_increase` is added to the fighter's cost, which propagates up to the list's `rating_current` (or `stash_current` for stash-linked fighters like vehicles and exotic beasts).
+- A `ListFighterEquipmentAssignment` is created linking the fighter to the equipment and its upgrades.
+- A `ListFighterAdvancement` record is created to track the advancement for history and reversal purposes.
+
+### Removing Advancements
+
+Users can delete (archive) an advancement from the fighter's advancement history. When an equipment advancement is removed:
+
+- The XP is restored to the fighter.
+- The rating increase is reversed.
+- However, the equipment itself must be removed manually by the user. The system displays a warning about this.
+
+## Common Admin Tasks
+
+### Creating a New Equipment Advancement
+
+1. Navigate to the Equipment Advancements section in the admin.
+2. Click "Add" to create a new `ContentAdvancementEquipment`.
+3. Fill in the `name` (e.g., "Gang Weapons"), `xp_cost`, and `cost_increase`.
+4. Enable at least one of `enable_chosen` or `enable_random`. Enable both if you want players to have either option.
+5. In the inline section below, add one or more `ContentAdvancementAssignment` records by selecting equipment items and optionally attaching upgrades.
+6. Optionally expand the Restrictions section to limit the advancement to specific houses or fighter categories.
+7. Save the record.
+
+### Adding Equipment Options to an Existing Advancement
+
+1. Open the `ContentAdvancementEquipment` record you want to modify.
+2. Scroll down to the inline assignment section.
+3. Add a new row, select the `equipment`, and optionally select upgrades from the horizontal filter.
+4. Save. The new option will immediately appear in the advancement selection form for eligible fighters.
+
+### Restricting an Advancement to Specific Houses
+
+1. Open the `ContentAdvancementEquipment` record.
+2. Expand the "Restrictions" fieldset (it is collapsed by default).
+3. Use the `restricted_to_houses` horizontal filter to move houses from the "Available" list to the "Chosen" list.
+4. Save. Only fighters in lists belonging to the selected houses will see this advancement option.
+
+### Restricting an Advancement to Specific Fighter Categories
+
+1. Open the `ContentAdvancementEquipment` record.
+2. Expand the "Restrictions" fieldset.
+3. Check the boxes next to the fighter categories that should be eligible (e.g., `GANGER`, `CHAMPION`).
+4. Save. Only fighters with a matching category will see this advancement option.
+
+### Configuring an Advancement with Both Random and Chosen Options
+
+Some advancements should offer both selection methods at different costs. Since `xp_cost` and `cost_increase` are set at the advancement level (not the selection method level), you will need to create two separate `ContentAdvancementEquipment` records if you want different costs for random versus chosen selection:
+
+1. Create one record with `enable_random` checked and the random-specific XP cost and rating increase.
+2. Create a second record with `enable_chosen` checked and the chosen-specific XP cost and rating increase.
+3. Add the same set of assignments to both records.
+
+If the random and chosen options should have the same cost, you can use a single record with both `enable_random` and `enable_chosen` enabled.
+
+### Reviewing Existing Advancements
+
+Use the list view filters to quickly audit your advancement configuration:
+
+- Filter by `enable_chosen` or `enable_random` to see which selection methods are in use.
+- Filter by `restricted_to_houses` to see advancements limited to specific factions.
+- The "Assignment Options" column shows how many equipment options each advancement offers. An advancement with zero assignments will not be useful to players.
+- The "Restrictions" column provides a summary of any house or category restrictions.

--- a/docs/content-library/content-packs.md
+++ b/docs/content-library/content-packs.md
@@ -1,0 +1,204 @@
+# Content Packs
+
+## Overview
+
+Content Packs are user-created collections of custom game content. They allow users to group together custom houses, fighters, equipment, and other content items into a named, shareable package. A list represents a user's collection of fighters (called a "gang" in Necromunda). A pack might represent homebrew content for a list, a fan-made expansion, or a collection of house rules with associated game data.
+
+The content pack system is designed around a key principle: pack content is hidden from normal queries by default. When a user browses fighters, equipment, or other content in the application, they only see the official base content. Pack content only appears when a user explicitly opts in to a specific pack. This keeps the default experience clean while still allowing custom content to coexist in the same database.
+
+Content packs are a gated feature. Only users who belong to the "Custom Content" user group can access the packs interface, create packs, or browse community packs. This allows you to control the rollout of custom content functionality.
+
+## Key Concepts
+
+**Base content** is the standard game content that ships with the application -- all the official houses, fighters, equipment, and so on. Base content is visible to all users by default.
+
+**Pack content** is any content item that has been added to at least one content pack. Pack content is automatically excluded from normal content queries throughout the application.
+
+**Listed vs unlisted** packs control public visibility. A listed pack appears in search results and the community packs index. An unlisted pack can still be shared via its direct URL, but it will not show up when other users browse packs.
+
+**The "Custom Content" group** is a Django auth group. Users must be members of this group to access any pack-related pages. If a user who is not in this group tries to visit a pack URL, they receive a 404 response.
+
+**Content types** refer to the different kinds of game content that can be included in a pack. Currently, the supported content type is Houses (`ContentHouse`). The system is built using Django's `ContentType` framework, so extending it to additional content models is straightforward.
+
+## Models
+
+### `CustomContentPack`
+
+Represents a named collection of custom content items. Each pack is owned by a single user.
+
+`CustomContentPack` inherits from `AppBase`, which provides UUID primary keys, owner tracking, archive functionality, and history tracking.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (max 255) | The display name of the pack. Packs are ordered alphabetically by name. |
+| `summary` | TextField (blank) | A brief description shown on the packs index page. Supports rich text. |
+| `description` | TextField (blank) | A longer description shown on the pack detail page. Supports rich text. |
+| `listed` | BooleanField (default `False`) | Whether the pack appears in public search results and the community index. |
+| `owner` | ForeignKey (User) | The user who created and owns the pack. Inherited from `AppBase`. |
+
+History tracking is enabled via `HistoricalRecords`, so all changes to a pack are recorded with timestamps and the user who made the change.
+
+#### Admin interface
+
+- **List display:** `name`, `listed`, `owner`, `created`
+- **Search:** By pack name or owner username
+- **Filters:** By `listed` status and creation date
+- **Editable fields:** `name`, `summary`, `description`, `listed`, `owner`
+
+### `CustomContentPackItem`
+
+A through model that links a content object to a pack. Uses Django's `ContentType` framework to support polymorphic references -- a single `CustomContentPackItem` can point to a `ContentHouse`, a `ContentFighter`, a `ContentEquipment`, or any other content model.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pack` | ForeignKey (`CustomContentPack`) | The pack this item belongs to. Deleting a pack cascades to delete all its items. |
+| `content_type` | ForeignKey (`ContentType`) | The Django content type of the linked object. Limited to models in the `content` app. |
+| `object_id` | UUIDField | The primary key of the linked content object. |
+| `content_object` | GenericForeignKey | A convenience accessor that resolves to the actual content object. Not a database column. |
+| `owner` | ForeignKey (User) | The user who added this item. Inherited from `AppBase`. |
+
+#### Constraints and validation
+
+- **Unique together:** The combination of `pack`, `content_type`, and `object_id` must be unique. You cannot add the same content item to the same pack twice.
+- **Cross-pack sharing:** The same content item can belong to multiple different packs. The uniqueness constraint is scoped to a single pack.
+- **Object existence:** The `clean()` method validates that the referenced content object actually exists. It uses `all_content()` for this check, so it can find objects that are themselves pack content.
+- **Cascade delete:** Deleting a pack deletes all its `CustomContentPackItem` records. Deleting a `ContentType` also cascades, though this is unlikely in practice.
+- **Index:** A composite index on `content_type` and `object_id` ensures efficient lookups when determining which packs a content item belongs to.
+
+#### Admin interface
+
+- **List display:** `pack`, `content_type`, a clickable link to the content object, and `owner`
+- **Search:** By pack name or owner username
+- **Filters:** By pack and content type
+- **Editable fields:** `pack`, `content_type`, `object_id`, and a read-only link to the content object
+
+The content object link in the admin navigates directly to the Django admin change page for the referenced content item.
+
+## Pack Filtering System
+
+The pack filtering system is the mechanism that keeps pack content separate from base content in application queries. It is built into the `ContentManager` and `ContentQuerySet` classes that all content models use.
+
+### How default filtering works
+
+Every content model (such as `ContentFighter`, `ContentEquipment`, `ContentWeaponProfile`) uses `ContentManager` as its default manager. The manager's `get_queryset()` method automatically calls `exclude_pack_content()`, which adds a subquery filter that excludes any content object linked to a `CustomContentPackItem`.
+
+This means that any code using `ContentFighter.objects.all()` or `ContentFighter.objects.filter(...)` will never return pack content. This is intentional -- pack content should not appear in the normal application flow unless explicitly requested.
+
+### Query methods
+
+The `ContentManager` provides three ways to query content:
+
+| Method | What it returns |
+|--------|----------------|
+| `.all()` / `.filter(...)` | Base content only. Pack content is excluded. This is the default behaviour. |
+| `.all_content()` | All content, including pack content. Bypasses the pack filter entirely. |
+| `.with_packs(packs)` | Base content plus content from the specified packs. Content from other packs is still excluded. |
+
+The `with_packs()` method accepts a list of `CustomContentPack` instances. It returns a queryset containing all base content (items not in any pack) combined with items that belong to any of the specified packs. Items belonging to other, non-specified packs remain excluded.
+
+### How the admin handles pack content
+
+The `ContentAdmin` base class in the content admin overrides `get_queryset()` to use `all_content()`. This ensures that when you view content models in the Django admin, you see all items including pack content. Without this override, pack content would be invisible in the admin.
+
+The same override is applied to `ContentTabularInline` and `ContentStackedInline`, so inline content displays in the admin also show pack content.
+
+### The `packs_display` column
+
+Every content model's admin list view includes a "Packs" column at the end. This column shows which packs (if any) a content item belongs to. If the item is not in any pack, the column displays a dash. If the item belongs to one or more packs, it displays their names separated by commas.
+
+This column also appears as a read-only field on each content item's detail/edit page in the admin.
+
+## How It Works in the Application
+
+### The Customisation page
+
+Users in the "Custom Content" group access content packs through the Customisation page at `/packs/`. This page shows a searchable, paginated list of content packs.
+
+By default, authenticated users see only their own packs (the "My packs only" toggle is on). Turning the toggle off shows all publicly listed packs from the community. Full-text search covers pack names, summaries, and author usernames.
+
+Each pack in the list shows its name, author, summary, and an "Unlisted" badge if the pack is not publicly listed.
+
+### Pack detail page
+
+Clicking a pack opens its detail page at `/pack/<id>`. This page shows:
+
+- The pack name, author, and public/unlisted status
+- The summary and description (if provided)
+- A content section for each supported content type (currently Houses), listing the items in the pack
+- A recent activity feed showing the last 5 changes, with a link to the full activity history
+
+Pack owners see an "Edit" button. Unlisted packs return a 404 for users who are not the owner.
+
+### Creating and editing packs
+
+Users create packs at `/packs/new/`. The form includes fields for name, summary (rich text), description (rich text), and the listed toggle. The pack is automatically owned by the current user.
+
+Editing a pack at `/pack/<id>/edit/` uses the same form. Only the pack owner can edit it.
+
+### Activity history
+
+Each pack has a full activity history at `/pack/<id>/activity/`. This combines history records from both the pack itself and its items into a single chronological feed. The activity feed shows:
+
+- Who made a change and when
+- Whether the change was to the pack or to an item
+- For items: the name and type of the affected content object
+- For updates: which fields changed and their new values (text fields just show "updated" rather than the full content diff)
+
+Activity is paginated at 50 entries per page.
+
+### Pack content visibility in lists and fighters
+
+When users build lists and add fighters or equipment, they interact with the normal content queries that exclude pack content by default. Pack content does not appear in fighter selection dropdowns, equipment lists, or any other content-driven interface unless the application explicitly uses `with_packs()` to include specific packs.
+
+## Common Admin Tasks
+
+### Adding a user to the Custom Content group
+
+Before a user can create or browse content packs, they must be a member of the "Custom Content" Django auth group. To add a user:
+
+1. Navigate to the user's record in the Django admin under Authentication and Authorization > Users
+2. In the Groups section, add the "Custom Content" group
+3. Save the user record
+
+### Creating a pack via the admin
+
+While users typically create packs through the application interface, you can also create them directly in the admin:
+
+1. Navigate to Custom Content Packs in the admin
+2. Click "Add Custom Content Pack"
+3. Fill in the name, optional summary and description, set the listed flag, and choose an owner
+4. Save
+
+### Adding content to a pack via the admin
+
+To add a content item to a pack:
+
+1. Navigate to Custom Content Pack Items in the admin
+2. Click "Add Custom Content Pack Item"
+3. Select the pack, the content type (e.g., "content | content house"), and paste the UUID of the content object into the `object_id` field
+4. Set the owner and save
+
+The content object link will appear as a read-only field after saving, confirming the item was linked correctly.
+
+### Checking which packs a content item belongs to
+
+When viewing any content model in the admin (houses, fighters, equipment, etc.), look at the "Packs" column on the right side of the list view. This shows the pack names for items that belong to packs, or a dash for base content.
+
+You can also see this information on the detail page of any content item, where "Packs" appears as a read-only field at the bottom.
+
+### Making a pack publicly listed
+
+By default, new packs are unlisted. To make a pack visible in community search results:
+
+1. Navigate to Custom Content Packs in the admin
+2. Find the pack and click to edit it
+3. Check the `listed` checkbox
+4. Save
+
+Alternatively, the pack owner can toggle the "Listed" checkbox when editing their pack through the application interface.
+
+### Reviewing pack activity
+
+To review the history of changes to a pack, navigate to the pack's detail page in the application and scroll to the Activity section. For the full history, click "View all". This shows a chronological feed of all pack and item changes.
+
+In the admin, you can also review history by navigating to the historical records for `CustomContentPack` or `CustomContentPackItem` through the History link on any record.

--- a/docs/content-library/equipment-and-weapons.md
+++ b/docs/content-library/equipment-and-weapons.md
@@ -1,0 +1,401 @@
+# Equipment & Weapons
+
+## Overview
+
+The equipment and weapons area of the content library defines every item that fighters can carry, wear, or wield in
+Gyrinx. This spans everything from basic armour and grenades through to exotic weaponry with multiple firing modes. When
+a user creates a list -- their collection of fighters (called a "gang" in Necromunda) -- and assigns equipment to those
+fighters, the data they interact with comes from these content models.
+
+Equipment and weapons share a single underlying model (`ContentEquipment`) but diverge in an important way: weapons have
+one or more weapon profiles (`ContentWeaponProfile`) attached to them, which define stat lines like range, strength, and
+damage. Equipment without any weapon profiles is treated as non-weapon gear. This distinction is determined automatically
+-- you never mark an item as "weapon" or "gear" explicitly. Instead, add weapon profiles to an equipment item and it
+becomes a weapon.
+
+Beyond the core equipment and weapon profile models, this area also covers weapon traits (special rules like Rapid Fire
+or Blaze), weapon accessories (sights, suspensors), equipment upgrades (cyberteknika, genesmithing), and equipment
+categories that organise items into groups for display and filtering.
+
+## Key Concepts
+
+**Equipment vs. weapon.** All items start as `ContentEquipment`. An equipment item that has at least one
+`ContentWeaponProfile` is considered a weapon. One without any profiles is non-weapon gear. This is evaluated
+automatically based on the presence of linked weapon profiles.
+
+**Equipment categories and groups.** Every equipment item belongs to a `ContentEquipmentCategory`, and each category
+belongs to one of four groups: Gear, Vehicle & Mount, Weapons & Ammo, or Other. These groups control display ordering in
+the admin and in user-facing equipment lists.
+
+**Availability (rarity).** Equipment, weapon profiles, and weapon accessories each have an availability level that
+controls where they can be purchased and whether a dice roll is needed. The availability system uses a letter code plus an
+optional numeric level.
+
+**Cost expressions.** Most costs are simple integers, but the `ContentEquipment.cost` field is a text field that supports
+non-numeric values like `2D6x10` for random-cost items. Weapon accessories can also use cost expressions that calculate
+their price relative to the base weapon cost.
+
+**The dirty system.** When you change a cost in the content library, Gyrinx automatically detects the change and marks
+all affected user lists and fighter assignments as "dirty". A dirty assignment is one whose stored cost no longer matches
+the current content library cost. On save, the application walks every dirty assignment, recalculates the fighter's
+rating and the list's total rating, and -- for lists in campaign mode -- creates an audit trail entry recording the old
+and new cost and adjusts the list's credits (charging more if the cost increased, refunding if it decreased). This
+propagation is fully automatic: saving the content change is the only action required. Other documentation files
+reference this section as the canonical description of the dirty/cost recalculation system.
+
+**Modifiers.** Equipment, upgrades, and accessories can each carry modifiers that change a fighter's stats, grant skills,
+or add rules. These are managed through the separate Modifiers system and attached via many-to-many relationships. For
+full details on the modifier system and how modifiers are created and applied, see [Modifiers](modifiers.md).
+
+## Models
+
+### `ContentEquipmentCategory`
+
+Organises equipment items into named categories such as "Pistols", "Basic Weapons", "Armour", or "Grenades". Each
+category belongs to a group that controls its position in the overall ordering.
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | CharField | Unique name for the category (e.g. "Heavy Weapons"). |
+| `group` | CharField (choices) | One of `Gear`, `Vehicle & Mount`, `Weapons & Ammo`, or `Other`. Controls sort order. |
+| `restricted_to` | ManyToManyField (`ContentHouse`) | If set, only fighters from these houses can access equipment in this category. Leave blank for universally available categories. |
+| `visible_only_if_in_equipment_list` | BooleanField | When `True`, this category is hidden on a fighter's card unless the fighter actually has equipment from this category assigned. Useful for categories like "Status Items" that should not appear as empty slots. |
+
+#### Fighter Category Restrictions
+
+Categories can be further restricted to specific fighter categories (Leader, Champion, Ganger, etc.) using the
+`ContentEquipmentCategoryFighterRestriction` inline. When restrictions are set, only fighters of the listed categories
+can equip items from this category.
+
+#### Fighter Equipment Category Limits
+
+When a category has fighter category restrictions, you can also set per-fighter limits using the
+`ContentFighterEquipmentCategoryLimit` inline. This controls the maximum number of items from a category that a specific
+fighter type can carry. For example, you might limit a Ganger to 1 item from the "Special Weapons" category. Limits can
+only be configured on categories that already have fighter category restrictions.
+
+#### Admin Interface
+
+- **Search:** by name and group.
+- **Filters:** group, restricted houses, and `visible_only_if_in_equipment_list`.
+- **Inlines:** Fighter Category Restrictions, Fighter Equipment Category Limits.
+
+---
+
+### `ContentEquipment`
+
+The central model for all equipment items. Each record represents a distinct piece of gear or weapon that can be
+assigned to fighters.
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | CharField | The item name (e.g. "Lasgun", "Mesh Armour"). Must be unique within its category. |
+| `category` | ForeignKey (`ContentEquipmentCategory`) | The category this item belongs to. |
+| `cost` | CharField | The credit cost at the Trading Post. This is a text field to support expressions like `2D6x10` for random costs. For weapons, this base cost is typically overridden by the Standard weapon profile cost. |
+| `rarity` | CharField (choices) | The availability code. See the Availability System section below. |
+| `rarity_roll` | IntegerField | The numeric availability level needed to acquire this item (e.g. `9` means a 9+ roll). Blank for Common items. |
+| `upgrade_mode` | CharField (choices) | Either `SINGLE` or `MULTI`. Controls how upgrades are presented and costed. See Upgrades below. |
+| `upgrade_stack_name` | CharField | A label for the upgrade track, such as "Augmentation" or "Upgrade". Used in display. Defaults to "Upgrade" if blank. |
+| `modifiers` | ManyToManyField (`ContentMod`) | Modifiers that apply to the fighter when this equipment is equipped. Filtered in admin to show only fighter-affecting modifiers (stat changes, rules, skills, skill tree access, psyker discipline access). |
+
+#### Uniqueness
+
+Equipment names must be unique within their category (`unique_together = ["name", "category"]`). You can have two items
+named "Stub Gun" only if they are in different categories.
+
+#### Is This a Weapon?
+
+An equipment item is considered a weapon if it has at least one `ContentWeaponProfile` linked to it. The queryset
+annotates every equipment record with a `has_weapon_profiles` flag automatically, so you do not need to set this
+yourself.
+
+#### Admin Interface
+
+- **Search:** by name, category name, and weapon profile name.
+- **Filters:** by category.
+- **Inlines:** Weapon Profiles, Equipment-Fighter Links, Equipment-Equipment Links, Equipment Upgrades.
+- **Actions:** Clone (see below).
+
+---
+
+### `ContentWeaponProfile`
+
+Defines a weapon's stat line. Every weapon has at least one profile. A weapon with a blank-name profile has a single
+"Standard" firing mode. Weapons with multiple profiles represent different firing modes (e.g. a combi-weapon with
+bolter and melta profiles).
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `equipment` | ForeignKey (`ContentEquipment`) | The parent equipment item. |
+| `name` | CharField | The profile name. Leave blank for the Standard (default) profile. Named profiles represent alternate firing modes (e.g. "Krak", "Frag"). Do not include a leading hyphen. |
+| `cost` | IntegerField | The credit cost. Standard (blank-name) profiles must have zero cost. Named profiles with a positive cost represent upgrades the user can purchase (e.g. paying extra for a special ammo type). |
+| `rarity` | CharField (choices) | Availability code for this specific profile. |
+| `rarity_roll` | IntegerField | Availability level for this profile. |
+| `range_short` | CharField | Short range (e.g. `8"`). Automatically appends `"` if a number is entered without one. |
+| `range_long` | CharField | Long range (e.g. `24"`). Same auto-formatting. |
+| `accuracy_short` | CharField | Short range accuracy modifier (e.g. `+1`). |
+| `accuracy_long` | CharField | Long range accuracy modifier (e.g. `-1`). |
+| `strength` | CharField | Weapon strength (e.g. `4`, `S+2`). |
+| `armour_piercing` | CharField | Armour Piercing value (e.g. `-1`). |
+| `damage` | CharField | Damage value (e.g. `2`). |
+| `ammo` | CharField | Ammo roll value (e.g. `4+`). |
+| `traits` | ManyToManyField (`ContentWeaponTrait`) | Weapon traits such as Rapid Fire, Knockback, or Blaze. |
+
+All stat fields are `CharField` rather than numeric fields because some values include special characters (e.g. `S+2`
+for strength, `4+` for ammo rolls, `E` for template range). Leave a field blank to show a dash on the fighter card.
+Do not enter a literal `-` character -- blank fields are automatically displayed as dashes.
+
+#### Validation Rules
+
+- Standard (blank-name) profiles must have `cost` of 0.
+- Profile names must not start with a hyphen.
+- Profile names must not be `(Standard)` literally.
+- Cost cannot be negative.
+- Smart quotes (curly quotes) are rejected in stat fields.
+- Range values that start with a digit automatically get a trailing `"` appended.
+
+#### Uniqueness
+
+Profile names must be unique within their parent equipment (`unique_together = ["equipment", "name"]`).
+
+#### Admin Interface
+
+Weapon profiles appear as a stacked inline on the `ContentEquipment` admin page. They can also be managed directly
+through their own admin page with search by name and autocomplete on the equipment field.
+
+---
+
+### `ContentWeaponTrait`
+
+A named trait that can be assigned to weapon profiles. Traits represent special rules that modify how a weapon behaves
+in the game, such as "Rapid Fire (1)", "Knockback", "Blaze", or "Scarce".
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | CharField | The unique trait name. |
+
+Traits are simple named records. The game rule text itself lives in the rulebook -- the content library just tracks
+which traits exist so they can be linked to weapon profiles.
+
+#### Admin Interface
+
+- **Search:** by name.
+
+---
+
+### `ContentWeaponAccessory`
+
+Accessories that can be attached to weapons to modify their capabilities, such as sights, suspensors, or mono-sights.
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | CharField | Unique accessory name (e.g. "Telescopic Sight"). |
+| `cost` | IntegerField | Base credit cost. Used when no cost expression is provided. |
+| `cost_expression` | CharField | Optional formula for calculating cost relative to the weapon's base cost. When provided, this overrides the fixed `cost` field. |
+| `rarity` | CharField (choices) | Availability code. |
+| `rarity_roll` | IntegerField | Availability level. |
+| `modifiers` | ManyToManyField (`ContentMod`) | Modifiers applied to the weapon's stat line and traits when this accessory is attached. |
+
+#### Cost Expressions
+
+The `cost_expression` field allows accessory prices to scale with the weapon they are attached to. The expression is
+evaluated safely using the `simpleeval` library (not Python's built-in `eval`). The variable `cost_int` represents the
+base weapon's integer cost.
+
+Available functions: `min()`, `max()`, `round()`, `ceil()`, `floor()`.
+
+For example, the expression `ceil(cost_int * 0.25 / 5) * 5` would price the accessory at 25% of the weapon cost,
+rounded up to the nearest 5 credits. If evaluation fails for any reason, the system falls back to the fixed `cost`
+value.
+
+#### Admin Interface
+
+- **Search:** by name.
+
+---
+
+### `ContentEquipmentUpgrade`
+
+Represents an upgrade that can be applied to a piece of equipment. Upgrades are used for systems like cyberteknika
+(where each level builds on the previous) and genesmithing (where each option is independent).
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `equipment` | ForeignKey (`ContentEquipment`) | The parent equipment item this upgrade belongs to. |
+| `name` | CharField | The upgrade name. Must be unique within the parent equipment. |
+| `position` | IntegerField | The position in the upgrade stack. Used for ordering and cumulative cost calculation in `SINGLE` mode. |
+| `cost` | IntegerField | The credit cost of this upgrade level. Interpretation depends on the parent equipment's `upgrade_mode`. |
+| `modifiers` | ManyToManyField (`ContentMod`) | Modifiers applied to the equipment or fighter when this upgrade is active. |
+
+#### Upgrade Modes
+
+The parent `ContentEquipment` controls how upgrades behave via its `upgrade_mode` field:
+
+- **SINGLE mode:** Upgrades form a sequential stack. The fighter progresses through upgrade levels in order. Costs are
+  cumulative -- the total cost of reaching a level equals the sum of all upgrade costs at that position and below. For
+  example, if a cyberteknika has three levels costing 10, 15, and 20, reaching level 3 costs 10 + 15 + 20 = 45 credits.
+
+- **MULTI mode:** Each upgrade is an independent option. The fighter can pick any combination. Each upgrade's cost
+  stands on its own and is not summed with others.
+
+The `upgrade_stack_name` on the parent equipment provides the display label (e.g. "Augmentation", "Upgrade") for the
+upgrade track.
+
+#### Admin Interface
+
+Upgrades appear as a tabular inline on the `ContentEquipment` admin page. They can also be managed directly with
+search by name and equipment name, and autocomplete on the equipment field.
+
+---
+
+## Availability System
+
+Equipment, weapon profiles, and weapon accessories all use the same availability system with two fields working
+together:
+
+| Code | Label | Meaning |
+|---|---|---|
+| `C` | Common | Freely available at the Trading Post. No roll required. |
+| `R` | Rare | Available at the Trading Post but requires a successful availability roll. |
+| `I` | Illegal | Available through the Black Market. Requires an availability roll. |
+| `E` | Exclusive | Not available for purchase at the Trading Post. Used for items that can only be obtained through special means (starting equipment, scenario rewards, etc.). |
+| `U` | Unique | Unique to a specific fighter. Not available for general purchase. Only used on `ContentEquipment`, not on profiles or accessories. |
+
+The `rarity_roll` field specifies the target number for the availability roll (e.g. `8` means the item is available on
+an 8+). This field should be left blank for Common items and is typically in the range of 7-12 for Rare and Illegal
+items.
+
+## How It Works in the Application
+
+### Equipment on Fighter Cards
+
+When a user views a fighter card, the application displays two categories of equipment:
+
+1. **Weapons** -- shown in a table with their full stat line (range, accuracy, strength, AP, damage, ammo) and trait
+   list. If a weapon has multiple profiles, each profile appears as a separate row.
+
+2. **Non-weapon gear** -- shown as a simpler list grouped by category.
+
+Categories with `visible_only_if_in_equipment_list` set to `True` only appear on the fighter card when the fighter has
+at least one item from that category. This prevents empty category headings from cluttering the display.
+
+### Assigning Equipment to Fighters
+
+Users assign equipment to their list fighters through the application interface. The system checks equipment
+categories, house restrictions, and fighter category restrictions to determine what each fighter is allowed to equip.
+Costs are drawn from the fighter's available credits, and the list's total rating is updated accordingly.
+
+Equipment can also be granted to fighters through the advancement system during campaigns. See
+[Advancements](advancements.md).
+
+### Cost Overrides
+
+The base cost on `ContentEquipment` and `ContentWeaponProfile` can be overridden on a per-fighter-type basis through
+the equipment availability system. When a fighter-specific cost override exists, it takes precedence over the base
+cost. This is how different fighter types can pay different prices for the same item. Fighter-specific equipment lists
+and cost overrides are configured through the equipment availability system. See [Equipment Availability &
+Restrictions](equipment-availability.md) for details.
+
+### Cost Change Propagation
+
+When you change the `cost` field on any content model in this area, the system automatically:
+
+1. Detects that the cost has changed (via a pre-save signal).
+2. Marks all user-level equipment assignments (`ListFighterEquipmentAssignment`) that reference this content as
+   "dirty" -- meaning their stored cost no longer matches the current content library cost.
+3. After saving, recalculates ratings for every affected list by walking each dirty assignment, updating the
+   fighter's rating, and recomputing the list total.
+4. For lists in campaign mode, creates an audit trail entry recording the old and new cost and adjusts the list's
+   credits (charging more if the cost increased, refunding if it decreased).
+
+This means you can correct a pricing error in the content library and have it automatically reflected across all user
+lists that use that item. No manual intervention is needed beyond saving the content change. This section is the
+canonical description of the dirty/cost recalculation system; other documentation files reference it.
+
+### Modifiers on Equipment
+
+When equipment, upgrades, or accessories carry modifiers, those modifiers are applied to the fighter's stat line and
+rules whenever the item is assigned. For weapon accessories, modifiers affect the weapon's profile stats and traits
+rather than the fighter directly. For full details on the modifier system and how modifiers are created and applied, see
+[Modifiers](modifiers.md).
+
+## Common Admin Tasks
+
+### Adding a New Weapon
+
+1. Open the Equipment admin and click "Add".
+2. Enter the weapon name and select the appropriate category (e.g. "Basic Weapons").
+3. Set the `cost` field. For weapons, this base cost is typically overridden by the Standard profile cost, but it
+   serves as a fallback.
+4. Set the availability (`rarity`) and availability level (`rarity_roll`) if applicable.
+5. In the **Weapon Profiles** inline, add a profile with a blank name for the Standard firing mode. Enter the full
+   stat line (range, accuracy, strength, AP, damage, ammo) and select any applicable traits.
+6. If the weapon has additional firing modes, add more profiles with descriptive names. Set their cost to the
+   additional credits required above the Standard profile price.
+7. Save.
+
+### Adding a New Piece of Non-Weapon Gear
+
+1. Open the Equipment admin and click "Add".
+2. Enter the item name and select the appropriate category (e.g. "Armour", "Personal Equipment").
+3. Set the `cost` field to the credit price.
+4. Set availability as needed.
+5. If the equipment modifies the fighter (e.g. armour that changes a save stat), attach the relevant modifiers.
+6. Do not add any weapon profiles.
+7. Save.
+
+### Cloning an Equipment Item
+
+When you need to create a variation of an existing item, use the clone action rather than re-entering everything
+manually:
+
+1. In the Equipment list view, select the item or items you want to clone.
+2. From the action dropdown, select "Clone selected Equipment" and click Go.
+3. The system creates a copy of each selected item with "(Clone)" appended to the name. All weapon profiles and their
+   traits are also duplicated.
+4. Open the cloned item and edit the name, cost, profiles, or other fields as needed.
+
+### Setting Up Equipment with Upgrades
+
+1. Create the base equipment item (e.g. a cyberteknika implant) with its base cost.
+2. Set `upgrade_mode` to `SINGLE` for sequential upgrade tracks, or `MULTI` for independent options.
+3. Optionally set `upgrade_stack_name` to a descriptive label (e.g. "Augmentation").
+4. In the **Equipment Upgrades** inline, add each upgrade level with a name, position (for ordering), and cost.
+5. Attach any modifiers to each upgrade level as needed.
+
+For `SINGLE` mode, pay attention to the `position` field. Costs accumulate from position 0 upward, so the total cost
+to reach any level is the sum of all levels at or below that position.
+
+### Creating a New Equipment Category
+
+1. Open the Equipment Categories admin and click "Add".
+2. Enter the category name and select the group (`Gear`, `Weapons & Ammo`, `Vehicle & Mount`, or `Other`).
+3. If this category should only be visible when a fighter actually has equipment from it, check
+   `visible_only_if_in_equipment_list`.
+4. If the category is house-specific, add houses to the `restricted_to` field.
+5. If only certain fighter categories should access this equipment, add Fighter Category Restrictions in the inline.
+6. If you need per-fighter limits on items from this category, add Fighter Equipment Category Limits (this requires
+   fighter category restrictions to be set first).
+
+### Correcting a Cost Error
+
+If you discover that an equipment item, weapon profile, upgrade, or accessory has an incorrect cost:
+
+1. Open the relevant record in the admin.
+2. Change the `cost` field to the correct value.
+3. Save.
+
+The dirty system automatically propagates the change to all affected user lists. In campaign mode, lists will receive
+a cost change audit entry and their credits will be adjusted. You do not need to take any additional action.

--- a/docs/content-library/equipment-availability.md
+++ b/docs/content-library/equipment-availability.md
@@ -1,0 +1,361 @@
+# Equipment Availability & Restrictions
+
+## Overview
+
+This documentation explains how to configure fighter-specific equipment lists and restrictions for the equipment system documented in [Equipment & Weapons](equipment-and-weapons.md).
+
+The equipment availability and restrictions system controls which equipment each fighter type can access, and at what cost. A list represents a user's collection of fighters (called a "gang" in Necromunda). In Necromunda, different fighter types have access to different equipment lists with varying prices -- a Leader might buy a Power Sword for 40 credits while a Ganger pays 50, and some equipment categories are entirely off-limits to certain fighter types.
+
+This area of the content library lets you configure all of these rules. It includes fighter-specific equipment lists with custom pricing, category-level restrictions that limit which fighter types can browse certain equipment groups, availability presets that control default Trading Post filters, and linking models that connect equipment items to fighters or other equipment for automatic creation.
+
+When a user opens the weapons or gear page for one of their fighters, the application combines all of these configurations to determine exactly which items appear, what prices are shown, and which categories are visible. Getting this configuration right is essential for an accurate game experience.
+
+## Key Concepts
+
+**Equipment List** -- The set of equipment items available to a specific fighter type, as published in the rulebook. Each fighter type (e.g. "Goliath Forge Boss") has its own equipment list with potentially different costs for the same items.
+
+**Equipment List Cost Override** -- When an equipment item appears on a fighter's equipment list at a price different from the base Trading Post price, that fighter-specific price is an equipment list cost override (stored on `ContentFighterEquipmentListItem.cost`).
+
+**Fighter Category** -- The broad classification of a fighter (Leader, Champion, Ganger, Juve, etc.). Category restrictions operate at this level rather than on individual fighter types.
+
+**Availability** -- Each equipment item and weapon profile has an availability type (Common, Rare, Illegal, Exclusive, Unique) and optionally an availability level (a numeric value representing the dice roll needed). These control what appears in the Trading Post.
+
+**Equipment List Mode vs Trading Post Mode** -- When a user browses equipment for a fighter, they can toggle between "Equipment List" mode (showing only items from the fighter's equipment list) and the full Trading Post view (showing all equipment filtered by availability). Availability presets control the defaults for Trading Post mode.
+
+**Can Buy Any** -- A flag on `ContentHouse` that, when enabled, gives all fighters in that house access to the full Trading Post by default rather than just their equipment list.
+
+## Models
+
+### `ContentFighterEquipmentListItem`
+
+Represents a single entry on a fighter's equipment list. This is the primary model for defining which equipment items a fighter type can buy and at what price.
+
+Each record links a `ContentFighter` to a `ContentEquipment` item, optionally specifying a particular weapon profile and an equipment list cost override. When a user views their fighter's equipment in "Equipment List" mode, these records determine what appears.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter type this equipment list entry belongs to |
+| `equipment` | ForeignKey to `ContentEquipment` | The equipment item available to this fighter |
+| `weapon_profile` | ForeignKey to `ContentWeaponProfile` (optional) | A specific weapon profile with its own cost override. Leave blank when setting the base equipment cost. |
+| `cost` | Integer | The fighter-specific cost for this item. This overrides the equipment's base Trading Post cost. |
+
+**Relationships:**
+
+- Belongs to a `ContentFighter` and a `ContentEquipment`
+- Optionally references a `ContentWeaponProfile` for profile-level cost overrides
+- Referenced by the equipment views to build the "Equipment List" filter and to annotate fighter-specific costs
+
+**Validation rules:**
+
+- The combination of `fighter`, `equipment`, and `weapon_profile` must be unique
+- If a `weapon_profile` is specified, it must belong to the specified `equipment`
+- `equipment` is required
+
+**Admin interface:**
+
+- Searchable by fighter type, equipment name, and weapon profile name
+- `fighter` and `equipment` use autocomplete fields for faster data entry
+- The weapon profile dropdown is filtered to show only profiles belonging to the selected equipment, and only those with a cost greater than zero (since zero-cost profiles are "standard" and don't need overrides)
+- Supports the "Copy to another Fighter" bulk action
+
+**How equipment list cost overrides work:**
+
+When you create a `ContentFighterEquipmentListItem` without a `weapon_profile`, the `cost` field overrides the base price of the equipment for that fighter type. When you include a `weapon_profile`, the `cost` field overrides the price of that specific profile. This allows you to set both an equipment-level override and individual profile-level overrides for the same weapon on the same fighter.
+
+For example, for a Boltgun that costs 55 credits at the Trading Post:
+
+- A record with fighter=Goliath Leader, equipment=Boltgun, weapon_profile=null, cost=45 means the Leader buys the base Boltgun for 45 credits
+- A record with fighter=Goliath Leader, equipment=Boltgun, weapon_profile=Rapid Fire, cost=30 means the Leader buys the Rapid Fire profile for 30 credits
+
+### `ContentFighterEquipmentListWeaponAccessory`
+
+Defines which weapon accessories are available to a fighter type and at what cost. This works the same way as `ContentFighterEquipmentListItem` but for weapon accessories rather than equipment.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter type this accessory is available to |
+| `weapon_accessory` | ForeignKey to `ContentWeaponAccessory` | The weapon accessory |
+| `cost` | Integer | The fighter-specific cost for this accessory |
+
+**Relationships:**
+
+- Belongs to a `ContentFighter` and a `ContentWeaponAccessory`
+- Referenced when a user adds accessories to an assigned weapon
+
+**Validation rules:**
+
+- The combination of `fighter` and `weapon_accessory` must be unique
+- Cost cannot be negative
+
+**Admin interface:**
+
+- Searchable by fighter type and weapon accessory name
+- `fighter` and `weapon_accessory` use autocomplete fields
+- Supports the "Copy to another Fighter" bulk action
+
+### `ContentFighterEquipmentListUpgrade`
+
+Defines fighter-specific cost overrides for equipment upgrades. When an equipment item has upgrades (like cyberteknika upgrades or genesmithing options), this model lets you set different prices per fighter type.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter type this upgrade cost applies to |
+| `upgrade` | ForeignKey to `ContentEquipmentUpgrade` | The specific equipment upgrade |
+| `cost` | Integer | The fighter-specific cost for this upgrade |
+
+**Relationships:**
+
+- Belongs to a `ContentFighter` and a `ContentEquipmentUpgrade`
+- Referenced when calculating upgrade costs on a fighter's equipment assignment
+
+**Validation rules:**
+
+- The combination of `fighter` and `upgrade` must be unique
+- Cost cannot be negative
+
+**Admin interface:**
+
+- Searchable by fighter type, upgrade name, and parent equipment name
+- `fighter` and `upgrade` use autocomplete fields
+- Filterable by equipment upgrade mode (Single or Multi)
+- Supports the "Copy to another Fighter" bulk action
+
+### `ContentEquipmentCategoryFighterRestriction`
+
+Controls which fighter categories can access equipment from a given equipment category. If no restrictions are set on a category, all fighter categories can access it. When one or more restrictions exist, only the listed fighter categories can see equipment from that category.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `equipment_category` | ForeignKey to `ContentEquipmentCategory` | The equipment category being restricted |
+| `fighter_category` | CharField (choices) | A fighter category that is allowed to access this equipment category |
+
+**Relationships:**
+
+- Belongs to a `ContentEquipmentCategory`
+- Managed as an inline on the `ContentEquipmentCategory` admin page
+
+**Validation rules:**
+
+- The combination of `equipment_category` and `fighter_category` must be unique
+
+**How restrictions work in practice:**
+
+If the "Heavy Weapons" equipment category has two restriction records -- one for `LEADER` and one for `CHAMPION` -- then only Leaders and Champions will see Heavy Weapons when browsing equipment. Gangers, Juves, and other categories will not see that category at all.
+
+If an equipment category has no restriction records, it is available to all fighter categories.
+
+This model works in conjunction with `ContentFighterEquipmentCategoryLimit`, which can impose numeric limits on how many items from a restricted category a specific fighter type can take.
+
+### `ContentFighterEquipmentCategoryLimit`
+
+Sets per-fighter-type limits on how many items from a given equipment category can be assigned. This only works for categories that already have fighter category restrictions (via `ContentEquipmentCategoryFighterRestriction`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The specific fighter type this limit applies to |
+| `equipment_category` | ForeignKey to `ContentEquipmentCategory` | The equipment category being limited |
+| `limit` | PositiveInteger | Maximum number of items from this category the fighter can have (default: 1) |
+
+**Relationships:**
+
+- Belongs to a `ContentFighter` and a `ContentEquipmentCategory`
+- Managed as an inline on both the `ContentEquipmentCategory` admin page and the `ContentFighter` admin page
+
+**Validation rules:**
+
+- The combination of `fighter` and `equipment_category` must be unique
+- The equipment category must have at least one fighter category restriction before a limit can be set
+
+**Admin interface:**
+
+- On the `ContentEquipmentCategory` page, appears as an inline with fighters grouped by house
+- On the `ContentFighter` page, appears as an inline with equipment categories filtered to only show those that have fighter restrictions, grouped by category group
+
+### `ContentAvailabilityPreset`
+
+Defines default availability filter settings for the Trading Post view. When a user opens the equipment browsing page in Trading Post mode, the system looks up the most specific matching preset to pre-populate the availability type checkboxes and maximum availability level.
+
+Presets can be defined at three levels of specificity, and they stack: a preset for a specific fighter takes precedence over a preset for a fighter category, which takes precedence over one for a house.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` (optional) | Specific fighter type this preset applies to |
+| `category` | CharField (optional) | Fighter category (Leader, Champion, etc.) this preset applies to |
+| `house` | ForeignKey to `ContentHouse` (optional) | House this preset applies to |
+| `availability_types` | MultiSelectField | Which availability types to show by default (Common, Rare, Illegal, Exclusive, Unique) |
+| `max_availability_level` | Integer (optional) | Maximum availability level (rarity roll). Leave blank for no limit. |
+| `fighter_can_buy_any` | Boolean | If checked, this fighter defaults to showing all equipment (full Trading Post view) similar to the house-level `can_buy_any` flag |
+
+**Specificity matching:**
+
+When the system looks up a preset, it finds all presets where every non-null field matches the current fighter/category/house combination. It then picks the most specific match (the one with the most non-null fields). In case of a tie, the most recently created preset wins.
+
+For example, with these presets:
+
+1. Category=Leader, availability_types=[C, R, I]
+2. Category=Leader, House=Goliath, availability_types=[C, R]
+3. Fighter=Goliath Forge Boss, availability_types=[C, R, I], max_availability_level=9
+
+A Goliath Forge Boss would match preset 3 (most specific). A Goliath Leader (who is not a Forge Boss) would match preset 2. An Escher Leader would match preset 1.
+
+**Validation rules:**
+
+- At least one of `fighter`, `category`, or `house` must be specified
+- The combination of `fighter`, `category`, and `house` must be unique
+- `max_availability_level` must be at least 1 if set
+
+**Admin interface:**
+
+- Searchable by fighter type and house name
+- Filterable by category and house
+- `fighter` and `house` use autocomplete fields
+
+### `ContentEquipmentFighterProfile`
+
+Links an equipment item to a fighter type for automatic fighter creation. When a user assigns the linked equipment to one of their fighters, the application automatically creates a new `ListFighter` of the specified type and links it as a child of the equipment assignment. This is used for Exotic Beasts and Vehicles -- equipment items that, when purchased, create an associated fighter on the list.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `equipment` | ForeignKey to `ContentEquipment` | The equipment item that triggers fighter creation |
+| `content_fighter` | ForeignKey to `ContentFighter` | The fighter type to create when this equipment is assigned |
+
+**Relationships:**
+
+- Belongs to a `ContentEquipment` and a `ContentFighter`
+- Managed as an inline on the `ContentEquipment` admin page
+- When the linked equipment is assigned to a `ListFighter`, the system automatically creates a new child `ListFighter`
+- When the equipment assignment is deleted, the child fighter is also deleted
+
+**Validation rules:**
+
+- The combination of `equipment` and `content_fighter` must be unique
+- Each equipment item should have at most one fighter profile (the system raises an error if multiple exist)
+- The fighter profile must not point to the same fighter type as the one equipping it
+
+**Admin interface:**
+
+- Searchable by equipment name and fighter type
+- `equipment` and `content_fighter` use autocomplete fields
+- The fighter dropdown is grouped by house
+
+### `ContentEquipmentEquipmentProfile`
+
+Links an equipment item to another equipment item for automatic assignment. When the main equipment is assigned to a fighter, the linked equipment is automatically assigned as well. This is used for items that come bundled together, such as a weapon that includes specific ammunition types.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `equipment` | ForeignKey to `ContentEquipment` | The main equipment item |
+| `linked_equipment` | ForeignKey to `ContentEquipment` | The equipment item to auto-assign alongside the main item |
+
+**Relationships:**
+
+- Belongs to two `ContentEquipment` instances
+- Managed as an inline on the `ContentEquipment` admin page
+- The auto-assigned equipment is tracked as a "linked child" of the parent assignment
+- When the parent equipment assignment is deleted, all linked child assignments are also deleted
+
+**Validation rules:**
+
+- The combination of `equipment` and `linked_equipment` must be unique
+- An equipment item cannot link to itself
+- The linked equipment cannot itself have equipment-equipment links (no chaining)
+
+**Admin interface:**
+
+- Searchable by both equipment names
+- Both fields use autocomplete
+
+## How It Works in the Application
+
+### Equipment browsing
+
+When a user navigates to the weapons or gear page for one of their fighters, the application builds the list of available equipment through several filtering stages:
+
+1. **Base equipment query** -- All equipment is fetched (weapons or non-weapons depending on the page), annotated with fighter-specific costs from `ContentFighterEquipmentListItem`.
+
+2. **Category restrictions** -- The system checks `ContentEquipmentCategoryFighterRestriction` records. Any equipment category that has restrictions but does not include the current fighter's category is excluded entirely. Categories with no restrictions remain available to all.
+
+3. **Equipment list vs Trading Post mode** -- In Equipment List mode, only items that appear in `ContentFighterEquipmentListItem` records for the fighter are shown. In Trading Post mode, all equipment passing the category filter is shown, filtered by availability type and level.
+
+4. **Availability presets** -- When in Trading Post mode, the system looks up a `ContentAvailabilityPreset` to determine default filter values. If the house has `can_buy_any` enabled or the preset has `fighter_can_buy_any` set, the view defaults to Trading Post mode with the preset's availability filters applied.
+
+5. **Weapon profile filtering** -- For weapons, profiles are filtered by availability type and level. Profiles with zero cost (standard profiles) always appear. Profile-specific cost overrides from `ContentFighterEquipmentListItem` records with a `weapon_profile` set are applied.
+
+### Cost display
+
+Throughout the application, equipment costs displayed on fighter cards and equipment browsing pages reflect the fighter-specific override when one exists. The priority for cost resolution is:
+
+1. Expansion cost override (from Equipment List Expansions, if applicable)
+2. Equipment list cost override (from `ContentFighterEquipmentListItem`)
+3. Base equipment cost (from `ContentEquipment.cost`)
+
+The same priority applies to weapon profile costs and upgrade costs, using their respective override models.
+
+### Auto-creation from equipment links
+
+When a user assigns equipment that has a `ContentEquipmentFighterProfile`, the system automatically creates a new fighter on the list. For example, assigning an Exotic Beast equipment item creates the corresponding Exotic Beast fighter. The child fighter appears on the list and is linked to the equipment assignment -- removing the equipment also removes the fighter.
+
+When a user assigns equipment that has `ContentEquipmentEquipmentProfile` links, the linked equipment items are automatically assigned to the same fighter. For example, assigning a weapon that comes with specific ammunition automatically adds that ammunition as a separate equipment assignment. These linked assignments are tracked and deleted together with the parent.
+
+### Legacy fighters and combined equipment lists
+
+When a `ListFighter` has a legacy content fighter assigned (via the `legacy_content_fighter` field), the system considers equipment lists from both the base content fighter and the legacy content fighter. Cost overrides are checked against both, and in Equipment List mode, items from both fighters' equipment lists are shown. This means legacy fighters effectively have access to a combined equipment list.
+
+## Common Admin Tasks
+
+### Setting up a new fighter's equipment list
+
+1. Create the `ContentFighter` record with its house, category, and stats.
+2. For each item on the fighter's equipment list in the rulebook, create a `ContentFighterEquipmentListItem` record linking the fighter to the equipment with the correct cost.
+3. For weapons with non-standard profiles at different costs, create additional `ContentFighterEquipmentListItem` records with the `weapon_profile` field set.
+4. For any weapon accessories available to this fighter, create `ContentFighterEquipmentListWeaponAccessory` records.
+5. For equipment with upgrades that have fighter-specific pricing, create `ContentFighterEquipmentListUpgrade` records.
+
+### Copying an equipment list to another fighter
+
+When multiple fighter types share the same or similar equipment lists, use the "Copy to another Fighter" admin action:
+
+1. Go to the Equipment List Items admin page.
+2. Filter or search for the source fighter's equipment list items.
+3. Select all the items you want to copy.
+4. Choose "Copy to another Fighter" from the actions dropdown.
+5. Select one or more target fighters and confirm.
+
+This creates duplicate records for the target fighters. You can then edit individual costs as needed. The same action is available on `ContentFighterEquipmentListWeaponAccessory` and `ContentFighterEquipmentListUpgrade`.
+
+### Copying a fighter to another house
+
+When adding a new house that shares fighter types with an existing house, use the "Copy to another House" action on the `ContentFighter` admin page. This copies the fighter and all of its associated data -- equipment list items, weapon accessories, upgrades, default assignments, skills, and rules -- to the target house.
+
+### Restricting an equipment category to certain fighter types
+
+1. Go to the Equipment Categories admin page and select the category.
+2. In the "Fighter Category Restrictions" inline section, add records for each fighter category that should have access.
+3. Once restrictions are added, only the listed categories will see equipment from this category.
+
+If you also need per-fighter limits (e.g. "Leaders can take at most 2 Heavy Weapons"), add `ContentFighterEquipmentCategoryLimit` records in the "Fighter Equipment Category Limits" inline on the same page, or from the fighter's own admin page.
+
+### Configuring Trading Post defaults for a house
+
+1. Determine what availability types and levels are appropriate for the house's fighter types.
+2. Create `ContentAvailabilityPreset` records at the desired level of specificity:
+   - House-level: set only `house` to apply defaults to all fighters in that house
+   - Category-level: set `category` (and optionally `house`) to apply defaults to a fighter category
+   - Fighter-level: set `fighter` for the most specific control
+3. Set the `availability_types` (e.g. Common and Rare) and optionally `max_availability_level`.
+4. If a specific fighter or category should default to showing all equipment, check `fighter_can_buy_any`.
+
+### Setting up equipment that creates a fighter (Exotic Beasts, Vehicles)
+
+1. Create the `ContentEquipment` record for the item (e.g. "Phyrr Cat").
+2. Create the `ContentFighter` record for the fighter type it produces (e.g. the Phyrr Cat fighter with its stats).
+3. On the equipment's admin page, add a `ContentEquipmentFighterProfile` inline record linking the equipment to the fighter type.
+4. When a user assigns this equipment to one of their fighters, a new fighter of the linked type is automatically created on their list.
+
+### Setting up equipment that auto-assigns other equipment
+
+1. Create both `ContentEquipment` records (the main item and the linked item).
+2. On the main equipment's admin page, add a `ContentEquipmentEquipmentProfile` inline record pointing to the linked equipment.
+3. When a user assigns the main equipment, the linked equipment is automatically assigned to the same fighter.
+
+Note that the linked equipment cannot itself have equipment-equipment links -- only one level of linking is supported.

--- a/docs/content-library/equipment-list-expansions.md
+++ b/docs/content-library/equipment-list-expansions.md
@@ -1,0 +1,203 @@
+# Equipment List Expansions
+
+## Overview
+
+Equipment List Expansions allow you to define additional equipment that becomes available to fighters under specific conditions. In the base game, each fighter type has a fixed equipment list. A list represents a user's collection of fighters (called a "gang" in Necromunda). Expansions extend this by granting access to extra equipment when a list meets certain criteria -- such as having a particular affiliation, belonging to a specific house, or the fighter being a certain category.
+
+This system is how Gyrinx handles conditional equipment access. For example, a Cawdor gang that has chosen the "Word-Keepers" alliance gains access to special devotional equipment that other Cawdor gangs do not have. Or Delaque vehicles might get access to house-specific vehicle upgrades. Expansions make this possible without duplicating equipment lists or creating separate fighter entries for every combination.
+
+When an expansion applies, its equipment items appear alongside the fighter's normal equipment list in the equipment selection interface. Users see these items seamlessly integrated -- they may not even realise the equipment came from an expansion rather than the base equipment list. Expansion items can also override the base cost of equipment, allowing you to offer items at different prices depending on the context.
+
+## Key Concepts
+
+**Expansion**: A named collection of equipment items that becomes available when all of its rules are satisfied. An expansion has a name, a set of rules, and a set of equipment items.
+
+**Rule**: A condition that must be met for an expansion to apply. Rules are evaluated against the context of a specific list and fighter. Multiple rules on an expansion use AND logic -- every rule must match for the expansion to activate.
+
+**Rule Types**: There are three types of rules, each checking a different aspect of the list or fighter. You can combine rule types on a single expansion to create precise conditions.
+
+**Expansion Item**: A piece of equipment (and optionally a specific weapon profile) that becomes available through an expansion, with an optional cost override.
+
+**Expansion Cost Override**: An expansion item can specify a different cost than the equipment's base cost. This allows the same equipment to be available at different prices depending on the expansion context. If no cost override is set, the equipment's base cost is used.
+
+**Cost Priority**: When a fighter has access to equipment through multiple sources, the cost resolution order is: expansion cost override (highest priority), then equipment list cost override (from `ContentFighterEquipmentListItem.cost`), then base equipment cost. This means expansion cost overrides always win over standard equipment list cost overrides.
+
+## Models
+
+### `ContentEquipmentListExpansion`
+
+Represents a named expansion set. This is the top-level model that ties together a set of rules and a collection of equipment items.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (unique) | The name of this expansion, used to identify it in the admin interface and in string representations. Example: "Cawdor Word-Keepers Equipment" or "Delaque Vehicle Upgrades". |
+| `rules` | ManyToManyField | The set of rules that must all match (AND logic) for this expansion to apply. Links to `ContentEquipmentListExpansionRule` instances. |
+
+**Relationships:**
+
+- Has many `ContentEquipmentListExpansionRule` instances via the `rules` many-to-many field. All rules must match for the expansion to apply.
+- Has many `ContentEquipmentListExpansionItem` instances via the `items` reverse relation (ForeignKey from the item model).
+
+**Admin interface:**
+
+- Searchable by `name`.
+- List view shows the expansion name, number of rules, and number of items.
+- The `rules` field uses a horizontal filter widget, allowing you to select from all available rules.
+- Equipment items are managed inline directly on the expansion's edit page.
+
+### `ContentEquipmentListExpansionItem`
+
+Represents a single piece of equipment that becomes available as part of an expansion. Each item links an expansion to a specific equipment entry and optionally a specific weapon profile.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `expansion` | ForeignKey | The expansion this item belongs to. |
+| `equipment` | ForeignKey | The `ContentEquipment` that becomes available. Uses autocomplete for selection. |
+| `weapon_profile` | ForeignKey (nullable) | An optional specific weapon profile for this item. Use this when you want to make a particular variant available (such as a specific ammo type) rather than the entire equipment entry. Must belong to the selected equipment. |
+| `cost` | IntegerField (nullable) | An override cost for this equipment within the expansion. Set to `null` to use the equipment's base cost. Set to `0` to make the item free. Any other value replaces the base cost. |
+
+**Validation rules:**
+
+- The `weapon_profile`, if set, must belong to the selected `equipment`. The admin enforces this through model validation.
+- The combination of `expansion`, `equipment`, and `weapon_profile` must be unique. You cannot add the same equipment/profile combination to the same expansion twice.
+
+**Admin interface:**
+
+- Managed as inline rows on the `ContentEquipmentListExpansion` edit page.
+- Each row shows fields for equipment (autocomplete), weapon profile (autocomplete), and cost.
+- One empty row is shown by default for adding new items.
+
+### `ContentEquipmentListExpansionRule`
+
+The base model for expansion rules. This uses Django's polymorphic model system, meaning each rule is actually one of the three specific rule types described below. You do not create base rules directly -- you always create one of the typed rule subclasses.
+
+The parent rule admin page shows all rules of all types in a single list view, filterable by rule type. From there, you can click through to the specific rule type's edit page.
+
+### `ContentEquipmentListExpansionRuleByAttribute`
+
+A rule that matches based on a list's attribute values. This is the most common rule type, used for affiliations, alliances, alignments, and other list attributes configured through the [Gang Attributes](gang-attributes.md) system.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `attribute` | ForeignKey | The `ContentAttribute` to check (e.g., "Affiliation", "Alliance"). Uses autocomplete for selection. |
+| `attribute_values` | ManyToManyField (optional) | Specific `ContentAttributeValue` entries to match. If left empty, the rule matches any non-empty value for the attribute. If populated, the list must have at least one of the specified values assigned. |
+
+**Matching behaviour:**
+
+- The rule checks the list's active (non-archived) attribute assignments.
+- If the list has no assignment for the specified attribute, the rule does not match.
+- If `attribute_values` is empty, the rule matches any list that has any active value for that attribute.
+- If `attribute_values` contains specific values, the rule matches if the list has at least one of those values assigned.
+- Archived attribute assignments are ignored. If a list's attribute assignment is archived, expansions dependent on that attribute will stop applying.
+
+**Admin interface:**
+
+- The `attribute` field uses autocomplete, searchable by attribute name.
+- The `attribute_values` field uses a horizontal filter widget.
+- List view displays the rule's string representation and the attribute name.
+
+### `ContentEquipmentListExpansionRuleByHouse`
+
+A rule that matches based on the list's house.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `house` | ForeignKey | The `ContentHouse` the list must belong to. Uses autocomplete for selection. |
+
+**Matching behaviour:**
+
+- The rule checks if the list's house matches the specified house exactly.
+
+**Admin interface:**
+
+- The `house` field uses autocomplete, searchable by house name.
+- List view displays the rule's string representation and the house name.
+
+### `ContentEquipmentListExpansionRuleByFighterCategory`
+
+A rule that matches based on the fighter's category (Leader, Champion, Ganger, Vehicle, etc.).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter_categories` | MultiSelectField | One or more fighter categories that this rule matches. Uses the standard `FighterCategoryChoices` values: Leader, Champion, Ganger, Juve, Crew, Exotic Beast, Hanger-on, Brute, Hired Gun, Bounty Hunter, House Agent, Hive Scum, Dramatis Personae, Prospect, Specialist, Stash, Vehicle, Ally, Gang Terrain. |
+
+**Matching behaviour:**
+
+- The rule checks if the fighter's category is in the list of selected categories.
+- If no fighter context is provided (for example, when evaluating at the list level only), the rule does not match.
+
+**Admin interface:**
+
+- The `fighter_categories` field is a multi-select widget.
+- List view displays the rule's string representation and the selected categories (up to three shown).
+
+## How It Works in the Application
+
+When a user opens the equipment selection screen for a fighter, the application evaluates all expansions against the current context. The context includes the list, its house, its active attribute assignments, and the fighter's category. These inputs are bundled into an `ExpansionRuleInputs` structure that the rule system uses for evaluation.
+
+For each expansion, every attached rule is checked. If all rules match (AND logic), the expansion applies. The equipment items from all applicable expansions are then merged into the fighter's available equipment. This happens transparently -- expansion equipment appears in the same list as the fighter's normal equipment.
+
+When a user toggles the "Equipment List" filter (which shows only equipment from the fighter's designated equipment list), expansion items are included alongside the fighter's standard equipment list items. Both sources of equipment are treated equally in this filtered view.
+
+Cost overrides from expansions take the highest priority. If a piece of equipment appears both on a fighter's standard equipment list (with its own equipment list cost override) and in an applicable expansion (with a different expansion cost override), the expansion's cost is used. This priority order ensures that special conditions like affiliations can grant discounted or premium pricing that supersedes the default fighter-specific pricing.
+
+Weapon profiles are also supported. An expansion item can specify a particular weapon profile, making only that profile available rather than the whole equipment entry. Profile-specific cost overrides follow the same priority rules.
+
+## Common Admin Tasks
+
+### Creating an Expansion for a Gang Affiliation
+
+This is the most common scenario: a gang with a specific affiliation (like "Malstrain Corrupted" or "Water Guild") gains access to additional equipment for certain fighter types.
+
+1. **Create the attribute rule.** Go to the Expansion Rules section and create a new "Expansion Rule by Attribute". Select the attribute (e.g., "Affiliation") and then select the specific values that should trigger this expansion (e.g., "Malstrain Corrupted"). If you want the expansion to apply for any value of the attribute, leave the attribute values empty.
+
+2. **Create the fighter category rule** (if applicable). If only certain fighter categories should get the equipment, create a new "Expansion Rule by Fighter Category" and select the relevant categories (e.g., Leader, Champion).
+
+3. **Create the expansion.** Go to Equipment List Expansions and create a new expansion. Give it a descriptive name (e.g., "Malstrain Leader/Champion Equipment"). In the rules section, add both rules you created. Remember, all rules must match -- adding both an attribute rule and a fighter category rule means the expansion only applies when both conditions are met.
+
+4. **Add equipment items.** In the inline section at the bottom of the expansion form, add equipment entries. For each item, select the equipment and optionally set a cost override. Leave the cost blank to use the equipment's base cost.
+
+### Creating a House-Specific Expansion
+
+For equipment that should only be available to lists of a specific house:
+
+1. **Create the house rule.** Create a new "Expansion Rule by House" and select the target house (e.g., "Delaque").
+
+2. **Optionally create a fighter category rule** to further restrict which fighters get access.
+
+3. **Create the expansion** and add both rules.
+
+4. **Add the equipment items** with optional cost overrides.
+
+### Adding a Weapon Profile to an Expansion
+
+Sometimes you want to make a specific weapon variant available rather than the base equipment:
+
+1. On the expansion's edit page, add a new item row in the inline section.
+2. Select the equipment first.
+3. Then select the specific weapon profile. The weapon profile must belong to the selected equipment -- the system validates this.
+4. Optionally set a cost override for this specific profile.
+
+This is useful for making specific ammo types or weapon configurations available through an expansion.
+
+### Changing an Expansion Item's Cost
+
+When you change the cost of an expansion item, affected user data is automatically marked for recalculation. See the cost propagation section in [Equipment & Weapons](equipment-and-weapons.md) for details.
+
+Simply edit the cost field on the expansion item and save. The cost propagation happens automatically.
+
+### Reusing Rules Across Expansions
+
+Rules are standalone objects that can be shared across multiple expansions. For example, if you have an attribute rule for "Malstrain Corrupted" and a fighter category rule for "Leader, Champion", you can attach these same rules to multiple expansions. This avoids duplicating rule definitions and makes it easy to manage conditions that apply to several different equipment sets.
+
+When browsing the rules list, you can see which expansions reference each rule. If you modify a rule (for example, adding a new fighter category), the change affects all expansions that use that rule.
+
+### Verifying an Expansion Works
+
+After creating an expansion, you can verify it by:
+
+1. Creating (or using an existing) list of the appropriate house.
+2. Setting the relevant attribute values on the list (if the expansion uses attribute rules).
+3. Selecting a fighter of the correct category.
+4. Opening the equipment selection screen and toggling the "Equipment List" filter.
+5. Checking that the expansion equipment appears in the list with the correct costs.

--- a/docs/content-library/fighters.md
+++ b/docs/content-library/fighters.md
@@ -1,0 +1,326 @@
+# Fighters & Fighter Types
+
+## Overview
+
+Fighters are the core building blocks of the Gyrinx content library. A list represents a user's collection of fighters (called a "gang" in Necromunda). Every fighter that a user can add to their list starts as a `ContentFighter` -- a template that defines the fighter's archetype, base statistics, default equipment, and available skill trees. When a user adds a fighter to their list, they are creating a `ListFighter` instance based on one of these content templates.
+
+The content library separates fighter definitions from user data. As an administrator, you manage the archetypes (the "what exists in the game") while users manage their own instances (the "what's in my list"). Changes you make to a `ContentFighter` affect how new fighters are created and how existing fighters display their base characteristics.
+
+This area also includes supporting models that control default equipment loadouts, category-specific terminology, and equipment carrying limits per fighter type.
+
+## Key Concepts
+
+**Fighter archetype**: A `ContentFighter` record that defines a type of fighter from the rulebooks. For example, "Gang Queen" or "Death Maiden" for House Escher. Users select from these archetypes when adding fighters to their lists.
+
+**Fighter category**: A broad classification such as `LEADER`, `CHAMPION`, or `GANGER` that determines the fighter's role in the gang hierarchy. Categories control sorting order, which equipment a fighter can access, and how terminology is displayed.
+
+**Fighter type**: The specific name of the fighter archetype within its category. For example, the category might be `CHAMPION` and the type might be "Death Maiden". The `type` field is the human-readable label users see when selecting a fighter.
+
+**House**: The faction a fighter belongs to (see the Houses documentation area). Fighters are linked to a house, and users can only add fighters from their list's house -- plus fighters from generic houses that are available to everyone.
+
+**Default assignment**: Equipment that comes with a fighter automatically when a user adds that fighter to their list. This represents the standard loadout described in the rulebooks.
+
+**Legacy fighter**: A secondary fighter template that can be attached to certain fighters, representing a previous incarnation or inherited role. Controlled by the `can_take_legacy` and `can_be_legacy` flags.
+
+## Models
+
+### ContentFighter
+
+The primary model in this area. Each record represents one fighter archetype from the game's rulebooks.
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | CharField | The fighter's specific name (e.g. "Gang Queen", "Death Maiden", "Juve"). This is the label users see when selecting a fighter. |
+| `category` | CharField (choices) | The fighter's role classification. See the full list of categories below. |
+| `house` | ForeignKey to `ContentHouse` | The faction this fighter belongs to. Can be null for universal fighters. |
+| `base_cost` | IntegerField | The credit cost to hire this fighter. Defaults to 0. |
+| `skills` | ManyToMany to `ContentSkill` | Default skills the fighter starts with. |
+| `primary_skill_categories` | ManyToMany to `ContentSkillCategory` | Skill trees the fighter can advance in as primary (cheaper XP cost). |
+| `secondary_skill_categories` | ManyToMany to `ContentSkillCategory` | Skill trees available as secondary (more expensive XP cost). |
+| `rules` | ManyToMany to `ContentRule` | Special rules that apply to this fighter type. |
+| `can_take_legacy` | BooleanField | Whether user fighters of this type can have a legacy content fighter attached. Default: false. |
+| `can_be_legacy` | BooleanField | Whether this fighter type can be assigned as someone else's legacy content fighter. Default: false. |
+| `is_stash` | BooleanField | Whether this fighter represents a gang's stash rather than an actual fighter. Stash fighters only show gear/weapons and must have a `base_cost` of 0. Default: false. |
+| `hide_skills` | BooleanField | Whether to hide the skills section on the fighter card in the application. Useful for fighter types that don't use skills. Default: false. |
+| `hide_house_restricted_gear` | BooleanField | Whether to hide the house-restricted gear section on the fighter card. Default: false. |
+
+#### Stat Fields
+
+`ContentFighter` has twelve built-in stat fields that represent the traditional Necromunda statline. These are all `CharField` fields with a max length of 12, allowing values like `"4"`, `"2+"`, or `"-"`:
+
+| Field | Verbose Name | Description |
+|-------|-------------|-------------|
+| `movement` | M | Movement distance |
+| `weapon_skill` | WS | Weapon Skill |
+| `ballistic_skill` | BS | Ballistic Skill |
+| `strength` | S | Strength |
+| `toughness` | T | Toughness |
+| `wounds` | W | Wounds |
+| `initiative` | I | Initiative |
+| `attacks` | A | Attacks |
+| `leadership` | Ld | Leadership |
+| `cool` | Cl | Cool |
+| `willpower` | Wil | Willpower |
+| `intelligence` | Int | Intelligence |
+
+These fields are stored as strings rather than integers because some stats use dice notation (e.g. `"2+"`) or may be left blank with `"-"`.
+
+There is also a custom statline system (via `ContentStatline`) that allows fighters to use an entirely different set of stats. When a fighter has a custom statline attached, it takes precedence over these built-in fields. This is used for fighter types like vehicles that have different stat categories (e.g. Front Armour, Handling, etc.). For full details on configuring stats and custom statlines, see [Stats & Statlines](stats-and-statlines.md).
+
+#### Fighter Categories
+
+The `category` field uses the `FighterCategoryChoices` enum. Fighters are sorted in lists by category in this order:
+
+| Category | Label | Typical Use |
+|----------|-------|-------------|
+| `LEADER` | Leader | Gang leader, one per gang |
+| `CHAMPION` | Champion | Experienced gang members |
+| `PROSPECT` | Prospect | Fighters working toward full membership |
+| `SPECIALIST` | Specialist | Fighters with specialised roles |
+| `GANGER` | Ganger | Standard gang members |
+| `JUVE` | Juve | Young/inexperienced gang members |
+| `CREW` | Crew | Vehicle crew members |
+| `EXOTIC_BEAST` | Exotic Beast | Companion creatures, added via equipment rather than directly |
+| `BRUTE` | Brute | Large hired muscle |
+| `HANGER_ON` | Hanger-on | Non-combat gang associates |
+| `HIRED_GUN` | Hired Gun | Mercenaries for hire |
+| `BOUNTY_HUNTER` | Bounty Hunter | Independent bounty hunters |
+| `HOUSE_AGENT` | House Agent | Faction agents |
+| `HIVE_SCUM` | Hive Scum | Underhive mercenaries |
+| `DRAMATIS_PERSONAE` | Dramatis Personae | Named special characters |
+| `ALLY` | Ally | Allied fighters |
+| `VEHICLE` | Vehicle | Vehicles, which use a different statline |
+| `STASH` | Stash | Special category for the gang's equipment stash |
+| `GANG_TERRAIN` | Gang Terrain | Gang-specific terrain pieces |
+
+Fighters with categories `EXOTIC_BEAST`, `VEHICLE`, and `STASH` are excluded from the normal fighter selection dropdown when users add fighters to their lists. Exotic beasts and vehicles are added through equipment assignments instead. Stash fighters are handled automatically.
+
+#### How Base Cost Works
+
+The `base_cost` field defines the default credit cost to hire a fighter of this type. When a user adds a fighter to their list, this is the cost they pay.
+
+However, the cost can be overridden per house using `ContentFighterHouseOverride` records (documented in the Houses area). This is used when a fighter type costs different amounts depending on which house is hiring them. When a house override exists, the application uses `cost_for_house()` to look up the overridden cost for the specific house.
+
+Stash fighters must always have a `base_cost` of 0. The application enforces this through validation.
+
+#### Admin Interface
+
+The `ContentFighter` admin page provides:
+
+- **Search**: by `type`, `category`, and `house__name`
+- **Filters**: by `category`, `house`, and `psyker_disciplines__discipline`
+- **Autocomplete**: on the `house` field
+- **Inlines**:
+  - **Fighter Statline**: attach a custom statline type (max one per fighter)
+  - **Equipment Category Limits**: set per-category equipment limits (see `ContentFighterEquipmentCategoryLimit` below)
+  - **Psyker Discipline Assignments**: assign psyker disciplines to this fighter
+  - **Psyker Power Default Assignments**: assign default psyker powers
+- **Actions**: "Copy selected to house" -- duplicates selected fighters (with all their equipment lists, default assignments, and relationships) into a different house
+
+### ContentFighterDefaultAssignment
+
+Defines the equipment that comes with a fighter by default. When a user adds a fighter to their list, the application creates equipment assignments based on these records.
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter archetype this default equipment belongs to. |
+| `equipment` | ForeignKey to `ContentEquipment` | The piece of equipment included by default. |
+| `weapon_profiles_field` | ManyToMany to `ContentWeaponProfile` | Specific weapon profiles to include. If a weapon has multiple profiles (e.g. different firing modes), this controls which non-standard profiles are included by default. Standard profiles (cost 0) are always included. |
+| `weapon_accessories_field` | ManyToMany to `ContentWeaponAccessory` | Weapon accessories included with this default assignment. |
+| `cost` | IntegerField | Cost override for this assignment. You typically should not change this from 0, as default equipment is included in the fighter's `base_cost`. |
+
+#### How Default Assignments Work
+
+Each `ContentFighterDefaultAssignment` record represents one piece of equipment that a fighter starts with. For example, a Gang Queen might have default assignments for a Laspistol and a Stiletto Knife.
+
+For weapons, the assignment automatically includes all "standard" weapon profiles (those with a cost of 0). If a weapon has additional profiles that cost extra -- for example, special ammunition types -- you can add those specific profiles through the `weapon_profiles_field` to include them in the default loadout.
+
+The `cost` field on a default assignment is typically 0 because the equipment cost is already factored into the fighter's `base_cost`. Only set a non-zero cost if the equipment should add cost beyond the base fighter cost.
+
+#### Admin Interface
+
+The `ContentFighterDefaultAssignment` admin page provides:
+
+- **Search**: by `fighter__type`, `equipment__name`, and `weapon_profiles_field__name`
+- **Autocomplete**: on `fighter` and `equipment` fields
+- **Actions**: "Copy selected to fighter" -- duplicates selected default assignments to a different fighter
+
+### ContentFighterCategoryTerms
+
+Controls the terminology used in the application for different fighter categories. This allows the application to use context-appropriate language -- for example, referring to a vehicle's "Damage" instead of "Injuries", or calling it "The stash" instead of "This fighter".
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `categories` | MultiSelectField | One or more fighter categories that use these terms. Each category can only appear in one terms record. |
+| `singular` | CharField | The singular noun for this type. Default: "Fighter". Examples: "Vehicle", "Beast". |
+| `proximal_demonstrative` | CharField | How the application refers to "this" entity. Default: "This fighter". Examples: "The vehicle", "The stash". |
+| `injury_singular` | CharField | Singular form for injuries. Default: "Injury". Examples: "Damage", "Glitch". |
+| `injury_plural` | CharField | Plural form for injuries. Default: "Injuries". Examples: "Damage". |
+| `recovery_singular` | CharField | Singular form for recovery. Default: "Recovery". Examples: "Repair". |
+
+#### When to Use
+
+You only need to create `ContentFighterCategoryTerms` records for categories that use non-standard terminology. If a category should use the defaults ("Fighter", "This fighter", "Injury", etc.), you do not need to create a record for it.
+
+Common examples:
+
+- Vehicles might use "Vehicle" / "The vehicle" / "Damage" / "Damage" / "Repair"
+- The stash might use "Stash" / "The stash" with the injury/recovery fields left at defaults since they are not displayed
+
+#### Admin Interface
+
+The `ContentFighterCategoryTerms` admin page shows all fields in the default list view. The `categories` field enforces uniqueness -- each combination of categories can only have one terms record.
+
+### ContentFighterEquipmentCategoryLimit
+
+Sets a maximum number of items from a specific equipment category that a fighter type can carry. Note the distinction: restrictions control which fighter categories can access an equipment category; limits control how many items from that category a fighter can carry. This is used to enforce game rules like "a fighter can carry at most 3 grenades" or "a vehicle can mount at most 2 heavy weapons".
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter type this limit applies to. |
+| `equipment_category` | ForeignKey to `ContentEquipmentCategory` | The equipment category being limited. |
+| `limit` | PositiveIntegerField | The maximum number of items from this category the fighter can have. Default: 1. |
+
+#### Validation Rules
+
+- The `fighter` and `equipment_category` combination must be unique -- you can only set one limit per category per fighter.
+- The equipment category must have at least one `ContentEquipmentCategoryFighterRestriction` before limits can be set. This means the category must already be configured with fighter category restrictions (see Equipment Categories documentation).
+
+#### Admin Interface
+
+Equipment category limits can be managed in two places:
+
+1. **From the `ContentFighter` admin page**: an inline at the bottom of each fighter's edit page lets you add limits for that fighter. The equipment category dropdown is filtered to only show categories that have fighter restrictions configured.
+
+2. **From the `ContentEquipmentCategory` admin page**: an inline shows all fighter limits for that category. The fighter dropdown is grouped by house for easier navigation.
+
+## How It Works in the Application
+
+### Adding a Fighter to a List
+
+When a user clicks "Add Fighter" on their list, the application shows a form with a dropdown of available fighter types. This dropdown is populated by the `available_for_house()` method, which returns:
+
+- All `ContentFighter` records belonging to the list's house
+- All `ContentFighter` records from generic houses (houses with `generic=True`), which represent universally available fighters like Hired Guns
+- If the house has `can_hire_any=True`, all fighters from all houses are shown (except stash fighters)
+
+Fighters with categories `EXOTIC_BEAST`, `VEHICLE`, and `STASH` are excluded from this dropdown. Exotic beasts and vehicles are added through equipment assignments, and the stash is managed automatically.
+
+The dropdown groups fighters by house, so the user sees their house's fighters first, followed by generic fighters.
+
+### Fighter Cost Calculation
+
+When a user selects a fighter type, the cost shown is determined by:
+
+1. First checking for a `ContentFighterHouseOverride` matching this fighter and the list's house
+2. If no override exists, using the fighter's `base_cost`
+
+In campaign mode, this cost is deducted from the list's available credits when the fighter is hired. If the list does not have enough credits, the hire is rejected.
+
+### Default Equipment
+
+After a fighter is created, the application looks up all `ContentFighterDefaultAssignment` records for that fighter's content type. Each default assignment creates an equipment assignment on the user's `ListFighter`. This means the fighter immediately appears with their standard loadout.
+
+### Fighter Display
+
+On the list view, each fighter card shows:
+
+- The fighter's name (user-assigned) and type (from `ContentFighter.type`)
+- The fighter's category label (e.g. "Leader", "Champion")
+- The statline -- either from the custom statline system or the built-in stat fields
+- Equipment, including default assignments and any user-added gear
+- Skills (hidden if `hide_skills` is true)
+- House-restricted gear section (hidden if `hide_house_restricted_gear` is true)
+- Special rules from the `rules` relationship
+
+### Category Terminology
+
+Throughout the application, when displaying text about a fighter, the system checks for `ContentFighterCategoryTerms` matching the fighter's category. If found, it uses the custom terminology. For example, a vehicle's injury table heading would say "Damage" instead of "Injuries".
+
+### Sorting
+
+Fighters in a list are sorted by category in a defined order: Stash first (if present), then Leaders, Champions, Prospects, Specialists, Gangers, Juves, with other categories in the middle, and Gang Terrain last. Within the same category, fighters are sorted by their type name.
+
+## Common Admin Tasks
+
+### Adding a New Fighter Type
+
+1. Open the Fighters admin page and click "Add Fighter"
+2. Fill in the `type` field with the fighter's name as it appears in the rulebooks (e.g. "Gang Queen")
+3. Select the appropriate `category` (e.g. `LEADER`)
+4. Select the `house` this fighter belongs to
+5. Set the `base_cost` in credits
+6. Fill in the stat fields (M, WS, BS, S, T, W, I, A, Ld, Cl, Wil, Int) with values from the rulebooks. Use `"-"` or leave blank for stats that don't apply.
+7. Add any default skills, primary/secondary skill categories, and rules
+8. Set the boolean flags as needed (`can_take_legacy`, `hide_skills`, etc.)
+9. Save the fighter
+
+After saving, you can add a custom statline, equipment category limits, and psyker disciplines using the inline forms.
+
+### Setting Up Default Equipment
+
+1. Navigate to the Default Equipment Assignments admin page
+2. Click "Add Default Equipment Assignment"
+3. Select the `fighter` (the content fighter archetype)
+4. Select the `equipment` (the piece of gear or weapon)
+5. If the equipment is a weapon with multiple profiles, optionally select the specific `weapon_profiles_field` entries that should be included beyond the standard (free) profiles
+6. Leave `cost` at 0 unless you have a specific reason to override it
+7. Save
+
+Repeat for each piece of equipment the fighter starts with.
+
+### Copying a Fighter to Another House
+
+Some fighter types exist across multiple houses with the same or similar stats. Rather than creating each one from scratch:
+
+1. Go to the Fighters admin page
+2. Select the fighter(s) you want to copy using the checkboxes
+3. Choose the "Copy selected to house" action from the dropdown
+4. Select the target house
+5. Execute the action
+
+This copies the fighter along with all its equipment lists, default assignments, skill categories, rules, and other relationships. You can then edit the copy to adjust any house-specific differences like cost or stat variations.
+
+### Configuring Equipment Category Limits
+
+1. Open the fighter you want to restrict in the Fighters admin page
+2. Scroll down to the "Equipment Category Limits" inline section
+3. Select an equipment category from the dropdown (only categories with fighter restrictions are shown)
+4. Set the `limit` value
+5. Save
+
+For example, to limit a Ganger to carrying 3 grenades, you would select the "Grenades" equipment category and set the limit to 3.
+
+### Setting Up Custom Terminology
+
+1. Go to the Fighter Category Terms admin page
+2. Click "Add Fighter Category Terms"
+3. Select the categories this terminology applies to (e.g. `VEHICLE`)
+4. Fill in the custom terms:
+   - `singular`: "Vehicle"
+   - `proximal_demonstrative`: "The vehicle"
+   - `injury_singular`: "Damage"
+   - `injury_plural`: "Damage"
+   - `recovery_singular`: "Repair"
+5. Save
+
+### Creating a Stash Fighter
+
+Each house typically needs one stash fighter to represent the gang's equipment stash:
+
+1. Add a new fighter with `type` set to something like "Stash"
+2. Set the `category` to `STASH`
+3. Set the `house` to the relevant house
+4. Ensure `base_cost` is 0 (this is enforced by validation)
+5. Check the `is_stash` flag
+6. You can usually check `hide_skills` and `hide_house_restricted_gear` since a stash does not need these sections
+7. Stat fields can be left blank
+8. Save

--- a/docs/content-library/gang-attributes.md
+++ b/docs/content-library/gang-attributes.md
@@ -1,0 +1,141 @@
+# Gang Attributes
+
+## Overview
+
+Gang attributes represent characteristics that apply to an entire list rather than to individual fighters. A list represents a user's collection of fighters (called a "gang" in Necromunda). These are properties like a list's Alignment (Law Abiding or Outlaw), its Alliance affiliations, or its broader political Affiliation within the underhive.
+
+Attributes are defined in the content library as named categories, each with a set of allowed values. When a user creates or manages a list, they can assign values to the available attributes. These assignments have a direct mechanical effect on gameplay: they determine which equipment list expansions are available to the list, adding or removing equipment options based on the list's chosen attributes.
+
+The attribute system is intentionally flexible. Administrators can define any number of attributes with any number of values, restrict certain attributes to specific houses, and control whether an attribute allows a single selection or multiple selections. This makes it straightforward to model both current Necromunda rules and future rule additions.
+
+## Key Concepts
+
+**Attribute** -- A named category of list characteristic, such as "Alignment" or "Affiliation". Each attribute has a defined set of allowed values and a selection mode (single-select or multi-select).
+
+**Attribute Value** -- A specific option within an attribute. For example, "Law Abiding" and "Outlaw" are values within the "Alignment" attribute.
+
+**Single-select vs Multi-select** -- An attribute marked as single-select allows only one value to be chosen per list. A multi-select attribute allows the user to pick multiple values simultaneously.
+
+**House Restriction** -- An attribute can optionally be restricted to specific houses. If restrictions are set, only lists belonging to those houses will see the attribute. If no restrictions are set, the attribute is available to all houses.
+
+**Attribute Assignment** -- The record that links a specific attribute value to a user's list. Assignments can be archived (soft-deleted) rather than permanently removed.
+
+## Models
+
+### `ContentAttribute`
+
+Represents an attribute category that can be associated with lists.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (unique) | The attribute name, such as "Alignment", "Alliance", or "Affiliation". Must be unique across all attributes. |
+| `is_single_select` | BooleanField (default: True) | Controls selection mode. When `True`, users can pick only one value for this attribute per list. When `False`, users can select multiple values. |
+| `restricted_to` | ManyToManyField to `ContentHouse` (optional) | Limits which houses can see and use this attribute. When empty, the attribute is available to all houses. |
+
+**Ordering:** Attributes are ordered alphabetically by `name`.
+
+**Admin interface:** The attribute admin displays each attribute's name, whether it is single-select, and a count of its values. You can filter the list by the `is_single_select` flag. The `restricted_to` field uses a horizontal filter widget for easy house selection. Attribute values are managed inline directly on the attribute's edit page.
+
+### `ContentAttributeValue`
+
+Represents a specific allowed value within an attribute.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `attribute` | ForeignKey to `ContentAttribute` | The parent attribute this value belongs to. Deleting an attribute cascades to delete all its values. |
+| `name` | CharField | The value name, such as "Law Abiding", "Outlaw", or "Chaos Cult". Must be unique within its parent attribute. |
+| `description` | TextField (optional) | An optional description explaining what this value represents in the game. |
+
+**Ordering:** Values are ordered first by their parent attribute's name, then alphabetically by their own name.
+
+**Constraints:** The combination of `attribute` and `name` must be unique -- you cannot have two values with the same name under the same attribute.
+
+**Admin interface:** Attribute values can be managed in two ways. You can edit them inline on the parent `ContentAttribute` page, where they appear as a tabular inline with `name` and `description` fields. You can also manage them through their own admin list, which shows name, parent attribute, and description, with search across all three fields and filtering by parent attribute.
+
+## How It Works in the Application
+
+### Viewing Attributes on a List
+
+When a user views their list, the Attributes section appears alongside other list details. It shows a table with every attribute available to the list's house. Each row displays the attribute name and either the currently assigned value(s) or "Not set" if no value has been chosen. List owners see an Edit link next to each attribute.
+
+The system determines which attributes to show by checking the `restricted_to` field on each `ContentAttribute`. An attribute appears if it has no house restrictions at all, or if the list's house is included in its `restricted_to` set.
+
+### Editing Attributes
+
+When the list owner clicks Edit on an attribute, they see a form tailored to the attribute's selection mode:
+
+- **Single-select attributes** present radio buttons with all available values plus a "None" option to clear the selection.
+- **Multi-select attributes** present checkboxes for all available values.
+
+Saving the form archives any existing assignments for that attribute and creates new assignments for the selected values. If the list is in campaign mode, the change is also recorded as a campaign action.
+
+Attribute editing is not available on archived lists.
+
+### Effect on Equipment Availability
+
+This is the most important downstream effect of attribute assignments. The Equipment List Expansions system uses attribute values as one of its rule types to determine which additional equipment becomes available to a list's fighters.
+
+Attribute values drive which equipment list expansions apply. See [Equipment List Expansions](equipment-list-expansions.md) for details on configuring expansion rules.
+
+A `ContentEquipmentListExpansionRuleByAttribute` links an expansion to a specific attribute and optionally to specific values of that attribute. When the system evaluates which expansions apply to a list:
+
+- If the rule specifies particular attribute values, the list must have one of those values assigned for the expansion to apply.
+- If the rule specifies only the attribute (with no specific values), the expansion applies as long as the list has any value set for that attribute.
+- If the list has no value set for the relevant attribute, the expansion does not apply.
+
+For example, if an equipment list expansion is configured with a rule matching the "Affiliation" attribute with the value "Chaos Cult", then only lists that have selected "Chaos Cult" as their Affiliation will gain access to the equipment items in that expansion.
+
+### List Cloning
+
+When a list is cloned, all active attribute assignments are copied to the new list. This happens before fighters are cloned so that equipment cost calculations on the new list can account for any expansion-based equipment that depends on attribute values.
+
+## Common Admin Tasks
+
+### Creating a New Attribute
+
+1. Open the Gang Attributes section in the admin.
+2. Click "Add Gang Attribute".
+3. Enter the attribute `name` (e.g., "Alignment").
+4. Set `is_single_select` based on the game rules. Most Necromunda attributes like Alignment are single-select.
+5. If this attribute only applies to certain houses, use the `restricted_to` horizontal filter to select the relevant houses. Leave it empty if the attribute applies to all houses.
+6. In the Attribute Values inline section, add each allowed value with a `name` and optional `description`.
+7. Save the attribute.
+
+After saving, the attribute will immediately appear on all applicable lists in the user-facing application.
+
+### Adding a New Value to an Existing Attribute
+
+1. Open the Gang Attributes section and click the attribute you want to modify.
+2. Scroll down to the inline values section.
+3. Add a new row with the value `name` and optional `description`.
+4. Save.
+
+The new value will immediately be available for users to select on their lists.
+
+### Changing an Attribute from Single-Select to Multi-Select
+
+1. Open the attribute in the admin.
+2. Change `is_single_select` from checked to unchecked (or vice versa).
+3. Save.
+
+Be aware that switching from multi-select to single-select does not automatically clean up lists that already have multiple values assigned. Those existing assignments will remain, but the `ListAttributeAssignment` validation will prevent adding new conflicting assignments going forward.
+
+### Restricting an Attribute to Specific Houses
+
+1. Open the attribute in the admin.
+2. Use the `restricted_to` horizontal filter to select the houses that should have access.
+3. Save.
+
+Lists belonging to houses not in the restriction set will no longer see this attribute. Existing assignments on those lists are not automatically removed, but the attribute will no longer appear in their Attributes section.
+
+### Setting Up an Attribute-Based Equipment List Expansion
+
+To make equipment availability depend on a list attribute:
+
+1. Create the attribute and its values as described above (if they do not already exist).
+2. In the Equipment List Expansion Rules section, create a new "Expansion Rule by Attribute".
+3. Select the `attribute` to match on.
+4. Optionally select specific `attribute_values` to match. Leave empty to match any value of that attribute.
+5. Attach the rule to the relevant Equipment List Expansion.
+
+See the [Equipment List Expansions](equipment-list-expansions.md) documentation for the full process of creating expansions and linking rules to them.

--- a/docs/content-library/houses-and-factions.md
+++ b/docs/content-library/houses-and-factions.md
@@ -1,0 +1,167 @@
+# Houses & Factions
+
+Houses are the core organisational unit in the Gyrinx content library. A list represents a user's collection of fighters (called a "gang" in Necromunda). Every list a user creates is associated with exactly one house, and that house determines which fighters can be hired, which equipment is available, and which skill categories are accessible. Houses represent the major factions from the Necromunda tabletop game -- Escher, Goliath, Orlock, Cawdor, Van Saar, Delaque, and many others.
+
+When a user creates a new list, they choose a house. From that point on, the house acts as a filter across the entire application: the fighters shown in the "add fighter" form, the equipment lists available on weapon and gear pages, and the skill trees offered during advancement are all determined by the house. Getting house configuration right is essential because it shapes the entire user experience of building and managing a list.
+
+The content library also supports house-level cost overrides for individual fighters through the `ContentFighterHouseOverride` model. This lets you set a different price for the same fighter type depending on which house is hiring them -- a common pattern in Necromunda where hired guns and hangers-on cost different amounts for different factions.
+
+## Key Concepts
+
+**House** -- A faction or house type (e.g., House Escher, House Goliath, Underhive Outcasts). Each user list belongs to exactly one house.
+
+**Generic house** -- A special category of house whose fighters are available to all other houses. Used for mercenaries, hired guns, hangers-on, and other faction-neutral fighter types. Generic houses cannot be selected as the primary house when creating a list.
+
+**Legacy house** -- An older or deprecated faction that still appears in the list creation form but is grouped separately under "Legacy House" to distinguish it from current factions.
+
+**House override** -- A per-house cost adjustment for a specific fighter type. When a fighter has a house override, the overridden cost is used instead of the fighter's base cost whenever that fighter appears in a list belonging to the specified house.
+
+## Models
+
+### ContentHouse
+
+`ContentHouse` represents a faction or house that fighters can belong to. It is the central model that ties together fighters, equipment access, and skill trees.
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | CharField | The display name of the house (e.g., "House Escher", "Underhive Outcasts"). Indexed for search. |
+| `generic` | BooleanField | When checked, fighters belonging to this house are available to lists of any other house. Generic houses cannot be selected as a primary house during list creation. Defaults to `false`. |
+| `legacy` | BooleanField | When checked, marks this house as a legacy/older faction. Legacy houses are grouped separately in the list creation form under a "Legacy House" heading. Defaults to `false`. |
+| `can_hire_any` | BooleanField | When checked, lists belonging to this house can hire any fighter from any house (except stash fighters). Used for factions like Underhive Outcasts that have unrestricted recruitment. Defaults to `false`. |
+| `can_buy_any` | BooleanField | When checked, lists belonging to this house can buy any equipment from any equipment list and the Trading Post. Equipment pages default to showing all available equipment rather than the fighter's own equipment list. Defaults to `false`. |
+| `skill_categories` | ManyToManyField | Links to `ContentSkillCategory` records. These are the "Unique Skill Categories" available to fighters in this house. They appear as a separate section on the skill advancement page alongside the standard (non-restricted) skill categories. |
+
+**Relationships:**
+
+- Each `ContentFighter` has a foreign key to `ContentHouse`, establishing which house a fighter template belongs to.
+- Each user `List` has a foreign key to `ContentHouse`, establishing the house for the entire list.
+- Skill categories linked via `skill_categories` appear on the fighter skill advancement page as house-specific skill trees.
+
+**Admin interface:**
+
+The `ContentHouse` admin page displays all fields for the house and includes an inline listing of all `ContentFighter` records belonging to that house. You can search houses by name.
+
+### ContentFighterHouseOverride
+
+`ContentFighterHouseOverride` captures cases where a fighter has a different cost when being hired by a specific house. This is a common pattern for faction-neutral fighters (bounty hunters, hangers-on, dramatis personae) whose hiring cost varies by faction.
+
+| Field | Type | Description |
+|---|---|---|
+| `fighter` | ForeignKey | The `ContentFighter` whose cost is being overridden. |
+| `house` | ForeignKey | The `ContentHouse` for which this override applies. |
+| `cost` | IntegerField | The overridden cost in credits. Nullable -- if left blank, the fighter's base cost is used. |
+
+**Constraints:**
+
+- The combination of `fighter` and `house` must be unique. You cannot create two overrides for the same fighter-house pair.
+- Overrides are ordered by house name, then fighter type.
+
+**Admin interface:**
+
+The `ContentFighterHouseOverride` admin page provides autocomplete fields for both `fighter` and `house`, making it quick to find the correct records. You can search by fighter type or house name, and filter by fighter type or house.
+
+## How It Works in the Application
+
+### List Creation
+
+When a user creates a new list, they see a dropdown of all available houses. The form filters out generic houses (since those exist only to provide shared fighters) and groups the remaining houses into two sections: "House" for current factions and "Legacy House" for older ones. The user's selection becomes the `content_house` for their list and cannot be changed after creation.
+
+### Fighter Selection
+
+When a user adds a fighter to their list, the available fighters are determined by the list's house:
+
+- **Standard houses** (`can_hire_any` is `false`): The form shows fighters belonging to the list's own house plus fighters from all generic houses. Exotic beasts, vehicles, and stash fighters are excluded from the dropdown (exotic beasts and vehicles are added through equipment assignments instead).
+- **Unrestricted houses** (`can_hire_any` is `true`): The form shows all fighters from every house, except stash fighters. This allows factions like Underhive Outcasts to recruit from any house.
+
+Fighter costs in the dropdown reflect house-specific pricing. If a `ContentFighterHouseOverride` exists for the fighter-house combination, that override cost is displayed. Otherwise, the fighter's standard `base_cost` is shown.
+
+### Equipment Access
+
+The `can_buy_any` flag controls how equipment pages behave:
+
+- **Standard houses** (`can_buy_any` is `false`): Equipment pages default to showing only items from the fighter's own equipment list.
+- **Unrestricted houses** (`can_buy_any` is `true`): Equipment pages automatically redirect to show all equipment from every equipment list and the Trading Post. Users can still switch back to the equipment list view manually.
+
+### Skill Advancement
+
+Each house can have unique skill categories linked via the `skill_categories` field. When a user advances a fighter's skills, the skill page shows:
+
+1. Standard (non-restricted) skill categories available to all fighters.
+2. House-specific skill categories from the fighter's house, displayed in a separate section.
+
+This allows houses like Escher to have access to faction-specific skill trees alongside the universal ones.
+
+### Lists Browsing and Filtering
+
+On the public lists page, users can filter lists by house. The house filter shows all houses (not just non-generic ones), and the search also matches against house names.
+
+### Cost Recalculation
+
+When a `ContentFighterHouseOverride` cost changes, the system automatically marks all affected `ListFighter` records as "dirty" -- meaning their cached cost data needs recalculation. This ensures that user-facing list totals stay accurate after content changes. The dirty fighters are recalculated the next time their list is viewed.
+
+## Common Admin Tasks
+
+### Adding a New House
+
+1. Open the Houses admin page and click "Add House".
+2. Enter the house `name` (e.g., "House Escher").
+3. Set the flags as appropriate:
+   - Leave `generic` unchecked for a standard selectable house.
+   - Leave `legacy` unchecked unless this is an older faction you want to separate visually in the list creation form.
+   - Leave `can_hire_any` unchecked unless this faction can recruit from any other house.
+   - Leave `can_buy_any` unchecked unless this faction has unrestricted equipment access.
+4. Optionally link skill categories in the `skill_categories` field if the house has unique skill trees.
+5. Save the house. It will now appear in the list creation form.
+
+### Adding a Generic House for Shared Fighters
+
+Generic houses hold fighters that should be available across all factions (e.g., hired guns, hangers-on, dramatis personae).
+
+1. Create a new house and check the `generic` flag.
+2. Add fighters to this house as you normally would.
+3. These fighters will automatically appear in the "add fighter" dropdown for lists belonging to any house.
+
+Users will not see generic houses in the list creation form -- they exist only as containers for shared content.
+
+### Setting a House-Specific Fighter Cost
+
+Some fighters cost different amounts depending on which house hires them. To configure this:
+
+1. Open the Fighter-House Overrides admin page and click "Add Fighter-House Override".
+2. Use the autocomplete fields to select the `fighter` and the `house`.
+3. Enter the override `cost` in credits.
+4. Save. The next time a user views a list belonging to that house, the fighter's cost will reflect the override.
+
+You can also search for existing overrides by fighter type or house name and filter by house to see all overrides for a particular faction.
+
+### Marking a House as Legacy
+
+If a house is being retired or replaced but existing lists still reference it:
+
+1. Open the house in the admin.
+2. Check the `legacy` flag.
+3. Save. The house will continue to work for existing lists but will appear in the "Legacy House" group in the list creation form, visually separated from current factions.
+
+### Configuring Unrestricted Recruitment
+
+For factions that can hire from any house (e.g., Underhive Outcasts):
+
+1. Open the house in the admin.
+2. Check the `can_hire_any` flag.
+3. Save. Lists belonging to this house will now show all fighters from every house in the "add fighter" form (excluding stash fighters).
+
+### Configuring Unrestricted Equipment Access
+
+For factions that can buy from any equipment list (e.g., Venators):
+
+1. Open the house in the admin.
+2. Check the `can_buy_any` flag.
+3. Save. Equipment pages for fighters in this house will default to showing all available equipment rather than just the fighter's equipment list.
+
+### Linking Unique Skill Categories to a House
+
+If a house has faction-specific skill trees:
+
+1. Open the house in the admin.
+2. In the `skill_categories` (labelled "Unique Skill Categories") field, select the relevant `ContentSkillCategory` entries.
+3. Save. These skill categories will now appear in a dedicated section on the skill advancement page for fighters belonging to this house.

--- a/docs/content-library/injuries.md
+++ b/docs/content-library/injuries.md
@@ -1,0 +1,192 @@
+# Injuries
+
+## Overview
+
+Injuries represent lasting harm that fighters sustain during campaign play. When a fighter suffers a serious wound in a battle, the result is tracked as an injury on their fighter card. These injuries persist across battles and can affect a fighter's stats, availability, and long-term viability in a campaign. A list represents a user's collection of fighters (called a "gang" in Necromunda).
+
+The injury system in the content library defines what injuries exist, how they are organized into groups, and what happens to a fighter when they receive each type of injury. Content administrators configure injury groups and individual injuries here; users then apply those injuries to their fighters during campaign play through the application's injury management interface.
+
+Injuries are a campaign-mode feature. They cannot be added to fighters outside of campaign mode. Each injury can optionally carry stat modifiers that change a fighter's profile for as long as the injury is active, reflecting the lasting mechanical consequences of serious wounds.
+
+## Key Concepts
+
+**Injury Group** -- A named collection of related injuries. Groups control which fighter categories and houses can receive the injuries they contain. For example, a "Vehicle Damage" group might be restricted to vehicles only, while "Lasting Injuries" applies to most fighter types.
+
+**Injury** -- A specific type of lasting harm, such as "Humiliated", "Eye Injury", or "Spinal Injury". Each injury belongs to a group and has a default outcome that determines what state the fighter should be placed into when the injury is applied.
+
+**Default Outcome** -- The fighter state that an injury suggests when it is applied. For example, a minor injury might leave the fighter `Active`, while a critical injury might put them into `Convalescence` or mark them as `Dead`. The user can override this suggestion when adding the injury.
+
+**Modifier** -- A stat modification attached to an injury. When a fighter has an active injury with modifiers, those modifiers are applied to the fighter's statline. For example, a leg injury might worsen the fighter's Movement stat.
+
+**Fighter State** -- The availability status of a fighter in campaign mode. Injuries drive state changes, but the state is tracked on the fighter itself, not on the injury. See the "Fighter States and Availability" section below for details.
+
+## Models
+
+### `ContentInjuryGroup`
+
+Represents a group of related injuries. Injury groups serve two purposes: they organize injuries into logical categories for display, and they control which fighters can receive the injuries in the group through category and house restrictions.
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | CharField (max 100, unique) | The display name for this group, such as "Lasting Injuries" or "Vehicle Damage". |
+| `description` | TextField (blank) | Optional description of the group. |
+| `restricted_to` | MultiSelectField | If set, only fighters with one of the selected categories can receive injuries from this group. When blank, all fighter categories are eligible. |
+| `unavailable_to` | MultiSelectField | If set, fighters with any of the selected categories cannot receive injuries from this group, even if they match `restricted_to`. |
+| `restricted_to_house` | ManyToManyField to `ContentHouse` | If set, only fighters belonging to one of the selected houses can receive injuries from this group. When empty, no house restriction applies. |
+
+#### How Restrictions Work
+
+The `restricted_to` and `unavailable_to` fields use the fighter category system. The available categories include Leader, Champion, Ganger, Juve, Crew, Exotic Beast, Hanger-on, Brute, Hired Gun, Bounty Hunter, House Agent, Hive Scum, Dramatis Personae, Prospect, Specialist, Stash, Vehicle, Ally, and Gang Terrain.
+
+The restriction logic follows this order:
+
+1. If `restricted_to` is set, the fighter's category must be in that list.
+2. If `unavailable_to` is set, the fighter's category must not be in that list. This takes effect even if the category passes the `restricted_to` check.
+3. If `restricted_to_house` has any entries, the fighter's house must be one of them.
+
+When all restriction fields are left blank, the group's injuries are available to all fighters.
+
+#### Admin Interface
+
+The Injury Group admin page displays a list of groups with columns for name, description, restricted houses, restricted fighter categories, and unavailable fighter categories. Each group's detail page includes an inline table of all injuries belonging to that group, letting you manage injuries directly from the group page.
+
+### `ContentInjury`
+
+Represents an individual injury type that can be applied to a fighter.
+
+#### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | CharField (max 255, unique) | The name of the injury, such as "Humiliated", "Eye Injury", or "Spinal Injury". |
+| `description` | TextField (blank) | A text description of the injury and its effects. This is shown to users when they view injury details. |
+| `phase` | CharField (labelled "Default Outcome") | The suggested fighter state when this injury is applied. Uses the `ContentInjuryDefaultOutcome` choices (see below). Defaults to `no_change`. |
+| `injury_group` | ForeignKey to `ContentInjuryGroup` (nullable) | The group this injury belongs to. This determines which fighters can receive the injury based on the group's restrictions. |
+| `group` | CharField (max 100, blank) | **Deprecated:** The `group` CharField is deprecated in favour of the `injury_group` ForeignKey. Do not use the `group` field for new injuries. |
+| `modifiers` | ManyToManyField to `ContentMod` | Stat modifiers that are applied to a fighter's profile when this injury is active. See "Injury Modifiers and Stats" below. |
+
+#### Admin Interface
+
+The Injury admin page supports searching by `name` and `description`, and filtering by `phase` (Default Outcome). The list view shows columns for name, description, default outcome, and modifier count.
+
+Each injury's detail page includes an inline section for managing the modifiers associated with that injury. You can add, edit, or remove modifiers directly from the injury detail page.
+
+### `ContentInjuryDefaultOutcome`
+
+An enumeration of the possible default outcomes for injuries. These values map to the fighter states used in campaign mode.
+
+| Value | Display Name | Meaning |
+|---|---|---|
+| `no_change` | No Change | The injury does not suggest changing the fighter's current state. |
+| `active` | Active | The fighter remains available for battles. |
+| `recovery` | Recovery | The fighter is temporarily unavailable and must recover before participating in battles. |
+| `convalescence` | Convalescence | The fighter is out for an extended period and cannot participate in battles. |
+| `dead` | Dead | The fighter is killed. Dead fighters cannot participate in battles and their equipment is hidden from the fighter card. |
+| `in_repair` | In Repair | Used for vehicles. The vehicle is damaged and must be repaired before it can be used again. |
+
+When a user adds an injury to a fighter, the form automatically suggests the injury's default outcome as the new fighter state. The user can override this selection before confirming.
+
+## How It Works in the Application
+
+### Fighter States and Availability
+
+Every fighter in campaign mode has an `injury_state` field that tracks their current availability. This state determines whether the fighter can participate in battles:
+
+- **Active** -- The fighter is available and can participate in battles.
+- **Recovery** and **Convalescence** -- The fighter is temporarily unavailable and cannot participate.
+- **Dead** -- The fighter is permanently out. Dead fighters remain on the list but their wargear is hidden from the fighter card.
+- **In Repair** -- Vehicles only. The vehicle is out of action until repaired.
+
+The fighter's state is displayed as a colour-coded badge on their card: green for Active, yellow for Recovery/Convalescence/In Repair, and red for Dead.
+
+### Adding an Injury
+
+When a user (the list owner or the campaign arbitrator) adds an injury to a fighter, the application:
+
+1. Presents a form showing only the injuries available to that fighter, filtered by the fighter's category and house against the injury group restrictions.
+2. Groups the available injuries by their injury group in the dropdown.
+3. Pre-selects the fighter state based on the chosen injury's default outcome (unless the outcome is `no_change`).
+4. Creates a `ListFighterInjury` record linking the fighter to the content injury, along with the date and any notes.
+5. Updates the fighter's `injury_state` to the selected state.
+6. Logs the event to the campaign action log.
+
+If the selected state is Dead, the user is redirected to a kill confirmation page.
+
+### Injury Modifiers and Stats
+
+When an injury has modifiers attached, those modifiers are applied to the fighter's calculated statline in campaign mode. For full details on how modifiers work and the different modifier types, see [Modifiers](modifiers.md). The modifier system supports several types of changes relevant to injuries:
+
+- **Fighter Stat Modifiers** (`ContentModFighterStat`) -- Change a specific stat value. For example, an eye injury might worsen Ballistic Skill by 1, or a leg wound might worsen Movement.
+- **Fighter Rule Modifiers** (`ContentModFighterRule`) -- Add or remove rules from the fighter.
+
+Modifiers use a mode of `improve`, `worsen`, or `set` to determine how they change the stat value. The modifiers are applied in real time: as soon as the injury is added to the fighter, the stat changes appear on the fighter card. When the injury is removed, the modifiers are removed as well.
+
+### Removing an Injury
+
+Users can remove injuries from fighters when they recover. Removing an injury:
+
+1. Deletes the `ListFighterInjury` record.
+2. If the fighter has no remaining injuries, automatically resets the fighter's state to Active.
+3. Logs the recovery to the campaign action log.
+4. Immediately removes any stat modifiers that were applied by the injury.
+
+### Injuries on Fighter Cards
+
+In campaign mode, fighter cards display an "Injuries" row in the statline area. This row lists the names of all active injuries. If the list owner or campaign arbitrator is viewing the card, an "Edit" link appears next to the injuries, or an "Add" link if the fighter has no injuries yet. Outside of campaign mode, the injuries row is not shown.
+
+### Custom Terminology
+
+Different fighter categories may use different terminology for injuries. For example, vehicles use "Damage" instead of "Injury". The application handles this through the `term_injury_singular` and `term_injury_plural` properties on fighters, which pull from category-specific term configuration. All templates use these dynamic terms rather than hard-coding "Injury" or "Injuries".
+
+## Common Admin Tasks
+
+### Creating a New Injury Group
+
+1. Go to the Injury Groups section in the admin.
+2. Click "Add Injury Group".
+3. Enter the group name (for example, "Lasting Injuries" or "Vehicle Lasting Damage").
+4. Optionally add a description.
+5. If this group should only apply to certain fighter types, select the appropriate categories in `restricted_to`. For vehicle damage, you would select "Vehicle".
+6. If this group should be excluded from certain fighter types, select those categories in `unavailable_to`. For example, you might exclude "Exotic Beast" from standard lasting injuries.
+7. If the group is house-specific, select the relevant houses in `restricted_to_house`.
+8. Save the group.
+
+### Adding Injuries to a Group
+
+You can add injuries directly from the injury group's detail page using the inline injury table at the bottom.
+
+1. Open the injury group.
+2. In the inline injuries section, fill in the name, description, and default outcome for each injury.
+3. Save the group.
+
+Alternatively, you can create injuries individually through the Injuries admin section and assign them to a group using the `injury_group` dropdown.
+
+### Attaching Modifiers to an Injury
+
+1. Go to the Injuries section in the admin and open the injury you want to modify.
+2. In the "Modifiers" inline section, click "Add another Modifier".
+3. Select the appropriate modifier. These are shared `ContentMod` objects, so you need to have already created the modifier (for example, a Fighter Stat Modifier that worsens Movement by 1). See the Modifiers documentation for details on creating modifiers.
+4. Save the injury.
+
+The modifier will now be applied to any fighter who receives this injury during campaign play.
+
+### Setting Up Vehicle Damage
+
+Vehicles use a separate set of injuries with different terminology. To configure vehicle damage:
+
+1. Create an injury group named something like "Vehicle Lasting Damage".
+2. Set `restricted_to` to "Vehicle" so only vehicles can receive these injuries.
+3. Add injuries with appropriate default outcomes. Use `in_repair` as the default outcome for damage that takes the vehicle out of action.
+4. Attach any relevant stat modifiers (for example, worsening the vehicle's Handling or Movement).
+
+### Migrating from the Deprecated Group Field
+
+The `group` CharField on `ContentInjury` is a legacy text field that stored the group name as plain text. It has been replaced by the `injury_group` ForeignKey, which provides a proper relationship to `ContentInjuryGroup`.
+
+If you encounter injuries that have a value in the `group` text field but no `injury_group` set, you should:
+
+1. Find or create the appropriate `ContentInjuryGroup`.
+2. Set the `injury_group` ForeignKey on the injury to point to that group.
+3. The `group` text field can be left as-is; it is retained for backward compatibility but is not used by the application logic.

--- a/docs/content-library/modifiers.md
+++ b/docs/content-library/modifiers.md
@@ -1,0 +1,248 @@
+# Modifiers
+
+## Overview
+
+Modifiers are the content library's mechanism for expressing how equipment, upgrades, weapon accessories, and injuries change a fighter's characteristics. Rather than hard-coding the effects of every item into application logic, modifiers let you declare effects as data: "this piece of equipment improves Movement by 1" or "this injury removes the Infiltrate skill."
+
+The modifier system uses a polymorphic architecture. There is a single base model, `ContentMod`, and several specialized child types that each handle a different kind of modification -- weapon stats, fighter stats, weapon traits, fighter rules, fighter skills, skill tree access, and psyker discipline access. When you create a modifier in the admin, you choose which type of modifier you need, then fill in the details specific to that type.
+
+These modifiers are then attached to equipment, equipment upgrades, weapon accessories, or injuries through many-to-many relationships. When a user views a fighter on their list -- a list represents a user's collection of fighters (called a "gang" in Necromunda) -- the system collects all modifiers from the fighter's equipment (including accessories and upgrades) and any active injuries, then applies them to produce the final fighter statline, weapon profiles, rules, and skills the user sees.
+
+## Key Concepts
+
+### Polymorphic Modifiers
+
+All modifier types share a single database table hierarchy rooted in `ContentMod`. This means you can attach any type of modifier to any item that accepts modifiers -- the system does not restrict which modifier types can go on which items. In the admin interface, the main Modifications list shows all modifier types together, and you can filter by type.
+
+### Mode
+
+Every modifier has a `mode` field that controls how the modifier takes effect. The available modes vary by modifier type:
+
+- **Stat modifiers** (`ContentModStat`, `ContentModFighterStat`): `improve`, `worsen`, or `set`
+- **Trait, rule, and skill modifiers**: `add` or `remove`
+- **Skill tree access modifiers**: `add_primary`, `add_secondary`, `remove_primary`, `remove_secondary`, or `disable`
+- **Psyker discipline access modifiers**: `add` or `remove`
+
+### Improve vs. Worsen
+
+For stat modifiers, `improve` and `worsen` are relative to the game meaning of the stat, not the raw number. Some stats are "inverted" -- a lower number is better (for example, Ballistic Skill 3+ is better than 4+). The modifier system handles this automatically: `improve` always makes the stat better for the fighter, and `worsen` always makes it worse, regardless of the underlying number direction.
+
+### Attachment Points
+
+Modifiers can be attached to four types of content:
+
+- **Equipment** (`ContentEquipment.modifiers`) -- for fighter-level effects like stat changes, rules, and skills
+- **Equipment Upgrades** (`ContentEquipmentUpgrade.modifiers`) -- for effects that come from upgrading equipment
+- **Weapon Accessories** (`ContentWeaponAccessory.modifiers`) -- for effects that modify weapon statlines and traits
+- **Injuries** (`ContentInjury.modifiers`) -- for lasting effects from campaign injuries
+
+### Virtual Weapon Profile
+
+When a weapon has accessories attached, the application creates a `VirtualWeaponProfile` -- a computed wrapper around the base weapon profile that applies all relevant weapon stat and trait modifiers. This means users see the final modified weapon stats rather than the base stats plus a separate list of changes.
+
+## Models
+
+### `ContentMod`
+
+The base polymorphic model for all modifications. You do not create `ContentMod` instances directly; instead, you create one of the specific child types listed below.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Auto-generated primary key |
+
+In the admin, the main Modifications list shows all modifier types together. You can filter by modifier type using the polymorphic type filter in the sidebar.
+
+### `ContentModStat`
+
+Modifies a weapon's statline values (range, accuracy, strength, etc.). These modifiers are applied through the `VirtualWeaponProfile` system and affect how weapon stats are displayed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stat` | Choice | The weapon stat to modify. Options: `strength`, `range_short`, `range_long`, `accuracy_short`, `accuracy_long`, `armour_piercing`, `damage`, `ammo` |
+| `mode` | Choice | How to apply the change: `improve` (make the stat better), `worsen` (make the stat worse), or `set` (replace the stat value entirely) |
+| `value` | String (max 5 chars) | The modification value. For `improve`/`worsen`, this is the amount to change by. For `set`, this is the new value |
+
+**Stat display format:** The `value` field should contain a plain number. The system automatically handles the correct display format based on the stat type -- adding `"` for range stats, `+` prefix for accuracy/AP, and `+` suffix for ammo rolls.
+
+**Example:** A modifier with `stat=strength`, `mode=improve`, `value=1` applied to a weapon with Strength 4 produces Strength 5. The same modifier with `mode=worsen` would produce Strength 3.
+
+### `ContentModFighterStat`
+
+Modifies a fighter's statline values (movement, toughness, wounds, etc.). These modifiers are collected from all of a fighter's equipment and injuries and applied to the fighter's base statline.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stat` | String (max 50 chars) | The fighter stat to modify. Choices are dynamically generated from `ContentStat` objects, ensuring all defined stats are available |
+| `mode` | Choice | How to apply the change: `improve`, `worsen`, or `set` |
+| `value` | String (max 5 chars) | The modification value |
+
+**Validation:** The system prevents duplicate `ContentModFighterStat` records. If a modifier with the same `stat`, `mode`, and `value` already exists, validation will reject the new entry. This means you can reuse the same modifier across multiple items.
+
+**Admin form:** The `stat` field uses a dropdown populated from `ContentStat` objects. This ensures consistency with the statline system and means the available fighter stats update automatically when new stats are defined.
+
+### `ContentModTrait`
+
+Adds or removes weapon traits from a weapon profile.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trait` | FK to `ContentWeaponTrait` | The weapon trait to add or remove |
+| `mode` | Choice | `add` (give the weapon this trait) or `remove` (take the trait away) |
+
+**Example:** A weapon accessory that grants the Knockback trait would have a `ContentModTrait` with `trait=Knockback` and `mode=add`.
+
+### `ContentModFighterRule`
+
+Adds or removes rules from a fighter.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rule` | FK to `ContentRule` | The rule to add or remove |
+| `mode` | Choice | `add` or `remove` |
+
+The `rule` field uses autocomplete in the admin for easier searching across the full rule catalogue.
+
+### `ContentModFighterSkill`
+
+Adds or removes skills from a fighter.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `skill` | FK to `ContentSkill` | The skill to add or remove |
+| `mode` | Choice | `add` or `remove` |
+
+The admin form groups skills by their skill category for easier selection.
+
+### `ContentModSkillTreeAccess`
+
+Modifies which skill trees a fighter has access to. This affects which skills the fighter can choose when advancing.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `skill_category` | FK to `ContentSkillCategory` | The skill category (tree) to modify access to |
+| `mode` | Choice | `add_primary` (grant primary access), `add_secondary` (grant secondary access), `remove_primary` (revoke primary access), `remove_secondary` (revoke secondary access), `disable` (remove all access to this category) |
+
+**How modes interact:** The `disable` mode removes a skill category from both primary and secondary access. The `add_primary` and `add_secondary` modes are additive -- they add the category without affecting existing access through other sources. The `remove_primary` and `remove_secondary` modes only remove the specific access level.
+
+### `ContentModPsykerDisciplineAccess`
+
+Modifies which psyker disciplines a fighter has access to.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `discipline` | FK to `ContentPsykerDiscipline` | The psyker discipline to grant or revoke |
+| `mode` | Choice | `add` (grant access to this discipline) or `remove` (revoke access) |
+
+### `ContentModStatApplyMixin`
+
+This is not a model but a shared mixin class used by both `ContentModStat` and `ContentModFighterStat`. It contains the `apply()` method that handles the arithmetic of stat modifications. Understanding this logic is helpful when verifying that modifiers produce the expected results.
+
+**How `apply()` works:**
+
+1. If the mode is `set`, the method returns the modifier's value directly, replacing whatever was there before.
+2. For `improve` or `worsen`, the method determines the direction of change. For `improve`, the value increases; for `worsen`, it decreases.
+3. For inverted stats (where lower is better, such as BS 3+), the direction is reversed -- `improve` decreases the number and `worsen` increases it.
+4. The method parses the current stat value, handling the various display formats:
+   - `"-"` or empty string is treated as 0
+   - Values ending in `"` are inch measurements (e.g., `12"`)
+   - Values ending in `+` are target rolls (e.g., `4+`)
+   - Values starting with `+` are modifiers (e.g., `+1`)
+   - Values containing `S` are strength-linked (e.g., `S`, `S+1`, `S-1`)
+   - Plain numbers are treated as-is
+5. The modifier value is added (or subtracted) and the result is formatted back into the appropriate display format.
+
+**Stat categories:** The system classifies each stat using four properties from `ContentStat`:
+
+| Property | Meaning | Example Stats |
+|----------|---------|---------------|
+| `is_inverted` | Lower number is better | WS, BS, Int, Ld, Cl, Wil, Init, Save, Ammo, AP, Handling |
+| `is_inches` | Displayed with `"` suffix | Range Short, Range Long, Movement |
+| `is_modifier` | Displayed with `+` prefix | Accuracy Short, Accuracy Long, AP |
+| `is_target` | Displayed with `+` suffix | Ammo, WS, BS, Int, Ld, Cl, Wil, Init, Save, Handling |
+
+## How It Works in the Application
+
+### Fighter Statline Modifications
+
+When a user views a fighter, the application computes the final statline through several steps:
+
+1. The fighter's base statline comes from the `ContentFighter` definition.
+2. Any manual overrides from the user (stat advancements) are applied.
+3. All modifiers from the fighter's equipment, upgrades, and active injuries are collected.
+4. Each stat in the statline is run through the relevant modifiers using the `apply()` method.
+5. If the final value differs from the base, the stat is visually marked as modified in the UI, so users can see at a glance which stats have been changed.
+
+Modifiers from different sources stack. If a fighter has two pieces of equipment that each improve Movement by 1, the fighter's Movement increases by 2 total.
+
+### Weapon Profile Modifications
+
+Weapon stat and trait modifiers work through the `VirtualWeaponProfile` system:
+
+1. When a fighter's equipment assignment includes weapon accessories (or the equipment itself has weapon-level modifiers), the system wraps each weapon profile in a `VirtualWeaponProfile`.
+2. The `VirtualWeaponProfile` applies all `ContentModStat` modifiers to each weapon stat value on initialization.
+3. Trait modifiers (`ContentModTrait`) are applied when the trait list is accessed -- adding traits the weapon does not have, or removing traits it does.
+4. The modified statline and trait list are displayed to the user. Modified stat values are visually highlighted.
+
+### Rules and Skills
+
+`ContentModFighterRule` and `ContentModFighterSkill` modifiers are collected alongside stat modifiers. The application maintains separate lists of rule mods and skill mods and applies them when displaying a fighter's rules and skills. An `add` modifier grants the rule or skill; a `remove` modifier takes it away.
+
+### Skill Tree and Psyker Discipline Access
+
+When a fighter advances, the application determines which skill trees are available as primary or secondary. `ContentModSkillTreeAccess` modifiers adjust these lists. Similarly, `ContentModPsykerDisciplineAccess` modifiers control which psyker disciplines a fighter can access. These modifiers are checked at the point of advancement.
+
+### Equipment vs. Weapon Modifiers
+
+It is important to understand which modifier types belong where:
+
+- **On equipment** (`ContentEquipment.modifiers`): Use fighter-level modifiers -- `ContentModFighterStat`, `ContentModFighterRule`, `ContentModFighterSkill`, `ContentModSkillTreeAccess`, `ContentModPsykerDisciplineAccess`. The admin form for equipment automatically filters the modifier list to show only these types.
+- **On weapon accessories** (`ContentWeaponAccessory.modifiers`): Use weapon-level modifiers -- `ContentModStat` and `ContentModTrait` -- to change weapon profiles. You can also use fighter-level modifiers if the accessory affects the fighter directly.
+- **On equipment upgrades** (`ContentEquipmentUpgrade.modifiers`): Can use any modifier type depending on whether the upgrade affects the weapon or the fighter.
+- **On injuries** (`ContentInjury.modifiers`): Typically use fighter-level modifiers, since injuries affect the fighter rather than individual weapons.
+
+## Common Admin Tasks
+
+### Creating a Weapon Stat Modifier
+
+1. Navigate to the Modifications list and click "Add Modification."
+2. Select "Weapon Stat Modifier" as the type.
+3. Choose the `stat` you want to modify (e.g., Strength).
+4. Set the `mode` to `improve`, `worsen`, or `set`.
+5. Enter the `value` -- for `improve`/`worsen`, this is the numeric amount (e.g., `1` to improve by one step). For `set`, this is the replacement value.
+6. Save the modifier.
+7. Go to the relevant weapon accessory or equipment upgrade and add this modifier to its `modifiers` field.
+
+### Creating a Fighter Stat Modifier
+
+1. Navigate to the Modifications list and click "Add Modification."
+2. Select "Fighter Stat Modifier" as the type.
+3. Choose the `stat` from the dropdown (populated from `ContentStat` definitions).
+4. Set the `mode` and `value`.
+5. Save the modifier.
+6. Attach it to the relevant equipment, equipment upgrade, or injury.
+
+Note: If you try to create a fighter stat modifier that duplicates an existing one (same stat, mode, and value), validation will reject it. Search for the existing modifier and reuse it instead.
+
+### Adding a Trait to a Weapon via an Accessory
+
+1. Create a `ContentModTrait` with `mode=add` and the desired `trait`.
+2. Go to the weapon accessory and add this modifier to its `modifiers` field.
+3. When a user attaches this accessory to a weapon, the trait will appear in the weapon's trait list.
+
+### Modelling an Injury That Reduces a Stat
+
+1. Create a `ContentModFighterStat` with the target `stat`, `mode=worsen`, and the appropriate `value`.
+2. Go to the injury and add this modifier to its `modifiers` field.
+3. When the injury is applied to a fighter in a campaign, the stat reduction will appear on the fighter's statline.
+
+### Modelling Equipment That Grants Skill Tree Access
+
+1. Create a `ContentModSkillTreeAccess` with the target `skill_category` and `mode=add_primary` (or `add_secondary`).
+2. Go to the equipment item and add this modifier to its `modifiers` field.
+3. When a fighter has this equipment, they will gain access to the specified skill tree during advancement.
+
+### Reviewing All Modifiers Attached to an Item
+
+From any equipment, equipment upgrade, weapon accessory, or injury admin page, the `modifiers` field shows all attached modifiers. Each modifier displays a human-readable string describing its effect (e.g., "Improve weapon Strength by 1" or "Add Knockback"). You can click through to edit any modifier directly.
+
+To see all items that use a particular modifier, navigate to the main Modifications list, find the modifier, and check its usage through the related objects.

--- a/docs/content-library/reference-library.md
+++ b/docs/content-library/reference-library.md
@@ -1,0 +1,173 @@
+# Reference Library
+
+## Overview
+
+The Reference Library tracks the published source material behind the game content in Gyrinx. Every fighter type, skill, scenario, and rule in Necromunda originates from a specific book and page number. The Reference Library stores these book and page reference entries so the application can cite them automatically when displaying content to users.
+
+A list represents a user's collection of fighters (called a "gang" in Necromunda). When a user hovers over a fighter type, skill name, or rule on a list or fighter card, the application looks up matching page references and shows a tooltip with the book shortname and page number (for example, "Core p256"). This gives players a quick way to find the original rule text in their physical or digital rulebooks without cluttering the interface.
+
+The Reference Library consists of two active models -- `ContentBook` for publications and `ContentPageRef` for individual page citations -- plus a deprecated `ContentPolicy` model that is no longer in use.
+
+## Key Concepts
+
+**Book** -- A published Necromunda rulebook, supplement, or expansion. Each book has a short identifier (like "Core" or "HoB") used in compact citations.
+
+**Page Reference** -- A pointer to a specific topic within a book, identified by title, page number, and category. Page references can be nested: a parent reference (such as a chapter heading) can have child references (such as individual skills within that chapter) that inherit its page number.
+
+**Category** -- A free-text label on a page reference that groups related entries. Common categories include "Skills", "Fighters", "Scenarios", and "Other". Categories are used to narrow down searches when the application looks up references by title.
+
+**Obsolete Book** -- A book that has been superseded by a newer publication. Marking a book as obsolete does not remove its page references, but signals to administrators that its content may be outdated.
+
+**Book Reference String** -- The compact citation format shown to users, combining a book's `shortname` and resolved page number. For example, a page reference in the Core Rulebook on page 256 produces the string "Core p256".
+
+## Models
+
+### `ContentBook`
+
+Represents a published rulebook or supplement. Books are the top-level organisational unit for all page references.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (255) | Full name of the book (e.g. "Core Rulebook", "House of Blades") |
+| `shortname` | CharField (50) | Abbreviated name used in citations (e.g. "Core", "HoB"). Can be blank |
+| `year` | CharField | Year of publication. Stored as text to allow values like "2018" or ranges |
+| `description` | TextField | Optional longer description of the book's contents |
+| `type` | CharField (50) | Type of publication (e.g. "Rulebook", "Supplement"). Free text |
+| `obsolete` | BooleanField | Whether this book has been superseded by a newer publication. Defaults to `False` |
+
+The string representation of a book displays as `"{name} ({type}, {year})"`, for example "Core Rulebook (Rulebook, 2023)".
+
+Books are ordered alphabetically by `name` in the admin.
+
+**Admin interface:** The `ContentBook` admin includes a search over `title`, `shortname`, and `description`. Each book's detail page shows an inline table of its `ContentPageRef` entries, ordered by page number, so you can see all references for a book at a glance.
+
+### `ContentPageRef`
+
+Represents a reference to a specific topic within a book. This is the core model of the Reference Library -- it connects game content (by title) to a location in a published book (by page number).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `book` | ForeignKey to `ContentBook` | The book this reference belongs to |
+| `title` | CharField (255) | The name of the referenced content, used to match against other entities like skills, fighter types, and rules |
+| `page` | CharField (50) | Page number within the book. Can be blank if the reference inherits its page from a parent |
+| `parent` | ForeignKey to self (nullable) | Optional parent reference, used for hierarchical grouping |
+| `category` | CharField (255) | Grouping label such as "Skills", "Fighters", or "Scenarios". Can be blank |
+| `description` | TextField | Optional description of the referenced content |
+
+The string representation combines all key fields: `"{book.shortname} - {category} - p{resolved_page} - {title}"`, for example "Core - Skills - p256 - Agility".
+
+Default ordering is by `category`, then `book name`, then `title`.
+
+#### Hierarchical Structure
+
+Page references support a parent-child relationship through the `parent` field. This is useful when a section of a book covers multiple related items on the same page. For example:
+
+- A parent reference titled "Agility Skills" might point to page 256 of the Core Rulebook.
+- Child references for individual skills ("Catfall", "Dodge", "Sprint") can omit their `page` field and inherit page 256 from the parent.
+
+This avoids duplicating page numbers across many entries and keeps maintenance simpler when page numbers change in a new printing.
+
+#### Key Methods
+
+**`resolve_page()`** -- Returns the page number for this reference. If the `page` field is set, it returns that value directly. If `page` is blank, it walks up the parent chain to find a page number. Returns `None` if no page can be resolved at any level.
+
+**`bookref()`** -- Returns a compact human-readable citation string. Combines the book's `shortname` with the resolved page number, producing output like "Core p256" or "HoB p42". This is the format users see in tooltips.
+
+**`children_ordered()`** -- Returns the child references of this page reference that have an explicit `page` value, ordered with Core Rulebook entries first, then alphabetically by book shortname, then numerically by page number, then by title.
+
+**`children_no_page()`** -- Returns child references that do not have a page value (they inherit from this parent), ordered by book shortname and title.
+
+**`find_similar(title, **kwargs)`** -- A class method that searches for page references whose titles contain the given string (case-insensitive). Accepts additional filter keyword arguments such as `category="Skills"`. Results are cached in a dedicated `content_page_ref_cache` to avoid repeated database lookups, since page references rarely change.
+
+**`all_ordered()`** -- A class method that returns all top-level page references (those without a parent) that have an explicit page number. Results are ordered with Core Rulebook entries first, then by book shortname, then numerically by page number.
+
+**`find()`** -- A class method that returns the first page reference matching the given filter arguments, or `None`.
+
+**Admin interface:** The `ContentPageRef` admin includes search over `title`, `page`, and `description`. Each page reference's detail page shows an inline table of its child references, allowing you to manage the hierarchy from either direction -- from the book down, or from a parent reference down.
+
+### `ContentPolicy` (Deprecated)
+
+**Deprecated:** `ContentPolicy` is no longer in active use. Do not create new policy records. This model is retained for historical data only.
+
+`ContentPolicy` was designed to capture rules for restricting or allowing certain equipment to specific fighters. It is not currently in use and is considered legacy code.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter this policy applies to |
+| `rules` | JSONField | A JSON structure of allow/deny rules for equipment |
+
+The `rules` field was intended to hold a list of rule objects with `allow` and `deny` keys, each containing equipment category and name filters. The `allows()` method evaluates these rules in reverse order to determine whether a piece of equipment is permitted for the fighter.
+
+This model should be treated as read-only. Equipment availability is now managed through the Equipment List system described in other areas of the content library documentation.
+
+## How It Works in the Application
+
+### Tooltip Citations
+
+The primary user-facing feature powered by the Reference Library is the `{% ref %}` template tag. When the application renders a fighter card, skill name, or rule, it wraps the text in a call to this tag. The tag works as follows:
+
+1. It takes the displayed text (such as a skill name "Agility" or a fighter type "Charter Master") and searches for matching `ContentPageRef` entries using `find_similar()`.
+2. If matches are found, it calls `bookref()` on each matching reference to build a citation string (e.g. "Core p256").
+3. It wraps the original text in a `<span>` with a Bootstrap tooltip containing the citation string.
+4. When the user hovers over the text, they see where to find the rule in their rulebook.
+
+If multiple books contain a reference with the same title (for example, "Settlement Raid" appears in both the Core Rulebook and Book of the Outcast), the tooltip shows all matching citations separated by commas.
+
+The tag caches its results so that repeated lookups for the same text within a page do not cause additional database queries.
+
+### Where Tooltips Appear
+
+- **Fighter type names** on fighter cards (e.g. hovering over "Prospector Digger" shows the book reference)
+- **Skill names** in a fighter's skill list
+- **Rule names** in a fighter's special rules section
+
+Tooltips are only rendered in the interactive web view. When content is displayed in print mode, the raw text is shown without tooltip markup.
+
+### Visual Styling
+
+Referenced text is styled with an underline decoration (using the `tooltipped` CSS class) to indicate that hovering will reveal a citation. This gives users a subtle visual cue that source information is available without adding visual clutter.
+
+## Common Admin Tasks
+
+### Adding a New Book
+
+1. Navigate to the Book list in the admin.
+2. Click "Add Book".
+3. Fill in the `name` (full title), `shortname` (abbreviated form for citations), `year`, and `type`.
+4. Leave `obsolete` unchecked unless you are adding a historical reference that has been replaced.
+5. Save the book. You can then add page references either through the inline on the book's detail page or through the Page Reference list.
+
+When choosing a `shortname`, keep it short and distinctive. Existing conventions include "Core" for the Core Rulebook and abbreviations like "HoB" (House of Blades), "HoC" (House of Chains), and "Outcast" (Book of the Outcast). The shortname appears directly in user-facing tooltips.
+
+### Adding Page References
+
+**From a book's detail page:** Open the book in the admin. At the bottom you will see the "Page References" inline. Add rows with the `title`, `page` number, `category`, and optional `description`. This is the fastest way to add multiple references for the same book.
+
+**From the Page Reference list:** Navigate to the Page Reference list, click "Add Page Reference", and fill in all fields including the `book` selection. This approach is useful when you need to set a `parent` reference, which is not available in the book inline.
+
+### Creating Hierarchical References
+
+To group several related references under a single parent:
+
+1. Create the parent reference first, setting its `title` (e.g. "Agility Skills"), `book`, `page`, and `category`.
+2. Save the parent.
+3. Create child references for each individual item. Set their `title`, `book`, and `category`, but leave the `page` field blank. Select the parent reference in the `parent` dropdown.
+4. The children will automatically inherit the page number from the parent when displayed.
+
+You can also add children directly from a parent's detail page using the inline table.
+
+### Marking a Book as Obsolete
+
+Open the book in the admin and check the `obsolete` field. This flags the book for administrators but does not remove or hide its page references. You may want to review whether any page references from the obsolete book should be replaced with references to a newer publication.
+
+### Finding and Updating References
+
+The Page Reference admin supports search by `title`, `page`, and `description`. If you need to update page numbers after a new printing, search for the book's references, update the parent references first (since children inherit from them), and the child page numbers will update automatically.
+
+### Understanding the Title Matching
+
+The `title` field on a page reference is the key used for matching against content displayed in the application. When the `{% ref %}` template tag looks up "Agility", it searches for page references whose title contains "Agility" (case-insensitive). To ensure accurate matches:
+
+- Use the exact name as it appears in the game content. For fighter types, use the full type name (e.g. "Ironhead Squat Prospectors Charter Master").
+- Use the `category` field to disambiguate when the same title might appear in multiple contexts.
+- Be aware that partial matches will also be returned. A reference titled "Spring" would match a search for "Sprint" through substring matching.

--- a/docs/content-library/skills-rules-and-psyker-powers.md
+++ b/docs/content-library/skills-rules-and-psyker-powers.md
@@ -1,0 +1,241 @@
+# Skills, Rules & Psyker Powers
+
+## Overview
+
+Skills, rules, and psyker powers are the three categories of special abilities that define what a fighter can do beyond their base statistics and equipment. In Gyrinx, a list represents a user's collection of fighters (called a "gang" in Necromunda). Together, these abilities capture the narrative and mechanical identity of each fighter archetype in the content library.
+
+Skills represent trained abilities grouped into themed categories (called skill trees) such as Agility, Brawn, or Combat. Rules represent special rules and abilities inherent to certain fighter types -- things like "Psyker", "Gang Fighter", or faction-specific traits. Psyker powers are supernatural abilities available only to fighters with one of the psyker rules, organised into thematic disciplines.
+
+Content configured in this area flows directly into what users see on their fighter cards. When a user views a fighter in their list, the card displays the fighter's rules, skills, and (for psykers) powers. Users can also add, remove, enable, or disable these abilities on their own fighters, with the content library providing both the defaults and the full catalogue of available options.
+
+## Key Concepts
+
+**Skill tree** -- A category of skills (e.g., Agility, Brawn, Combat). Referred to as "Skill Tree" in the admin interface. Each skill belongs to exactly one tree.
+
+**Primary skill tree** -- A skill tree that a fighter type has full access to. During advancement, primary skills are typically easier or cheaper to acquire.
+
+**Secondary skill tree** -- A skill tree that a fighter type has limited access to. Secondary skills are typically harder to acquire during advancement.
+
+**Default skill** -- A skill that comes pre-assigned to a fighter type by the content library. Users can disable but not permanently remove default skills.
+
+**Rule** -- A named special ability or trait assigned to a fighter type. Rules are simpler than skills -- they have no category hierarchy, just a name.
+
+**Psyker** -- A fighter who possesses one of the psyker rules ("Psyker", "Non-Sanctioned Psyker", or "Sanctioned Psyker"). Psyker status is derived automatically from the fighter's rules, not set as a separate flag.
+
+**Discipline** -- A thematic grouping of psyker powers, such as Telekinesis or Pyromancy.
+
+**Generic discipline** -- A discipline that any psyker can access, regardless of their fighter type. Generic disciplines cannot be directly assigned to a `ContentFighter` -- they are available to all psykers automatically.
+
+## Models
+
+### `ContentSkillCategory` (Skill Tree)
+
+Represents a category or tree of skills. Skill trees organise individual skills into themed groups and determine which fighter types can access them.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (unique) | The name of the skill tree (e.g., "Agility", "Brawn", "Combat"). |
+| `restricted` | BooleanField | If checked, this skill tree is only available to specific lists. Unrestricted trees are available to all fighters. |
+
+**Admin interface:** The admin page for a skill tree shows its skills as an inline table, so you can manage the tree and all its skills in one place. You can search by name and see the `restricted` flag in the list view.
+
+### `ContentSkill`
+
+Represents an individual skill within a skill tree.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField | The name of the skill (e.g., "Catfall", "Iron Jaw"). |
+| `category` | ForeignKey to `ContentSkillCategory` | The skill tree this skill belongs to. Displayed as "tree" in the admin. |
+
+**Constraints:** A skill name must be unique within its tree (`unique_together` on `name` and `category`).
+
+**Admin interface:** Skills can be searched by name or tree name, and filtered by tree. Skills are also shown inline when editing a skill tree.
+
+### `ContentRule`
+
+Represents a named special rule or ability from the game system.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField | The name of the rule (e.g., "Psyker", "Gang Fighter", "Mounted"). |
+
+Rules are intentionally simple -- just a name. The game semantics of each rule are understood by the players and the application; the content library just needs to track which rules exist and which fighters have them.
+
+Certain rule names have special significance in the application. The names `Psyker`, `Non-Sanctioned Psyker`, and `Sanctioned Psyker` (case-insensitive) determine whether a fighter is considered a psyker, which unlocks the psyker powers section of their fighter card.
+
+**Admin interface:** Rules have a simple admin with search by name.
+
+### `ContentPsykerDiscipline`
+
+Represents a discipline (themed grouping) of psyker powers.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (unique) | The name of the discipline (e.g., "Telekinesis", "Pyromancy"). |
+| `generic` | BooleanField | If checked, this discipline is available to any psyker fighter, not just those with an explicit assignment. |
+
+**The `generic` flag:** Generic disciplines serve as a shared pool of powers available to all psykers. Because they are universally available, they cannot be assigned to individual fighter types via `ContentFighterPsykerDisciplineAssignment` -- attempting to do so will raise a validation error. Non-generic disciplines must be explicitly assigned to fighter types that should have access to them.
+
+**Admin interface:** Disciplines are listed with search by name and a filter on the `generic` flag. Editing a discipline shows its powers as an inline table.
+
+### `ContentPsykerPower`
+
+Represents a specific power within a psyker discipline.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField | The name of the power. |
+| `discipline` | ForeignKey to `ContentPsykerDiscipline` | The discipline this power belongs to. |
+
+**Constraints:** A power name must be unique within its discipline (`unique_together` on `name` and `discipline`).
+
+**Admin interface:** Powers are primarily managed inline when editing their parent discipline. They can also be managed via the standalone admin, which groups powers by discipline name in the selection dropdown.
+
+### `ContentFighterPsykerDisciplineAssignment`
+
+Links a `ContentFighter` to a `ContentPsykerDiscipline`, indicating that fighters of this type have access to powers from this discipline.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter type receiving discipline access. |
+| `discipline` | ForeignKey to `ContentPsykerDiscipline` | The discipline being granted. |
+
+**Validation rules:**
+
+- You cannot assign a generic discipline to a fighter. Generic disciplines are automatically available to all psykers and should not be assigned individually. Attempting this raises a validation error.
+
+**Constraints:** Each fighter-discipline combination must be unique (`unique_together` on `fighter` and `discipline`).
+
+**Admin interface:** Discipline assignments are managed as inline rows when editing a `ContentFighter`. They can also be managed through a standalone admin page with autocomplete for both fighter and discipline, plus search and filter capabilities.
+
+### `ContentFighterPsykerPowerDefaultAssignment`
+
+Assigns a specific psyker power as a default for a fighter type. Default powers are automatically available to users' fighters of this type.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fighter` | ForeignKey to `ContentFighter` | The fighter type that starts with this power. |
+| `psyker_power` | ForeignKey to `ContentPsykerPower` | The power assigned by default. |
+
+**Validation rules:**
+
+- You cannot assign a default power to a non-psyker fighter. The fighter must have one of the psyker rules for this assignment to be valid.
+
+**Constraints:** Each fighter-power combination must be unique (`unique_together` on `fighter` and `psyker_power`).
+
+**Admin interface:** Default power assignments are managed as inline rows when editing a `ContentFighter`, with powers grouped by discipline name in the dropdown. They can also be managed through a standalone admin page with search and filter by fighter type and discipline.
+
+## Fighter Relationships to Skills, Rules & Powers
+
+The `ContentFighter` model ties all of these systems together through several fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `skills` | ManyToManyField to `ContentSkill` | Default skills that come with this fighter type (labelled "Default Skills" in the admin). |
+| `primary_skill_categories` | ManyToManyField to `ContentSkillCategory` | Skill trees where this fighter has primary access (labelled "Primary Skill Trees"). |
+| `secondary_skill_categories` | ManyToManyField to `ContentSkillCategory` | Skill trees where this fighter has secondary access (labelled "Secondary Skill Trees"). |
+| `rules` | ManyToManyField to `ContentRule` | Special rules assigned to this fighter type. |
+| `hide_skills` | BooleanField | If checked, the skills section is hidden on the fighter card. Useful for fighter types where skills are not relevant, such as exotic beasts or similar. |
+
+**Psyker detection:** A fighter is considered a psyker if any of its rules (case-insensitive) match "Psyker", "Non-Sanctioned Psyker", or "Sanctioned Psyker". This check is performed automatically -- there is no separate "is psyker" checkbox.
+
+## How It Works in the Application
+
+### Fighter Cards
+
+When a user views a fighter in their list, the fighter card displays:
+
+- **Rules** -- Always shown. Lists the fighter's rules, including defaults from the content library, custom user-added rules, and any rules added or removed by equipment modifiers. Users with edit access see an "Edit" or "Add" link to manage rules.
+- **Skills** -- Shown unless the `hide_skills` flag is set on the fighter's `ContentFighter`. Lists default skills and user-added skills, with equipment modifiers applied. Users with edit access can add or edit skills.
+- **Powers** -- Only shown if the fighter is a psyker. Lists default powers and user-assigned powers, with a link to manage them.
+
+### Editing Skills
+
+The skills editing page for a fighter shows three sections:
+
+1. **Default Skills** -- Skills that come from the `ContentFighter` template. Users can disable these (shown with strikethrough styling) or re-enable them, but cannot permanently remove them.
+2. **User-added Skills** -- Skills the user has manually added. These can be fully removed.
+3. **Skill Categories** -- A browsable grid of all available skill trees and their skills. Each tree is labelled as "Primary" or "Secondary" based on the fighter's content configuration. The page supports filtering by primary/secondary status and searching by skill name.
+
+### Editing Rules
+
+The rules editing page shows:
+
+1. **Default Rules** -- Rules from the `ContentFighter` template. These can be disabled or re-enabled.
+2. **User-added Rules** -- Rules manually added by the user, which can be removed.
+3. **Add Rules** -- A searchable, paginated list of all available rules that can be added to the fighter.
+
+### Editing Psyker Powers
+
+Only available for fighters with a psyker rule. The powers editing page shows:
+
+1. **Current Psyker Powers** -- All currently assigned powers, with each marked as "Default" if it comes from the content library. Default powers can be disabled; user-added powers can be removed.
+2. **Available Disciplines** -- A browsable grid of disciplines and their powers. This includes both the fighter's explicitly assigned disciplines and any generic disciplines. Powers can be searched and added from here.
+
+### Skill Tree Access and Equipment Modifiers
+
+The skill trees a fighter can access are not fixed -- they can be modified by equipment. The modifier system includes `ContentModSkillTreeAccess`, which can add or remove primary/secondary skill tree access, and `ContentModPsykerDisciplineAccess`, which can add or remove psyker discipline access. This means equipping certain items can grant a fighter access to new skill trees or psyker disciplines. See [Modifiers](modifiers.md) for details on how `ContentModSkillTreeAccess` and `ContentModPsykerDisciplineAccess` work.
+
+Similarly, `ContentModFighterRule` can add or remove rules from a fighter via equipment, and `ContentModFighterSkill` can add or remove specific skills. These modifiers are applied automatically when the user equips or unequips items.
+
+## Common Admin Tasks
+
+### Adding a new skill tree
+
+1. Open the Skill Trees admin.
+2. Click "Add Skill Tree".
+3. Enter the tree name (e.g., "Savant").
+4. Set `restricted` if this tree should only be available to certain lists.
+5. Save, then use the inline table to add individual skills to the tree.
+
+### Assigning skill trees to a fighter type
+
+1. Open the Fighters admin and find the fighter type.
+2. In the "Primary Skill Trees" and "Secondary Skill Trees" fields, select the appropriate trees.
+3. Save. Users creating fighters of this type will now see those trees labelled as primary or secondary on the skills editing page.
+
+### Adding default skills to a fighter type
+
+1. Open the Fighters admin and find the fighter type.
+2. In the "Default Skills" field, select the skills that should come pre-assigned.
+3. Save. These skills will appear automatically on every user's fighter of this type.
+
+### Adding a new rule
+
+1. Open the Rules admin.
+2. Click "Add Rule".
+3. Enter the rule name exactly as it appears in the game system.
+4. Save. The rule is now available for assignment to fighter types or for users to add to their fighters.
+
+Be careful with the names "Psyker", "Non-Sanctioned Psyker", and "Sanctioned Psyker" -- assigning any of these rules to a fighter type causes the application to treat that fighter as a psyker, which enables the powers section on the fighter card.
+
+### Setting up a new psyker discipline
+
+1. Open the Psyker Disciplines admin.
+2. Click "Add Psyker Discipline".
+3. Enter the discipline name.
+4. Set `generic` if this discipline should be available to all psykers. Leave unchecked if it should only be available to specifically assigned fighter types.
+5. Save, then use the inline table to add individual powers to the discipline.
+
+### Assigning a discipline to a fighter type
+
+1. Open the Fighters admin and find the fighter type.
+2. In the inline section "Fighter Psyker Disciplines", add a new row and select the discipline.
+3. You cannot assign generic disciplines here -- they are available to all psykers automatically.
+4. Save.
+
+### Assigning default psyker powers to a fighter type
+
+1. Open the Fighters admin and find the fighter type.
+2. The fighter must have a psyker rule (e.g., "Psyker") in its rules. If it does not, you will get a validation error.
+3. In the inline section for default psyker power assignments, add rows and select powers. Powers are grouped by discipline in the dropdown.
+4. Save. Users' fighters of this type will start with these powers pre-assigned.
+
+### Hiding the skills section for a fighter type
+
+Some fighter types (such as exotic beasts or vehicles) do not use skills. To hide the skills section from their fighter cards:
+
+1. Open the Fighters admin and find the fighter type.
+2. Check the `hide_skills` flag.
+3. Save. The skills row will no longer appear on fighter cards of this type.

--- a/docs/content-library/stats-and-statlines.md
+++ b/docs/content-library/stats-and-statlines.md
@@ -1,0 +1,243 @@
+# Stats & Statlines
+
+## Overview
+
+Stats and statlines define the numerical characteristics of fighters in Necromunda -- values like Movement, Weapon Skill, Toughness, and so on. In Gyrinx, a list represents a user's collection of fighters (called a "gang" in Necromunda). These stats are managed through a flexible content library system that supports both the standard twelve-stat fighter profile and entirely custom stat layouts for non-standard units like vehicles.
+
+The stats system has two layers. The first is a set of individual stat definitions (`ContentStat`) that describe what each stat means and how it should be displayed. The second is a statline composition system that groups those stats into ordered layouts (`ContentStatlineType`) and assigns concrete values to specific fighters (`ContentStatline`). This separation means you define a stat like "Front Toughness" once, then reuse it across multiple statline types without duplication.
+
+When users view their fighters in the application, the statline appears as a compact table at the top of each fighter card. Stats are displayed with short abbreviations as column headers (M, WS, BS, etc.) and the corresponding values below. Some stats are visually highlighted, and visual group separators can break the statline into logical sections. The stat display properties you configure here directly control how equipment modifiers and advancements calculate and format their effects.
+
+## Key Concepts
+
+**Stat** -- A single measurable characteristic, such as Movement or Weapon Skill. Each stat has display properties that tell the system how to format its values and how modifiers should be applied.
+
+**Statline Type** -- A template that defines which stats appear in a statline and in what order. For example, the standard fighter statline type includes M, WS, BS, S, T, W, I, A, Ld, Cl, Wil, and Int. A vehicle statline type might include different stats like Front Toughness, Side Toughness, and Rear Toughness.
+
+**Statline** -- A concrete set of stat values assigned to a specific `ContentFighter`. It links a fighter to a statline type and stores the actual numeric values for each stat in that type.
+
+**Legacy Statline** -- The original system where stat values are stored as direct fields on `ContentFighter` (e.g., `movement`, `weapon_skill`). This still works and is the default for fighters that do not have a custom statline assigned. Most standard fighters use this approach.
+
+**Custom Statline** -- The newer system where stat values are stored in separate `ContentStatline` and `ContentStatlineStat` records. This is required for fighters whose stats do not match the standard twelve-stat layout, such as vehicles.
+
+## Models
+
+### `ContentStat`
+
+Represents a single stat definition that can be shared across multiple statline types. This is the canonical source of truth for what a stat is, how it is abbreviated, and how its values should be formatted and modified.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `field_name` | CharField (unique) | Internal identifier, auto-generated from `full_name` on first save (e.g., `movement`, `front_toughness`). Read-only in admin. |
+| `short_name` | CharField | Short display abbreviation shown in stat table headers (e.g., `M`, `WS`, `Fr`). |
+| `full_name` | CharField | Full human-readable name (e.g., `Movement`, `Weapon Skill`, `Front Toughness`). |
+| `is_inverted` | BooleanField | When true, "improving" this stat means decreasing the number. Used for target-roll stats like Cool, where 3+ is better than 4+. This flag controls modifier direction. |
+| `is_inches` | BooleanField | When true, values are displayed with a trailing quote mark to indicate inches (e.g., `5"`). |
+| `is_modifier` | BooleanField | When true, values are displayed with a plus prefix for positive numbers (e.g., `+3`). Used for accuracy-style modifiers. |
+| `is_target` | BooleanField | When true, values are displayed with a trailing plus to indicate a target roll (e.g., `3+`). |
+
+The four display-property flags (`is_inverted`, `is_inches`, `is_modifier`, `is_target`) serve two purposes. First, they control how stat values are formatted when displayed. Second, and more importantly, they tell the modifier system how to correctly apply "improve" and "worsen" effects. For example, if `is_inverted` is true, an "improve" modifier will subtract from the value rather than add to it, because a lower number is better for that stat.
+
+The `field_name` is auto-generated from `full_name` when first saved: the name is lowercased, non-alphanumeric characters are replaced with underscores, and multiple underscores are collapsed. Once created, it is read-only in the admin interface and serves as the stable identifier used throughout the system.
+
+**Admin interface:** Searchable by `field_name`, `short_name`, and `full_name`. The list view shows all three name fields. The `field_name` field is read-only since it is auto-generated.
+
+### `ContentStatlineType`
+
+Defines a type of statline -- essentially a named template for a particular layout of stats. Different fighter categories can use different statline types.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField (unique) | The name of this statline type (e.g., `Fighter`, `Vehicle`, `Crew`). |
+
+A statline type on its own is just a name. Its stats are defined through `ContentStatlineTypeStat` records, which are managed as inlines on the statline type's admin page.
+
+**Admin interface:** Searchable by name. The list view shows the name and a count of how many stats belong to the type. The stat composition is managed through an inline table directly on the statline type edit page.
+
+### `ContentStatlineTypeStat`
+
+Links a `ContentStat` to a `ContentStatlineType` with positioning and visual display settings. This is the join table that defines which stats appear in a statline type and how they are arranged.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `statline_type` | ForeignKey to `ContentStatlineType` | The statline type this stat belongs to. |
+| `stat` | ForeignKey to `ContentStat` | The stat definition being included. |
+| `position` | IntegerField | Display order position. Lower numbers appear first (leftmost in the stat table). |
+| `is_highlighted` | BooleanField | Whether this stat gets a highlighted background in the UI. In the standard fighter statline, Ld, Cl, Wil, and Int are highlighted. |
+| `is_first_of_group` | BooleanField | Whether this stat starts a new visual group, which adds a left border separator in the display. Used to visually separate stat clusters. |
+
+Each stat can only appear once per statline type (enforced by the `unique_together` constraint on `statline_type` and `stat`). Records are ordered by `statline_type` then `position`.
+
+This model also exposes `field_name`, `short_name`, and `full_name` as properties that delegate to the underlying `ContentStat`, making it convenient to access stat details without an extra lookup.
+
+**Admin interface:** Managed as an inline on `ContentStatlineType`. The inline shows the stat dropdown, position, highlighting toggle, and group-start toggle, ordered by position.
+
+### `ContentStatline`
+
+Assigns a statline type to a specific `ContentFighter` and serves as the container for that fighter's stat values. Each fighter can have at most one custom statline (enforced as a `OneToOneField`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `content_fighter` | OneToOneField to `ContentFighter` | The fighter this statline belongs to. Accessed via `content_fighter.custom_statline`. |
+| `statline_type` | ForeignKey to `ContentStatlineType` | The type of statline, which determines which stats need values. |
+
+When you save a `ContentStatline` in the admin, the system automatically creates `ContentStatlineStat` entries with a default value of `-` for any stats required by the statline type that do not already have values. This means you can create the statline, save it, and then fill in the actual values.
+
+Validation on existing statlines checks that all stats required by the statline type have corresponding `ContentStatlineStat` records. This validation is skipped during initial creation since the stat records are created after the statline is saved.
+
+**Admin interface:** Searchable by fighter type and statline type name. Filterable by statline type. The list view shows the fighter and statline type. Stat values are managed through the `ContentStatlineStat` inline. The fighter field uses autocomplete. The statline is also available as an inline on the `ContentFighter` admin page, limited to one per fighter.
+
+### `ContentStatlineStat`
+
+Stores a single stat value within a `ContentStatline`. This is where the actual numbers live for fighters using the custom statline system.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `statline` | ForeignKey to `ContentStatline` | The statline this value belongs to. |
+| `statline_type_stat` | ForeignKey to `ContentStatlineTypeStat` | The stat position within the statline type that this value corresponds to. |
+| `value` | CharField | The stat value as a string (e.g., `5"`, `12`, `4+`, `-`). Values are stored as-is and include any formatting characters. |
+
+Each stat can only have one value per statline (enforced by `unique_together` on `statline` and `statline_type_stat`). Records are ordered by the `position` of their `statline_type_stat`.
+
+The value field accepts any string up to 10 characters. You should include the appropriate formatting in the value itself (e.g., `5"` for an inches stat, `4+` for a target roll). The display properties on `ContentStat` are primarily used by the modifier system for calculations, not for formatting stored values.
+
+Smart quotes are validated against and rejected in the admin form -- always use straight quote marks (`"`) rather than curly quotes.
+
+**Admin interface:** Managed as an inline on `ContentStatline`. The inline shows the stat dropdown (filtered to only show stats valid for the parent statline's type) and the value field. When editing, the stat dropdown is automatically filtered based on the statline type.
+
+## The Two-Tier Stat System
+
+Gyrinx supports two ways of defining a fighter's stats, and the system transparently handles both.
+
+### Legacy Direct Fields
+
+The `ContentFighter` model has twelve built-in stat fields: `movement`, `weapon_skill`, `ballistic_skill`, `strength`, `toughness`, `wounds`, `initiative`, `attacks`, `leadership`, `cool`, `willpower`, and `intelligence`. These are simple `CharField` fields directly on the fighter.
+
+When a fighter does not have a `ContentStatline` assigned, the system uses these fields to build the statline display. The legacy system hardcodes the stat order, and it always highlights Leadership, Cool, Willpower, and Intelligence as a group. It also hardcodes that Leadership starts a new visual group.
+
+This is the simpler approach and works well for the vast majority of fighters that follow the standard Necromunda stat profile.
+
+### Custom Statlines
+
+When a fighter has a `ContentStatline` assigned (accessible via `content_fighter.custom_statline`), the system uses that instead of the legacy fields. The custom statline pulls its stats, their order, highlighting, and grouping from the associated `ContentStatlineType`.
+
+This approach is necessary for units that have a different set of stats, such as vehicles with Front/Side/Rear Toughness values, or crew members with a reduced stat profile.
+
+### How the System Chooses
+
+When rendering a fighter's stats, the `ContentFighter.statline()` method first checks for a `custom_statline`. If one exists, it builds the stat list from `ContentStatlineStat` records. If not, it falls back to `_legacy_statline()`, which reads the twelve direct fields. This check is automatic and transparent -- you simply assign or remove a custom statline, and the display updates accordingly.
+
+## Display Dataclasses
+
+Two dataclasses are used to structure stat and rule data for template rendering.
+
+**`StatlineDisplay`** represents a single stat for display in the fighter card template:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `name` | str | Short display name (e.g., `M`, `WS`). |
+| `field_name` | str | Internal field name, used for matching overrides and modifiers. |
+| `value` | str | The displayed value, after applying overrides and modifiers. |
+| `classes` | str | CSS classes for display, such as `border-start` for group separators. |
+| `modded` | bool | Whether the value has been modified from the base value by equipment, upgrades, or manual overrides. When true, the value is displayed with a tooltip indicating it has been modified. |
+| `highlight` | bool | Whether the stat should have a highlighted background. |
+
+**`RulelineDisplay`** represents a single rule for display:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `value` | str | The rule text. |
+| `modded` | bool | Whether this rule was added by a modifier. |
+
+## How It Works in the Application
+
+### Fighter Cards
+
+When a user views their list, each fighter card shows a stat table at the top. The table header row displays the stat short names (M, WS, BS, etc.) and the body row shows the values. Stats marked as `is_highlighted` through the statline type get a subtle warning-coloured background. Stats marked as `is_first_of_group` get a left border to visually separate stat clusters.
+
+If any stat has been modified (by equipment modifiers, advancements, or manual overrides), the value appears with a tooltip indicating it has been changed from the base value.
+
+### Stat Overrides
+
+Users can manually override stat values for their fighters through the "Edit Stats" interface. The system handles this differently depending on the statline type:
+
+- **Legacy statline fighters:** Overrides are stored in `_override` fields directly on `ListFighter` (e.g., `movement_override`, `weapon_skill_override`). A non-empty override replaces the base value from `ContentFighter`.
+- **Custom statline fighters:** Overrides are stored as `ListFighterStatOverride` records, which reference the specific `ContentStatlineTypeStat` being overridden.
+
+### Equipment Modifiers
+
+Equipment and weapon accessories can include `ContentModFighterStat` modifiers that alter a fighter's stats. These modifiers reference stats by `field_name` and use the display properties (`is_inverted`, `is_inches`, `is_modifier`, `is_target`) from `ContentStat` to determine how to correctly apply their effects.
+
+For example, a modifier that "improves" Weapon Skill by 1 will subtract 1 from the value (because WS is `is_inverted` -- a lower target roll is better), and the result will be formatted with a trailing `+` (because WS is `is_target`).
+
+### Performance
+
+The custom statline system involves several related models and can be expensive to compute naively. In the application, the `ListFighter` queryset uses subqueries and annotations to pre-load custom statline data in a single query pass. The `annotated_content_fighter_statline` annotation fetches the full statline as a JSON array, avoiding N+1 query issues when rendering lists of fighters.
+
+## Common Admin Tasks
+
+### Defining a New Stat
+
+1. Navigate to the Stats list in the admin.
+2. Click "Add Stat".
+3. Enter the `short_name` (e.g., `Fr`) and `full_name` (e.g., `Front Toughness`). The `field_name` will be auto-generated (e.g., `front_toughness`).
+4. Set the display property flags as appropriate. For a toughness-like stat that is just a plain number, leave all four flags unchecked. For a target-roll stat like Weapon Skill, check `is_inverted` and `is_target`.
+5. Save.
+
+### Creating a New Statline Type
+
+1. Navigate to the Statline Types list in the admin.
+2. Click "Add Statline Type" and give it a descriptive name (e.g., `Vehicle`).
+3. Save it once to create the record.
+4. Use the inline table to add stats. For each stat, select the `ContentStat` from the dropdown, set its `position` (starting from 0 or 1), and optionally mark it as highlighted or as the start of a new visual group.
+5. Save.
+
+The stats will appear in the order defined by `position`, from left to right in the stat table.
+
+### Assigning a Custom Statline to a Fighter
+
+You can do this from either the fighter's admin page or the statline admin:
+
+**From the fighter page:**
+
+1. Navigate to the fighter in the Content Fighters admin.
+2. In the "Fighter Statline" inline section, select the statline type from the dropdown.
+3. Save. The system will automatically create stat value entries with `-` as the default value.
+4. Navigate to the created statline (via the change link in the inline) to enter the actual stat values.
+
+**From the statline admin:**
+
+1. Navigate to the Fighter Statlines list.
+2. Click "Add Fighter Statline".
+3. Select the fighter (via autocomplete) and the statline type.
+4. Save. Default stat entries are created automatically.
+5. Fill in the stat values in the inline table and save again.
+
+### Updating Stat Values
+
+1. Navigate to the Fighter Statlines list and find the statline for the fighter you want to update.
+2. Edit the `value` field for the relevant stats in the inline table.
+3. Save.
+
+Remember that values are stored as display strings. Enter them exactly as they should appear (e.g., `5"` for an inches value, `4+` for a target roll, `3` for a plain number, `-` for no value).
+
+### Removing a Custom Statline
+
+If you delete a fighter's `ContentStatline`, the fighter will fall back to using the legacy direct stat fields. Make sure the legacy fields have appropriate values if you do this.
+
+1. Navigate to the fighter in the Content Fighters admin.
+2. Check the delete checkbox on the "Fighter Statline" inline.
+3. Save.
+
+### Setting Display Properties for Correct Modifier Behaviour
+
+The display flags on `ContentStat` are critical for the modifier system to work correctly. Here is a guide for common stat types:
+
+| Stat Type | `is_inverted` | `is_inches` | `is_modifier` | `is_target` | Example |
+|-----------|:---:|:---:|:---:|:---:|---------|
+| Distance | No | Yes | No | No | Movement `5"` |
+| Plain number | No | No | No | No | Strength `4`, Wounds `2` |
+| Target roll | Yes | No | No | Yes | WS `3+`, BS `4+`, Cool `5+` |
+| Roll modifier | No | No | Yes | No | Accuracy `+1` |
+
+Getting these flags right ensures that when equipment or advancements modify a stat, the system correctly determines whether to add or subtract, and how to format the result.


### PR DESCRIPTION
## Summary

- Add 13 documentation files covering every content model area in the content library (houses, fighters, stats, skills/rules/psyker powers, equipment, equipment availability, equipment list expansions, modifiers, injuries, gang attributes, advancements, content packs, reference library)
- Each document covers models, fields, admin interface configuration, user-facing behaviour, and common admin tasks
- Add an index page (`docs/content-library/README.md`) and integrate into GitBook via `SUMMARY.md`

## Test plan

- [ ] Verify GitBook builds and renders the new Content Library section
- [ ] Spot-check field tables against actual model definitions
- [ ] Verify cross-references between documents resolve correctly