### PR TITLE
Add weekly Claude content library docs update workflow

### DIFF
--- a/.github/workflows/claude-docs-update.yml
+++ b/.github/workflows/claude-docs-update.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -135,7 +136,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "github-merge-queue[bot]"
-          direct_prompt: true
 
           claude_args: |
             --model claude-opus-4-6
@@ -237,10 +237,13 @@ jobs:
                  the changes
                - Label: "documentation"
 
-            If `./scripts/fmt.sh` modifies any files, stage those changes too before committing.
+            If `./scripts/fmt.sh` modifies any documentation files, stage those changes too before committing.
+            Otherwise ignore the formatting changes.
+
+            Before commit, use `git diff --name-only` to verify it contains only paths under docs/ or CLAUDE.md files.
 
             IMPORTANT:
-            - Only modify files under docs/. Never modify source code.
+            - Only modify files under docs/ or CLAUDE.md. Never modify source code.
             - If you're unsure whether a change warrants documentation, err on the side of
               documenting it.
             - Read the actual source code to understand what changed; don't rely solely on PR


### PR DESCRIPTION
## Summary

- Adds a new GitHub Action that runs every Sunday at 9am UTC to automatically maintain content library documentation
- Reviews PRs merged in the past week, identifies documentation gaps in `docs/content-library/`, and creates a PR with updates
- Uses `claude-code-action` with Opus to read source code and write docs matching the existing style

## How it works

1. A shell step fetches merged PRs from the last 7 days via `gh pr list`
2. If no PRs were merged, the workflow exits early (no Claude API cost)
3. Claude reads the PR data, existing docs, and relevant source code
4. Claude decides what needs updating or creating, writes the changes, and opens a PR
5. The prompt includes a comprehensive style guide extracted from the existing content-library docs

## Test plan

- [ ] Trigger manually via `workflow_dispatch` and verify it runs
- [ ] Verify it correctly identifies documentation-worthy changes from recent PRs
- [ ] Verify generated docs match the existing style in `docs/content-library/`
- [ ] Verify it creates a properly formatted PR with the documentation label
- [ ] Verify it exits cleanly when no PRs need documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)