### PR TITLE
Enable credit tracking in list building mode

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -754,7 +754,7 @@ class EditFighterXPForm(forms.Form):
 
 
 class EditListCreditsForm(forms.Form):
-    """Form for modifying list credits in campaign mode."""
+    """Form for modifying list credits."""
 
     CREDIT_OPERATION_CHOICES = [
         ("add", "Add Credits"),
@@ -778,7 +778,7 @@ class EditListCreditsForm(forms.Form):
         widget=forms.Textarea(attrs={"rows": 3, "class": "form-control"}),
         required=False,
         label="Description",
-        help_text="Optional description for this credit change (will be included in campaign log)",
+        help_text="Optional description for this credit change",
     )
 
     def __init__(self, *args, **kwargs):

--- a/gyrinx/core/templates/core/includes/fighter_card_stash.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_stash.html
@@ -22,7 +22,7 @@
                 <h4 class="h6 mb-0">Stash Credits</h4>
                 <div class="hstack gap-2 align-items-center">
                     {% if list.owner_cached == user or list.campaign and list.campaign.owner == user %}
-                        {% if not print and not list.is_list_building %}
+                        {% if not print %}
                             <a href="{% url 'core:list-credits-edit' list.id %}" class="fs-7 linked">Edit</a>
                         {% endif %}
                     {% endif %}

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -554,7 +554,9 @@ def edit_list(request, id):
 @login_required
 def edit_list_credits(request, id):
     """
-    Modify credits for a :model:`core.List` in campaign mode.
+    Modify credits for a :model:`core.List`.
+
+    Credits can be edited in both list building and campaign mode.
 
     **Context**
 
@@ -585,13 +587,6 @@ def edit_list_credits(request, id):
                 request, "You don't have permission to modify credits for this list."
             )
             return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
-
-    # Check campaign mode
-    if lst.status != List.CAMPAIGN_MODE:
-        messages.error(
-            request, "Credits can only be tracked for lists in campaign mode."
-        )
-        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
 
     if request.method == "POST":
         form = EditListCreditsForm(request.POST, lst=lst)


### PR DESCRIPTION
## Summary
This PR extends credit tracking functionality to work in both list building and campaign modes, removing the previous restriction that limited credit editing to campaign mode only.

## Key Changes
- **Form Updates**: Removed campaign-mode-specific language from `EditListCreditsForm` docstring and help text
- **View Logic**: Removed the campaign mode check in `edit_list_credits()` view, allowing credit modifications for lists in any status
- **Template**: Simplified the condition for showing the "Edit Credits" link by removing the `list.is_list_building` check
- **Tests**: 
  - Updated test expectations to verify credit editing works in list building mode
  - Added new tests for adding and spending credits in list building mode
  - Added test to verify cloning a list building list preserves credits
  - Confirmed that campaign actions are not created when editing credits in list building mode

## Implementation Details
- Credit tracking now functions consistently across both list building and campaign modes
- The distinction between modes is maintained where relevant (e.g., campaign actions are only created in campaign mode)
- All existing campaign mode credit functionality remains unchanged
- List building lists can now accumulate and track credits throughout their lifecycle

https://claude.ai/code/session_01K5YatNgSe2VXYcxLA2ZvAF