### PR TITLE
fix: default rules not saving on custom fighter edit page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ in the workflow.
 - `/feature-dev [description]` — Guided 7-phase feature development workflow: discovery, codebase exploration,
   clarifying questions, architecture design, implementation, quality review, and summary. Uses `code-explorer`,
   `code-architect`, and `code-reviewer` agents.
+
 ### Skills (`.claude/skills/`)
 
 Skills are loaded automatically by agents that need them. They can also be referenced directly:

--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -143,11 +143,11 @@ class ContentFighterPackForm(forms.ModelForm):
         # model_to_dict() uses instance.rules.all() which goes through
         # ContentManager.get_queryset() and excludes pack content, so
         # pack rules assigned to this fighter are not pre-selected.
-        # Bypass the default manager to include all assigned rules.
+        # Use the field queryset to stay consistent with available choices.
         if not self.instance._state.adding:
             self.initial["rules"] = list(
-                ContentRule.objects.all_content()
-                .filter(contentfighter=self.instance)
+                self.fields["rules"]
+                .queryset.filter(contentfighter=self.instance)
                 .values_list("pk", flat=True)
             )
 

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1425,9 +1425,11 @@ def test_edit_fighter_saves_pack_rules(
 
     # Assign the pack rule to the fighter.
     fighter.rules.add(rule)
-    assert ContentRule.objects.all_content().filter(
-        contentfighter=fighter, pk=rule.pk
-    ).exists()
+    assert (
+        ContentRule.objects.all_content()
+        .filter(contentfighter=fighter, pk=rule.pk)
+        .exists()
+    )
 
     # Submit the edit form with the rule selected.
     client.force_login(group_user)
@@ -1476,6 +1478,7 @@ def test_edit_fighter_form_preselects_pack_rules(
     response = client.get(f"/pack/{pack.id}/item/{pack_fighter.id}/edit/")
     assert response.status_code == 200
 
-    # The rule should appear as a selected option in the form.
-    content = response.content.decode()
-    assert f'value="{rule.pk}" selected' in content
+    # The rule should appear as a selected value in the form.
+    form = response.context["form"]
+    rules_value = form["rules"].value()
+    assert str(rule.pk) in {str(v) for v in rules_value}


### PR DESCRIPTION
## Summary
- Fix pack rules not appearing as pre-selected when editing a custom fighter in a content pack
- The root cause was `model_to_dict()` using `instance.rules.all()` which goes through `ContentManager.get_queryset()` and excludes pack content, so pack-specific rules were never shown as selected on the edit form
- Override `initial["rules"]` in `ContentFighterPackForm.__init__()` to bypass the default manager filter

## Test plan
- [x] `test_edit_fighter_saves_pack_rules` — verifies pack rules persist after form submission
- [x] `test_edit_fighter_form_preselects_pack_rules` — verifies pack rules are pre-selected in the edit form

Closes #1437

https://claude.ai/code/session_01BKQrCPPB4ot1rjd7Nj8S6v