### PR TITLE
fix: broaden bot actor workaround for scheduled Claude workflows

### DIFF
--- a/.github/workflows/claude-code-improvement.yml
+++ b/.github/workflows/claude-code-improvement.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Workaround for anthropics/claude-code-action#900: the action's
+      # checkHumanActor calls the GitHub API before checking allowed_bots,
+      # which 404s for bot actors like github-merge-queue[bot]. Override
+      # GITHUB_ACTOR so the action sees a real user. Run unconditionally
+      # for scheduled events because github.actor may be a bot name with
+      # or without the [bot] suffix.
+      - name: Fix actor for scheduled runs
+        if: github.event_name == 'schedule'
+        run: echo "GITHUB_ACTOR=${{ github.repository_owner }}" >> "$GITHUB_ENV"
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -69,6 +79,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Belt-and-suspenders: also declare the bot as allowed in case the
+          # GITHUB_ACTOR override above is removed once the upstream bug is fixed.
+          allowed_bots: "github-merge-queue[bot]"
 
           # Claude configuration via CLI arguments
           claude_args: |

--- a/.github/workflows/claude-docs-update.yml
+++ b/.github/workflows/claude-docs-update.yml
@@ -22,9 +22,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Workaround for anthropics/claude-code-action#900
+      # Workaround for anthropics/claude-code-action#900: the action's
+      # checkHumanActor calls the GitHub API before checking allowed_bots,
+      # which 404s for bot actors like github-merge-queue[bot]. Override
+      # GITHUB_ACTOR so the action sees a real user. Run unconditionally
+      # for scheduled events because github.actor may be a bot name with
+      # or without the [bot] suffix.
       - name: Fix actor for scheduled runs
-        if: github.event_name == 'schedule' && contains(github.actor, '[bot]')
+        if: github.event_name == 'schedule'
         run: echo "GITHUB_ACTOR=${{ github.repository_owner }}" >> "$GITHUB_ENV"
 
       - name: Get merged PRs from last 7 days

--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -23,9 +23,11 @@ jobs:
       # Workaround for anthropics/claude-code-action#900: the action's
       # checkHumanActor calls the GitHub API before checking allowed_bots,
       # which 404s for bot actors like github-merge-queue[bot]. Override
-      # GITHUB_ACTOR so the action sees a real user.
+      # GITHUB_ACTOR so the action sees a real user. Run unconditionally
+      # for scheduled events because github.actor may be a bot name with
+      # or without the [bot] suffix.
       - name: Fix actor for scheduled runs
-        if: github.event_name == 'schedule' && contains(github.actor, '[bot]')
+        if: github.event_name == 'schedule'
         run: echo "GITHUB_ACTOR=${{ github.repository_owner }}" >> "$GITHUB_ENV"
 
       - name: Get date range


### PR DESCRIPTION
## Summary

- Broadens the `GITHUB_ACTOR` override condition in scheduled workflows from `contains(github.actor, '[bot]')` to unconditional for all scheduled events, since `github.actor` can be `github-merge-queue` without the `[bot]` suffix
- Adds the missing workaround and `allowed_bots` to `claude-code-improvement.yml`

Fixes the failure at https://github.com/gyrinx-app/gyrinx/actions/runs/21795621289/job/62882604789 where the claude-docs-update workflow failed with `GET /users/github-merge-queue - 404` because the workaround step was skipped.

## Test plan

- [ ] Verify the weekly-summary, claude-docs-update, and claude-code-improvement workflows succeed on their next scheduled run (or via manual `workflow_dispatch` trigger)

https://claude.ai/code/session_016Z6W4vD1ALeGPGc6ZrWRoA