### PR TITLE
fix: restructure URL redirect validation to address CodeQL false positives

### DIFF
--- a/gyrinx/core/utils.py
+++ b/gyrinx/core/utils.py
@@ -19,16 +19,15 @@ def safe_redirect(request, url, fallback_url="/"):
     Returns:
         HttpResponseRedirect to either the validated URL or the fallback
     """
-    # Validate the URL is safe
-    if url and url_has_allowed_host_and_scheme(
-        url=url,
-        allowed_hosts={request.get_host()},
-        require_https=request.is_secure(),
-    ):
-        return HttpResponseRedirect(url)
+    if not url:
+        return HttpResponseRedirect(fallback_url)
 
-    # Fall back to the provided fallback URL
-    return HttpResponseRedirect(fallback_url)
+    if not url_has_allowed_host_and_scheme(
+        url, allowed_hosts={request.get_host()}, require_https=request.is_secure()
+    ):
+        return HttpResponseRedirect(fallback_url)
+
+    return HttpResponseRedirect(url)
 
 
 def build_safe_url(request, path=None, query_string=None):
@@ -54,15 +53,12 @@ def build_safe_url(request, path=None, query_string=None):
         url = path
 
     # Validate the URL is safe
-    if url_has_allowed_host_and_scheme(
-        url=url,
-        allowed_hosts={request.get_host()},
-        require_https=request.is_secure(),
+    if not url_has_allowed_host_and_scheme(
+        url, allowed_hosts={request.get_host()}, require_https=request.is_secure()
     ):
-        return url
+        return path
 
-    # Return just the path if validation fails
-    return path
+    return url
 
 
 def get_return_url(request, default_url):
@@ -88,16 +84,17 @@ def get_return_url(request, default_url):
         "return_url", default_url
     )
 
-    # Validate the URL is safe
-    if return_url and url_has_allowed_host_and_scheme(
-        url=return_url,
+    if not return_url:
+        return default_url
+
+    if not url_has_allowed_host_and_scheme(
+        return_url,
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),
     ):
-        return return_url
+        return default_url
 
-    # Fall back to the provided default URL
-    return default_url
+    return return_url
 
 
 def get_list_attributes(list_obj):

--- a/gyrinx/core/views/campaign/actions.py
+++ b/gyrinx/core/views/campaign/actions.py
@@ -87,9 +87,8 @@ def campaign_log_action(request, id):
             outcome_url = reverse(
                 "core:campaign-action-outcome", args=(campaign.id, action.id)
             )
-            return HttpResponseRedirect(
-                f"{outcome_url}?{urlencode({'return_url': return_url})}"
-            )
+            redirect_url = f"{outcome_url}?{urlencode({'return_url': return_url})}"
+            return safe_redirect(request, redirect_url, fallback_url=default_url)
     else:
         # Pre-populate gang/list if provided
         gang = request.GET.get("gang")
@@ -168,9 +167,10 @@ def campaign_action_outcome(request, id, action_id):
                 new_action_url = reverse(
                     "core:campaign-action-new", args=(campaign.id,)
                 )
-                return HttpResponseRedirect(
+                redirect_url = (
                     f"{new_action_url}?{urlencode({'return_url': return_url})}"
                 )
+                return safe_redirect(request, redirect_url, fallback_url=default_url)
             else:
                 # Default: redirect to return URL
                 return safe_redirect(request, return_url, fallback_url=default_url)


### PR DESCRIPTION
## Summary

- Restructure `safe_redirect`, `get_return_url`, and `build_safe_url` in `gyrinx/core/utils.py` to use guard-clause patterns with positional arguments, which CodeQL's taint analysis can model more effectively
- Route campaign action redirects in `gyrinx/core/views/campaign/actions.py` through `safe_redirect` instead of direct `HttpResponseRedirect`, consolidating all user-influenced redirect validation through a single validated path

Closes #1448

## Test plan

- [x] All 18 URL/redirect tests pass (`test_tags.py`)
- [x] All 4 campaign action tests pass (`test_campaign_actions.py`)
- [x] Full test suite passes (1918 passed, 1 pre-existing failure unrelated to changes)
- [ ] Verify CodeQL alerts #36, #37, #38 are resolved after merge

https://claude.ai/code/session_01GVYFVhqj3hLLfK5i822ovf