### PR TITLE
Add font-weight-normal class to campaign attribute badges

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_attributes.html
+++ b/gyrinx/core/templates/core/campaign/campaign_attributes.html
@@ -96,7 +96,7 @@
                                                     {% if list_assignments %}
                                                         <div class="hstack gap-2 flex-wrap">
                                                             {% for assignment in list_assignments %}
-                                                                <span class="badge text-bg-light border d-inline-flex align-items-center gap-1">
+                                                                <span class="badge fw-normal text-bg-light border d-inline-flex align-items-center gap-1">
                                                                     {% if assignment.attribute_value.colour %}
                                                                         <span class="d-inline-block rounded-circle"
                                                                               style="width: 10px;

--- a/gyrinx/core/templates/core/campaign/includes/campaign_lists.html
+++ b/gyrinx/core/templates/core/campaign/includes/campaign_lists.html
@@ -24,7 +24,7 @@
                                     {% if list_assignments %}
                                         <div class="hstack gap-1 flex-wrap">
                                             {% for assignment in list_assignments %}
-                                                <span class="badge text-bg-light border d-inline-flex align-items-center gap-1">
+                                                <span class="badge fw-normal text-bg-light border d-inline-flex align-items-center gap-1">
                                                     {% if assignment.attribute_value.colour %}
                                                         <span class="d-inline-block rounded-circle"
                                                               style="width: 8px;


### PR DESCRIPTION
## Summary
This PR adds the `fw-normal` Bootstrap utility class to badge elements displaying campaign attribute assignments, ensuring consistent font weight styling across the application.

## Changes
- Added `fw-normal` class to badge spans in `campaign_attributes.html`
- Added `fw-normal` class to badge spans in `campaign_lists.html`

## Details
Both template files display attribute value badges with color indicators. The `fw-normal` class explicitly sets the font-weight to normal (400), preventing badges from inheriting bold font-weight from parent elements and ensuring a consistent, lighter visual appearance across campaign attribute displays.

https://claude.ai/code/session_013vFdmVpzSVzwkQ9WMhxyyJ