### PR TITLE
fix: use Claude CLI directly for weekly summary

### DIFF
--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -40,8 +40,13 @@ jobs:
               f.write(f"week_of={week_of}\n")
           PY
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
+        run: npm install -g @anthropic-ai/claude-code@2.1.39
 
       - name: Write prompt
         env:
@@ -111,7 +116,7 @@ jobs:
         run: |
           claude -p \
             --model claude-sonnet-4-20250514 \
-            --allowedTools "Bash(git:*),Bash(gh:*)" \
+            --allowedTools "Bash(gh:*)" \
             < /tmp/claude-prompt.txt \
             > /tmp/weekly-summary.txt
 


### PR DESCRIPTION
## Summary

- Replaces `anthropics/claude-code-action@v1` with direct `claude -p` CLI invocation for the weekly summary workflow
- The upstream action has a bug ([anthropics/claude-code-action#900](https://github.com/anthropics/claude-code-action/issues/900)) where `checkHumanActor` 404s for bot actors before checking `allowed_bots` — the `GITHUB_ACTOR` override workaround wasn't effective
- Using the CLI directly sidesteps the actor validation entirely, which isn't needed for a scheduled workflow

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it completes successfully
- [ ] Verify the generated discussion appears in the Announcements category with the expected format

Note: `claude-docs-update.yml` and `claude-code-improvement.yml` have the same upstream bug — they should be migrated similarly in a follow-up.

https://claude.ai/code/session_0156PwU8v3Cmbhxoc5TgcmgC