### PR TITLE
feat: add pr-feedback skill for triaging PR review comments

### DIFF
--- a/.claude/skills/pr-feedback/SKILL.md
+++ b/.claude/skills/pr-feedback/SKILL.md
@@ -1,6 +1,11 @@
 ---
-description: Review PR feedback from reviewers and Copilot, decide what to implement, and make a plan
-argument-hint: [PR number or URL]
+name: pr-feedback
+description: |
+  Review PR feedback from reviewers and Copilot, triage each comment
+  (implement / acknowledge / decline), plan changes, and implement approved
+  fixes. Use when you need to act on pull request review feedback.
+argument-hint: "[PR number or URL]"
+disable-model-invocation: true
 ---
 
 # PR Feedback
@@ -10,9 +15,9 @@ Your job is to review it, decide what is correct and worth implementing, and act
 
 ## Phase 1: Fetch feedback
 
-Load the `pr-comments` skill to fetch all PR comments, reviews, and review threads.
+Run the pr-comments fetch script to get all PR comments, reviews, and review threads.
 
-/skill pr-comments $ARGUMENTS
+!`.claude/skills/pr-comments/scripts/fetch-pr-comments.sh $ARGUMENTS 2>&1`
 
 ## Phase 2: Triage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,6 @@ in the workflow.
 - `/feature-dev [description]` — Guided 7-phase feature development workflow: discovery, codebase exploration,
   clarifying questions, architecture design, implementation, quality review, and summary. Uses `code-explorer`,
   `code-architect`, and `code-reviewer` agents.
-- `/pr-feedback [PR number or URL]` — Review PR feedback from reviewers and Copilot, triage each comment
-  (implement / acknowledge / decline), plan changes, and implement approved fixes. Uses the `pr-comments` skill.
 
 ### Skills (`.claude/skills/`)
 
@@ -77,6 +75,9 @@ Skills are loaded automatically by agents that need them. They can also be refer
 - **pr-comments** — Fetch all PR comments, reviews, and review threads in a single GraphQL call. Shows
   resolved/unresolved status, groups by file, and summarises action items. Auto-detects PR from current branch.
   Claude loads this automatically when it needs PR feedback data.
+- **pr-feedback** — Review PR feedback from reviewers and Copilot, triage each comment
+  (implement / acknowledge / decline), plan changes, and implement approved fixes. Invoke with
+  `/pr-feedback [PR number or URL]`. Uses the `pr-comments` fetch script for data.
 
 ## Critical Workflow
 


### PR DESCRIPTION
Adds a new Claude Code skill that fetches PR feedback using the
existing pr-comments fetch script (via dynamic context injection),
triages each comment into implement/acknowledge/decline buckets, and
walks through planning and implementing the approved changes.

Implemented as a proper skill (`.claude/skills/pr-feedback/SKILL.md`)
rather than a slash command, with frontmatter for description,
argument hint, and `disable-model-invocation: true`.

https://claude.ai/code/session_013xHYKgPbhBZyhucD8FH8v2