### PR TITLE
feat: add support for custom houses in content packs

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -164,6 +164,21 @@ class ContentFighterPackForm(forms.ModelForm):
                 del self.fields[field_name]
 
 
+class ContentHouseForm(forms.ModelForm):
+    class Meta:
+        model = ContentHouse
+        fields = ["name"]
+        labels = {
+            "name": "Name",
+        }
+        help_texts = {
+            "name": "The name of the house or faction.",
+        }
+        widgets = {
+            "name": forms.TextInput(attrs={"class": "form-control"}),
+        }
+
+
 class ContentRuleForm(forms.ModelForm):
     class Meta:
         model = ContentRule

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -23,7 +23,12 @@ from gyrinx.content.models.statline import (
     ContentStatlineStat,
     ContentStatlineType,
 )
-from gyrinx.core.forms.pack import ContentFighterPackForm, ContentRuleForm, PackForm
+from gyrinx.core.forms.pack import (
+    ContentFighterPackForm,
+    ContentHouseForm,
+    ContentRuleForm,
+    PackForm,
+)
 from gyrinx.core.models.campaign import Campaign
 from gyrinx.core.models.list import List
 from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
@@ -50,7 +55,7 @@ SUPPORTED_CONTENT_TYPES = [
         "Houses",
         "Custom factions and houses for your fighters.",
         "bi-house-door",
-        None,
+        ContentHouseForm,
         "house",
     ),
     ContentTypeEntry(


### PR DESCRIPTION
Closes #1462

## Summary

- Add `ContentHouseForm` (name field) and register it in `SUPPORTED_CONTENT_TYPES` so pack owners can create, edit, and archive custom houses
- No model changes, migrations, or template changes needed — the existing polymorphic views handle everything
- Replace the old 404 test with full house CRUD test coverage (add, edit, archive, permissions)

## Test plan

- [x] Automated: `pytest -n auto gyrinx/core/tests/test_views_pack.py` — 101 tests pass
- [x] Manual: Verified in browser — add, edit, archive, and archived items page all work correctly