### PR TITLE
fix: use {% url %} tag for back button on content packs page

### DIFF
--- a/gyrinx/core/templates/core/list_packs.html
+++ b/gyrinx/core/templates/core/list_packs.html
@@ -4,7 +4,8 @@
     Content Packs - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
-    {% include "core/includes/back.html" with url=list.get_absolute_url text=list.name %}
+    {% url 'core:list' list.id as list_url %}
+    {% include "core/includes/back.html" with url=list_url text=list.name %}
     <div class="col-12 col-xl-6 px-0 vstack gap-4">
         <h1 class="h3">Content Packs</h1>
         <p class="text-muted small">


### PR DESCRIPTION
The back button on the content packs page used `list.get_absolute_url` which doesn't exist on the List model, producing a broken link. Replaced with the standard `{% url 'core:list' list.id %}` pattern.

Closes #1479

Generated with [Claude Code](https://claude.ai/code)