### PR TITLE
feat: show private notes to list owner on gang-wide notes page

### DIFF
--- a/gyrinx/core/templates/core/includes/list_notes.html
+++ b/gyrinx/core/templates/core/includes/list_notes.html
@@ -11,7 +11,9 @@
     <nav class="nav card card-body flex-column mb-3 p-2">
         <a class="nav-link p-2 py-1" href="#notes-list">Overview</a>
         {% for fighter in list.active_fighters %}
-            {% if fighter.notes %}<a class="nav-link p-2 py-1" href="#notes-{{ fighter.id }}">{{ fighter.name }}</a>{% endif %}
+            {% if fighter.notes or list.owner_cached == user and fighter.private_notes %}
+                <a class="nav-link p-2 py-1" href="#notes-{{ fighter.id }}">{{ fighter.name }}</a>
+            {% endif %}
         {% endfor %}
     </nav>
     <div id="list-overview" class="mb-4">
@@ -38,7 +40,7 @@
     </div>
     <div class="grid auto-flow-dense">
         {% for fighter in list.active_fighters %}
-            {% if fighter.notes %}
+            {% if fighter.notes or list.owner_cached == user and fighter.private_notes %}
                 <div class="g-col-12 g-col-md-6" id="notes-{{ fighter.id }}">
                     <div class="hstack">
                         <h3 class="h4">{{ fighter.fully_qualified_name }}</h3>
@@ -51,7 +53,13 @@
                             </div>
                         {% endif %}
                     </div>
-                    {{ fighter.notes|safe_rich_text|safe }}
+                    {% if fighter.notes %}{{ fighter.notes|safe_rich_text|safe }}{% endif %}
+                    {% if list.owner_cached == user and fighter.private_notes %}
+                        <div class="mb-2 mt-2">
+                            <div class="text-uppercase fs-7 fw-light text-secondary mb-1">Private</div>
+                            <div>{{ fighter.private_notes|safe_rich_text|safe }}</div>
+                        </div>
+                    {% endif %}
                 </div>
             {% else %}
                 <div class="g-col-12 g-col-md-6" id="notes-{{ fighter.id }}">

--- a/gyrinx/core/tests/test_notes_page.py
+++ b/gyrinx/core/tests/test_notes_page.py
@@ -41,18 +41,71 @@ def test_notes_page_shows_fighter_notes(client, user, make_list, make_list_fight
 
 
 @pytest.mark.django_db
-def test_notes_page_does_not_show_private_notes(
+def test_notes_page_shows_private_notes_to_owner(
     client, user, make_list, make_list_fighter
 ):
-    """Test that private_notes are NOT shown on the public notes page."""
+    """Test that private_notes are shown to the owner on the notes page."""
+    lst = make_list("Test Gang")
+    fighter = make_list_fighter(lst, "Test Fighter")
+    fighter.private_notes = "<p>Secret private notes.</p>"
+    fighter.save()
+    client.force_login(user)
+
+    response = client.get(reverse("core:list-notes", args=[lst.id]))
+    content = response.content.decode()
+    assert "Secret private notes." in content
+    assert "Private" in content
+
+
+@pytest.mark.django_db
+def test_notes_page_hides_private_notes_from_non_owner(
+    client, user, make_user, make_list, make_list_fighter
+):
+    """Test that private_notes are NOT shown to non-owners on the notes page."""
     lst = make_list("Test Gang")
     fighter = make_list_fighter(lst, "Test Fighter")
     fighter.private_notes = "<p>Secret private notes.</p>"
     fighter.save()
 
+    other_user = make_user("otheruser", "password")
+    client.force_login(other_user)
+
     response = client.get(reverse("core:list-notes", args=[lst.id]))
     content = response.content.decode()
     assert "Secret private notes." not in content
+
+
+@pytest.mark.django_db
+def test_notes_page_hides_private_notes_from_anonymous(
+    client, user, make_list, make_list_fighter
+):
+    """Test that private_notes are NOT shown to anonymous users on the notes page."""
+    lst = make_list("Test Gang")
+    fighter = make_list_fighter(lst, "Test Fighter")
+    fighter.private_notes = "<p>Secret private notes.</p>"
+    fighter.save()
+    client.logout()
+
+    response = client.get(reverse("core:list-notes", args=[lst.id]))
+    content = response.content.decode()
+    assert "Secret private notes." not in content
+
+
+@pytest.mark.django_db
+def test_notes_page_shows_fighter_with_only_private_notes_to_owner(
+    client, user, make_list, make_list_fighter
+):
+    """Test that fighters with only private notes (no public notes) appear for the owner."""
+    lst = make_list("Test Gang")
+    fighter = make_list_fighter(lst, "Test Fighter")
+    fighter.private_notes = "<p>Only private notes.</p>"
+    fighter.save()
+    client.force_login(user)
+
+    response = client.get(reverse("core:list-notes", args=[lst.id]))
+    content = response.content.decode()
+    assert "Only private notes." in content
+    assert fighter.name in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Show private notes to the list owner on the gang-wide notes page. Non-owners and anonymous users still cannot see private notes. Fighters with only private notes now appear on the page for the owner.

Closes #1567

Generated with [Claude Code](https://claude.ai/code)