### PR TITLE
fix: improve content pack selection page layout and copy

### DIFF
--- a/gyrinx/core/templates/core/list_new_packs.html
+++ b/gyrinx/core/templates/core/list_new_packs.html
@@ -4,16 +4,16 @@
     Content Packs
 {% endblock head_title %}
 {% block content %}
-    <div class="col-12 col-xl-6 px-0 vstack gap-4">
+    <div class="col-12 col-xl-6 px-0 vstack gap-3">
         <h1 class="h3">Content Packs</h1>
         <form method="post"
               action="{% url 'core:lists-new-packs' %}"
-              class="vstack gap-4">
+              class="vstack gap-3">
             {% csrf_token %}
             <!-- Default game content -->
-            <div class="border rounded p-3 bg-body-secondary">
+            <div class="border rounded p-2 bg-body-secondary">
                 <div class="d-flex align-items-center gap-2">
-                    <i class="bi-book fs-4"></i>
+                    <i class="bi-book fs-5"></i>
                     <div>
                         <div class="fw-medium">Default Game Content</div>
                         <div class="text-muted small">Standard fighters, equipment, and rules from the core rulebooks.</div>
@@ -21,11 +21,16 @@
                     <span class="ms-auto badge bg-success">Included</span>
                 </div>
             </div>
+            <!-- Continue button -->
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Continue</button>
+                <a href="{% url 'core:lists-new' %}?skip_packs=1" class="btn btn-link">Skip</a>
+            </div>
             {% if available_packs %}
                 <!-- Separator -->
                 <div class="d-flex align-items-center gap-3">
                     <hr class="flex-grow-1">
-                    <span class="text-muted small">Or also use content packs</span>
+                    <span class="text-muted small">Optionally add content packs</span>
                     <hr class="flex-grow-1">
                 </div>
                 <!-- Search -->
@@ -41,14 +46,14 @@
                 <!-- Pack list -->
                 <div class="vstack gap-2" id="pack-list">
                     {% for pack in available_packs %}
-                        <label class="border rounded p-3 d-flex align-items-start gap-2 pack-item"
+                        <label class="border rounded p-2 d-flex align-items-start gap-2 pack-item"
                                data-name="{{ pack.name|lower }}">
                             <input type="checkbox"
                                    name="pack_ids"
                                    value="{{ pack.id }}"
                                    class="form-check-input mt-1">
                             <div class="flex-grow-1">
-                                <div class="fw-medium">{{ pack.name }}</div>
+                                <div class="fw-medium small">{{ pack.name }}</div>
                                 <div class="text-muted small">by {{ pack.owner }}</div>
                                 {% if pack.summary %}<div class="text-muted small mt-1">{{ pack.summary|striptags|truncatewords:20 }}</div>{% endif %}
                             </div>
@@ -56,10 +61,6 @@
                     {% endfor %}
                 </div>
             {% endif %}
-            <div class="d-flex gap-2">
-                <button type="submit" class="btn btn-primary">Continue</button>
-                <a href="{% url 'core:lists-new' %}?skip_packs=1" class="btn btn-link">Skip</a>
-            </div>
         </form>
     </div>
     <script>


### PR DESCRIPTION
Fixes the content pack selection page layout and misleading copy:

- Reword "Or also use" to "Optionally add content packs"
- Move Continue button above pack list for prominence
- Reduce vertical size of pack cards
- Improve overall page hierarchy

Closes #1570

Generated with [Claude Code](https://claude.ai/code)