### PR TITLE
fix: move icon outside link for "Add Content Pack" on list pages

### DIFF
--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -75,9 +75,8 @@
                             </div>
                         {% elif list.owner_cached == user and user|in_group:"Custom Content" %}
                             <div>
-                                <a href="{% url 'core:list-packs' list.id %}" class="icon-link linked">
-                                    <i class="bi-box-seam"></i> Add Content Pack
-                                </a>
+                                <i class="bi-box-seam"></i>
+                                <a href="{% url 'core:list-packs' list.id %}" class="linked">Add Content Pack</a>
                             </div>
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION
Closes #1566

Moved the icon outside the hyperlink so only the text "Add Content Pack" is clickable, consistent with other top links.

Generated with [Claude Code](https://claude.ai/code)