### PR TITLE
feat: improve fighter type picker on Add Fighter page

### DIFF
--- a/gyrinx/core/templates/core/list_fighter_new.html
+++ b/gyrinx/core/templates/core/list_fighter_new.html
@@ -11,7 +11,54 @@
               method="post"
               class="vstack gap-3">
             {% csrf_token %}
-            {{ form }}
+            <div>
+                {{ form.name.label_tag }}
+                {{ form.name }}
+                {% if form.name.help_text %}<div class="form-text">{{ form.name.help_text }}</div>{% endif %}
+                {% for error in form.name.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
+            <div>
+                <label class="form-label">{{ form.content_fighter.label }}</label>
+                {% if form.content_fighter.help_text %}
+                    <div class="form-text mb-2">{{ form.content_fighter.help_text }}</div>
+                {% endif %}
+                {% for error in form.content_fighter.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                {% for house_name, fighters in fighter_groups %}
+                    <div class="mb-3">
+                        <div class="text-uppercase text-secondary small mb-1">{{ house_name }}</div>
+                        {% for fighter in fighters %}
+                            {# djlint:off H021,H023 #}
+                            <label class="d-flex align-items-start gap-2 py-2 px-2 rounded fighter-type-option{% if form.content_fighter.value == fighter.id %} bg-light{% endif %}"
+                                   style="cursor: pointer">
+                                <input type="radio"
+                                       name="content_fighter"
+                                       value="{{ fighter.id }}"
+                                       class="form-check-input mt-1"
+                                       {% if form.content_fighter.value == fighter.id %}checked{% endif %}>
+                                <span class="flex-grow-1">
+                                    <span class="d-block">{{ fighter.type }}</span>
+                                    <span class="d-block text-secondary small">{{ fighter.category }} &middot; {{ fighter.cost }}&cent;</span>
+                                </span>
+                            </label>
+                            {# djlint:on #}
+                        {% endfor %}
+                    </div>
+                {% endfor %}
+            </div>
+            <div>
+                {{ form.category_override.label_tag }}
+                {{ form.category_override }}
+                {% if form.category_override.help_text %}
+                    <div class="form-text">{{ form.category_override.help_text }}</div>
+                {% endif %}
+                {% for error in form.category_override.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
+            <div>
+                {{ form.cost_override.label_tag }}
+                {{ form.cost_override }}
+                {% if form.cost_override.help_text %}<div class="form-text">{{ form.cost_override.help_text }}</div>{% endif %}
+                {% for error in form.cost_override.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
             <div class="mt-3">
                 <button type="submit" class="btn btn-primary">Add Fighter</button>
                 <a href="{% safe_referer list.get_absolute_url %}" class="btn btn-link">Cancel</a>

--- a/gyrinx/core/views/fighter/crud.py
+++ b/gyrinx/core/views/fighter/crud.py
@@ -1,5 +1,6 @@
 """Fighter CRUD views (create, read, update, delete, archive, restore, kill, resurrect)."""
 
+from itertools import groupby
 from urllib.parse import urlencode
 
 from django.contrib.auth.decorators import login_required
@@ -13,6 +14,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 
 from gyrinx import messages
 from gyrinx.core.forms.list import CloneListFighterForm, ListFighterForm
+from gyrinx.forms import fighter_group_key, group_sorter
 from gyrinx.core.handlers.fighter import (
     FighterCloneParams,
     handle_fighter_archive_toggle,
@@ -28,6 +30,43 @@ from gyrinx.core.models.list import List, ListFighter
 from gyrinx.core.views.list.common import get_clean_list_or_404
 
 
+def _build_grouped_fighters(form, content_house):
+    """Build grouped fighter data for the add fighter template.
+
+    Returns a list of (house_name, fighters) tuples where each fighter is a dict
+    with id, type, category, and cost fields for structured template rendering.
+    """
+    queryset = form.fields["content_fighter"].queryset
+    sort_key = group_sorter(content_house.name if content_house else "")
+
+    groups = []
+    for house_name, fighters in groupby(queryset, key=fighter_group_key):
+        fighter_list = []
+        for f in fighters:
+            cost = f.cost_for_house(content_house) if content_house else f.cost_int()
+            fighter_list.append(
+                {
+                    "id": str(f.id),
+                    "type": f.type,
+                    "category": f.cat(),
+                    "cost": cost,
+                }
+            )
+        groups.append((house_name, fighter_list))
+
+    groups.sort(key=lambda x: sort_key(x[0]))
+
+    # Merge adjacent groups with the same key after sorting
+    merged = []
+    for house_name, fighters in groups:
+        if merged and merged[-1][0] == house_name:
+            merged[-1] = (house_name, merged[-1][1] + fighters)
+        else:
+            merged.append((house_name, fighters))
+
+    return merged
+
+
 @login_required
 def new_list_fighter(request, id):
     """
@@ -41,6 +80,8 @@ def new_list_fighter(request, id):
         The :model:`core.List` to which this fighter will be added.
     ``error_message``
         None or a string describing a form error.
+    ``fighter_groups``
+        List of (house_name, fighters) tuples for the fighter type picker.
 
     **Template**
 
@@ -70,7 +111,14 @@ def new_list_fighter(request, id):
                 return render(
                     request,
                     "core/list_fighter_new.html",
-                    {"form": form, "list": lst, "error_message": error_message},
+                    {
+                        "form": form,
+                        "list": lst,
+                        "error_message": error_message,
+                        "fighter_groups": _build_grouped_fighters(
+                            form, lst.content_house
+                        ),
+                    },
                 )
 
             # Log the fighter creation event (HTTP-specific)
@@ -99,7 +147,12 @@ def new_list_fighter(request, id):
     return render(
         request,
         "core/list_fighter_new.html",
-        {"form": form, "list": lst, "error_message": error_message},
+        {
+            "form": form,
+            "list": lst,
+            "error_message": error_message,
+            "fighter_groups": _build_grouped_fighters(form, lst.content_house),
+        },
     )
 
 


### PR DESCRIPTION
Replace the dropdown select with a grouped radio button list that makes fighter names more prominent. Fighters are grouped by house (uppercase label), with the fighter type as the main content and category + cost as secondary information.

Closes #1575

Generated with [Claude Code](https://claude.ai/code)