### PR TITLE
feat: improve fighter name rendering in content pack page

### DIFF
--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -115,6 +115,43 @@
                     {% else %}
                         <p class="text-center text-secondary mb-0">No {{ section.label|lower }} in this Content Pack yet.</p>
                     {% endif %}
+                {% elif section.slug == "fighter" %}
+                    {% if section.items %}
+                        {% regroup section.items by content_object.house as fighters_by_house %}
+                        <div class="vstack gap-3">
+                            {% for house_group in fighters_by_house %}
+                                <div>
+                                    {% if house_group.grouper %}
+                                        <div class="text-secondary text-uppercase small mb-1">{{ house_group.grouper }}</div>
+                                    {% endif %}
+                                    <ul class="list-unstyled mb-0">
+                                        {% for entry in house_group.list %}
+                                            <li class="py-1">
+                                                <div class="d-flex justify-content-between align-items-center">
+                                                    <div>
+                                                        <span class="fw-medium">{{ entry.content_object.type }}</span>
+                                                        <div class="text-secondary small">{{ entry.content_object.get_category_display }}</div>
+                                                    </div>
+                                                    {% if can_edit %}
+                                                        <span class="d-flex gap-2">
+                                                            {% if section.can_add %}
+                                                                <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
+                                                                   class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover small">Edit</a>
+                                                            {% endif %}
+                                                            <a href="{% url 'core:pack-delete-item' pack.id entry.pack_item.id %}"
+                                                               class="link-danger link-underline-opacity-25 link-underline-opacity-100-hover small">Archive</a>
+                                                        </span>
+                                                    {% endif %}
+                                                </div>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <p class="text-center text-secondary mb-0">No {{ section.label|lower }} in this Content Pack yet.</p>
+                    {% endif %}
                 {% elif section.items %}
                     <ul class="list-unstyled mb-0">
                         {% for entry in section.items %}

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -512,6 +512,14 @@ class PackDetailView(GroupMembershipRequiredMixin, generic.DetailView):
                 else:
                     active_by_slug[slug].append(entry_data)
 
+        # Sort fighter items by house name for grouped display.
+        fighter_items = active_by_slug.get("fighter", [])
+        fighter_items.sort(
+            key=lambda e: (
+                str(e["content_object"].house) if e["content_object"].house else "",
+            )
+        )
+
         content_sections = []
         for ct_entry in SUPPORTED_CONTENT_TYPES:
             items = active_by_slug.get(ct_entry.slug, [])


### PR DESCRIPTION
Closes #1575

Group fighters by house (uppercase header), show fighter type as the main prominent text, and display category as a secondary sub-label.

Generated with [Claude Code](https://claude.ai/code)