### PR TITLE
refactor: extract inline filter JS into reusable module

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -464,6 +464,36 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
+// Filterable lists: wire up search inputs with data-gy-filter-target
+document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("[data-gy-filter-target]").forEach((input) => {
+        input.addEventListener("input", () => {
+            const query = input.value.toLowerCase();
+            const container = document.getElementById(
+                input.getAttribute("data-gy-filter-target"),
+            );
+            if (!container) return;
+
+            const items = container.querySelectorAll("[data-filter-label]");
+            let visible = 0;
+
+            items.forEach((item) => {
+                const match = item
+                    .getAttribute("data-filter-label")
+                    .toLowerCase()
+                    .includes(query);
+                item.style.display = match ? "" : "none";
+                if (match) visible++;
+            });
+
+            const emptyMsg = container.querySelector("[data-filter-empty]");
+            if (emptyMsg) {
+                emptyMsg.style.display = visible === 0 ? "" : "none";
+            }
+        });
+    });
+});
+
 // Handle banner dismissal
 document.addEventListener("DOMContentLoaded", () => {
     // Find all elements with data-gy-banner-dismiss attribute

--- a/gyrinx/core/templates/core/list_new_packs.html
+++ b/gyrinx/core/templates/core/list_new_packs.html
@@ -41,13 +41,13 @@
                            placeholder="Filter packs..."
                            value="{{ search_query }}"
                            id="pack-search"
-                           oninput="filterPacks(this.value)">
+                           data-gy-filter-target="pack-list">
                 </div>
                 <!-- Pack list -->
                 <div class="vstack gap-2" id="pack-list">
                     {% for pack in available_packs %}
                         <label class="border rounded p-2 d-flex align-items-start gap-2 pack-item"
-                               data-name="{{ pack.name|lower }}">
+                               data-filter-label="{{ pack.name|lower }}">
                             <input type="checkbox"
                                    name="pack_ids"
                                    value="{{ pack.id }}"
@@ -61,17 +61,10 @@
                             </div>
                         </label>
                     {% endfor %}
+                    {# djlint:off H021 #}
+                    <div class="text-secondary fs-7" data-filter-empty style="display: none;">No matches.</div>
                 </div>
             {% endif %}
         </form>
     </div>
-    <script>
-    function filterPacks(query) {
-        query = query.toLowerCase();
-        document.querySelectorAll('.pack-item').forEach(function(item) {
-            var name = item.getAttribute('data-name');
-            item.style.display = name.includes(query) ? '' : 'none';
-        });
-    }
-    </script>
 {% endblock content %}

--- a/gyrinx/core/templates/core/pack/includes/weapon_profile_stats_form.html
+++ b/gyrinx/core/templates/core/pack/includes/weapon_profile_stats_form.html
@@ -4,8 +4,7 @@
         <input type="search"
                class="form-control form-control-sm mb-2"
                placeholder="Filter..."
-               data-filter-target="wp_traits_list"
-               oninput="(function(el){ var t=el.value.toLowerCase(); var container=document.getElementById(el.dataset.filterTarget); var items=container.querySelectorAll('[data-filter-label]'); var visible=0; for(var i=0;i&lt;items.length;i++){ var show=items[i].dataset.filterLabel.toLowerCase().indexOf(t)!==-1; items[i].style.display=show?'':'none'; if(show) visible++; } container.querySelector('[data-filter-empty]').style.display=visible===0?'':'none'; })(this)">
+               data-gy-filter-target="wp_traits_list">
         {# djlint:off H021 #}
         <div id="wp_traits_list"
              class="border rounded p-2"

--- a/gyrinx/pages/templates/pages/forms/widgets/bs_checkbox_select_compact.html
+++ b/gyrinx/pages/templates/pages/forms/widgets/bs_checkbox_select_compact.html
@@ -3,8 +3,7 @@
         <input type="search"
                class="form-control form-control-sm mb-2"
                placeholder="Filter..."
-               data-filter-target="{{ id }}"
-               oninput="(function(el){ var t=el.value.toLowerCase(); var container=document.getElementById(el.dataset.filterTarget); var items=container.querySelectorAll('[data-filter-label]'); var visible=0; for(var i=0;i&lt;items.length;i++){ var show=items[i].dataset.filterLabel.toLowerCase().indexOf(t)!==-1; items[i].style.display=show?'':'none'; if(show) visible++; } container.querySelector('[data-filter-empty]').style.display=visible===0?'':'none'; })(this)">
+               data-gy-filter-target="{{ id }}">
         {# djlint:off H021 #}
         <div {% if id %}id="{{ id }}"{% endif %}
              class="border rounded p-2"


### PR DESCRIPTION
Extract the inline oninput filter function from three templates into a shared handler in `index.js`, wired up declaratively via `data-gy-filter-target` attributes.

Closes #1616

Generated with [Claude Code](https://claude.ai/code)