### PR TITLE
docs: add breadcrumb and dark mode contrast to design system

### DIFF
--- a/gyrinx/core/templates/core/debug/design_system.html
+++ b/gyrinx/core/templates/core/debug/design_system.html
@@ -133,6 +133,24 @@
                     <span class="text-secondary fs-7 d-block">Delete / archive</span>
                 </div>
             </div>
+            <h3 class="h6 caps-label mb-2">Dark mode contrast overrides</h3>
+            <p class="text-secondary fs-7 mb-3">
+                In dark mode, <code>.text-secondary</code> and <code>.link-secondary</code> are lightened
+                (<code>lighten($secondary, 10%)</code>) for better contrast against dark backgrounds.
+                This is a direct class override in <code>styles.scss</code> — it does not affect
+                <code>bg-secondary</code> or <code>text-bg-secondary</code>.
+            </p>
+            <div class="d-flex flex-wrap gap-3 mb-4">
+                <div class="bg-dark rounded p-3 text-center" style="min-width: 10rem">
+                    <span class="text-secondary">text-secondary</span>
+                    <div class="fs-7 text-body-tertiary mt-1">on dark bg</div>
+                </div>
+                <div class="bg-dark rounded p-3 text-center" style="min-width: 10rem">
+                    <a href="#"
+                       class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">link-secondary</a>
+                    <div class="fs-7 text-body-tertiary mt-1">on dark bg</div>
+                </div>
+            </div>
             <h3 class="h6 caps-label mb-2">Colour rules</h3>
             <table class="table table-sm table-borderless mb-0 fs-7">
                 <thead>
@@ -1073,6 +1091,7 @@
             <div class="border rounded p-3 mb-4">
                 <div class="col-lg-12 px-0 vstack gap-4">
                     <div class="vstack gap-0">
+                        {% include "core/includes/breadcrumb.html" with type="List" owner=user name="My Gang" name_url="#" only %}
                         <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
                             <h1 class="h2 mb-0">My Gang</h1>
                             <nav class="nav btn-group flex-nowrap ms-md-auto">
@@ -1092,7 +1111,6 @@
                             </nav>
                         </div>
                         <div class="d-flex flex-wrap gap-2 text-secondary fs-7">
-                            <span><i class="bi-person"></i> admin</span>
                             <span><i class="bi-eye"></i> Public</span>
                         </div>
                     </div>
@@ -1128,218 +1146,241 @@
         <!-- ============================================================ -->
         <section>
             <h2 class="h4 mb-3">Page patterns</h2>
-            <h3 class="h6 caps-label mb-2">List/detail header</h3>
-            <p class="text-secondary fs-7 mb-2">Title left, action buttons right, metadata below.</p>
-            <div class="border rounded p-3 mb-4">
-                <div class="vstack gap-0">
-                    <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
-                        <h1 class="h2 mb-0">Cawdor Facts</h1>
-                        <div class="ms-md-auto d-flex gap-1 flex-nowrap">
-                            <a href="#" class="btn btn-primary btn-sm"><i class="bi-person-add"></i> Add fighter</a>
-                            <a href="#" class="btn btn-primary btn-sm"><i class="bi-truck"></i> Add vehicle</a>
-                            <nav class="btn-group">
-                                <a href="#" class="btn btn-secondary btn-sm"><i class="bi-pencil"></i> Edit</a>
-                                <div class="btn-group" role="group">
-                                    <button type="button"
-                                            class="btn btn-secondary btn-sm dropdown-toggle"
-                                            data-bs-toggle="dropdown">
-                                        <i class="bi-three-dots-vertical"></i>
-                                    </button>
-                                    <ul class="dropdown-menu">
-                                        <li>
-                                            <a class="dropdown-item" href="#">Archive</a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </nav>
-                        </div>
-                    </div>
-                    <div class="d-flex flex-wrap gap-2 text-secondary fs-7">
-                        <span><i class="bi-person"></i> admin</span>
-                        <span><i class="bi-eye"></i> Public</span>
-                        <span>Cawdor (HoF)</span>
-                        <span>1397¢</span>
-                    </div>
-                </div>
-                <div class="bg-body-tertiary rounded px-2 py-2 d-flex justify-content-between align-items-center mt-4 mb-2">
-                    <h2 class="h5 mb-0">Gangs</h2>
-                    <a href="#" class="icon-link linked fs-7"><i class="bi-plus-lg"></i> Add Gangs</a>
-                </div>
-                <div class="px-2">
-                    <p class="text-secondary fs-7 mb-0">
-                        <strong>Pattern:</strong> Add buttons are separate <code>btn-primary</code>. Edit + dropdown are grouped in <code>btn-group btn-secondary</code>.
-                        Section-level add links use <code>icon-link linked</code> in the section header bar.
-                    </p>
-                </div>
-            </div>
-            <h3 class="h6 caps-label mb-2">Campaign info columns</h3>
+            <h3 class="h6 caps-label mb-2">Breadcrumb</h3>
             <p class="text-secondary fs-7 mb-2">
-                Key metadata as horizontal label/value pairs with <code>caps-label</code>. Wraps on mobile.
-            </p>
-            <div class="border rounded p-3 mb-4">
-                <div class="d-flex flex-wrap gap-3 border-bottom pb-3 mb-2">
-                    <div class="flex-grow-1 col-md-3 flex-md-grow-0">
-                        <div class="caps-label">Status</div>
-                        <div>In Progress</div>
-                    </div>
-                    <div class="flex-grow-1 col-md-3 flex-md-grow-0">
-                        <div class="caps-label">Phase</div>
-                        <div>Occupation</div>
-                    </div>
-                    <div class="flex-grow-1 col-md-3 flex-md-grow-0">
-                        <div class="caps-label">Budget</div>
-                        <div>1500¢</div>
-                    </div>
-                    <div class="flex-grow-1 col-md-3 flex-md-grow-0">
-                        <div class="caps-label">Content Packs</div>
-                        <div>Scavvy</div>
-                        <a href="#" class="fs-7 linked">Edit</a>
-                    </div>
-                </div>
-            </div>
-            <h3 class="h6 caps-label mb-2">Step progress (multi-step flows)</h3>
-            <p class="text-secondary fs-7 mb-2">
+                Sits above the page title on entity detail pages. Shows <code>owner / type / name</code> with optional campaign link.
                 Use <code>
                 {% verbatim %}
-                    {% include "core/includes/step_progress.html" with step=N total_steps=N title="..." %}
+                    {% include "core/includes/breadcrumb.html" with type="List" owner=user name="My Gang" name_url="#" only %}
                 {% endverbatim %}
-            </code> for multi-step forms (advancement, vehicle, equipment sell).
+            </code>.
         </p>
         <div class="border rounded p-3 mb-4">
-            <div class="col-12 col-md-8 col-lg-6">
-                {% include "core/includes/step_progress.html" with step=2 total_steps=3 title="Add Vehicle" subtitle="Select crew" %}
-                <div class="mt-3">
-                    <p class="text-secondary fs-7 mb-0">
-                        Step content goes here. The progress bar, h1.h3 title, and optional h2.h5 subtitle are rendered by the include.
-                    </p>
+            <div class="vstack gap-1">
+                {% include "core/includes/breadcrumb.html" with type="List" owner=user name="Cawdor Facts" name_url="#" only %}
+                {% include "core/includes/breadcrumb.html" with type="Campaign Gang" owner=user name="Iron Hounds" name_url="#" campaign=ds_campaign only %}
+                {% include "core/includes/breadcrumb.html" with type="Pack" owner=user name="Scavvy Pack" name_url="#" only %}
+                {% include "core/includes/breadcrumb.html" with type="List" owner=user name="My Gang" print=True only %}
+            </div>
+        </div>
+        <p class="text-secondary fs-7 mb-4">
+            Pass <code>only</code> to prevent context leakage. Pass <code>print=True</code> to render without links (print view).
+            Pass <code>campaign=obj</code> for campaign gangs to show <code>· Campaign Name</code>.
+        </p>
+        <h3 class="h6 caps-label mb-2">List/detail header (with breadcrumb)</h3>
+        <p class="text-secondary fs-7 mb-2">Breadcrumb above title. Title left, action buttons right, metadata below.</p>
+        <div class="border rounded p-3 mb-4">
+            <div class="vstack gap-0">
+                {% include "core/includes/breadcrumb.html" with type="List" owner=user name="Cawdor Facts" name_url="#" only %}
+                <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
+                    <h1 class="h2 mb-0">Cawdor Facts</h1>
+                    <div class="ms-md-auto d-flex gap-1 flex-nowrap">
+                        <a href="#" class="btn btn-primary btn-sm"><i class="bi-person-add"></i> Add fighter</a>
+                        <a href="#" class="btn btn-primary btn-sm"><i class="bi-truck"></i> Add vehicle</a>
+                        <nav class="btn-group">
+                            <a href="#" class="btn btn-secondary btn-sm"><i class="bi-pencil"></i> Edit</a>
+                            <div class="btn-group" role="group">
+                                <button type="button"
+                                        class="btn btn-secondary btn-sm dropdown-toggle"
+                                        data-bs-toggle="dropdown">
+                                    <i class="bi-three-dots-vertical"></i>
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li>
+                                        <a class="dropdown-item" href="#">Archive</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </nav>
+                    </div>
+                </div>
+                <div class="d-flex flex-wrap gap-2 text-secondary fs-7">
+                    <span><i class="bi-eye"></i> Public</span>
+                    <span>Cawdor (HoF)</span>
+                    <span>1397¢</span>
+                </div>
+            </div>
+            <div class="bg-body-tertiary rounded px-2 py-2 d-flex justify-content-between align-items-center mt-4 mb-2">
+                <h2 class="h5 mb-0">Gangs</h2>
+                <a href="#" class="icon-link linked fs-7"><i class="bi-plus-lg"></i> Add Gangs</a>
+            </div>
+            <div class="px-2">
+                <p class="text-secondary fs-7 mb-0">
+                    <strong>Pattern:</strong> Breadcrumb above the title replaces inline owner metadata. Add buttons are separate <code>btn-primary</code>.
+                    Edit + dropdown are grouped in <code>btn-group btn-secondary</code>.
+                    Section-level add links use <code>icon-link linked</code> in the section header bar.
+                </p>
+            </div>
+        </div>
+        <h3 class="h6 caps-label mb-2">Campaign info columns</h3>
+        <p class="text-secondary fs-7 mb-2">
+            Key metadata as horizontal label/value pairs with <code>caps-label</code>. Wraps on mobile.
+        </p>
+        <div class="border rounded p-3 mb-4">
+            <div class="d-flex flex-wrap gap-3 border-bottom pb-3 mb-2">
+                <div class="flex-grow-1 col-md-3 flex-md-grow-0">
+                    <div class="caps-label">Status</div>
+                    <div>In Progress</div>
+                </div>
+                <div class="flex-grow-1 col-md-3 flex-md-grow-0">
+                    <div class="caps-label">Phase</div>
+                    <div>Occupation</div>
+                </div>
+                <div class="flex-grow-1 col-md-3 flex-md-grow-0">
+                    <div class="caps-label">Budget</div>
+                    <div>1500¢</div>
+                </div>
+                <div class="flex-grow-1 col-md-3 flex-md-grow-0">
+                    <div class="caps-label">Content Packs</div>
+                    <div>Scavvy</div>
+                    <a href="#" class="fs-7 linked">Edit</a>
                 </div>
             </div>
         </div>
-    </section>
-    <!-- ============================================================ -->
-    <!-- 13. EMPTY STATES -->
-    <!-- ============================================================ -->
-    <section>
-        <h2 class="h4 mb-3">Empty states</h2>
-        <h3 class="h6 caps-label mb-2">Block empty state</h3>
-        <div class="border rounded p-3 mb-3">
-            <p class="text-secondary mb-0">No fighters yet.</p>
+        <h3 class="h6 caps-label mb-2">Step progress (multi-step flows)</h3>
+        <p class="text-secondary fs-7 mb-2">
+            Use <code>
+            {% verbatim %}
+                {% include "core/includes/step_progress.html" with step=N total_steps=N title="..." %}
+            {% endverbatim %}
+        </code> for multi-step forms (advancement, vehicle, equipment sell).
+    </p>
+    <div class="border rounded p-3 mb-4">
+        <div class="col-12 col-md-8 col-lg-6">
+            {% include "core/includes/step_progress.html" with step=2 total_steps=3 title="Add Vehicle" subtitle="Select crew" %}
+            <div class="mt-3">
+                <p class="text-secondary fs-7 mb-0">
+                    Step content goes here. The progress bar, h1.h3 title, and optional h2.h5 subtitle are rendered by the include.
+                </p>
+            </div>
         </div>
-        <h3 class="h6 caps-label mb-2">Inline empty value (table cell)</h3>
-        <table class="table table-sm table-borderless mb-0 fs-7">
-            <thead>
+    </div>
+</section>
+<!-- ============================================================ -->
+<!-- 13. EMPTY STATES -->
+<!-- ============================================================ -->
+<section>
+    <h2 class="h4 mb-3">Empty states</h2>
+    <h3 class="h6 caps-label mb-2">Block empty state</h3>
+    <div class="border rounded p-3 mb-3">
+        <p class="text-secondary mb-0">No fighters yet.</p>
+    </div>
+    <h3 class="h6 caps-label mb-2">Inline empty value (table cell)</h3>
+    <table class="table table-sm table-borderless mb-0 fs-7">
+        <thead>
+            <tr>
+                <th>Fighter</th>
+                <th>Skill</th>
+                <th>Notes</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Stig</td>
+                <td>Infiltrate</td>
+                <td>
+                    <span class="text-secondary fst-italic">None</span>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<!-- ============================================================ -->
+<!-- 14. LINKS -->
+<!-- ============================================================ -->
+<section>
+    <h2 class="h4 mb-3">Links</h2>
+    <div class="vstack gap-2 mb-4">
+        <div>
+            <a href="#">Default link</a>
+            <code class="ms-2 fs-7 text-secondary">&lt;a&gt;</code>
+        </div>
+        <div>
+            <a href="#" class="linked">Linked style</a>
+            <code class="ms-2 fs-7 text-secondary">.linked (secondary + underline-opacity)</code>
+        </div>
+        <div>
+            <a href="#"
+               class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Secondary link</a>
+            <code class="ms-2 fs-7 text-secondary">.link-secondary (edit/reset actions)</code>
+        </div>
+        <div>
+            <a href="#"
+               class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover">Danger link</a>
+            <code class="ms-2 fs-7 text-secondary">.link-danger (delete/archive)</code>
+        </div>
+        <div>
+            <a href="#" class="link-primary">Primary link</a>
+            <code class="ms-2 fs-7 text-secondary">.link-primary (add/create)</code>
+        </div>
+        <div>
+            <span class="tooltipped">Tooltipped style</span>
+            <code class="ms-2 fs-7 text-secondary">.tooltipped (info underline, cursor: help)</code>
+        </div>
+    </div>
+    <p class="text-secondary fs-7 mb-0">
+        All links inherit the parent font size. Add <code>fs-7</code> to make them compact when needed.
+        <code>.linked</code> is shorthand for <code>.link-secondary .link-underline-opacity-50 .link-underline-opacity-100-hover</code>.
+        Underline opacity is <code>50</code> (not 25) for better visibility in dark mode.
+    </p>
+</section>
+<!-- ============================================================ -->
+<!-- 15. CUSTOM CSS REFERENCE -->
+<!-- ============================================================ -->
+<section>
+    <h2 class="h4 mb-3">Custom CSS reference</h2>
+    <p class="text-secondary fs-7 mb-2">
+        Custom classes defined in <code>styles.scss</code> to fill gaps Bootstrap doesn't cover.
+    </p>
+    <table class="table table-sm table-borderless mb-0 fs-7">
+        <thead>
+            <tr>
+                <th>Class</th>
+                <th>Purpose</th>
+                <th>Preview</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cls, purpose in custom_classes %}
                 <tr>
-                    <th>Fighter</th>
-                    <th>Skill</th>
-                    <th>Notes</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Stig</td>
-                    <td>Infiltrate</td>
                     <td>
-                        <span class="text-secondary fst-italic">None</span>
+                        <code>{{ cls }}</code>
+                    </td>
+                    <td>{{ purpose }}</td>
+                    <td>
+                        {% if cls == ".alert-icon" %}
+                            <span class="text-secondary">(see Feedback section)</span>
+                        {% elif cls == ".caps-label" %}
+                            <span class="caps-label">Example</span>
+                        {% elif cls == ".linked" %}
+                            <a href="#" class="linked">linked text</a>
+                        {% elif cls == ".fs-7" %}
+                            <span class="fs-7">compact text</span>
+                        {% elif cls == ".mb-last-0" %}
+                            <span class="text-secondary">(removes last-child margin)</span>
+                        {% elif cls == ".flash-warn" %}
+                            <span class="text-secondary">(see Flash highlight below)</span>
+                        {% elif cls == ".tooltipped" %}
+                            <span class="tooltipped">hover me</span>
+                        {% elif cls == ".table-fixed" %}
+                            <span class="text-secondary">(table-layout: fixed)</span>
+                        {% endif %}
                     </td>
                 </tr>
-            </tbody>
-        </table>
-    </section>
-    <!-- ============================================================ -->
-    <!-- 14. LINKS -->
-    <!-- ============================================================ -->
-    <section>
-        <h2 class="h4 mb-3">Links</h2>
-        <div class="vstack gap-2 mb-4">
-            <div>
-                <a href="#">Default link</a>
-                <code class="ms-2 fs-7 text-secondary">&lt;a&gt;</code>
-            </div>
-            <div>
-                <a href="#" class="linked">Linked style</a>
-                <code class="ms-2 fs-7 text-secondary">.linked (secondary + underline-opacity)</code>
-            </div>
-            <div>
-                <a href="#"
-                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Secondary link</a>
-                <code class="ms-2 fs-7 text-secondary">.link-secondary (edit/reset actions)</code>
-            </div>
-            <div>
-                <a href="#"
-                   class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover">Danger link</a>
-                <code class="ms-2 fs-7 text-secondary">.link-danger (delete/archive)</code>
-            </div>
-            <div>
-                <a href="#" class="link-primary">Primary link</a>
-                <code class="ms-2 fs-7 text-secondary">.link-primary (add/create)</code>
-            </div>
-            <div>
-                <span class="tooltipped">Tooltipped style</span>
-                <code class="ms-2 fs-7 text-secondary">.tooltipped (info underline, cursor: help)</code>
-            </div>
-        </div>
-        <p class="text-secondary fs-7 mb-0">
-            All links inherit the parent font size. Add <code>fs-7</code> to make them compact when needed.
-            <code>.linked</code> is shorthand for <code>.link-secondary .link-underline-opacity-50 .link-underline-opacity-100-hover</code>.
-        </p>
-    </section>
-    <!-- ============================================================ -->
-    <!-- 15. CUSTOM CSS REFERENCE -->
-    <!-- ============================================================ -->
-    <section>
-        <h2 class="h4 mb-3">Custom CSS reference</h2>
-        <p class="text-secondary fs-7 mb-2">
-            Custom classes defined in <code>styles.scss</code> to fill gaps Bootstrap doesn't cover.
-        </p>
-        <table class="table table-sm table-borderless mb-0 fs-7">
-            <thead>
-                <tr>
-                    <th>Class</th>
-                    <th>Purpose</th>
-                    <th>Preview</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for cls, purpose in custom_classes %}
-                    <tr>
-                        <td>
-                            <code>{{ cls }}</code>
-                        </td>
-                        <td>{{ purpose }}</td>
-                        <td>
-                            {% if cls == ".alert-icon" %}
-                                <span class="text-secondary">(see Feedback section)</span>
-                            {% elif cls == ".caps-label" %}
-                                <span class="caps-label">Example</span>
-                            {% elif cls == ".linked" %}
-                                <a href="#" class="linked">linked text</a>
-                            {% elif cls == ".fs-7" %}
-                                <span class="fs-7">compact text</span>
-                            {% elif cls == ".mb-last-0" %}
-                                <span class="text-secondary">(removes last-child margin)</span>
-                            {% elif cls == ".flash-warn" %}
-                                <span class="text-secondary">(see Flash highlight below)</span>
-                            {% elif cls == ".tooltipped" %}
-                                <span class="tooltipped">hover me</span>
-                            {% elif cls == ".table-fixed" %}
-                                <span class="text-secondary">(table-layout: fixed)</span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </section>
-    <!-- ============================================================ -->
-    <!-- 16. FLASH ANIMATION -->
-    <!-- ============================================================ -->
-    <section>
-        <h2 class="h4 mb-3">Flash highlight</h2>
-        <div class="flash-warn border rounded p-3">
-            This element has the <code>.flash-warn</code> class, which animates a warning background fade over 2s.
-            Used when returning from add pages to highlight the newly added item.
-        </div>
-    </section>
+            {% endfor %}
+        </tbody>
+    </table>
+</section>
+<!-- ============================================================ -->
+<!-- 16. FLASH ANIMATION -->
+<!-- ============================================================ -->
+<section>
+    <h2 class="h4 mb-3">Flash highlight</h2>
+    <div class="flash-warn border rounded p-3">
+        This element has the <code>.flash-warn</code> class, which animates a warning background fade over 2s.
+        Used when returning from add pages to highlight the newly added item.
+    </div>
+</section>
 </div>
 <script>
         // Compute and display actual rendered font sizes in pixels.

--- a/gyrinx/core/views/debug.py
+++ b/gyrinx/core/views/debug.py
@@ -149,6 +149,13 @@ def debug_design_system(request):
         (".table-fixed", "table-layout: fixed for stat grids"),
     ]
 
+    # Mock campaign for breadcrumb demo (needs .id and .name)
+    from types import SimpleNamespace
+
+    ds_campaign = SimpleNamespace(
+        id="00000000-0000-0000-0000-000000000000", name="Underhive Wars"
+    )
+
     return render(
         request,
         "core/debug/design_system.html",
@@ -160,6 +167,7 @@ def debug_design_system(request):
             "spacing_scale": spacing_scale,
             "page_shells": page_shells,
             "custom_classes": custom_classes,
+            "ds_campaign": ds_campaign,
         },
     )
 


### PR DESCRIPTION
## Summary

- Add breadcrumb component section to design system page patterns with four live examples (list, campaign gang, pack, print mode)
- Document dark mode contrast overrides for `text-secondary` and `link-secondary` in colour section
- Update link underline opacity documentation (25 → 50)
- Update page pattern and page shell examples to include breadcrumbs above entity headers

## Test plan
- [x] Visit `/_debug/design-system/` and check breadcrumb section renders correctly
- [x] Check dark mode contrast section shows samples on dark background
- [x] Verify page pattern examples include breadcrumb above headers

🤖 Generated with [Claude Code](https://claude.ai/claude-code)