### PR TITLE
style: content pack equipment UI visual tweaks

### DIFF
--- a/gyrinx/core/templates/core/pack/includes/fighter_default_equipment.html
+++ b/gyrinx/core/templates/core/pack/includes/fighter_default_equipment.html
@@ -1,9 +1,13 @@
 {% load custom_tags %}
-<div class="vstack gap-3 mt-3">
-    <h2 class="h5 mb-0">Default equipment</h2>
-    <p class="text-secondary fs-7 mb-0">Equipment that Fighters based on this template receive when hired.</p>
-    <!-- Weapons -->
+<section class="vstack gap-3 mt-3">
     <div>
+        <div class="d-flex justify-content-between align-items-center mb-2 bg-body-tertiary rounded px-2 py-2">
+            <h2 class="h5 mb-0">Default equipment</h2>
+        </div>
+        <p class="text-secondary fs-7 mb-0 px-2">Equipment that Fighters based on this template receive when hired.</p>
+    </div>
+    <!-- Weapons -->
+    <div class="px-2">
         <div class="d-flex align-items-center gap-2 mb-2">
             <h3 class="h6 mb-0">Weapons</h3>
             <a href="{% url 'core:pack-fighter-default-weapon-add' pack.id pack_item.id %}"
@@ -43,7 +47,7 @@
         {% endif %}
     </div>
     <!-- Gear -->
-    <div>
+    <div class="px-2">
         <div class="d-flex align-items-center gap-2 mb-2">
             <h3 class="h6 mb-0">Gear</h3>
             <a href="{% url 'core:pack-fighter-default-gear-add' pack.id pack_item.id %}"
@@ -66,4 +70,4 @@
             <p class="text-secondary fs-7 mb-0">No default gear.</p>
         {% endif %}
     </div>
-</div>
+</section>

--- a/gyrinx/core/templates/core/pack/includes/fighter_equipment_list.html
+++ b/gyrinx/core/templates/core/pack/includes/fighter_equipment_list.html
@@ -1,9 +1,13 @@
 {% load custom_tags %}
-<div class="vstack gap-3 mt-3">
-    <h2 class="h5 mb-0">Equipment list</h2>
-    <p class="text-secondary fs-7 mb-0">Equipment list for this Fighter type.</p>
-    <!-- Weapons -->
+<section class="vstack gap-3 mt-3">
     <div>
+        <div class="d-flex justify-content-between align-items-center mb-2 bg-body-tertiary rounded px-2 py-2">
+            <h2 class="h5 mb-0">Equipment list</h2>
+        </div>
+        <p class="text-secondary fs-7 mb-0 px-2">Equipment list for this Fighter type.</p>
+    </div>
+    <!-- Weapons -->
+    <div class="px-2">
         <div class="d-flex align-items-center gap-2 mb-2">
             <h3 class="h6 mb-0">Weapons</h3>
             <a href="{% url 'core:pack-fighter-equipment-list-weapon-add' pack.id pack_item.id %}"
@@ -47,7 +51,7 @@
         {% endif %}
     </div>
     <!-- Gear -->
-    <div>
+    <div class="px-2">
         <div class="d-flex align-items-center gap-2 mb-2">
             <h3 class="h6 mb-0">Gear</h3>
             <a href="{% url 'core:pack-fighter-equipment-list-gear-add' pack.id pack_item.id %}"
@@ -77,4 +81,4 @@
             <p class="text-secondary fs-7 mb-0">No available gear.</p>
         {% endif %}
     </div>
-</div>
+</section>

--- a/gyrinx/core/templates/core/pack/pack_fighter_default_gear_add.html
+++ b/gyrinx/core/templates/core/pack/pack_fighter_default_gear_add.html
@@ -15,17 +15,22 @@
             </div>
         {% endif %}
         <!-- Search -->
-        <form method="get" class="d-flex gap-2" id="search">
-            <input type="text"
-                   name="q"
-                   value="{{ search_q }}"
-                   class="form-control form-control-sm"
-                   placeholder="Search gear...">
-            <button type="submit" class="btn btn-secondary btn-sm">Search</button>
-            {% if search_q %}
-                <a href="{% url 'core:pack-fighter-default-gear-add' pack.id pack_item.id %}"
-                   class="btn btn-outline-secondary btn-sm">Clear</a>
-            {% endif %}
+        <form method="get" id="search">
+            <div class="d-flex gap-2 align-items-center">
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi-search"></i></span>
+                    <input type="search"
+                           name="q"
+                           value="{{ search_q }}"
+                           class="form-control"
+                           placeholder="Search gear...">
+                    <button type="submit" class="btn btn-primary">Search</button>
+                </div>
+                {% if search_q %}
+                    <a href="{% url 'core:pack-fighter-default-gear-add' pack.id pack_item.id %}"
+                       class="fs-7 text-nowrap">Clear</a>
+                {% endif %}
+            </div>
         </form>
         <!-- Gear by category -->
         <div class="grid">

--- a/gyrinx/core/templates/core/pack/pack_fighter_default_weapons_add.html
+++ b/gyrinx/core/templates/core/pack/pack_fighter_default_weapons_add.html
@@ -15,17 +15,22 @@
             </div>
         {% endif %}
         <!-- Search -->
-        <form method="get" class="d-flex gap-2" id="search">
-            <input type="text"
-                   name="q"
-                   value="{{ search_q }}"
-                   class="form-control form-control-sm"
-                   placeholder="Search weapons...">
-            <button type="submit" class="btn btn-secondary btn-sm">Search</button>
-            {% if search_q %}
-                <a href="{% url 'core:pack-fighter-default-weapon-add' pack.id pack_item.id %}"
-                   class="btn btn-outline-secondary btn-sm">Clear</a>
-            {% endif %}
+        <form method="get" id="search">
+            <div class="d-flex gap-2 align-items-center">
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi-search"></i></span>
+                    <input type="search"
+                           name="q"
+                           value="{{ search_q }}"
+                           class="form-control"
+                           placeholder="Search weapons...">
+                    <button type="submit" class="btn btn-primary">Search</button>
+                </div>
+                {% if search_q %}
+                    <a href="{% url 'core:pack-fighter-default-weapon-add' pack.id pack_item.id %}"
+                       class="fs-7 text-nowrap">Clear</a>
+                {% endif %}
+            </div>
         </form>
         <!-- Weapons by category -->
         <div class="grid">


### PR DESCRIPTION
## Summary

- Update search bars on default weapon/gear add pages to match the design system pattern (icon prepend, `type=search`, `btn-primary`)
- Apply section header bar pattern (`bg-body-tertiary`) to Default Equipment and Equipment List sections on the fighter edit page

## Test plan
- [ ] Check search bar styling on default weapon/gear add pages
- [ ] Verify section headers on fighter edit page in content pack

🤖 Generated with [Claude Code](https://claude.ai/claude-code)