### PR TITLE
fix: reorder campaign gang breadcrumb to user / type / campaign / name

### DIFF
--- a/gyrinx/core/templates/core/includes/breadcrumb.html
+++ b/gyrinx/core/templates/core/includes/breadcrumb.html
@@ -11,15 +11,15 @@
     <span class="mx-1">/</span>
     {{ type }}
     <span class="mx-1">/</span>
+    {% if campaign %}
+        <a class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover"
+           href="{% url 'core:campaign' campaign.id %}">{{ campaign.name }}</a>
+        <span class="mx-1">/</span>
+    {% endif %}
     {% if print or not name_url %}
         {{ name }}
     {% else %}
         <a class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover"
            href="{{ name_url }}">{{ name }}</a>
-    {% endif %}
-    {% if campaign %}
-        ·
-        <a class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover"
-           href="{% url 'core:campaign' campaign.id %}">{{ campaign.name }}</a>
     {% endif %}
 </div>


### PR DESCRIPTION
## Summary

- Reorder campaign gang breadcrumb from `user / Campaign Gang / name · campaign` to `user / Campaign Gang / campaign / name`

## Test plan
- [x] Check breadcrumb on a campaign gang list page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)