### PR TITLE
fix: exclude Ammo category from weapon dropdown in content packs

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -542,9 +542,11 @@ class ContentWeaponPackForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Filter to weapon categories only, ordered by group then name.
+        # Filter to weapon categories only (exclude Ammo), ordered by name.
         self.fields["category"].queryset = (
-            ContentEquipmentCategory.objects.filter(group="Weapons & Ammo")
+            ContentEquipmentCategory.objects.filter(group="Weapons & Ammo").exclude(
+                name="Ammo"
+            )
         ).order_by("name")
 
     def clean_name(self):


### PR DESCRIPTION
## Summary

- Remove "Ammo" from the weapon category dropdown when creating custom weapons in a content pack — it's not a valid weapon type

## Test plan
- [ ] Go to a content pack, add a weapon — verify "Ammo" is not in the category dropdown

🤖 Generated with [Claude Code](https://claude.ai/claude-code)