### PR TITLE
fix: separate public and unlisted lists on user profile page

### DIFF
--- a/gyrinx/core/templates/core/user.html
+++ b/gyrinx/core/templates/core/user.html
@@ -10,7 +10,9 @@
             <h1 class="h2 mb-0">{{ profile_user.username }}</h1>
             <div class="d-flex flex-wrap gap-2 text-secondary fs-7">
                 <span><i class="bi-clock"></i> Joined {{ profile_user.date_joined|naturaltime }}</span>
-                <span><i class="bi-list-ul"></i> {{ public_lists|length }} public list{{ public_lists|length|pluralize }}</span>
+                <span><i class="bi-list-ul"></i> {{ public_lists|length }} public list{{ public_lists|length|pluralize }}
+                    {% if unlisted_lists %}, {{ unlisted_lists|length }} unlisted{% endif %}
+                </span>
                 {% if profile_user.is_staff %}<span class="badge text-bg-success">Staff</span>{% endif %}
             </div>
         </div>
@@ -18,7 +20,7 @@
         {% if public_lists or is_own_profile %}
             <section>
                 <div class="d-flex justify-content-between align-items-center mb-2 bg-body-tertiary rounded px-2 py-2">
-                    <h2 class="h5 mb-0">Public Lists</h2>
+                    <h2 class="h5 mb-0">Public lists</h2>
                     {% if is_own_profile %}
                         <a href="{% url 'core:lists-new' %}" class="btn btn-primary btn-sm">
                             <i class="bi-plus-lg"></i> Add
@@ -43,6 +45,31 @@
                     {% else %}
                         <p class="text-secondary mb-0">No public lists yet.</p>
                     {% endif %}
+                </div>
+            </section>
+        {% endif %}
+        <!-- Unlisted Lists (only visible to the owner) -->
+        {% if unlisted_lists %}
+            <section>
+                <div class="d-flex justify-content-between align-items-center mb-2 bg-body-tertiary rounded px-2 py-2">
+                    <h2 class="h5 mb-0">
+                        <i class="bi-eye-slash"></i> Unlisted
+                    </h2>
+                </div>
+                <div class="px-2">
+                    <ul class="list-unstyled mb-0">
+                        {% for list in unlisted_lists %}
+                            <li class="py-1">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <a href="{% url 'core:list' list.id %}" class="fw-medium">{{ list.name }}</a>
+                                        <span class="text-secondary fs-7 ms-1">{{ list.content_house_name }}</span>
+                                    </div>
+                                    <span class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</span>
+                                </div>
+                            </li>
+                        {% endfor %}
+                    </ul>
                 </div>
             </section>
         {% endif %}

--- a/gyrinx/core/tests/test_user_profile.py
+++ b/gyrinx/core/tests/test_user_profile.py
@@ -1,0 +1,108 @@
+import pytest
+from django.urls import reverse
+
+from gyrinx.core.models.list import List
+
+
+@pytest.mark.django_db
+def test_own_profile_separates_public_and_unlisted_lists(client, user, content_house):
+    """Test that the owner's profile page separates public and unlisted lists."""
+    public_list = List.objects.create(
+        name="My Public List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+    unlisted_list = List.objects.create(
+        name="My Unlisted List",
+        owner=user,
+        content_house=content_house,
+        public=False,
+    )
+
+    client.force_login(user)
+    url = reverse("core:user", args=[user.username])
+    response = client.get(url)
+    content = response.content.decode()
+
+    assert response.status_code == 200
+    assert public_list.name in content
+    assert unlisted_list.name in content
+    # The public list should appear in the public section, unlisted in the unlisted section
+    assert "Public lists" in content
+    assert "Unlisted" in content
+
+
+@pytest.mark.django_db
+def test_own_profile_no_unlisted_section_when_none(client, user, content_house):
+    """Test that the unlisted section doesn't appear when there are no unlisted lists."""
+    List.objects.create(
+        name="My Public List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+
+    client.force_login(user)
+    url = reverse("core:user", args=[user.username])
+    response = client.get(url)
+    content = response.content.decode()
+
+    assert response.status_code == 200
+    assert "My Public List" in content
+    # The unlisted section heading should not appear
+    assert "bi-eye-slash" not in content
+
+
+@pytest.mark.django_db
+def test_other_user_cannot_see_unlisted_lists(client, user, make_user, content_house):
+    """Test that other users cannot see unlisted lists on a profile."""
+    List.objects.create(
+        name="My Public List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+    List.objects.create(
+        name="My Secret List",
+        owner=user,
+        content_house=content_house,
+        public=False,
+    )
+
+    other_user = make_user("otheruser", "password")
+    client.force_login(other_user)
+    url = reverse("core:user", args=[user.username])
+    response = client.get(url)
+    content = response.content.decode()
+
+    assert response.status_code == 200
+    assert "My Public List" in content
+    assert "My Secret List" not in content
+    assert "bi-eye-slash" not in content
+
+
+@pytest.mark.django_db
+def test_anonymous_user_cannot_see_unlisted_lists(client, user, content_house):
+    """Test that anonymous users cannot see unlisted lists on a profile."""
+    List.objects.create(
+        name="My Public List",
+        owner=user,
+        content_house=content_house,
+        public=True,
+    )
+    List.objects.create(
+        name="My Secret List",
+        owner=user,
+        content_house=content_house,
+        public=False,
+    )
+
+    url = reverse("core:user", args=[user.username])
+    response = client.get(url)
+    content = response.content.decode()
+
+    assert response.status_code == 200
+    assert "My Public List" in content
+    assert "My Secret List" not in content
+    assert "bi-eye-slash" not in content

--- a/gyrinx/core/views/user.py
+++ b/gyrinx/core/views/user.py
@@ -50,14 +50,28 @@ def user(request, slug_or_id):
     is_own_profile = request.user.is_authenticated and request.user == profile_user
 
     # --- Public Lists (non-campaign, non-archived) ---
-    public_lists_qs = List.objects.filter(
-        owner=profile_user, status=List.LIST_BUILDING, archived=False
+    public_lists_qs = (
+        List.objects.filter(
+            owner=profile_user, status=List.LIST_BUILDING, archived=False, public=True
+        )
+        .with_latest_actions()
+        .select_related("content_house", "owner")
     )
-    if not is_own_profile:
-        public_lists_qs = public_lists_qs.filter(public=True)
-    public_lists = public_lists_qs.with_latest_actions().select_related(
-        "content_house", "owner"
-    )
+    public_lists = public_lists_qs
+
+    # --- Unlisted Lists (only visible to the owner) ---
+    unlisted_lists = List.objects.none()
+    if is_own_profile:
+        unlisted_lists = (
+            List.objects.filter(
+                owner=profile_user,
+                status=List.LIST_BUILDING,
+                archived=False,
+                public=False,
+            )
+            .with_latest_actions()
+            .select_related("content_house", "owner")
+        )
 
     # --- Campaign Gangs (campaign-mode lists) ---
     campaign_gangs_qs = List.objects.filter(
@@ -104,6 +118,7 @@ def user(request, slug_or_id):
             "profile_user": profile_user,
             "is_own_profile": is_own_profile,
             "public_lists": public_lists,
+            "unlisted_lists": unlisted_lists,
             "campaign_gangs": campaign_gangs,
             "campaigns": campaigns,
             "packs": packs,


### PR DESCRIPTION
Closes #1629

When viewing your own profile, unlisted lists were shown under the "public lists" heading. Now they appear in a separate "Unlisted" section only visible to the profile owner.

Generated with [Claude Code](https://claude.ai/code)