### PR TITLE
fix: detect rule source and show accurate attribution label

### DIFF
--- a/gyrinx/content/models/base.py
+++ b/gyrinx/content/models/base.py
@@ -93,8 +93,23 @@ class Content(Base):
 class RulelineDisplay:
     """A dataclass for displaying rules in a consistent format."""
 
+    # Source constants
+    SOURCE_DEFAULT = "default"
+    SOURCE_EQUIPMENT = "equipment"
+    SOURCE_USER = "user"
+
     value: str
     modded: bool = False
+    source: str = SOURCE_DEFAULT
+
+    @property
+    def source_label(self):
+        """Human-readable label for the source of this rule."""
+        labels = {
+            self.SOURCE_EQUIPMENT: "Added by equipment, accessories or upgrades",
+            self.SOURCE_USER: "Added by user edit",
+        }
+        return labels.get(self.source, "")
 
 
 @dataclass

--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -2678,14 +2678,15 @@ class ListFighter(AppBase):
             disabled_rules_set = set(rules_qs.filter(disabled_by_fighters=self))
             custom_rules = list(rules_qs.filter(custom_for_fighters=self))
 
-        modded = []
+        equipment_modded = set()
+        user_modded = set()
         rules = [r for r in rules if r not in disabled_rules_set]
 
         # Apply modifications from equipment/items
         for mod in self._rulemods:
             if mod.mode == "add" and mod.rule not in rules:
                 rules.append(mod.rule)
-                modded.append(mod.rule)
+                equipment_modded.add(mod.rule)
             elif mod.mode == "remove" and mod.rule in rules:
                 rules.remove(mod.rule)
 
@@ -2693,9 +2694,24 @@ class ListFighter(AppBase):
         for custom_rule in custom_rules:
             if custom_rule not in rules:
                 rules.append(custom_rule)
-                modded.append(custom_rule)
+                user_modded.add(custom_rule)
 
-        return [RulelineDisplay(rule.name, rule in modded) for rule in rules]
+        def _make_display(rule):
+            if rule in equipment_modded:
+                return RulelineDisplay(
+                    rule.name,
+                    modded=True,
+                    source=RulelineDisplay.SOURCE_EQUIPMENT,
+                )
+            elif rule in user_modded:
+                return RulelineDisplay(
+                    rule.name,
+                    modded=True,
+                    source=RulelineDisplay.SOURCE_USER,
+                )
+            return RulelineDisplay(rule.name)
+
+        return [_make_display(rule) for rule in rules]
 
     # Assignments
 

--- a/gyrinx/core/templates/core/includes/rule.html
+++ b/gyrinx/core/templates/core/includes/rule.html
@@ -5,7 +5,7 @@
             <span bs-tooltip
                   data-bs-toggle="tooltip"
                   class="tooltipped"
-                  title="Added by equipment, accessories or upgrades">{{ rule.value }}</span>
+                  title="{{ rule.source_label }}">{{ rule.value }}</span>
         {% else %}
             <span>{% ref rule.value value=rule.value %}</span>
         {% endif %}

--- a/gyrinx/core/tests/test_assignments.py
+++ b/gyrinx/core/tests/test_assignments.py
@@ -679,6 +679,7 @@ def test_upgrade_fighter_stat_mod(
         RulelineDisplay(
             value="Add Me",
             modded=True,
+            source=RulelineDisplay.SOURCE_EQUIPMENT,
         )
     ]
     assert fighter.skilline() == [
@@ -732,6 +733,7 @@ def test_equipment_fighter_stat_mod(
         RulelineDisplay(
             value="Add Me",
             modded=True,
+            source=RulelineDisplay.SOURCE_EQUIPMENT,
         )
     ]
 

--- a/gyrinx/core/tests/test_list_fighter_rules.py
+++ b/gyrinx/core/tests/test_list_fighter_rules.py
@@ -99,11 +99,12 @@ def test_list_fighter_ruleline_includes_custom_rules(client):
     assert "Default Rule" in ruleline_names
     assert "Custom Rule" in ruleline_names
 
-    # Custom rule should be marked as modded
+    # Custom rule should be marked as modded with user source
     custom_rule_display = next(
         r for r in list_fighter.ruleline if r.value == "Custom Rule"
     )
     assert custom_rule_display.modded
+    assert custom_rule_display.source == "user"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #1649

Rules added by equipment show "Added by equipment, accessories or upgrades" while rules added manually by users now show "Added by user edit". Extended RulelineDisplay with a source field to track provenance separately.

Generated with [Claude Code](https://claude.ai/code)