### PR TITLE
fix: remove count pill from "Recommended by Campaign" heading

### DIFF
--- a/gyrinx/core/templates/core/list_packs.html
+++ b/gyrinx/core/templates/core/list_packs.html
@@ -16,10 +16,7 @@
             <!-- Recommended by Campaign -->
             <section>
                 <div class="d-flex justify-content-between align-items-center mb-2 bg-body-tertiary rounded px-2 py-2">
-                    <h2 class="h5 mb-0">
-                        Recommended by Campaign
-                        <span class="badge text-bg-info">{{ campaign_packs|length }}</span>
-                    </h2>
+                    <h2 class="h5 mb-0">Recommended by Campaign</h2>
                 </div>
                 <div class="px-2">
                     <p class="text-secondary fs-7">These Content Packs are used by a Campaign this gang is in.</p>


### PR DESCRIPTION
Removes the badge showing the number of campaign-recommended packs on the list content packs page, consistent with the design direction of removing count pills across the application.

Closes #1645

Generated with [Claude Code](https://claude.ai/code)