### PR TITLE
feat: show "Added by [Pack name]" in custom content tooltips

### DIFF
--- a/gyrinx/core/templates/core/includes/fighter_card_content.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content.html
@@ -89,7 +89,7 @@
                         {% if fighter.from_pack_name %}
                             <i class="bi-dot fs-7 text-secondary pack-icon"
                                data-bs-toggle="tooltip"
-                               data-bs-title="{{ fighter.from_pack_name }}"></i>
+                               data-bs-title="Added by {{ fighter.from_pack_name }}"></i>
                         {% endif %}
                     {% else %}
                         {{ fighter.content_fighter_cached.type }}
@@ -101,7 +101,7 @@
                         {% if fighter.from_pack_name %}
                             <i class="bi-dot fs-7 text-secondary pack-icon"
                                data-bs-toggle="tooltip"
-                               data-bs-title="{{ fighter.from_pack_name }}"></i>
+                               data-bs-title="Added by {{ fighter.from_pack_name }}"></i>
                         {% endif %}
                     {% endif %}
                 </div>

--- a/gyrinx/core/templates/core/includes/gear_assign_name.html
+++ b/gyrinx/core/templates/core/includes/gear_assign_name.html
@@ -14,7 +14,7 @@
             {% if pname %}
                 <span>&nbsp;<i class="bi-dot fs-7 text-secondary pack-icon"
    data-bs-toggle="tooltip"
-   data-bs-title="{{ pname }}"></i></span>
+   data-bs-title="Added by {{ pname }}"></i></span>
             {% endif %}
         {% endwith %}
     {% endif %}

--- a/gyrinx/core/templates/core/includes/list_fighter_weapon_assign_name.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_weapon_assign_name.html
@@ -22,7 +22,7 @@
         {% if pname %}
             <i class="bi-dot fs-7 text-secondary pack-icon"
                data-bs-toggle="tooltip"
-               data-bs-title="{{ pname }}"></i>
+               data-bs-title="Added by {{ pname }}"></i>
         {% endif %}
     {% endwith %}
 {% endif %}


### PR DESCRIPTION
Update the bi-dot pack indicator tooltips to show "Added by [Pack name]" for clearer attribution of custom content sources.

Closes #1667

Generated with [Claude Code](https://claude.ai/code)