### PR TITLE
fix: content pack customisation tweaks

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -2,13 +2,13 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models import Case, When
 
-from gyrinx.core.forms import BsCheckboxSelectMultipleCompact
 from gyrinx.content.models.equipment import ContentEquipment, ContentEquipmentCategory
 from gyrinx.content.models.fighter import ContentFighter
 from gyrinx.content.models.house import ContentHouse
 from gyrinx.content.models.metadata import ContentRule
 from gyrinx.content.models.skill import ContentSkill, ContentSkillCategory
 from gyrinx.content.models.weapon import ContentWeaponProfile, ContentWeaponTrait
+from gyrinx.core.forms import BsCheckboxSelectMultipleCompact
 from gyrinx.core.models.pack import CustomContentPack
 from gyrinx.core.widgets import TINYMCE_EXTRA_ATTRS, TinyMCEWithUpload
 from gyrinx.forms import group_select
@@ -19,6 +19,7 @@ _EXCLUDED_FIGHTER_CATEGORIES = {
     FighterCategoryChoices.STASH,
     FighterCategoryChoices.VEHICLE,
     FighterCategoryChoices.GANG_TERRAIN,
+    FighterCategoryChoices.EXOTIC_BEAST,
 }
 
 
@@ -582,8 +583,8 @@ class ContentWeaponProfilePackForm(forms.ModelForm):
             "traits": "Traits",
         }
         help_texts = {
-            "name": "Leave blank for the standard profile. Named profiles represent alternate fire modes.",
-            "cost": "The credit cost. Standard (unnamed) profiles must have zero cost.",
+            "name": "e.g. ranged, melee, gas shells...",
+            "cost": "The credit cost. If free, the other free profiles must be named.",
             "rarity": "The availability of this profile.",
             "rarity_roll": "The roll required to find this profile (e.g. 7, 10).",
         }

--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -5,6 +5,7 @@ from django.db.models import Case, When
 from gyrinx.content.models.equipment import ContentEquipment, ContentEquipmentCategory
 from gyrinx.content.models.fighter import ContentFighter
 from gyrinx.content.models.house import ContentHouse
+from gyrinx.content.models.statline import ContentStatlineType
 from gyrinx.content.models.metadata import ContentRule
 from gyrinx.content.models.skill import ContentSkill, ContentSkillCategory
 from gyrinx.content.models.weapon import ContentWeaponProfile, ContentWeaponTrait
@@ -63,6 +64,26 @@ class ContentFighterPackForm(forms.ModelForm):
     to include both base library content and pack-specific content.
     """
 
+    override_statline = forms.BooleanField(
+        required=False,
+        label="Override default statline for this Category?",
+        widget=forms.CheckboxInput(
+            attrs={"class": "form-check-input", "id": "id_override_statline"}
+        ),
+    )
+    statline_type = forms.ModelChoiceField(
+        queryset=ContentStatlineType.objects.none(),
+        required=False,
+        label="Statline type",
+        widget=forms.Select(
+            attrs={
+                "class": "form-select",
+                "disabled": "disabled",
+                "id": "id_statline_type",
+            }
+        ),
+    )
+
     class Meta:
         model = ContentFighter
         fields = [
@@ -119,6 +140,35 @@ class ContentFighterPackForm(forms.ModelForm):
             for value, label in FighterCategoryChoices.choices
             if value not in _EXCLUDED_FIGHTER_CATEGORIES
         ]
+
+        # Populate statline type choices filtered to types relevant to
+        # the categories available in this form.
+        allowed_categories = {
+            value
+            for value, _ in FighterCategoryChoices.choices
+            if value not in _EXCLUDED_FIGHTER_CATEGORIES
+        }
+        relevant_ids = [
+            st.pk
+            for st in ContentStatlineType.objects.all()
+            if set(st.default_for_categories) & allowed_categories
+        ]
+        self.fields["statline_type"].queryset = ContentStatlineType.objects.filter(
+            pk__in=relevant_ids
+        )
+        self.fields["statline_type"].empty_label = "Default"
+        # Remove disabled attr when override is checked so the value submits.
+        if self.data.get("override_statline"):
+            del self.fields["statline_type"].widget.attrs["disabled"]
+
+        # Place the override/statline fields right after category.
+        field_order = list(self.fields.keys())
+        cat_idx = field_order.index("category") + 1
+        for name in ("override_statline", "statline_type"):
+            field_order.remove(name)
+        field_order.insert(cat_idx, "override_statline")
+        field_order.insert(cat_idx + 1, "statline_type")
+        self.order_fields(field_order)
 
         # House is required for pack fighters.
         self.fields["house"].required = True
@@ -224,6 +274,10 @@ class ContentFighterPackForm(forms.ModelForm):
                 "secondary_skill_categories",
             ]:
                 del self.fields[field_name]
+        else:
+            # Override statline is only relevant during creation.
+            for field_name in ["override_statline", "statline_type"]:
+                self.fields.pop(field_name, None)
 
     def clean_type(self):
         value = self.cleaned_data["type"]

--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -279,6 +279,13 @@ class ContentFighterPackForm(forms.ModelForm):
             for field_name in ["override_statline", "statline_type"]:
                 self.fields.pop(field_name, None)
 
+    def clean(self):
+        cleaned = super().clean()
+        # Server-side enforcement: ignore statline_type unless override is checked.
+        if not cleaned.get("override_statline"):
+            cleaned["statline_type"] = None
+        return cleaned
+
     def clean_type(self):
         value = self.cleaned_data["type"]
         qs = ContentFighter.objects.filter(type__iexact=value)

--- a/gyrinx/core/templates/core/pack/pack_item_add.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add.html
@@ -45,7 +45,7 @@
                     </div>
                 </div>
                 <div class="alert alert-info alert-icon mb-0" role="alert">
-                    <i class="bi-info-circle"></i>
+                    <i class="bi-info-circle" aria-hidden="true"></i>
                     <div>
                         <p class="mb-0">You can add further profiles or special ammo later.</p>
                     </div>
@@ -56,7 +56,7 @@
             {% endif %}
             {% if next_step_hint %}
                 <div class="alert alert-info alert-icon mb-0 mt-3" role="alert">
-                    <i class="bi-info-circle"></i>
+                    <i class="bi-info-circle" aria-hidden="true"></i>
                     <div>{{ next_step_hint }}</div>
                 </div>
             {% endif %}

--- a/gyrinx/core/templates/core/pack/pack_item_add.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add.html
@@ -44,6 +44,12 @@
                         {% include "core/pack/includes/weapon_profile_stats_form.html" with weapon_stats=weapon_stat_fields_2 prefix="wp2" selected_trait_ids=selected_trait_ids_2 %}
                     </div>
                 </div>
+                <div class="alert alert-info alert-icon mb-0" role="alert">
+                    <i class="bi-info-circle"></i>
+                    <div>
+                        <p class="mb-0">You can add further profiles or special ammo later.</p>
+                    </div>
+                </div>
             {% elif weapon_stat_fields %}
                 <input type="hidden" name="profile_mode" value="single">
                 {% include "core/pack/includes/weapon_profile_stats_form.html" with weapon_stats=weapon_stat_fields %}

--- a/gyrinx/core/templates/core/pack/pack_item_add.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add.html
@@ -76,3 +76,24 @@
         </form>
     </div>
 {% endblock content %}
+{% block extra_script %}
+    <script>
+        (function () {
+            const checkbox = document.getElementById("id_override_statline");
+            const select = document.getElementById("id_statline_type");
+            if (!checkbox || !select) return;
+
+            function toggle() {
+                if (checkbox.checked) {
+                    select.removeAttribute("disabled");
+                } else {
+                    select.setAttribute("disabled", "disabled");
+                    select.value = "";
+                }
+            }
+
+            checkbox.addEventListener("change", toggle);
+            toggle();
+        })();
+    </script>
+{% endblock extra_script %}

--- a/gyrinx/core/templates/core/pack/pack_weapon_mode_select.html
+++ b/gyrinx/core/templates/core/pack/pack_weapon_mode_select.html
@@ -9,6 +9,7 @@
             <i class="bi-crosshair"></i> Add weapon
         </h1>
         <p class="mb-0">Does this weapon come with multiple profiles or ammo by default?</p>
+        <p class="text-secondary">You can add further free or costed profiles or special ammo later.</p>
         <div class="row g-3">
             <div class="col-12 col-md-6 col-lg-4">
                 <div class="border rounded p-3 vstack gap-2 h-100">
@@ -19,8 +20,8 @@
                             {% include "core/includes/weapon_stat_headers.html" %}
                             <tbody class="table-group-divider">
                                 <tr>
-                                    <td class="text-center">
-                                        <strong>Example</strong>
+                                    <td class="text-start">
+                                        <strong>Example Weapon</strong>
                                     </td>
                                     <td class="text-center">-</td>
                                     <td class="text-center">-</td>
@@ -41,10 +42,10 @@
             <div class="col-12 col-md-6 col-lg-4">
                 <div class="border rounded p-3 vstack gap-2 h-100">
                     <strong>Multiple profiles</strong>
-                    <p class="text-secondary mb-0 fs-7">Two or more named profiles (e.g. special ammo types).</p>
+                    <p class="text-secondary mb-0 fs-7">Two or more named profiles (e.g. ranged and melee).</p>
                     <div class="table-responsive">
                         <table class="table table-sm table-borderless fs-7 mb-0">
-                            {% include "core/includes/weapon_stat_headers.html" with first_col="Example" %}
+                            {% include "core/includes/weapon_stat_headers.html" with first_col="Example Weapon" %}
                             <tbody class="table-group-divider">
                                 <tr>
                                     <td class="text-secondary fst-italic">Profile 1</td>
@@ -76,6 +77,5 @@
                 </div>
             </div>
         </div>
-        <p class="text-secondary">You can add further, costed special profiles or ammo later.</p>
     </div>
 {% endblock content %}

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1555,13 +1555,14 @@ def test_add_fighter_with_rules(
 def test_add_fighter_excludes_special_categories(
     client, group_user, pack, fighter_statline_type
 ):
-    """Test that STASH, VEHICLE, GANG_TERRAIN are not in the category choices."""
+    """Test that STASH, VEHICLE, GANG_TERRAIN, EXOTIC_BEAST are not in the category choices."""
     client.force_login(group_user)
     response = client.get(f"/pack/{pack.id}/add/fighter/")
     content = response.content.decode()
     assert "STASH" not in content
     assert "VEHICLE" not in content
     assert "GANG_TERRAIN" not in content
+    assert "EXOTIC_BEAST" not in content
     # Normal categories should be present
     assert "LEADER" in content
     assert "GANGER" in content

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1297,7 +1297,29 @@ def test_archived_items_page_requires_ownership(
 @pytest.fixture
 def fighter_statline_type():
     """Create the Fighter ContentStatlineType with standard stats."""
-    statline_type, _ = ContentStatlineType.objects.get_or_create(name="Fighter")
+    statline_type, _ = ContentStatlineType.objects.get_or_create(
+        name="Fighter",
+        defaults={
+            "default_for_categories": [
+                "LEADER",
+                "CHAMPION",
+                "GANGER",
+                "JUVE",
+                "SPECIALIST",
+                "PROSPECT",
+            ]
+        },
+    )
+    if not statline_type.default_for_categories:
+        statline_type.default_for_categories = [
+            "LEADER",
+            "CHAMPION",
+            "GANGER",
+            "JUVE",
+            "SPECIALIST",
+            "PROSPECT",
+        ]
+        statline_type.save()
 
     # (field_name, short_name, full_name, position, is_inches, is_target)
     stat_defs = [

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1569,6 +1569,95 @@ def test_add_fighter_excludes_special_categories(
 
 
 @pytest.mark.django_db
+def test_add_fighter_statline_type_excludes_vehicle(
+    client, group_user, pack, fighter_statline_type
+):
+    """Test that Vehicle statline type is not available when VEHICLE category is excluded."""
+    ContentStatlineType.objects.get_or_create(
+        name="Vehicle", defaults={"default_for_categories": ["VEHICLE"]}
+    )
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}/add/fighter/")
+    content = response.content.decode()
+    assert ">Vehicle<" not in content
+    assert ">Fighter<" in content
+
+
+@pytest.mark.django_db
+def test_add_fighter_statline_override(
+    client, group_user, pack, fighter_statline_type, content_house
+):
+    """Test that override_statline + statline_type passes through to step 2."""
+    # Create a Crew statline type with different stats.
+    crew_type, _ = ContentStatlineType.objects.get_or_create(
+        name="Crew", defaults={"default_for_categories": ["CREW"]}
+    )
+    if not crew_type.default_for_categories:
+        crew_type.default_for_categories = ["CREW"]
+        crew_type.save()
+    stat, _ = ContentStat.objects.get_or_create(
+        field_name="movement",
+        defaults={"short_name": "M", "full_name": "Movement", "is_inches": True},
+    )
+    ContentStatlineTypeStat.objects.get_or_create(
+        statline_type=crew_type, stat=stat, defaults={"position": 1}
+    )
+
+    client.force_login(group_user)
+
+    # Step 1: POST with override_statline checked and Crew selected.
+    response = client.post(
+        f"/pack/{pack.id}/add/fighter/",
+        {
+            "type": "Crew Fighter",
+            "category": "GANGER",
+            "house": str(content_house.pk),
+            "base_cost": "50",
+            "override_statline": "on",
+            "statline_type": str(crew_type.pk),
+        },
+    )
+    assert response.status_code == 302
+    step2_url = response.url
+    assert f"statline_type_id={crew_type.pk}" in step2_url
+
+    # Step 2: GET should show the Crew statline fields.
+    response = client.get(step2_url)
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Crew type has only Movement; Fighter statline has 12 stats.
+    assert "stat_movement" in content
+    assert "stat_weapon_skill" not in content
+
+    # Step 2: POST to create the fighter.
+    response = client.post(step2_url, {"stat_movement": "5"})
+    assert response.status_code == 302
+
+    fighter = ContentFighter.objects.all_content().get(type="Crew Fighter")
+    assert fighter.custom_statline.statline_type == crew_type
+
+
+@pytest.mark.django_db
+def test_add_fighter_default_statline_no_override(
+    client, group_user, pack, fighter_statline_type, content_house
+):
+    """Test that without override, no statline_type_id is in the URL."""
+    client.force_login(group_user)
+
+    response = client.post(
+        f"/pack/{pack.id}/add/fighter/",
+        {
+            "type": "Normal Fighter",
+            "category": "GANGER",
+            "house": str(content_house.pk),
+            "base_cost": "50",
+        },
+    )
+    assert response.status_code == 302
+    assert "statline_type_id" not in response.url
+
+
+@pytest.mark.django_db
 def test_add_fighter_requires_type(
     client, group_user, pack, fighter_statline_type, content_house
 ):

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -820,6 +820,7 @@ class AddFighterFlowParams(BaseModel):
     house_id: uuid.UUID
     base_cost: int
     rule_ids: list[uuid.UUID] = []
+    statline_type_id: uuid.UUID | None = None
 
 
 WEAPON_PROFILE_MODES = {"single", "multi"}
@@ -844,9 +845,11 @@ def _get_statline_type_for_category(category):
     )
 
 
-def _get_fighter_stat_definitions(category=None):
+def _get_fighter_stat_definitions(category=None, statline_type_override=None):
     """Load the stat definitions for a fighter category's statline type."""
-    if category:
+    if statline_type_override:
+        statline_type = statline_type_override
+    elif category:
         statline_type = _get_statline_type_for_category(category)
     else:
         statline_type = ContentStatlineType.objects.get(name="Fighter")
@@ -916,9 +919,13 @@ def _stat_placeholder(content_stat):
     return "3"
 
 
-def _create_fighter_statline(fighter, stat_definitions, post_data, category=None):
+def _create_fighter_statline(
+    fighter, stat_definitions, post_data, category=None, statline_type_override=None
+):
     """Create a ContentStatline and populate stat values from POST data."""
-    if category:
+    if statline_type_override:
+        statline_type = statline_type_override
+    elif category:
         statline_type = _get_statline_type_for_category(category)
     else:
         statline_type = ContentStatlineType.objects.get(name="Fighter")
@@ -1170,14 +1177,16 @@ def add_pack_item(request, id, content_type_slug):
         if form.is_valid() and not wp_name_errors:
             if is_fighter:
                 # Redirect to Step 2 with form data in query params.
+                statline_type = form.cleaned_data.get("statline_type")
                 params = AddFighterFlowParams(
                     type=form.cleaned_data["type"],
                     category=form.cleaned_data["category"],
                     house_id=form.cleaned_data["house"].pk,
                     base_cost=form.cleaned_data["base_cost"],
                     rule_ids=[r.pk for r in form.cleaned_data.get("rules", [])],
+                    statline_type_id=statline_type.pk if statline_type else None,
                 )
-                query_data = params.model_dump(mode="json")
+                query_data = params.model_dump(mode="json", exclude_none=True)
                 if "save_and_add_another" in request.POST:
                     query_data["save_and_add_another"] = "1"
                 qs = urlencode(query_data, doseq=True)
@@ -1305,12 +1314,14 @@ def add_pack_fighter_stats(request, id):
     # Parse flow params from query string.
     try:
         rule_ids = request.GET.getlist("rule_ids")
+        statline_type_id = request.GET.get("statline_type_id") or None
         params = AddFighterFlowParams(
             type=request.GET["type"],
             category=request.GET["category"],
             house_id=request.GET["house_id"],
             base_cost=request.GET["base_cost"],
             rule_ids=rule_ids,
+            statline_type_id=statline_type_id,
         )
     except (KeyError, ValidationError):
         # Invalid or missing params — redirect back to Step 1.
@@ -1318,8 +1329,17 @@ def add_pack_fighter_stats(request, id):
             reverse("core:pack-add-item", args=(pack.id, "fighter"))
         )
 
+    # Resolve statline type override if provided.
+    statline_type_override = None
+    if params.statline_type_id:
+        statline_type_override = ContentStatlineType.objects.filter(
+            pk=params.statline_type_id
+        ).first()
+
     save_and_add_another = request.GET.get("save_and_add_another") == "1"
-    stat_definitions = _get_fighter_stat_definitions(category=params.category)
+    stat_definitions = _get_fighter_stat_definitions(
+        category=params.category, statline_type_override=statline_type_override
+    )
 
     if request.method == "POST":
         # Re-validate fighter data via the same form used in Step 1.
@@ -1350,7 +1370,11 @@ def add_pack_fighter_stats(request, id):
             )
             item.save_with_user(user=request.user)
             _create_fighter_statline(
-                fighter, stat_definitions, request.POST, category=params.category
+                fighter,
+                stat_definitions,
+                request.POST,
+                category=params.category,
+                statline_type_override=statline_type_override,
             )
 
         log_event(
@@ -1385,7 +1409,7 @@ def add_pack_fighter_stats(request, id):
         )
 
     # Build the query string for the back button / form action.
-    query_data = params.model_dump(mode="json")
+    query_data = params.model_dump(mode="json", exclude_none=True)
     if save_and_add_another:
         query_data["save_and_add_another"] = "1"
     qs = urlencode(query_data, doseq=True)

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -1329,11 +1329,23 @@ def add_pack_fighter_stats(request, id):
             reverse("core:pack-add-item", args=(pack.id, "fighter"))
         )
 
-    # Resolve statline type override if provided.
+    # Resolve statline type override if provided, validating it against
+    # the same allowed set that Step 1 offers.
     statline_type_override = None
     if params.statline_type_id:
+        from gyrinx.core.forms.pack import _EXCLUDED_FIGHTER_CATEGORIES
+        from gyrinx.models import FighterCategoryChoices as FCC
+
+        allowed_categories = {
+            v for v, _ in FCC.choices if v not in _EXCLUDED_FIGHTER_CATEGORIES
+        }
+        allowed_ids = [
+            st.pk
+            for st in ContentStatlineType.objects.all()
+            if set(st.default_for_categories) & allowed_categories
+        ]
         statline_type_override = ContentStatlineType.objects.filter(
-            pk=params.statline_type_id
+            pk=params.statline_type_id, pk__in=allowed_ids
         ).first()
 
     save_and_add_another = request.GET.get("save_and_add_another") == "1"


### PR DESCRIPTION
## Summary

- Exclude Exotic Beast from pack fighter category choices
- Add statline type override to fighter creation flow (checkbox + filtered dropdown)
- Improve weapon profile help text and mode selection wording

## Test plan

- [x] Create a fighter in a content pack — verify Exotic Beast is not in category choices
- [x] Check "Override default statline" — verify dropdown enables with Fighter/Crew (no Vehicle)
- [x] Select Crew statline override — verify step 2 shows Crew stats
- [x] Create fighter without override — verify default statline behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)