### PR TITLE
feat: remove Custom Content group restrictions from content packs

### DIFF
--- a/docs/content-library/content-packs.md
+++ b/docs/content-library/content-packs.md
@@ -6,7 +6,7 @@ Content Packs are user-created collections of custom game content. They allow us
 
 The content pack system is designed around a key principle: pack content is hidden from normal queries by default. When a user browses fighters, equipment, or other content in the application, they only see the official base content. Pack content only appears when a user explicitly opts in to a specific pack. This keeps the default experience clean while still allowing custom content to coexist in the same database.
 
-Content packs are a gated feature. Only users who belong to the "Custom Content" user group can access the packs interface, create packs, or browse community packs. This allows you to control the rollout of custom content functionality.
+Content packs are available to all authenticated users. Any logged-in user can access the packs interface, create packs, and browse community packs.
 
 ## Key Concepts
 
@@ -15,8 +15,6 @@ Content packs are a gated feature. Only users who belong to the "Custom Content"
 **Pack content** is any content item that has been added to at least one content pack. Pack content is automatically excluded from normal content queries throughout the application.
 
 **Listed vs unlisted** packs control public visibility. A listed pack appears in search results and the community packs index. An unlisted pack can still be shared via its direct URL, but it will not show up when other users browse packs.
-
-**The "Custom Content" group** is a Django auth group. Users must be members of this group to access any pack-related pages. If a user who is not in this group tries to visit a pack URL, they receive a 404 response.
 
 **Content types** refer to the different kinds of game content that can be included in a pack. Currently, the supported content type is Houses (`ContentHouse`). The system is built using Django's `ContentType` framework, so extending it to additional content models is straightforward.
 
@@ -112,7 +110,7 @@ This column also appears as a read-only field on each content item's detail/edit
 
 ### The Customisation page
 
-Users in the "Custom Content" group access content packs through the Customisation page at `/packs/`. This page shows a searchable, paginated list of content packs.
+Authenticated users access content packs through the Customisation page at `/packs/`. This page shows a searchable, paginated list of content packs.
 
 By default, authenticated users see only their own packs (the "My packs only" toggle is on). Turning the toggle off shows all publicly listed packs from the community. Full-text search covers pack names, summaries, and author usernames.
 
@@ -151,14 +149,6 @@ Activity is paginated at 50 entries per page.
 When users build lists and add fighters or equipment, they interact with the normal content queries that exclude pack content by default. Pack content does not appear in fighter selection dropdowns, equipment lists, or any other content-driven interface unless the application explicitly uses `with_packs()` to include specific packs.
 
 ## Common Admin Tasks
-
-### Adding a user to the Custom Content group
-
-Before a user can create or browse content packs, they must be a member of the "Custom Content" Django auth group. To add a user:
-
-1. Navigate to the user's record in the Django admin under Authentication and Authorization > Users
-2. In the Groups section, add the "Custom Content" group
-3. Save the user record
 
 ### Creating a pack via the admin
 

--- a/gyrinx/conftest.py
+++ b/gyrinx/conftest.py
@@ -587,27 +587,17 @@ def stash_fighter_type(content_house, make_content_fighter):
 
 
 @pytest.fixture
-def custom_content_group():
-    """Create the Custom Content group."""
-    from django.contrib.auth.models import Group
-
-    group, _ = Group.objects.get_or_create(name="Custom Content")
-    return group
-
-
-@pytest.fixture
-def cc_user(user, custom_content_group):
-    """A user in the Custom Content group."""
-    user.groups.add(custom_content_group)
+def cc_user(user):
+    """A user for content pack operations (group membership no longer required)."""
     return user
 
 
 @pytest.fixture
-def make_pack(cc_user):
+def make_pack(user):
     """Factory fixture to create CustomContentPack objects."""
 
     def make_pack_(name="Test Pack", **kwargs):
-        kwargs = {"owner": cc_user, "listed": True, **kwargs}
+        kwargs = {"owner": user, "listed": True, **kwargs}
         return CustomContentPack.objects.create(name=name, **kwargs)
 
     return make_pack_

--- a/gyrinx/core/migrations/0141_remove_custom_content_group.py
+++ b/gyrinx/core/migrations/0141_remove_custom_content_group.py
@@ -1,0 +1,26 @@
+"""Remove the Custom Content group — content pack features are now available to all users."""
+
+from django.db import migrations
+
+
+def remove_custom_content_group(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name="Custom Content").delete()
+
+
+def recreate_custom_content_group(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.get_or_create(name="Custom Content")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0140_add_patreon_fields_to_user_profile"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_custom_content_group,
+            recreate_custom_content_group,
+        ),
+    ]

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -1,4 +1,4 @@
-{% load custom_tags color_tags group_tags %}
+{% load custom_tags color_tags %}
 <div>
     {% if list.archived %}
         <div class="border rounded p-2 mb-3 hstack gap-2 align-items-center text-secondary">
@@ -81,7 +81,7 @@
                                 <i class="bi-box-seam"></i>
                                 <a href="{% url 'core:list-packs' list.id %}" class="linked">{{ suggested_campaign_packs_count }} suggested</a>
                             </div>
-                        {% elif list.owner_cached == user and user|in_group:"Custom Content" %}
+                        {% elif list.owner_cached == user %}
                             <div>
                                 <i class="bi-box-seam"></i>
                                 <a href="{% url 'core:list-packs' list.id %}" class="linked">Add Content Pack</a>

--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -1,5 +1,5 @@
 {% extends "core/layouts/foundation.html" %}
-{% load static custom_tags pages group_tags %}
+{% load static custom_tags pages %}
 {% block base %}
     <a class="visually-hidden-focusable" href="#content">Skip to main content</a>
     {% include "core/includes/site_banner.html" %}
@@ -47,7 +47,7 @@
                         <a class="nav-link {% active_path '/campaigns/' '/campaign/' '/battle/' %}"
                            href="{% url 'core:campaigns' %}">Campaigns</a>
                     </li>
-                    {% if user|in_group:"Custom Content" %}
+                    {% if user.is_authenticated %}
                         <li class="nav-item">
                             <a class="nav-link {% active_path '/packs/' '/pack/' %}"
                                href="{% url 'core:packs' %}">Customisation</a>

--- a/gyrinx/core/templates/core/list_edit.html
+++ b/gyrinx/core/templates/core/list_edit.html
@@ -18,15 +18,13 @@
                 {% include "core/includes/cancel.html" %}
             </div>
         </form>
-        {% if has_custom_content %}
-            <div class="border-top pt-3 mt-2">
-                <h2 class="h5">Content Packs</h2>
-                <p class="text-secondary fs-7">Content packs add custom fighters, rules, and other content to your list.</p>
-                <a href="{% url 'core:list-packs' form.instance.id %}"
-                   class="btn btn-secondary btn-sm">
-                    <i class="bi-box-seam"></i> Manage Content Packs
-                </a>
-            </div>
-        {% endif %}
+        <div class="border-top pt-3 mt-2">
+            <h2 class="h5">Content Packs</h2>
+            <p class="text-secondary fs-7">Content packs add custom fighters, rules, and other content to your list.</p>
+            <a href="{% url 'core:list-packs' form.instance.id %}"
+               class="btn btn-secondary btn-sm">
+                <i class="bi-box-seam"></i> Manage Content Packs
+            </a>
+        </div>
     </div>
 {% endblock content %}

--- a/gyrinx/core/tests/test_campaign_packs.py
+++ b/gyrinx/core/tests/test_campaign_packs.py
@@ -156,20 +156,10 @@ def test_campaign_packs_view_requires_login(client, make_campaign):
 
 
 @pytest.mark.django_db
-def test_campaign_packs_view_requires_custom_content_group(client, user, make_campaign):
-    """Pack management view requires Custom Content group membership."""
-    campaign = make_campaign("Test Campaign")
-
-    client.force_login(user)
-    response = client.get(reverse("core:campaign-packs", args=[campaign.id]))
-
-    # group_membership_required returns 404 for users without the group
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_campaign_packs_view_accessible_with_group(client, cc_user, make_campaign):
-    """Pack management view is accessible to Custom Content group members."""
+def test_campaign_packs_view_accessible_to_authenticated_user(
+    client, cc_user, make_campaign
+):
+    """Pack management view is accessible to authenticated users."""
     campaign = make_campaign("Test Campaign")
 
     client.force_login(cc_user)
@@ -876,11 +866,10 @@ def test_pack_filter_shown_when_campaign_has_packs(
 
 @pytest.mark.django_db
 def test_campaign_packs_page_accessible_to_member(
-    client, cc_user, make_user, make_campaign, content_house, custom_content_group
+    client, cc_user, make_user, make_campaign, content_house
 ):
     """A campaign member (non-owner) can access the campaign packs page."""
     member = make_user("member", "password")
-    member.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
     member_list = List.objects.create(
@@ -902,11 +891,10 @@ def test_campaign_packs_page_accessible_to_member(
 
 @pytest.mark.django_db
 def test_campaign_packs_page_404_for_non_member(
-    client, cc_user, make_user, make_campaign, custom_content_group
+    client, cc_user, make_user, make_campaign
 ):
     """A user with no gang in the campaign gets 404."""
     stranger = make_user("stranger", "password")
-    stranger.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
 
@@ -918,11 +906,10 @@ def test_campaign_packs_page_404_for_non_member(
 
 @pytest.mark.django_db
 def test_campaign_packs_member_sees_add_to_dropdown(
-    client, cc_user, make_user, make_campaign, content_house, custom_content_group
+    client, cc_user, make_user, make_campaign, content_house
 ):
     """A member sees the 'Add to...' dropdown with their unsubscribed gangs."""
     member = make_user("member", "password")
-    member.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
     gang = List.objects.create(
@@ -946,11 +933,10 @@ def test_campaign_packs_member_sees_add_to_dropdown(
 
 @pytest.mark.django_db
 def test_campaign_packs_hides_subscribed_gangs_from_dropdown(
-    client, cc_user, make_user, make_campaign, content_house, custom_content_group
+    client, cc_user, make_user, make_campaign, content_house
 ):
     """Gangs already subscribed to a pack are hidden from the dropdown."""
     member = make_user("member", "password")
-    member.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
     gang = List.objects.create(
@@ -972,12 +958,9 @@ def test_campaign_packs_hides_subscribed_gangs_from_dropdown(
 
 
 @pytest.mark.django_db
-def test_campaign_packs_my_filter(
-    client, cc_user, make_user, make_campaign, custom_content_group
-):
+def test_campaign_packs_my_filter(client, cc_user, make_user, make_campaign):
     """The 'Your Packs only' filter shows only packs owned by the current user."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
 
@@ -1001,11 +984,10 @@ def test_campaign_packs_my_filter(
 
 @pytest.mark.django_db
 def test_campaign_packs_member_does_not_see_add_remove_controls(
-    client, cc_user, make_user, make_campaign, content_house, custom_content_group
+    client, cc_user, make_user, make_campaign, content_house
 ):
     """A non-owner member should not see the 'Add Packs' section or remove links."""
     member = make_user("member", "password")
-    member.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
     gang = List.objects.create(
@@ -1028,11 +1010,10 @@ def test_campaign_packs_member_does_not_see_add_remove_controls(
 
 @pytest.mark.django_db
 def test_campaign_packs_subscribe_from_dropdown(
-    client, cc_user, make_user, make_campaign, content_house, custom_content_group
+    client, cc_user, make_user, make_campaign, content_house
 ):
     """Subscribing a gang via the dropdown redirects back to campaign packs."""
     member = make_user("member", "password")
-    member.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
     gang = List.objects.create(
@@ -1062,11 +1043,10 @@ def test_campaign_packs_subscribe_from_dropdown(
 
 @pytest.mark.django_db
 def test_campaign_packs_dropdown_shows_other_link(
-    client, cc_user, make_user, make_campaign, content_house, custom_content_group
+    client, cc_user, make_user, make_campaign, content_house
 ):
     """The dropdown always includes an 'Other...' link to the pack's lists page."""
     member = make_user("member", "password")
-    member.groups.add(custom_content_group)
 
     campaign = make_campaign("Test Campaign")
     gang = List.objects.create(

--- a/gyrinx/core/tests/test_csrf.py
+++ b/gyrinx/core/tests/test_csrf.py
@@ -25,8 +25,8 @@ def test_csrf_failure_redirects_with_message(client: Client):
     user = User.objects.create_user(username="testuser", password="password")
     client.force_login(user)
 
-    # Get the form page
-    response = client.get(form_url)
+    # Get the form page (skip_packs=1 to bypass pack interstitial redirect)
+    response = client.get(form_url + "?skip_packs=1")
     assert response.status_code == 200
 
     # Now post without CSRF token (simulating expired token)

--- a/gyrinx/core/tests/test_invitation_pack_setup.py
+++ b/gyrinx/core/tests/test_invitation_pack_setup.py
@@ -1,24 +1,10 @@
 """Tests for the invitation pack setup flow."""
 
 import pytest
-from django.contrib.auth.models import Group
 from django.urls import reverse
 
 from gyrinx.core.models.invitation import CampaignInvitation
 from gyrinx.core.models.pack import CustomContentPack
-
-
-@pytest.fixture
-def custom_content_group():
-    group, _ = Group.objects.get_or_create(name="Custom Content")
-    return group
-
-
-@pytest.fixture
-def cc_user(user, custom_content_group):
-    """User in the Custom Content group."""
-    user.groups.add(custom_content_group)
-    return user
 
 
 @pytest.mark.django_db
@@ -92,10 +78,10 @@ def test_pack_setup_subscribes_packs(client, cc_user, make_campaign, make_list):
 
 
 @pytest.mark.django_db
-def test_pack_setup_requires_custom_content_group(
+def test_pack_setup_accessible_to_authenticated_user(
     client, user, make_campaign, make_list
 ):
-    """Pack setup page requires Custom Content group membership."""
+    """Pack setup page is accessible to any authenticated user."""
     campaign = make_campaign("Test Campaign")
     lst = make_list("Test List")
     campaign.lists.add(lst)
@@ -105,7 +91,7 @@ def test_pack_setup_requires_custom_content_group(
         reverse("core:invitation-pack-setup", args=[lst.id, campaign.id])
     )
 
-    assert response.status_code == 404
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_list_packs.py
+++ b/gyrinx/core/tests/test_list_packs.py
@@ -68,19 +68,6 @@ class TestPackSubscriptionViews:
         lst.refresh_from_db()
         assert pack not in lst.packs.all()
 
-    def test_subscribe_requires_custom_content_group(
-        self, client, make_user, pack, content_house
-    ):
-        """Users not in Custom Content group get 404."""
-        other_user = make_user("otheruser", "password")
-        client.force_login(other_user)
-        lst = List.objects.create(
-            name="Other List", content_house=content_house, owner=other_user
-        )
-        url = reverse("core:pack-subscribe", args=(pack.id,))
-        response = client.post(url, {"list_id": str(lst.id)})
-        assert response.status_code == 404
-
     def test_subscribe_requires_post(self, client, cc_user, pack):
         client.force_login(cc_user)
         url = reverse("core:pack-subscribe", args=(pack.id,))
@@ -126,18 +113,6 @@ class TestListPacksManageView:
         assert response.status_code == 302
         lst.refresh_from_db()
         assert pack in lst.packs.all()
-
-    def test_manage_packs_requires_custom_content_group(
-        self, client, make_user, content_house
-    ):
-        other_user = make_user("otheruser2", "password")
-        client.force_login(other_user)
-        lst = List.objects.create(
-            name="Other List", content_house=content_house, owner=other_user
-        )
-        url = reverse("core:list-packs", args=(lst.id,))
-        response = client.get(url)
-        assert response.status_code == 404
 
     def test_manage_packs_search(self, client, cc_user, make_list, pack):
         client.force_login(cc_user)
@@ -222,26 +197,16 @@ class TestNewListPacksInterstitial:
         assert response.status_code == 302
         assert "/packs" in response.url
 
-    def test_regular_user_sees_form_directly(self, client, make_user, content_house):
-        """Non-CC user goes straight to the new list form."""
+    def test_user_redirected_to_packs_interstitial(
+        self, client, make_user, content_house
+    ):
+        """Any authenticated user is redirected to pack interstitial."""
         other_user = make_user("regularuser", "password")
         client.force_login(other_user)
         url = reverse("core:lists-new")
         response = client.get(url)
-        assert response.status_code == 200
-
-    def test_regular_user_creates_list_directly(self, client, make_user, content_house):
-        """Non-CC user creates list and goes to list detail."""
-        other_user = make_user("regularuser", "password")
-        client.force_login(other_user)
-        url = reverse("core:lists-new")
-        response = client.post(
-            url,
-            {"name": "New List", "content_house": content_house.id, "public": True},
-        )
         assert response.status_code == 302
-        # Should redirect to list detail, not packs
-        assert "/packs" not in response.url
+        assert response.url == reverse("core:lists-new-packs")
 
     def test_packs_interstitial_page(self, client, cc_user, pack):
         """Interstitial page shows available packs."""
@@ -336,15 +301,6 @@ class TestNewListPacksInterstitial:
         assert response.status_code == 200
         assert b"Pack-Only House" in response.content
         assert b"Content Pack" in response.content
-
-    def test_non_cc_user_redirected_away(self, client, make_user, content_house):
-        """Non-CC user at interstitial is redirected to lists-new."""
-        other_user = make_user("regularuser2", "password")
-        client.force_login(other_user)
-        url = reverse("core:lists-new-packs")
-        response = client.get(url)
-        assert response.status_code == 302
-        assert "skip_packs=1" in response.url
 
 
 @pytest.mark.django_db
@@ -482,7 +438,7 @@ class TestListDetailShowsPacks:
     def test_list_detail_shows_add_pack_link_for_cc_owner(
         self, client, cc_user, make_list
     ):
-        """Owner in Custom Content group sees 'Add Content Pack' when no packs."""
+        """Owner sees 'Add Content Pack' when no packs."""
         client.force_login(cc_user)
         lst = make_list("Test List")
         url = reverse("core:list", args=(lst.id,))
@@ -490,13 +446,13 @@ class TestListDetailShowsPacks:
         assert response.status_code == 200
         assert b"Add Content Pack" in response.content
 
-    def test_list_detail_hides_add_pack_link_for_non_cc_owner(
+    def test_list_detail_shows_add_pack_link_for_any_owner(
         self, client, user, make_list
     ):
-        """Owner NOT in Custom Content group does not see 'Add Content Pack'."""
+        """Any authenticated owner sees 'Add Content Pack' when no packs."""
         client.force_login(user)
         lst = make_list("Test List")
         url = reverse("core:list", args=(lst.id,))
         response = client.get(url)
         assert response.status_code == 200
-        assert b"Add Content Pack" not in response.content
+        assert b"Add Content Pack" in response.content

--- a/gyrinx/core/tests/test_pack_skills.py
+++ b/gyrinx/core/tests/test_pack_skills.py
@@ -1,7 +1,6 @@
 """Tests for custom skills in content packs."""
 
 import pytest
-from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
@@ -12,14 +11,8 @@ from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 
 
 @pytest.fixture
-def custom_content_group():
-    group, _ = Group.objects.get_or_create(name="Custom Content")
-    return group
-
-
-@pytest.fixture
-def group_user(user, custom_content_group):
-    user.groups.add(custom_content_group)
+def group_user(user):
+    """A user for pack operations (group membership no longer required)."""
     return user
 
 

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 
@@ -19,15 +18,8 @@ from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 
 
 @pytest.fixture
-def custom_content_group():
-    group, _ = Group.objects.get_or_create(name="Custom Content")
-    return group
-
-
-@pytest.fixture
-def group_user(user, custom_content_group):
-    """A user who is in the Custom Content group."""
-    user.groups.add(custom_content_group)
+def group_user(user):
+    """A user for pack operations (group membership no longer required)."""
     return user
 
 
@@ -46,24 +38,14 @@ def pack(group_user):
 
 
 @pytest.mark.django_db
-def test_customisation_link_visible_for_group_members(client, group_user):
-    """Test that the Customisation link is visible for group members."""
-    client.force_login(group_user)
+def test_customisation_link_visible_for_authenticated_users(client, user):
+    """Test that the Customisation link is visible for authenticated users."""
+    client.force_login(user)
     response = client.get("/")
 
     assert response.status_code == 200
     assert b'href="/packs/"' in response.content
     assert b">Customisation</a>" in response.content
-
-
-@pytest.mark.django_db
-def test_customisation_link_hidden_for_non_members(client, user):
-    """Test that the Customisation link is hidden for non-members."""
-    client.force_login(user)
-    response = client.get("/")
-
-    assert response.status_code == 200
-    assert b'href="/packs/"' not in response.content
 
 
 @pytest.mark.django_db
@@ -73,43 +55,6 @@ def test_customisation_link_hidden_for_anonymous(client):
 
     assert response.status_code == 200
     assert b'href="/packs/"' not in response.content
-
-
-# --- View access gating ---
-
-
-@pytest.mark.django_db
-def test_packs_index_requires_group(client, user):
-    """Test that the packs index returns 404 for non-group members."""
-    client.force_login(user)
-    response = client.get("/packs/")
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_pack_detail_requires_group(client, pack, make_user):
-    """Test that the pack detail returns 404 for non-group members."""
-    non_member = make_user("nonmember", "password")
-    client.force_login(non_member)
-    response = client.get(f"/pack/{pack.id}")
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_pack_create_requires_group(client, user):
-    """Test that creating a pack returns 404 for non-group members."""
-    client.force_login(user)
-    response = client.get("/packs/new/")
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_pack_edit_requires_group(client, pack, make_user):
-    """Test that editing a pack returns 404 for non-group members."""
-    non_member = make_user("nonmember", "password")
-    client.force_login(non_member)
-    response = client.get(f"/pack/{pack.id}/edit/")
-    assert response.status_code == 404
 
 
 # --- Pack index view ---
@@ -133,12 +78,9 @@ def test_packs_index_shows_own_packs(client, group_user, pack):
 
 
 @pytest.mark.django_db
-def test_packs_index_hides_other_users_packs(
-    client, group_user, custom_content_group, make_user
-):
+def test_packs_index_hides_other_users_packs(client, group_user, make_user):
     """Test that the index doesn't show other users' packs by default."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     CustomContentPack.objects.create(name="Other Pack", listed=True, owner=other_user)
     client.force_login(group_user)
     response = client.get("/packs/")
@@ -147,12 +89,9 @@ def test_packs_index_hides_other_users_packs(
 
 
 @pytest.mark.django_db
-def test_packs_index_shows_listed_packs_when_my_off(
-    client, group_user, custom_content_group, make_user
-):
+def test_packs_index_shows_listed_packs_when_my_off(client, group_user, make_user):
     """Test that toggling off 'your packs' shows listed packs."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     CustomContentPack.objects.create(name="Other Pack", listed=True, owner=other_user)
     client.force_login(group_user)
     response = client.get("/packs/?my=0")
@@ -161,9 +100,7 @@ def test_packs_index_shows_listed_packs_when_my_off(
 
 
 @pytest.mark.django_db
-def test_packs_index_shows_own_packs_when_my_off(
-    client, group_user, custom_content_group, make_user
-):
+def test_packs_index_shows_own_packs_when_my_off(client, group_user, make_user):
     """Test that toggling off 'your packs' still shows the user's own packs."""
     # Create an unlisted pack owned by the current user
     CustomContentPack.objects.create(
@@ -171,7 +108,6 @@ def test_packs_index_shows_own_packs_when_my_off(
     )
     # Create a listed pack from another user
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     CustomContentPack.objects.create(name="Other Pack", listed=True, owner=other_user)
 
     # Create an unlisted pack from another user shared via permission
@@ -235,12 +171,9 @@ def test_pack_detail_shows_edit_for_owner(client, group_user, pack):
 
 
 @pytest.mark.django_db
-def test_pack_detail_hides_edit_for_non_owner(
-    client, group_user, pack, custom_content_group, make_user
-):
+def test_pack_detail_hides_edit_for_non_owner(client, group_user, pack, make_user):
     """Test that the edit button is hidden for non-owners."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}")
     assert response.status_code == 200
@@ -268,15 +201,12 @@ def test_unlisted_pack_visible_to_owner(client, group_user):
 
 
 @pytest.mark.django_db
-def test_unlisted_pack_hidden_from_others(
-    client, group_user, custom_content_group, make_user
-):
+def test_unlisted_pack_hidden_from_others(client, group_user, make_user):
     """Test that an unlisted pack returns 404 for non-owners."""
     unlisted = CustomContentPack.objects.create(
         name="Secret Pack", listed=False, owner=group_user
     )
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{unlisted.id}")
     assert response.status_code == 404
@@ -284,12 +214,13 @@ def test_unlisted_pack_hidden_from_others(
 
 @pytest.mark.django_db
 def test_unlisted_pack_hidden_from_anonymous(client, group_user):
-    """Test that an unlisted pack returns 404 for anonymous users."""
+    """Test that an unlisted pack redirects anonymous users to login."""
     unlisted = CustomContentPack.objects.create(
         name="Secret Pack", listed=False, owner=group_user
     )
     response = client.get(f"/pack/{unlisted.id}")
-    assert response.status_code == 404
+    assert response.status_code == 302
+    assert "/accounts/login/" in response.url
 
 
 # --- Pack create view ---
@@ -336,10 +267,9 @@ def test_pack_edit_requires_login(client, pack):
 
 
 @pytest.mark.django_db
-def test_pack_edit_requires_ownership(client, pack, custom_content_group, make_user):
+def test_pack_edit_requires_ownership(client, pack, make_user):
     """Test that only the owner can edit a pack."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}/edit/")
     assert response.status_code == 404
@@ -489,24 +419,21 @@ def test_pack_activity_page_loads(client, group_user, pack):
 
 
 @pytest.mark.django_db
-def test_pack_activity_page_requires_group(client, pack, make_user):
-    """Test that the activity page requires group membership."""
-    non_member = make_user("nonmember", "password")
-    client.force_login(non_member)
+def test_pack_activity_page_accessible_to_authenticated_user(client, pack, make_user):
+    """Test that the activity page is accessible to any authenticated user."""
+    other_user = make_user("otheruser", "password")
+    client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}/activity/")
-    assert response.status_code == 404
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_pack_activity_page_respects_visibility(
-    client, group_user, custom_content_group, make_user
-):
+def test_pack_activity_page_respects_visibility(client, group_user, make_user):
     """Test that the activity page respects pack visibility rules."""
     unlisted = CustomContentPack.objects.create(
         name="Secret Pack", listed=False, owner=group_user
     )
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{unlisted.id}/activity/")
     assert response.status_code == 404
@@ -708,20 +635,10 @@ def test_add_rule_requires_login(client, pack):
 
 
 @pytest.mark.django_db
-def test_add_rule_requires_ownership(client, pack, custom_content_group, make_user):
+def test_add_rule_requires_ownership(client, pack, make_user):
     """Test that only the pack owner can add rules."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
-    response = client.get(f"/pack/{pack.id}/add/rule/")
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_add_rule_requires_group(client, pack, make_user):
-    """Test that adding a rule requires Custom Content group."""
-    non_member = make_user("nonmember", "password")
-    client.force_login(non_member)
     response = client.get(f"/pack/{pack.id}/add/rule/")
     assert response.status_code == 404
 
@@ -745,12 +662,9 @@ def test_pack_detail_shows_add_rule_button(client, group_user, pack):
 
 
 @pytest.mark.django_db
-def test_pack_detail_hides_add_button_for_non_owner(
-    client, pack, custom_content_group, make_user
-):
+def test_pack_detail_hides_add_button_for_non_owner(client, pack, make_user):
     """Test that the Add button is hidden for non-owners."""
     other_user = make_user("viewer", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}")
     assert response.status_code == 200
@@ -793,12 +707,9 @@ def test_edit_rule_updates_content(client, group_user, pack, pack_rule):
 
 
 @pytest.mark.django_db
-def test_edit_rule_requires_ownership(
-    client, pack, pack_rule, custom_content_group, make_user
-):
+def test_edit_rule_requires_ownership(client, pack, pack_rule, make_user):
     """Test that only the pack owner can edit rules."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}/item/{pack_rule.id}/edit/")
     assert response.status_code == 404
@@ -833,12 +744,9 @@ def test_delete_rule_archives_item_and_preserves_content(
 
 
 @pytest.mark.django_db
-def test_delete_rule_requires_ownership(
-    client, pack, pack_rule, custom_content_group, make_user
-):
+def test_delete_rule_requires_ownership(client, pack, pack_rule, make_user):
     """Test that only the pack owner can delete rules."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.post(f"/pack/{pack.id}/item/{pack_rule.id}/delete/")
     assert response.status_code == 404
@@ -899,20 +807,10 @@ def test_add_house_requires_login(client, pack):
 
 
 @pytest.mark.django_db
-def test_add_house_requires_ownership(client, pack, custom_content_group, make_user):
+def test_add_house_requires_ownership(client, pack, make_user):
     """Test that only the pack owner can add houses."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
-    response = client.get(f"/pack/{pack.id}/add/house/")
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_add_house_requires_group(client, pack, make_user):
-    """Test that adding a house requires Custom Content group."""
-    non_member = make_user("nonmember", "password")
-    client.force_login(non_member)
     response = client.get(f"/pack/{pack.id}/add/house/")
     assert response.status_code == 404
 
@@ -976,12 +874,9 @@ def test_edit_house_updates_content(client, group_user, pack, pack_house):
 
 
 @pytest.mark.django_db
-def test_edit_house_requires_ownership(
-    client, pack, pack_house, custom_content_group, make_user
-):
+def test_edit_house_requires_ownership(client, pack, pack_house, make_user):
     """Test that only the pack owner can edit houses."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}/item/{pack_house.id}/edit/")
     assert response.status_code == 404
@@ -1015,12 +910,9 @@ def test_delete_house_archives_item_and_preserves_content(
 
 
 @pytest.mark.django_db
-def test_delete_house_requires_ownership(
-    client, pack, pack_house, custom_content_group, make_user
-):
+def test_delete_house_requires_ownership(client, pack, pack_house, make_user):
     """Test that only the pack owner can delete houses."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.post(f"/pack/{pack.id}/item/{pack_house.id}/delete/")
     assert response.status_code == 404
@@ -1082,16 +974,13 @@ def test_restore_pack_item(client, group_user, pack, pack_rule):
 
 
 @pytest.mark.django_db
-def test_restore_requires_ownership(
-    client, pack, pack_rule, custom_content_group, make_user
-):
+def test_restore_requires_ownership(client, pack, pack_rule, make_user):
     """Test that only the pack owner can restore items."""
     # Archive first (directly, since we need it archived)
     pack_rule._history_user = pack.owner
     pack_rule.archive()
 
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.post(f"/pack/{pack.id}/item/{pack_rule.id}/restore/")
     assert response.status_code == 404
@@ -1277,15 +1166,12 @@ def test_archived_items_page_loads(client, group_user, pack, pack_rule):
 
 
 @pytest.mark.django_db
-def test_archived_items_page_requires_ownership(
-    client, pack, pack_rule, custom_content_group, make_user
-):
+def test_archived_items_page_requires_ownership(client, pack, pack_rule, make_user):
     """Test that only the pack owner can view archived items."""
     pack_rule._history_user = pack.owner
     pack_rule.archive()
 
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}/archived/rule/")
     assert response.status_code == 404
@@ -1867,10 +1753,9 @@ def test_edit_fighter_form_preselects_pack_rules(
 
 
 @pytest.fixture
-def editor_user(custom_content_group, make_user):
-    """A second user in the Custom Content group to be used as an editor."""
+def editor_user(make_user):
+    """A second user to be used as an editor."""
     editor = make_user("editor", "password")
-    editor.groups.add(custom_content_group)
     return editor
 
 
@@ -1901,18 +1786,18 @@ def test_can_edit_returns_true_for_editor(pack_with_editor, editor_user):
 
 
 @pytest.mark.django_db
-def test_can_edit_returns_false_for_non_editor(pack, custom_content_group, make_user):
+def test_can_edit_returns_false_for_non_editor(pack, make_user):
     """Test that can_edit returns False for a non-editor user."""
     other = make_user("other", "password")
-    other.groups.add(custom_content_group)
+
     assert pack.can_edit(other) is False
 
 
 @pytest.mark.django_db
-def test_can_view_returns_true_for_listed_pack(pack, custom_content_group, make_user):
+def test_can_view_returns_true_for_listed_pack(pack, make_user):
     """Test that can_view returns True for any user on a listed pack."""
     other = make_user("other", "password")
-    other.groups.add(custom_content_group)
+
     assert pack.can_view(other) is True
 
 
@@ -1945,12 +1830,11 @@ def test_can_view_returns_true_for_unlisted_pack_editor(
 @pytest.mark.django_db
 def test_can_view_returns_false_for_unlisted_pack_non_editor(
     group_user,
-    custom_content_group,
     make_user,
 ):
     """Test that can_view returns False for a non-editor on an unlisted pack."""
     other = make_user("other", "password")
-    other.groups.add(custom_content_group)
+
     unlisted = CustomContentPack.objects.create(
         name="Unlisted", listed=False, owner=group_user
     )
@@ -2063,7 +1947,6 @@ def test_editor_can_see_unlisted_pack(
     client,
     editor_user,
     group_user,
-    custom_content_group,
 ):
     """Test that an editor can view an unlisted pack."""
     from gyrinx.core.models.pack import CustomContentPackPermission
@@ -2150,12 +2033,11 @@ def test_permissions_page_loads_for_owner(client, group_user, pack):
 def test_permissions_page_404_for_non_owner(
     client,
     pack,
-    custom_content_group,
     make_user,
 ):
     """Test that the permissions page returns 404 for non-owners."""
     other = make_user("other", "password")
-    other.groups.add(custom_content_group)
+
     client.force_login(other)
     response = client.get(f"/pack/{pack.id}/permissions/")
     assert response.status_code == 404
@@ -2230,19 +2112,6 @@ def test_permissions_add_owner_as_editor(client, group_user, pack):
     )
     assert response.status_code == 200
     assert b"already has full access" in response.content
-
-
-@pytest.mark.django_db
-def test_permissions_add_non_group_user(client, group_user, pack, make_user):
-    """Test that adding a user not in the Custom Content group shows an error."""
-    make_user("regular", "password")
-    client.force_login(group_user)
-    response = client.post(
-        f"/pack/{pack.id}/permissions/",
-        {"action": "add", "username": "regular"},
-    )
-    assert response.status_code == 200
-    assert b"not in the Custom Content group" in response.content
 
 
 # --- My Packs index shows editor packs ---
@@ -2348,10 +2217,9 @@ def test_add_gear_requires_login(client, pack):
 
 
 @pytest.mark.django_db
-def test_add_gear_requires_ownership(client, pack, custom_content_group, make_user):
+def test_add_gear_requires_ownership(client, pack, make_user):
     """Test that only pack editors can add gear."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}/add/gear/")
     assert response.status_code == 404
@@ -2412,12 +2280,9 @@ def test_edit_gear_without_changing_name(
 
 
 @pytest.mark.django_db
-def test_edit_gear_requires_ownership(
-    client, pack, pack_equipment, custom_content_group, make_user
-):
+def test_edit_gear_requires_ownership(client, pack, pack_equipment, make_user):
     """Test that only pack editors can edit gear."""
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     response = client.get(f"/pack/{pack.id}/item/{pack_equipment.id}/edit/")
     assert response.status_code == 404

--- a/gyrinx/core/tests/test_views_pack_default_equipment.py
+++ b/gyrinx/core/tests/test_views_pack_default_equipment.py
@@ -1,7 +1,6 @@
 """Tests for pack fighter default equipment views."""
 
 import pytest
-from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
@@ -12,14 +11,8 @@ from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 
 
 @pytest.fixture
-def custom_content_group():
-    group, _ = Group.objects.get_or_create(name="Custom Content")
-    return group
-
-
-@pytest.fixture
-def group_user(user, custom_content_group):
-    user.groups.add(custom_content_group)
+def group_user(user):
+    """A user for pack operations (group membership no longer required)."""
     return user
 
 
@@ -335,12 +328,9 @@ def test_remove_default_assignment_post(
 
 
 @pytest.mark.django_db
-def test_non_owner_cannot_access_add_weapon(
-    client, make_user, pack, pack_fighter, custom_content_group
-):
+def test_non_owner_cannot_access_add_weapon(client, make_user, pack, pack_fighter):
     fighter, pack_item = pack_fighter
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse("core:pack-fighter-default-weapon-add", args=(pack.id, pack_item.id))
     response = client.get(url)
@@ -348,12 +338,9 @@ def test_non_owner_cannot_access_add_weapon(
 
 
 @pytest.mark.django_db
-def test_non_owner_cannot_access_add_gear(
-    client, make_user, pack, pack_fighter, custom_content_group
-):
+def test_non_owner_cannot_access_add_gear(client, make_user, pack, pack_fighter):
     fighter, pack_item = pack_fighter
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse("core:pack-fighter-default-gear-add", args=(pack.id, pack_item.id))
     response = client.get(url)
@@ -362,14 +349,13 @@ def test_non_owner_cannot_access_add_gear(
 
 @pytest.mark.django_db
 def test_non_owner_cannot_remove_assignment(
-    client, make_user, pack, pack_fighter, base_weapon, custom_content_group
+    client, make_user, pack, pack_fighter, base_weapon
 ):
     fighter, pack_item = pack_fighter
     assignment = ContentFighterDefaultAssignment.objects.create(
         fighter=fighter, equipment=base_weapon, cost=0
     )
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse(
         "core:pack-fighter-default-assignment-remove",
@@ -394,11 +380,10 @@ def test_default_equipment_tab_requires_login(client, pack, pack_fighter):
 
 @pytest.mark.django_db
 def test_default_equipment_tab_requires_pack_owner(
-    client, pack, pack_fighter, make_user, custom_content_group
+    client, pack, pack_fighter, make_user
 ):
     fighter, pack_item = pack_fighter
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse("core:pack-item-default-equipment", args=(pack.id, pack_item.id))
     response = client.get(url)

--- a/gyrinx/core/tests/test_views_pack_equipment_list.py
+++ b/gyrinx/core/tests/test_views_pack_equipment_list.py
@@ -1,7 +1,6 @@
 """Tests for pack fighter equipment list views."""
 
 import pytest
-from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
@@ -12,14 +11,8 @@ from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 
 
 @pytest.fixture
-def custom_content_group():
-    group, _ = Group.objects.get_or_create(name="Custom Content")
-    return group
-
-
-@pytest.fixture
-def group_user(user, custom_content_group):
-    user.groups.add(custom_content_group)
+def group_user(user):
+    """A user for pack operations (group membership no longer required)."""
     return user
 
 
@@ -633,12 +626,9 @@ def test_edit_equipment_list_weapon_group(
 
 
 @pytest.mark.django_db
-def test_non_owner_cannot_access_add_weapon(
-    client, make_user, pack, pack_fighter, custom_content_group
-):
+def test_non_owner_cannot_access_add_weapon(client, make_user, pack, pack_fighter):
     fighter, pack_item = pack_fighter
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse(
         "core:pack-fighter-equipment-list-weapon-add", args=(pack.id, pack_item.id)
@@ -648,12 +638,9 @@ def test_non_owner_cannot_access_add_weapon(
 
 
 @pytest.mark.django_db
-def test_non_owner_cannot_access_add_gear(
-    client, make_user, pack, pack_fighter, custom_content_group
-):
+def test_non_owner_cannot_access_add_gear(client, make_user, pack, pack_fighter):
     fighter, pack_item = pack_fighter
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse(
         "core:pack-fighter-equipment-list-gear-add", args=(pack.id, pack_item.id)
@@ -664,14 +651,13 @@ def test_non_owner_cannot_access_add_gear(
 
 @pytest.mark.django_db
 def test_non_owner_cannot_remove_item(
-    client, make_user, pack, pack_fighter, base_weapon, custom_content_group
+    client, make_user, pack, pack_fighter, base_weapon
 ):
     fighter, pack_item = pack_fighter
     eli = ContentFighterEquipmentListItem.objects.create(
         fighter=fighter, equipment=base_weapon, cost=0
     )
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse(
         "core:pack-fighter-equipment-list-item-remove",
@@ -683,15 +669,12 @@ def test_non_owner_cannot_remove_item(
 
 
 @pytest.mark.django_db
-def test_non_owner_cannot_edit_item(
-    client, make_user, pack, pack_fighter, base_weapon, custom_content_group
-):
+def test_non_owner_cannot_edit_item(client, make_user, pack, pack_fighter, base_weapon):
     fighter, pack_item = pack_fighter
     eli = ContentFighterEquipmentListItem.objects.create(
         fighter=fighter, equipment=base_weapon, cost=10
     )
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse(
         "core:pack-fighter-equipment-list-edit",
@@ -718,12 +701,9 @@ def test_equipment_list_tab_requires_login(client, pack, pack_fighter):
 
 
 @pytest.mark.django_db
-def test_equipment_list_tab_requires_pack_owner(
-    client, pack, pack_fighter, make_user, custom_content_group
-):
+def test_equipment_list_tab_requires_pack_owner(client, pack, pack_fighter, make_user):
     fighter, pack_item = pack_fighter
     other_user = make_user("other", "password")
-    other_user.groups.add(custom_content_group)
     client.force_login(other_user)
     url = reverse("core:pack-item-equipment-list", args=(pack.id, pack_item.id))
     response = client.get(url)

--- a/gyrinx/core/views/campaign/packs.py
+++ b/gyrinx/core/views/campaign/packs.py
@@ -9,11 +9,9 @@ from django.urls import reverse
 from gyrinx import messages
 from gyrinx.core.models.campaign import Campaign
 from gyrinx.core.models.pack import CustomContentPack
-from gyrinx.core.views.auth import group_membership_required
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def campaign_packs(request, id):
     """
     Manage content packs for a campaign.
@@ -114,7 +112,6 @@ def campaign_packs(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def campaign_pack_add(request, id, pack_id):
     """Add a pack to the campaign's allowed packs."""
     if request.method != "POST":
@@ -138,7 +135,6 @@ def campaign_pack_add(request, id, pack_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def campaign_pack_remove(request, id, pack_id):
     """Remove a pack from the campaign's allowed packs."""
     campaign = get_object_or_404(Campaign, id=id, owner=request.user)

--- a/gyrinx/core/views/home.py
+++ b/gyrinx/core/views/home.py
@@ -185,13 +185,9 @@ def account_home(request):
     ).count()
     battles_count = Battle.objects.filter(campaign__owner=user).count()
 
-    # Content Packs - only if user is in "Custom Content" group
-    show_packs = user.groups.filter(name="Custom Content").exists()
-    packs_count = 0
-    if show_packs:
-        packs_count = CustomContentPack.objects.filter(
-            owner=user, archived=False
-        ).count()
+    # Content Packs
+    show_packs = True
+    packs_count = CustomContentPack.objects.filter(owner=user, archived=False).count()
 
     stats = {
         "lists_count": lists_count,

--- a/gyrinx/core/views/list/invitations.py
+++ b/gyrinx/core/views/list/invitations.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from gyrinx import messages
 from gyrinx.core.models.events import EventNoun, EventVerb, log_event
 from gyrinx.core.models.list import List
-from gyrinx.core.views.auth import group_membership_required
 from gyrinx.core.views.list.common import get_clean_list_or_404
 
 
@@ -128,7 +127,6 @@ def accept_invitation(request, id, invitation_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def invitation_pack_setup(request, id, campaign_id):
     """Show campaign packs for subscription after accepting an invitation."""
     lst = get_clean_list_or_404(List, id=id, owner=request.user)

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -279,12 +279,7 @@ class ListDetailView(generic.DetailView):
         context["subscribed_packs"] = list_obj.packs.all().select_related("owner")
 
         # Suggested campaign packs (for the "X suggested" indicator)
-        # Only show if user is in the Custom Content group (list-packs page requires it)
-        if (
-            self.request.user.is_authenticated
-            and list_obj.owner == self.request.user
-            and self.request.user.groups.filter(name="Custom Content").exists()
-        ):
+        if self.request.user.is_authenticated and list_obj.owner == self.request.user:
             suggested = list_obj.get_suggested_campaign_packs()
             context["suggested_campaign_packs_count"] = suggested.count()
 
@@ -562,8 +557,8 @@ def new_list(request):
     """
     Create a new :model:`core.List` owned by the current user.
 
-    For Custom Content users, redirects to pack selection interstitial first
-    unless packs have already been selected (stored in session) or skipped.
+    Redirects to pack selection interstitial first unless packs have already
+    been selected (stored in session) or skipped.
 
     **Context**
 
@@ -580,8 +575,6 @@ def new_list(request):
     """
     from gyrinx.core.models.pack import CustomContentPack
 
-    is_cc_user = request.user.groups.filter(name="Custom Content").exists()
-
     if request.method == "POST":
         raw_pack_ids = request.POST.getlist("packs")
     else:
@@ -590,8 +583,8 @@ def new_list(request):
 
     skip_packs = request.GET.get("skip_packs") == "1"
 
-    # CC users who haven't visited the interstitial yet get redirected there
-    if request.method == "GET" and is_cc_user and not skip_packs and not pack_ids:
+    # Users who haven't visited the interstitial yet get redirected there
+    if request.method == "GET" and not skip_packs and not pack_ids:
         return HttpResponseRedirect(reverse("core:lists-new-packs"))
 
     # Resolve selected packs
@@ -667,16 +660,12 @@ def new_list_packs(request):
     """
     Interstitial page for selecting content packs before creating a new list.
 
-    Only available to users in the Custom Content group.
     Stores selected pack IDs in session, then redirects to the new list form.
 
     **Template**
 
     :template:`core/list_new_packs.html`
     """
-    if not request.user.groups.filter(name="Custom Content").exists():
-        return HttpResponseRedirect(reverse("core:lists-new") + "?skip_packs=1")
-
     from gyrinx.core.models.pack import CustomContentPack
 
     # All packs the user can access (for POST validation)
@@ -820,15 +809,13 @@ def edit_list(request, id):
     else:
         form = EditListForm(instance=list_)
 
-    has_custom_content = request.user.groups.filter(name="Custom Content").exists()
-
     return render(
         request,
         "core/list_edit.html",
         {
             "form": form,
             "error_message": error_message,
-            "has_custom_content": has_custom_content,
+            "has_custom_content": True,
         },
     )
 

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -558,7 +558,7 @@ def new_list(request):
     Create a new :model:`core.List` owned by the current user.
 
     Redirects to pack selection interstitial first unless packs have already
-    been selected (stored in session) or skipped.
+    been selected (passed via query parameters) or skipped with ``skip_packs=1``.
 
     **Context**
 
@@ -660,7 +660,8 @@ def new_list_packs(request):
     """
     Interstitial page for selecting content packs before creating a new list.
 
-    Stores selected pack IDs in session, then redirects to the new list form.
+    On POST, validates selected pack IDs and redirects to the new list form
+    with pack IDs encoded as query parameters, or ``skip_packs=1`` if none selected.
 
     **Template**
 
@@ -815,7 +816,6 @@ def edit_list(request, id):
         {
             "form": form,
             "error_message": error_message,
-            "has_custom_content": True,
         },
     )
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -7,6 +7,7 @@ from typing import NamedTuple
 from urllib.parse import urlencode
 
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.paginator import Paginator
@@ -53,10 +54,6 @@ from gyrinx.core.models.pack import (
     CustomContentPackPermission,
 )
 from gyrinx.core.utils import safe_redirect, search_queryset
-from gyrinx.core.views.auth import (
-    GroupMembershipRequiredMixin,
-    group_membership_required,
-)
 from gyrinx.models import is_valid_uuid
 
 
@@ -456,10 +453,9 @@ def _get_pack_activity(pack, limit=None):
     return combined
 
 
-class PacksView(GroupMembershipRequiredMixin, generic.ListView):
+class PacksView(LoginRequiredMixin, generic.ListView):
     template_name = "core/pack/packs.html"
     context_object_name = "packs"
-    required_groups = ["Custom Content"]
     paginate_by = 20
 
     def get_queryset(self):
@@ -494,10 +490,9 @@ class PacksView(GroupMembershipRequiredMixin, generic.ListView):
         return queryset.order_by("name")
 
 
-class PackDetailView(GroupMembershipRequiredMixin, generic.DetailView):
+class PackDetailView(LoginRequiredMixin, generic.DetailView):
     template_name = "core/pack/pack.html"
     context_object_name = "pack"
-    required_groups = ["Custom Content"]
 
     def get_object(self):
         pack = get_object_or_404(
@@ -659,7 +654,6 @@ class PackDetailView(GroupMembershipRequiredMixin, generic.DetailView):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def new_pack(request):
     """Create a new content pack owned by the current user."""
     if request.method == "POST":
@@ -693,7 +687,6 @@ def new_pack(request):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def edit_pack(request, id):
     """Edit an existing content pack (owner or editor)."""
     pack = _get_pack_for_edit(id, request.user)
@@ -727,11 +720,10 @@ def edit_pack(request, id):
     )
 
 
-class PackActivityView(GroupMembershipRequiredMixin, generic.TemplateView):
+class PackActivityView(LoginRequiredMixin, generic.TemplateView):
     """Display full activity history for a pack."""
 
     template_name = "core/pack/pack_activity.html"
-    required_groups = ["Custom Content"]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -758,12 +750,11 @@ class PackActivityView(GroupMembershipRequiredMixin, generic.TemplateView):
         return context
 
 
-class PackArchivedItemsView(GroupMembershipRequiredMixin, generic.DetailView):
+class PackArchivedItemsView(LoginRequiredMixin, generic.DetailView):
     """Display archived items for a pack section."""
 
     template_name = "core/pack/pack_archived.html"
     context_object_name = "pack"
-    required_groups = ["Custom Content"]
 
     def get_object(self):
         pack = get_object_or_404(
@@ -1110,7 +1101,6 @@ def _update_weapon_profile_stats(profile, post_data, user):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def add_pack_weapon_mode(request, id):
     """Step 1 of the add-weapon flow: choose single or multi-profile mode."""
     pack = _get_pack_for_edit(id, request.user)
@@ -1123,7 +1113,6 @@ def add_pack_weapon_mode(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def add_pack_item(request, id, content_type_slug):
     """Add a new content item to a pack.
 
@@ -1297,7 +1286,6 @@ def add_pack_item(request, id, content_type_slug):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def add_pack_fighter_stats(request, id):
     """Step 2 of the add-fighter flow: enter stat values."""
     pack = _get_pack_for_edit(id, request.user)
@@ -1420,7 +1408,6 @@ def add_pack_fighter_stats(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def edit_pack_item(request, id, item_id):
     """Edit a content item in a pack."""
     pack = _get_pack_for_edit(id, request.user)
@@ -1592,7 +1579,6 @@ def edit_pack_item(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def delete_pack_item(request, id, item_id):
     """Archive a content item from a pack (soft-delete)."""
     pack = _get_pack_for_edit(id, request.user)
@@ -1664,7 +1650,6 @@ def delete_pack_item(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def restore_pack_item(request, id, item_id):
     """Restore an archived content item in a pack."""
     if request.method != "POST":
@@ -1787,7 +1772,6 @@ def _get_weapon_and_pack(pack_id, item_id, user):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def add_weapon_profile(request, id, item_id):
     """Add an additional weapon profile to a weapon in a pack."""
     pack, pack_item, equipment = _get_weapon_and_pack(id, item_id, request.user)
@@ -1899,7 +1883,6 @@ def add_weapon_profile(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def edit_weapon_profile(request, id, item_id, profile_id):
     """Edit a weapon profile on a weapon in a pack."""
     pack, pack_item, equipment = _get_weapon_and_pack(id, item_id, request.user)
@@ -2021,7 +2004,6 @@ def edit_weapon_profile(request, id, item_id, profile_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def delete_weapon_profile(request, id, item_id, profile_id):
     """Archive a weapon profile's pack item (soft-delete from the pack).
 
@@ -2097,7 +2079,6 @@ def delete_weapon_profile(request, id, item_id, profile_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def archived_weapon_profiles(request, id, item_id):
     """Display archived weapon profiles for a weapon pack item."""
     pack, pack_item, equipment = _get_weapon_and_pack(id, item_id, request.user)
@@ -2132,12 +2113,11 @@ def archived_weapon_profiles(request, id, item_id):
     )
 
 
-class PackListsView(GroupMembershipRequiredMixin, generic.ListView):
+class PackListsView(LoginRequiredMixin, generic.ListView):
     """Manage which of the user's lists are subscribed to a content pack."""
 
     template_name = "core/pack/pack_lists.html"
     context_object_name = "lists"
-    required_groups = ["Custom Content"]
     paginate_by = 10
 
     def get_queryset(self):
@@ -2243,7 +2223,6 @@ def _pack_subscription_source(return_url):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def subscribe_pack(request, id):
     """Subscribe one of the user's lists to a content pack."""
     if request.method != "POST":
@@ -2288,7 +2267,6 @@ def subscribe_pack(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def unsubscribe_pack(request, id):
     """Unsubscribe a list from a content pack."""
     if request.method != "POST":
@@ -2331,7 +2309,6 @@ def unsubscribe_pack(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def list_packs_manage(request, id):
     """Manage content pack subscriptions for a list."""
     lst = get_object_or_404(List, id=id, owner=request.user)
@@ -2405,7 +2382,6 @@ def list_packs_manage(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def pack_campaigns(request, id):
     """Manage which of the user's campaigns are subscribed to a content pack."""
     pack = get_object_or_404(
@@ -2442,7 +2418,6 @@ def pack_campaigns(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def subscribe_pack_campaign(request, id):
     """Subscribe one of the user's campaigns to a content pack."""
     if request.method != "POST":
@@ -2480,7 +2455,6 @@ def subscribe_pack_campaign(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def unsubscribe_pack_campaign(request, id):
     """Remove a content pack from a campaign."""
     if request.method != "POST":
@@ -2513,7 +2487,6 @@ def unsubscribe_pack_campaign(request, id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def pack_permissions(request, id):
     """Manage editor permissions for a pack (owner only)."""
     pack = get_object_or_404(
@@ -2543,8 +2516,6 @@ def pack_permissions(request, id):
                 else:
                     if target_user == pack.owner:
                         error = "The owner already has full access."
-                    elif not target_user.groups.filter(name="Custom Content").exists():
-                        error = f'"{username}" is not in the Custom Content group.'
                     elif pack.permissions.filter(user=target_user).exists():
                         error = f'"{username}" is already an editor.'
                     else:
@@ -2750,7 +2721,6 @@ def _load_fighter_preview_context(pack, content_fighter):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 def pack_item_equipment(request, id, item_id):
     """Combined equipment tab for a fighter in a pack."""
     pack = _get_pack_for_edit(id, request.user)
@@ -2775,7 +2745,6 @@ def pack_item_equipment(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 @transaction.atomic
 def add_pack_fighter_default_weapon(request, id, item_id):
     """Add a default weapon to a pack fighter."""
@@ -2872,7 +2841,6 @@ def add_pack_fighter_default_weapon(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 @transaction.atomic
 def add_pack_fighter_default_gear(request, id, item_id):
     """Add default gear to a pack fighter."""
@@ -2950,7 +2918,6 @@ def add_pack_fighter_default_gear(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 @transaction.atomic
 def remove_pack_fighter_default_assignment(request, id, item_id, assignment_id):
     """Remove a default equipment assignment from a pack fighter."""
@@ -3001,7 +2968,6 @@ def remove_pack_fighter_default_assignment(request, id, item_id, assignment_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 @transaction.atomic
 def add_pack_fighter_equipment_list_weapon(request, id, item_id):
     """Add available weapons to a pack fighter's equipment list (bulk)."""
@@ -3127,7 +3093,6 @@ def add_pack_fighter_equipment_list_weapon(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 @transaction.atomic
 def add_pack_fighter_equipment_list_gear(request, id, item_id):
     """Add available gear to a pack fighter's equipment list (bulk)."""
@@ -3216,7 +3181,6 @@ def add_pack_fighter_equipment_list_gear(request, id, item_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 @transaction.atomic
 def remove_pack_fighter_equipment_list_item(request, id, item_id, eli_id):
     """Remove an equipment list item from a pack fighter."""
@@ -3286,7 +3250,6 @@ def remove_pack_fighter_equipment_list_item(request, id, item_id, eli_id):
 
 
 @login_required
-@group_membership_required(["Custom Content"])
 @transaction.atomic
 def edit_pack_fighter_equipment_list_item(request, id, item_id, eli_id):
     """Edit cost of equipment list items for a pack fighter."""

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -461,24 +461,20 @@ class PacksView(LoginRequiredMixin, generic.ListView):
     def get_queryset(self):
         queryset = CustomContentPack.objects.all().select_related("owner")
 
-        # Default to user's own packs if authenticated
-        if self.request.user.is_authenticated:
-            has_permission = CustomContentPackPermission.objects.filter(
-                pack=OuterRef("pk"), user=self.request.user
+        has_permission = CustomContentPackPermission.objects.filter(
+            pack=OuterRef("pk"), user=self.request.user
+        )
+        show_my_packs = self.request.GET.get("my", "1")
+        if show_my_packs == "1":
+            queryset = queryset.filter(
+                models.Q(owner=self.request.user) | models.Q(Exists(has_permission))
             )
-            show_my_packs = self.request.GET.get("my", "1")
-            if show_my_packs == "1":
-                queryset = queryset.filter(
-                    models.Q(owner=self.request.user) | models.Q(Exists(has_permission))
-                )
-            else:
-                queryset = queryset.filter(
-                    models.Q(listed=True)
-                    | models.Q(owner=self.request.user)
-                    | models.Q(Exists(has_permission))
-                )
         else:
-            queryset = queryset.filter(listed=True)
+            queryset = queryset.filter(
+                models.Q(listed=True)
+                | models.Q(owner=self.request.user)
+                | models.Q(Exists(has_permission))
+            )
 
         # Search
         q = self.request.GET.get("q", "").strip()

--- a/gyrinx/core/views/user.py
+++ b/gyrinx/core/views/user.py
@@ -30,8 +30,7 @@ def user(request, slug_or_id):
     ``campaigns``
         Campaigns owned by the profile user, visible to the viewer.
     ``packs``
-        Content packs owned by the profile user (only if user is in
-        "Custom Content" group).
+        Content packs owned by the profile user.
     ``show_packs``
         Whether the packs section should be shown.
 
@@ -89,14 +88,12 @@ def user(request, slug_or_id):
         campaigns_qs = campaigns_qs.filter(public=True)
     campaigns = campaigns_qs
 
-    # --- Packs (only if profile user is in Custom Content group) ---
-    show_packs = profile_user.groups.filter(name="Custom Content").exists()
-    packs = CustomContentPack.objects.none()
-    if show_packs:
-        packs_qs = CustomContentPack.objects.filter(owner=profile_user, archived=False)
-        if not is_own_profile:
-            packs_qs = packs_qs.filter(listed=True)
-        packs = packs_qs
+    # --- Packs ---
+    show_packs = True
+    packs_qs = CustomContentPack.objects.filter(owner=profile_user, archived=False)
+    if not is_own_profile:
+        packs_qs = packs_qs.filter(listed=True)
+    packs = packs_qs
 
     # Log the user profile view
     if request.user.is_authenticated:


### PR DESCRIPTION
Remove all "Custom Content" group membership gates so that content pack features are available to all authenticated users.

Closes #1686

Generated with [Claude Code](https://claude.ai/code)