### PR TITLE
feat: show available attribute previews instead of '+N more'

### DIFF
--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -34,19 +34,21 @@
                         {% with unset=list.unset_attributes unset_count=list.unset_attributes|length %}
                             {% if unset_count > 0 %}
                                 <span class="text-secondary">
-                                    Add
-                                    {% for attr in unset|slice:":3" %}
-                                        {% if not forloop.first %}
-                                            {% if forloop.last and unset_count <= 3 %}
-                                                or
-                                            {% else %}
-                                                ,
+                                    {% spaceless %}
+                                        <span>Add&nbsp;</span>
+                                        {% for attr in unset|slice:":3" %}
+                                            {% if not forloop.first %}
+                                                {% if forloop.last and unset_count <= 3 %}
+                                                    <span>&nbsp;or&nbsp;</span>
+                                                {% else %}
+                                                    <span>,&nbsp;</span>
+                                                {% endif %}
                                             {% endif %}
-                                        {% endif %}
-                                        <a href="{% url 'core:list-attribute-edit' list.id attr.id %}"
-                                           class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">{{ attr.name }}</a>
-                                    {% endfor %}
-                                    {% if unset_count > 3 %}or {{ unset_count|add:"-3" }} more...{% endif %}
+                                            <a href="{% url 'core:list-attribute-edit' list.id attr.id %}"
+                                               class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">{{ attr.name }}</a>
+                                        {% endfor %}
+                                        {% if unset_count > 3 %}<span>&nbsp;or {{ unset_count|add:"-3" }} more...</span>{% endif %}
+                                    {% endspaceless %}
                                 </span>
                                 <span class="text-secondary mx-1">·</span>
                             {% endif %}

--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -31,20 +31,16 @@
             {% if not print %}
                 {% if list.owner_cached == user and not list.archived %}
                     <div class="fs-7 text-end {% if list.set_attributes %}mt-1{% endif %}">
-                        {% with unset_count=list.unset_attributes|length %}
+                        {% with unset=list.unset_attributes unset_count=list.unset_attributes|length %}
                             {% if unset_count > 0 %}
-                                <span class="text-secondary">+{{ unset_count }} more</span>
+                                {# djlint:off #}
+                                <span class="text-secondary">Add {% for attr in unset|slice:":3" %}{% if not forloop.first %}{% if forloop.last and unset_count <= 3 %} or {% else %}, {% endif %}{% endif %}<a href="{% url 'core:list-attribute-edit' list.id attr.id %}" class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">{{ attr.name }}</a>{% endfor %}{% if unset_count > 3 %} or {{ unset_count|add:"-3" }} more...{% endif %}</span>
+                                {# djlint:on #}
                                 <span class="text-secondary mx-1">·</span>
                             {% endif %}
                         {% endwith %}
                         <a href="{% url 'core:list-attributes-manage' list.id %}"
-                           class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">
-                            {% if list.set_attributes %}
-                                Manage
-                            {% else %}
-                                Add
-                            {% endif %}
-                        </a>
+                           class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Manage</a>
                     </div>
                 {% elif not list.set_attributes %}
                     <p class="text-secondary fs-7 mb-0">No attributes set.</p>

--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -33,9 +33,21 @@
                     <div class="fs-7 text-end {% if list.set_attributes %}mt-1{% endif %}">
                         {% with unset=list.unset_attributes unset_count=list.unset_attributes|length %}
                             {% if unset_count > 0 %}
-                                {# djlint:off #}
-                                <span class="text-secondary">Add {% for attr in unset|slice:":3" %}{% if not forloop.first %}{% if forloop.last and unset_count <= 3 %} or {% else %}, {% endif %}{% endif %}<a href="{% url 'core:list-attribute-edit' list.id attr.id %}" class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">{{ attr.name }}</a>{% endfor %}{% if unset_count > 3 %} or {{ unset_count|add:"-3" }} more...{% endif %}</span>
-                                {# djlint:on #}
+                                <span class="text-secondary">
+                                    Add
+                                    {% for attr in unset|slice:":3" %}
+                                        {% if not forloop.first %}
+                                            {% if forloop.last and unset_count <= 3 %}
+                                                or
+                                            {% else %}
+                                                ,
+                                            {% endif %}
+                                        {% endif %}
+                                        <a href="{% url 'core:list-attribute-edit' list.id attr.id %}"
+                                           class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">{{ attr.name }}</a>
+                                    {% endfor %}
+                                    {% if unset_count > 3 %}or {{ unset_count|add:"-3" }} more...{% endif %}
+                                </span>
                                 <span class="text-secondary mx-1">·</span>
                             {% endif %}
                         {% endwith %}

--- a/gyrinx/core/tests/test_attribute_manage.py
+++ b/gyrinx/core/tests/test_attribute_manage.py
@@ -96,10 +96,10 @@ def test_list_view_only_shows_set_attributes(client, user, make_list):
     # But "Not set" should not appear since we hide unset attributes
     assert "Not set" not in content
 
-    # Should show "Add Alignment" link for the unset attribute
-    assert "Add" in content
-    assert "Alignment" in content
-    assert reverse("core:list-attribute-edit", args=[lst.id, alignment.id]) in content
+    # Should show "Add Alignment" with a link to edit that attribute
+    edit_url = reverse("core:list-attribute-edit", args=[lst.id, alignment.id])
+    assert edit_url in content
+    assert f">{alignment.name}</a>" in content
 
 
 @pytest.mark.django_db
@@ -113,9 +113,50 @@ def test_list_view_shows_manage_link(client, user, make_list):
     response = client.get(reverse("core:list", args=[lst.id]))
     content = response.content.decode()
 
-    # When no attributes are set, should show "Add" link
+    # When no attributes are set, should show "Add" preview and "Manage" link
     assert "Add" in content
+    assert "Alignment" in content
     assert reverse("core:list-attributes-manage", args=[lst.id]) in content
+
+
+@pytest.mark.django_db
+def test_list_view_shows_or_n_more_for_many_unset_attributes(client, user, make_list):
+    """Test that >3 unset attributes shows 'or N more...' after the first 3."""
+    client.force_login(user)
+    lst = make_list("Test Gang")
+
+    # Alphabetical order: Affiliation, Allegiance, Alignment, Alliance
+    for name in ["Affiliation", "Alignment", "Alliance", "Allegiance"]:
+        ContentAttribute.objects.create(name=name, is_single_select=True)
+
+    response = client.get(reverse("core:list", args=[lst.id]))
+    content = response.content.decode()
+
+    # First 3 alphabetically should be linked
+    assert "Affiliation" in content
+    assert "Allegiance" in content
+    assert "Alignment" in content
+    # 4th (Alliance) should be counted in "or N more..."
+    assert "or 1 more..." in content
+
+
+@pytest.mark.django_db
+def test_list_view_shows_separator_for_two_unset_attributes(client, user, make_list):
+    """Test that exactly 2 unset attributes shows 'or' separator."""
+    client.force_login(user)
+    lst = make_list("Test Gang")
+
+    ContentAttribute.objects.create(name="Alignment", is_single_select=True)
+    ContentAttribute.objects.create(name="Alliance", is_single_select=True)
+
+    response = client.get(reverse("core:list", args=[lst.id]))
+    content = response.content.decode()
+
+    assert "Add" in content
+    assert "Alignment" in content
+    assert "Alliance" in content
+    # Should use "or" separator, not comma
+    assert "or" in content
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_attribute_manage.py
+++ b/gyrinx/core/tests/test_attribute_manage.py
@@ -96,8 +96,10 @@ def test_list_view_only_shows_set_attributes(client, user, make_list):
     # But "Not set" should not appear since we hide unset attributes
     assert "Not set" not in content
 
-    # Should show "+1 more" link
-    assert "+1 more" in content
+    # Should show "Add Alignment" link for the unset attribute
+    assert "Add" in content
+    assert "Alignment" in content
+    assert reverse("core:list-attribute-edit", args=[lst.id, alignment.id]) in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Replace the generic "+N more" indicator in the list attributes table with linked previews of unset attribute names (up to 3), making it easier for users to discover and set attributes directly.

Closes #1690

Generated with [Claude Code](https://claude.ai/claude-code)