### PR TITLE
fix: use PAT for Claude Code action to trigger CI workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -93,6 +93,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Use a PAT so that pushes trigger CI workflows (the default
+          # GITHUB_TOKEN suppresses events from bot accounts).
+          github_token: ${{ secrets.CLAUDE_PAT }}
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

- Use `CLAUDE_PAT` secret instead of default `GITHUB_TOKEN` for `claude-code-action` so bot pushes trigger CI workflows

Closes #1689

## Test plan

- [x] Add `CLAUDE_PAT` fine-grained PAT as a repo secret with `contents: write` and `pull-requests: write`
- [ ] Trigger Claude on a PR and verify tests/format-check run on the resulting push

🤖 Generated with [Claude Code](https://claude.com/claude-code)