### PR TITLE
fix: show pack rules and skills in fighter preview card

### DIFF
--- a/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
+++ b/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
@@ -59,10 +59,12 @@
                         <th scope="row" class="w-25">Rules</th>
                         <td>
                             {% if preview_rules %}
-                                {% for rule in preview_rules %}
-                                    {{ rule.name }}
-                                    {% if not forloop.last %},{% endif %}
-                                {% endfor %}
+                                {% spaceless %}
+                                    {% for rule in preview_rules %}
+                                        <span>{{ rule.name }}</span>
+                                        {% if not forloop.last %}<span>,&nbsp;</span>{% endif %}
+                                    {% endfor %}
+                                {% endspaceless %}
                             {% else %}
                                 <span class="text-secondary fst-italic">None</span>
                             {% endif %}
@@ -74,10 +76,12 @@
                             <th scope="row">Skills</th>
                             <td>
                                 {% if preview_skills %}
-                                    {% for skill in preview_skills %}
-                                        {{ skill.name }}
-                                        {% if not forloop.last %},{% endif %}
-                                    {% endfor %}
+                                    {% spaceless %}
+                                        {% for skill in preview_skills %}
+                                            <span>{{ skill.name }}</span>
+                                            {% if not forloop.last %}<span>,&nbsp;</span>{% endif %}
+                                        {% endfor %}
+                                    {% endspaceless %}
                                 {% else %}
                                     <span class="text-secondary fst-italic">None</span>
                                 {% endif %}

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1861,6 +1861,23 @@ def test_edit_fighter_form_preselects_pack_rules(
     assert str(rule.pk) in {str(v) for v in rules_value}
 
 
+@pytest.mark.django_db
+def test_edit_fighter_preview_card_shows_pack_rules(
+    client, group_user, pack, pack_fighter, pack_rule
+):
+    """Test that pack rules appear in the fighter preview card context."""
+    fighter = pack_fighter.content_object
+    rule = ContentRule.objects.all_content().get(pk=pack_rule.object_id)
+    fighter.rules.add(rule)
+
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}/item/{pack_fighter.id}/edit/")
+    assert response.status_code == 200
+
+    preview_rules = response.context["preview_rules"]
+    assert rule in preview_rules
+
+
 # --- Editor Permissions ---
 
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -2722,8 +2722,14 @@ def _load_equipment_list_context(content_fighter):
 def _load_fighter_preview_context(pack, content_fighter):
     """Load data for the fighter preview card on edit pages."""
     statline = content_fighter.statline()
-    rules = list(content_fighter.rules.all())
-    skills = list(content_fighter.skills.all())
+    # Query from the ContentRule/ContentSkill side with all_content() to
+    # include pack rules — the default M2M manager excludes pack content.
+    rules = list(
+        ContentRule.objects.all_content().filter(contentfighter=content_fighter)
+    )
+    skills = list(
+        ContentSkill.objects.all_content().filter(contentfighter=content_fighter)
+    )
 
     # Default weapon assignments with profiles
     default_assignments = (

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -2722,13 +2722,13 @@ def _load_equipment_list_context(content_fighter):
 def _load_fighter_preview_context(pack, content_fighter):
     """Load data for the fighter preview card on edit pages."""
     statline = content_fighter.statline()
-    # Query from the ContentRule/ContentSkill side with all_content() to
-    # include pack rules — the default M2M manager excludes pack content.
+    # Query from the ContentRule/ContentSkill side with with_packs() to
+    # include pack content — the default M2M manager excludes it.
     rules = list(
-        ContentRule.objects.all_content().filter(contentfighter=content_fighter)
+        ContentRule.objects.with_packs([pack]).filter(contentfighter=content_fighter)
     )
     skills = list(
-        ContentSkill.objects.all_content().filter(contentfighter=content_fighter)
+        ContentSkill.objects.with_packs([pack]).filter(contentfighter=content_fighter)
     )
 
     # Default weapon assignments with profiles


### PR DESCRIPTION
## Summary

- Fix pack rules/skills not appearing in fighter preview card on pack edit page
- Fix comma-space rendering in rules/skills lists using `{% spaceless %}` pattern

Closes #1695

## Test plan

- [ ] Open a content pack fighter that has custom (pack) rules assigned
- [ ] Verify rules appear in the preview card on the right
- [ ] Verify comma separation has no extra whitespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)