### PR TITLE
feat: display weapon availability (AL) column on pack screen

### DIFF
--- a/gyrinx/core/templates/core/includes/weapon_stat_headers.html
+++ b/gyrinx/core/templates/core/includes/weapon_stat_headers.html
@@ -9,5 +9,6 @@
         <th class="text-center" scope="col">Ap</th>
         <th class="text-center" scope="col">D</th>
         <th class="text-center" scope="col">Am</th>
+        {% if show_al %}<th class="text-center border-start" scope="col">AL</th>{% endif %}
     </tr>
 </thead>

--- a/gyrinx/core/templates/core/pack/includes/weapon_profiles_display.html
+++ b/gyrinx/core/templates/core/pack/includes/weapon_profiles_display.html
@@ -16,10 +16,13 @@ Cases (from weapon-profiles-display-spec.md):
                 {% if weapon.cost_display %}({{ weapon.cost_display }}){% endif %}
             </td>
             {% for stat in profile.statline %}<td class="text-center {{ stat.classes }}">{{ stat.value }}</td>{% endfor %}
+            {% if show_al %}
+                <td class="text-center border-start">{{ weapon.rarity }}{% firstof weapon.rarity_roll "" %}</td>
+            {% endif %}
         </tr>
         {% if profile.traitline|length > 0 %}
             <tr>
-                <td colspan="8">{{ profile.traitline|join:", " }}</td>
+                <td colspan="{% if show_al %}9{% else %}8{% endif %}">{{ profile.traitline|join:", " }}</td>
             </tr>
         {% endif %}
     {% endwith %}
@@ -28,7 +31,7 @@ Cases (from weapon-profiles-display-spec.md):
     {% with profiles.0 as first_profile %}
         {% if first_profile.name %}
             <tr class="align-bottom">
-                <td colspan="9">
+                <td colspan="{% if show_al %}10{% else %}9{% endif %}">
                     {{ weapon }}
                     {% if weapon.cost_display %}({{ weapon.cost_display }}){% endif %}
                 </td>
@@ -54,17 +57,24 @@ Cases (from weapon-profiles-display-spec.md):
                 {% endif %}
             </td>
             {% for stat in profile.statline %}<td class="text-center {{ stat.classes }}">{{ stat.value }}</td>{% endfor %}
+            {% if show_al %}
+                {% if forloop.first %}
+                    <td class="text-center border-start">{{ weapon.rarity }}{% firstof weapon.rarity_roll "" %}</td>
+                {% else %}
+                    <td class="text-center border-start"></td>
+                {% endif %}
+            {% endif %}
         </tr>
         {% if profile.traitline|length > 0 %}
             <tr>
-                <td colspan="8">{{ profile.traitline|join:", " }}</td>
+                <td colspan="{% if show_al %}9{% else %}8{% endif %}">{{ profile.traitline|join:", " }}</td>
             </tr>
         {% endif %}
     {% endfor %}
 {% endif %}
 {% if can_edit %}
     <tr>
-        <td colspan="9">
+        <td colspan="{% if show_al %}10{% else %}9{% endif %}">
             <div class="d-flex gap-1 align-items-center fs-7 mb-1">
                 <i class="bi-arrow-90deg-up text-secondary me-1"></i>
                 <a href="{% url 'core:pack-add-weapon-profile' pack.id pack_item.id %}"

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -142,10 +142,10 @@
                         {% if section.slug == "weapon" %}
                             {% if section.items %}
                                 <table class="table table-sm table-borderless mb-0 fs-7">
-                                    {% include "core/includes/weapon_stat_headers.html" %}
+                                    {% include "core/includes/weapon_stat_headers.html" with show_al=True %}
                                     {% for entry in section.items %}
                                         <tbody class="table-group-divider" id="item-{{ entry.pack_item.id }}">
-                                            {% include "core/pack/includes/weapon_profiles_display.html" with profiles=entry.profiles pack_item=entry.pack_item weapon=entry.content_object can_edit=can_edit %}
+                                            {% include "core/pack/includes/weapon_profiles_display.html" with profiles=entry.profiles pack_item=entry.pack_item weapon=entry.content_object can_edit=can_edit show_al=True %}
                                         </tbody>
                                     {% endfor %}
                                 </table>


### PR DESCRIPTION
Closes #1693

Adds the "AL" (Availability) column to the weapon statline table on the pack detail page, matching the trading post view.

Generated with [Claude Code](https://claude.ai/code)