### PR TITLE
feat: show fighter stats, equipment, and trait descriptions on pack detail page

### DIFF
--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -161,9 +161,9 @@
                                             {% if house_group.grouper %}
                                                 <div class="text-secondary text-uppercase fs-7 mb-1">{{ house_group.grouper }}</div>
                                             {% endif %}
-                                            <div class="vstack gap-2">
+                                            <ul class="list-unstyled vstack gap-2 mb-0">
                                                 {% for entry in house_group.list %}
-                                                    <div class="py-1" id="item-{{ entry.pack_item.id }}">
+                                                    <li class="py-1" id="item-{{ entry.pack_item.id }}">
                                                         <div class="d-flex justify-content-between align-items-start">
                                                             <div>
                                                                 <span class="fw-medium">{{ entry.content_object.type }}</span>
@@ -202,9 +202,9 @@
                                                                 {% endif %}
                                                             </div>
                                                         {% endif %}
-                                                    </div>
+                                                    </li>
                                                 {% endfor %}
-                                            </div>
+                                            </ul>
                                         </div>
                                     {% endfor %}
                                 </div>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -184,43 +184,22 @@
                                                             {% endif %}
                                                         </div>
                                                         {% if entry.statline %}
-                                                            <div class="fs-7 text-secondary mt-1 font-monospace">
+                                                            <div class="fs-7 text-secondary mt-1">
                                                                 {% for stat in entry.statline %}
                                                                     {{ stat.name }}&nbsp;{{ stat.value }}
-                                                                    {% if not forloop.last %}{% endif %}
+                                                                    {% if not forloop.last %}·{% endif %}
                                                                 {% endfor %}
                                                             </div>
                                                         {% endif %}
-                                                        {% if entry.fighter_rules or entry.fighter_skills %}
+                                                        {% if entry.fighter_rules or entry.fighter_skills or entry.default_equipment_names %}
                                                             <div class="fs-7 text-secondary">
-                                                                {% if entry.fighter_rules %}
-                                                                    Rules:
-                                                                    {% for rule in entry.fighter_rules %}
-                                                                        {{ rule.name }}
-                                                                        {% if not forloop.last %},{% endif %}
-                                                                    {% endfor %}
-                                                                {% endif %}
+                                                                {% if entry.fighter_rules %}{{ entry.fighter_rules|join_names }}{% endif %}
                                                                 {% if entry.fighter_rules and entry.fighter_skills %}·{% endif %}
-                                                                {% if entry.fighter_skills %}
-                                                                    Skills:
-                                                                    {% for skill in entry.fighter_skills %}
-                                                                        {{ skill.name }}
-                                                                        {% if not forloop.last %},{% endif %}
-                                                                    {% endfor %}
+                                                                {% if entry.fighter_skills %}{{ entry.fighter_skills|join_names }}{% endif %}
+                                                                {% if entry.default_equipment_names %}
+                                                                    {% if entry.fighter_rules or entry.fighter_skills %}·{% endif %}
+                                                                    {{ entry.default_equipment_names }}
                                                                 {% endif %}
-                                                            </div>
-                                                        {% endif %}
-                                                        {% if entry.default_weapons or entry.default_gear %}
-                                                            <div class="fs-7 text-secondary">
-                                                                Equipment:
-                                                                {% for da in entry.default_weapons %}
-                                                                    {{ da.equipment.name }}
-                                                                    {% if not forloop.last or entry.default_gear %},{% endif %}
-                                                                {% endfor %}
-                                                                {% for da in entry.default_gear %}
-                                                                    {{ da.equipment.name }}
-                                                                    {% if not forloop.last %},{% endif %}
-                                                                {% endfor %}
                                                             </div>
                                                         {% endif %}
                                                     </div>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -161,16 +161,19 @@
                                             {% if house_group.grouper %}
                                                 <div class="text-secondary text-uppercase fs-7 mb-1">{{ house_group.grouper }}</div>
                                             {% endif %}
-                                            <ul class="list-unstyled mb-0">
+                                            <div class="vstack gap-2">
                                                 {% for entry in house_group.list %}
-                                                    <li class="py-1" id="item-{{ entry.pack_item.id }}">
-                                                        <div class="d-flex justify-content-between align-items-center">
+                                                    <div class="py-1" id="item-{{ entry.pack_item.id }}">
+                                                        <div class="d-flex justify-content-between align-items-start">
                                                             <div>
                                                                 <span class="fw-medium">{{ entry.content_object.type }}</span>
-                                                                <div class="text-secondary fs-7">{{ entry.content_object.get_category_display }}</div>
+                                                                <span class="text-secondary fs-7">{{ entry.content_object.get_category_display }}</span>
+                                                                {% if entry.content_object.base_cost %}
+                                                                    <span class="text-secondary fs-7">· {% credits entry.content_object.base_cost %}</span>
+                                                                {% endif %}
                                                             </div>
                                                             {% if can_edit %}
-                                                                <span class="d-flex gap-2">
+                                                                <span class="d-flex gap-2 flex-shrink-0">
                                                                     {% if section.can_add %}
                                                                         <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
                                                                            class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Edit</a>
@@ -180,9 +183,49 @@
                                                                 </span>
                                                             {% endif %}
                                                         </div>
-                                                    </li>
+                                                        {% if entry.statline %}
+                                                            <div class="fs-7 text-secondary mt-1 font-monospace">
+                                                                {% for stat in entry.statline %}
+                                                                    {{ stat.name }}&nbsp;{{ stat.value }}
+                                                                    {% if not forloop.last %}{% endif %}
+                                                                {% endfor %}
+                                                            </div>
+                                                        {% endif %}
+                                                        {% if entry.fighter_rules or entry.fighter_skills %}
+                                                            <div class="fs-7 text-secondary">
+                                                                {% if entry.fighter_rules %}
+                                                                    Rules:
+                                                                    {% for rule in entry.fighter_rules %}
+                                                                        {{ rule.name }}
+                                                                        {% if not forloop.last %},{% endif %}
+                                                                    {% endfor %}
+                                                                {% endif %}
+                                                                {% if entry.fighter_rules and entry.fighter_skills %}·{% endif %}
+                                                                {% if entry.fighter_skills %}
+                                                                    Skills:
+                                                                    {% for skill in entry.fighter_skills %}
+                                                                        {{ skill.name }}
+                                                                        {% if not forloop.last %},{% endif %}
+                                                                    {% endfor %}
+                                                                {% endif %}
+                                                            </div>
+                                                        {% endif %}
+                                                        {% if entry.default_weapons or entry.default_gear %}
+                                                            <div class="fs-7 text-secondary">
+                                                                Equipment:
+                                                                {% for da in entry.default_weapons %}
+                                                                    {{ da.equipment.name }}
+                                                                    {% if not forloop.last or entry.default_gear %},{% endif %}
+                                                                {% endfor %}
+                                                                {% for da in entry.default_gear %}
+                                                                    {{ da.equipment.name }}
+                                                                    {% if not forloop.last %},{% endif %}
+                                                                {% endfor %}
+                                                            </div>
+                                                        {% endif %}
+                                                    </div>
                                                 {% endfor %}
-                                            </ul>
+                                            </div>
                                         </div>
                                     {% endfor %}
                                 </div>
@@ -248,8 +291,10 @@
                                         <div class="d-flex justify-content-between align-items-center">
                                             <div>
                                                 <span>{{ entry.content_object }}</span>
-                                                {% if section.slug == "rule" and entry.content_object.description %}
-                                                    <div class="text-secondary fs-7">{{ entry.content_object.description|linebreaksbr }}</div>
+                                                {% if section.slug == "rule" or section.slug == "weapon-trait" %}
+                                                    {% if entry.content_object.description %}
+                                                        <div class="text-secondary fs-7">{{ entry.content_object.description|linebreaksbr }}</div>
+                                                    {% endif %}
                                                 {% endif %}
                                             </div>
                                             {% if can_edit %}

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -220,14 +220,14 @@
                                                 <div class="text-secondary text-uppercase fs-7 fw-semibold">{{ group.category.name }}</div>
                                                 <span class="d-flex gap-2 align-items-center">
                                                     {% if can_edit %}
+                                                        <a href="{% url 'core:pack-add-item' pack.id 'skill' %}?category={{ group.category.id }}"
+                                                           class="link-primary link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Add skill</a>
                                                         {% if group.pack_item %}
                                                             <a href="{% url 'core:pack-edit-item' pack.id group.pack_item.id %}"
                                                                class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Edit tree</a>
                                                             <a href="{% url 'core:pack-delete-item' pack.id group.pack_item.id %}"
                                                                class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive tree</a>
                                                         {% endif %}
-                                                        <a href="{% url 'core:pack-add-item' pack.id 'skill' %}?category={{ group.category.id }}"
-                                                           class="link-primary link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Add skill</a>
                                                     {% endif %}
                                                 </span>
                                             </div>

--- a/gyrinx/core/templatetags/custom_tags.py
+++ b/gyrinx/core/templatetags/custom_tags.py
@@ -97,6 +97,15 @@ def get_item(obj, key):
         return None
 
 
+@register.filter
+def join_names(items, attr="name"):
+    """Join a list of objects by an attribute, comma-separated.
+
+    Usage: {{ rules|join_names }} or {{ items|join_names:"type" }}
+    """
+    return ", ".join(str(getattr(item, attr, item)) for item in items)
+
+
 @register.simple_tag
 def qt(request, **kwargs):
     updated = request.GET.copy()

--- a/gyrinx/core/tests/test_list_packs.py
+++ b/gyrinx/core/tests/test_list_packs.py
@@ -490,8 +490,8 @@ class TestPackDetailFighterDisplay:
         response = client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # pack_fighter has base_cost=50
-        assert "50" in content
+        # pack_fighter has base_cost=50, rendered via {% credits %} formatter.
+        assert "50¢" in content
 
     def test_fighter_skills_shown(
         self, client, cc_user, pack, pack_fighter, make_content_skill

--- a/gyrinx/core/tests/test_list_packs.py
+++ b/gyrinx/core/tests/test_list_packs.py
@@ -1,9 +1,11 @@
 """Tests for list pack subscription functionality."""
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
 from gyrinx.content.models import ContentFighter, ContentHouse, ContentRule
+from gyrinx.content.models.weapon import ContentWeaponTrait
 from gyrinx.core.models.list import List
 from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 from gyrinx.models import FighterCategoryChoices
@@ -456,3 +458,140 @@ class TestListDetailShowsPacks:
         response = client.get(url)
         assert response.status_code == 200
         assert b"Add Content Pack" in response.content
+
+
+@pytest.mark.django_db
+class TestPackDetailFighterDisplay:
+    """Test that pack detail page shows fighter stats, skills, rules, and equipment."""
+
+    def test_fighter_statline_shown(self, client, cc_user, pack, pack_fighter):
+        """Fighter stat values should be visible on the pack detail page."""
+        pack_fighter.movement = '5"'
+        pack_fighter.weapon_skill = "4+"
+        pack_fighter.ballistic_skill = "5+"
+        pack_fighter.strength = "3"
+        pack_fighter.toughness = "3"
+        pack_fighter.wounds = "1"
+        pack_fighter.save()
+
+        client.force_login(cc_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert '5"' in content
+        assert "4+" in content
+        assert "5+" in content
+
+    def test_fighter_base_cost_shown(self, client, cc_user, pack, pack_fighter):
+        """Fighter base cost should be visible on the pack detail page."""
+        client.force_login(cc_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        # pack_fighter has base_cost=50
+        assert "50" in content
+
+    def test_fighter_skills_shown(
+        self, client, cc_user, pack, pack_fighter, make_content_skill
+    ):
+        """Fighter skills should be listed on the pack detail page."""
+        skill = make_content_skill("Parry", "Combat")
+        pack_fighter.skills.add(skill)
+
+        client.force_login(cc_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b"Parry" in response.content
+
+    def test_fighter_rules_shown(self, client, cc_user, pack, pack_fighter):
+        """Fighter rules should be listed on the pack detail page."""
+        rule = ContentRule.objects.create(name="Gang Fighter (Ganger)")
+        pack_fighter.rules.add(rule)
+
+        client.force_login(cc_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b"Gang Fighter (Ganger)" in response.content
+
+    def test_fighter_default_equipment_shown(
+        self, client, cc_user, pack, pack_fighter, make_equipment
+    ):
+        """Fighter default equipment should be listed on the pack detail page."""
+        from gyrinx.content.models.default_assignment import (
+            ContentFighterDefaultAssignment,
+        )
+
+        gear = make_equipment("Flak Armour", category="Armour")
+        ContentFighterDefaultAssignment.objects.create(
+            fighter=pack_fighter,
+            equipment=gear,
+        )
+
+        client.force_login(cc_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b"Flak Armour" in response.content
+
+    def test_non_owner_sees_fighter_stats(self, client, make_user, pack, pack_fighter):
+        """Non-owner should also see fighter stats on the pack detail page."""
+        pack_fighter.movement = '4"'
+        pack_fighter.save()
+
+        other_user = make_user("other", "password")
+        client.force_login(other_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b'4"' in response.content
+
+
+@pytest.mark.django_db
+class TestPackDetailWeaponTraitDescriptions:
+    """Test that weapon trait descriptions are shown on the pack detail page."""
+
+    def test_weapon_trait_description_shown(self, client, cc_user, pack):
+        """Weapon trait descriptions should appear below the trait name."""
+        trait = ContentWeaponTrait.objects.create(
+            name="Blaze",
+            description="After being hit, roll a D6. On a 4+, the target is set ablaze.",
+        )
+        ct = ContentType.objects.get_for_model(ContentWeaponTrait)
+        CustomContentPackItem.objects.create(
+            pack=pack,
+            content_type=ct,
+            object_id=trait.pk,
+            owner=cc_user,
+        )
+
+        client.force_login(cc_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Blaze" in content
+        assert "set ablaze" in content
+
+    def test_weapon_trait_without_description(self, client, cc_user, pack):
+        """Weapon traits without descriptions should still render without error."""
+        trait = ContentWeaponTrait.objects.create(
+            name="Knockback",
+            description="",
+        )
+        ct = ContentType.objects.get_for_model(ContentWeaponTrait)
+        CustomContentPackItem.objects.create(
+            pack=pack,
+            content_type=ct,
+            object_id=trait.pk,
+            owner=cc_user,
+        )
+
+        client.force_login(cc_user)
+        url = reverse("core:pack", args=(pack.id,))
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b"Knockback" in response.content

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -610,15 +610,20 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
             for entry_data in fighter_entries:
                 cf = entry_data["content_object"]
                 entry_data["statline"] = cf.statline()
-                entry_data["fighter_skills"] = list(cf.skills.all())
-                entry_data["fighter_rules"] = list(cf.rules.all())
+                # Use with_packs() to include pack-owned rules/skills.
+                entry_data["fighter_rules"] = list(
+                    ContentRule.objects.with_packs([pack]).filter(contentfighter=cf)
+                )
+                entry_data["fighter_skills"] = list(
+                    ContentSkill.objects.with_packs([pack]).filter(contentfighter=cf)
+                )
                 das = list(cf.default_assignments.all())
-                entry_data["default_weapons"] = [
-                    da for da in das if da.equipment_id in weapon_equipment_ids
+                weapons = [da for da in das if da.equipment_id in weapon_equipment_ids]
+                gear = [da for da in das if da.equipment_id not in weapon_equipment_ids]
+                names = [da.equipment.name for da in weapons] + [
+                    da.equipment.name for da in gear
                 ]
-                entry_data["default_gear"] = [
-                    da for da in das if da.equipment_id not in weapon_equipment_ids
-                ]
+                entry_data["default_equipment_names"] = ", ".join(names)
 
         # Sort fighter items by house name for grouped display.
         fighter_entries.sort(

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -508,37 +508,120 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
         context["is_owner"] = user.is_authenticated and user == pack.owner
         context["can_edit"] = pack.can_edit(user)
 
-        # Group prefetched items by slug, splitting active/archived.
-        # For ContentEquipment, disambiguate gear vs weapons.
+        # Batch-resolve GenericFK content objects to avoid N+1 queries.
+        # Group items by content_type and bulk-fetch per type with
+        # type-specific select_related/prefetch_related.
+        items = list(pack.items.all())
+        items_by_ct = defaultdict(list)
+        for item in items:
+            items_by_ct[item.content_type_id].append(item)
+
         equipment_ct = ContentType.objects.get_for_model(ContentEquipment)
+        fighter_ct = ContentType.objects.get_for_model(ContentFighter)
+        skill_ct = ContentType.objects.get_for_model(ContentSkill)
+
+        content_objects_map = {}
+        for ct_id, ct_items in items_by_ct.items():
+            ct = ContentType.objects.get_for_id(ct_id)
+            model = ct.model_class()
+            object_ids = [item.object_id for item in ct_items]
+            # Use all_content() to include pack-owned content that the
+            # default ContentManager would exclude.
+            qs = model.objects.all_content().filter(id__in=object_ids)
+
+            if ct_id == fighter_ct.id:
+                qs = qs.select_related(
+                    "house", "custom_statline", "custom_statline__statline_type"
+                ).prefetch_related(
+                    "rules",
+                    "skills",
+                    "custom_statline__stats__statline_type_stat",
+                    "custom_statline__statline_type__stats",
+                    Prefetch(
+                        "default_assignments",
+                        queryset=ContentFighterDefaultAssignment.objects.select_related(
+                            "equipment",
+                        ),
+                    ),
+                )
+            elif ct_id == equipment_ct.id:
+                qs = qs.annotate(
+                    has_weapon_profiles=Exists(
+                        ContentWeaponProfile.objects.all_content().filter(
+                            equipment=OuterRef("pk")
+                        )
+                    )
+                )
+            elif ct_id == skill_ct.id:
+                qs = qs.select_related("category")
+
+            for obj in qs:
+                content_objects_map[(ct_id, obj.id)] = obj
+
+        # Pre-compute content_type_id → slug mapping for non-equipment types.
+        ct_slug_map = {}
+        for entry in SUPPORTED_CONTENT_TYPES:
+            if entry.model_class != ContentEquipment:
+                ct_slug_map.setdefault(
+                    ContentType.objects.get_for_model(entry.model_class).id, entry.slug
+                )
+
+        # Group items by slug, splitting active/archived.
         active_by_slug = defaultdict(list)
         archived_by_slug = defaultdict(list)
-        for item in pack.items.all():
-            if item.content_object is not None:
-                entry_data = {"pack_item": item, "content_object": item.content_object}
-                # Determine slug for equipment items.
-                if item.content_type_id == equipment_ct.id:
-                    slug = "weapon" if item.content_object.is_weapon() else "gear"
-                else:
-                    slug = None
-                    for e in SUPPORTED_CONTENT_TYPES:
-                        if (
-                            ContentType.objects.get_for_model(e.model_class).id
-                            == item.content_type_id
-                        ):
-                            slug = e.slug
-                            break
-                    if slug is None:
-                        continue
+        for item in items:
+            content_obj = content_objects_map.get(
+                (item.content_type_id, item.object_id)
+            )
+            if content_obj is None:
+                continue
+            entry_data = {"pack_item": item, "content_object": content_obj}
+            if item.content_type_id == equipment_ct.id:
+                slug = "weapon" if content_obj.is_weapon() else "gear"
+            else:
+                slug = ct_slug_map.get(item.content_type_id)
+                if slug is None:
+                    continue
 
-                if item.archived:
-                    archived_by_slug[slug].append(entry_data)
-                else:
-                    active_by_slug[slug].append(entry_data)
+            if item.archived:
+                archived_by_slug[slug].append(entry_data)
+            else:
+                active_by_slug[slug].append(entry_data)
+
+        # Pre-compute fighter preview data (statline, skills, rules, default equipment).
+        fighter_entries = active_by_slug.get("fighter", [])
+        if fighter_entries:
+            # Batch-determine which default equipment IDs are weapons.
+            all_equipment_ids = set()
+            for entry_data in fighter_entries:
+                for da in entry_data["content_object"].default_assignments.all():
+                    all_equipment_ids.add(da.equipment_id)
+            weapon_equipment_ids = (
+                set(
+                    ContentWeaponProfile.objects.all_content()
+                    .filter(equipment_id__in=all_equipment_ids)
+                    .values_list("equipment_id", flat=True)
+                    .distinct()
+                )
+                if all_equipment_ids
+                else set()
+            )
+
+            for entry_data in fighter_entries:
+                cf = entry_data["content_object"]
+                entry_data["statline"] = cf.statline()
+                entry_data["fighter_skills"] = list(cf.skills.all())
+                entry_data["fighter_rules"] = list(cf.rules.all())
+                das = list(cf.default_assignments.all())
+                entry_data["default_weapons"] = [
+                    da for da in das if da.equipment_id in weapon_equipment_ids
+                ]
+                entry_data["default_gear"] = [
+                    da for da in das if da.equipment_id not in weapon_equipment_ids
+                ]
 
         # Sort fighter items by house name for grouped display.
-        fighter_items = active_by_slug.get("fighter", [])
-        fighter_items.sort(
+        fighter_entries.sort(
             key=lambda e: (
                 str(e["content_object"].house) if e["content_object"].house else "",
             )

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -526,15 +526,28 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
             model = ct.model_class()
             object_ids = [item.object_id for item in ct_items]
             # Use all_content() to include pack-owned content that the
-            # default ContentManager would exclude.
-            qs = model.objects.all_content().filter(id__in=object_ids)
+            # default ContentManager would exclude. Fall back to .all()
+            # for models that don't use ContentManager.
+            manager = model._default_manager
+            base_qs = (
+                manager.all_content()
+                if hasattr(manager, "all_content")
+                else manager.all()
+            )
+            qs = base_qs.filter(id__in=object_ids)
 
             if ct_id == fighter_ct.id:
                 qs = qs.select_related(
                     "house", "custom_statline", "custom_statline__statline_type"
                 ).prefetch_related(
-                    "rules",
-                    "skills",
+                    Prefetch(
+                        "rules",
+                        queryset=ContentRule.objects.with_packs([pack]),
+                    ),
+                    Prefetch(
+                        "skills",
+                        queryset=ContentSkill.objects.with_packs([pack]),
+                    ),
                     "custom_statline__stats__statline_type_stat",
                     "custom_statline__statline_type__stats",
                     Prefetch(
@@ -610,13 +623,9 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
             for entry_data in fighter_entries:
                 cf = entry_data["content_object"]
                 entry_data["statline"] = cf.statline()
-                # Use with_packs() to include pack-owned rules/skills.
-                entry_data["fighter_rules"] = list(
-                    ContentRule.objects.with_packs([pack]).filter(contentfighter=cf)
-                )
-                entry_data["fighter_skills"] = list(
-                    ContentSkill.objects.with_packs([pack]).filter(contentfighter=cf)
-                )
+                # Use prefetched pack-aware rules/skills.
+                entry_data["fighter_rules"] = list(cf.rules.all())
+                entry_data["fighter_skills"] = list(cf.skills.all())
                 das = list(cf.default_assignments.all())
                 weapons = [da for da in das if da.equipment_id in weapon_equipment_ids]
                 gear = [da for da in das if da.equipment_id not in weapon_equipment_ids]

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -511,9 +511,9 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
         # Batch-resolve GenericFK content objects to avoid N+1 queries.
         # Group items by content_type and bulk-fetch per type with
         # type-specific select_related/prefetch_related.
-        items = list(pack.items.all())
+        pack_items = list(pack.items.all())
         items_by_ct = defaultdict(list)
-        for item in items:
+        for item in pack_items:
             items_by_ct[item.content_type_id].append(item)
 
         equipment_ct = ContentType.objects.get_for_model(ContentEquipment)
@@ -524,7 +524,7 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
         for ct_id, ct_items in items_by_ct.items():
             ct = ContentType.objects.get_for_id(ct_id)
             model = ct.model_class()
-            object_ids = [item.object_id for item in ct_items]
+            object_ids = list({item.object_id for item in ct_items})
             # Use all_content() to include pack-owned content that the
             # default ContentManager would exclude. Fall back to .all()
             # for models that don't use ContentManager.
@@ -582,7 +582,7 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
         # Group items by slug, splitting active/archived.
         active_by_slug = defaultdict(list)
         archived_by_slug = defaultdict(list)
-        for item in items:
+        for item in pack_items:
             content_obj = content_objects_map.get(
                 (item.content_type_id, item.object_id)
             )


### PR DESCRIPTION
## Summary

- Show compact inline fighter preview (statline, skills, rules, default equipment) grouped by house on the pack detail page
- Show weapon trait descriptions below trait names
- Batch-resolve GenericFK content objects to fix N+1 queries on the pack detail view

## Test plan

- [ ] View a pack with fighters — stats, skills, rules, and default equipment should be visible
- [ ] View a pack with weapon traits — descriptions should appear below trait names
- [ ] View a pack as a non-owner — same information should be visible
- [ ] View a pack with no fighters — "No fighters" message still shows
- [ ] Weapon traits without descriptions render without error

Closes #1694