### PR TITLE
fix: show other users' packs on interstitial when pre-selected via URL

### DIFF
--- a/gyrinx/core/tests/test_list_packs.py
+++ b/gyrinx/core/tests/test_list_packs.py
@@ -265,6 +265,45 @@ class TestNewListPacksInterstitial:
         assert response.status_code == 302
         assert "skip_packs=1" in response.url
 
+    def test_packs_interstitial_shows_other_users_preselected_pack(
+        self, client, make_user, make_pack
+    ):
+        """A pack owned by another user appears when pre-selected via ?pack=<id>.
+
+        Regression test for #1699: clicking "Use in new List" on another user's
+        pack should show it on the interstitial even though "Your Packs Only"
+        defaults to on.
+        """
+        viewer = make_user("viewer", "password")
+        pack_owner = make_user("packowner", "password")
+        other_pack = make_pack("Other Pack", owner=pack_owner, listed=True)
+
+        client.force_login(viewer)
+        url = reverse("core:lists-new-packs") + f"?pack={other_pack.id}"
+        response = client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        # The other user's pack must be visible and pre-checked
+        assert other_pack.name in content
+        assert f'value="{other_pack.id}"' in content
+        assert "checked" in content
+
+    def test_packs_interstitial_other_user_pack_not_shown_without_preselect(
+        self, client, make_user, make_pack
+    ):
+        """Without ?pack=<id>, another user's pack is hidden by default filter."""
+        viewer = make_user("viewer", "password")
+        pack_owner = make_user("packowner", "password")
+        other_pack = make_pack("Other Pack", owner=pack_owner, listed=True)
+
+        client.force_login(viewer)
+        url = reverse("core:lists-new-packs")
+        response = client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        # Without pre-selection, "Your Packs Only" hides other user's packs
+        assert other_pack.name not in content
+
     def test_pack_house_appears_in_dropdown(self, client, cc_user, pack):
         """Pack house appears in the House dropdown on the new list form."""
         # Create a house that only exists inside the pack

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -696,10 +696,24 @@ def new_list_packs(request):
     # Display filtering for GET requests
     available_packs = accessible_packs.select_related("owner")
 
+    # Pre-select packs from ?pack=<id> query params (e.g. from "Use in new List"
+    # button on a pack detail page).  Parse early so the "Your Packs Only" filter
+    # can include them.
+    preselected_pack_ids = set(request.GET.getlist("pack"))
+    valid_preselected_ids = [pid for pid in preselected_pack_ids if is_valid_uuid(pid)]
+
     # "Your Packs Only" toggle (default on)
     show_my_packs = request.GET.get("my", "1")
     if show_my_packs == "1":
-        available_packs = available_packs.filter(owner=request.user)
+        if valid_preselected_ids:
+            # Always include pre-selected packs so they remain visible even
+            # when the "Your Packs Only" filter is active.  This ensures that
+            # clicking "Use in new List" on another user's pack shows it.
+            available_packs = available_packs.filter(
+                Q(owner=request.user) | Q(id__in=valid_preselected_ids)
+            )
+        else:
+            available_packs = available_packs.filter(owner=request.user)
 
     # Search
     search_query = request.GET.get("q", "").strip()
@@ -756,9 +770,6 @@ def new_list_packs(request):
                     }
                 )
         pack.content_preview = preview_parts
-
-    # Pre-select packs from ?pack=<id> query params
-    preselected_pack_ids = set(request.GET.getlist("pack"))
 
     return render(
         request,


### PR DESCRIPTION
When clicking "Use in new List" on a pack owned by another user, the "Your Packs Only" filter (on by default) was hiding the pre-selected pack. Now pre-selected packs from the URL are always included in the available list.

Closes #1699

Generated with [Claude Code](https://claude.ai/code)