### PR TITLE
fix: improve lore page fighter headings and edit return URLs

### DIFF
--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -30,7 +30,7 @@
             {{ list.narrative|safe_rich_text|safe }}
         {% elif list.owner_cached == user %}
             <div class="text-secondary fst-italic">
-                No lore added yet. <a href="{% url 'core:list-edit' list.id %}">Add some</a> to tell the story of your gang.
+                No lore added yet. <a href="{% url 'core:list-edit' list.id %}?return_url={% url 'core:list-about' list.id %}">Add some</a> to tell the story of your gang.
             </div>
         {% else %}
             <div class="text-secondary fst-italic">No lore added yet.</div>

--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -15,11 +15,11 @@
         {% endfor %}
     </nav>
     <div id="list-overview" class="mb-4">
-        <div class="hstack">
+        <div class="hstack align-items-start">
             <h3 class="h4" id="about-list">Overview</h3>
             {% if list.owner_cached == user %}
-                <div class="ms-auto">
-                    <a href="{% url 'core:list-edit' list.id %}"
+                <div class="ms-auto flex-shrink-0">
+                    <a href="{% url 'core:list-edit' list.id %}?return_url={% url 'core:list-about' list.id %}"
                        class="btn btn-outline-secondary btn-sm">
                         <i class="bi-pencil"></i> Edit
                     </a>
@@ -40,11 +40,14 @@
         {% for fighter in list.active_fighters %}
             {% if fighter.narrative %}
                 <div class="g-col-12 g-col-md-6" id="about-{{ fighter.id }}">
-                    <div class="hstack">
-                        <h3 class="h4">{{ fighter.fully_qualified_name }}</h3>
+                    <div class="hstack align-items-start">
+                        <div>
+                            <h3 class="h4 mb-0">{{ fighter.name }}</h3>
+                            <div class="text-secondary">{{ fighter.content_fighter_cached.name }}</div>
+                        </div>
                         {% if list.owner_cached == user %}
-                            <div class="ms-auto">
-                                <a href="{% url 'core:list-fighter-narrative-edit' list.id fighter.id %}"
+                            <div class="ms-auto flex-shrink-0">
+                                <a href="{% url 'core:list-fighter-narrative-edit' list.id fighter.id %}?return_url={% url 'core:list-about' list.id %}%23about-{{ fighter.id }}"
                                    class="btn btn-outline-secondary btn-sm">
                                     <i class="bi-pencil"></i> Edit
                                 </a>
@@ -62,8 +65,9 @@
                 </div>
             {% else %}
                 <div class="g-col-12 g-col-md-6" id="about-{{ fighter.id }}">
-                    <div class="hstack">
-                        <h3 class="h4">{{ fighter.fully_qualified_name }}</h3>
+                    <div>
+                        <h3 class="h4 mb-0">{{ fighter.name }}</h3>
+                        <div class="text-secondary">{{ fighter.content_fighter_cached.name }}</div>
                     </div>
                     {% if fighter.image %}
                         <div class="mb-2">
@@ -75,7 +79,7 @@
                     <p class="text-secondary">No lore added yet.</p>
                     {% if list.owner_cached == user %}
                         <p>
-                            <a href="{% url 'core:list-fighter-narrative-edit' list.id fighter.id %}"
+                            <a href="{% url 'core:list-fighter-narrative-edit' list.id fighter.id %}?return_url={% url 'core:list-about' list.id %}%23about-{{ fighter.id }}"
                                class="btn btn-outline-secondary btn-sm">
                                 <i class="bi-plus"></i> Add lore for {{ fighter.name }}
                             </a>

--- a/gyrinx/core/templates/core/list_edit.html
+++ b/gyrinx/core/templates/core/list_edit.html
@@ -11,6 +11,7 @@
               method="post"
               class="vstack gap-3">
             {% csrf_token %}
+            <input type="hidden" name="return_url" value="{{ return_url }}">
             {{ form.media }}
             {{ form }}
             <div class="mt-3">

--- a/gyrinx/core/tests/test_integration_core_functionality.py
+++ b/gyrinx/core/tests/test_integration_core_functionality.py
@@ -622,6 +622,46 @@ def test_rename_list_and_change_properties(client, user, make_list):
 
 
 @pytest.mark.django_db
+def test_edit_list_with_return_url(client, user, make_list):
+    """Test that edit_list redirects to return_url when provided."""
+    lst = make_list("Test Gang")
+    client.force_login(user)
+
+    about_url = reverse("core:list-about", args=[lst.id])
+    edit_url = reverse("core:list-edit", args=[lst.id])
+
+    # GET with return_url should render the form
+    response = client.get(f"{edit_url}?return_url={about_url}")
+    assert response.status_code == 200
+
+    # POST with return_url should redirect to the lore page
+    response = client.post(
+        edit_url,
+        {"name": "Updated Gang", "return_url": about_url},
+    )
+    assert response.status_code == 302
+    assert about_url in response.url
+
+
+@pytest.mark.django_db
+def test_edit_list_rejects_unsafe_return_url(client, user, make_list):
+    """Test that edit_list falls back to default for unsafe return_url."""
+    lst = make_list("Test Gang")
+    client.force_login(user)
+
+    edit_url = reverse("core:list-edit", args=[lst.id])
+    default_url = reverse("core:list", args=[lst.id])
+
+    # POST with external return_url should fall back to default
+    response = client.post(
+        edit_url,
+        {"name": "Updated Gang", "return_url": "https://evil.com/"},
+    )
+    assert response.status_code == 302
+    assert default_url in response.url
+
+
+@pytest.mark.django_db
 def test_non_public_lists_visibility(client, user, make_user):
     """Test that non-public lists are not visible on the home page."""
     other_user = make_user("otheruser", "password")

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -24,6 +24,7 @@ from gyrinx.core.utils import (
     get_list_campaign_resources,
     get_list_held_assets,
     get_list_recent_campaign_actions,
+    get_return_url,
     safe_redirect,
     search_queryset,
 )
@@ -800,6 +801,9 @@ def edit_list(request, id):
     """
     list_ = get_object_or_404(List, id=id, owner=request.user)
 
+    default_url = reverse("core:list", args=(list_.id,))
+    return_url = get_return_url(request, default_url)
+
     error_message = None
     if request.method == "POST":
         form = EditListForm(request.POST, instance=list_)
@@ -817,7 +821,7 @@ def edit_list(request, id):
                 list_name=updated_list.name,
             )
 
-            return HttpResponseRedirect(reverse("core:list", args=(list_.id,)))
+            return safe_redirect(request, return_url, fallback_url=default_url)
     else:
         form = EditListForm(instance=list_)
 
@@ -827,6 +831,7 @@ def edit_list(request, id):
         {
             "form": form,
             "error_message": error_message,
+            "return_url": return_url,
         },
     )
 


### PR DESCRIPTION
## Summary
- Split fighter name and content fighter type onto separate lines in the lore view (name as heading, type below in secondary text)
- Add `return_url` query params to edit links on the lore page so saving redirects back to lore instead of the list overview
- Add `flex-shrink-0` and `align-items-start` to edit button wrappers to prevent layout collapse

## Test plan
- [ ] Visit a list's Lore tab and verify fighter headings show name on line 1, type/category on line 2
- [ ] Click Edit on a fighter's lore, save, and verify redirect back to the Lore page
- [ ] Click Edit on the Overview section, save, and verify redirect back to the Lore page
- [ ] Click "Add lore" for a fighter without lore, save, and verify redirect back to Lore
- [ ] Verify edit buttons don't collapse on narrow viewports