### PR TITLE
feat: use fighter preview cards on pack detail page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ screenshots/
 .claude/settings.local.json
 .claude/memory.local.json
 .claude/test-plans/
+.claude/worktrees/
 CLAUDE.local.md
 media/
 # Ignore the latest content data export file

--- a/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
+++ b/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
@@ -15,6 +15,7 @@
     - fighter_edit_url: URL for edit link (shows Edit/Archive actions when set)
     - fighter_archive_url: URL for archive link
     - fighter_can_add: whether the edit link should be shown (section.can_add)
+    - fighter_equipment_url: URL for equipment tab edit link
 {% endcomment %}
 <div class="card">
     <div class="card-header p-2">
@@ -106,7 +107,13 @@
                     {% endif %}
                     <!-- Gear -->
                     <tr class="fs-7">
-                        <th scope="row">Gear</th>
+                        <th scope="row">
+                            Gear
+                            {% if fighter_equipment_url %}
+                                <a href="{{ fighter_equipment_url }}"
+                                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fw-normal ms-1">Edit</a>
+                            {% endif %}
+                        </th>
                         <td>
                             {% if preview_gear %}
                                 {% for da in preview_gear %}
@@ -124,7 +131,25 @@
         <!-- Weapons -->
         {% if preview_weapons %}
             <table class="table table-sm table-borderless mb-0 fs-7">
-                {% include "core/includes/weapon_stat_headers.html" with first_col="Weapons" %}
+                <thead class="table-group-divider">
+                    <tr>
+                        <th scope="col">
+                            Weapons
+                            {% if fighter_equipment_url %}
+                                <a href="{{ fighter_equipment_url }}"
+                                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fw-normal ms-1">Edit</a>
+                            {% endif %}
+                        </th>
+                        <th class="text-center" scope="col">S</th>
+                        <th class="text-center" scope="col">L</th>
+                        <th class="text-center border-start" scope="col">S</th>
+                        <th class="text-center" scope="col">L</th>
+                        <th class="text-center border-start" scope="col">Str</th>
+                        <th class="text-center" scope="col">Ap</th>
+                        <th class="text-center" scope="col">D</th>
+                        <th class="text-center" scope="col">Am</th>
+                    </tr>
+                </thead>
                 {% for da in preview_weapons %}
                     <tbody class="table-group-divider">
                         {% for profile in da.all_profiles %}
@@ -151,7 +176,13 @@
             <table class="table table-sm table-borderless mb-0 fs-7">
                 <thead class="table-group-divider">
                     <tr>
-                        <th scope="col">Weapons</th>
+                        <th scope="col">
+                            Weapons
+                            {% if fighter_equipment_url %}
+                                <a href="{{ fighter_equipment_url }}"
+                                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fw-normal ms-1">Edit</a>
+                            {% endif %}
+                        </th>
                     </tr>
                 </thead>
                 <tbody>

--- a/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
+++ b/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
@@ -11,23 +11,39 @@
     - preview_skills: list of ContentSkill objects
     - preview_weapons: list of ContentFighterDefaultAssignment (weapons)
     - preview_gear: list of ContentFighterDefaultAssignment (gear)
+    Optional:
+    - fighter_edit_url: URL for edit link (shows Edit/Archive actions when set)
+    - fighter_archive_url: URL for archive link
+    - fighter_can_add: whether the edit link should be shown (section.can_add)
 {% endcomment %}
 <div class="card">
     <div class="card-header p-2">
         <div class="hstack align-items-start">
-            <div class="vstack gap-1">
-                <h3 class="h5 mb-0">{{ content_fighter.type }}</h3>
-                <div class="text-secondary fs-7">
-                    {{ content_fighter.get_category_display }}
-                    {% if content_fighter.house %}· {{ content_fighter.house.name }}{% endif %}
-                </div>
-            </div>
+            <h3 class="h5 mb-0">{{ content_fighter.type }}</h3>
             <div class="ms-auto">
                 <span class="badge text-bg-primary">{% credits content_fighter.base_cost %}</span>
             </div>
         </div>
+        <div class="hstack gap-2 align-items-baseline">
+            <span class="text-secondary fs-7">
+                {{ content_fighter.get_category_display }}
+                {% if content_fighter.house %}· {{ content_fighter.house.name }}{% endif %}
+            </span>
+            {% if fighter_edit_url or fighter_archive_url %}
+                <span class="d-flex gap-2 flex-shrink-0 ms-auto">
+                    {% if fighter_can_add and fighter_edit_url %}
+                        <a href="{{ fighter_edit_url }}"
+                           class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Edit</a>
+                    {% endif %}
+                    {% if fighter_archive_url %}
+                        <a href="{{ fighter_archive_url }}"
+                           class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive</a>
+                    {% endif %}
+                </span>
+            {% endif %}
+        </div>
     </div>
-    <div class="card-body p-0">
+    <div class="card-body p-0 p-sm-2 pt-2">
         <!-- Stats -->
         {% if preview_statline %}
             <table class="table table-sm table-borderless table-fixed mb-0">

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -166,7 +166,8 @@
                                                             {% if can_edit %}
                                                                 {% url 'core:pack-edit-item' pack.id entry.pack_item.id as edit_url %}
                                                                 {% url 'core:pack-delete-item' pack.id entry.pack_item.id as archive_url %}
-                                                                {% include "core/pack/includes/fighter_preview_card.html" with fighter_edit_url=edit_url fighter_archive_url=archive_url fighter_can_add=section.can_add %}
+                                                                {% url 'core:pack-item-equipment' pack.id entry.pack_item.id as equipment_url %}
+                                                                {% include "core/pack/includes/fighter_preview_card.html" with fighter_edit_url=edit_url fighter_archive_url=archive_url fighter_can_add=section.can_add fighter_equipment_url=equipment_url %}
                                                             {% else %}
                                                                 {% include "core/pack/includes/fighter_preview_card.html" %}
                                                             {% endif %}

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -158,53 +158,22 @@
                                 <div class="vstack gap-3">
                                     {% for house_group in fighters_by_house %}
                                         <div>
-                                            {% if house_group.grouper %}
-                                                <div class="text-secondary text-uppercase fs-7 mb-1">{{ house_group.grouper }}</div>
-                                            {% endif %}
-                                            <ul class="list-unstyled vstack gap-2 mb-0">
+                                            {% if house_group.grouper %}<div class="caps-label mb-2">{{ house_group.grouper }}</div>{% endif %}
+                                            <div class="vstack gap-3">
                                                 {% for entry in house_group.list %}
-                                                    <li class="py-1" id="item-{{ entry.pack_item.id }}">
-                                                        <div class="d-flex justify-content-between align-items-start">
-                                                            <div>
-                                                                <span class="fw-medium">{{ entry.content_object.type }}</span>
-                                                                <span class="text-secondary fs-7">{{ entry.content_object.get_category_display }}</span>
-                                                                {% if entry.content_object.base_cost %}
-                                                                    <span class="text-secondary fs-7">· {% credits entry.content_object.base_cost %}</span>
-                                                                {% endif %}
-                                                            </div>
+                                                    <div id="item-{{ entry.pack_item.id }}">
+                                                        {% with content_fighter=entry.content_object preview_statline=entry.preview_statline preview_rules=entry.preview_rules preview_skills=entry.preview_skills preview_weapons=entry.preview_weapons preview_gear=entry.preview_gear %}
                                                             {% if can_edit %}
-                                                                <span class="d-flex gap-2 flex-shrink-0">
-                                                                    {% if section.can_add %}
-                                                                        <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
-                                                                           class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Edit</a>
-                                                                    {% endif %}
-                                                                    <a href="{% url 'core:pack-delete-item' pack.id entry.pack_item.id %}"
-                                                                       class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive</a>
-                                                                </span>
+                                                                {% url 'core:pack-edit-item' pack.id entry.pack_item.id as edit_url %}
+                                                                {% url 'core:pack-delete-item' pack.id entry.pack_item.id as archive_url %}
+                                                                {% include "core/pack/includes/fighter_preview_card.html" with fighter_edit_url=edit_url fighter_archive_url=archive_url fighter_can_add=section.can_add %}
+                                                            {% else %}
+                                                                {% include "core/pack/includes/fighter_preview_card.html" %}
                                                             {% endif %}
-                                                        </div>
-                                                        {% if entry.statline %}
-                                                            <div class="fs-7 text-secondary mt-1">
-                                                                {% for stat in entry.statline %}
-                                                                    {{ stat.name }}&nbsp;{{ stat.value }}
-                                                                    {% if not forloop.last %}·{% endif %}
-                                                                {% endfor %}
-                                                            </div>
-                                                        {% endif %}
-                                                        {% if entry.fighter_rules or entry.fighter_skills or entry.default_equipment_names %}
-                                                            <div class="fs-7 text-secondary">
-                                                                {% if entry.fighter_rules %}{{ entry.fighter_rules|join_names }}{% endif %}
-                                                                {% if entry.fighter_rules and entry.fighter_skills %}·{% endif %}
-                                                                {% if entry.fighter_skills %}{{ entry.fighter_skills|join_names }}{% endif %}
-                                                                {% if entry.default_equipment_names %}
-                                                                    {% if entry.fighter_rules or entry.fighter_skills %}·{% endif %}
-                                                                    {{ entry.default_equipment_names }}
-                                                                {% endif %}
-                                                            </div>
-                                                        {% endif %}
-                                                    </li>
+                                                        {% endwith %}
+                                                    </div>
                                                 {% endfor %}
-                                            </ul>
+                                            </div>
                                         </div>
                                     {% endfor %}
                                 </div>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -159,9 +159,9 @@
                                     {% for house_group in fighters_by_house %}
                                         <div>
                                             {% if house_group.grouper %}<div class="caps-label mb-2">{{ house_group.grouper }}</div>{% endif %}
-                                            <div class="vstack gap-3">
+                                            <div class="row g-3">
                                                 {% for entry in house_group.list %}
-                                                    <div id="item-{{ entry.pack_item.id }}">
+                                                    <div id="item-{{ entry.pack_item.id }}" class="col-12 col-lg-6">
                                                         {% with content_fighter=entry.content_object preview_statline=entry.preview_statline preview_rules=entry.preview_rules preview_skills=entry.preview_skills preview_weapons=entry.preview_weapons preview_gear=entry.preview_gear %}
                                                             {% if can_edit %}
                                                                 {% url 'core:pack-edit-item' pack.id entry.pack_item.id as edit_url %}

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -560,12 +560,22 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
                                 "weapon_profiles_field",
                                 queryset=ContentWeaponProfile.objects.with_packs(
                                     [pack]
+                                ).prefetch_related(
+                                    Prefetch(
+                                        "traits",
+                                        queryset=ContentWeaponTrait.objects.all_content(),
+                                    )
                                 ),
                             ),
                             Prefetch(
                                 "equipment__contentweaponprofile_set",
                                 queryset=ContentWeaponProfile.objects.with_packs(
                                     [pack]
+                                ).prefetch_related(
+                                    Prefetch(
+                                        "traits",
+                                        queryset=ContentWeaponTrait.objects.all_content(),
+                                    )
                                 ),
                             ),
                         ),

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -578,6 +578,7 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
                                     )
                                 ),
                             ),
+                            "weapon_accessories_field__modifiers",
                         ),
                     ),
                 )

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -554,6 +554,20 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
                         "default_assignments",
                         queryset=ContentFighterDefaultAssignment.objects.select_related(
                             "equipment",
+                            "equipment__category",
+                        ).prefetch_related(
+                            Prefetch(
+                                "weapon_profiles_field",
+                                queryset=ContentWeaponProfile.objects.with_packs(
+                                    [pack]
+                                ),
+                            ),
+                            Prefetch(
+                                "equipment__contentweaponprofile_set",
+                                queryset=ContentWeaponProfile.objects.with_packs(
+                                    [pack]
+                                ),
+                            ),
                         ),
                     ),
                 )
@@ -622,17 +636,17 @@ class PackDetailView(LoginRequiredMixin, generic.DetailView):
 
             for entry_data in fighter_entries:
                 cf = entry_data["content_object"]
-                entry_data["statline"] = cf.statline()
+                entry_data["preview_statline"] = cf.statline()
                 # Use prefetched pack-aware rules/skills.
-                entry_data["fighter_rules"] = list(cf.rules.all())
-                entry_data["fighter_skills"] = list(cf.skills.all())
+                entry_data["preview_rules"] = list(cf.rules.all())
+                entry_data["preview_skills"] = list(cf.skills.all())
                 das = list(cf.default_assignments.all())
-                weapons = [da for da in das if da.equipment_id in weapon_equipment_ids]
-                gear = [da for da in das if da.equipment_id not in weapon_equipment_ids]
-                names = [da.equipment.name for da in weapons] + [
-                    da.equipment.name for da in gear
+                entry_data["preview_weapons"] = [
+                    da for da in das if da.equipment_id in weapon_equipment_ids
                 ]
-                entry_data["default_equipment_names"] = ", ".join(names)
+                entry_data["preview_gear"] = [
+                    da for da in das if da.equipment_id not in weapon_equipment_ids
+                ]
 
         # Sort fighter items by house name for grouped display.
         fighter_entries.sort(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ exclude_dirs = [
     "*/tests/*",
     "scripts/test.sh",
     # Python... in node_modules?
-    "node_modules"
+    "node_modules",
+    ".claude/worktrees"
 ]
 skips = [
     "B101",  # assert_used - we use assert in tests


### PR DESCRIPTION
## Summary

- Replace inline fighter list items on pack detail page with full preview cards (stats table, rules, skills, weapons with profiles, gear)
- Reuse existing `fighter_preview_card.html` partial, extended with optional Edit/Archive action links in the card header
- Prefetch weapon profiles and equipment categories in `PackDetailView` to support card rendering without N+1 queries

## Test plan

- [ ] View a pack detail page with fighters — verify full cards render with stats, rules, skills, weapons, and gear
- [ ] Verify Edit/Archive links appear in card header for pack owners/editors
- [ ] Verify cards are read-only for non-owner viewers
- [ ] Verify house grouping still works with caps-label headings
- [ ] Verify pack edit page fighter preview card still renders correctly (no regression from card header restructure)
- [ ] Check responsive layout on mobile