### PR TITLE
Add safe redirect with fallback for new list packs view

### DIFF
--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -692,7 +692,7 @@ def new_list_packs(request):
             url = f"{url}?{urlencode([('packs', pid) for pid in pack_ids], doseq=True)}"
         else:
             url = f"{url}?{urlencode({'skip_packs': '1'})}"
-        return HttpResponseRedirect(url)
+        return safe_redirect(request, url, fallback_url=reverse("core:lists-new"))
 
     # Display filtering for GET requests
     available_packs = accessible_packs.select_related("owner")


### PR DESCRIPTION
## Summary
Updated the redirect behavior in the `new_list_packs` view to use a safe redirect function with a fallback URL, improving security and user experience.

## Key Changes
- Replaced direct `HttpResponseRedirect(url)` with `safe_redirect(request, url, fallback_url=reverse("core:lists-new"))`
- This ensures redirects are validated and prevents potential open redirect vulnerabilities
- Added a fallback URL that directs users to the new lists page if the redirect target is invalid

## Implementation Details
The change applies to the redirect logic after pack selection in the `new_list_packs` view. The `safe_redirect` function now validates the redirect URL before executing it, with `reverse("core:lists-new")` serving as a safe fallback destination if the original URL is deemed unsafe.

https://claude.ai/code/session_01NDiBzAr3Deh33ZnBVjpoEx