### PR TITLE
feat: make content pack pages accessible to logged-out users

### DIFF
--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -47,12 +47,10 @@
                         <a class="nav-link {% active_path '/campaigns/' '/campaign/' '/battle/' %}"
                            href="{% url 'core:campaigns' %}">Campaigns</a>
                     </li>
-                    {% if user.is_authenticated %}
-                        <li class="nav-item">
-                            <a class="nav-link {% active_path '/packs/' '/pack/' %}"
-                               href="{% url 'core:packs' %}">Customisation</a>
-                        </li>
-                    {% endif %}
+                    <li class="nav-item">
+                        <a class="nav-link {% active_path '/packs/' '/pack/' %}"
+                           href="{% url 'core:packs' %}">Customisation</a>
+                    </li>
                     {% get_page_by_url '/help/' as help_page %}
                     {% if help_page %}
                         <li class="nav-item">

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -11,73 +11,75 @@
             {% include "core/includes/breadcrumb.html" with type="Pack" owner=pack.owner name=pack.name type_url=packs_url only %}
             <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2 mb-2">
                 <h1 class="h2 mb-0">{{ pack.name }}</h1>
-                <nav class="d-flex flex-nowrap gap-2 ms-md-auto">
-                    <a href="{% url 'core:lists-new-packs' %}?pack={{ pack.id }}"
-                       class="btn btn-primary btn-sm">
-                        <i class="bi-plus-lg"></i> Use in new List
-                    </a>
-                    {% if user_lists or user_campaigns %}
-                        <div class="btn-group" role="group">
-                            <button type="button"
-                                    class="btn btn-primary btn-sm dropdown-toggle"
-                                    data-bs-toggle="dropdown"
-                                    aria-expanded="false">Add to…</button>
-                            <ul class="dropdown-menu dropdown-menu-end">
-                                {% if user_lists %}
-                                    <li>
-                                        <a href="{% url 'core:pack-lists' pack.id %}"
-                                           class="dropdown-item icon-link">
-                                            <i class="bi-list-ul"></i> List
-                                            {% if subscribed_list_ids %}
-                                                <span class="badge text-bg-secondary ms-1">{{ subscribed_list_ids|length }}</span>
-                                            {% endif %}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                                {% if user_campaigns %}
-                                    <li>
-                                        <a href="{% url 'core:pack-campaigns' pack.id %}"
-                                           class="dropdown-item icon-link">
-                                            <i class="bi-award"></i> Campaign
-                                            {% if subscribed_campaign_ids %}
-                                                <span class="badge text-bg-secondary ms-1">{{ subscribed_campaign_ids|length }}</span>
-                                            {% endif %}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </div>
-                    {% endif %}
-                    {% if can_edit or is_owner %}
-                        <div class="btn-group flex-nowrap">
-                            {% if can_edit %}
-                                <a href="{% url 'core:pack-edit' pack.id %}"
-                                   class="btn btn-secondary btn-sm">
-                                    <i class="bi-pencil"></i> Edit
-                                </a>
-                            {% endif %}
-                            {% if is_owner %}
-                                <div class="btn-group" role="group">
-                                    <button type="button"
-                                            class="btn btn-secondary btn-sm dropdown-toggle"
-                                            data-bs-toggle="dropdown"
-                                            aria-expanded="false"
-                                            aria-label="More options">
-                                        <i class="bi-three-dots-vertical"></i>
-                                    </button>
-                                    <ul class="dropdown-menu dropdown-menu-end">
+                {% if user.is_authenticated %}
+                    <nav class="d-flex flex-nowrap gap-2 ms-md-auto">
+                        <a href="{% url 'core:lists-new-packs' %}?pack={{ pack.id }}"
+                           class="btn btn-primary btn-sm">
+                            <i class="bi-plus-lg"></i> Use in new List
+                        </a>
+                        {% if user_lists or user_campaigns %}
+                            <div class="btn-group" role="group">
+                                <button type="button"
+                                        class="btn btn-primary btn-sm dropdown-toggle"
+                                        data-bs-toggle="dropdown"
+                                        aria-expanded="false">Add to…</button>
+                                <ul class="dropdown-menu dropdown-menu-end">
+                                    {% if user_lists %}
                                         <li>
-                                            <a href="{% url 'core:pack-permissions' pack.id %}"
+                                            <a href="{% url 'core:pack-lists' pack.id %}"
                                                class="dropdown-item icon-link">
-                                                <i class="bi-people"></i> Permissions
+                                                <i class="bi-list-ul"></i> List
+                                                {% if subscribed_list_ids %}
+                                                    <span class="badge text-bg-secondary ms-1">{{ subscribed_list_ids|length }}</span>
+                                                {% endif %}
                                             </a>
                                         </li>
-                                    </ul>
-                                </div>
-                            {% endif %}
-                        </div>
-                    {% endif %}
-                </nav>
+                                    {% endif %}
+                                    {% if user_campaigns %}
+                                        <li>
+                                            <a href="{% url 'core:pack-campaigns' pack.id %}"
+                                               class="dropdown-item icon-link">
+                                                <i class="bi-award"></i> Campaign
+                                                {% if subscribed_campaign_ids %}
+                                                    <span class="badge text-bg-secondary ms-1">{{ subscribed_campaign_ids|length }}</span>
+                                                {% endif %}
+                                            </a>
+                                        </li>
+                                    {% endif %}
+                                </ul>
+                            </div>
+                        {% endif %}
+                        {% if can_edit or is_owner %}
+                            <div class="btn-group flex-nowrap">
+                                {% if can_edit %}
+                                    <a href="{% url 'core:pack-edit' pack.id %}"
+                                       class="btn btn-secondary btn-sm">
+                                        <i class="bi-pencil"></i> Edit
+                                    </a>
+                                {% endif %}
+                                {% if is_owner %}
+                                    <div class="btn-group" role="group">
+                                        <button type="button"
+                                                class="btn btn-secondary btn-sm dropdown-toggle"
+                                                data-bs-toggle="dropdown"
+                                                aria-expanded="false"
+                                                aria-label="More options">
+                                            <i class="bi-three-dots-vertical"></i>
+                                        </button>
+                                        <ul class="dropdown-menu dropdown-menu-end">
+                                            <li>
+                                                <a href="{% url 'core:pack-permissions' pack.id %}"
+                                                   class="dropdown-item icon-link">
+                                                    <i class="bi-people"></i> Permissions
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    </nav>
+                {% endif %}
             </div>
             <div class="d-flex flex-wrap gap-2 text-secondary fs-7">
                 {% if pack.listed %}

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -49,15 +49,34 @@ def test_customisation_link_visible_for_authenticated_users(client, user):
 
 
 @pytest.mark.django_db
-def test_customisation_link_hidden_for_anonymous(client):
-    """Test that the Customisation link is hidden for anonymous users."""
+def test_customisation_link_visible_for_anonymous(client):
+    """Test that the Customisation link is visible for anonymous users."""
     response = client.get("/")
 
     assert response.status_code == 200
-    assert b'href="/packs/"' not in response.content
+    assert b'href="/packs/"' in response.content
+    assert b">Customisation</a>" in response.content
 
 
 # --- Pack index view ---
+
+
+@pytest.mark.django_db
+def test_packs_index_loads_for_anonymous(client, pack):
+    """Test that the packs index page loads for anonymous users."""
+    response = client.get("/packs/")
+    assert response.status_code == 200
+    # Anonymous users see listed packs
+    assert b"Test Pack" in response.content
+
+
+@pytest.mark.django_db
+def test_packs_index_hides_unlisted_from_anonymous(client, group_user):
+    """Test that anonymous users don't see unlisted packs."""
+    CustomContentPack.objects.create(name="Secret Pack", listed=False, owner=group_user)
+    response = client.get("/packs/")
+    assert response.status_code == 200
+    assert b"Secret Pack" not in response.content
 
 
 @pytest.mark.django_db
@@ -209,6 +228,33 @@ def test_featured_pack_description_falls_back_to_summary(client, group_user, mak
 
 
 @pytest.mark.django_db
+def test_pack_detail_loads_for_anonymous(client, pack):
+    """Test that the pack detail page loads for anonymous users (listed pack)."""
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    assert b"Test Pack" in response.content
+
+
+@pytest.mark.django_db
+def test_pack_detail_hides_buttons_for_anonymous(client, pack):
+    """Test that action buttons are hidden for anonymous users."""
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    assert b"Use in new List" not in response.content
+    assert b"bi-pencil" not in response.content
+
+
+@pytest.mark.django_db
+def test_pack_detail_unlisted_returns_404_for_anonymous(client, group_user):
+    """Test that an unlisted pack returns 404 for anonymous users."""
+    unlisted = CustomContentPack.objects.create(
+        name="Secret Pack", listed=False, owner=group_user
+    )
+    response = client.get(f"/pack/{unlisted.id}")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_pack_detail_loads(client, group_user, pack):
     """Test that the pack detail page loads."""
     client.force_login(group_user)
@@ -270,13 +316,12 @@ def test_unlisted_pack_hidden_from_others(client, group_user, make_user):
 
 @pytest.mark.django_db
 def test_unlisted_pack_hidden_from_anonymous(client, group_user):
-    """Test that an unlisted pack redirects anonymous users to login."""
+    """Test that an unlisted pack returns 404 for anonymous users."""
     unlisted = CustomContentPack.objects.create(
         name="Secret Pack", listed=False, owner=group_user
     )
     response = client.get(f"/pack/{unlisted.id}")
-    assert response.status_code == 302
-    assert "/accounts/login/" in response.url
+    assert response.status_code == 404
 
 
 # --- Pack create view ---

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -453,28 +453,33 @@ def _get_pack_activity(pack, limit=None):
     return combined
 
 
-class PacksView(LoginRequiredMixin, generic.ListView):
+class PacksView(generic.ListView):
     template_name = "core/pack/packs.html"
     context_object_name = "packs"
     paginate_by = 20
 
     def get_queryset(self):
         queryset = CustomContentPack.objects.all().select_related("owner")
+        user = self.request.user
 
-        has_permission = CustomContentPackPermission.objects.filter(
-            pack=OuterRef("pk"), user=self.request.user
-        )
-        show_my_packs = self.request.GET.get("my", "1")
-        if show_my_packs == "1":
-            queryset = queryset.filter(
-                models.Q(owner=self.request.user) | models.Q(Exists(has_permission))
-            )
+        if not user.is_authenticated:
+            # Anonymous users only see listed (public) packs
+            queryset = queryset.filter(listed=True)
         else:
-            queryset = queryset.filter(
-                models.Q(listed=True)
-                | models.Q(owner=self.request.user)
-                | models.Q(Exists(has_permission))
+            has_permission = CustomContentPackPermission.objects.filter(
+                pack=OuterRef("pk"), user=user
             )
+            show_my_packs = self.request.GET.get("my", "1")
+            if show_my_packs == "1":
+                queryset = queryset.filter(
+                    models.Q(owner=user) | models.Q(Exists(has_permission))
+                )
+            else:
+                queryset = queryset.filter(
+                    models.Q(listed=True)
+                    | models.Q(owner=user)
+                    | models.Q(Exists(has_permission))
+                )
 
         # Search
         q = self.request.GET.get("q", "").strip()
@@ -504,7 +509,7 @@ class PacksView(LoginRequiredMixin, generic.ListView):
         return context
 
 
-class PackDetailView(LoginRequiredMixin, generic.DetailView):
+class PackDetailView(generic.DetailView):
     template_name = "core/pack/pack.html"
     context_object_name = "pack"
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -459,7 +459,9 @@ class PacksView(generic.ListView):
     paginate_by = 20
 
     def get_queryset(self):
-        queryset = CustomContentPack.objects.all().select_related("owner")
+        queryset = CustomContentPack.objects.filter(archived=False).select_related(
+            "owner"
+        )
         user = self.request.user
 
         if not user.is_authenticated:
@@ -515,9 +517,9 @@ class PackDetailView(generic.DetailView):
 
     def get_object(self):
         pack = get_object_or_404(
-            CustomContentPack.objects.select_related("owner").prefetch_related(
-                "items__content_type"
-            ),
+            CustomContentPack.objects.filter(archived=False)
+            .select_related("owner")
+            .prefetch_related("items__content_type"),
             id=self.kwargs["id"],
         )
         _check_pack_visible(pack, self.request.user)


### PR DESCRIPTION
Closes #1715

## Summary

- Remove auth requirement from pack list and detail views
- Anonymous users see only listed (public) packs; unlisted packs return 404
- Action buttons hidden for logged-out users
- Customisation nav link always visible

## Test plan

- [ ] Visit /packs/ while logged out — page loads, shows listed packs
- [ ] Visit a listed pack detail page while logged out — content visible, no action buttons
- [ ] Visit an unlisted pack while logged out — returns 404
- [ ] Customisation nav link visible in header when logged out

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pack listings and details are now publicly accessible to anonymous visitors.
  * "Customisation" navigation item is visible to all visitors.

* **Bug Fixes**
  * Action buttons (Edit, Add to List, Permissions) are now hidden for non-authenticated users on pack pages.
  * Unlisted packs now return 404 for anonymous users instead of redirecting to login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->