### PR TITLE
fix: handle IntegrityError on duplicate content pack item creation

### DIFF
--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -4295,3 +4295,90 @@ def test_add_fighter_step2_uses_category_statline(
     assert "stat_ballistic_skill" in content
     assert "stat_leadership" in content
     assert "stat_movement" not in content
+
+
+@pytest.mark.django_db
+def test_add_weapon_duplicate_name_integrity_error(
+    client, group_user, pack, weapon_category
+):
+    """Duplicate weapon name + category returns a form error, not a 500.
+
+    The form's ``clean_name`` catches most duplicates, but a race condition
+    (e.g. double-submit) can bypass it. The DB unique constraint then fires
+    an ``IntegrityError`` which must be caught gracefully.
+    """
+    from unittest.mock import patch
+
+    # Create a weapon in the same category first.
+    ContentEquipment.objects.all_content().create(
+        name="Londaxi Maimer",
+        category=weapon_category,
+        cost="30",
+        rarity="R",
+    )
+
+    client.force_login(group_user)
+
+    # Patch clean_name to bypass form-level validation so the DB constraint fires.
+    with patch(
+        "gyrinx.core.forms.pack.ContentWeaponPackForm.clean_name",
+        lambda self: self.cleaned_data["name"],
+    ):
+        response = client.post(
+            f"/pack/{pack.id}/add/weapon/",
+            {
+                "name": "Londaxi Maimer",
+                "category": str(weapon_category.pk),
+                "cost": "30",
+                "rarity": "R",
+                "wp_range_short": '8"',
+                "wp_strength": "4",
+                "wp_damage": "2",
+            },
+        )
+
+    # Should re-render the form with an error, not crash with a 500.
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "already exists" in content
+
+
+@pytest.mark.django_db
+def test_add_gear_duplicate_name_integrity_error(
+    client, group_user, pack, equipment_category
+):
+    """Duplicate gear name + category returns a form error, not a 500.
+
+    Same race-condition defence as the weapon test above, but for gear items.
+    """
+    from unittest.mock import patch
+
+    # Create gear in the same category first.
+    ContentEquipment.objects.all_content().create(
+        name="Duplicate Armour",
+        category=equipment_category,
+        cost="20",
+        rarity="C",
+    )
+
+    client.force_login(group_user)
+
+    # Patch clean_name to bypass form-level validation so the DB constraint fires.
+    with patch(
+        "gyrinx.core.forms.pack.ContentGearPackForm.clean_name",
+        lambda self: self.cleaned_data["name"],
+    ):
+        response = client.post(
+            f"/pack/{pack.id}/add/gear/",
+            {
+                "name": "Duplicate Armour",
+                "category": str(equipment_category.pk),
+                "cost": "20",
+                "rarity": "C",
+            },
+        )
+
+    # Should re-render the form with an error, not crash with a 500.
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "already exists" in content

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -1498,54 +1498,66 @@ def add_pack_item(request, id, content_type_slug):
                 )
 
             # Non-fighter types: create directly.
-            with transaction.atomic():
-                content_obj = form.save(commit=False)
-                content_obj._history_user = request.user
-                content_obj.save()
-                form.save_m2m()
-                ct = ContentType.objects.get_for_model(entry.model_class)
-                item = CustomContentPackItem(
-                    pack=pack,
-                    content_type=ct,
-                    object_id=content_obj.pk,
-                    owner=request.user,
-                )
-                item.save_with_user(user=request.user)
-                if is_weapon:
-                    if profile_mode == "multi":
-                        _create_named_weapon_profiles(
-                            content_obj, request.POST, request.user, pack
-                        )
-                    else:
-                        _create_standard_weapon_profile(
-                            content_obj, request.POST, request.user, pack
-                        )
-            log_event(
-                user=request.user,
-                noun=EventNoun.CONTENT_PACK,
-                verb=EventVerb.CREATE,
-                object=pack,
-                request=request,
-                pack_name=pack.name,
-                pack_id=str(pack.id),
-                content_type=content_type_slug,
-                item_name=str(content_obj),
-            )
-            if "save_and_add_another" in request.POST:
-                messages.success(request, f'{singular_label} "{content_obj}" saved.')
-                if is_weapon:
-                    # Return to mode selection for the next weapon.
-                    url = reverse("core:pack-add-weapon-mode", args=(pack.id,))
-                else:
-                    url = reverse(
-                        "core:pack-add-item",
-                        args=(pack.id, content_type_slug),
+            try:
+                with transaction.atomic():
+                    content_obj = form.save(commit=False)
+                    content_obj._history_user = request.user
+                    content_obj.save()
+                    form.save_m2m()
+                    ct = ContentType.objects.get_for_model(entry.model_class)
+                    item = CustomContentPackItem(
+                        pack=pack,
+                        content_type=ct,
+                        object_id=content_obj.pk,
+                        owner=request.user,
                     )
-                    # Preserve category selection (e.g. skill tree → skill)
-                    if hasattr(content_obj, "category") and content_obj.category_id:
-                        url += f"?category={content_obj.category_id}"
-                return HttpResponseRedirect(url)
-            return HttpResponseRedirect(_pack_url(pack, f"item-{item.id}"))
+                    item.save_with_user(user=request.user)
+                    if is_weapon:
+                        if profile_mode == "multi":
+                            _create_named_weapon_profiles(
+                                content_obj, request.POST, request.user, pack
+                            )
+                        else:
+                            _create_standard_weapon_profile(
+                                content_obj, request.POST, request.user, pack
+                            )
+            except IntegrityError as e:
+                if "name" in str(e).lower():
+                    form.add_error(
+                        "name",
+                        "An item with this name already exists in this category.",
+                    )
+                else:
+                    raise
+            else:
+                log_event(
+                    user=request.user,
+                    noun=EventNoun.CONTENT_PACK,
+                    verb=EventVerb.CREATE,
+                    object=pack,
+                    request=request,
+                    pack_name=pack.name,
+                    pack_id=str(pack.id),
+                    content_type=content_type_slug,
+                    item_name=str(content_obj),
+                )
+                if "save_and_add_another" in request.POST:
+                    messages.success(
+                        request, f'{singular_label} "{content_obj}" saved.'
+                    )
+                    if is_weapon:
+                        # Return to mode selection for the next weapon.
+                        url = reverse("core:pack-add-weapon-mode", args=(pack.id,))
+                    else:
+                        url = reverse(
+                            "core:pack-add-item",
+                            args=(pack.id, content_type_slug),
+                        )
+                        # Preserve category selection (e.g. skill tree → skill)
+                        if hasattr(content_obj, "category") and content_obj.category_id:
+                            url += f"?category={content_obj.category_id}"
+                    return HttpResponseRedirect(url)
+                return HttpResponseRedirect(_pack_url(pack, f"item-{item.id}"))
         elif wp_name_errors:
             for err in wp_name_errors:
                 form.add_error(None, err)

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -1499,28 +1499,11 @@ def add_pack_item(request, id, content_type_slug):
 
             # Non-fighter types: create directly.
             try:
+                content_obj = form.save(commit=False)
+                content_obj._history_user = request.user
                 with transaction.atomic():
-                    content_obj = form.save(commit=False)
-                    content_obj._history_user = request.user
                     content_obj.save()
                     form.save_m2m()
-                    ct = ContentType.objects.get_for_model(entry.model_class)
-                    item = CustomContentPackItem(
-                        pack=pack,
-                        content_type=ct,
-                        object_id=content_obj.pk,
-                        owner=request.user,
-                    )
-                    item.save_with_user(user=request.user)
-                    if is_weapon:
-                        if profile_mode == "multi":
-                            _create_named_weapon_profiles(
-                                content_obj, request.POST, request.user, pack
-                            )
-                        else:
-                            _create_standard_weapon_profile(
-                                content_obj, request.POST, request.user, pack
-                            )
             except IntegrityError as e:
                 if "name" in str(e).lower():
                     form.add_error(
@@ -1530,6 +1513,23 @@ def add_pack_item(request, id, content_type_slug):
                 else:
                     raise
             else:
+                ct = ContentType.objects.get_for_model(entry.model_class)
+                item = CustomContentPackItem(
+                    pack=pack,
+                    content_type=ct,
+                    object_id=content_obj.pk,
+                    owner=request.user,
+                )
+                item.save_with_user(user=request.user)
+                if is_weapon:
+                    if profile_mode == "multi":
+                        _create_named_weapon_profiles(
+                            content_obj, request.POST, request.user, pack
+                        )
+                    else:
+                        _create_standard_weapon_profile(
+                            content_obj, request.POST, request.user, pack
+                        )
                 log_event(
                     user=request.user,
                     noun=EventNoun.CONTENT_PACK,


### PR DESCRIPTION
Wrap the `content_obj.save()` call for non-fighter pack items in a `try/except IntegrityError` block to gracefully handle race conditions (e.g. double-submit) where the form-level `clean_name()` validation passes but the DB unique constraint on `(name, category_id)` fires.

Closes #1727

Generated with [Claude Code](https://claude.ai/code)