### PR TITLE
fix: small UX tweaks for pack fighter/vehicle creation

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -776,10 +776,12 @@ class ContentGearPackForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         # Filter to gear categories only (exclude weapons), ordered by group then name.
+        # "Vehicles" is also excluded — pack vehicles are auto-created from
+        # VEHICLE fighters, so users should never pick it manually.
         self.fields["category"].queryset = (
             ContentEquipmentCategory.objects.exclude(
                 group__in=["Weapons & Ammo", "Other"]
-            )
+            ).exclude(name="Vehicles")
         ).order_by(
             Case(
                 *[

--- a/gyrinx/core/templates/core/pack/pack_item_add_stats.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add_stats.html
@@ -29,6 +29,25 @@
                 </dd>
             </dl>
         </div>
+        {% if params.category == "VEHICLE" %}
+            <div class="alert alert-info alert-icon mb-0" role="alert">
+                <i class="bi-info-circle" aria-hidden="true"></i>
+                <div>
+                    Saving will also create a matching equipment entry under
+                    <strong>Vehicles</strong> so subscribed lists can buy this Vehicle.
+                    The cost stays in sync with the fighter's base cost.
+                </div>
+            </div>
+        {% elif params.category == "EXOTIC_BEAST" %}
+            <div class="alert alert-info alert-icon mb-0" role="alert">
+                <i class="bi-info-circle" aria-hidden="true"></i>
+                <div>
+                    Saving will also create a matching equipment entry under
+                    <strong>Status Items</strong> so subscribed Fighters can buy this Exotic Beast.
+                    The cost stays in sync with the fighter's base cost.
+                </div>
+            </div>
+        {% endif %}
         <form action="{% url 'core:pack-add-fighter-stats' pack.id %}?{{ query_string }}"
               method="post"
               class="vstack gap-3">

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -92,8 +92,8 @@ SUPPORTED_CONTENT_TYPES = [
     ),
     ContentTypeEntry(
         ContentFighter,
-        "Fighters",
-        "Custom fighters for your Content Pack.",
+        "Fighters & Vehicles",
+        "Custom fighters, vehicles, and exotic beasts for your Content Pack.",
         "bi-person",
         ContentFighterPackForm,
         "fighter",


### PR DESCRIPTION
## Summary

- Pack section "Fighters" → "Fighters & Vehicles" so the entry-point label matches users' mental model
- Exclude the "Vehicles" equipment category from the gear form's category dropdown — vehicle equipment is auto-created from VEHICLE fighters, so manual selection is never desired
- Add a static info alert on the fighter configure-stats step explaining that saving a VEHICLE / EXOTIC_BEAST fighter also creates the matching equipment entry (Vehicles / Status Items), so users know what they're committing to

## Test plan

- [x] Open a pack — section header reads "Fighters & Vehicles"
- [x] Open Add gear — "Vehicles" category is not in the dropdown
- [x] Create a fighter with category Vehicle — the configure-stats step shows the Vehicles info alert
- [x] Create a fighter with category Exotic Beast — the configure-stats step shows the Status Items info alert
- [x] Create a fighter with any other category — no info alert on configure-stats