### PR TITLE
chore: upgrade Claude GitHub Actions to Opus 4.7 and Sonnet 4.6

### DIFF
--- a/.github/workflows/claude-code-improvement.yml
+++ b/.github/workflows/claude-code-improvement.yml
@@ -85,7 +85,7 @@ jobs:
 
           # Claude configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowedTools "Edit,View,Replace,Write,Create,BatchTool,GlobTool,GrepTool,NotebookEditCell,Bash,mcp__*"
             --system-prompt "The repo is gyrinx-app/gyrinx.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,7 +43,7 @@ jobs:
 
           # Claude configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowedTools "Bash(./scripts/fmt.sh:*),Bash(./scripts/check_migrations.sh:*),Bash(python -m pytest:*),Bash(pytest:*)"
 
           # Automated PR review prompt

--- a/.github/workflows/claude-docs-update.yml
+++ b/.github/workflows/claude-docs-update.yml
@@ -143,7 +143,7 @@ jobs:
           allowed_bots: "github-merge-queue[bot]"
 
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowedTools "Edit,View,Replace,Write,Create,GlobTool,GrepTool,Bash(git:*),Bash(gh:*),Bash(./scripts/fmt.sh:*),Bash(cat:*),Bash(ls:*)"
 
           prompt: |

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -52,7 +52,7 @@ jobs:
 
           # Allowed tools: gh CLI for issue management, file reading for codebase context, web access for documentation
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowedTools "Bash(gh issue:*),Bash(gh label:*),Bash(gh search:*),Bash(rg:*),Bash(grep:*),Bash(find:*),Bash(ls:*),Bash(cat:*),View,GlobTool,GrepTool,WebFetch,WebSearch"
 
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -109,7 +109,7 @@ jobs:
 
           # Claude configuration via CLI arguments
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowedTools Bash
             --system-prompt "IMPORTANT: Before running any Python code, tests, or linting tools, you MUST first run:
             pip install --editable .

--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -118,7 +118,7 @@ jobs:
           allowed_bots: "github-merge-queue[bot]"
 
           claude_args: |
-            --model claude-sonnet-4-20250514
+            --model claude-sonnet-4-6
             --allowedTools "Bash(git:*),Bash(gh:*)"
             --json-schema '{"type":"object","properties":{"summary":{"type":"string","description":"The bullet-point summary in markdown format"}},"required":["summary"]}'
 


### PR DESCRIPTION
## Summary
- Upgrade 5 workflows from `claude-opus-4-6` to `claude-opus-4-7`
- Upgrade weekly summary from pinned `claude-sonnet-4-20250514` to `claude-sonnet-4-6`

## Test plan
- [ ] Verify workflows trigger correctly on next relevant event