### PR TITLE
feat: pack support for customising existing weapons

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -1591,6 +1591,20 @@ class ListFighterQuerySet(models.QuerySet):
                     "content_fighter__default_assignments__equipment__contentweaponprofile_set",
                     queryset=ContentWeaponProfile.objects.all_content(),
                 ),
+                # Default-assignment M2Ms also need all_content() so that
+                # pack-scoped weapon profiles / accessories chosen on a
+                # ContentFighterDefaultAssignment aren't dropped by the
+                # default ContentManager when the fighter is hired.
+                Prefetch(
+                    "content_fighter__default_assignments__weapon_profiles_field",
+                    queryset=ContentWeaponProfile.objects.all_content(),
+                ),
+                Prefetch(
+                    "content_fighter__default_assignments__weapon_accessories_field",
+                    queryset=ContentWeaponAccessory.objects.all_content().prefetch_related(
+                        "modifiers"
+                    ),
+                ),
                 # Prefetch equipment list items for cost override lookups
                 "content_fighter__contentfighterequipmentlistitem_set",
                 "legacy_content_fighter__contentfighterequipmentlistitem_set",

--- a/gyrinx/core/templates/core/pack/customise_weapon.html
+++ b/gyrinx/core/templates/core/pack/customise_weapon.html
@@ -5,7 +5,7 @@
 {% endblock head_title %}
 {% block content %}
     {% include "core/includes/back.html" with url=back_url text=pack.name %}
-    <div class="col-12 col-lg-10 px-0 vstack gap-4">
+    <div class="col-12 col-lg-8 col-xl-6 px-0 vstack gap-4">
         <div>
             <h1 class="h3 mb-1">
                 <i class="bi-crosshair"></i> Customise {{ equipment.name }}

--- a/gyrinx/core/templates/core/pack/customise_weapon.html
+++ b/gyrinx/core/templates/core/pack/customise_weapon.html
@@ -1,0 +1,54 @@
+{% extends "core/layouts/base.html" %}
+{% load custom_tags %}
+{% block head_title %}
+    Customise {{ equipment.name }} - {{ pack.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with url=back_url text=pack.name %}
+    <div class="col-12 col-lg-10 px-0 vstack gap-4">
+        <div>
+            <h1 class="h3 mb-1">
+                <i class="bi-crosshair"></i> Customise {{ equipment.name }}
+            </h1>
+            <p class="text-secondary mb-0">
+                Add new profiles (e.g. special ammo) to this weapon. The weapon itself
+                isn't modified — your changes are scoped to this Content Pack.
+            </p>
+        </div>
+        <div>
+            <div class="d-flex justify-content-between align-items-baseline mb-2">
+                <h2 class="h5 mb-0">Profiles</h2>
+                {% if archived_pack_profile_count > 0 %}
+                    <a href="{% url 'core:pack-customise-weapon-archived-profiles' pack.id equipment.id %}"
+                       class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archived profiles ({{ archived_pack_profile_count }})</a>
+                {% endif %}
+            </div>
+            {% if profiles %}
+                <table class="table table-sm table-borderless mb-0 fs-7 border rounded">
+                    {% include "core/includes/weapon_stat_headers.html" with show_al=True %}
+                    <tbody class="table-group-divider">
+                        {% include "core/pack/includes/weapon_profiles_display.html" with profiles=profiles weapon=equipment can_edit=True show_al=True is_customised=True show_actions_row=False %}
+                    </tbody>
+                </table>
+            {% else %}
+                <p class="text-secondary mb-0">No profiles yet.</p>
+            {% endif %}
+            {% if pack_profile_count == 0 %}<p class="text-secondary fs-7 mt-2 mb-0">No customisations yet.</p>{% endif %}
+        </div>
+        <div>
+            <h2 class="h5 mb-2">Add</h2>
+            <div class="row g-3">
+                <div class="col-12 col-md-6 col-lg-4">
+                    <a href="{% url 'core:pack-customise-weapon-profile-add' pack.id equipment.id %}"
+                       class="border rounded p-3 d-flex flex-column gap-1 text-decoration-none h-100">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="bi-plus-lg"></i>
+                            <span class="h6 mb-0">New profile</span>
+                        </div>
+                        <span class="text-secondary fs-7">Add a special-ammo or alternate profile to this weapon.</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/pack/customise_weapon.html
+++ b/gyrinx/core/templates/core/pack/customise_weapon.html
@@ -24,7 +24,7 @@
                 {% endif %}
             </div>
             {% if profiles %}
-                <table class="table table-sm table-borderless mb-0 fs-7 border rounded">
+                <table class="table table-sm table-borderless mb-0 fs-7">
                     {% include "core/includes/weapon_stat_headers.html" with show_al=True %}
                     <tbody class="table-group-divider">
                         {% include "core/pack/includes/weapon_profiles_display.html" with profiles=profiles weapon=equipment can_edit=True show_al=True is_customised=True show_actions_row=False %}

--- a/gyrinx/core/templates/core/pack/customise_weapon_picker.html
+++ b/gyrinx/core/templates/core/pack/customise_weapon_picker.html
@@ -1,0 +1,54 @@
+{% extends "core/layouts/base.html" %}
+{% load custom_tags %}
+{% block head_title %}
+    Customise existing weapon - {{ pack.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with url=back_url text=pack.name %}
+    <div class="col-12 col-lg-8 px-0 vstack gap-3">
+        <div>
+            <h1 class="h3 mb-1">
+                <i class="bi-crosshair"></i> Customise existing weapon
+            </h1>
+            <p class="text-secondary mb-0">
+                Pick an existing weapon to add new profiles to (e.g. special ammo).
+                The weapon itself stays untouched — only your custom profiles are added.
+            </p>
+        </div>
+        <form method="get"
+              action="{% url 'core:pack-customise-weapon-picker' pack.id %}"
+              class="d-flex gap-2">
+            <input type="search"
+                   name="q"
+                   value="{{ search_query }}"
+                   placeholder="Search weapons by name or category"
+                   class="form-control form-control-sm"
+                   aria-label="Search weapons">
+            <button type="submit" class="btn btn-secondary btn-sm">Search</button>
+        </form>
+        {% if weapons %}
+            <div class="border rounded">
+                <ul class="list-group list-group-flush">
+                    {% for weapon in weapons %}
+                        <li class="list-group-item d-flex align-items-center gap-2">
+                            <a href="{% url 'core:pack-customise-weapon' pack.id weapon.id %}"
+                               class="link-primary link-underline-opacity-25 link-underline-opacity-100-hover">
+                                {{ weapon.name }}
+                            </a>
+                            {% if weapon.category %}<span class="text-secondary fs-7">{{ weapon.category.name }}</span>{% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% include "core/includes/pagination.html" %}
+        {% else %}
+            <p class="text-secondary mb-0">
+                {% if search_query %}
+                    No weapons match "{{ search_query }}".
+                {% else %}
+                    No weapons available to customise.
+                {% endif %}
+            </p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/pack/includes/weapon_profiles_display.html
+++ b/gyrinx/core/templates/core/pack/includes/weapon_profiles_display.html
@@ -10,7 +10,7 @@ Cases (from weapon-profiles-display-spec.md):
 {% if profiles|length == 1 %}
     {% comment %} Case 1: single profile — weapon name + stats inline {% endcomment %}
     {% with profiles.0 as profile %}
-        <tr class="align-top">
+        <tr class="align-top{% if is_customised and not profile.is_pack_scoped %} text-secondary{% endif %}">
             <td rowspan="{% if profile.traitline|length > 0 %}2{% else %}1{% endif %}">
                 {{ weapon }}
                 {% if weapon.cost_display %}({{ weapon.cost_display }}){% endif %}
@@ -30,7 +30,7 @@ Cases (from weapon-profiles-display-spec.md):
     {% comment %} Case 3 check: if the first profile is named, add a title row {% endcomment %}
     {% with profiles.0 as first_profile %}
         {% if first_profile.name %}
-            <tr class="align-bottom">
+            <tr class="align-bottom{% if is_customised %} text-secondary{% endif %}">
                 <td colspan="{% if show_al %}10{% else %}9{% endif %}">
                     {{ weapon }}
                     {% if weapon.cost_display %}({{ weapon.cost_display }}){% endif %}
@@ -40,7 +40,7 @@ Cases (from weapon-profiles-display-spec.md):
     {% endwith %}
     {% comment %} Profile rows {% endcomment %}
     {% for profile in profiles %}
-        <tr class="align-top">
+        <tr class="align-top{% if is_customised and not profile.is_pack_scoped %} text-secondary{% endif %}">
             <td rowspan="{% if profile.traitline|length > 0 %}2{% else %}1{% endif %}">
                 {% if forloop.first and not profile.name %}
                     {% comment %} Case 2: standard profile — inline weapon name {% endcomment %}
@@ -50,7 +50,16 @@ Cases (from weapon-profiles-display-spec.md):
                     <i class="bi-dash"></i>
                     {{ profile.name }}
                     {% if profile.cost_display %}({{ profile.cost_display }}){% endif %}
-                    {% if can_edit %}
+                    {% if is_customised and profile.is_pack_scoped %}
+                        <i class="bi-dot fs-7 text-secondary pack-icon"
+                           data-bs-toggle="tooltip"
+                           data-bs-title="Added by this Content Pack"></i>
+                        {% if can_edit %}
+                            <span class="fs-7"><a href="{% url 'core:pack-customise-weapon-profile-edit' pack.id weapon.id profile.id %}"
+   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Edit</a> · <a href="{% url 'core:pack-customise-weapon-profile-delete' pack.id weapon.id profile.id %}"
+    class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover text-danger">Archive</a></span>
+                        {% endif %}
+                    {% elif can_edit and not is_customised %}
                         <span class="text-secondary fs-7">· <a href="{% url 'core:pack-edit-weapon-profile' pack.id pack_item.id profile.id %}"
     class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Edit profile</a></span>
                     {% endif %}
@@ -66,25 +75,33 @@ Cases (from weapon-profiles-display-spec.md):
             {% endif %}
         </tr>
         {% if profile.traitline|length > 0 %}
-            <tr>
+            <tr {% if is_customised and not profile.is_pack_scoped %}class="text-secondary"{% endif %}>
                 <td colspan="{% if show_al %}9{% else %}8{% endif %}">{{ profile.traitline|join:", " }}</td>
             </tr>
         {% endif %}
     {% endfor %}
 {% endif %}
-{% if can_edit %}
+{% if can_edit and show_actions_row %}
     <tr>
         <td colspan="{% if show_al %}10{% else %}9{% endif %}">
             <div class="d-flex gap-1 align-items-center fs-7 mb-1">
                 <i class="bi-arrow-90deg-up text-secondary me-1"></i>
-                <a href="{% url 'core:pack-add-weapon-profile' pack.id pack_item.id %}"
-                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Add profile</a>
-                ·
-                <a href="{% url 'core:pack-edit-item' pack.id pack_item.id %}"
-                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Edit</a>
-                ·
-                <a href="{% url 'core:pack-delete-item' pack.id pack_item.id %}"
-                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover text-danger">Archive</a>
+                {% if is_customised %}
+                    <a href="{% url 'core:pack-customise-weapon-profile-add' pack.id weapon.id %}"
+                       class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Add profile</a>
+                    ·
+                    <a href="{% url 'core:pack-customise-weapon' pack.id weapon.id %}"
+                       class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Edit</a>
+                {% else %}
+                    <a href="{% url 'core:pack-add-weapon-profile' pack.id pack_item.id %}"
+                       class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Add profile</a>
+                    ·
+                    <a href="{% url 'core:pack-edit-item' pack.id pack_item.id %}"
+                       class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Edit</a>
+                    ·
+                    <a href="{% url 'core:pack-delete-item' pack.id pack_item.id %}"
+                       class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover text-danger">Archive</a>
+                {% endif %}
             </div>
         </td>
     </tr>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -149,6 +149,15 @@
                                        class="btn btn-primary btn-sm">
                                         <i class="bi-plus-lg"></i> Add
                                     </a>
+                                {% elif section.slug == "weapon" %}
+                                    <a href="{% url 'core:pack-customise-weapon-picker' pack.id %}"
+                                       class="linked fs-7">Customise existing weapon</a>
+                                    {% if section.can_add %}
+                                        <a href="{% url 'core:pack-add-item' pack.id section.slug %}"
+                                           class="btn btn-primary btn-sm">
+                                            <i class="bi-plus-lg"></i> Add
+                                        </a>
+                                    {% endif %}
                                 {% elif section.can_add %}
                                     <a href="{% url 'core:pack-add-item' pack.id section.slug %}"
                                        class="btn btn-primary btn-sm">
@@ -164,8 +173,9 @@
                                 <table class="table table-sm table-borderless mb-0 fs-7">
                                     {% include "core/includes/weapon_stat_headers.html" with show_al=True %}
                                     {% for entry in section.items %}
-                                        <tbody class="table-group-divider" id="item-{{ entry.pack_item.id }}">
-                                            {% include "core/pack/includes/weapon_profiles_display.html" with profiles=entry.profiles pack_item=entry.pack_item weapon=entry.content_object can_edit=can_edit show_al=True %}
+                                        <tbody class="table-group-divider"
+                                               {% if entry.pack_item %} id="item-{{ entry.pack_item.id }}"{% else %} id="weapon-{{ entry.content_object.id }}"{% endif %}>
+                                            {% include "core/pack/includes/weapon_profiles_display.html" with profiles=entry.profiles pack_item=entry.pack_item weapon=entry.content_object can_edit=can_edit show_al=True is_customised=entry.is_customised show_actions_row=True %}
                                         </tbody>
                                     {% endfor %}
                                 </table>

--- a/gyrinx/core/templates/core/pack/weapon_profile_add.html
+++ b/gyrinx/core/templates/core/pack/weapon_profile_add.html
@@ -9,9 +9,7 @@
         <h1 class="h3">
             <i class="bi-crosshair"></i> Add profile to {{ equipment.name }}
         </h1>
-        <form action="{% url 'core:pack-add-weapon-profile' pack.id pack_item.id %}"
-              method="post"
-              class="vstack gap-3">
+        <form action="{{ form_action_url }}" method="post" class="vstack gap-3">
             {% csrf_token %}
             {{ form }}
             {% include "core/pack/includes/weapon_profile_stats_form.html" with weapon_stats=weapon_stat_fields %}

--- a/gyrinx/core/templates/core/pack/weapon_profile_delete.html
+++ b/gyrinx/core/templates/core/pack/weapon_profile_delete.html
@@ -11,8 +11,7 @@
             Are you sure you want to archive the profile <strong>{{ profile.name }}</strong> from <strong>{{ equipment.name }}</strong>?
         </p>
         <p class="text-secondary fs-7">Archived items can be restored later.</p>
-        <form action="{% url 'core:pack-delete-weapon-profile' pack.id pack_item.id profile.id %}"
-              method="post">
+        <form action="{{ form_action_url }}" method="post">
             {% csrf_token %}
             <div class="d-flex gap-2">
                 <button type="submit" class="btn btn-danger btn-sm">Archive</button>

--- a/gyrinx/core/templates/core/pack/weapon_profile_edit.html
+++ b/gyrinx/core/templates/core/pack/weapon_profile_edit.html
@@ -11,9 +11,7 @@
             {% if profile.name %}: {{ profile.name }}{% endif %}
             — {{ equipment.name }}
         </h1>
-        <form action="{% url 'core:pack-edit-weapon-profile' pack.id pack_item.id profile.id %}"
-              method="post"
-              class="vstack gap-3">
+        <form action="{{ form_action_url }}" method="post" class="vstack gap-3">
             {% csrf_token %}
             {{ form }}
             {% include "core/pack/includes/weapon_profile_stats_form.html" with weapon_stats=weapon_stat_values %}
@@ -21,8 +19,7 @@
                 <button type="submit" class="btn btn-success">Save</button>
                 <a href="{{ back_url }}" class="btn btn-link">Cancel</a>
                 {% if profile.name %}
-                    <a href="{% url 'core:pack-delete-weapon-profile' pack.id pack_item.id profile.id %}"
-                       class="btn btn-link text-danger ms-auto">Archive profile</a>
+                    <a href="{{ delete_url }}" class="btn btn-link text-danger ms-auto">Archive profile</a>
                 {% endif %}
             </div>
         </form>

--- a/gyrinx/core/tests/test_pack_customise_weapon.py
+++ b/gyrinx/core/tests/test_pack_customise_weapon.py
@@ -1,0 +1,461 @@
+"""Tests for customising existing (library) weapons in content packs."""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentCategory,
+)
+from gyrinx.content.models.default_assignment import ContentFighterDefaultAssignment
+from gyrinx.content.models.weapon import ContentWeaponProfile
+from gyrinx.core.models.list import ListFighter
+from gyrinx.core.models.pack import CustomContentPackItem
+
+
+def _add_to_pack(pack, obj):
+    """Helper to associate a content object with a pack."""
+    ct = ContentType.objects.get_for_model(type(obj))
+    CustomContentPackItem.objects.create(
+        pack=pack, content_type=ct, object_id=obj.pk, owner=pack.owner
+    )
+
+
+@pytest.fixture
+def weapon_category():
+    return ContentEquipmentCategory.objects.create(
+        name="Customise Weapon Tests", group="Weapons & Ammo"
+    )
+
+
+@pytest.fixture
+def library_weapon(weapon_category):
+    weapon = ContentEquipment.objects.create(
+        name="Library Lasgun", category=weapon_category, cost=10
+    )
+    # A standard library profile so the equipment is recognised as a weapon.
+    ContentWeaponProfile.objects.create(
+        equipment=weapon, name="", cost=0, range_short="8", range_long="24"
+    )
+    return weapon
+
+
+# --- Picker -------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_picker_shows_library_weapons(client, user, pack, library_weapon):
+    client.force_login(user)
+    url = reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Library Lasgun" in response.content
+
+
+@pytest.mark.django_db
+def test_picker_excludes_pack_owned_weapon(client, user, pack, weapon_category):
+    client.force_login(user)
+    pack_weapon = ContentEquipment.objects.create(
+        name="Pack Bolter", category=weapon_category, cost=20
+    )
+    ContentWeaponProfile.objects.create(equipment=pack_weapon, name="", cost=0)
+    _add_to_pack(pack, pack_weapon)
+
+    url = reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Pack Bolter" not in response.content
+
+
+@pytest.mark.django_db
+def test_picker_filters_by_q(client, user, pack, weapon_category):
+    client.force_login(user)
+    a = ContentEquipment.objects.create(
+        name="Autopistol", category=weapon_category, cost=10
+    )
+    b = ContentEquipment.objects.create(
+        name="Boltgun", category=weapon_category, cost=15
+    )
+    ContentWeaponProfile.objects.create(equipment=a, name="", cost=0)
+    ContentWeaponProfile.objects.create(equipment=b, name="", cost=0)
+
+    url = reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+    response = client.get(url + "?q=auto")
+    assert response.status_code == 200
+    assert b"Autopistol" in response.content
+    assert b"Boltgun" not in response.content
+
+
+@pytest.mark.django_db
+def test_picker_requires_edit_permission(client, make_user, pack, library_weapon):
+    other = make_user("other", "password")
+    client.force_login(other)
+    url = reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+    response = client.get(url)
+    assert response.status_code == 404
+
+
+# --- Customise weapon page ---------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_customise_page_lists_existing_profiles(client, user, pack, library_weapon):
+    client.force_login(user)
+    url = reverse("core:pack-customise-weapon", args=(pack.id, library_weapon.id))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Library Lasgun" in response.content
+    assert b"New profile" in response.content
+    assert b"No customisations yet" in response.content
+
+
+@pytest.mark.django_db
+def test_customise_page_shows_pack_scoped_profile(client, user, pack, library_weapon):
+    client.force_login(user)
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Inferno", cost=5
+    )
+    _add_to_pack(pack, profile)
+    url = reverse("core:pack-customise-weapon", args=(pack.id, library_weapon.id))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Inferno" in response.content
+    # Pack-scoped row exposes inline Edit + Archive links.
+    assert (
+        reverse(
+            "core:pack-customise-weapon-profile-edit",
+            args=(pack.id, library_weapon.id, profile.id),
+        ).encode()
+        in response.content
+    )
+    assert (
+        reverse(
+            "core:pack-customise-weapon-profile-delete",
+            args=(pack.id, library_weapon.id, profile.id),
+        ).encode()
+        in response.content
+    )
+
+
+@pytest.mark.django_db
+def test_customise_page_redirects_for_pack_owned_weapon(
+    client, user, pack, weapon_category
+):
+    client.force_login(user)
+    weapon = ContentEquipment.objects.create(
+        name="Owned Weapon", category=weapon_category, cost=10
+    )
+    ContentWeaponProfile.objects.create(equipment=weapon, name="", cost=0)
+    _add_to_pack(pack, weapon)
+
+    url = reverse("core:pack-customise-weapon", args=(pack.id, weapon.id))
+    response = client.get(url)
+    # Redirects to the regular pack page item anchor.
+    assert response.status_code == 302
+    assert reverse("core:pack", args=(pack.id,)) in response["Location"]
+
+
+# --- Add profile flow --------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_add_profile_creates_pack_item(client, user, pack, library_weapon):
+    client.force_login(user)
+    url = reverse(
+        "core:pack-customise-weapon-profile-add", args=(pack.id, library_weapon.id)
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+
+    response = client.post(
+        url,
+        data={
+            "name": "Plasma Round",
+            "cost": "10",
+            "rarity": "C",
+            "rarity_roll": "",
+            "wp_range_short": "12",
+            "wp_range_long": "24",
+            "wp_accuracy_short": "+1",
+            "wp_accuracy_long": "",
+            "wp_strength": "6",
+            "wp_armour_piercing": "-1",
+            "wp_damage": "2",
+            "wp_ammo": "5+",
+        },
+    )
+    assert response.status_code == 302
+    assert response["Location"].endswith(
+        reverse("core:pack-customise-weapon", args=(pack.id, library_weapon.id))
+    )
+
+    profile = ContentWeaponProfile.objects.all_content().get(
+        equipment=library_weapon, name="Plasma Round"
+    )
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    assert CustomContentPackItem.objects.filter(
+        pack=pack, content_type=profile_ct, object_id=profile.pk
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_add_profile_rejects_duplicate_name(client, user, pack, library_weapon):
+    client.force_login(user)
+    ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Hotshot", cost=4
+    )
+    url = reverse(
+        "core:pack-customise-weapon-profile-add", args=(pack.id, library_weapon.id)
+    )
+    response = client.post(
+        url,
+        data={
+            "name": "Hotshot",
+            "cost": "4",
+            "rarity": "C",
+            "wp_range_short": "8",
+            "wp_range_long": "24",
+        },
+    )
+    assert response.status_code == 200
+    assert b"already exists" in response.content
+
+
+# --- Edit / delete profile ---------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_edit_pack_scoped_profile(client, user, pack, library_weapon):
+    client.force_login(user)
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon,
+        name="Inferno",
+        cost=5,
+        range_short="8",
+        range_long="20",
+    )
+    _add_to_pack(pack, profile)
+    url = reverse(
+        "core:pack-customise-weapon-profile-edit",
+        args=(pack.id, library_weapon.id, profile.id),
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Inferno" in response.content
+
+    response = client.post(
+        url,
+        data={
+            "name": "Inferno",
+            "cost": "8",
+            "rarity": "R",
+            "wp_range_short": "8",
+            "wp_range_long": "20",
+        },
+    )
+    assert response.status_code == 302
+    profile.refresh_from_db()
+    assert profile.cost == 8
+
+
+@pytest.mark.django_db
+def test_edit_library_profile_blocked(client, user, pack, library_weapon):
+    """Editing a profile that isn't pack-scoped is not allowed."""
+    client.force_login(user)
+    library_profile = ContentWeaponProfile.objects.get(
+        equipment=library_weapon, name=""
+    )
+    url = reverse(
+        "core:pack-customise-weapon-profile-edit",
+        args=(pack.id, library_weapon.id, library_profile.id),
+    )
+    response = client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_delete_pack_scoped_profile_archives_pack_item(
+    client, user, pack, library_weapon
+):
+    client.force_login(user)
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Inferno", cost=5
+    )
+    _add_to_pack(pack, profile)
+    url = reverse(
+        "core:pack-customise-weapon-profile-delete",
+        args=(pack.id, library_weapon.id, profile.id),
+    )
+    response = client.post(url)
+    assert response.status_code == 302
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    item = CustomContentPackItem.objects.get(
+        pack=pack, content_type=profile_ct, object_id=profile.pk
+    )
+    assert item.archived
+
+
+# --- Pack detail surfacing ---------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_pack_detail_shows_customised_weapon(client, user, pack, library_weapon):
+    client.force_login(user)
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Plasma Round", cost=10
+    )
+    _add_to_pack(pack, profile)
+    url = reverse("core:pack", args=(pack.id,))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Library Lasgun" in response.content
+    assert b"Plasma Round" in response.content
+
+
+@pytest.mark.django_db
+def test_pack_detail_customised_weapon_not_shown_when_no_pack_profiles(
+    client, user, pack, library_weapon
+):
+    """The library weapon should not appear in the pack page at all if no
+    pack-scoped profiles are attached."""
+    client.force_login(user)
+    url = reverse("core:pack", args=(pack.id,))
+    response = client.get(url)
+    assert response.status_code == 200
+    # Nothing customised — library weapon should not appear in the weapons section.
+    assert b"Library Lasgun" not in response.content
+
+
+# --- Subscribed list visibility ---------------------------------------------
+
+
+@pytest.mark.django_db
+def test_subscribed_list_sees_pack_scoped_profile(
+    user, pack, library_weapon, make_list
+):
+    """A list subscribed to the pack should see the pack-scoped profile via
+    with_packs filtering."""
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Plasma Round", cost=10
+    )
+    _add_to_pack(pack, profile)
+
+    lst = make_list("Sub List")
+    lst.packs.add(pack)
+
+    visible = list(
+        ContentWeaponProfile.objects.with_packs(lst.packs.all()).filter(
+            equipment=library_weapon
+        )
+    )
+    assert profile in visible
+
+
+@pytest.mark.django_db
+def test_unsubscribed_list_does_not_see_pack_scoped_profile(
+    user, pack, library_weapon, make_list
+):
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Plasma Round", cost=10
+    )
+    _add_to_pack(pack, profile)
+
+    lst = make_list("Solo List")
+    visible = list(
+        ContentWeaponProfile.objects.with_packs(lst.packs.all()).filter(
+            equipment=library_weapon
+        )
+    )
+    assert profile not in visible
+
+
+# --- Multi-pack safety ------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_delete_in_one_pack_does_not_affect_other_pack(
+    client, user, make_pack, library_weapon
+):
+    """Archiving the pack item in one pack must leave the other pack's
+    pack item alone."""
+    client.force_login(user)
+    pack_a = make_pack("Pack A")
+    pack_b = make_pack("Pack B")
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Inferno", cost=5
+    )
+    _add_to_pack(pack_a, profile)
+    _add_to_pack(pack_b, profile)
+
+    url = reverse(
+        "core:pack-customise-weapon-profile-delete",
+        args=(pack_a.id, library_weapon.id, profile.id),
+    )
+    response = client.post(url)
+    assert response.status_code == 302
+
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    a_item = CustomContentPackItem.objects.get(
+        pack=pack_a, content_type=profile_ct, object_id=profile.pk
+    )
+    b_item = CustomContentPackItem.objects.get(
+        pack=pack_b, content_type=profile_ct, object_id=profile.pk
+    )
+    assert a_item.archived
+    assert not b_item.archived
+
+
+# --- Default-assignment regression: pack profile on default-assignment -----
+
+
+@pytest.mark.django_db
+def test_pack_profile_on_default_assignment_shows_on_list_page(
+    client, user, pack, library_weapon, content_house, make_content_fighter, make_list
+):
+    """Regression: a pack-scoped weapon profile attached to a
+    ContentFighterDefaultAssignment via weapon_profiles_field must appear on
+    the list page when the list subscribes to the pack.
+
+    The ListFighter prefetch chain previously only prefetched the equipment's
+    contentweaponprofile_set, not the default-assignment's own
+    weapon_profiles_field — so pack-scoped profiles were silently dropped by
+    the M2M target's default ContentManager.
+    """
+    client.force_login(user)
+
+    # Pack defines a "Custom ammo" profile on the library weapon.
+    custom_ammo = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Custom ammo", cost=50
+    )
+    _add_to_pack(pack, custom_ammo)
+
+    # Pack also defines a fighter with the library weapon as a default
+    # assignment, with the pack-scoped Custom ammo selected on it.
+    cf = make_content_fighter(
+        type="Pack Test Fighter",
+        category="GANGER",
+        house=content_house,
+        base_cost=50,
+    )
+    _add_to_pack(pack, cf)
+    da = ContentFighterDefaultAssignment.objects.create(
+        fighter=cf, equipment=library_weapon
+    )
+    da.weapon_profiles_field.add(custom_ammo)
+
+    # Subscribe a list to the pack and hire the fighter.
+    lst = make_list("Sub List")
+    lst.packs.add(pack)
+    fighter = ListFighter.objects.create(
+        name="Hired", list=lst, owner=user, content_fighter=cf
+    )
+
+    url = reverse("core:list", args=(lst.id,))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Custom ammo" in response.content
+    # Smoke: the default-assignment equipment is still visible too.
+    assert library_weapon.name.encode() in response.content
+    # Avoid an unused-name warning while still touching the fighter.
+    assert fighter is not None

--- a/gyrinx/core/tests/test_pack_customise_weapon.py
+++ b/gyrinx/core/tests/test_pack_customise_weapon.py
@@ -296,6 +296,41 @@ def test_delete_pack_scoped_profile_archives_pack_item(
     assert item.archived
 
 
+@pytest.mark.django_db
+def test_archived_profiles_link_visible_after_archiving_only_profile(
+    client, user, pack, library_weapon
+):
+    """Regression: after archiving a pack-scoped profile, the customise page
+    must still show the "Archived profiles" link so the user can restore it.
+
+    The bug was that the archived-count denominator used ``with_packs([pack])``,
+    which excludes archived pack items — so the count came back 0 and the link
+    disappeared.
+    """
+    client.force_login(user)
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Inferno", cost=5
+    )
+    _add_to_pack(pack, profile)
+
+    # Archive the pack item.
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    item = CustomContentPackItem.objects.get(
+        pack=pack, content_type=profile_ct, object_id=profile.pk
+    )
+    item.archived = True
+    item.save()
+
+    url = reverse("core:pack-customise-weapon", args=(pack.id, library_weapon.id))
+    response = client.get(url)
+    assert response.status_code == 200
+    archived_url = reverse(
+        "core:pack-customise-weapon-archived-profiles",
+        args=(pack.id, library_weapon.id),
+    )
+    assert archived_url.encode() in response.content
+
+
 # --- Pack detail surfacing ---------------------------------------------------
 
 

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -843,6 +843,38 @@ urlpatterns = [
         pack_views.archived_weapon_profiles,
         name="pack-archived-weapon-profiles",
     ),
+    # Customise an existing (library) weapon — add pack-scoped profiles
+    # without owning the equipment row.
+    path(
+        "pack/<id>/customise-weapon/",
+        pack_views.customise_weapon_picker,
+        name="pack-customise-weapon-picker",
+    ),
+    path(
+        "pack/<id>/customise-weapon/<equipment_id>/",
+        pack_views.customise_weapon,
+        name="pack-customise-weapon",
+    ),
+    path(
+        "pack/<id>/customise-weapon/<equipment_id>/profile/add/",
+        pack_views.add_customised_weapon_profile,
+        name="pack-customise-weapon-profile-add",
+    ),
+    path(
+        "pack/<id>/customise-weapon/<equipment_id>/profile/<profile_id>/edit/",
+        pack_views.edit_customised_weapon_profile,
+        name="pack-customise-weapon-profile-edit",
+    ),
+    path(
+        "pack/<id>/customise-weapon/<equipment_id>/profile/<profile_id>/delete/",
+        pack_views.delete_customised_weapon_profile,
+        name="pack-customise-weapon-profile-delete",
+    ),
+    path(
+        "pack/<id>/customise-weapon/<equipment_id>/archived-profiles/",
+        pack_views.archived_customised_weapon_profiles,
+        name="pack-customise-weapon-archived-profiles",
+    ),
     path(
         "pack/<id>/item/<item_id>/default-equipment/weapons/add/",
         pack_views.add_pack_fighter_default_weapon,

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -937,18 +937,18 @@ class PackDetailView(generic.DetailView):
         # (i.e. customised existing weapons) — they aren't pack items themselves
         # so the equipment-driven loop above misses them.
         profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
-        pack_profile_items = CustomContentPackItem.objects.filter(
-            pack=pack, content_type=profile_ct, archived=False
+        pack_profile_ids = list(
+            CustomContentPackItem.objects.filter(
+                pack=pack, content_type=profile_ct, archived=False
+            ).values_list("object_id", flat=True)
         )
         owned_equipment_ids = {
             item.object_id
             for item in pack_items
             if item.content_type_id == equipment_ct.id and not item.archived
         }
-        if pack_profile_items.exists():
-            pack_profile_ids = list(
-                pack_profile_items.values_list("object_id", flat=True)
-            )
+        if pack_profile_ids:
+            pack_profile_id_set = set(pack_profile_ids)
             customised_equipment_ids = (
                 set(
                     ContentWeaponProfile.objects.all_content()
@@ -970,31 +970,28 @@ class PackDetailView(generic.DetailView):
                     (s for s in content_sections if s["slug"] == "weapon"), None
                 )
                 if weapon_section is not None:
-                    customised_entries = []
-                    for eq in customised_weapons:
-                        profiles = list(
-                            ContentWeaponProfile.objects.with_packs([pack])
-                            .filter(equipment=eq)
-                            .prefetch_related(
-                                Prefetch(
-                                    "traits",
-                                    queryset=ContentWeaponTrait.objects.all_content(),
-                                )
+                    # Bulk-fetch all profiles for all customised weapons in
+                    # one query, then group in Python — avoids an N+1 across
+                    # customised weapons. Reuse pack_profile_id_set to mark
+                    # pack-scoped rows without another CustomContentPackItem
+                    # query per weapon.
+                    profiles_by_equipment = defaultdict(list)
+                    for p in (
+                        ContentWeaponProfile.objects.with_packs([pack])
+                        .filter(equipment_id__in=customised_equipment_ids)
+                        .prefetch_related(
+                            Prefetch(
+                                "traits",
+                                queryset=ContentWeaponTrait.objects.all_content(),
                             )
                         )
-                        # Identify which profiles are pack-scoped (vs library) so
-                        # the template knows which Edit links to render and to
-                        # sort pack-scoped rows to the bottom.
-                        pack_profile_object_ids = set(
-                            CustomContentPackItem.objects.filter(
-                                pack=pack,
-                                content_type=profile_ct,
-                                object_id__in=[p.pk for p in profiles],
-                                archived=False,
-                            ).values_list("object_id", flat=True)
-                        )
-                        for p in profiles:
-                            p.is_pack_scoped = p.pk in pack_profile_object_ids
+                    ):
+                        p.is_pack_scoped = p.pk in pack_profile_id_set
+                        profiles_by_equipment[p.equipment_id].append(p)
+
+                    customised_entries = []
+                    for eq in customised_weapons:
+                        profiles = profiles_by_equipment.get(eq.id, [])
                         profiles.sort(
                             key=lambda p: (
                                 2 if p.is_pack_scoped else (0 if not p.name else 1),
@@ -2883,13 +2880,18 @@ def customise_weapon(request, id, equipment_id):
     pack, equipment = _get_pack_and_existing_weapon(id, equipment_id, request.user)
 
     if _equipment_already_in_pack(pack, equipment):
-        # The weapon is owned by the pack — manage profiles via the regular flow.
+        # The weapon is owned by the pack — manage profiles via the regular
+        # flow. Filter on archived=False because the unique constraint on
+        # CustomContentPackItem only applies to active rows; an archived row
+        # could otherwise be returned and produce a dead anchor.
         equipment_ct = ContentType.objects.get_for_model(ContentEquipment)
-        owning_item = CustomContentPackItem.objects.filter(
-            pack=pack, content_type=equipment_ct, object_id=equipment.pk
-        ).first()
-        if owning_item is not None:
-            return HttpResponseRedirect(_pack_url(pack, f"item-{owning_item.id}"))
+        owning_item = CustomContentPackItem.objects.get(
+            pack=pack,
+            content_type=equipment_ct,
+            object_id=equipment.pk,
+            archived=False,
+        )
+        return HttpResponseRedirect(_pack_url(pack, f"item-{owning_item.id}"))
 
     profiles_qs = (
         ContentWeaponProfile.objects.with_packs([pack])
@@ -2903,19 +2905,28 @@ def customise_weapon(request, id, equipment_id):
     )
 
     profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
-    profile_ids = list(profiles_qs.values_list("pk", flat=True))
+    visible_profile_ids = list(profiles_qs.values_list("pk", flat=True))
+    # Use all_content() for the archived count denominator — profiles_qs comes
+    # from with_packs() which excludes archived pack items, so archived
+    # pack-scoped profiles wouldn't be in visible_profile_ids and the
+    # archived-count query would always be empty.
+    all_profile_ids = list(
+        ContentWeaponProfile.objects.all_content()
+        .filter(equipment=equipment)
+        .values_list("pk", flat=True)
+    )
     pack_profile_object_ids = set(
         CustomContentPackItem.objects.filter(
             pack=pack,
             content_type=profile_ct,
-            object_id__in=profile_ids,
+            object_id__in=visible_profile_ids,
             archived=False,
         ).values_list("object_id", flat=True)
     )
     archived_pack_profile_count = CustomContentPackItem.objects.filter(
         pack=pack,
         content_type=profile_ct,
-        object_id__in=profile_ids,
+        object_id__in=all_profile_ids,
         archived=True,
     ).count()
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -933,6 +933,86 @@ class PackDetailView(generic.DetailView):
 
             content_sections.append(section)
 
+        # Surface library weapons that have pack-scoped profiles attached
+        # (i.e. customised existing weapons) — they aren't pack items themselves
+        # so the equipment-driven loop above misses them.
+        profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+        pack_profile_items = CustomContentPackItem.objects.filter(
+            pack=pack, content_type=profile_ct, archived=False
+        )
+        owned_equipment_ids = {
+            item.object_id
+            for item in pack_items
+            if item.content_type_id == equipment_ct.id and not item.archived
+        }
+        if pack_profile_items.exists():
+            pack_profile_ids = list(
+                pack_profile_items.values_list("object_id", flat=True)
+            )
+            customised_equipment_ids = (
+                set(
+                    ContentWeaponProfile.objects.all_content()
+                    .filter(pk__in=pack_profile_ids)
+                    .values_list("equipment_id", flat=True)
+                    .distinct()
+                )
+                - owned_equipment_ids
+            )
+
+            if customised_equipment_ids:
+                customised_weapons = list(
+                    ContentEquipment.objects.with_packs([pack])
+                    .filter(id__in=customised_equipment_ids)
+                    .select_related("category")
+                    .order_by("category__name", "name")
+                )
+                weapon_section = next(
+                    (s for s in content_sections if s["slug"] == "weapon"), None
+                )
+                if weapon_section is not None:
+                    customised_entries = []
+                    for eq in customised_weapons:
+                        profiles = list(
+                            ContentWeaponProfile.objects.with_packs([pack])
+                            .filter(equipment=eq)
+                            .prefetch_related(
+                                Prefetch(
+                                    "traits",
+                                    queryset=ContentWeaponTrait.objects.all_content(),
+                                )
+                            )
+                        )
+                        # Identify which profiles are pack-scoped (vs library) so
+                        # the template knows which Edit links to render and to
+                        # sort pack-scoped rows to the bottom.
+                        pack_profile_object_ids = set(
+                            CustomContentPackItem.objects.filter(
+                                pack=pack,
+                                content_type=profile_ct,
+                                object_id__in=[p.pk for p in profiles],
+                                archived=False,
+                            ).values_list("object_id", flat=True)
+                        )
+                        for p in profiles:
+                            p.is_pack_scoped = p.pk in pack_profile_object_ids
+                        profiles.sort(
+                            key=lambda p: (
+                                2 if p.is_pack_scoped else (0 if not p.name else 1),
+                                p.name or "",
+                            )
+                        )
+                        customised_entries.append(
+                            {
+                                "pack_item": None,
+                                "content_object": eq,
+                                "profiles": profiles,
+                                "is_customised": True,
+                                "is_auto_equipment": False,
+                            }
+                        )
+                    weapon_section["items"].extend(customised_entries)
+                    weapon_section["count"] = len(weapon_section["items"])
+
         context["content_sections"] = content_sections
         all_activities = _get_pack_activity(pack)
         context["recent_activities"] = all_activities[:5]
@@ -2473,6 +2553,9 @@ def add_weapon_profile(request, id, item_id):
         "equipment": equipment,
         "slug": "weapon",
         "back_url": _pack_url(pack, f"item-{pack_item.id}"),
+        "form_action_url": reverse(
+            "core:pack-add-weapon-profile", args=(pack.id, pack_item.id)
+        ),
         "weapon_stat_fields": _build_weapon_stat_context(request),
     }
     return render(request, "core/pack/weapon_profile_add.html", context)
@@ -2594,6 +2677,14 @@ def edit_weapon_profile(request, id, item_id, profile_id):
         "profile": profile,
         "slug": "weapon",
         "back_url": _pack_url(pack, f"item-{pack_item.id}"),
+        "form_action_url": reverse(
+            "core:pack-edit-weapon-profile",
+            args=(pack.id, pack_item.id, profile.id),
+        ),
+        "delete_url": reverse(
+            "core:pack-delete-weapon-profile",
+            args=(pack.id, pack_item.id, profile.id),
+        ),
         "weapon_stat_values": weapon_stat_context,
     }
     return render(request, "core/pack/weapon_profile_edit.html", context)
@@ -2670,6 +2761,10 @@ def delete_weapon_profile(request, id, item_id, profile_id):
         "profile": profile,
         "slug": "weapon",
         "back_url": _pack_url(pack, f"item-{pack_item.id}"),
+        "form_action_url": reverse(
+            "core:pack-delete-weapon-profile",
+            args=(pack.id, pack_item.id, profile.id),
+        ),
     }
     return render(request, "core/pack/weapon_profile_delete.html", context)
 
@@ -2705,6 +2800,416 @@ def archived_weapon_profiles(request, id, item_id):
             "back_url": edit_url,
             "back_text": str(equipment),
             "restore_next": edit_url,
+        },
+    )
+
+
+# --- Customise existing (library) weapons ---------------------------------
+#
+# These views support adding pack-scoped weapon profiles to library
+# weapons that are NOT owned by the pack. The pack only owns the new
+# CustomContentPackItem rows for the profiles it adds.
+
+
+def _get_pack_and_existing_weapon(pack_id, equipment_id, user):
+    """Fetch a pack and an existing (library) weapon, verifying user can edit pack.
+
+    The equipment is looked up via ``with_packs([pack])`` so pack-scoped
+    custom weapons are also valid targets — though the typical use case is
+    a library weapon. Non-weapon equipment is rejected.
+    """
+    pack = _get_pack_for_edit(pack_id, user)
+    equipment = get_object_or_404(
+        ContentEquipment.objects.with_packs([pack]),
+        id=equipment_id,
+    )
+    if not equipment.is_weapon():
+        raise Http404
+    return pack, equipment
+
+
+def _customise_weapon_back_url(pack, equipment):
+    return reverse("core:pack-customise-weapon", args=(pack.id, equipment.id))
+
+
+def _equipment_already_in_pack(pack, equipment):
+    """Return True if the given equipment is itself a pack item in this pack."""
+    equipment_ct = ContentType.objects.get_for_model(ContentEquipment)
+    return CustomContentPackItem.objects.filter(
+        pack=pack,
+        content_type=equipment_ct,
+        object_id=equipment.pk,
+        archived=False,
+    ).exists()
+
+
+@login_required
+def customise_weapon_picker(request, id):
+    """Searchable picker of library weapons to customise with new profiles."""
+    pack = _get_pack_for_edit(id, request.user)
+
+    # Library weapons only — pack-owned weapons are managed via the regular
+    # weapon flow. ``ContentEquipmentManager.get_queryset`` already excludes
+    # pack content.
+    weapons_qs = (
+        ContentEquipment.objects.weapons()
+        .select_related("category")
+        .order_by("category__name", "name")
+    )
+
+    q = request.GET.get("q", "").strip()
+    if q:
+        weapons_qs = search_queryset(weapons_qs, q, ["name", "category__name"])
+
+    paginator = Paginator(weapons_qs, 25)
+    page_number = request.GET.get("page", 1)
+    page = paginator.get_page(page_number)
+
+    context = {
+        "pack": pack,
+        "weapons": page.object_list,
+        "page_obj": page,
+        "paginator": paginator,
+        "is_paginated": page.has_other_pages(),
+        "search_query": q,
+        "back_url": _pack_url(pack),
+    }
+    return render(request, "core/pack/customise_weapon_picker.html", context)
+
+
+@login_required
+def customise_weapon(request, id, equipment_id):
+    """Show pack-scoped profiles for a library weapon and let the user add more."""
+    pack, equipment = _get_pack_and_existing_weapon(id, equipment_id, request.user)
+
+    if _equipment_already_in_pack(pack, equipment):
+        # The weapon is owned by the pack — manage profiles via the regular flow.
+        equipment_ct = ContentType.objects.get_for_model(ContentEquipment)
+        owning_item = CustomContentPackItem.objects.filter(
+            pack=pack, content_type=equipment_ct, object_id=equipment.pk
+        ).first()
+        if owning_item is not None:
+            return HttpResponseRedirect(_pack_url(pack, f"item-{owning_item.id}"))
+
+    profiles_qs = (
+        ContentWeaponProfile.objects.with_packs([pack])
+        .filter(equipment=equipment)
+        .prefetch_related(
+            Prefetch(
+                "traits",
+                queryset=ContentWeaponTrait.objects.all_content(),
+            )
+        )
+    )
+
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    profile_ids = list(profiles_qs.values_list("pk", flat=True))
+    pack_profile_object_ids = set(
+        CustomContentPackItem.objects.filter(
+            pack=pack,
+            content_type=profile_ct,
+            object_id__in=profile_ids,
+            archived=False,
+        ).values_list("object_id", flat=True)
+    )
+    archived_pack_profile_count = CustomContentPackItem.objects.filter(
+        pack=pack,
+        content_type=profile_ct,
+        object_id__in=profile_ids,
+        archived=True,
+    ).count()
+
+    profiles = list(profiles_qs)
+    for p in profiles:
+        p.is_pack_scoped = p.pk in pack_profile_object_ids
+    # Sort: library standard (no name) first, library named, pack-scoped last —
+    # so the pack author's customisations are anchored at the bottom.
+    profiles.sort(
+        key=lambda p: (
+            2 if p.is_pack_scoped else (0 if not p.name else 1),
+            p.name or "",
+        )
+    )
+
+    context = {
+        "pack": pack,
+        "equipment": equipment,
+        "profiles": profiles,
+        "pack_profile_count": len(pack_profile_object_ids),
+        "archived_pack_profile_count": archived_pack_profile_count,
+        "back_url": _pack_url(pack),
+    }
+    return render(request, "core/pack/customise_weapon.html", context)
+
+
+def _save_customised_weapon_profile(request, pack, equipment, profile, form, *, is_new):
+    """Shared save logic for add/edit of a customised-weapon profile.
+
+    Returns True on success (and writes a pack item for new profiles), or
+    False with errors attached to ``form``.
+    """
+    profile._history_user = request.user
+    for field_name, _, _ in _WEAPON_PROFILE_STAT_FIELDS:
+        raw = request.POST.get(f"wp_{field_name}", "") or ""
+        setattr(profile, field_name, raw.strip())
+
+    profile_name = (profile.name or "").strip()
+
+    duplicate_q = ContentWeaponProfile.objects.all_content().filter(
+        equipment=equipment, name=profile_name
+    )
+    if not is_new:
+        duplicate_q = duplicate_q.exclude(pk=profile.pk)
+    if duplicate_q.exists():
+        if profile_name == "":
+            msg = "This weapon already has a standard (unnamed) profile."
+        else:
+            msg = f'A profile named "{profile_name}" already exists for this weapon.'
+        form.add_error("name", msg)
+        return False
+
+    if profile_name != "" and profile.cost == 0:
+        unnamed_q = ContentWeaponProfile.objects.all_content().filter(
+            equipment=equipment, name=""
+        )
+        if not is_new:
+            unnamed_q = unnamed_q.exclude(pk=profile.pk)
+        if unnamed_q.exists():
+            form.add_error(
+                "cost",
+                "This weapon already has an unnamed standard profile. "
+                "Additional profiles must have a non-zero cost.",
+            )
+            return False
+
+    try:
+        with transaction.atomic():
+            profile.full_clean()
+            profile.save()
+            form.save_m2m()
+            if is_new:
+                ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+                pack_item = CustomContentPackItem(
+                    pack=pack,
+                    content_type=ct,
+                    object_id=profile.pk,
+                    owner=request.user,
+                )
+                pack_item.save_with_user(request.user)
+        log_event(
+            user=request.user,
+            noun=EventNoun.CONTENT_PACK,
+            verb=EventVerb.CREATE if is_new else EventVerb.UPDATE,
+            object=pack,
+            request=request,
+            pack_name=pack.name,
+            pack_id=str(pack.id),
+            content_type="weapon_profile",
+            weapon_name=str(equipment),
+            profile_name=profile.name or "(Standard)",
+        )
+        return True
+    except DjangoValidationError as e:
+        if hasattr(e, "message_dict"):
+            for field, messages_list in e.message_dict.items():
+                for message in messages_list:
+                    form.add_error(field if field != "__all__" else None, message)
+        else:
+            form.add_error(None, e.message)
+        return False
+    except IntegrityError as e:
+        if "equipment_id" in str(e).lower() or "name" in str(e).lower():
+            form.add_error(
+                "name",
+                "A profile with this name already exists for this weapon.",
+            )
+            return False
+        raise
+
+
+@login_required
+def add_customised_weapon_profile(request, id, equipment_id):
+    """Add a pack-scoped weapon profile to an existing library weapon."""
+    pack, equipment = _get_pack_and_existing_weapon(id, equipment_id, request.user)
+    back_url = _customise_weapon_back_url(pack, equipment)
+
+    if request.method == "POST":
+        form = ContentWeaponProfilePackForm(request.POST, pack=pack)
+        if form.is_valid():
+            profile = form.save(commit=False)
+            profile.equipment = equipment
+            if _save_customised_weapon_profile(
+                request, pack, equipment, profile, form, is_new=True
+            ):
+                return HttpResponseRedirect(back_url)
+    else:
+        form = ContentWeaponProfilePackForm(pack=pack)
+
+    context = {
+        "form": form,
+        "pack": pack,
+        "equipment": equipment,
+        "slug": "weapon",
+        "back_url": back_url,
+        "form_action_url": reverse(
+            "core:pack-customise-weapon-profile-add",
+            args=(pack.id, equipment.id),
+        ),
+        "weapon_stat_fields": _build_weapon_stat_context(request),
+    }
+    return render(request, "core/pack/weapon_profile_add.html", context)
+
+
+@login_required
+def edit_customised_weapon_profile(request, id, equipment_id, profile_id):
+    """Edit a pack-scoped weapon profile attached to a library weapon."""
+    pack, equipment = _get_pack_and_existing_weapon(id, equipment_id, request.user)
+    profile = get_object_or_404(
+        ContentWeaponProfile.objects.all_content(),
+        id=profile_id,
+        equipment=equipment,
+    )
+
+    # The profile must be owned by this pack — we only allow editing
+    # pack-scoped profiles, not library ones.
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    if not CustomContentPackItem.objects.filter(
+        pack=pack,
+        content_type=profile_ct,
+        object_id=profile.pk,
+        archived=False,
+    ).exists():
+        raise Http404
+
+    back_url = _customise_weapon_back_url(pack, equipment)
+
+    if request.method == "POST":
+        form = ContentWeaponProfilePackForm(request.POST, instance=profile, pack=pack)
+        if form.is_valid():
+            updated = form.save(commit=False)
+            if _save_customised_weapon_profile(
+                request, pack, equipment, updated, form, is_new=False
+            ):
+                return HttpResponseRedirect(back_url)
+    else:
+        form = ContentWeaponProfilePackForm(instance=profile, pack=pack)
+
+    weapon_stat_context = []
+    for field_name, short_name, placeholder in _WEAPON_PROFILE_STAT_FIELDS:
+        entry_dict = {
+            "field_name": field_name,
+            "short_name": short_name,
+            "placeholder": placeholder,
+        }
+        if request.method == "POST":
+            entry_dict["value"] = request.POST.get(f"wp_{field_name}", "")
+        else:
+            entry_dict["value"] = getattr(profile, field_name, "")
+        weapon_stat_context.append(entry_dict)
+
+    context = {
+        "form": form,
+        "pack": pack,
+        "equipment": equipment,
+        "profile": profile,
+        "slug": "weapon",
+        "back_url": back_url,
+        "form_action_url": reverse(
+            "core:pack-customise-weapon-profile-edit",
+            args=(pack.id, equipment.id, profile.id),
+        ),
+        "delete_url": reverse(
+            "core:pack-customise-weapon-profile-delete",
+            args=(pack.id, equipment.id, profile.id),
+        ),
+        "weapon_stat_values": weapon_stat_context,
+    }
+    return render(request, "core/pack/weapon_profile_edit.html", context)
+
+
+@login_required
+def delete_customised_weapon_profile(request, id, equipment_id, profile_id):
+    """Archive a pack-scoped profile that was added to a library weapon."""
+    pack, equipment = _get_pack_and_existing_weapon(id, equipment_id, request.user)
+    profile = get_object_or_404(
+        ContentWeaponProfile.objects.all_content(),
+        id=profile_id,
+        equipment=equipment,
+    )
+
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    profile_pack_item = get_object_or_404(
+        CustomContentPackItem,
+        pack=pack,
+        content_type=profile_ct,
+        object_id=profile.pk,
+        archived=False,
+    )
+
+    back_url = _customise_weapon_back_url(pack, equipment)
+
+    if request.method == "POST":
+        profile_pack_item._history_user = request.user
+        profile_pack_item.archive()
+        log_event(
+            user=request.user,
+            noun=EventNoun.CONTENT_PACK,
+            verb=EventVerb.ARCHIVE,
+            object=pack,
+            request=request,
+            pack_name=pack.name,
+            pack_id=str(pack.id),
+            content_type="weapon_profile",
+            weapon_name=str(equipment),
+            profile_name=profile.name or "(Standard)",
+        )
+        return HttpResponseRedirect(back_url)
+
+    context = {
+        "pack": pack,
+        "equipment": equipment,
+        "profile": profile,
+        "slug": "weapon",
+        "back_url": back_url,
+        "form_action_url": reverse(
+            "core:pack-customise-weapon-profile-delete",
+            args=(pack.id, equipment.id, profile.id),
+        ),
+    }
+    return render(request, "core/pack/weapon_profile_delete.html", context)
+
+
+@login_required
+def archived_customised_weapon_profiles(request, id, equipment_id):
+    """Display archived pack-scoped profiles for a customised library weapon."""
+    pack, equipment = _get_pack_and_existing_weapon(id, equipment_id, request.user)
+
+    profile_ct = ContentType.objects.get_for_model(ContentWeaponProfile)
+    profile_ids = (
+        ContentWeaponProfile.objects.all_content()
+        .filter(equipment=equipment)
+        .values_list("pk", flat=True)
+    )
+    archived_items = []
+    for item in CustomContentPackItem.objects.filter(
+        pack=pack, content_type=profile_ct, object_id__in=profile_ids, archived=True
+    ):
+        if item.content_object is not None:
+            archived_items.append(
+                {"pack_item": item, "content_object": item.content_object}
+            )
+
+    back_url = _customise_weapon_back_url(pack, equipment)
+    return render(
+        request,
+        "core/pack/pack_archived.html",
+        {
+            "pack": pack,
+            "archived_items": archived_items,
+            "section_label": "Weapon Profiles",
+            "back_url": back_url,
+            "back_text": str(equipment),
+            "restore_next": back_url,
         },
     )
 


### PR DESCRIPTION
## Summary

- Pack authors can customise existing (library) weapons by adding new profiles (e.g. special ammo). New picker + customise-weapon page; reuses the existing add/edit/archive profile flow scoped to the pack via ``CustomContentPackItem``.
- Customised library weapons surface in the pack detail Weapons section with library profiles muted and pack-scoped profiles anchored at the bottom with a dot indicator and inline Edit/Archive.
- Fix: pack-scoped weapon profiles selected on a ``ContentFighterDefaultAssignment`` (e.g. default ammo on a default-equipped weapon) were silently dropped on the list page for subscribed lists. The fighter prefetch chain now uses ``all_content()`` for the default-assignment's ``weapon_profiles_field`` and ``weapon_accessories_field``.

## Test plan

- [x] Pack page: ``+ Customise existing weapon`` opens a searchable picker; ``q=`` filters; pack-owned weapons excluded.
- [x] Customise-weapon page: existing library profiles muted; ``+ New profile`` adds a pack-scoped profile; new profile sorted to bottom with dot icon and inline Edit/Archive.
- [x] Pack detail Weapons section surfaces customised library weapons with the same treatment.
- [x] Edit + Archive of a pack-scoped profile work; archive removes it from the table; ``Archived profiles`` link appears.
- [x] Multi-pack safety: same profile linked to two packs, archiving in one doesn't affect the other.
- [x] Subscribed list sees pack-scoped profile via ``with_packs``; unsubscribed list does not.
- [x] Regression: pack-scoped profile attached to a ``ContentFighterDefaultAssignment.weapon_profiles_field`` shows on the list page for hired fighters.
- [x] Full ``pytest -n auto`` passes (2052 + 7 skipped).

Closes #1739