### PR TITLE
docs: add localized CLAUDE.md files for core, static, and templates

### DIFF
--- a/gyrinx/core/CLAUDE.md
+++ b/gyrinx/core/CLAUDE.md
@@ -35,7 +35,7 @@ into N+1 territory silently in dev and shows up only under load.
   a helper: `get_list_and_fighter()` in [views/fighter/permissions.py](views/fighter/permissions.py).
   Prefer it for new code. Older modules (`state.py`, `xp.py`) still inline the `Q()` and may
   be migrated when touched.
-- Validate redirect targets with `safe_redirect` from [gyrinx/util.py](../util.py) whenever
+- Validate redirect targets with `safe_redirect` from [gyrinx/core/utils.py](utils.py) whenever
   a `next=` or similar comes from user input.
 
 ## Tests

--- a/gyrinx/core/CLAUDE.md
+++ b/gyrinx/core/CLAUDE.md
@@ -1,0 +1,53 @@
+# Core App
+
+User-data domain: lists, fighters, campaigns, battles, assignments. The hot core of the app.
+
+Load the `gyrinx-conventions` skill before non-trivial work — it documents the layered
+architecture (views → handlers → models), form/test conventions, cost system, and state
+machines.
+
+## Models
+
+- All core models inherit from `AppBase` ([models/base.py](models/base.py)) — UUID PK,
+  `Owned`, `Archived`, `HistoryMixin`, history-aware manager. Don't subclass `models.Model`
+  directly.
+- Every concrete model declares `history = HistoricalRecords()` for django-simple-history.
+- For state-bearing models (campaigns, battles), use [models/state_machine.py](models/state_machine.py)
+  rather than rolling status fields by hand.
+
+### Prefetch invariant
+
+The fighter list view is the project's hottest query path. When you add a FK or M2M to
+`ListFighter` (or anything fetched alongside it), you **must** update both:
+
+1. `ListFighterQuerySet.with_related_data()` in [models/list.py](models/list.py) — the
+   central prefetch method.
+2. The query-count snapshot at [tests/fixtures/performance_view_queries.json](tests/fixtures/performance_view_queries.json).
+
+Tests will fail if the snapshot drifts. If a relation isn't prefetched, the view degrades
+into N+1 territory silently in dev and shows up only under load.
+
+## Views and permissions
+
+- Views are split by domain: `views/fighter/`, `views/campaign/`, `views/list/`, plus
+  root-level views.
+- The owner-or-arbitrator permission pattern (`Q(owner=user) | Q(campaign__owner=user)`) has
+  a helper: `get_list_and_fighter()` in [views/fighter/permissions.py](views/fighter/permissions.py).
+  Prefer it for new code. Older modules (`state.py`, `xp.py`) still inline the `Q()` and may
+  be migrated when touched.
+- Validate redirect targets with `safe_redirect` from [gyrinx/util.py](../util.py) whenever
+  a `next=` or similar comes from user input.
+
+## Tests
+
+Use the canonical fixtures in [gyrinx/conftest.py](../conftest.py) — `user`, `make_user`,
+`content_house`, `content_fighter`, `make_list`, `make_list_fighter`, `make_campaign`,
+`campaign`, `list_with_campaign`. Read the conftest before writing fixture setup inline.
+
+Tests are module-level pytest functions with `@pytest.mark.django_db`; no `TestCase`.
+
+## Templates and static
+
+Template and SCSS work has its own localized guidance — see
+[templates/CLAUDE.md](templates/CLAUDE.md) and [static/CLAUDE.md](static/CLAUDE.md). Both
+point at the `design-system` skill, which should be loaded before changing UI.

--- a/gyrinx/core/static/CLAUDE.md
+++ b/gyrinx/core/static/CLAUDE.md
@@ -13,8 +13,10 @@ maps to tokens defined here.
 - Entry points: `screen.scss`, `print.scss`, `styles.scss`.
 - Spec: [docs/DESIGN-SYSTEM.md](../../../docs/DESIGN-SYSTEM.md)
 
-**Never commit `.css` files.** They are generated from SCSS by `npm run css` (one-shot) or
-`npm run watch` (rebuild on change). The pre-commit hooks and CI will fail on committed CSS.
+**Don't commit generated CSS.** It is built from SCSS by `npm run css` (one-shot) or
+`npm run watch` (rebuild on change), and the build outputs (e.g. `core/css/styles.css`,
+`core/css/styles.css.map`) are listed in `.gitignore`. Committing CSS bypasses the build
+and causes drift between source and what's served.
 
 ## JavaScript
 

--- a/gyrinx/core/static/CLAUDE.md
+++ b/gyrinx/core/static/CLAUDE.md
@@ -1,0 +1,22 @@
+# Static Assets
+
+Stylesheets, JavaScript, and image assets for the core app.
+
+## Styles (SCSS)
+
+Before changing styles, load the `design-system` skill. The semantic vocabulary it documents
+maps to tokens defined here.
+
+- Tokens: [core/scss/_tokens.scss](core/scss/_tokens.scss) — semantic aliases (state, action,
+  surface) layered on top of Bootstrap. Prefer extending tokens over hard-coded colours,
+  spacing, or font sizes.
+- Entry points: `screen.scss`, `print.scss`, `styles.scss`.
+- Spec: [docs/DESIGN-SYSTEM.md](../../../docs/DESIGN-SYSTEM.md)
+
+**Never commit `.css` files.** They are generated from SCSS by `npm run css` (one-shot) or
+`npm run watch` (rebuild on change). The pre-commit hooks and CI will fail on committed CSS.
+
+## JavaScript
+
+Vanilla JS only — no framework. Use it for one-off enhancements; default to server-rendered
+HTML and form submissions for behaviour. Format with `npm run js-fmt`.

--- a/gyrinx/core/templates/CLAUDE.md
+++ b/gyrinx/core/templates/CLAUDE.md
@@ -7,7 +7,7 @@ reference for components, colours, typography, spacing, buttons, tables, forms, 
 and inline action menus.
 
 - Spec: [docs/DESIGN-SYSTEM.md](../../../docs/DESIGN-SYSTEM.md)
-- Live HTML reference: [core/debug/design_system.html](core/debug/design_system.html) — render at `/debug/design-system/` to see real components in context
+- Live HTML reference: [core/debug/design_system.html](core/debug/design_system.html) — render at `/_debug/design-system/` to see real components in context
 - Semantic colour vocabulary: [_tokens.scss](../static/core/scss/_tokens.scss)
 
 Working rules:
@@ -20,7 +20,9 @@ Working rules:
   btn-sm`, etc.) rather than inventing new ones.
 - Mobile-first; responsive utilities scale up. Left-aligned content typically `col-12 col-xl-6`.
 - Avoid `alert` classes — prefer `border rounded p-2`. Cards are reserved for fighter grids.
-- User-supplied HTML uses the `|safe` filter; ordinary content does not.
+- Never apply `|safe` directly to user-supplied content. Sanitize first — the project ships
+  the `safe_rich_text` template filter (in `core/templatetags/custom_tags.py`) for this.
+  Only use `|safe` on values you control or that have already been sanitized.
 
 ## Microcopy Guidelines
 

--- a/gyrinx/core/templates/CLAUDE.md
+++ b/gyrinx/core/templates/CLAUDE.md
@@ -1,5 +1,27 @@
 # Templates
 
+## Design System
+
+Before any non-trivial template work, load the `design-system` skill — it is the canonical
+reference for components, colours, typography, spacing, buttons, tables, forms, page shells,
+and inline action menus.
+
+- Spec: [docs/DESIGN-SYSTEM.md](../../../docs/DESIGN-SYSTEM.md)
+- Live HTML reference: [core/debug/design_system.html](core/debug/design_system.html) — render at `/debug/design-system/` to see real components in context
+- Semantic colour vocabulary: [_tokens.scss](../static/core/scss/_tokens.scss)
+
+Working rules:
+
+- Extend `core/layouts/base.html` for full-page layouts and `core/layouts/page.html` for
+  simple content pages. Don't roll a new top-level layout.
+- Reach for an existing snippet in `core/includes/` before writing new markup. The fighter
+  card lives at [core/includes/fighter_card_content_inner.html](core/includes/fighter_card_content_inner.html).
+- Use the Bootstrap 5 button classes documented in the root `CLAUDE.md` (`btn btn-primary
+  btn-sm`, etc.) rather than inventing new ones.
+- Mobile-first; responsive utilities scale up. Left-aligned content typically `col-12 col-xl-6`.
+- Avoid `alert` classes — prefer `border rounded p-2`. Cards are reserved for fighter grids.
+- User-supplied HTML uses the `|safe` filter; ordinary content does not.
+
 ## Microcopy Guidelines
 
 ### Casing


### PR DESCRIPTION
## Summary

- Add three nested \`CLAUDE.md\` files so Claude Code loads the right skills and invariants when working in specific areas of the core app.
- The driving change: template work had no explicit pointer to the \`design-system\` skill, so component patterns, colours, and spacing tended to get reinvented rather than reused.

## What's in each file

- **\`gyrinx/core/templates/CLAUDE.md\`** (modified) — prepends a Design System section pointing at the \`design-system\` skill, [\`docs/DESIGN-SYSTEM.md\`](docs/DESIGN-SYSTEM.md), the live \`core/debug/design_system.html\` reference, and \`_tokens.scss\`. The existing microcopy guidelines (sentence case, button labels) are preserved.
- **\`gyrinx/core/static/CLAUDE.md\`** (new) — SCSS guardrails: load the design-system skill, prefer extending \`_tokens.scss\` over hard-coded values, never commit \`.css\` (it's generated by \`npm run css\`/\`npm run watch\`), vanilla JS only.
- **\`gyrinx/core/CLAUDE.md\`** (new) — core-app invariants: \`AppBase\` inheritance is mandatory; when adding FK/M2M to \`ListFighter\`, update both \`ListFighterQuerySet.with_related_data()\` and the \`performance_view_queries.json\` snapshot; prefer \`get_list_and_fighter()\` for the owner-or-arbitrator permission pattern; use the canonical fixtures in \`gyrinx/conftest.py\`.

## Why nested rather than expanding the root \`CLAUDE.md\`

These notes are directory-scoped — they should fire when Claude is editing templates / static / core code, not in every session. Nested \`CLAUDE.md\` files load automatically based on working directory, which keeps the root file from bloating further.

## Test plan

- [ ] In a fresh session under \`gyrinx/core/templates/\`, ask Claude to add a button — it should load the \`design-system\` skill rather than reinventing classes.
- [ ] In a fresh session under \`gyrinx/core/static/core/scss/\`, ask Claude to add a colour — it should edit \`_tokens.scss\` and not try to commit a \`.css\` file.
- [ ] In a fresh session under \`gyrinx/core/\`, ask Claude to add an M2M to \`ListFighter\` — it should propose updating \`with_related_data()\` and the performance snapshot.
- [ ] Microcopy rule still fires (sentence case for buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)