### PR TITLE
feat: rapid pack iteration — customise-weapon shortcut, special rules, quick-add tweaks

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -115,7 +115,7 @@ class ContentFighterPackForm(forms.ModelForm):
             "skills": "Default skills",
             "primary_skill_categories": "Primary skill trees",
             "secondary_skill_categories": "Secondary skill trees",
-            "rules": "Rules",
+            "rules": "Special rules",
         }
         help_texts = {
             "type": "The name of this fighter or vehicle (e.g. 'Gang Leader', 'Goliath Mauler').",

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -614,12 +614,12 @@
                             </div>
                             <i class="bi-chevron-right flex-shrink-0"></i>
                         </a>
-                        <a href="{% url 'core:pack-add-item' pack.id 'rule' %}"
+                        <a href="{% url 'core:pack-add-item' pack.id 'gear' %}"
                            class="border rounded p-3 d-flex align-items-center gap-3 text-decoration-none">
                             <i class="bi-plus-lg flex-shrink-0"></i>
                             <div class="flex-grow-1">
-                                <h2 class="h5 mb-1">Add a Rule</h2>
-                                <p class="text-secondary fs-7 mb-0">Short named special rules that can be attached to fighters.</p>
+                                <h2 class="h5 mb-1">Add gear</h2>
+                                <p class="text-secondary fs-7 mb-0">Custom non-weapon equipment that fighters in this pack can buy.</p>
                             </div>
                             <i class="bi-chevron-right flex-shrink-0"></i>
                         </a>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -540,7 +540,7 @@
                                             Short named special rules. Once created, they can be attached to fighters in this pack or subscribed lists &amp; gangs.
                                             {% if can_edit and section.can_add %}
                                                 <a href="{% url 'core:pack-add-item' pack.id 'rule' %}"
-                                                   class="linked fs-7">Add a rule →</a>
+                                                   class="linked fs-7">Add a special rule →</a>
                                             {% endif %}
                                         </p>
                                     {% elif section.slug == "gear" %}

--- a/gyrinx/core/templates/core/pack/weapon_profile_add.html
+++ b/gyrinx/core/templates/core/pack/weapon_profile_add.html
@@ -13,11 +13,17 @@
             {% csrf_token %}
             {{ form }}
             {% include "core/pack/includes/weapon_profile_stats_form.html" with weapon_stats=weapon_stat_fields %}
-            <div class="mt-3 d-flex gap-2 align-items-center">
+            <div class="mt-3 d-flex gap-2 align-items-center flex-wrap">
                 <button type="submit" class="btn btn-success">
                     <i class="bi-check-lg me-1"></i>
                     Add profile
                 </button>
+                {% if customise_another_url %}
+                    <span>or</span>
+                    <button type="submit"
+                            name="save_and_customise_another"
+                            class="btn btn-secondary">Save and customise a different weapon</button>
+                {% endif %}
                 <a href="{{ back_url }}" class="btn btn-link">Cancel</a>
             </div>
         </form>

--- a/gyrinx/core/templates/core/pack/weapon_profile_edit.html
+++ b/gyrinx/core/templates/core/pack/weapon_profile_edit.html
@@ -15,8 +15,14 @@
             {% csrf_token %}
             {{ form }}
             {% include "core/pack/includes/weapon_profile_stats_form.html" with weapon_stats=weapon_stat_values %}
-            <div class="mt-3 d-flex align-items-center gap-2">
+            <div class="mt-3 d-flex align-items-center gap-2 flex-wrap">
                 <button type="submit" class="btn btn-success">Save</button>
+                {% if customise_another_url %}
+                    <span>or</span>
+                    <button type="submit"
+                            name="save_and_customise_another"
+                            class="btn btn-secondary">Save and customise a different weapon</button>
+                {% endif %}
                 <a href="{{ back_url }}" class="btn btn-link">Cancel</a>
                 {% if profile.name %}
                     <a href="{{ delete_url }}" class="btn btn-link text-danger ms-auto">Archive profile</a>

--- a/gyrinx/core/tests/test_pack_customise_weapon.py
+++ b/gyrinx/core/tests/test_pack_customise_weapon.py
@@ -200,6 +200,73 @@ def test_add_profile_creates_pack_item(client, user, pack, library_weapon):
 
 
 @pytest.mark.django_db
+def test_add_profile_save_and_customise_another_redirects_to_picker(
+    client, user, pack, library_weapon
+):
+    client.force_login(user)
+    url = reverse(
+        "core:pack-customise-weapon-profile-add", args=(pack.id, library_weapon.id)
+    )
+    response = client.post(
+        url,
+        data={
+            "name": "Plasma Round",
+            "cost": "10",
+            "rarity": "C",
+            "wp_range_short": "12",
+            "wp_range_long": "24",
+            "wp_strength": "6",
+            "wp_armour_piercing": "-1",
+            "wp_damage": "2",
+            "wp_ammo": "5+",
+            "save_and_customise_another": "1",
+        },
+    )
+    assert response.status_code == 302
+    assert response["Location"].endswith(
+        reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+    )
+    # The profile was still saved.
+    assert (
+        ContentWeaponProfile.objects.all_content()
+        .filter(equipment=library_weapon, name="Plasma Round")
+        .exists()
+    )
+
+
+@pytest.mark.django_db
+def test_edit_profile_save_and_customise_another_redirects_to_picker(
+    client, user, pack, library_weapon
+):
+    client.force_login(user)
+    profile = ContentWeaponProfile.objects.create(
+        equipment=library_weapon, name="Inferno", cost=5
+    )
+    _add_to_pack(pack, profile)
+    url = reverse(
+        "core:pack-customise-weapon-profile-edit",
+        args=(pack.id, library_weapon.id, profile.id),
+    )
+    response = client.post(
+        url,
+        data={
+            "name": "Inferno",
+            "cost": "9",
+            "rarity": "R",
+            "wp_range_short": "8",
+            "wp_range_long": "20",
+            "save_and_customise_another": "1",
+        },
+    )
+    assert response.status_code == 302
+    assert response["Location"].endswith(
+        reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+    )
+    profile.refresh_from_db()
+    assert profile.cost == 9
+
+
+@pytest.mark.django_db
 def test_add_profile_rejects_duplicate_name(client, user, pack, library_weapon):
     client.force_login(user)
     ContentWeaponProfile.objects.create(

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -633,7 +633,7 @@ def test_add_rule_form_loads(client, group_user, pack):
     client.force_login(group_user)
     response = client.get(f"/pack/{pack.id}/add/rule/")
     assert response.status_code == 200
-    assert b"Add Rule" in response.content
+    assert b"Add Special Rule" in response.content
 
 
 @pytest.mark.django_db
@@ -787,7 +787,7 @@ def test_edit_rule_form_loads(client, group_user, pack, pack_rule):
     client.force_login(group_user)
     response = client.get(f"/pack/{pack.id}/item/{pack_rule.id}/edit/")
     assert response.status_code == 200
-    assert b"Edit Rule" in response.content
+    assert b"Edit Special Rule" in response.content
     assert b"Test Rule" in response.content
 
 
@@ -822,7 +822,7 @@ def test_delete_rule_confirmation_loads(client, group_user, pack, pack_rule):
     client.force_login(group_user)
     response = client.get(f"/pack/{pack.id}/item/{pack_rule.id}/delete/")
     assert response.status_code == 200
-    assert b"Archive Rule" in response.content
+    assert b"Archive Special Rule" in response.content
     assert b"Test Rule" in response.content
 
 
@@ -1261,7 +1261,7 @@ def test_archived_items_page_loads(client, group_user, pack, pack_rule):
     response = client.get(f"/pack/{pack.id}/archived/rule/")
     assert response.status_code == 200
     content = response.content.decode()
-    assert "Archived Rules" in content
+    assert "Archived Special Rules" in content
     assert "Test Rule" in content
     assert "Restore" in content
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -137,11 +137,12 @@ SUPPORTED_CONTENT_TYPES = [
     ),
     ContentTypeEntry(
         ContentRule,
-        "Rules",
-        "Custom rules for your Content Pack.",
+        "Special Rules",
+        "Custom special rules for your Content Pack.",
         "bi-journal-text",
         ContentRuleForm,
         "rule",
+        singular_label="Special Rule",
     ),
     ContentTypeEntry(
         ContentSkillCategory,

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -1821,7 +1821,9 @@ def add_pack_item(request, id, content_type_slug):
 
     if is_fighter:
         context["next_step_hint"] = (
-            "You can configure the Fighter statline on the next screen."
+            "You can configure the Fighter statline on the next screen. "
+            "Skill trees and Psyker disciplines can be set after you create "
+            "this Fighter — open it from the pack and use Edit."
         )
         context["next_step_button"] = "Next →"
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -3160,6 +3160,11 @@ def add_customised_weapon_profile(request, id, equipment_id):
             if _save_customised_weapon_profile(
                 request, pack, equipment, profile, form, is_new=True
             ):
+                if "save_and_customise_another" in request.POST:
+                    messages.success(request, f'Profile added to "{equipment}".')
+                    return HttpResponseRedirect(
+                        reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+                    )
                 return HttpResponseRedirect(back_url)
     else:
         form = ContentWeaponProfilePackForm(pack=pack)
@@ -3173,6 +3178,9 @@ def add_customised_weapon_profile(request, id, equipment_id):
         "form_action_url": reverse(
             "core:pack-customise-weapon-profile-add",
             args=(pack.id, equipment.id),
+        ),
+        "customise_another_url": reverse(
+            "core:pack-customise-weapon-picker", args=(pack.id,)
         ),
         "weapon_stat_fields": _build_weapon_stat_context(request),
     }
@@ -3209,6 +3217,11 @@ def edit_customised_weapon_profile(request, id, equipment_id, profile_id):
             if _save_customised_weapon_profile(
                 request, pack, equipment, updated, form, is_new=False
             ):
+                if "save_and_customise_another" in request.POST:
+                    messages.success(request, f'Profile on "{equipment}" saved.')
+                    return HttpResponseRedirect(
+                        reverse("core:pack-customise-weapon-picker", args=(pack.id,))
+                    )
                 return HttpResponseRedirect(back_url)
     else:
         form = ContentWeaponProfilePackForm(instance=profile, pack=pack)
@@ -3240,6 +3253,9 @@ def edit_customised_weapon_profile(request, id, equipment_id, profile_id):
         "delete_url": reverse(
             "core:pack-customise-weapon-profile-delete",
             args=(pack.id, equipment.id, profile.id),
+        ),
+        "customise_another_url": reverse(
+            "core:pack-customise-weapon-picker", args=(pack.id,)
         ),
         "weapon_stat_values": weapon_stat_context,
     }


### PR DESCRIPTION
## Summary

Small UX iteration on content packs:

- Add "Save and customise a different weapon" button on the customise-weapon profile add/edit forms, redirecting to the picker.
- Swap "Add a Rule" for "Add gear" in the pack quick-add panel.
- Rename pack "Rules" section to "Special Rules" to disambiguate from the new House Rules section. Slug/URL/model names unchanged.
- Update the fighter-creation hint to mention that skill trees and psyker disciplines are configured after initial creation via Edit.

## Test plan

- [ ] Customise a library weapon: add a profile, click "Save and customise a different weapon" → lands on the customise-weapon picker.
- [ ] Edit an existing pack-scoped profile, click "Save and customise a different weapon" → lands on the picker with the profile saved.
- [ ] Pack page quick-add panel shows "Add gear" in place of "Add a Rule".
- [ ] Pack section header reads "Special Rules"; empty-state link reads "Add a special rule →".
- [ ] Fighter create form shows the updated next-step hint mentioning skill trees and psyker disciplines.