### PR TITLE
chore: tighten dependabot grouping to reduce PR fragmentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
     groups:
-      minor-and-patch:
+      python-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
           - "patch"
           - "minor"
-      major:
+      python-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
           - "major"
     ignore:
@@ -24,12 +32,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
     groups:
-      minor-and-patch:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
           - "patch"
           - "minor"
-      major:
+      npm-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
           - "major"
     ignore:


### PR DESCRIPTION
## Summary

- Add explicit `patterns: ["*"]` and `applies-to: version-updates` to every group, plus ecosystem-prefixed names — makes grouping intent unambiguous and avoids cross-ecosystem collisions
- Add `versioning-strategy: increase` for pip so range-bound deps stay classified as version updates rather than getting routed as requirement-only updates
- Raise `open-pull-requests-limit` to 10 as a safety ceiling

## Why

Right now Dependabot opens individual PRs every week for `>=`-constrained pip deps (pyasn1, pynacl, google-cloud-pubsub, opentelemetry-propagator-gcp) instead of folding them into the minor-and-patch group, because those changes are emitted as "requirement updates" with a different code path from `==`-pinned "version updates". The config tweaks here make the group rules as explicit as the format supports.

## Test plan

- [ ] Wait for the next Dependabot weekly run and verify it produces at most two pip PRs (minor-and-patch group + major group)
- [ ] If individual range-update PRs still appear, follow up by pinning the direct-dep subset of `>=` entries (`google-cloud-pubsub`, `google-cloud-scheduler`, `opentelemetry-*`, `pyasn1`, `PyNaCl`, `requests`, `filelock`) with `==`. Leaving `urllib3` / `virtualenv` as `>=` floors per the existing comment in requirements.txt
- [ ] Once merged, comment `@dependabot recreate` on the currently open Dependabot PRs (#1757–#1761) to re-evaluate them against the new config