### PR TITLE
chore: remove full_clean() from model save() methods

### DIFF
--- a/gyrinx/content/models/weapon.py
+++ b/gyrinx/content/models/weapon.py
@@ -82,13 +82,6 @@ class ContentWeaponTrait(Content):
                 {"name": "A base weapon trait with this name already exists."}
             )
 
-    def save(self, *args, **kwargs):
-        # Run full_clean so direct ORM writes (objects.create, fixtures, data
-        # migrations) also enforce base-only name uniqueness. ModelForm flows
-        # already trigger this via form.is_valid().
-        self.full_clean()
-        return super().save(*args, **kwargs)
-
     def __str__(self):
         return self.name
 
@@ -501,13 +494,6 @@ class ContentWeaponAccessory(FighterCostMixin, Content):
             raise ValidationError(
                 {"name": "A base weapon accessory with this name already exists."}
             )
-
-    def save(self, *args, **kwargs):
-        # Run full_clean so direct ORM writes (objects.create, fixtures, data
-        # migrations) also enforce base-only name uniqueness. ModelForm flows
-        # already trigger this via form.is_valid().
-        self.full_clean()
-        return super().save(*args, **kwargs)
 
     def __str__(self):
         return self.name

--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -5949,11 +5949,6 @@ class ListAttributeAssignment(Base, Archived):
                         f"The attribute '{attribute.name}' is single-select and already has a value assigned to this list."
                     )
 
-    def save(self, *args, **kwargs):
-        """Override save to call full_clean() for validation."""
-        self.full_clean()
-        super().save(*args, **kwargs)
-
 
 class CapturedFighter(AppBase):
     """Tracks a fighter being held captive by another gang."""

--- a/gyrinx/core/models/upload.py
+++ b/gyrinx/core/models/upload.py
@@ -127,9 +127,3 @@ class UploadedFile(AppBase):
                 raise ValidationError(
                     f"File type '{self.content_type}' is not allowed. Allowed types: JPEG, PNG, GIF, WebP, SVG."
                 )
-
-    def save(self, *args, **kwargs):
-        """Override save to validate before saving."""
-        # Always validate before saving
-        self.full_clean()
-        super().save(*args, **kwargs)

--- a/gyrinx/core/tests/test_pack_weapon_accessories.py
+++ b/gyrinx/core/tests/test_pack_weapon_accessories.py
@@ -678,16 +678,6 @@ def test_base_accessory_model_level_uniqueness():
     assert "name" in exc_info.value.message_dict
 
 
-@pytest.mark.django_db
-def test_base_accessory_orm_create_rejects_duplicate():
-    """Direct objects.create() also enforces base uniqueness via save() →
-    full_clean(). Without this hook, fixtures or data migrations could quietly
-    insert duplicate base accessories."""
-    ContentWeaponAccessory.objects.create(name="Hot Shot Las")
-    with pytest.raises(ValidationError):
-        ContentWeaponAccessory.objects.create(name="Hot Shot Las")
-
-
 # --- Pack detail rendering ----------------------------------------------------
 
 

--- a/gyrinx/core/views/upload.py
+++ b/gyrinx/core/views/upload.py
@@ -52,6 +52,7 @@ def tinymce_upload(request):
             file_size=file_size,
             content_type=content_type,
         )
+        upload.full_clean()
         upload.save()
 
         # Log the file upload event


### PR DESCRIPTION
## Summary

- Drop `self.full_clean()` from `save()` on `ContentWeaponTrait`, `ContentWeaponAccessory`, `ListAttributeAssignment`, and `UploadedFile` — per the **Base Model Architecture** convention in `CLAUDE.md`.
- Move upload validation to the boundary: `views/upload.py` now calls `upload.full_clean()` before `save()`, keeping the 10MB per-file cap and image-MIME allow-list enforced. Without this, the TinyMCE endpoint would silently accept arbitrary file types and sizes up to the 100MB daily quota.
- Weapon trait/accessory uniqueness is covered by `ContentWeaponTraitPackForm.clean_name` / `ContentWeaponAccessoryPackForm.clean_name` (which also add in-pack uniqueness — stronger than the model's `clean()`). The list-attribute single-select invariant is satisfied by construction in `AttributeForm.save()`, which archives existing values before `get_or_create`.

## Test plan

- [x] `pytest gyrinx/core/tests/test_list_attributes.py gyrinx/core/tests/test_upload.py` — 22 pass
- [x] `pytest gyrinx/content/tests/test_weapons.py gyrinx/content/tests/test_weapon_accessory_cost_expression.py gyrinx/core/tests/test_models_pack.py gyrinx/core/tests/test_pack_weapon_accessories.py` — 67 pass
- [x] `test_upload_file_too_large` and `test_upload_invalid_file_type` still fail the request, confirming validation moved cleanly to the view layer

Closes #1749