### PR TITLE
feat: required Content Packs for Campaigns

### DIFF
--- a/gyrinx/core/admin/campaign.py
+++ b/gyrinx/core/admin/campaign.py
@@ -9,10 +9,18 @@ from gyrinx.core.models.campaign import (
     CampaignAssetType,
     CampaignAttributeType,
     CampaignAttributeValue,
+    CampaignContentPack,
     CampaignListAttributeAssignment,
     CampaignListResource,
     CampaignResourceType,
 )
+
+
+class CampaignContentPackInline(admin.TabularInline):
+    model = CampaignContentPack
+    extra = 0
+    autocomplete_fields = ["pack"]
+    fields = ["pack", "required"]
 
 
 @admin.register(Campaign)
@@ -21,6 +29,15 @@ class CampaignAdmin(BaseAdmin):
     search_fields = ["name", "owner__username"]
     list_filter = ["status", "public", "template", "created"]
     fields = ["name", "owner", "status", "public", "template", "summary", "narrative"]
+    inlines = [CampaignContentPackInline]
+
+
+@admin.register(CampaignContentPack)
+class CampaignContentPackAdmin(admin.ModelAdmin):
+    list_display = ["campaign", "pack", "required"]
+    list_filter = ["required"]
+    search_fields = ["campaign__name", "pack__name"]
+    autocomplete_fields = ["campaign", "pack"]
 
 
 @admin.register(CampaignAction)

--- a/gyrinx/core/handlers/campaign_copy.py
+++ b/gyrinx/core/handlers/campaign_copy.py
@@ -10,6 +10,7 @@ from gyrinx.core.models.campaign import (
     CampaignAssetType,
     CampaignAttributeType,
     CampaignAttributeValue,
+    CampaignContentPack,
     CampaignResourceType,
     CampaignSubAsset,
 )
@@ -277,13 +278,20 @@ def copy_campaign_content(
                 )
                 result.attribute_values_copied += 1
 
-    # Copy packs (add by reference — packs are shared entities, not cloned)
+    # Copy packs (add by reference — packs are shared entities, not cloned).
+    # Carry the `required` flag from the source link onto the target link.
     if pack_ids:
         existing_pack_ids = set(target_campaign.packs.values_list("id", flat=True))
-        source_packs = source_campaign.packs.filter(id__in=pack_ids)
-        for pack in source_packs:
-            if pack.id not in existing_pack_ids:
-                target_campaign.packs.add(pack)
+        source_links = source_campaign.pack_links.filter(
+            pack_id__in=pack_ids
+        ).select_related("pack")
+        for link in source_links:
+            if link.pack_id not in existing_pack_ids:
+                CampaignContentPack.objects.create(
+                    campaign=target_campaign,
+                    pack=link.pack,
+                    required=link.required,
+                )
                 result.packs_copied += 1
 
     return result

--- a/gyrinx/core/migrations/0143_campaign_content_pack_through.py
+++ b/gyrinx/core/migrations/0143_campaign_content_pack_through.py
@@ -1,0 +1,92 @@
+"""Promote Campaign.packs to a through-model so packs can be flagged as required.
+
+The existing implicit M2M join table (`core_campaign_packs`) keeps its data —
+state-only operations introduce the through model and rewire `Campaign.packs`,
+while the database is only altered to add the new `required` column.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0142_add_featured_fields_to_custom_content_pack"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="CampaignContentPack",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        (
+                            "required",
+                            models.BooleanField(
+                                default=False,
+                                help_text=(
+                                    "If true, every list in this campaign must "
+                                    "be subscribed to this pack."
+                                ),
+                            ),
+                        ),
+                        (
+                            "campaign",
+                            models.ForeignKey(
+                                on_delete=django.db.models.deletion.CASCADE,
+                                related_name="pack_links",
+                                to="core.campaign",
+                            ),
+                        ),
+                        (
+                            "pack",
+                            models.ForeignKey(
+                                db_column="customcontentpack_id",
+                                on_delete=django.db.models.deletion.CASCADE,
+                                related_name="campaign_links",
+                                to="core.customcontentpack",
+                            ),
+                        ),
+                    ],
+                    options={
+                        "db_table": "core_campaign_packs",
+                        "unique_together": {("campaign", "pack")},
+                    },
+                ),
+                migrations.AlterField(
+                    model_name="campaign",
+                    name="packs",
+                    field=models.ManyToManyField(
+                        blank=True,
+                        help_text=(
+                            "Content packs allowed for this campaign. "
+                            "Empty means no restrictions."
+                        ),
+                        related_name="campaigns",
+                        through="core.CampaignContentPack",
+                        to="core.customcontentpack",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        "ALTER TABLE core_campaign_packs "
+                        "ADD COLUMN required boolean NOT NULL DEFAULT false;"
+                    ),
+                    reverse_sql=(
+                        "ALTER TABLE core_campaign_packs DROP COLUMN required;"
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/gyrinx/core/models/campaign.py
+++ b/gyrinx/core/models/campaign.py
@@ -87,6 +87,7 @@ class Campaign(AppBase):
         "CustomContentPack",
         blank=True,
         related_name="campaigns",
+        through="CampaignContentPack",
         help_text="Content packs allowed for this campaign. Empty means no restrictions.",
     )
 
@@ -211,6 +212,15 @@ class Campaign(AppBase):
             return True
         return False
 
+    def required_packs(self):
+        """Return packs marked as required for this campaign."""
+        from gyrinx.core.models.pack import CustomContentPack
+
+        return CustomContentPack.objects.filter(
+            campaign_links__campaign=self,
+            campaign_links__required=True,
+        )
+
     def validate_list_packs(self, list_to_add):
         """Validate that a list's packs are compatible with campaign packs.
 
@@ -234,6 +244,33 @@ class Campaign(AppBase):
         incompatible = [p for p in list_packs if p.id not in campaign_pack_ids]
 
         return len(incompatible) == 0, incompatible
+
+    def validate_list_required_packs(self, list_to_add):
+        """Validate the list is subscribed to every required pack on this campaign.
+
+        Args:
+            list_to_add: The List to validate
+
+        Returns:
+            tuple: (is_valid: bool, missing_packs: list[CustomContentPack])
+        """
+        from gyrinx.core.models.pack import CustomContentPack
+
+        required_ids = set(
+            self.pack_links.filter(required=True).values_list("pack_id", flat=True)
+        )
+        if not required_ids:
+            return True, []
+
+        list_pack_ids = set(list_to_add.packs.values_list("id", flat=True))
+        missing = required_ids - list_pack_ids
+        if not missing:
+            return True, []
+
+        missing_packs = list(
+            CustomContentPack.objects.filter(id__in=missing).order_by("name")
+        )
+        return False, missing_packs
 
     def add_list_to_campaign(self, list_to_add, user=None):
         """Add a list to the campaign, cloning if necessary.
@@ -262,6 +299,14 @@ class Campaign(AppBase):
             raise ValueError(
                 f"This gang has content packs not allowed by this campaign: {pack_names}. "
                 f"Unsubscribe from these packs before joining."
+            )
+
+        has_required, missing_required = self.validate_list_required_packs(list_to_add)
+        if not has_required:
+            pack_names = ", ".join(p.name for p in missing_required)
+            raise ValueError(
+                f"This gang is missing required Content Packs for this Campaign: {pack_names}. "
+                f"Subscribe to these packs before joining."
             )
 
         if self.is_pre_campaign:
@@ -311,6 +356,37 @@ class Campaign(AppBase):
         else:
             # Post-campaign: cannot add lists
             raise ValueError("Cannot add lists to a completed campaign")
+
+
+class CampaignContentPack(models.Model):
+    """Through-model for Campaign.packs. The `required` flag means every list
+    in the campaign must be subscribed to this pack."""
+
+    campaign = models.ForeignKey(
+        Campaign,
+        related_name="pack_links",
+        on_delete=models.CASCADE,
+    )
+    pack = models.ForeignKey(
+        "CustomContentPack",
+        related_name="campaign_links",
+        on_delete=models.CASCADE,
+        # Preserve the existing implicit-M2M column name so the data migration
+        # is state-only — no table drop/rebuild.
+        db_column="customcontentpack_id",
+    )
+    required = models.BooleanField(
+        default=False,
+        help_text="If true, every list in this campaign must be subscribed to this pack.",
+    )
+
+    class Meta:
+        # Keep the table Django implicitly created for the original M2M.
+        db_table = "core_campaign_packs"
+        unique_together = [("campaign", "pack")]
+
+    def __str__(self):
+        return f"{self.campaign.name} ⇒ {self.pack.name}"
 
 
 class CampaignAction(AppBase):

--- a/gyrinx/core/models/campaign.py
+++ b/gyrinx/core/models/campaign.py
@@ -292,7 +292,9 @@ class Campaign(AppBase):
         if user is None:
             user = self.owner
 
-        # Validate pack compatibility
+        # Validate pack subset (campaign packs ⊇ list packs). Reads M2M state
+        # that isn't mutated by the required-toggle path, so it doesn't need
+        # the through-row lock.
         is_valid, incompatible_packs = self.validate_list_packs(list_to_add)
         if not is_valid:
             pack_names = ", ".join(p.name for p in incompatible_packs)
@@ -301,61 +303,72 @@ class Campaign(AppBase):
                 f"Unsubscribe from these packs before joining."
             )
 
-        has_required, missing_required = self.validate_list_required_packs(list_to_add)
-        if not has_required:
-            pack_names = ", ".join(p.name for p in missing_required)
-            raise ValueError(
-                f"This gang is missing required Content Packs for this Campaign: {pack_names}. "
-                f"Subscribe to these packs before joining."
-            )
-
-        if self.is_pre_campaign:
-            # Pre-campaign: check if list is already in campaign
-            if list_to_add in self.lists.all():
-                return list_to_add, False
-            # Add the list directly
-            self.lists.add(list_to_add)
-            return list_to_add, True
-        elif self.is_in_progress:
-            with transaction.atomic():
-                # Check if we already have a clone of this list
-                if self.has_clone_of_list(list_to_add):
-                    logger.warning(
-                        f"Campaign {self.id} already has a clone of list {list_to_add.id}, skipping"
-                    )
-                    # Return the existing clone
-                    return self.lists.get(original_list=list_to_add), False
-
-                # In-progress: clone the list using the handler
-                from gyrinx.core.handlers.list import handle_list_clone
-
-                clone_result = handle_list_clone(
-                    user=user,
-                    original_list=list_to_add,
-                    for_campaign=self,
-                )
-                campaign_clone = clone_result.cloned_list
-                self.lists.add(campaign_clone)
-
-                # Distribute budget credits to the new gang
-                self._distribute_budget_to_list(campaign_clone)
-
-                # Allocate default resources to the new list
-                for resource_type in self.resource_types.all():
-                    CampaignListResource.objects.get_or_create(
-                        campaign=self,
-                        resource_type=resource_type,
-                        list=campaign_clone,
-                        defaults={
-                            "amount": resource_type.default_amount,
-                            "owner": self.owner,  # Campaign owner owns the resource tracking
-                        },
-                    )
-
-                return campaign_clone, True
-        else:
+        if not (self.is_pre_campaign or self.is_in_progress):
             # Post-campaign: cannot add lists
             raise ValueError("Cannot add lists to a completed campaign")
+
+        # Take the same row lock as campaign_pack_set_required so a concurrent
+        # required-flag flip can't sneak in between validate_list_required_packs
+        # and the list write below. Without this, the toggle's "are all
+        # current lists compliant?" check would succeed (the list isn't in
+        # self.lists yet) and commit required=True, then we'd add a list that
+        # lacks the now-required pack.
+        with transaction.atomic():
+            list(self.pack_links.select_for_update().all())
+
+            has_required, missing_required = self.validate_list_required_packs(
+                list_to_add
+            )
+            if not has_required:
+                pack_names = ", ".join(p.name for p in missing_required)
+                raise ValueError(
+                    f"This gang is missing required Content Packs for this Campaign: {pack_names}. "
+                    f"Subscribe to these packs before joining."
+                )
+
+            if self.is_pre_campaign:
+                # Pre-campaign: check if list is already in campaign
+                if list_to_add in self.lists.all():
+                    return list_to_add, False
+                # Add the list directly
+                self.lists.add(list_to_add)
+                return list_to_add, True
+
+            # In-progress: clone the list using the handler
+            # Check if we already have a clone of this list
+            if self.has_clone_of_list(list_to_add):
+                logger.warning(
+                    f"Campaign {self.id} already has a clone of list {list_to_add.id}, skipping"
+                )
+                # Return the existing clone
+                return self.lists.get(original_list=list_to_add), False
+
+            from gyrinx.core.handlers.list import handle_list_clone
+
+            clone_result = handle_list_clone(
+                user=user,
+                original_list=list_to_add,
+                for_campaign=self,
+            )
+            campaign_clone = clone_result.cloned_list
+            self.lists.add(campaign_clone)
+
+            # Distribute budget credits to the new gang
+            self._distribute_budget_to_list(campaign_clone)
+
+            # Allocate default resources to the new list
+            for resource_type in self.resource_types.all():
+                CampaignListResource.objects.get_or_create(
+                    campaign=self,
+                    resource_type=resource_type,
+                    list=campaign_clone,
+                    defaults={
+                        "amount": resource_type.default_amount,
+                        "owner": self.owner,  # Campaign owner owns the resource tracking
+                    },
+                )
+
+            return campaign_clone, True
 
 
 class CampaignContentPack(models.Model):

--- a/gyrinx/core/templates/core/campaign/campaign_packs.html
+++ b/gyrinx/core/templates/core/campaign/campaign_packs.html
@@ -27,12 +27,30 @@
                 {% if campaign_packs %}
                     <ul class="list-unstyled mb-0">
                         {% for pack in campaign_packs %}
-                            <li class="py-2 d-flex justify-content-between align-items-center border-bottom">
+                            <li class="py-2 d-flex justify-content-between align-items-center gap-2 border-bottom">
                                 <div>
                                     <a href="{% url 'core:pack' pack.id %}" class="linked fw-medium">{{ pack.name }}</a>
                                     <span class="text-secondary fs-7">by {{ pack.owner.username }}</span>
+                                    {% if pack.is_required and not can_edit_required %}<span class="badge text-bg-warning ms-1">Required</span>{% endif %}
                                 </div>
                                 <div class="d-flex align-items-center gap-2">
+                                    {% if can_edit_required %}
+                                        <form method="post"
+                                              action="{% url 'core:campaign-pack-set-required' campaign.id pack.id %}"
+                                              class="form-check form-switch mb-0">
+                                            {% csrf_token %}
+                                            <input type="hidden" name="required" value="0">
+                                            <input class="form-check-input"
+                                                   type="checkbox"
+                                                   role="switch"
+                                                   id="required-{{ pack.id }}"
+                                                   name="required"
+                                                   value="1"
+                                                   data-gy-toggle-submit
+                                                   {% if pack.is_required %}checked{% endif %}>
+                                            <label class="form-check-label fs-7 mb-0" for="required-{{ pack.id }}">Required</label>
+                                        </form>
+                                    {% endif %}
                                     {% if user_campaign_lists %}
                                         <div class="btn-group" role="group">
                                             <button type="button"

--- a/gyrinx/core/templates/core/campaign/campaign_packs.html
+++ b/gyrinx/core/templates/core/campaign/campaign_packs.html
@@ -84,7 +84,7 @@
                                             </ul>
                                         </div>
                                     {% endif %}
-                                    {% if is_owner and not campaign.archived %}
+                                    {% if is_owner and not campaign.archived and not campaign.is_post_campaign %}
                                         <a href="{% url 'core:campaign-pack-remove' campaign.id pack.id %}"
                                            class="icon-link link-danger fs-7"
                                            aria-label="Remove {{ pack.name }} from campaign">
@@ -107,7 +107,7 @@
             </div>
         </section>
         <!-- Add packs (owner only) -->
-        {% if is_owner and not campaign.archived %}
+        {% if is_owner and not campaign.archived and not campaign.is_post_campaign %}
             <section>
                 <div class="d-flex justify-content-between align-items-center mb-2 bg-body-tertiary rounded px-2 py-2">
                     <h2 class="h5 mb-0">Add Packs</h2>

--- a/gyrinx/core/templates/core/list/invitation_pack_setup.html
+++ b/gyrinx/core/templates/core/list/invitation_pack_setup.html
@@ -9,6 +9,7 @@
         <p class="text-muted small">
             {{ campaign.name }} uses the following Content Packs.
             Select the ones you'd like to add to <strong>{{ list.name }}</strong>.
+            Packs marked <span class="badge text-bg-warning">Required</span> must be added to join this Campaign.
         </p>
         <form method="post"
               action="{% url 'core:invitation-pack-setup' list.id campaign.id %}"
@@ -22,9 +23,14 @@
                                name="pack_ids"
                                value="{{ pack.id }}"
                                class="form-check-input mt-1"
-                               checked>
+                               checked
+                               {% if pack.is_required %}disabled{% endif %}>
+                        {% if pack.is_required %}<input type="hidden" name="pack_ids" value="{{ pack.id }}">{% endif %}
                         <div class="flex-grow-1">
-                            <div class="fw-medium small">{{ pack.name }}</div>
+                            <div class="fw-medium small">
+                                {{ pack.name }}
+                                {% if pack.is_required %}<span class="badge text-bg-warning ms-1">Required</span>{% endif %}
+                            </div>
                             <div class="text-muted small">by {{ pack.owner }}</div>
                             {% if pack.summary %}<div class="text-muted small mt-1">{{ pack.summary|striptags|truncatewords:20 }}</div>{% endif %}
                         </div>

--- a/gyrinx/core/templates/core/list_packs.html
+++ b/gyrinx/core/templates/core/list_packs.html
@@ -56,7 +56,7 @@
                 {% if subscribed_packs %}
                     <ul class="list-unstyled mb-0">
                         {% for pack in subscribed_packs %}
-                            <li class="py-2 d-flex justify-content-between align-items-center border-bottom">
+                            <li class="py-2 d-flex justify-content-between align-items-center gap-2 border-bottom">
                                 <div>
                                     {% if pack.listed or pack.owner == request.user %}
                                         <a href="{% url 'core:pack' pack.id %}" class="linked fw-medium">{{ pack.name }}</a>
@@ -64,16 +64,24 @@
                                         <span class="fw-medium">{{ pack.name }}</span>
                                     {% endif %}
                                     <span class="text-secondary fs-7">by {{ pack.owner }}</span>
+                                    {% if pack.required_by_campaigns %}
+                                        <span class="badge text-bg-warning ms-1"
+                                              title="Required by {{ pack.required_by_campaigns|join:', ' }}">
+                                            Required by {{ pack.required_by_campaigns|join:", " }}
+                                        </span>
+                                    {% endif %}
                                     {% if pack.summary %}<div class="text-secondary fs-7">{{ pack.summary|striptags|truncatewords:20 }}</div>{% endif %}
                                 </div>
-                                <form method="post"
-                                      action="{% url 'core:pack-unsubscribe' pack.id %}"
-                                      class="d-inline">
-                                    {% csrf_token %}
-                                    <input type="hidden" name="list_id" value="{{ list.id }}">
-                                    <input type="hidden" name="return_url" value="list">
-                                    <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>
-                                </form>
+                                {% if not pack.required_by_campaigns %}
+                                    <form method="post"
+                                          action="{% url 'core:pack-unsubscribe' pack.id %}"
+                                          class="d-inline">
+                                        {% csrf_token %}
+                                        <input type="hidden" name="list_id" value="{{ list.id }}">
+                                        <input type="hidden" name="return_url" value="list">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>
+                                    </form>
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>

--- a/gyrinx/core/tests/test_campaign_packs.py
+++ b/gyrinx/core/tests/test_campaign_packs.py
@@ -1091,3 +1091,372 @@ def test_campaign_packs_owner_sees_both_controls(
     assert "Owner Gang" in content
     assert "Add Packs" in content
     assert "bi-trash" in content
+
+
+# --- Required content pack tests ---
+
+
+def _mark_pack_required(campaign, pack):
+    """Helper: flip the through-row's required flag without going through the view."""
+    from gyrinx.core.models.campaign import CampaignContentPack
+
+    link = CampaignContentPack.objects.get(campaign=campaign, pack=pack)
+    link.required = True
+    link.save()
+    return link
+
+
+@pytest.mark.django_db
+def test_validate_list_required_packs_no_required(user, make_campaign, make_list):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Pack A", owner=user, listed=True)
+    campaign.packs.add(pack)
+
+    has_all, missing = campaign.validate_list_required_packs(lst)
+    assert has_all is True
+    assert missing == []
+
+
+@pytest.mark.django_db
+def test_validate_list_required_packs_missing(user, make_campaign, make_list):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Mandatory", owner=user, listed=True)
+    campaign.packs.add(pack)
+    _mark_pack_required(campaign, pack)
+
+    has_all, missing = campaign.validate_list_required_packs(lst)
+    assert has_all is False
+    assert [p.name for p in missing] == ["Mandatory"]
+
+
+@pytest.mark.django_db
+def test_validate_list_required_packs_satisfied(user, make_campaign, make_list):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Mandatory", owner=user, listed=True)
+    campaign.packs.add(pack)
+    _mark_pack_required(campaign, pack)
+    lst.packs.add(pack)
+
+    has_all, missing = campaign.validate_list_required_packs(lst)
+    assert has_all is True
+    assert missing == []
+
+
+@pytest.mark.django_db
+def test_add_list_to_campaign_blocks_missing_required_pack(
+    user, make_campaign, make_list
+):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Mandatory", owner=user, listed=True)
+    campaign.packs.add(pack)
+    _mark_pack_required(campaign, pack)
+
+    with pytest.raises(ValueError, match="Mandatory"):
+        campaign.add_list_to_campaign(lst, user=user)
+    assert lst not in campaign.lists.all()
+
+
+@pytest.mark.django_db
+def test_add_list_to_campaign_blocks_required_in_progress(
+    user, make_campaign, make_list
+):
+    """Required-pack check runs for in-progress campaigns too (pre-clone)."""
+    campaign = make_campaign("Test Campaign")
+    pack = CustomContentPack.objects.create(name="Mandatory", owner=user, listed=True)
+    campaign.packs.add(pack)
+    _mark_pack_required(campaign, pack)
+
+    # Add a compliant list first, then start the campaign.
+    compliant = make_list("Compliant")
+    compliant.packs.add(pack)
+    campaign.add_list_to_campaign(compliant, user=user)
+    campaign.status = Campaign.IN_PROGRESS
+    campaign.save()
+
+    non_compliant = make_list("Non-Compliant")
+    with pytest.raises(ValueError, match="Mandatory"):
+        campaign.add_list_to_campaign(non_compliant, user=user)
+
+
+@pytest.mark.django_db
+def test_add_list_succeeds_when_required_packs_satisfied(
+    user, make_campaign, make_list
+):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Mandatory", owner=user, listed=True)
+    campaign.packs.add(pack)
+    _mark_pack_required(campaign, pack)
+    lst.packs.add(pack)
+
+    added, was_added = campaign.add_list_to_campaign(lst, user=user)
+    assert was_added is True
+    assert lst in campaign.lists.all()
+
+
+@pytest.mark.django_db
+def test_pack_unsubscribe_blocked_when_required(client, user, make_campaign, make_list):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Mandatory", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+    _mark_pack_required(campaign, pack)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:pack-unsubscribe", args=[pack.id]),
+        {"list_id": str(lst.id), "return_url": "list"},
+    )
+    assert response.status_code == 302
+    assert pack in lst.packs.all()  # still subscribed
+
+
+@pytest.mark.django_db
+def test_pack_unsubscribe_allowed_when_not_required(
+    client, user, make_campaign, make_list
+):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Optional", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+    # Not marked as required.
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:pack-unsubscribe", args=[pack.id]),
+        {"list_id": str(lst.id), "return_url": "list"},
+    )
+    assert response.status_code == 302
+    assert pack not in lst.packs.all()
+
+
+@pytest.mark.django_db
+def test_campaign_pack_set_required_success(client, user, make_campaign, make_list):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Pack A", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:campaign-pack-set-required", args=[campaign.id, pack.id]),
+        {"required": "1"},
+    )
+    assert response.status_code == 302
+    from gyrinx.core.models.campaign import CampaignContentPack
+
+    link = CampaignContentPack.objects.get(campaign=campaign, pack=pack)
+    assert link.required is True
+
+
+@pytest.mark.django_db
+def test_campaign_pack_set_required_blocks_non_compliant(
+    client, user, make_campaign, make_list
+):
+    """Cannot flip required=True while a list in the campaign lacks the pack."""
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Pack A", owner=user, listed=True)
+    campaign.packs.add(pack)
+    # Note: list is NOT subscribed to pack.
+    campaign.add_list_to_campaign(lst, user=user)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:campaign-pack-set-required", args=[campaign.id, pack.id]),
+        {"required": "1"},
+    )
+    assert response.status_code == 302
+    from gyrinx.core.models.campaign import CampaignContentPack
+
+    link = CampaignContentPack.objects.get(campaign=campaign, pack=pack)
+    assert link.required is False
+
+
+@pytest.mark.django_db
+def test_campaign_pack_set_required_unset_always_allowed(
+    client, user, make_campaign, make_list
+):
+    """Flipping required=False is allowed even if lists were depending on it."""
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Pack A", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+    _mark_pack_required(campaign, pack)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:campaign-pack-set-required", args=[campaign.id, pack.id]),
+        {"required": "0"},
+    )
+    assert response.status_code == 302
+    from gyrinx.core.models.campaign import CampaignContentPack
+
+    link = CampaignContentPack.objects.get(campaign=campaign, pack=pack)
+    assert link.required is False
+    # Subscription stays put.
+    assert pack in lst.packs.all()
+
+
+@pytest.mark.django_db
+def test_campaign_pack_set_required_blocked_post_campaign(
+    client, user, make_campaign, make_list
+):
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Pack A", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+    campaign.status = Campaign.POST_CAMPAIGN
+    campaign.save()
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:campaign-pack-set-required", args=[campaign.id, pack.id]),
+        {"required": "1"},
+    )
+    assert response.status_code == 302
+    from gyrinx.core.models.campaign import CampaignContentPack
+
+    link = CampaignContentPack.objects.get(campaign=campaign, pack=pack)
+    assert link.required is False
+
+
+@pytest.mark.django_db
+def test_campaign_pack_remove_preserves_list_subscriptions(
+    client, user, make_campaign, make_list
+):
+    """Removing a pack from the campaign should not unsubscribe lists."""
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack = CustomContentPack.objects.create(name="Pack A", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:campaign-pack-remove", args=[campaign.id, pack.id])
+    )
+    assert response.status_code == 302
+    assert pack not in campaign.packs.all()
+    assert pack in lst.packs.all()
+
+
+@pytest.mark.django_db
+def test_invitation_pack_setup_rejects_unticked_required(
+    client, user, make_campaign, make_list
+):
+    """The user cannot submit invitation_pack_setup without ticking required packs."""
+    campaign = make_campaign("Test Campaign")
+    lst = make_list("Test List")
+    pack_required = CustomContentPack.objects.create(
+        name="Mandatory", owner=user, listed=True
+    )
+    pack_optional = CustomContentPack.objects.create(
+        name="Optional", owner=user, listed=True
+    )
+    campaign.packs.add(pack_required, pack_optional)
+    _mark_pack_required(campaign, pack_required)
+    campaign.lists.add(lst)
+
+    client.force_login(user)
+    # POST only the optional pack — the required one is missing.
+    response = client.post(
+        reverse("core:invitation-pack-setup", args=[lst.id, campaign.id]),
+        {"pack_ids": [str(pack_optional.id)]},
+    )
+    # Re-renders the form with an error message rather than subscribing.
+    assert response.status_code == 200
+    assert pack_required not in lst.packs.all()
+    assert pack_optional not in lst.packs.all()
+
+
+@pytest.mark.django_db
+def test_copy_packs_carries_required_flag(user, make_campaign):
+    """Copying a campaign pack preserves the required flag on the target."""
+    from gyrinx.core.handlers.campaign_copy import copy_campaign_content
+    from gyrinx.core.models.campaign import CampaignContentPack
+
+    src = make_campaign("Source")
+    tgt = make_campaign("Target")
+    pack_req = CustomContentPack.objects.create(name="Req", owner=user, listed=True)
+    pack_opt = CustomContentPack.objects.create(name="Opt", owner=user, listed=True)
+    src.packs.add(pack_req, pack_opt)
+    _mark_pack_required(src, pack_req)
+
+    copy_campaign_content(
+        source_campaign=src,
+        target_campaign=tgt,
+        user=user,
+        pack_ids=[str(pack_req.id), str(pack_opt.id)],
+    )
+
+    assert pack_req in tgt.packs.all()
+    assert pack_opt in tgt.packs.all()
+    req_link = CampaignContentPack.objects.get(campaign=tgt, pack=pack_req)
+    opt_link = CampaignContentPack.objects.get(campaign=tgt, pack=pack_opt)
+    assert req_link.required is True
+    assert opt_link.required is False
+
+
+@pytest.mark.django_db
+def test_required_packs_helper_returns_only_required(user, make_campaign):
+    campaign = make_campaign("Test Campaign")
+    pack_req = CustomContentPack.objects.create(name="Req", owner=user, listed=True)
+    pack_opt = CustomContentPack.objects.create(name="Opt", owner=user, listed=True)
+    campaign.packs.add(pack_req, pack_opt)
+    _mark_pack_required(campaign, pack_req)
+
+    required = list(campaign.required_packs())
+    assert pack_req in required
+    assert pack_opt not in required
+
+
+@pytest.mark.django_db
+def test_campaign_packs_template_shows_required_toggle(client, user, make_campaign):
+    campaign = make_campaign("Test Campaign")
+    pack = CustomContentPack.objects.create(name="Pack A", owner=user, listed=True)
+    campaign.packs.add(pack)
+
+    client.force_login(user)
+    response = client.get(reverse("core:campaign-packs", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert f"required-{pack.id}" in content
+    assert "campaign-pack-set-required" in content or "/required" in content
+
+
+@pytest.mark.django_db
+def test_list_packs_template_shows_required_by_pill(
+    client, user, make_campaign, make_list
+):
+    campaign = make_campaign("Skull Wars")
+    lst = make_list("My Gang")
+    pack = CustomContentPack.objects.create(name="House Rules", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+    _mark_pack_required(campaign, pack)
+
+    client.force_login(user)
+    response = client.get(reverse("core:list-packs", args=[lst.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Required by Skull Wars" in content
+    # The unsubscribe form action should not appear, since the pack is required.
+    unsubscribe_url = reverse("core:pack-unsubscribe", args=[pack.id])
+    assert unsubscribe_url not in content

--- a/gyrinx/core/tests/test_campaign_packs.py
+++ b/gyrinx/core/tests/test_campaign_packs.py
@@ -1530,3 +1530,66 @@ def test_unsubscribe_pack_locks_through_rows(client, user, make_campaign, make_l
         "Expected a SELECT ... FOR UPDATE on core_campaign_packs in the "
         f"unsubscribe path; got: {[q['sql'] for q in ctx.captured_queries]}"
     )
+
+
+@pytest.mark.django_db
+def test_campaign_pack_add_blocked_in_post_campaign(client, user, make_campaign):
+    """Pack add is blocked after the Campaign has ended."""
+    campaign = make_campaign("Ended Campaign")
+    pack = CustomContentPack.objects.create(
+        name="Latecomer Pack", owner=user, listed=True
+    )
+    campaign.status = Campaign.POST_CAMPAIGN
+    campaign.save()
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:campaign-pack-add", args=[campaign.id, pack.id])
+    )
+    assert response.status_code == 302
+    assert pack not in campaign.packs.all()
+
+
+@pytest.mark.django_db
+def test_campaign_pack_remove_blocked_in_post_campaign(client, user, make_campaign):
+    """Pack remove is blocked after the Campaign has ended."""
+    campaign = make_campaign("Ended Campaign 2")
+    pack = CustomContentPack.objects.create(name="Stuck Pack", owner=user, listed=True)
+    campaign.packs.add(pack)
+    campaign.status = Campaign.POST_CAMPAIGN
+    campaign.save()
+
+    client.force_login(user)
+    response = client.post(
+        reverse("core:campaign-pack-remove", args=[campaign.id, pack.id])
+    )
+    assert response.status_code == 302
+    # Still attached.
+    assert pack in campaign.packs.all()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_add_list_to_campaign_locks_through_rows(user, make_campaign, make_list):
+    """add_list_to_campaign locks pack_links so a concurrent required-flip
+    can't slip in between validation and the list write."""
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    campaign = make_campaign("Lock Test 3")
+    lst = make_list("Lock Gang 3")
+    pack = CustomContentPack.objects.create(name="Lock Pack 3", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+
+    with CaptureQueriesContext(connection) as ctx:
+        campaign.add_list_to_campaign(lst, user=user)
+
+    locking_qs = [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "core_campaign_packs" in q["sql"] and "FOR UPDATE" in q["sql"].upper()
+    ]
+    assert locking_qs, (
+        "Expected a SELECT ... FOR UPDATE on core_campaign_packs during the "
+        f"join path; got: {[q['sql'] for q in ctx.captured_queries]}"
+    )

--- a/gyrinx/core/tests/test_campaign_packs.py
+++ b/gyrinx/core/tests/test_campaign_packs.py
@@ -1460,3 +1460,73 @@ def test_list_packs_template_shows_required_by_pill(
     # The unsubscribe form action should not appear, since the pack is required.
     unsubscribe_url = reverse("core:pack-unsubscribe", args=[pack.id])
     assert unsubscribe_url not in content
+
+
+# --- Concurrency lock regression tests ---
+#
+# These assert that the required-flag toggle and the unsubscribe endpoint each
+# acquire a row lock on the CampaignContentPack through-row before reading or
+# mutating it. The lock is what serialises the two endpoints — without it, a
+# concurrent unsubscribe can slip a list out of compliance between the
+# toggle's check and its save (or vice versa).
+
+
+@pytest.mark.django_db(transaction=True)
+def test_campaign_pack_set_required_locks_through_row(
+    client, user, make_campaign, make_list
+):
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    campaign = make_campaign("Lock Test")
+    lst = make_list("Lock Gang")
+    pack = CustomContentPack.objects.create(name="Lock Pack", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+
+    client.force_login(user)
+    with CaptureQueriesContext(connection) as ctx:
+        client.post(
+            reverse("core:campaign-pack-set-required", args=[campaign.id, pack.id]),
+            {"required": "1"},
+        )
+    locking_qs = [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "core_campaign_packs" in q["sql"] and "FOR UPDATE" in q["sql"].upper()
+    ]
+    assert locking_qs, (
+        "Expected a SELECT ... FOR UPDATE on core_campaign_packs in the toggle "
+        f"path; got: {[q['sql'] for q in ctx.captured_queries]}"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_unsubscribe_pack_locks_through_rows(client, user, make_campaign, make_list):
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    campaign = make_campaign("Lock Test 2")
+    lst = make_list("Lock Gang 2")
+    pack = CustomContentPack.objects.create(name="Lock Pack 2", owner=user, listed=True)
+    campaign.packs.add(pack)
+    lst.packs.add(pack)
+    campaign.add_list_to_campaign(lst, user=user)
+    # Not required — the unsubscribe should succeed, but still emits the lock.
+
+    client.force_login(user)
+    with CaptureQueriesContext(connection) as ctx:
+        client.post(
+            reverse("core:pack-unsubscribe", args=[pack.id]),
+            {"list_id": str(lst.id), "return_url": "list"},
+        )
+    locking_qs = [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "core_campaign_packs" in q["sql"] and "FOR UPDATE" in q["sql"].upper()
+    ]
+    assert locking_qs, (
+        "Expected a SELECT ... FOR UPDATE on core_campaign_packs in the "
+        f"unsubscribe path; got: {[q['sql'] for q in ctx.captured_queries]}"
+    )

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -694,6 +694,11 @@ urlpatterns = [
         campaign_packs.campaign_pack_remove,
         name="campaign-pack-remove",
     ),
+    path(
+        "campaign/<id>/packs/<pack_id>/required",
+        campaign_packs.campaign_pack_set_required,
+        name="campaign-pack-set-required",
+    ),
     # Battles
     path(
         "campaign/<id>/battles",

--- a/gyrinx/core/views/campaign/packs.py
+++ b/gyrinx/core/views/campaign/packs.py
@@ -133,6 +133,10 @@ def campaign_pack_add(request, id, pack_id):
         messages.error(request, "Cannot modify packs for an archived Campaign.")
         return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
 
+    if campaign.is_post_campaign:
+        messages.error(request, "Cannot modify packs after a Campaign has ended.")
+        return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
+
     if not pack.listed and pack.owner != request.user:
         messages.error(request, "You don't have access to this pack.")
         return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
@@ -151,6 +155,10 @@ def campaign_pack_remove(request, id, pack_id):
 
     if campaign.archived:
         messages.error(request, "Cannot modify packs for an archived Campaign.")
+        return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
+
+    if campaign.is_post_campaign:
+        messages.error(request, "Cannot modify packs after a Campaign has ended.")
         return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
 
     if request.method == "POST":

--- a/gyrinx/core/views/campaign/packs.py
+++ b/gyrinx/core/views/campaign/packs.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
 from gyrinx import messages
-from gyrinx.core.models.campaign import Campaign
+from gyrinx.core.models.campaign import Campaign, CampaignContentPack
 from gyrinx.core.models.pack import CustomContentPack
 
 
@@ -48,6 +48,9 @@ def campaign_packs(request, id):
         raise Http404
 
     campaign_packs_qs = campaign.packs.select_related("owner").order_by("name")
+    required_pack_ids = set(
+        campaign.pack_links.filter(required=True).values_list("pack_id", flat=True)
+    )
 
     # User's gangs in this campaign, for the "Add to..." dropdown.
     user_campaign_lists = (
@@ -70,7 +73,12 @@ def campaign_packs(request, id):
         pack.unsubscribed_user_lists = [
             lst for lst in user_campaign_lists if lst.id not in subscribed_ids
         ]
+        pack.is_required = pack.id in required_pack_ids
         packs_with_lists.append(pack)
+
+    can_edit_required = (
+        is_owner and not campaign.archived and not campaign.is_post_campaign
+    )
 
     # Owner-only: available packs to add to the campaign.
     available_packs = None
@@ -107,6 +115,7 @@ def campaign_packs(request, id):
             "user_campaign_lists": user_campaign_lists,
             "search_query": search_query,
             "show_my_packs": show_my_packs,
+            "can_edit_required": can_edit_required,
         },
     )
 
@@ -157,3 +166,65 @@ def campaign_pack_remove(request, id, pack_id):
             "pack": pack,
         },
     )
+
+
+@login_required
+def campaign_pack_set_required(request, id, pack_id):
+    """Toggle whether a content pack is required for this campaign.
+
+    Arbitrator-only. Flipping a pack to required is blocked if any current list
+    in the campaign is not subscribed to it — that would silently exclude those
+    lists from the constraint. The arbitrator must either ask owners to
+    subscribe first, or remove the non-compliant lists. Flipping to optional is
+    always allowed.
+    """
+    if request.method != "POST":
+        return HttpResponseRedirect(reverse("core:campaign-packs", args=(id,)))
+
+    campaign = get_object_or_404(Campaign, id=id, owner=request.user)
+    pack = get_object_or_404(CustomContentPack, id=pack_id)
+
+    if campaign.archived:
+        messages.error(request, "Cannot modify packs for an archived Campaign.")
+        return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
+
+    if campaign.is_post_campaign:
+        messages.error(
+            request, "Cannot change required packs after a Campaign has ended."
+        )
+        return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
+
+    try:
+        link = CampaignContentPack.objects.get(campaign=campaign, pack=pack)
+    except CampaignContentPack.DoesNotExist:
+        raise Http404
+
+    required = request.POST.get("required") == "1"
+
+    if required and not link.required:
+        non_compliant = list(
+            campaign.lists.exclude(packs=pack)
+            .order_by("name")
+            .values_list("name", flat=True)
+        )
+        if non_compliant:
+            names = ", ".join(non_compliant)
+            messages.error(
+                request,
+                f"Cannot mark {pack.name} as required: these Gangs are not "
+                f"subscribed to it: {names}. Ask their owners to subscribe, or "
+                f"remove them from the Campaign first.",
+            )
+            return HttpResponseRedirect(
+                reverse("core:campaign-packs", args=(campaign.id,))
+            )
+
+    link.required = required
+    link.save(update_fields=["required"])
+
+    if required:
+        messages.success(request, f"{pack.name} is now required.")
+    else:
+        messages.success(request, f"{pack.name} is no longer required.")
+
+    return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))

--- a/gyrinx/core/views/campaign/packs.py
+++ b/gyrinx/core/views/campaign/packs.py
@@ -1,7 +1,7 @@
 """Campaign pack management views."""
 
 from django.contrib.auth.decorators import login_required
-from django.db import models
+from django.db import models, transaction
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -194,33 +194,40 @@ def campaign_pack_set_required(request, id, pack_id):
         )
         return HttpResponseRedirect(reverse("core:campaign-packs", args=(campaign.id,)))
 
-    try:
-        link = CampaignContentPack.objects.get(campaign=campaign, pack=pack)
-    except CampaignContentPack.DoesNotExist:
-        raise Http404
-
     required = request.POST.get("required") == "1"
 
-    if required and not link.required:
-        non_compliant = list(
-            campaign.lists.exclude(packs=pack)
-            .order_by("name")
-            .values_list("name", flat=True)
-        )
-        if non_compliant:
-            names = ", ".join(non_compliant)
-            messages.error(
-                request,
-                f"Cannot mark {pack.name} as required: these Gangs are not "
-                f"subscribed to it: {names}. Ask their owners to subscribe, or "
-                f"remove them from the Campaign first.",
+    # Take a row lock on the through-model row so a concurrent unsubscribe
+    # request can't slip a list out of compliance between our check and our
+    # save. `unsubscribe_pack` acquires the same row lock before reading
+    # `required`, so the two paths serialize.
+    with transaction.atomic():
+        try:
+            link = CampaignContentPack.objects.select_for_update().get(
+                campaign=campaign, pack=pack
             )
-            return HttpResponseRedirect(
-                reverse("core:campaign-packs", args=(campaign.id,))
-            )
+        except CampaignContentPack.DoesNotExist:
+            raise Http404
 
-    link.required = required
-    link.save(update_fields=["required"])
+        if required and not link.required:
+            non_compliant = list(
+                campaign.lists.exclude(packs=pack)
+                .order_by("name")
+                .values_list("name", flat=True)
+            )
+            if non_compliant:
+                names = ", ".join(non_compliant)
+                messages.error(
+                    request,
+                    f"Cannot mark {pack.name} as required: these Gangs are not "
+                    f"subscribed to it: {names}. Ask their owners to subscribe, or "
+                    f"remove them from the Campaign first.",
+                )
+                return HttpResponseRedirect(
+                    reverse("core:campaign-packs", args=(campaign.id,))
+                )
+
+        link.required = required
+        link.save(update_fields=["required"])
 
     if required:
         messages.success(request, f"{pack.name} is now required.")

--- a/gyrinx/core/views/list/invitations.py
+++ b/gyrinx/core/views/list/invitations.py
@@ -146,10 +146,38 @@ def invitation_pack_setup(request, id, campaign_id):
     # Compute suggestions from campaign packs directly — works even when the
     # list is only associated via a clone (in-progress campaigns).
     subscribed_ids = set(lst.packs.values_list("id", flat=True))
-    suggested_packs = campaign.packs.exclude(id__in=subscribed_ids)
+    required_pack_ids = set(
+        campaign.pack_links.filter(required=True).values_list("pack_id", flat=True)
+    )
+    suggested_qs = campaign.packs.exclude(id__in=subscribed_ids).order_by("name")
+    suggested_packs = []
+    for pack in suggested_qs:
+        pack.is_required = pack.id in required_pack_ids
+        suggested_packs.append(pack)
 
     if request.method == "POST":
-        pack_ids = request.POST.getlist("pack_ids")
+        pack_ids = set(request.POST.getlist("pack_ids"))
+        # Required packs cannot be skipped — always include them.
+        unmet_required = [
+            p for p in suggested_packs if p.is_required and str(p.id) not in pack_ids
+        ]
+        if unmet_required:
+            names = ", ".join(p.name for p in unmet_required)
+            messages.error(
+                request,
+                f"This Campaign requires these Content Packs: {names}. "
+                f"You must subscribe to them to join.",
+            )
+            return render(
+                request,
+                "core/list/invitation_pack_setup.html",
+                {
+                    "list": lst,
+                    "campaign": campaign,
+                    "suggested_packs": suggested_packs,
+                },
+            )
+
         if pack_ids:
             from gyrinx.core.models.pack import CustomContentPack
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -71,7 +71,7 @@ from gyrinx.core.forms.pack import (
     PackForm,
     HOUSE_RULE_TARGET_CHOICES,
 )
-from gyrinx.core.models.campaign import Campaign
+from gyrinx.core.models.campaign import Campaign, CampaignContentPack
 from gyrinx.core.models.events import EventNoun, EventVerb, log_event
 from gyrinx.core.models.list import List
 from gyrinx.core.models.pack import (
@@ -3518,9 +3518,35 @@ def unsubscribe_pack(request, id):
         raise Http404
 
     lst = get_object_or_404(List, id=list_id, owner=request.user)
-    lst.packs.remove(pack)
 
     return_url = request.POST.get("return_url", "")
+
+    # Hard-block: a pack required by any campaign this list is in cannot be
+    # unsubscribed. The arbitrator would have to flip it to optional first.
+    blocking = list(
+        Campaign.objects.filter(
+            lists=lst,
+            pack_links__pack=pack,
+            pack_links__required=True,
+        )
+        .distinct()
+        .values_list("name", flat=True)
+    )
+    if blocking:
+        names = ", ".join(blocking)
+        messages.error(
+            request,
+            f"{pack.name} is required by Campaign(s): {names}. "
+            f"You cannot unsubscribe while this Gang is in those Campaigns.",
+        )
+        if return_url == "list":
+            return HttpResponseRedirect(reverse("core:list-packs", args=(lst.id,)))
+        if return_url == "pack-lists":
+            return HttpResponseRedirect(reverse("core:pack-lists", args=(pack.id,)))
+        return HttpResponseRedirect(reverse("core:pack", args=(pack.id,)))
+
+    lst.packs.remove(pack)
+
     source = _pack_subscription_source(return_url)
     log_event(
         user=request.user,
@@ -3552,12 +3578,28 @@ def list_packs_manage(request, id):
     """Manage content pack subscriptions for a list."""
     lst = get_object_or_404(List, id=id, owner=request.user)
 
-    subscribed_packs = lst.packs.all().select_related("owner")
+    subscribed_packs = list(lst.packs.all().select_related("owner"))
+
+    # For each subscribed pack, find any Campaign this list is in that requires
+    # it. Required-by Campaigns block unsubscription and surface as a pill.
+    required_by_pack = {}
+    for link in (
+        CampaignContentPack.objects.filter(
+            required=True,
+            pack__in=subscribed_packs,
+            campaign__lists=lst,
+        )
+        .select_related("campaign")
+        .distinct()
+    ):
+        required_by_pack.setdefault(link.pack_id, []).append(link.campaign.name)
+    for pack in subscribed_packs:
+        pack.required_by_campaigns = required_by_pack.get(pack.id, [])
 
     # Available packs: listed packs or packs owned by user, excluding already subscribed
     available_packs = (
         CustomContentPack.objects.filter(archived=False)
-        .exclude(id__in=subscribed_packs.values_list("id", flat=True))
+        .exclude(id__in=[p.id for p in subscribed_packs])
         .filter(models.Q(listed=True) | models.Q(owner=request.user))
         .select_related("owner")
         .order_by("name")

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -3523,29 +3523,33 @@ def unsubscribe_pack(request, id):
 
     # Hard-block: a pack required by any campaign this list is in cannot be
     # unsubscribed. The arbitrator would have to flip it to optional first.
-    blocking = list(
-        Campaign.objects.filter(
-            lists=lst,
-            pack_links__pack=pack,
-            pack_links__required=True,
+    #
+    # The row lock here pairs with the lock in `campaign_pack_set_required` —
+    # both endpoints touch the same CampaignContentPack rows, so a concurrent
+    # required-flag flip can't race against this unsubscribe.
+    with transaction.atomic():
+        locked_links = list(
+            CampaignContentPack.objects.select_for_update()
+            .filter(pack=pack, campaign__lists=lst)
+            .select_related("campaign")
         )
-        .distinct()
-        .values_list("name", flat=True)
-    )
-    if blocking:
-        names = ", ".join(blocking)
-        messages.error(
-            request,
-            f"{pack.name} is required by Campaign(s): {names}. "
-            f"You cannot unsubscribe while this Gang is in those Campaigns.",
+        blocking = sorted(
+            {link.campaign.name for link in locked_links if link.required}
         )
-        if return_url == "list":
-            return HttpResponseRedirect(reverse("core:list-packs", args=(lst.id,)))
-        if return_url == "pack-lists":
-            return HttpResponseRedirect(reverse("core:pack-lists", args=(pack.id,)))
-        return HttpResponseRedirect(reverse("core:pack", args=(pack.id,)))
+        if blocking:
+            names = ", ".join(blocking)
+            messages.error(
+                request,
+                f"{pack.name} is required by Campaign(s): {names}. "
+                f"You cannot unsubscribe while this Gang is in those Campaigns.",
+            )
+            if return_url == "list":
+                return HttpResponseRedirect(reverse("core:list-packs", args=(lst.id,)))
+            if return_url == "pack-lists":
+                return HttpResponseRedirect(reverse("core:pack-lists", args=(pack.id,)))
+            return HttpResponseRedirect(reverse("core:pack", args=(pack.id,)))
 
-    lst.packs.remove(pack)
+        lst.packs.remove(pack)
 
     source = _pack_subscription_source(return_url)
     log_event(

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -9,8 +9,8 @@
 #
 # Usage:
 #   ./scripts/dev.sh                # Normal startup; auto-provisions a
-#                                   # per-worktree .venv in child worktrees
-#                                   # if missing.
+#                                   # per-worktree .venv and node_modules in
+#                                   # child worktrees if missing.
 #   ./scripts/dev.sh --no-watch     # Skip npm watch (CSS already built)
 #   ./scripts/dev.sh --reset-db     # Drop and re-fork the worktree database
 #   ./scripts/dev.sh --reset-venv   # Rebuild the worktree's .venv from scratch
@@ -94,6 +94,23 @@ if [ "$WT_ROOT" != "$MAIN_WT" ]; then
   # had a .venv from before this change and would otherwise never get the
   # hook installed.
   install_worktree_venv_hook "$WT_VENV/bin/activate" || true
+fi
+
+# ---------------------------------------------------------------------------
+# Provision per-worktree node_modules (child worktrees only)
+# ---------------------------------------------------------------------------
+# `npm run watch` needs Bootstrap's SCSS partials from node_modules; without
+# this, sass fails with `Can't find stylesheet to import` and the dev server
+# serves unstyled pages.  Mirrors the venv block above — main worktree is
+# assumed to be set up by the initial install steps.
+if [ "$WT_ROOT" != "$MAIN_WT" ] && [ ! -d "${WT_ROOT}/node_modules" ]; then
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "ERROR: \`npm\` is required to provision frontend deps but isn't on PATH." >&2
+    echo "Install Node (e.g. via nvm) and re-run \`./scripts/dev.sh\`." >&2
+    exit 1
+  fi
+  echo "Provisioning per-worktree node_modules at ${WT_ROOT}/node_modules..."
+  (cd "$WT_ROOT" && npm install --no-fund --no-audit)
 fi
 
 # Activate venv — child worktree's own first, then main worktree as fallback.


### PR DESCRIPTION
## Summary

- Arbitrators can flip any of a Campaign's content packs to **required**; required packs are a hard compatibility constraint, not an auto-subscribe.
- `Campaign.packs` now routes through a new `CampaignContentPack` model with a `required` boolean. The migration is state-only on the existing `core_campaign_packs` table, so all existing rows backfill cleanly to `required=false`.
- Joins, owner unsubscribes, and required-flip toggles all hard-block when a list misses a required pack; arbitrator can flip back to optional with no side effects, and invitation pack-setup enforces required packs server-side. Campaign copy carries the flag onto the target.

## Test plan

- [x] Model: `validate_list_required_packs` covers no-required / missing / satisfied
- [x] Model: `add_list_to_campaign` blocks missing required packs for pre-campaign and in-progress (pre-clone) joins
- [x] View: list owner cannot unsubscribe a pack required by any of their campaigns; optional packs still unsubscribe
- [x] View: `campaign_pack_set_required` flips on success, refuses when any list lacks the pack, allows demotion freely, blocked in POST_CAMPAIGN
- [x] View: removing a pack from a campaign does not unsubscribe the lists
- [x] View: invitation pack-setup rejects POSTs that omit a required pack
- [x] Handler: `copy_campaign_content` carries the required flag onto the target through-row
- [x] Template: `campaign_packs.html` renders the Required toggle for the owner; `list_packs.html` renders the "Required by …" pill and hides the unsubscribe form
- [x] Full core test suite: 2095 passing, 7 skipped (no new failures)
- [x] Migrations apply cleanly under `--migrations`; schema verified (`required boolean NOT NULL DEFAULT false` on `core_campaign_packs`)

Closes #1756