### PR TITLE
chore: auto-enqueue Dependabot PRs in the merge queue

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,12 +13,14 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/dependabot-auto-merge.yml` runs on `pull_request_target` and only fires for PRs authored by `dependabot[bot]`.
- Uses `dependabot/fetch-metadata` to read the update type, then calls `gh pr merge --auto --squash` — with the repo's merge queue enabled, that enqueues the PR once required checks pass.
- Skips `version-update:semver-major` so major bumps (including grouped major PRs from the existing `dependabot.yml` config) are left for manual review.

## Test plan

- [ ] Wait for the next weekly Dependabot run (or trigger one via the Dependabot tab) and confirm a minor/patch PR auto-enqueues after CI passes.
- [ ] Confirm a major-bump Dependabot PR is *not* auto-enqueued.
- [ ] Verify the workflow run logs show the `Enable auto-merge` step running for minor/patch PRs and being skipped for majors.