### PR TITLE
feat: auto-provision per-worktree .venv (closes #1772)

### DIFF
--- a/.claude/skills/worktree-db/SKILL.md
+++ b/.claude/skills/worktree-db/SKILL.md
@@ -43,6 +43,37 @@ dropdb gyrinx_wt_a1b2c3d4
 ./scripts/dev.sh
 ```
 
+### Rebuild a worktree's .venv from scratch
+```bash
+./scripts/dev.sh --reset-venv   # no-op in the main worktree
+```
+
+## Per-Worktree `.venv` (issue #1772)
+
+Each child worktree has its own `.venv` with `gyrinx` editable-installed from
+that worktree. Without this, `import gyrinx` would always resolve to the main
+worktree's source — silently missing new migrations, new models, etc. The
+symptom is `manage migrate` reporting "No migrations to apply" even though the
+worktree has a new migration file, or `pytest` failing with `ImportError`
+because the imported `gyrinx` doesn't have the worktree's new code.
+
+`./scripts/dev.sh` provisions the venv on first run in a child worktree:
+
+```bash
+uv venv "${WT_ROOT}/.venv"
+( cd "$WT_ROOT" && uv pip install --python "$WT_VENV/bin/python" --editable . )
+```
+
+Then installs the per-worktree DB env hook via
+`install_worktree_venv_hook` (from `scripts/lib/worktree.sh`). The main worktree
+continues to use whatever venv it already had — provisioning is skipped there.
+
+To verify a venv is worktree-local:
+```bash
+.venv/bin/python -c "import gyrinx; print(gyrinx.__file__)"
+# Should print a path inside the current worktree.
+```
+
 ### Run migrations on a worktree database
 ```bash
 # dev.sh runs migrate automatically on startup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,16 +43,22 @@ Each git worktree gets its own Postgres database and Django port, started with a
 
 - **Setup (once per machine):** `./scripts/setup-local-postgres.sh` — installs Postgres 16 + pgAdmin via Homebrew,
   migrates data from Docker
-- **Start dev server:** `./scripts/dev.sh` — ensures DB exists (forks from template if needed), runs migrations,
-  starts Django runserver + npm watch
+- **Start dev server:** `./scripts/dev.sh` — ensures DB exists (forks from template if needed), provisions a
+  per-worktree `.venv` on first run in a child worktree, runs migrations, starts Django runserver + npm watch
 - **Reset a worktree DB:** `./scripts/dev.sh --reset-db` — drops and re-forks from template
-- **Clean up orphans:** `./scripts/cleanup-worktree-dbs.sh` — finds/drops DBs for deleted worktrees
+- **Rebuild a worktree's venv:** `./scripts/dev.sh --reset-venv` — wipes and re-provisions `${WT_ROOT}/.venv`
+- **Clean up orphans:** `./scripts/cleanup-worktree-dbs.sh` — drops orphan DBs + reports worktree `.venv` sizes
 
 **How it works:**
 
 - Main worktree uses `gyrinx_main` database (port 8000) — this is the template with curated test data
 - Child worktrees get `gyrinx_wt_{hash}` databases forked via `CREATE DATABASE ... TEMPLATE`
 - Ports are deterministic per worktree path (range 8100-9599)
+- **Each child worktree gets its own `.venv` with `gyrinx` editable-installed from that worktree**, so
+  `import gyrinx` always resolves to worktree-local code (new migrations, new models, etc.). Without this,
+  `manage migrate` from a child worktree silently misses new migrations and `pytest` fails with
+  `ImportError`. `./scripts/dev.sh` provisions the venv via `uv venv` + `uv pip install --editable .` on
+  first run (~1 minute). Main worktree continues to use whatever venv it already had.
 - The session hook (`activate_venv_hook.sh`) auto-sets `DB_NAME` and `DJANGO_PORT` for every
   Claude Code Bash invocation
 - `setup-local-postgres.sh` appends a block to `.venv/bin/activate` so that

--- a/scripts/cleanup-worktree-dbs.sh
+++ b/scripts/cleanup-worktree-dbs.sh
@@ -94,10 +94,36 @@ if [ "$INCLUDE_TESTS" = true ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Informational: report worktree .venv sizes
+# ---------------------------------------------------------------------------
+# Each child worktree has its own .venv (#1772).  We don't reap orphan .venvs
+# — a venv lives inside its worktree directory, so `git worktree remove` (or
+# rm -rf) takes it down with the worktree.  Surface the sizes so contributors
+# can eyeball disk usage.
+report_worktree_venvs() {
+  local any=0
+  while IFS= read -r wt_path; do
+    [ -z "$wt_path" ] && continue
+    if [ -d "$wt_path/.venv" ]; then
+      if [ "$any" = 0 ]; then
+        echo
+        echo "Worktree .venv sizes:"
+        any=1
+      fi
+      local size label
+      size=$(du -sh "$wt_path/.venv" 2>/dev/null | awk '{print $1}')
+      label=$(worktree_label "$wt_path")
+      echo "  - ${label} (${wt_path}/.venv): ${size}"
+    fi
+  done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+}
+
+# ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
 if [ ${#TO_DROP[@]} -eq 0 ]; then
-  echo "Nothing to clean up."
+  echo "No databases to clean up."
+  report_worktree_venvs
   exit 0
 fi
 
@@ -120,6 +146,7 @@ fi
 if [ "$FORCE" = false ]; then
   echo
   echo "Run with --force to drop these databases."
+  report_worktree_venvs
   exit 0
 fi
 
@@ -137,3 +164,4 @@ for db in "${TO_DROP[@]}"; do
   dropdb "$db"
 done
 echo "Done. Dropped ${#TO_DROP[@]} database(s) ($total_pretty)."
+report_worktree_venvs

--- a/scripts/cleanup-worktree-dbs.sh
+++ b/scripts/cleanup-worktree-dbs.sh
@@ -111,7 +111,10 @@ report_worktree_venvs() {
         any=1
       fi
       local size label
-      size=$(du -sh "$wt_path/.venv" 2>/dev/null | awk '{print $1}')
+      # Best-effort: `du` can fail (race on dir removal, unreadable subtrees).
+      # Don't let an informational lookup crash the script under `set -euo
+      # pipefail` — fall back to "?" instead.
+      size=$(du -sh "$wt_path/.venv" 2>/dev/null | awk '{print $1}' || echo "?")
       label=$(worktree_label "$wt_path")
       echo "  - ${label} (${wt_path}/.venv): ${size}"
     fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -8,9 +8,13 @@
 # Starts Django runserver + npm watch, logs to ./logs/
 #
 # Usage:
-#   ./scripts/dev.sh              # Normal startup
-#   ./scripts/dev.sh --no-watch   # Skip npm watch (CSS already built)
-#   ./scripts/dev.sh --reset-db   # Drop and re-fork the worktree database
+#   ./scripts/dev.sh                # Normal startup; auto-provisions a
+#                                   # per-worktree .venv in child worktrees
+#                                   # if missing.
+#   ./scripts/dev.sh --no-watch     # Skip npm watch (CSS already built)
+#   ./scripts/dev.sh --reset-db     # Drop and re-fork the worktree database
+#   ./scripts/dev.sh --reset-venv   # Rebuild the worktree's .venv from scratch
+#                                   # (no-op in the main worktree)
 
 set -euo pipefail
 
@@ -22,10 +26,12 @@ source "$SCRIPT_DIR/lib/worktree.sh"
 # ---------------------------------------------------------------------------
 NO_WATCH=false
 RESET_DB=false
+RESET_VENV=false
 for arg in "$@"; do
   case "$arg" in
     --no-watch) NO_WATCH=true ;;
     --reset-db) RESET_DB=true ;;
+    --reset-venv) RESET_VENV=true ;;
     *) echo "Unknown argument: $arg"; exit 1 ;;
   esac
 done
@@ -52,8 +58,41 @@ if [ -n "$PG_BIN_DIR" ]; then
   export PATH="$PG_BIN_DIR:$PATH"
 fi
 
-# Activate venv — check worktree first, then main worktree
 MAIN_WT=$(_main_worktree)
+
+# ---------------------------------------------------------------------------
+# Provision per-worktree venv (child worktrees only)
+# ---------------------------------------------------------------------------
+# Each child worktree gets its own .venv with gyrinx editable-installed from
+# that worktree, so `import gyrinx` resolves to worktree-local code (including
+# new migrations, new models, etc.).  Without this, every Python invocation
+# from a child worktree would resolve gyrinx from the main worktree's editable
+# install — see issue #1772.
+if [ "$WT_ROOT" != "$MAIN_WT" ]; then
+  WT_VENV="${WT_ROOT}/.venv"
+  if [ "$RESET_VENV" = true ] && [ -d "$WT_VENV" ]; then
+    echo "Removing existing per-worktree venv at $WT_VENV..."
+    rm -rf "$WT_VENV"
+  fi
+  if [ ! -d "$WT_VENV" ]; then
+    if ! command -v uv >/dev/null 2>&1; then
+      echo "ERROR: \`uv\` is required to provision per-worktree venvs but isn't on PATH." >&2
+      echo "Install from https://docs.astral.sh/uv/ or re-create .venv manually:" >&2
+      echo "    python -m venv ${WT_VENV} && ${WT_VENV}/bin/pip install --editable ${WT_ROOT}" >&2
+      exit 1
+    fi
+    echo "Provisioning per-worktree venv at $WT_VENV (~1 min)..."
+    uv venv "$WT_VENV" >/dev/null
+    (
+      cd "$WT_ROOT"
+      uv pip install --python "$WT_VENV/bin/python" --editable . --quiet
+    )
+    install_worktree_venv_hook "$WT_VENV/bin/activate"
+    echo "Provisioned: $WT_VENV"
+  fi
+fi
+
+# Activate venv — child worktree's own first, then main worktree as fallback.
 VENV_PATH="${WT_ROOT}/.venv"
 if [ ! -d "$VENV_PATH" ] && [ "$WT_ROOT" != "$MAIN_WT" ]; then
   VENV_PATH="${MAIN_WT}/.venv"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -87,9 +87,13 @@ if [ "$WT_ROOT" != "$MAIN_WT" ]; then
       cd "$WT_ROOT"
       uv pip install --python "$WT_VENV/bin/python" --editable . --quiet
     )
-    install_worktree_venv_hook "$WT_VENV/bin/activate"
     echo "Provisioned: $WT_VENV"
   fi
+  # Always (re-)ensure the activate hook is present.  Idempotent — no-op if
+  # the marker is already there.  Catches the case where a child worktree
+  # had a .venv from before this change and would otherwise never get the
+  # hook installed.
+  install_worktree_venv_hook "$WT_VENV/bin/activate" || true
 fi
 
 # Activate venv — child worktree's own first, then main worktree as fallback.

--- a/scripts/lib/worktree.sh
+++ b/scripts/lib/worktree.sh
@@ -157,8 +157,10 @@ _gyrinx_set_db_env() {
   wt_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
   lib="$wt_root/scripts/lib/worktree.sh"
   [ -f "$lib" ] || return 0
+  # POSIX `.` rather than bash-only `source` — the activate script is also
+  # used from zsh/ksh.
   # shellcheck source=/dev/null
-  source "$lib"
+  . "$lib"
   export DB_NAME
   DB_NAME=$(worktree_db_name "$wt_root")
   export DJANGO_PORT

--- a/scripts/lib/worktree.sh
+++ b/scripts/lib/worktree.sh
@@ -127,3 +127,50 @@ homebrew_postgres_data_dir() {
     echo "$prefix/var/postgresql@16"
   fi
 }
+
+# install_worktree_venv_hook <activate_path>
+#   Append the per-worktree DB env block to a venv's bin/activate file so
+#   `source .venv/bin/activate` exports DB_NAME / DJANGO_PORT / DB_CONFIG
+#   for the current worktree.  Idempotent — does nothing if the marker is
+#   already present.
+#
+#   Returns 0 on success or skip-when-already-installed.
+#   Returns 1 if the activate file doesn't exist.
+install_worktree_venv_hook() {
+  local activate="$1"
+  local marker="# >>> Gyrinx per-worktree DB env >>>"
+  if [ ! -f "$activate" ]; then
+    return 1
+  fi
+  if grep -qF "$marker" "$activate"; then
+    return 0
+  fi
+  cat >> "$activate" <<'BLOCK'
+
+# >>> Gyrinx per-worktree DB env >>>
+# Installed by scripts/setup-local-postgres.sh or scripts/dev.sh.  Makes
+# pytest, manage, and other tools target the current worktree's Postgres
+# database without manual exports.  Re-source the activate script after
+# `cd`ing between worktrees.
+_gyrinx_set_db_env() {
+  local wt_root lib
+  wt_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  lib="$wt_root/scripts/lib/worktree.sh"
+  [ -f "$lib" ] || return 0
+  # shellcheck source=/dev/null
+  source "$lib"
+  export DB_NAME
+  DB_NAME=$(worktree_db_name "$wt_root")
+  export DJANGO_PORT
+  DJANGO_PORT=$(worktree_port "$wt_root")
+  export DB_HOST=localhost
+  export DB_PORT=5432
+  export DB_CONFIG
+  DB_CONFIG="$(db_config_for_local)"
+}
+_gyrinx_set_db_env
+unset -f _gyrinx_set_db_env
+# <<< Gyrinx per-worktree DB env <<<
+BLOCK
+  return 0
+}

--- a/scripts/setup-local-postgres.sh
+++ b/scripts/setup-local-postgres.sh
@@ -319,39 +319,10 @@ if [ ! -d "$VENV_DIR" ]; then
   fi
 fi
 VENV_ACTIVATE="${VENV_DIR}/bin/activate"
-HOOK_MARKER="# >>> Gyrinx per-worktree DB env >>>"
-if [ ! -f "$VENV_ACTIVATE" ]; then
-  echo "No .venv found; skipping hook install."
-elif grep -qF "$HOOK_MARKER" "$VENV_ACTIVATE"; then
-  echo "Hook already installed in $VENV_ACTIVATE"
+if install_worktree_venv_hook "$VENV_ACTIVATE"; then
+  echo "Hook installed (or already present) in $VENV_ACTIVATE"
 else
-  cat >> "$VENV_ACTIVATE" <<'BLOCK'
-
-# >>> Gyrinx per-worktree DB env >>>
-# Added by scripts/setup-local-postgres.sh.  Makes pytest, manage, and other
-# tools target the current worktree's Postgres database without manual exports.
-# Re-source the activate script after `cd`ing between worktrees.
-_gyrinx_set_db_env() {
-  local wt_root lib
-  wt_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
-  lib="$wt_root/scripts/lib/worktree.sh"
-  [ -f "$lib" ] || return 0
-  # shellcheck source=/dev/null
-  source "$lib"
-  export DB_NAME
-  DB_NAME=$(worktree_db_name "$wt_root")
-  export DJANGO_PORT
-  DJANGO_PORT=$(worktree_port "$wt_root")
-  export DB_HOST=localhost
-  export DB_PORT=5432
-  export DB_CONFIG
-  DB_CONFIG="$(db_config_for_local)"
-}
-_gyrinx_set_db_env
-unset -f _gyrinx_set_db_env
-# <<< Gyrinx per-worktree DB env <<<
-BLOCK
-  echo "Installed hook in $VENV_ACTIVATE"
+  echo "No .venv found; skipping hook install."
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Each git worktree gets its own Postgres database via #1710, but the editable `gyrinx` install still lived in the main worktree's `.venv` only. `import gyrinx` from any child worktree resolved to main's code, silently missing new migrations and breaking pytest with `ImportError` whenever a child worktree had code main didn't.

This PR auto-provisions a per-worktree `.venv` with `gyrinx` editable-installed from that worktree, so `import gyrinx` always resolves to worktree-local code.

Closes #1772.

## Changes

- `scripts/lib/worktree.sh` — extracted the activate-script hook block into a reusable `install_worktree_venv_hook()` function
- `scripts/dev.sh` — provisions `${WT_ROOT}/.venv` on first run in a child worktree via `uv venv` + `uv pip install --editable .` + installs the activate hook. New `--reset-venv` flag rebuilds from scratch
- `scripts/setup-local-postgres.sh` — uses the new helper instead of inline-appending the hook
- `scripts/cleanup-worktree-dbs.sh` — reports each worktree's `.venv` size in dry-run, --force, and --include-tests paths
- Docs: CLAUDE.md + the `worktree-db` skill describe the new flow, the failure mode without it, and how to verify a venv is local

No orphan venv reaping — venvs live inside worktree directories so `git worktree remove` / `rm -rf` already clean them up.

## Test plan

- [x] Created a fresh child worktree at `/tmp/gyrinx-1772-test`
- [x] Manually ran the new provisioning block (`uv venv` + `uv pip install --editable .`) — completed in ~10s
- [x] `python -c "import gyrinx; print(gyrinx.__file__)"` → resolved to `/private/tmp/gyrinx-1772-test/gyrinx/__init__.py` (the test worktree, not main)
- [x] `pytest gyrinx/content/tests/test_ordering.py` → 5 passed using the per-worktree DB (`gyrinx_wt_31f693f7`)
- [x] `source .venv/bin/activate` → exports `DB_NAME=gyrinx_wt_31f693f7`, `DJANGO_PORT=8992`, `DB_CONFIG=...` for the test worktree
- [x] `./scripts/cleanup-worktree-dbs.sh` lists `.venv` sizes for all live worktrees
- [x] Helper is idempotent — re-running against main's existing hooked `.venv/bin/activate` is a no-op
- [x] `bash -n` passes on every modified script

## Out of scope

- Symlinking `node_modules` per worktree (npm watch in child worktrees still requires its own `npm install`)
- Sharing Python wheels across worktrees (uv already deduplicates at the cache level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)