### PR TITLE
feat: showcase featured content packs on the front page

### DIFF
--- a/gyrinx/core/templates/core/includes/featured_pack_card.html
+++ b/gyrinx/core/templates/core/includes/featured_pack_card.html
@@ -1,0 +1,14 @@
+{% load custom_tags %}
+<a href="{% url 'core:pack' pack.id %}"
+   class="border rounded p-3 d-flex align-items-center gap-3 text-decoration-none h-100">
+    <div class="flex-grow-1">
+        <h2 class="h4 mb-1">{{ pack.name }}</h2>
+        <div class="text-secondary fs-7 mb-1">
+            <i class="bi-person"></i> {{ pack.owner.username }}
+        </div>
+        {% with pack.featured_description|default:pack.summary as desc %}
+            {% if desc %}<p class="text-secondary mb-0">{{ desc|plain_text_truncate:150 }}</p>{% endif %}
+        {% endwith %}
+    </div>
+    <i class="bi-chevron-right flex-shrink-0"></i>
+</a>

--- a/gyrinx/core/templates/core/index.html
+++ b/gyrinx/core/templates/core/index.html
@@ -253,9 +253,42 @@
                         </div>
                     </div>
                 </div>
+                {% if featured_packs %}
+                    <div>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <h2 class="h4 mb-0">Featured Content Packs</h2>
+                            <span class="ms-auto fs-7">
+                                <a href="{% url 'core:packs' %}"
+                                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Browse all</a>
+                            </span>
+                        </div>
+                        <div class="row g-3">
+                            {% for pack in featured_packs %}
+                                <div class="col-12 col-md-4">{% include "core/includes/featured_pack_card.html" with pack=pack %}</div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         {% else %}
             <div class="mt-4 vstack gap-4">
+                {% if featured_packs %}
+                    <div>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <h2 class="h4 mb-0">Featured Content Packs</h2>
+                            <span class="ms-auto fs-7">
+                                <a href="{% url 'core:packs' %}"
+                                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Browse all</a>
+                            </span>
+                        </div>
+                        <div class="row g-3">
+                            {% for pack in featured_packs %}
+                                <div class="col-12 col-md-4">{% include "core/includes/featured_pack_card.html" with pack=pack %}</div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <hr class="col-1 my-4 align-self-center" />
+                {% endif %}
                 <div class="row">
                     <div class="col-md-4">
                         <h2>Build and manage your gangs</h2>

--- a/gyrinx/core/templates/core/pack/packs.html
+++ b/gyrinx/core/templates/core/pack/packs.html
@@ -55,16 +55,7 @@
                     <div class="caps-label mb-2">Featured</div>
                     <div class="vstack gap-2">
                         {% for pack in featured_packs %}
-                            <a href="{% url 'core:pack' pack.id %}"
-                               class="border rounded p-3 d-flex align-items-center gap-3 text-decoration-none">
-                                <div class="flex-grow-1">
-                                    <h2 class="h4 mb-1">{{ pack.name }}</h2>
-                                    {% with pack.featured_description|default:pack.summary as desc %}
-                                        {% if desc %}<p class="text-secondary mb-0">{{ desc|plain_text_truncate:150 }}</p>{% endif %}
-                                    {% endwith %}
-                                </div>
-                                <i class="bi-chevron-right flex-shrink-0"></i>
-                            </a>
+                            {% include "core/includes/featured_pack_card.html" with pack=pack %}
                         {% endfor %}
                     </div>
                 </div>

--- a/gyrinx/core/tests/test_homepage_featured_packs.py
+++ b/gyrinx/core/tests/test_homepage_featured_packs.py
@@ -1,0 +1,137 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from gyrinx.core.models.pack import CustomContentPack
+
+
+@pytest.mark.django_db
+def test_homepage_shows_featured_packs_for_anonymous(make_user):
+    """Featured + listed packs appear on the front page for anonymous users."""
+    owner = make_user("packowner", "password")
+    CustomContentPack.objects.create(
+        name="Prototype Weapons",
+        summary="A pack of experimental weapon traits.",
+        listed=True,
+        featured=True,
+        owner=owner,
+    )
+
+    client = Client()
+    response = client.get(reverse("core:index"))
+
+    assert response.status_code == 200
+    assert b"Featured Content Packs" in response.content
+    assert b"Prototype Weapons" in response.content
+
+
+@pytest.mark.django_db
+def test_homepage_shows_featured_packs_for_authenticated(client, user, make_user):
+    """Featured + listed packs appear on the front page for authenticated users."""
+    owner = make_user("packowner", "password")
+    CustomContentPack.objects.create(
+        name="Nasherhound Rules",
+        summary="Custom rules for Nasherhounds.",
+        listed=True,
+        featured=True,
+        owner=owner,
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("core:index"))
+
+    assert response.status_code == 200
+    assert b"Featured Content Packs" in response.content
+    assert b"Nasherhound Rules" in response.content
+
+
+@pytest.mark.django_db
+def test_homepage_hides_featured_section_when_none(client, user):
+    """The featured section is not rendered when there are no featured packs."""
+    client.force_login(user)
+    response = client.get(reverse("core:index"))
+
+    assert response.status_code == 200
+    assert b"Featured Content Packs" not in response.content
+
+
+@pytest.mark.django_db
+def test_homepage_excludes_unlisted_packs(make_user):
+    """Featured but unlisted packs are not shown on the front page."""
+    owner = make_user("packowner", "password")
+    CustomContentPack.objects.create(
+        name="Secret Sauce",
+        summary="A private pack.",
+        listed=False,
+        featured=True,
+        owner=owner,
+    )
+
+    client = Client()
+    response = client.get(reverse("core:index"))
+
+    assert response.status_code == 200
+    assert b"Secret Sauce" not in response.content
+    assert b"Featured Content Packs" not in response.content
+
+
+@pytest.mark.django_db
+def test_homepage_excludes_archived_packs(make_user):
+    """Archived featured packs are not shown on the front page (discovery surface)."""
+    owner = make_user("packowner", "password")
+    CustomContentPack.objects.create(
+        name="Old Pack",
+        summary="An archived pack.",
+        listed=True,
+        featured=True,
+        archived=True,
+        owner=owner,
+    )
+
+    client = Client()
+    response = client.get(reverse("core:index"))
+
+    assert response.status_code == 200
+    assert b"Old Pack" not in response.content
+    assert b"Featured Content Packs" not in response.content
+
+
+@pytest.mark.django_db
+def test_homepage_caps_featured_packs_at_three(make_user):
+    """Only up to 3 featured packs are shown on the front page."""
+    owner = make_user("packowner", "password")
+    for i in range(5):
+        CustomContentPack.objects.create(
+            name=f"Featured Pack {i}",
+            summary=f"Pack number {i}.",
+            listed=True,
+            featured=True,
+            owner=owner,
+        )
+
+    client = Client()
+    response = client.get(reverse("core:index"))
+
+    assert response.status_code == 200
+    featured_packs = response.context["featured_packs"]
+    assert len(list(featured_packs)) == 3
+
+
+@pytest.mark.django_db
+def test_homepage_featured_description_falls_back_to_summary(make_user):
+    """When featured_description is blank, the card falls back to summary text."""
+    owner = make_user("packowner", "password")
+    CustomContentPack.objects.create(
+        name="Fallback Pack",
+        summary="Summary used as fallback.",
+        featured_description="",
+        listed=True,
+        featured=True,
+        owner=owner,
+    )
+
+    client = Client()
+    response = client.get(reverse("core:index"))
+
+    assert response.status_code == 200
+    assert b"Summary used as fallback." in response.content

--- a/gyrinx/core/views/home.py
+++ b/gyrinx/core/views/home.py
@@ -138,6 +138,13 @@ def index(request):
             .order_by("name")
         )
 
+    # Pick up to 3 random featured packs to showcase on the front page.
+    featured_packs = (
+        CustomContentPack.objects.filter(featured=True, listed=True, archived=False)
+        .select_related("owner")
+        .order_by("?")[:3]
+    )
+
     return render(
         request,
         "core/index.html",
@@ -150,6 +157,7 @@ def index(request):
             "search_query": search_query,
             "search_gangs_query": search_gangs_query,
             "search_campaigns_query": search_campaigns_query,
+            "featured_packs": featured_packs,
         },
     )
 


### PR DESCRIPTION
## Summary

- Adds a "Featured Content Packs" section to the front page (`/`) for both anonymous and authenticated users, surfacing up to 3 admin-curated packs with name, owner, and description.
- Reuses the existing `CustomContentPack.featured` flag (already used on `/packs/`) — no model changes, no migration.
- Extracts the featured card markup to `core/includes/featured_pack_card.html` so the homepage and `/packs/` page stay in sync.

Closes #1730.

## Test plan

- [ ] Visit `/` while signed out — featured section appears at the top of the marketing area when at least one pack has `featured=True, listed=True, archived=False`
- [ ] Visit `/` while signed in — featured section appears below the three-column dashboard row
- [ ] Toggle `featured=False` in Django admin on the only featured pack — section disappears entirely
- [ ] Confirm the same featured section on `/packs/` still renders correctly (the card include is now shared)
- [ ] Click a featured pack card — navigates to `/pack/<id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)