### PR TITLE
fix: drop --reuse-db default so schema changes are picked up automatically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ ptw .
 # Run specific test
 pytest gyrinx/core/tests/test_models_core.py::test_basic_list
 
-# Run tests with pytest directly (faster, uses existing database)
+# Run tests with pytest directly
 pytest
 
 # Run tests in parallel using pytest-xdist (significant performance improvement)
@@ -210,15 +210,12 @@ pytest -n 4     # Uses 4 workers
 
 # Collect static files before running tests (required for templates with static assets)
 manage collectstatic --noinput
-
-# After adding new migrations, use --migrations to apply them to the test database
-pytest -n auto --migrations
 ```
 
-**IMPORTANT for Claude:** `pyproject.toml` addopts already includes `--reuse-db -n auto --nomigrations`.
-When you've added new migrations, just run `pytest -n auto --migrations` — that's all you need.
-Do NOT use `--create-db`, do NOT use `--reuse-db` (it's already the default), and do NOT try
-to disable xdist. Just `pytest -n auto --migrations`.
+**IMPORTANT for Claude:** `pyproject.toml` addopts already includes `-n auto --nomigrations`.
+The test DB is rebuilt from models on every run (via `--nomigrations` syncdb), so schema
+changes are picked up automatically — no `--create-db` or `--migrations` flag needed.
+If you want to reuse the test DB across runs for speed, pass `--reuse-db` explicitly.
 
 ### Frontend Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,9 @@ manage collectstatic --noinput
 **IMPORTANT for Claude:** `pyproject.toml` addopts already includes `-n auto --nomigrations`.
 The test DB is rebuilt from models on every run (via `--nomigrations` syncdb), so schema
 changes are picked up automatically — no `--create-db` or `--migrations` flag needed.
-If you want to reuse the test DB across runs for speed, pass `--reuse-db` explicitly.
+If you want to reuse the test DB across runs for speed, pass `--reuse-db` explicitly —
+but be aware that `--reuse-db` combined with `--nomigrations` does NOT detect schema
+staleness, so you'll need a one-off `--create-db` run after changing a model.
 
 ### Frontend Development
 

--- a/README.md
+++ b/README.md
@@ -213,19 +213,14 @@ The wrapper script is a thin convenience over `pytest`:
 ./scripts/test.sh -n 0            # serial
 ```
 
-Or invoke `pytest` directly — `pyproject.toml` already sets `-n auto --reuse-db
---nomigrations`, so the bare command runs the full suite in parallel:
+Or invoke `pytest` directly — `pyproject.toml` already sets `-n auto
+--nomigrations`, so the bare command runs the full suite in parallel and
+rebuilds the test DB from current model definitions on every run:
 
 ```bash
 pytest                            # full suite, parallel
 pytest gyrinx/core/tests/         # one directory
 pytest -k campaign                # by name
-```
-
-After adding migrations, run them once with `--migrations`:
-
-```bash
-pytest --migrations
 ```
 
 You can also use `pytest-watcher` for continuous testing:

--- a/docs/developing-gyrinx/testing.md
+++ b/docs/developing-gyrinx/testing.md
@@ -126,7 +126,7 @@ Tests are configured to use `StaticFilesStorage` instead of `CompressedManifestS
 
 ### Database
 
-Tests use a separate test database created by pytest-django. In local development, each worktree has its own database (`gyrinx_wt_{hash}`) and its own set of test databases. The `--reuse-db` flag (configured in `pyproject.toml`) speeds up repeated runs by keeping test databases between runs.
+Tests use a separate test database created by pytest-django. In local development, each worktree has its own database (`gyrinx_wt_{hash}`) and its own set of test databases. The schema is rebuilt from current model definitions on every run via `--nomigrations` (configured in `pyproject.toml`), so model changes are picked up automatically. Pass `--reuse-db` explicitly if you want to skip the rebuild for a tight focused-test loop — be aware this reintroduces the stale-schema risk if you then change a model.
 
 ### Fixtures
 

--- a/docs/useful-scripts.md
+++ b/docs/useful-scripts.md
@@ -33,15 +33,15 @@ Formats all code in the project including Python, JavaScript, SCSS, and Django t
 ### `scripts/test.sh`
 
 Thin wrapper over `pytest` against the local Postgres database. `pyproject.toml`
-already enables parallel execution (`-n auto`) and `--reuse-db --nomigrations`
-via addopts, so the bare invocation runs the full suite in parallel.
+already enables parallel execution (`-n auto`) and `--nomigrations` via addopts,
+so the bare invocation runs the full suite in parallel and rebuilds the test
+DB from current model definitions on every run.
 
 ```bash
 ./scripts/test.sh                  # full suite, parallel
 ./scripts/test.sh -n 0             # serial
 ./scripts/test.sh gyrinx/core/     # a directory
 ./scripts/test.sh -k campaign      # by name
-./scripts/test.sh --migrations     # after adding new migrations
 ```
 
 ### `scripts/check_migrations.sh`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = { file = ["requirements.txt"] }
 manage = "scripts.manage:main"
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=importlib -p no:warnings --reuse-db -n auto --nomigrations"
+addopts = "--import-mode=importlib -p no:warnings -n auto --nomigrations"
 DJANGO_SETTINGS_MODULE = "gyrinx.settings_dev"
 python_files = "tests.py test_*.py *_tests.py"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,8 +6,8 @@
 # for interactive use).  CI invokes pytest directly — see
 # .github/workflows/test.yaml.
 #
-# pyproject.toml already sets `-n auto --reuse-db --nomigrations`, so the
-# bare invocation runs in parallel by default.  Pass `-n 0` to force serial.
+# pyproject.toml already sets `-n auto --nomigrations`, so the bare
+# invocation runs in parallel by default.  Pass `-n 0` to force serial.
 #
 # Usage:
 #   ./scripts/test.sh                 # parallel (via addopts -n auto)


### PR DESCRIPTION
## Summary

- Removes `--reuse-db` from default pytest `addopts` so every run rebuilds the test DB from current model definitions
- With `--nomigrations` still in place, the rebuild is a fast syncdb (not migration replay)
- Updates CLAUDE.md to drop the now-obsolete `pytest --migrations` workaround

## Why

`--reuse-db --nomigrations` was a footgun: adding a migration left the test DB stale and tests failed mid-run with `column X does not exist`. The fix required remembering `pytest -n auto --migrations` or `--create-db`, which is friction every time. CI was already unaffected — its Postgres service starts empty, so `--reuse-db` is a no-op there.

Local cost of the change: full suite goes ~44s warm / ~63s cold on my machine, vs. a few seconds saved per run before. Reliability beats those seconds. Anyone who wants the old behaviour for a tight focused-test loop can pass `--reuse-db` explicitly.

Closes #1609.

## Test plan

- [x] `pytest -n auto` passes locally (2472 passed, 13 skipped)
- [x] Re-run passes (warm cache)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)