### PR TITLE
docs(agents): note pushpush notification when blocked at task start

### DIFF
--- a/.claude/agents/code-architect.md
+++ b/.claude/agents/code-architect.md
@@ -32,3 +32,7 @@ Deliver a decisive, complete architecture blueprint that provides everything nee
 - **Critical Details**: Error handling, state management, testing, performance, and security considerations
 
 Make confident architectural choices rather than presenting multiple options. Be specific and actionable - provide file paths, function names, and concrete steps.
+
+## If you're blocked at the start
+
+If you can't make meaningful progress at the start of the task — authentication is required, a critical tool/credential is missing, or any other major blocker (not just auth) — and the `pushpush` MCP server is connected, send a push notification on the `claude` topic via `send_push` to get the user's attention. Don't silently spin or give up early; flag it so they can unblock you.

--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -49,3 +49,7 @@ Provide a comprehensive analysis that helps developers understand the feature de
 - List of files that you think are absolutely essential to get an understanding of the topic in question
 
 Structure your response for maximum clarity and usefulness. Always include specific file paths and line numbers.
+
+## If you're blocked at the start
+
+If you can't make meaningful progress at the start of the task — authentication is required, a critical tool/credential is missing, or any other major blocker (not just auth) — and the `pushpush` MCP server is connected, send a push notification on the `claude` topic via `send_push` to get the user's attention. Don't silently spin or give up early; flag it so they can unblock you.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -44,3 +44,7 @@ Start by clearly stating what you're reviewing. For each high-confidence issue, 
 Group issues by severity (Critical vs Important). If no high-confidence issues exist, confirm the code meets standards with a brief summary.
 
 Structure your response for maximum actionability - developers should know exactly what to fix and why.
+
+## If you're blocked at the start
+
+If you can't make meaningful progress at the start of the task — authentication is required, a critical tool/credential is missing, or any other major blocker (not just auth) — and the `pushpush` MCP server is connected, send a push notification on the `claude` topic via `send_push` to get the user's attention. Don't silently spin or give up early; flag it so they can unblock you.

--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -125,3 +125,7 @@ If asked to implement changes:
 - Do not propose abstractions that serve fewer than 3 concrete uses
 - Do not increase the number of files, modules, or layers without strong justification
 - Do not "improve" error handling for impossible conditions
+
+## If you're blocked at the start
+
+If you can't make meaningful progress at the start of the task — authentication is required, a critical tool/credential is missing, or any other major blocker (not just auth) — and the `pushpush` MCP server is connected, send a push notification on the `claude` topic via `send_push` to get the user's attention. Don't silently spin or give up early; flag it so they can unblock you.

--- a/.claude/agents/diataxis-docs-expert.md
+++ b/.claude/agents/diataxis-docs-expert.md
@@ -196,3 +196,7 @@ When you identify issues, prioritise them:
 - **High**: Missing essential documentation, significant drift from code
 - **Medium**: Mixed content types, inconsistent terminology
 - **Low**: Style improvements, enhanced cross-references, optional additions
+
+## If you're blocked at the start
+
+If you can't make meaningful progress at the start of the task — authentication is required, a critical tool/credential is missing, or any other major blocker (not just auth) — and the `pushpush` MCP server is connected, send a push notification on the `claude` topic via `send_push` to get the user's attention. Don't silently spin or give up early; flag it so they can unblock you.

--- a/.claude/agents/feature-planner.md
+++ b/.claude/agents/feature-planner.md
@@ -81,3 +81,7 @@ Your output should be structured, detailed, and immediately actionable. Use clea
 If the request is vague or missing critical information, start your plan by listing the clarifications needed and make reasonable assumptions to proceed with the planning, clearly marking them as assumptions.
 
 Remember: Your plan should be so comprehensive that another developer could implement the feature without needing to make significant architectural decisions. Every technical decision should be specified in your plan.
+
+## If you're blocked at the start
+
+If you can't make meaningful progress at the start of the task — authentication is required, a critical tool/credential is missing, or any other major blocker (not just auth) — and the `pushpush` MCP server is connected, send a push notification on the `claude` topic via `send_push` to get the user's attention. Don't silently spin or give up early; flag it so they can unblock you.


### PR DESCRIPTION
## Summary

- Add a shared **If you're blocked at the start** section to all six project agents (`code-architect`, `code-explorer`, `code-reviewer`, `code-simplifier`, `diataxis-docs-expert`, `feature-planner`).
- The note tells agents that if they hit a major blocker at task start — authentication required, missing tool/credential, or anything else preventing meaningful progress — and the `pushpush` MCP server is connected, they should call `send_push` on the `claude` topic to flag the user instead of silently spinning or giving up.

## Test plan

- [ ] Review the section text on each agent file
- [ ] Confirm none of the agents had an existing pushpush note that's now duplicated