### PR TITLE
fix: install npm deps and seed CSS build in dev.sh

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -21,9 +21,36 @@ This single command:
 1. Ensures local Postgres is running
 2. Creates/forks the database if needed
 3. Runs pending migrations
-4. Starts `npm run watch` in the background
-5. Starts Django `runserver` in the foreground
-6. Logs to `./logs/runserver.log` and `./logs/npm-watch.log`
+4. Runs `npm install` if `node_modules` is missing or out of date (vs. `package*.json`)
+5. Runs an **initial** `npm run css` build if `styles.css` is missing or stale
+6. Starts `npm run watch` in the background (watches scss/html → rebuilds CSS on change)
+7. Starts Django `runserver` in the foreground
+8. Logs to `./logs/runserver.log`, `./logs/npm-watch.log`, and `./logs/npm-css-build.log`
+
+## Verifying CSS Is Built
+
+**Always confirm CSS exists before relying on the dev server** — `npm run watch` (the watcher) only
+rebuilds on file *changes*; it does no initial build, so a fresh worktree without an initial CSS
+build will render unstyled pages.
+
+`scripts/dev.sh` now guarantees this for you (steps 4–5 above) and prints a `CSS ready: <path>
+(<bytes> bytes)` line plus a `CSS file:` row in the startup banner. Before navigating Claude in
+Chrome (or otherwise treating the server as ready), check that line appeared and that the file is
+non-empty:
+
+```bash
+CSS=gyrinx/core/static/core/css/styles.css
+[ -s "$CSS" ] && echo "CSS OK ($(wc -c <"$CSS") bytes)" || echo "CSS MISSING — re-run scripts/dev.sh"
+```
+
+If CSS is missing or you see unstyled pages, the recovery is:
+
+```bash
+npm install              # only if node_modules is missing/stale
+npm run css              # one-shot initial build
+```
+
+Do **not** rely on `npm run watch` alone to produce the first build — it won't.
 
 ## Port Assignment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,11 @@ Each git worktree gets its own Postgres database and Django port, started with a
 - **Setup (once per machine):** `./scripts/setup-local-postgres.sh` — installs Postgres 16 + pgAdmin via Homebrew,
   migrates data from Docker
 - **Start dev server:** `./scripts/dev.sh` — ensures DB exists (forks from template if needed), provisions a
-  per-worktree `.venv` on first run in a child worktree, runs migrations, starts Django runserver + npm watch
+  per-worktree `.venv` on first run in a child worktree, runs migrations, runs `npm install` if
+  `node_modules` is missing/stale, does an initial `npm run css` build if `styles.css` is missing/stale,
+  then starts Django runserver + npm watch. **Always confirm the `CSS ready:` / `CSS file:` lines appear
+  in the startup output — `npm run watch` alone never produces an initial build, so without `dev.sh`
+  doing the seed build you'd get unstyled pages.**
 - **Reset a worktree DB:** `./scripts/dev.sh --reset-db` — drops and re-forks from template
 - **Rebuild a worktree's venv:** `./scripts/dev.sh --reset-venv` — wipes and re-provisions `${WT_ROOT}/.venv`
 - **Clean up orphans:** `./scripts/cleanup-worktree-dbs.sh` — drops orphan DBs + reports worktree `.venv` sizes

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -203,6 +203,43 @@ LOG_DIR="${WT_ROOT}/logs"
 mkdir -p "$LOG_DIR"
 
 # ---------------------------------------------------------------------------
+# Ensure frontend toolchain is installed and CSS is built
+# ---------------------------------------------------------------------------
+# `node_modules` is gitignored, so child worktrees (and fresh clones) start
+# without it. `npm run watch` only rebuilds on file *changes* — it never does
+# an initial build — so without these two steps the dev server boots against
+# a missing or stale styles.css and templates render unstyled.
+CSS_FILE="${WT_ROOT}/gyrinx/core/static/core/css/styles.css"
+
+if [ ! -d "${WT_ROOT}/node_modules" ] \
+  || [ "${WT_ROOT}/package-lock.json" -nt "${WT_ROOT}/node_modules" ] \
+  || [ "${WT_ROOT}/package.json" -nt "${WT_ROOT}/node_modules" ]; then
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "ERROR: \`npm\` is required to build CSS but isn't on PATH." >&2
+    exit 1
+  fi
+  echo "Installing npm dependencies (node_modules missing or out of date)..."
+  (cd "$WT_ROOT" && npm install --no-audit --no-fund)
+fi
+
+if [ ! -f "$CSS_FILE" ] || [ "${WT_ROOT}/package-lock.json" -nt "$CSS_FILE" ]; then
+  echo "Building CSS (initial build)..."
+  (cd "$WT_ROOT" && npm run css > "$LOG_DIR/npm-css-build.log" 2>&1) || {
+    echo "ERROR: Initial CSS build failed. See $LOG_DIR/npm-css-build.log" >&2
+    tail -20 "$LOG_DIR/npm-css-build.log" >&2 || true
+    exit 1
+  }
+fi
+
+if [ ! -s "$CSS_FILE" ]; then
+  echo "ERROR: Expected CSS file is missing or empty: $CSS_FILE" >&2
+  echo "Run \`npm install && npm run css\` from $WT_ROOT to diagnose." >&2
+  exit 1
+fi
+CSS_SIZE=$(wc -c < "$CSS_FILE" | tr -d ' ')
+echo "CSS ready: $CSS_FILE (${CSS_SIZE} bytes)"
+
+# ---------------------------------------------------------------------------
 # Background process management
 # ---------------------------------------------------------------------------
 PIDS=()
@@ -238,8 +275,9 @@ echo "  Worktree:  $WT_LABEL"
 echo "  Database:  $DB_NAME"
 echo "  URL:       http://localhost:${DJANGO_PORT}"
 echo "  Logs:      ${LOG_DIR}/"
+echo "  CSS file:  ${CSS_FILE} (${CSS_SIZE} bytes)"
 if [ "$NO_WATCH" = false ]; then
-echo "  CSS watch: running (PID ${PIDS[0]:-?})"
+echo "  CSS watch: running (PID ${PIDS[0]:-?}) → ${LOG_DIR}/npm-watch.log"
 fi
 echo "=========================================="
 echo

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -210,19 +210,37 @@ mkdir -p "$LOG_DIR"
 # an initial build — so without these two steps the dev server boots against
 # a missing or stale styles.css and templates render unstyled.
 CSS_FILE="${WT_ROOT}/gyrinx/core/static/core/css/styles.css"
+SCSS_DIR="${WT_ROOT}/gyrinx/core/static/core/scss"
+
+# `npm` is needed for the install step, the one-shot CSS build, and the
+# background watcher — so fail fast up front rather than letting any of those
+# emit a vague "command not found" later.
+if ! command -v npm >/dev/null 2>&1; then
+  echo "ERROR: \`npm\` is required to install frontend deps and build CSS, but isn't on PATH." >&2
+  exit 1
+fi
 
 if [ ! -d "${WT_ROOT}/node_modules" ] \
   || [ "${WT_ROOT}/package-lock.json" -nt "${WT_ROOT}/node_modules" ] \
   || [ "${WT_ROOT}/package.json" -nt "${WT_ROOT}/node_modules" ]; then
-  if ! command -v npm >/dev/null 2>&1; then
-    echo "ERROR: \`npm\` is required to build CSS but isn't on PATH." >&2
-    exit 1
-  fi
   echo "Installing npm dependencies (node_modules missing or out of date)..."
   (cd "$WT_ROOT" && npm install --no-audit --no-fund)
 fi
 
-if [ ! -f "$CSS_FILE" ] || [ "${WT_ROOT}/package-lock.json" -nt "$CSS_FILE" ]; then
+# Rebuild if styles.css is missing, older than package-lock.json (deps
+# changed), or older than any source file under the scss directory (a
+# `git pull` or branch switch may have updated scss without touching the
+# watcher's in-memory state).
+scss_changed=false
+if [ -f "$CSS_FILE" ] && [ -d "$SCSS_DIR" ]; then
+  if [ -n "$(find "$SCSS_DIR" -type f -newer "$CSS_FILE" -print -quit 2>/dev/null)" ]; then
+    scss_changed=true
+  fi
+fi
+
+if [ ! -f "$CSS_FILE" ] \
+  || [ "${WT_ROOT}/package-lock.json" -nt "$CSS_FILE" ] \
+  || [ "$scss_changed" = true ]; then
   echo "Building CSS (initial build)..."
   (cd "$WT_ROOT" && npm run css > "$LOG_DIR/npm-css-build.log" 2>&1) || {
     echo "ERROR: Initial CSS build failed. See $LOG_DIR/npm-css-build.log" >&2


### PR DESCRIPTION
## Summary

- `scripts/dev.sh` now runs `npm install` when `node_modules` is missing or stale and does a one-shot `npm run css` build before starting Django — `npm run watch` is just a nodemon watcher and never produces an initial build, so fresh worktrees were booting against missing CSS and rendering unstyled pages.
- Fails fast if `styles.css` is missing/empty after the build, prints `CSS ready: <path> (<bytes>)`, and adds a `CSS file:` row to the startup banner so agents can confirm CSS is built before navigating.
- Updates `.claude/skills/dev-server/SKILL.md` and `CLAUDE.md` to tell agents to look for those lines and how to recover (`npm install && npm run css`).

## Test plan

- [x] Syntax-check `scripts/dev.sh`
- [x] Wipe `node_modules` and `gyrinx/core/static/core/css/` in a child worktree, re-run `./scripts/dev.sh` → confirms `Installing npm dependencies...`, `Building CSS (initial build)...`, `CSS ready: …styles.css (250778 bytes)` appear in order, and the banner shows `CSS file: …`
- [x] Re-run `./scripts/dev.sh` with everything cached → install + build steps skip, banner still confirms CSS file/size
- [ ] Manual: visit `http://localhost:<port>/` and confirm pages are styled