### PR TITLE
feat: add fighter mod picker to pack gear and weapons (closes #1753)

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -544,7 +544,20 @@ class ContentWeaponTraitPackForm(forms.ModelForm):
         return value
 
 
-class ContentWeaponAccessoryPackForm(forms.ModelForm):
+class StandardFieldsMixin:
+    """Exposes ``standard_fields`` for templates that render synthetic-field
+    pickers alongside the regular ``Meta.fields`` (used by both the accessory
+    mod picker and the equipment fighter-mod picker).
+    """
+
+    @property
+    def standard_fields(self):
+        """Iterate the bound fields for the regular ModelForm fields only."""
+        for name in self.Meta.fields:
+            yield self[name]
+
+
+class ContentWeaponAccessoryPackForm(StandardFieldsMixin, forms.ModelForm):
     """Form for adding/editing weapon accessories in a content pack.
 
     Includes a synthetic mod picker (weapon stat mods + weapon trait mods)
@@ -598,12 +611,6 @@ class ContentWeaponAccessoryPackForm(forms.ModelForm):
             "rarity": forms.Select(attrs={"class": "form-select"}),
             "rarity_roll": forms.NumberInput(attrs={"class": "form-control"}),
         }
-
-    @property
-    def standard_fields(self):
-        """Iterate the bound fields for the regular ModelForm fields only."""
-        for name in self.Meta.fields:
-            yield self[name]
 
     @property
     def stat_mod_rows(self):
@@ -985,6 +992,243 @@ class ContentAttributeValuePackForm(forms.ModelForm):
                     "A value with this name already exists for this attribute."
                 )
         return value
+
+
+class FighterModPickerMixin(StandardFieldsMixin):
+    """Form mixin that exposes a fighter mod picker for ``ContentEquipment``.
+
+    Adds synthetic fields that find-or-create ``ContentModFighterStat``,
+    ``ContentModFighterRule`` and ``ContentModFighterSkill`` rows and attach
+    them to ``instance.modifiers`` (matching the pattern used by
+    ``ContentWeaponAccessoryPackForm`` for weapon stat/trait mods).
+
+    Host form contract:
+    - ``Meta.model`` must have a ``modifiers`` M2M to ``ContentMod``.
+    - ``__init__`` accepts ``pack`` (forwarded by ``super().__init__``).
+
+    The mixin overrides ``_save_m2m`` to call ``_save_fighter_mods`` itself,
+    so consumers don't have to remember the wiring.
+    """
+
+    FIGHTER_STAT_MODE_CHOICES = [
+        ("", "None"),
+        ("improve", "Improve"),
+        ("worsen", "Worsen"),
+        ("set", "Set"),
+    ]
+    FIGHTER_MOD_MODE_CHOICES = [
+        ("", "None"),
+        ("add", "Add"),
+        ("remove", "Remove"),
+    ]
+
+    def __init__(self, *args, pack=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._pack = pack
+
+        from gyrinx.content.models.statline import ContentStat
+
+        self._fmod_stats = list(ContentStat.objects.all().order_by("full_name"))
+        for stat in self._fmod_stats:
+            self.fields[f"fmod_stat_{stat.field_name}_mode"] = forms.ChoiceField(
+                choices=self.FIGHTER_STAT_MODE_CHOICES,
+                required=False,
+                label=stat.full_name,
+                widget=forms.Select(attrs={"class": "form-select form-select-sm"}),
+            )
+            self.fields[f"fmod_stat_{stat.field_name}_value"] = forms.CharField(
+                required=False,
+                max_length=5,
+                label=f"{stat.full_name} value",
+                widget=forms.TextInput(
+                    attrs={"class": "form-control form-control-sm", "size": "5"}
+                ),
+            )
+
+        if pack is not None:
+            rule_qs = ContentRule.objects.with_packs([pack])
+            skill_qs = ContentSkill.objects.with_packs([pack])
+        else:
+            rule_qs = ContentRule.objects.all_content()
+            skill_qs = ContentSkill.objects.all_content()
+        self._fmod_rules = list(rule_qs.order_by("name"))
+        self._fmod_skills = list(
+            skill_qs.select_related("category").order_by("category__name", "name")
+        )
+
+        for rule in self._fmod_rules:
+            self.fields[f"fmod_rule_{rule.pk}"] = forms.ChoiceField(
+                choices=self.FIGHTER_MOD_MODE_CHOICES,
+                required=False,
+                label=str(rule),
+                widget=forms.Select(attrs={"class": "form-select form-select-sm"}),
+            )
+        for skill in self._fmod_skills:
+            self.fields[f"fmod_skill_{skill.pk}"] = forms.ChoiceField(
+                choices=self.FIGHTER_MOD_MODE_CHOICES,
+                required=False,
+                label=str(skill),
+                widget=forms.Select(attrs={"class": "form-select form-select-sm"}),
+            )
+
+        if self.instance.pk and not self.is_bound:
+            self._populate_initial_fighter_mods()
+
+    @property
+    def fighter_stat_mod_rows(self):
+        return [
+            {
+                "stat": stat,
+                "label": stat.full_name,
+                "mode_field": self[f"fmod_stat_{stat.field_name}_mode"],
+                "value_field": self[f"fmod_stat_{stat.field_name}_value"],
+            }
+            for stat in self._fmod_stats
+        ]
+
+    @property
+    def fighter_rule_mod_rows(self):
+        return [
+            {"rule": rule, "field": self[f"fmod_rule_{rule.pk}"]}
+            for rule in self._fmod_rules
+        ]
+
+    @property
+    def fighter_skill_mod_rows(self):
+        return [
+            {"skill": skill, "field": self[f"fmod_skill_{skill.pk}"]}
+            for skill in self._fmod_skills
+        ]
+
+    @property
+    def any_fighter_rule_mod_set(self):
+        return any(self[f"fmod_rule_{rule.pk}"].value() for rule in self._fmod_rules)
+
+    @property
+    def any_fighter_skill_mod_set(self):
+        return any(
+            self[f"fmod_skill_{skill.pk}"].value() for skill in self._fmod_skills
+        )
+
+    @property
+    def any_fighter_stat_mod_set(self):
+        return any(
+            self[f"fmod_stat_{stat.field_name}_mode"].value()
+            for stat in self._fmod_stats
+        )
+
+    def _populate_initial_fighter_mods(self):
+        from gyrinx.content.models.modifier import (
+            ContentModFighterRule,
+            ContentModFighterSkill,
+            ContentModFighterStat,
+        )
+
+        for mod in self.instance.modifiers.all():
+            if isinstance(mod, ContentModFighterStat):
+                mode_key = f"fmod_stat_{mod.stat}_mode"
+                value_key = f"fmod_stat_{mod.stat}_value"
+                if mode_key in self.fields:
+                    self.initial[mode_key] = mod.mode
+                    self.initial[value_key] = mod.value
+            elif isinstance(mod, ContentModFighterRule):
+                key = f"fmod_rule_{mod.rule_id}"
+                if key in self.fields:
+                    self.initial[key] = mod.mode
+            elif isinstance(mod, ContentModFighterSkill):
+                key = f"fmod_skill_{mod.skill_id}"
+                if key in self.fields:
+                    self.initial[key] = mod.mode
+
+    def clean(self):
+        cleaned = super().clean()
+        for stat in self._fmod_stats:
+            mode_key = f"fmod_stat_{stat.field_name}_mode"
+            value_key = f"fmod_stat_{stat.field_name}_value"
+            mode = cleaned.get(mode_key)
+            value = (cleaned.get(value_key) or "").strip()
+            # Normalise so " 1 " and "1" dedupe in get_or_create.
+            cleaned[value_key] = value
+            if mode and not value:
+                self.add_error(
+                    value_key,
+                    f"A value is required when a mode is selected for {stat.full_name}.",
+                )
+            elif value and not mode:
+                self.add_error(
+                    mode_key,
+                    f"Choose a mode for the {stat.full_name} value, or clear the value.",
+                )
+            elif mode in {"improve", "worsen"} and value:
+                # ContentModFighterStat.apply() does int(self.value) for
+                # improve/worsen — reject non-integers up front.
+                try:
+                    int(value)
+                except (TypeError, ValueError):
+                    self.add_error(
+                        value_key,
+                        f"Enter an integer for {stat.full_name} when using {mode}.",
+                    )
+        return cleaned
+
+    def _save_fighter_mods(self, instance):
+        from gyrinx.content.models.modifier import (
+            ContentModFighterRule,
+            ContentModFighterSkill,
+            ContentModFighterStat,
+        )
+
+        new_mods = []
+        for stat in self._fmod_stats:
+            mode = self.cleaned_data.get(f"fmod_stat_{stat.field_name}_mode")
+            value = self.cleaned_data.get(f"fmod_stat_{stat.field_name}_value")
+            if mode and value:
+                mod, _ = ContentModFighterStat.objects.get_or_create(
+                    stat=stat.field_name, mode=mode, value=value
+                )
+                new_mods.append(mod)
+        for rule in self._fmod_rules:
+            mode = self.cleaned_data.get(f"fmod_rule_{rule.pk}")
+            if mode:
+                mod, _ = ContentModFighterRule.objects.get_or_create(
+                    rule=rule, mode=mode
+                )
+                new_mods.append(mod)
+        for skill in self._fmod_skills:
+            mode = self.cleaned_data.get(f"fmod_skill_{skill.pk}")
+            if mode:
+                mod, _ = ContentModFighterSkill.objects.get_or_create(
+                    skill=skill, mode=mode
+                )
+                new_mods.append(mod)
+
+        # Preserve any existing mods this picker doesn't manage (e.g. skill-tree
+        # or psyker-discipline access mods set via admin on library equipment).
+        managed = (
+            ContentModFighterStat,
+            ContentModFighterRule,
+            ContentModFighterSkill,
+        )
+        preserved = [m for m in instance.modifiers.all() if not isinstance(m, managed)]
+        instance.modifiers.set([*preserved, *new_mods])
+
+    def _save_m2m(self):
+        super()._save_m2m()
+        self._save_fighter_mods(self.instance)
+
+
+class EquipmentModifiersForm(FighterModPickerMixin, forms.ModelForm):
+    """Form for the Modifiers tab on a pack-defined gear/weapon edit page.
+
+    Carries no detail fields itself — those live on the Details tab via
+    ``ContentGearPackForm`` / ``ContentWeaponPackForm``. This form only
+    exposes the synthetic fighter-mod picker fields (stat / rule / skill)
+    and writes them to ``instance.modifiers``.
+    """
+
+    class Meta:
+        model = ContentEquipment
+        fields = []
 
 
 class ContentGearPackForm(forms.ModelForm):

--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -1028,7 +1028,15 @@ class FighterModPickerMixin(StandardFieldsMixin):
 
         from gyrinx.content.models.statline import ContentStat
 
-        self._fmod_stats = list(ContentStat.objects.all().order_by("full_name"))
+        # Only surface stats that belong to a fighter-side statline type
+        # (Fighter / Vehicle / Crew). ``ContentStat`` is shared with weapon
+        # profiles (ammo, AP, range, accuracy) — those have no meaning when
+        # applied to a fighter and would just confuse the picker.
+        self._fmod_stats = list(
+            ContentStat.objects.filter(statline_type_stats__isnull=False)
+            .distinct()
+            .order_by("full_name")
+        )
         for stat in self._fmod_stats:
             self.fields[f"fmod_stat_{stat.field_name}_mode"] = forms.ChoiceField(
                 choices=self.FIGHTER_STAT_MODE_CHOICES,

--- a/gyrinx/core/templates/core/pack/includes/_accessory_mods_picker.html
+++ b/gyrinx/core/templates/core/pack/includes/_accessory_mods_picker.html
@@ -7,7 +7,7 @@ ContentWeaponAccessoryPackForm. Expects:
 The form exposes ``stat_mod_rows`` and ``trait_mod_rows`` iterables for
 template rendering.
 {% endcomment %}
-<div class="vstack gap-3" data-accessory-mods-picker>
+<div class="vstack gap-3" data-mod-picker>
     <details class="border rounded p-2" open>
         <summary class="fw-semibold">Weapon stat modifiers</summary>
         <div class="text-secondary fs-7 mb-2 mt-1">Pick at most one modifier per stat. Leave the mode as "None" to skip.</div>
@@ -52,78 +52,7 @@ template rendering.
         {% endif %}
     </details>
 </div>
-<style>
-    [data-accessory-mods-picker] .mod-row {
-        border-radius: 0.25rem;
-        padding: 0.125rem 0.25rem;
-        transition: background-color 200ms ease;
-        /* Neutralise Bootstrap's .row gutter trick (negative margin-top on
-           the row + positive margin-top on each col). Without this the
-           highlight bg looks top-heavy because the row's negative offset
-           lives outside its background box. */
-        margin-top: 0;
-    }
-    [data-accessory-mods-picker] .mod-row > * {
-        margin-top: 0;
-    }
-    [data-accessory-mods-picker] .mod-row.mod-row-modified {
-        background-color: var(--bs-warning-bg-subtle, #fff3cd);
-        font-weight: 600;
-    }
-    [data-accessory-mods-picker] .mod-row.mod-row-flash {
-        animation: mod-row-flash 600ms ease-in-out;
-    }
-    @keyframes mod-row-flash {
-        0% { background-color: #ffe082; }
-        100% { background-color: var(--bs-warning-bg-subtle, #fff3cd); }
-    }
-</style>
-<script>
-    (function () {
-        const root = document.querySelector("[data-accessory-mods-picker]");
-        if (!root) return;
-
-        function rowIsModified(row) {
-            const select = row.querySelector("select");
-            return !!(select && select.value !== "");
-        }
-
-        function applyState(row, flash) {
-            const modified = rowIsModified(row);
-            row.classList.toggle("mod-row-modified", modified);
-            if (flash && modified) {
-                row.classList.remove("mod-row-flash");
-                void row.offsetWidth;
-                row.classList.add("mod-row-flash");
-            }
-        }
-
-        // Initial state.
-        root.querySelectorAll("[data-mod-row]").forEach((row) => applyState(row, false));
-
-        // Update on change.
-        root.addEventListener("change", (e) => {
-            if (!e.target.matches("select")) return;
-            const row = e.target.closest("[data-mod-row]");
-            if (row) applyState(row, true);
-        });
-
-        // Trait filter.
-        const filter = root.querySelector("[data-trait-filter]");
-        const empty = root.querySelector("[data-trait-empty]");
-        if (filter) {
-            filter.addEventListener("input", (e) => {
-                const q = e.target.value.trim().toLowerCase();
-                let visible = 0;
-                root.querySelectorAll("[data-trait-row]").forEach((row) => {
-                    const label = row.querySelector("label");
-                    const text = label ? label.textContent.toLowerCase() : "";
-                    const match = !q || text.includes(q);
-                    row.classList.toggle("d-none", !match);
-                    if (match) visible += 1;
-                });
-                if (empty) empty.classList.toggle("d-none", visible > 0 || !q);
-            });
-        }
-    })();
-</script>
+{% comment %}
+Styles and JS live in _mod_picker_shared.html, which the host page
+(pack_item_edit / pack_item_add) includes once.
+{% endcomment %}

--- a/gyrinx/core/templates/core/pack/includes/_equipment_mods_picker.html
+++ b/gyrinx/core/templates/core/pack/includes/_equipment_mods_picker.html
@@ -1,0 +1,86 @@
+{% comment %}
+Picker for the synthetic fighter-mod fields on ContentGearPackForm and
+ContentWeaponPackForm (provided by FighterModPickerMixin). Expects:
+
+    form  — bound form with fighter_stat_mod_rows, fighter_rule_mod_rows,
+            fighter_skill_mod_rows and the any_*_set helpers.
+
+Modifiers attached here apply to the fighter whenever this equipment is
+equipped.
+{% endcomment %}
+<div class="vstack gap-3" data-mod-picker>
+    <div class="text-secondary fs-7">These modifiers apply to the fighter while this equipment is equipped.</div>
+    <details class="border rounded p-2"
+             {% if form.any_fighter_stat_mod_set %}open{% endif %}>
+        <summary class="fw-semibold">Fighter stat modifiers</summary>
+        <div class="text-secondary fs-7 mb-2 mt-1">Pick at most one modifier per stat. Leave the mode as "None" to skip.</div>
+        <div class="vstack gap-2">
+            {% for row in form.fighter_stat_mod_rows %}
+                <div class="row g-2 align-items-center mod-row" data-mod-row>
+                    <label class="col-4 col-sm-3 mb-0 fs-7"
+                           for="{{ row.mode_field.id_for_label }}">{{ row.label }}</label>
+                    <div class="col-4 col-sm-3">{{ row.mode_field }}</div>
+                    <div class="col-4 col-sm-3">{{ row.value_field }}</div>
+                </div>
+                {% if row.mode_field.errors %}<div class="text-danger fs-7 ms-1">{{ row.mode_field.errors|join:" " }}</div>{% endif %}
+                {% if row.value_field.errors %}
+                    <div class="text-danger fs-7 ms-1">{{ row.value_field.errors|join:" " }}</div>
+                {% endif %}
+            {% endfor %}
+        </div>
+    </details>
+    <details class="border rounded p-2"
+             {% if form.any_fighter_rule_mod_set %}open{% endif %}>
+        <summary class="fw-semibold">Fighter rule modifiers</summary>
+        <div class="text-secondary fs-7 mb-2 mt-1">
+            Add or remove a special rule on the fighter while this equipment is equipped.
+        </div>
+        {% if form.fighter_rule_mod_rows %}
+            <input type="search"
+                   class="form-control form-control-sm mb-2"
+                   placeholder="Filter rules…"
+                   data-rule-filter
+                   aria-label="Filter rules">
+            <div class="vstack gap-2" data-rule-list>
+                {% for row in form.fighter_rule_mod_rows %}
+                    <div class="row g-2 align-items-center mod-row" data-mod-row data-rule-row>
+                        <label class="col-6 mb-0 fs-7" for="{{ row.field.id_for_label }}">{{ row.rule.name }}</label>
+                        <div class="col-6">{{ row.field }}</div>
+                    </div>
+                {% endfor %}
+            </div>
+            <div class="text-secondary fs-7 mt-2 d-none" data-rule-empty>No rules match.</div>
+        {% else %}
+            <p class="text-secondary mb-0 fs-7">No rules available.</p>
+        {% endif %}
+    </details>
+    <details class="border rounded p-2"
+             {% if form.any_fighter_skill_mod_set %}open{% endif %}>
+        <summary class="fw-semibold">Fighter skill modifiers</summary>
+        <div class="text-secondary fs-7 mb-2 mt-1">Add or remove a skill on the fighter while this equipment is equipped.</div>
+        {% if form.fighter_skill_mod_rows %}
+            <input type="search"
+                   class="form-control form-control-sm mb-2"
+                   placeholder="Filter skills…"
+                   data-skill-filter
+                   aria-label="Filter skills">
+            <div class="vstack gap-2" data-skill-list>
+                {% for row in form.fighter_skill_mod_rows %}
+                    <div class="row g-2 align-items-center mod-row"
+                         data-mod-row
+                         data-skill-row>
+                        <label class="col-6 mb-0 fs-7" for="{{ row.field.id_for_label }}">{{ row.skill }}</label>
+                        <div class="col-6">{{ row.field }}</div>
+                    </div>
+                {% endfor %}
+            </div>
+            <div class="text-secondary fs-7 mt-2 d-none" data-skill-empty>No skills match.</div>
+        {% else %}
+            <p class="text-secondary mb-0 fs-7">No skills available.</p>
+        {% endif %}
+    </details>
+</div>
+{% comment %}
+Styles and JS live in _mod_picker_shared.html, which the host page
+(pack_item_edit / pack_item_add) includes once.
+{% endcomment %}

--- a/gyrinx/core/templates/core/pack/includes/_equipment_mods_picker.html
+++ b/gyrinx/core/templates/core/pack/includes/_equipment_mods_picker.html
@@ -9,7 +9,7 @@ Modifiers attached here apply to the fighter whenever this equipment is
 equipped.
 {% endcomment %}
 <div class="vstack gap-3" data-mod-picker>
-    <div class="text-secondary">These modifiers apply to the fighter while this equipment is equipped.</div>
+    <div>These modifiers apply to the fighter while this equipment is equipped.</div>
     <details class="border rounded p-2"
              {% if form.any_fighter_stat_mod_set %}open{% endif %}>
         <summary class="fw-semibold">Fighter stat modifiers</summary>

--- a/gyrinx/core/templates/core/pack/includes/_equipment_mods_picker.html
+++ b/gyrinx/core/templates/core/pack/includes/_equipment_mods_picker.html
@@ -9,7 +9,7 @@ Modifiers attached here apply to the fighter whenever this equipment is
 equipped.
 {% endcomment %}
 <div class="vstack gap-3" data-mod-picker>
-    <div class="text-secondary fs-7">These modifiers apply to the fighter while this equipment is equipped.</div>
+    <div class="text-secondary">These modifiers apply to the fighter while this equipment is equipped.</div>
     <details class="border rounded p-2"
              {% if form.any_fighter_stat_mod_set %}open{% endif %}>
         <summary class="fw-semibold">Fighter stat modifiers</summary>

--- a/gyrinx/core/templates/core/pack/includes/_mod_picker_shared.html
+++ b/gyrinx/core/templates/core/pack/includes/_mod_picker_shared.html
@@ -1,0 +1,81 @@
+{% comment %}
+Shared styles + JS used by both the weapon-accessory mod picker
+(``_accessory_mods_picker.html``) and the equipment fighter-mod picker
+(``_equipment_mods_picker.html``).
+
+Include once per page. The JS auto-detects each picker root via its
+``[data-mod-picker]`` attribute and wires up highlight + filter behaviours
+without per-picker plumbing.
+{% endcomment %}
+<style>
+    [data-mod-picker] .mod-row {
+        border-radius: 0.25rem;
+        padding: 0.125rem 0.25rem;
+        transition: background-color 200ms ease;
+        margin-top: 0;
+    }
+    [data-mod-picker] .mod-row > * {
+        margin-top: 0;
+    }
+    [data-mod-picker] .mod-row.mod-row-modified {
+        background-color: var(--bs-warning-bg-subtle, #fff3cd);
+        font-weight: 600;
+    }
+    [data-mod-picker] .mod-row.mod-row-flash {
+        animation: mod-row-flash 600ms ease-in-out;
+    }
+    @keyframes mod-row-flash {
+        0% { background-color: #ffe082; }
+        100% { background-color: var(--bs-warning-bg-subtle, #fff3cd); }
+    }
+</style>
+<script>
+    (function () {
+        function rowIsModified(row) {
+            const select = row.querySelector("select");
+            return !!(select && select.value !== "");
+        }
+
+        function applyState(row, flash) {
+            const modified = rowIsModified(row);
+            row.classList.toggle("mod-row-modified", modified);
+            if (flash && modified) {
+                row.classList.remove("mod-row-flash");
+                void row.offsetWidth;
+                row.classList.add("mod-row-flash");
+            }
+        }
+
+        function wireFilter(root, filterAttr, rowAttr, emptyAttr) {
+            const filter = root.querySelector(`[${filterAttr}]`);
+            const empty = root.querySelector(`[${emptyAttr}]`);
+            if (!filter) return;
+            filter.addEventListener("input", (e) => {
+                const q = e.target.value.trim().toLowerCase();
+                let visible = 0;
+                root.querySelectorAll(`[${rowAttr}]`).forEach((row) => {
+                    const label = row.querySelector("label");
+                    const text = label ? label.textContent.toLowerCase() : "";
+                    const match = !q || text.includes(q);
+                    row.classList.toggle("d-none", !match);
+                    if (match) visible += 1;
+                });
+                if (empty) empty.classList.toggle("d-none", visible > 0 || !q);
+            });
+        }
+
+        document.querySelectorAll("[data-mod-picker]").forEach((root) => {
+            root.querySelectorAll("[data-mod-row]").forEach((row) => applyState(row, false));
+            root.addEventListener("change", (e) => {
+                if (!e.target.matches("select")) return;
+                const row = e.target.closest("[data-mod-row]");
+                if (row) applyState(row, true);
+            });
+            // Each picker declares its own filter inputs / row markers / empty
+            // hints via these attributes; the helper is a no-op when absent.
+            wireFilter(root, "data-trait-filter", "data-trait-row", "data-trait-empty");
+            wireFilter(root, "data-rule-filter", "data-rule-row", "data-rule-empty");
+            wireFilter(root, "data-skill-filter", "data-skill-row", "data-skill-empty");
+        });
+    })();
+</script>

--- a/gyrinx/core/templates/core/pack/includes/pack_item_edit_tabs_equipment.html
+++ b/gyrinx/core/templates/core/pack/includes/pack_item_edit_tabs_equipment.html
@@ -1,0 +1,10 @@
+<ul class="nav nav-tabs mb-3">
+    <li class="nav-item">
+        <a href="{% url 'core:pack-edit-item' pack.id pack_item.id %}"
+           class="nav-link{% if active_tab == 'details' %} active{% endif %}">Details</a>
+    </li>
+    <li class="nav-item">
+        <a href="{% url 'core:pack-item-modifiers' pack.id pack_item.id %}"
+           class="nav-link{% if active_tab == 'modifiers' %} active{% endif %}">Modifiers</a>
+    </li>
+</ul>

--- a/gyrinx/core/templates/core/pack/pack_item_add.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add.html
@@ -18,8 +18,15 @@
                 {% for field in form.hidden_fields %}{{ field }}{% endfor %}
                 {% for field in form.standard_fields %}<div>{{ field.as_field_group }}</div>{% endfor %}
                 {% include "core/pack/includes/_accessory_mods_picker.html" with form=form %}
+                {% include "core/pack/includes/_mod_picker_shared.html" %}
             {% else %}
                 {{ form }}
+            {% endif %}
+            {% if slug == "gear" or slug == "weapon" %}
+                <div class="border rounded p-2 text-secondary fs-7">
+                    <i class="bi-info-circle" aria-hidden="true"></i>
+                    You can add fighter stat, rule, and skill modifiers from the Modifiers tab after you create this {{ label|lower }}.
+                </div>
             {% endif %}
             {% if profile_mode == "multi" %}
                 <input type="hidden" name="profile_mode" value="multi">

--- a/gyrinx/core/templates/core/pack/pack_item_add.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add.html
@@ -23,9 +23,11 @@
                 {{ form }}
             {% endif %}
             {% if slug == "gear" or slug == "weapon" %}
-                <div class="border rounded p-2 text-secondary fs-7">
-                    <i class="bi-info-circle" aria-hidden="true"></i>
-                    You can add fighter stat, rule, and skill modifiers from the Modifiers tab after you create this {{ label|lower }}.
+                <div class="alert alert-secondary alert-icon" role="alert">
+                    <i class="bi-info-circle"></i>
+                    <div>
+                        You can add fighter stat, rule, and skill modifiers from the Modifiers tab after you create this {{ label|lower }}.
+                    </div>
                 </div>
             {% endif %}
             {% if profile_mode == "multi" %}

--- a/gyrinx/core/templates/core/pack/pack_item_edit.html
+++ b/gyrinx/core/templates/core/pack/pack_item_edit.html
@@ -107,6 +107,9 @@
             <h1 class="h3">
                 <i class="{{ icon }}"></i> Edit {{ label }}
             </h1>
+            {% if slug == "gear" or slug == "weapon" %}
+                {% include "core/pack/includes/pack_item_edit_tabs_equipment.html" with active_tab="details" %}
+            {% endif %}
             <form action="{% url 'core:pack-edit-item' pack.id pack_item.id %}"
                   method="post"
                   class="vstack gap-3">
@@ -116,6 +119,7 @@
                     {% for field in form.hidden_fields %}{{ field }}{% endfor %}
                     {% for field in form.standard_fields %}<div>{{ field.as_field_group }}</div>{% endfor %}
                     {% include "core/pack/includes/_accessory_mods_picker.html" with form=form %}
+                    {% include "core/pack/includes/_mod_picker_shared.html" %}
                 {% else %}
                     {{ form }}
                 {% endif %}

--- a/gyrinx/core/templates/core/pack/pack_item_modifiers.html
+++ b/gyrinx/core/templates/core/pack/pack_item_modifiers.html
@@ -1,0 +1,27 @@
+{% extends "core/layouts/base.html" %}
+{% load custom_tags %}
+{% block head_title %}
+    Modifiers for {{ content_obj }} - {{ pack.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with url=back_url text=pack.name %}
+    <div class="col-12 col-md-8 col-lg-6 vstack gap-3">
+        <h1 class="h3">
+            <i class="{{ icon }}"></i> Edit {{ label }}
+        </h1>
+        {% include "core/pack/includes/pack_item_edit_tabs_equipment.html" with active_tab="modifiers" %}
+        <form action="{% url 'core:pack-item-modifiers' pack.id pack_item.id %}"
+              method="post"
+              class="vstack gap-3">
+            {% csrf_token %}
+            {{ form.non_field_errors }}
+            {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+            {% include "core/pack/includes/_equipment_mods_picker.html" with form=form %}
+            {% include "core/pack/includes/_mod_picker_shared.html" %}
+            <div class="mt-3">
+                <button type="submit" class="btn btn-success">Save</button>
+                <a href="{{ back_url }}" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_pack_equipment_mods.py
+++ b/gyrinx/core/tests/test_pack_equipment_mods.py
@@ -45,15 +45,26 @@ def _add_to_pack(pack, obj):
 
 @pytest.fixture(autouse=True)
 def _seed_movement_stat(db):
-    """Ensure the ``movement`` ContentStat exists.
+    """Ensure the ``movement`` ContentStat exists and is linked to a Fighter
+    statline type.
 
     Data migration 0148 seeds the canonical set in production, but pytest
-    runs with ``--nomigrations`` so we materialise the one row the tests
-    need on the fly.
+    runs with ``--nomigrations`` so we materialise the rows the tests need
+    on the fly. The picker filters stats by membership in a statline type,
+    so the link is what makes ``movement`` visible to ``EquipmentModifiersForm``.
     """
-    ContentStat.objects.get_or_create(
+    from gyrinx.content.models.statline import (
+        ContentStatlineType,
+        ContentStatlineTypeStat,
+    )
+
+    stat, _ = ContentStat.objects.get_or_create(
         field_name="movement",
         defaults={"short_name": "M", "full_name": "Movement", "is_inches": True},
+    )
+    fighter_type, _ = ContentStatlineType.objects.get_or_create(name="Fighter")
+    ContentStatlineTypeStat.objects.get_or_create(
+        statline_type=fighter_type, stat=stat, defaults={"position": 1}
     )
 
 

--- a/gyrinx/core/tests/test_pack_equipment_mods.py
+++ b/gyrinx/core/tests/test_pack_equipment_mods.py
@@ -1,0 +1,364 @@
+"""Tests for fighter mod pickers on pack-defined gear and weapons (issue #1753).
+
+``EquipmentModifiersForm`` (driven by ``FighterModPickerMixin``) plumbs
+``ContentModFighterStat`` / ``ContentModFighterRule`` / ``ContentModFighterSkill``
+rows into ``ContentEquipment.modifiers`` from the Modifiers tab of the pack
+gear/weapon editor. Once attached, the runtime path in
+``ListFighterEquipmentAssignment._mods`` picks them up for subscribed lists.
+"""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentCategory,
+)
+from gyrinx.content.models.metadata import ContentRule
+from gyrinx.content.models.modifier import (
+    ContentModFighterRule,
+    ContentModFighterSkill,
+    ContentModFighterStat,
+    ContentModSkillTreeAccess,
+)
+from gyrinx.content.models.skill import ContentSkill, ContentSkillCategory
+from gyrinx.content.models.statline import ContentStat
+from gyrinx.core.forms.pack import (
+    ContentGearPackForm,
+    ContentWeaponPackForm,
+    EquipmentModifiersForm,
+)
+from gyrinx.core.models.list import ListFighterEquipmentAssignment
+from gyrinx.core.models.pack import CustomContentPackItem
+
+
+def _ct(model):
+    return ContentType.objects.get_for_model(model)
+
+
+def _add_to_pack(pack, obj):
+    CustomContentPackItem.objects.create(
+        pack=pack, content_type=_ct(type(obj)), object_id=obj.pk, owner=pack.owner
+    )
+
+
+@pytest.fixture(autouse=True)
+def _seed_movement_stat(db):
+    """Ensure the ``movement`` ContentStat exists.
+
+    Data migration 0148 seeds the canonical set in production, but pytest
+    runs with ``--nomigrations`` so we materialise the one row the tests
+    need on the fly.
+    """
+    ContentStat.objects.get_or_create(
+        field_name="movement",
+        defaults={"short_name": "M", "full_name": "Movement", "is_inches": True},
+    )
+
+
+@pytest.fixture
+def gear_category(db):
+    return ContentEquipmentCategory.objects.create(
+        name="Pack Gear Cat", group="Personal Equipment"
+    )
+
+
+@pytest.fixture
+def weapon_category(db):
+    return ContentEquipmentCategory.objects.create(
+        name="Pack Pistols Cat", group="Weapons & Ammo"
+    )
+
+
+@pytest.fixture
+def pack_gear(pack, gear_category):
+    gear = ContentEquipment.objects.create(
+        name="Pack Plate", category=gear_category, cost=10
+    )
+    _add_to_pack(pack, gear)
+    return gear
+
+
+@pytest.fixture
+def pack_weapon(pack, weapon_category):
+    weapon = ContentEquipment.objects.create(
+        name="Pack Pistol", category=weapon_category, cost=20
+    )
+    _add_to_pack(pack, weapon)
+    return weapon
+
+
+# --- Form-level behaviour -----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_gear_and_weapon_forms_have_no_mod_fields():
+    """The detail forms must NOT carry mod fields — those live on the
+    Modifiers tab via ``EquipmentModifiersForm``."""
+    gear_form = ContentGearPackForm()
+    weapon_form = ContentWeaponPackForm()
+    assert not any(name.startswith("fmod_") for name in gear_form.fields)
+    assert not any(name.startswith("fmod_") for name in weapon_form.fields)
+
+
+@pytest.mark.django_db
+def test_modifiers_form_exposes_fighter_mod_fields(pack):
+    form = EquipmentModifiersForm(pack=pack)
+    movement = ContentStat.objects.get(field_name="movement")
+    assert f"fmod_stat_{movement.field_name}_mode" in form.fields
+    assert f"fmod_stat_{movement.field_name}_value" in form.fields
+
+
+@pytest.mark.django_db
+def test_modifiers_form_validates_stat_value_required(pack, pack_gear):
+    movement = ContentStat.objects.get(field_name="movement")
+    form = EquipmentModifiersForm(
+        data={
+            f"fmod_stat_{movement.field_name}_mode": "improve",
+            f"fmod_stat_{movement.field_name}_value": "",
+        },
+        instance=pack_gear,
+        pack=pack,
+    )
+    assert not form.is_valid()
+    assert f"fmod_stat_{movement.field_name}_value" in form.errors
+
+
+@pytest.mark.django_db
+def test_modifiers_form_validates_integer_for_improve(pack, pack_gear):
+    movement = ContentStat.objects.get(field_name="movement")
+    form = EquipmentModifiersForm(
+        data={
+            f"fmod_stat_{movement.field_name}_mode": "improve",
+            f"fmod_stat_{movement.field_name}_value": "not-an-int",
+        },
+        instance=pack_gear,
+        pack=pack,
+    )
+    assert not form.is_valid()
+    assert f"fmod_stat_{movement.field_name}_value" in form.errors
+
+
+@pytest.mark.django_db
+def test_modifiers_form_save_attaches_fighter_stat_mod(pack, pack_gear):
+    movement = ContentStat.objects.get(field_name="movement")
+    form = EquipmentModifiersForm(
+        data={
+            f"fmod_stat_{movement.field_name}_mode": "improve",
+            f"fmod_stat_{movement.field_name}_value": "1",
+        },
+        instance=pack_gear,
+        pack=pack,
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save()
+    attached = list(obj.modifiers.all())
+    assert len(attached) == 1
+    mod = attached[0]
+    assert isinstance(mod, ContentModFighterStat)
+    assert mod.stat == movement.field_name
+    assert mod.mode == "improve"
+    assert mod.value == "1"
+
+
+@pytest.mark.django_db
+def test_modifiers_form_save_attaches_rule_and_skill_mods(pack, pack_weapon):
+    rule = ContentRule.objects.create(name="Pack Frenzy")
+    _add_to_pack(pack, rule)
+    cat = ContentSkillCategory.objects.create(name="Pack Combat")
+    _add_to_pack(pack, cat)
+    skill = ContentSkill.objects.create(name="Pack Parry", category=cat)
+    _add_to_pack(pack, skill)
+
+    form = EquipmentModifiersForm(
+        data={
+            f"fmod_rule_{rule.pk}": "add",
+            f"fmod_skill_{skill.pk}": "add",
+        },
+        instance=pack_weapon,
+        pack=pack,
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save()
+    mods = list(obj.modifiers.all())
+    assert len(mods) == 2
+    assert any(
+        isinstance(m, ContentModFighterRule)
+        and m.rule_id == rule.pk
+        and m.mode == "add"
+        for m in mods
+    )
+    assert any(
+        isinstance(m, ContentModFighterSkill)
+        and m.skill_id == skill.pk
+        and m.mode == "add"
+        for m in mods
+    )
+
+
+@pytest.mark.django_db
+def test_modifiers_form_initial_populates_from_existing_mods(pack, pack_gear):
+    """Visiting the Modifiers tab pre-populates from existing modifiers."""
+    movement = ContentStat.objects.get(field_name="movement")
+    mod = ContentModFighterStat.objects.create(
+        stat=movement.field_name, mode="improve", value="1"
+    )
+    pack_gear.modifiers.add(mod)
+
+    form = EquipmentModifiersForm(instance=pack_gear, pack=pack)
+    assert form.initial[f"fmod_stat_{movement.field_name}_mode"] == "improve"
+    assert form.initial[f"fmod_stat_{movement.field_name}_value"] == "1"
+
+
+@pytest.mark.django_db
+def test_modifiers_form_save_preserves_unmanaged_mod_types(pack, pack_gear):
+    """SkillTreeAccess mods set via admin survive a Modifiers-tab save."""
+    cat = ContentSkillCategory.objects.create(name="Brawl Cat")
+    sta = ContentModSkillTreeAccess.objects.create(
+        skill_category=cat, mode="add_primary"
+    )
+    pack_gear.modifiers.add(sta)
+    movement = ContentStat.objects.get(field_name="movement")
+
+    form = EquipmentModifiersForm(
+        data={
+            f"fmod_stat_{movement.field_name}_mode": "improve",
+            f"fmod_stat_{movement.field_name}_value": "1",
+        },
+        instance=pack_gear,
+        pack=pack,
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save()
+    mods = list(obj.modifiers.all())
+    assert any(m.pk == sta.pk for m in mods)
+    assert any(isinstance(m, ContentModFighterStat) for m in mods)
+
+
+# --- View-level behaviour -----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_add_gear_view_does_not_render_mod_picker(client, user, pack):
+    """The add view must NOT render the mod picker — that lives on the
+    Modifiers tab post-creation."""
+    client.force_login(user)
+    url = reverse("core:pack-add-item", args=(pack.id, "gear"))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"Fighter stat modifiers" not in response.content
+    assert b"Fighter rule modifiers" not in response.content
+    assert b"Fighter skill modifiers" not in response.content
+    # The help text pointing at the Modifiers tab is shown.
+    assert b"Modifiers tab" in response.content
+
+
+@pytest.mark.django_db
+def test_add_gear_view_creates_equipment_without_mods(
+    client, user, pack, gear_category
+):
+    client.force_login(user)
+    url = reverse("core:pack-add-item", args=(pack.id, "gear"))
+    response = client.post(
+        url,
+        {
+            "name": "Jump Boots",
+            "category": str(gear_category.pk),
+            "cost": "8",
+            "rarity": "C",
+            "rarity_roll": "",
+        },
+    )
+    assert response.status_code == 302
+    gear = ContentEquipment.objects.all_content().get(name="Jump Boots")
+    assert list(gear.modifiers.all()) == []
+
+
+@pytest.mark.django_db
+def test_edit_gear_view_shows_tabs_and_no_mod_picker(client, user, pack, pack_gear):
+    """The Details tab must show the Details/Modifiers tab nav and NOT the picker."""
+    client.force_login(user)
+    pack_item = CustomContentPackItem.objects.get(
+        pack=pack, content_type=_ct(ContentEquipment), object_id=pack_gear.pk
+    )
+    response = client.get(reverse("core:pack-edit-item", args=(pack.id, pack_item.id)))
+    assert response.status_code == 200
+    assert b"Modifiers" in response.content  # tab label
+    # The mod picker only appears on the Modifiers tab.
+    assert b"Fighter stat modifiers" not in response.content
+
+
+@pytest.mark.django_db
+def test_modifiers_view_renders_picker_and_round_trips(client, user, pack, pack_gear):
+    """The Modifiers tab GETs the picker, pre-populated with existing mods;
+    POST swaps the mod and redirects back to the Modifiers tab."""
+    client.force_login(user)
+    movement = ContentStat.objects.get(field_name="movement")
+    mod = ContentModFighterStat.objects.create(
+        stat=movement.field_name, mode="improve", value="1"
+    )
+    pack_gear.modifiers.add(mod)
+
+    pack_item = CustomContentPackItem.objects.get(
+        pack=pack, content_type=_ct(ContentEquipment), object_id=pack_gear.pk
+    )
+    modifiers_url = reverse("core:pack-item-modifiers", args=(pack.id, pack_item.id))
+
+    # GET — picker visible and existing mod pre-populated.
+    response = client.get(modifiers_url)
+    assert response.status_code == 200
+    assert b"Fighter stat modifiers" in response.content
+    assert b'value="improve" selected' in response.content
+
+    # POST — swap to worsen movement -1.
+    response = client.post(
+        modifiers_url,
+        {
+            f"fmod_stat_{movement.field_name}_mode": "worsen",
+            f"fmod_stat_{movement.field_name}_value": "1",
+        },
+    )
+    assert response.status_code == 302
+    assert response["Location"] == modifiers_url
+    mods = list(pack_gear.modifiers.all())
+    assert len(mods) == 1
+    assert isinstance(mods[0], ContentModFighterStat)
+    assert mods[0].mode == "worsen"
+
+
+@pytest.mark.django_db
+def test_modifiers_view_404s_for_non_equipment(client, user, pack):
+    """Only gear and weapons have a Modifiers tab. Other pack-item types 404."""
+    client.force_login(user)
+    rule = ContentRule.objects.create(name="Standalone Rule")
+    _add_to_pack(pack, rule)
+    item = CustomContentPackItem.objects.get(
+        pack=pack, content_type=_ct(ContentRule), object_id=rule.pk
+    )
+    response = client.get(reverse("core:pack-item-modifiers", args=(pack.id, item.id)))
+    assert response.status_code == 404
+
+
+# --- Subscriber runtime application ------------------------------------------
+
+
+@pytest.mark.django_db
+def test_subscriber_gets_pack_equipment_stat_mod(
+    user, make_list, make_list_fighter, pack, pack_gear
+):
+    """A subscribed list's fighter equipped with the pack gear sees the mod."""
+    movement = ContentStat.objects.get(field_name="movement")
+    mod = ContentModFighterStat.objects.create(
+        stat=movement.field_name, mode="improve", value="2"
+    )
+    pack_gear.modifiers.add(mod)
+
+    lst = make_list("Sub Test")
+    lst.packs.add(pack)
+    fighter = make_list_fighter(lst, "Subbed Fighter")
+
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=fighter, content_equipment=pack_gear
+    )
+    assert mod in assignment._mods

--- a/gyrinx/core/urls.py
+++ b/gyrinx/core/urls.py
@@ -793,6 +793,11 @@ urlpatterns = [
         name="pack-edit-item",
     ),
     path(
+        "pack/<id>/item/<item_id>/modifiers/",
+        pack_views.pack_item_modifiers,
+        name="pack-item-modifiers",
+    ),
+    path(
         "pack/<id>/item/<item_id>/equipment/",
         pack_views.pack_item_equipment,
         name="pack-item-equipment",

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -68,6 +68,7 @@ from gyrinx.core.forms.pack import (
     ContentWeaponPackForm,
     ContentWeaponProfilePackForm,
     ContentWeaponTraitPackForm,
+    EquipmentModifiersForm,
     PackForm,
     HOUSE_RULE_TARGET_CHOICES,
 )
@@ -2185,6 +2186,70 @@ def edit_pack_item(request, id, item_id):
         context.update(_load_fighter_preview_context(pack, content_obj))
 
     return render(request, "core/pack/pack_item_edit.html", context)
+
+
+@login_required
+def pack_item_modifiers(request, id, item_id):
+    """Modifiers tab for a pack-defined gear or weapon item.
+
+    Renders the fighter-mod picker (stat / rule / skill) against
+    ``ContentEquipment.modifiers``. Detail fields live on the Details
+    tab (``edit_pack_item``).
+    """
+    pack = _get_pack_for_edit(id, request.user)
+    pack_item = get_object_or_404(
+        CustomContentPackItem.objects.select_related("content_type"),
+        id=item_id,
+        pack=pack,
+        archived=False,
+    )
+
+    content_obj = pack_item.content_object
+    if content_obj is None:
+        raise Http404
+
+    entry = _get_entry_for_pack_item(pack_item)
+    # Only gear and weapons (ContentEquipment with these slugs) have the
+    # Modifiers tab. Other types 404.
+    if entry.slug not in ("gear", "weapon"):
+        raise Http404
+
+    singular_label = _singularize_label(entry)
+
+    if request.method == "POST":
+        form = EquipmentModifiersForm(request.POST, instance=content_obj, pack=pack)
+        if form.is_valid():
+            form.instance._history_user = request.user
+            form.save()
+            log_event(
+                user=request.user,
+                noun=EventNoun.CONTENT_PACK,
+                verb=EventVerb.UPDATE,
+                object=pack,
+                request=request,
+                pack_name=pack.name,
+                pack_id=str(pack.id),
+                content_type=entry.slug,
+                item_name=str(content_obj),
+                update_target="modifiers",
+            )
+            return HttpResponseRedirect(
+                reverse("core:pack-item-modifiers", args=(pack.id, pack_item.id))
+            )
+    else:
+        form = EquipmentModifiersForm(instance=content_obj, pack=pack)
+
+    context = {
+        "form": form,
+        "pack": pack,
+        "pack_item": pack_item,
+        "content_obj": content_obj,
+        "label": singular_label,
+        "icon": entry.icon,
+        "slug": entry.slug,
+        "back_url": _pack_url(pack, f"item-{pack_item.id}"),
+    }
+    return render(request, "core/pack/pack_item_modifiers.html", context)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- Adds a Modifiers tab to the pack gear/weapon editor with a picker for fighter stat, rule, and skill modifiers (writes to `ContentEquipment.modifiers`; the existing runtime path on `ListFighterEquipmentAssignment._mods` surfaces them on subscribed lists).
- Splits the editor into `Details` and `Modifiers` tabs, mirroring the fighter-editor tab pattern. The add view now only shows the detail fields with a one-line hint pointing at the Modifiers tab.
- New shared form mixin (`FighterModPickerMixin`) and template partials are factored so the existing weapon-accessory picker can adopt them later if useful.

## Test plan
- [x] Open a pack, add a custom gear item (no mod picker on this page; help text points to Modifiers tab)
- [x] Edit the gear → Details tab shows base fields and a `Details / Modifiers` tab nav
- [x] Switch to Modifiers → set a stat mod (e.g. Improve Movement +1) and a skill mod (e.g. Add Sprint), save
- [x] Re-open Modifiers tab; values are pre-populated
- [x] Repeat for a custom weapon
- [x] Subscribe a list to the pack, equip the gear on a fighter; statline shows the modded value and skill line shows the added skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)