### PR TITLE
fix: auto-activate per-worktree venv on every Bash invocation

### DIFF
--- a/scripts/activate_venv_hook.sh
+++ b/scripts/activate_venv_hook.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
-# SessionStart hook: persist virtualenv activation for all Claude Code commands.
+# SessionStart hook: activate the correct per-worktree virtualenv for every
+# Bash tool invocation, including mid-session worktree switches.
 #
-# This ensures every Bash tool invocation in the session has the project venv
-# active without manual `. .venv/bin/activate` prefixes.  It runs independently
-# of the heavier setup_web.sh so that venv activation succeeds even when other
-# setup steps fail.
+# The contents written to CLAUDE_ENV_FILE are sourced before every Bash tool
+# call.  We therefore write a small bash function that re-evaluates the
+# active worktree from the current working directory on every invocation —
+# without that, an agent that calls EnterWorktree mid-session ends up running
+# pre-commit / pytest / manage against the *main* worktree's venv, which
+# breaks pre-commit hooks that import gyrinx (they see the main worktree's
+# code, not the worktree the agent is actually editing).
+#
+# If a worktree under .claude/worktrees/ has no .venv yet, the function
+# provisions one on demand via provision_worktree_venv in lib/worktree.sh
+# (one-time ~1 min cost per worktree).
 #
 # Works in both local and remote (Claude Code on the Web) environments.
 # See .claude/settings.json for hook registration.
@@ -17,68 +25,120 @@ if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
   exit 0
 fi
 
-VENV_PATH="${CLAUDE_PROJECT_DIR:-.}/.venv"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-# If no venv in current worktree, try the main worktree
-if [ ! -d "$VENV_PATH" ]; then
-  MAIN_WT=$(git -C "${CLAUDE_PROJECT_DIR:-.}" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -1)
-  if [ -n "$MAIN_WT" ] && [ -d "${MAIN_WT}/.venv" ]; then
-    VENV_PATH="${MAIN_WT}/.venv"
-  else
-    exit 0
-  fi
-fi
-
-# Source the worktree library early so we can resolve the Postgres bin dir
-# and (further down) per-worktree DB identity.
-WORKTREE_LIB="${CLAUDE_PROJECT_DIR:-.}/scripts/lib/worktree.sh"
+# Source the worktree library so we can resolve the main worktree path
+# and (later) provision a venv if needed.  If the library is missing,
+# we still emit a minimal env file so the session is usable.
+WORKTREE_LIB="${PROJECT_DIR}/scripts/lib/worktree.sh"
 if [ -f "$WORKTREE_LIB" ]; then
   # shellcheck source=lib/worktree.sh
   source "$WORKTREE_LIB"
 fi
 
-# Resolve the Homebrew Postgres bin dir (Apple Silicon or Intel).  May be
-# empty on systems without Postgres 16 installed — in that case we just
-# omit it from PATH.
+# Resolve the main worktree path (where the canonical .venv lives) and
+# the Homebrew Postgres bin dir once at hook time.  These don't change
+# during the session, so embedding them as constants avoids re-resolving
+# on every Bash call.
+MAIN_WT=""
+if command -v _main_worktree >/dev/null 2>&1; then
+  MAIN_WT=$(cd "$PROJECT_DIR" 2>/dev/null && _main_worktree || true)
+fi
+if [ -z "$MAIN_WT" ]; then
+  MAIN_WT=$(git -C "$PROJECT_DIR" worktree list --porcelain 2>/dev/null \
+    | sed -n 's/^worktree //p' | head -1)
+fi
+
 PG_BIN_DIR=""
 if command -v homebrew_postgres_bin >/dev/null 2>&1; then
   PG_BIN_DIR=$(homebrew_postgres_bin)
 fi
 
-# Persist environment so every subsequent Bash tool call has the venv active.
-# Use `export` so values propagate to child processes (pytest, manage, etc.),
-# not just to the bash that sources this file.  Without `export`, the harness
-# would set these as shell vars but `pytest` would see settings.py defaults
-# (user=postgres, DB=gyrinx) and fail.
-{
-  if [ -n "$PG_BIN_DIR" ]; then
-    echo "export PATH=\"${PG_BIN_DIR}:${VENV_PATH}/bin:$HOME/.local/bin:$PATH\""
-  else
-    echo "export PATH=\"${VENV_PATH}/bin:$HOME/.local/bin:$PATH\""
+# Eagerly provision the venv for the session's *starting* worktree.  This
+# catches `isolation: "worktree"` subagents whose CWD is already a child
+# worktree at session start.  For mid-session EnterWorktree the per-Bash
+# function below handles it.
+if command -v provision_worktree_venv >/dev/null 2>&1; then
+  START_WT=$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -n "$START_WT" ] && [ "$START_WT" != "$MAIN_WT" ] \
+     && [[ "$START_WT" == *"/.claude/worktrees/"* ]]; then
+    provision_worktree_venv "$START_WT" || true
   fi
-  echo "export VIRTUAL_ENV=\"${VENV_PATH}\""
-  echo "export DJANGO_SETTINGS_MODULE=gyrinx.settings_dev"
-} >> "$CLAUDE_ENV_FILE"
-
-# Set per-worktree DB_NAME and DJANGO_PORT so manage/pytest target the right DB.
-# The worktree_* helpers rely on `git` running inside the worktree, so cd
-# into CLAUDE_PROJECT_DIR first — the SessionStart hook isn't guaranteed
-# to inherit that as its cwd.
-if command -v worktree_db_name >/dev/null 2>&1; then
-  (
-    cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
-    WT_ROOT=$(_worktree_root)
-    if [ -n "$WT_ROOT" ]; then
-      # DB_CONFIG is JSON containing `{`, `}`, `"` — wrap in single quotes
-      # so it survives shell sourcing (the harness re-sources CLAUDE_ENV_FILE
-      # before every Bash invocation; an unquoted value would trip the parser).
-      {
-        echo "export DB_NAME=$(worktree_db_name "$WT_ROOT")"
-        echo "export DJANGO_PORT=$(worktree_port "$WT_ROOT")"
-        echo "export DB_HOST=localhost"
-        echo "export DB_PORT=5432"
-        echo "export DB_CONFIG='$(db_config_for_local)'"
-      } >> "$CLAUDE_ENV_FILE"
-    fi
-  )
 fi
+
+# Capture the pristine PATH (no venv prepended) so each invocation can
+# rebuild PATH from a known base instead of accumulating duplicates.
+BASE_PATH="$PATH"
+
+# Emit the dynamic block.  Constants determined at hook time are quoted via
+# printf %q so they survive sourcing.  The heredoc body is single-quoted so
+# $vars are evaluated at *source* time (per Bash call), not at hook-write
+# time.
+{
+  echo "# >>> Gyrinx per-worktree venv activation >>>"
+  printf 'export __GYRINX_BASE_PATH=%q\n' "$BASE_PATH"
+  printf 'export __GYRINX_PG_BIN_DIR=%q\n' "$PG_BIN_DIR"
+  printf 'export __GYRINX_MAIN_WT=%q\n' "$MAIN_WT"
+  cat <<'BLOCK'
+_gyrinx_activate_worktree() {
+  local wt_root venv lib
+
+  # Determine which worktree we're currently in.  Fall back to the main
+  # worktree if cwd isn't a git checkout (e.g. the agent cd'd to /tmp).
+  wt_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [ -z "$wt_root" ]; then
+    wt_root="$__GYRINX_MAIN_WT"
+  fi
+
+  # Prefer the worktree's own scripts/lib/worktree.sh — it's identical to
+  # the main one for any committed state, and works even if the main
+  # worktree has been removed.  Fall back to the main worktree's copy.
+  lib="${wt_root}/scripts/lib/worktree.sh"
+  if [ ! -f "$lib" ]; then
+    lib="${__GYRINX_MAIN_WT}/scripts/lib/worktree.sh"
+  fi
+  if [ -f "$lib" ]; then
+    # shellcheck source=/dev/null
+    . "$lib"
+  fi
+
+  # Pick the venv: worktree's own first, main worktree as fallback.  For
+  # agent worktrees under .claude/worktrees/, auto-provision if missing so
+  # `python`, `pre-commit`, `pytest`, etc. all see worktree-local code.
+  venv="${wt_root}/.venv"
+  if [ ! -d "$venv" ] \
+     && [[ "$wt_root" == *"/.claude/worktrees/"* ]] \
+     && command -v provision_worktree_venv >/dev/null 2>&1; then
+    provision_worktree_venv "$wt_root" >&2 || true
+  fi
+  if [ ! -d "$venv" ]; then
+    venv="${__GYRINX_MAIN_WT}/.venv"
+  fi
+
+  if [ -d "$venv" ]; then
+    if [ -n "$__GYRINX_PG_BIN_DIR" ]; then
+      export PATH="${__GYRINX_PG_BIN_DIR}:${venv}/bin:${HOME}/.local/bin:${__GYRINX_BASE_PATH}"
+    else
+      export PATH="${venv}/bin:${HOME}/.local/bin:${__GYRINX_BASE_PATH}"
+    fi
+    export VIRTUAL_ENV="$venv"
+  fi
+
+  export DJANGO_SETTINGS_MODULE=gyrinx.settings_dev
+
+  # Per-worktree DB identity (DB_NAME / DJANGO_PORT / DB_CONFIG) — derived
+  # from wt_root so mid-session EnterWorktree retargets the right database.
+  if command -v worktree_db_name >/dev/null 2>&1 && [ -n "$wt_root" ]; then
+    DB_NAME=$(worktree_db_name "$wt_root")
+    DJANGO_PORT=$(worktree_port "$wt_root")
+    export DB_NAME DJANGO_PORT
+    export DB_HOST=localhost
+    export DB_PORT=5432
+    DB_CONFIG="$(db_config_for_local)"
+    export DB_CONFIG
+  fi
+}
+_gyrinx_activate_worktree
+# <<< Gyrinx per-worktree venv activation <<<
+BLOCK
+} >> "$CLAUDE_ENV_FILE"

--- a/scripts/activate_venv_hook.sh
+++ b/scripts/activate_venv_hook.sh
@@ -90,13 +90,14 @@ _gyrinx_activate_worktree() {
     wt_root="$__GYRINX_MAIN_WT"
   fi
 
-  # Prefer the worktree's own scripts/lib/worktree.sh — it's identical to
-  # the main one for any committed state, and works even if the main
-  # worktree has been removed.  Fall back to the main worktree's copy.
-  lib="${wt_root}/scripts/lib/worktree.sh"
-  if [ ! -f "$lib" ]; then
-    lib="${__GYRINX_MAIN_WT}/scripts/lib/worktree.sh"
-  fi
+  # Always source the *main* worktree's scripts/lib/worktree.sh — never the
+  # current worktree's copy.  Two reasons:
+  #   1. Trust boundary: sourcing the worktree's copy would auto-execute any
+  #      unreviewed changes to that file on every Bash invocation.
+  #   2. Staleness: older worktrees may have a worktree.sh from before
+  #      provision_worktree_venv existed; sourcing them would silently
+  #      disable auto-provisioning — the very failure mode this hook fixes.
+  lib="${__GYRINX_MAIN_WT}/scripts/lib/worktree.sh"
   if [ -f "$lib" ]; then
     # shellcheck source=/dev/null
     . "$lib"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -74,21 +74,7 @@ if [ "$WT_ROOT" != "$MAIN_WT" ]; then
     echo "Removing existing per-worktree venv at $WT_VENV..."
     rm -rf "$WT_VENV"
   fi
-  if [ ! -d "$WT_VENV" ]; then
-    if ! command -v uv >/dev/null 2>&1; then
-      echo "ERROR: \`uv\` is required to provision per-worktree venvs but isn't on PATH." >&2
-      echo "Install from https://docs.astral.sh/uv/ or re-create .venv manually:" >&2
-      echo "    python -m venv ${WT_VENV} && ${WT_VENV}/bin/pip install --editable ${WT_ROOT}" >&2
-      exit 1
-    fi
-    echo "Provisioning per-worktree venv at $WT_VENV (~1 min)..."
-    uv venv "$WT_VENV" >/dev/null
-    (
-      cd "$WT_ROOT"
-      uv pip install --python "$WT_VENV/bin/python" --editable . --quiet
-    )
-    echo "Provisioned: $WT_VENV"
-  fi
+  provision_worktree_venv "$WT_ROOT" || exit 1
   # Always (re-)ensure the activate hook is present.  Idempotent — no-op if
   # the marker is already there.  Catches the case where a child worktree
   # had a .venv from before this change and would otherwise never get the

--- a/scripts/lib/worktree.sh
+++ b/scripts/lib/worktree.sh
@@ -128,6 +128,47 @@ homebrew_postgres_data_dir() {
   fi
 }
 
+# provision_worktree_venv <worktree_root>
+#   Ensure <worktree_root>/.venv exists with gyrinx editable-installed from
+#   that worktree.  Idempotent — no-op if the venv already exists.
+#
+#   Used by dev.sh and activate_venv_hook.sh to give every child worktree
+#   (including the .claude/worktrees/* worktrees created by EnterWorktree)
+#   its own venv, so `import gyrinx` resolves to worktree-local code and
+#   pre-commit hooks see the worktree's migrations / models.  Without this,
+#   the main venv's editable install can get repointed to a child worktree
+#   by an errant `uv pip install --editable .`, corrupting every other
+#   session.  See issue #1772.
+#
+#   Echoes a one-line progress message to stderr on first provision so the
+#   ~1-minute delay isn't silent.  Returns 0 on success or skip; non-zero
+#   if uv is missing or provisioning fails.
+provision_worktree_venv() {
+  local wt_root="$1"
+  if [ -z "$wt_root" ] || [ ! -d "$wt_root" ]; then
+    return 1
+  fi
+  local venv="${wt_root}/.venv"
+  if [ -d "$venv" ]; then
+    return 0
+  fi
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "[gyrinx] uv not on PATH; cannot auto-provision ${venv}." >&2
+    echo "[gyrinx] Install uv or create the venv manually:" >&2
+    echo "[gyrinx]   python -m venv ${venv} && ${venv}/bin/pip install --editable ${wt_root}" >&2
+    return 1
+  fi
+  echo "[gyrinx] Provisioning per-worktree venv at ${venv} (~1 min)..." >&2
+  uv venv "$venv" >/dev/null || return 1
+  (
+    cd "$wt_root" || exit 1
+    uv pip install --python "$venv/bin/python" --editable . --quiet
+  ) || return 1
+  install_worktree_venv_hook "$venv/bin/activate" || true
+  echo "[gyrinx] Provisioned ${venv}." >&2
+  return 0
+}
+
 # install_worktree_venv_hook <activate_path>
 #   Append the per-worktree DB env block to a venv's bin/activate file so
 #   `source .venv/bin/activate` exports DB_NAME / DJANGO_PORT / DB_CONFIG

--- a/scripts/lib/worktree.sh
+++ b/scripts/lib/worktree.sh
@@ -159,11 +159,18 @@ provision_worktree_venv() {
     return 1
   fi
   echo "[gyrinx] Provisioning per-worktree venv at ${venv} (~1 min)..." >&2
-  uv venv "$venv" >/dev/null || return 1
-  (
-    cd "$wt_root" || exit 1
-    uv pip install --python "$venv/bin/python" --editable . --quiet
-  ) || return 1
+  # If provisioning fails after `uv venv` has created the directory, remove
+  # the partial venv before returning — otherwise the next call sees the
+  # directory, skips provisioning, and activation puts a half-built venv on
+  # PATH (no editable install, broken imports).
+  if ! uv venv "$venv" >/dev/null; then
+    rm -rf "$venv"
+    return 1
+  fi
+  if ! (cd "$wt_root" && uv pip install --python "$venv/bin/python" --editable . --quiet); then
+    rm -rf "$venv"
+    return 1
+  fi
   install_worktree_venv_hook "$venv/bin/activate" || true
   echo "[gyrinx] Provisioned ${venv}." >&2
   return 0


### PR DESCRIPTION
## Summary

- Agents that called `EnterWorktree` mid-session (or ran as `isolation: worktree` subagents) ended up with `PATH`/`VIRTUAL_ENV` still pointing at the *main* worktree's `.venv`. Pre-commit hooks (e.g. `check_migrations.sh`) then ran `python scripts/manage.py` against main's editable `gyrinx` install, which could be dangling or point at the wrong worktree — breaking commits.
- The SessionStart hook now writes a small bash function into `CLAUDE_ENV_FILE` that re-evaluates the active worktree on **every** Bash invocation via `git rev-parse --show-toplevel`, retargets `PATH` / `VIRTUAL_ENV` / `DB_NAME` / `DJANGO_PORT` / `DB_CONFIG`, and auto-provisions a `.venv` (via the new shared `provision_worktree_venv` helper) for any `.claude/worktrees/*` worktree on first use.
- `dev.sh` now uses the same `provision_worktree_venv` helper instead of duplicating the logic.

## Test plan

- [ ] Start a fresh background session that calls `EnterWorktree` mid-session — confirm `which python` / `import gyrinx` resolve into the *new* worktree's `.venv`.
- [ ] Run `git commit` inside that worktree — pre-commit's `check_migrations` / `check_migration_conflicts` hooks should pass without manual PATH munging.
- [ ] Start a fresh session in the main worktree — confirm `VIRTUAL_ENV` is main's `.venv`, `DB_NAME=gyrinx_main`, `DJANGO_PORT=8000` (unchanged behaviour).
- [ ] Re-run `./scripts/dev.sh` in an existing child worktree — should not re-provision, dev server still boots.
- [ ] `./scripts/dev.sh --reset-venv` still wipes and re-provisions correctly.