### PR TITLE
fix: wrap content pack fighter card gear line in spaceless

### DIFF
--- a/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
+++ b/gyrinx/core/templates/core/pack/includes/fighter_preview_card.html
@@ -116,10 +116,12 @@
                         </th>
                         <td>
                             {% if preview_gear %}
-                                {% for da in preview_gear %}
-                                    {{ da.equipment.name }}
-                                    {% if not forloop.last %},{% endif %}
-                                {% endfor %}
+                                {% spaceless %}
+                                    {% for da in preview_gear %}
+                                        <span>{{ da.equipment.name }}</span>
+                                        {% if not forloop.last %}<span>,&nbsp;</span>{% endif %}
+                                    {% endfor %}
+                                {% endspaceless %}
                             {% else %}
                                 <span class="text-secondary fst-italic">None</span>
                             {% endif %}


### PR DESCRIPTION
Closes #1720

Wrap the gear loop in the fighter preview card in `{% spaceless %}` with `<span>` elements, matching the pattern already used by Rules and Skills in the same template.

Generated with [Claude Code](https://claude.ai/code)