### PR TITLE
docs: record why CampaignContentPack stays a bare models.Model

### DIFF
--- a/gyrinx/core/models/campaign.py
+++ b/gyrinx/core/models/campaign.py
@@ -373,7 +373,17 @@ class Campaign(AppBase):
 
 class CampaignContentPack(models.Model):
     """Through-model for Campaign.packs. The `required` flag means every list
-    in the campaign must be subscribed to this pack."""
+    in the campaign must be subscribed to this pack.
+
+    Intentionally a bare ``models.Model`` (BigAutoField PK, no
+    ``HistoricalRecords``) rather than ``AppBase``. Promoting it was considered
+    and declined in #1774: ``AppBase`` mandates a UUID PK, which would force a
+    risky one-way PK swap on the live ``core_campaign_packs`` table for no
+    consumer benefit (nothing FKs to this leaf join, and the lock path keys on
+    ``(campaign, pack)``). History would also be near-useless here because
+    ``packs.add()/.remove()`` go through ``bulk_create``/bulk-delete and fire no
+    signals. If we ever want a `required`-flip audit trail, log a
+    ``CampaignAction`` instead."""
 
     campaign = models.ForeignKey(
         Campaign,


### PR DESCRIPTION
Follow-up to #1774, which proposed promoting `CampaignContentPack` to `AppBase` + `HistoricalRecords`. After weighing it, we declined and closed the issue. This records the decision at the model so it isn't re-litigated.

Reasoning:

- `AppBase` (via `Base`) mandates a UUID PK, so promoting forces a one-way PK swap from BigAutoField → UUID on the live `core_campaign_packs` table — the highest-risk class of Postgres migration, and one CI never runs (test DB is rebuilt from models with `--nomigrations`).
- Nothing FKs to this leaf join table; the `select_for_update()` lock path keys on `(campaign, pack)`, not the PK. The PK type is invisible to consumers, so the swap protects nothing.
- History would be near-useless: `packs.add()/.remove()` go through `bulk_create`/bulk-delete and fire no `post_save`/`post_delete` signals, so only `required` flips would ever be audited. If we want that audit trail later, a `CampaignAction` is the better fit.

Comment-only change — no schema or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)