### PR TITLE
feat: propagate pack default child-fighter assignments to existing gangs (closes #1725)

### DIFF
--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -3938,14 +3938,24 @@ def enqueue_propagate_default_child_fighter_assignment(
         return
     if not instance.equipment.contentequipmentfighterprofile_set.exists():
         return
-    try:
-        propagate_default_child_fighter_assignment.enqueue(
-            default_assignment_id=str(instance.pk)
-        )
-    except Exception as e:
-        logger.warning(
-            f"Failed to enqueue propagation for default assignment {instance.pk}: {e}"
-        )
+
+    default_assignment_id = str(instance.pk)
+
+    def _enqueue():
+        try:
+            propagate_default_child_fighter_assignment.enqueue(
+                default_assignment_id=default_assignment_id
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to enqueue propagation for default assignment "
+                f"{default_assignment_id}: {e}"
+            )
+
+    # Defer until the surrounding transaction commits: the worker runs in a
+    # separate process (prod Pub/Sub backend) and must not race the commit or
+    # run for an assignment that ends up rolled back.
+    transaction.on_commit(_enqueue)
 
 
 @receiver(

--- a/gyrinx/core/models/list.py
+++ b/gyrinx/core/models/list.py
@@ -68,7 +68,10 @@ from gyrinx.core.models.facts import AssignmentFacts, FighterFacts, ListFacts
 from gyrinx.core.models.history_aware_manager import HistoryAwareManager
 from gyrinx.core.models.history_mixin import HistoryMixin
 from gyrinx.core.models.util import ModContext
-from gyrinx.core.tasks import refresh_list_facts
+from gyrinx.core.tasks import (
+    propagate_default_child_fighter_assignment,
+    refresh_list_facts,
+)
 from gyrinx.models import (
     Archived,
     Base,
@@ -3856,21 +3859,35 @@ class ListFighter(AppBase):
     objects = ListFighterManager.from_queryset(ListFighterQuerySet)()
 
 
-@receiver(post_save, sender=ListFighter, dispatch_uid="create_linked_objects")
-@traced("signal_create_linked_objects")
-def create_linked_objects(sender, instance, **kwargs):
+def _materialise_child_fighter_defaults(list_fighter) -> int:
+    """Materialise a list-fighter's child-spawning default assignments.
+
+    For each default assignment on the fighter's ``content_fighter`` whose
+    equipment spawns a child fighter (``ContentEquipmentFighterProfile``) or
+    child equipment (``ContentEquipmentEquipmentProfile``), disable the default
+    and create a direct assignment with ``cost_override=0``. The direct
+    assignment's ``post_save`` (``create_related_objects``) then spawns the
+    child fighter / linked equipment.
+
+    Idempotent: skips defaults that are disabled or already materialised, so it
+    is safe to call repeatedly (used both at hire time and by the #1725
+    propagation task).
+
+    Returns the number of direct assignments created.
+    """
     # Find the default assignments where the equipment has a fighter profile
-    default_assigns = instance.content_fighter.default_assignments.exclude(
+    default_assigns = list_fighter.content_fighter.default_assignments.exclude(
         Q(equipment__contentequipmentfighterprofile__isnull=True)
         & Q(equipment__contentequipmentequipmentprofile__isnull=True)
     )
+    created = 0
     for assign in default_assigns:
         # Find disabled default assignments
-        is_disabled = instance.disabled_default_assignments.contains(assign)
+        is_disabled = list_fighter.disabled_default_assignments.contains(assign)
 
         # Find assignments on this fighter of that equipment
         exists = (
-            instance._direct_assignments()
+            list_fighter._direct_assignments()
             .filter(content_equipment=assign.equipment, from_default_assignment=assign)
             .exists()
         )
@@ -3879,13 +3896,56 @@ def create_linked_objects(sender, instance, **kwargs):
             # Disable the default assignment and assign the equipment directly
             # This will trigger the ListFighterEquipmentAssignment logic to
             # create the linked objects
-            instance.toggle_default_assignment(assign, enable=False)
+            list_fighter.toggle_default_assignment(assign, enable=False)
             ListFighterEquipmentAssignment.objects.create_with_facts(
-                list_fighter=instance,
+                list_fighter=list_fighter,
                 content_equipment=assign.equipment,
                 cost_override=0,
                 from_default_assignment=assign,
             )
+            created += 1
+    return created
+
+
+@receiver(post_save, sender=ListFighter, dispatch_uid="create_linked_objects")
+@traced("signal_create_linked_objects")
+def create_linked_objects(sender, instance, **kwargs):
+    _materialise_child_fighter_defaults(instance)
+
+
+@receiver(
+    post_save,
+    sender=ContentFighterDefaultAssignment,
+    dispatch_uid="propagate_default_child_fighter_assignment",
+)
+@traced("signal_propagate_default_child_fighter_assignment")
+def enqueue_propagate_default_child_fighter_assignment(
+    sender, instance, created, **kwargs
+):
+    """Propagate a newly-created child-spawning default to existing gangs.
+
+    When a pack author adds a ``ContentFighterDefaultAssignment`` whose
+    equipment spawns a child fighter (a vehicle / exotic beast), existing gangs
+    subscribed to the pack should also get the child materialised — not just
+    gangs created after the change (issue #1725).
+
+    Only fires for newly-created defaults whose equipment actually spawns a
+    child fighter; ordinary gear/weapon defaults are virtual at display time
+    and need no materialisation. The work is offloaded to a task because it can
+    touch many list-fighters across all subscribed gangs.
+    """
+    if not created:
+        return
+    if not instance.equipment.contentequipmentfighterprofile_set.exists():
+        return
+    try:
+        propagate_default_child_fighter_assignment.enqueue(
+            default_assignment_id=str(instance.pk)
+        )
+    except Exception as e:
+        logger.warning(
+            f"Failed to enqueue propagation for default assignment {instance.pk}: {e}"
+        )
 
 
 @receiver(

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -54,7 +54,6 @@ def propagate_default_child_fighter_assignment(default_assignment_id: str):
     from gyrinx.content.models.fighter import ContentFighter
     from gyrinx.core.models.action import ListActionType
     from gyrinx.core.models.list import (
-        List,
         ListFighter,
         _materialise_child_fighter_defaults,
     )
@@ -110,6 +109,7 @@ def propagate_default_child_fighter_assignment(default_assignment_id: str):
 
     equipment_name = default.equipment.name
 
+    propagated_count = 0
     for list_id, fighters in fighters_by_list.items():
         try:
             with transaction.atomic():
@@ -121,7 +121,9 @@ def propagate_default_child_fighter_assignment(default_assignment_id: str):
                 if created_total == 0:
                     continue
 
-                lst = List.objects.get(id=list_id)
+                # affected is select_related("list"), so reuse the loaded
+                # instance rather than re-fetching the list.
+                lst = fighters[0].list
 
                 # Keep the list's cached rating/stash consistent.
                 old_rating = lst.rating_current
@@ -147,16 +149,16 @@ def propagate_default_child_fighter_assignment(default_assignment_id: str):
                     update_credits=False,
                     skip_apply=["rating", "stash"],
                 )
-        except List.DoesNotExist:
-            continue
-        except Exception as e:
-            logger.error(
-                f"Failed to propagate default {default_assignment_id} "
-                f"to list {list_id}: {e}"
+                propagated_count += 1
+        except Exception:
+            logger.exception(
+                f"Failed to propagate default {default_assignment_id} to list {list_id}"
             )
 
     logger.info(
-        f"Propagated default {default_assignment_id} to {len(fighters_by_list)} list(s)"
+        f"Propagated default {default_assignment_id}: "
+        f"materialised on {propagated_count} list(s), "
+        f"checked {len(fighters_by_list)}"
     )
 
 

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 
 import requests
 from django.conf import settings
@@ -29,6 +30,134 @@ def refresh_list_facts(list_id: str):
         logger.info(f"Refreshed facts for list {list_id}")
     except List.DoesNotExist:
         logger.warning(f"List {list_id} not found for facts refresh")
+
+
+@task
+def propagate_default_child_fighter_assignment(default_assignment_id: str):
+    """Propagate a newly-created child-spawning default to existing gangs.
+
+    When a pack author adds a ``ContentFighterDefaultAssignment`` whose
+    equipment spawns a child fighter (a vehicle / exotic beast), every gang
+    already subscribed to a pack containing that fighter type — and holding a
+    list-fighter of that type — should get the child fighter materialised, not
+    just gangs created after the change (issue #1725).
+
+    Idempotent: re-running is safe (the materialisation helper skips disabled
+    and already-materialised defaults).
+    """
+    from django.contrib.contenttypes.models import ContentType
+    from django.db import transaction
+
+    from gyrinx.content.models.default_assignment import (
+        ContentFighterDefaultAssignment,
+    )
+    from gyrinx.content.models.fighter import ContentFighter
+    from gyrinx.core.models.action import ListActionType
+    from gyrinx.core.models.list import (
+        List,
+        ListFighter,
+        _materialise_child_fighter_defaults,
+    )
+    from gyrinx.core.models.pack import CustomContentPackItem
+
+    try:
+        default = ContentFighterDefaultAssignment.objects.get(pk=default_assignment_id)
+    except ContentFighterDefaultAssignment.DoesNotExist:
+        logger.warning(
+            f"Default assignment {default_assignment_id} not found for propagation"
+        )
+        return
+
+    # Re-verify at execution time: the profile may have been removed between
+    # enqueue and run. Only child-spawning defaults need materialising.
+    if not default.equipment.contentequipmentfighterprofile_set.exists():
+        return
+
+    # Packs containing this fighter type. This is a subscriber read path, so we
+    # must NOT filter `archived` on the pack or pack item — archived content
+    # stays visible to gangs already subscribed (see CLAUDE.md "Content packs:
+    # archive semantics", issue #1742).
+    fighter_ct = ContentType.objects.get_for_model(ContentFighter)
+    pack_ids = list(
+        CustomContentPackItem.objects.filter(
+            content_type=fighter_ct, object_id=default.fighter_id
+        )
+        .values_list("pack_id", flat=True)
+        .distinct()
+    )
+    if not pack_ids:
+        return
+
+    # Affected list-fighters: of this fighter type, on lists subscribed to a
+    # pack that contains the fighter. Legacy-only fighters
+    # (legacy_content_fighter) are a documented gap — the materialisation
+    # helper acts on content_fighter defaults only, matching the hire-time
+    # path.
+    affected = (
+        ListFighter.objects.filter(
+            content_fighter=default.fighter,
+            archived=False,
+            list__packs__in=pack_ids,
+        )
+        .select_related("list")
+        .distinct()
+    )
+
+    # Group by list so we create at most one action per affected gang.
+    fighters_by_list: dict[str, list] = defaultdict(list)
+    for fighter in affected:
+        fighters_by_list[fighter.list_id].append(fighter)
+
+    equipment_name = default.equipment.name
+
+    for list_id, fighters in fighters_by_list.items():
+        try:
+            with transaction.atomic():
+                created_total = 0
+                for fighter in fighters:
+                    created_total += _materialise_child_fighter_defaults(fighter)
+
+                # Idempotent no-op: already materialised on every fighter.
+                if created_total == 0:
+                    continue
+
+                lst = List.objects.get(id=list_id)
+
+                # Keep the list's cached rating/stash consistent.
+                old_rating = lst.rating_current
+                old_stash = lst.stash_current
+                facts = lst.facts_from_db(update=True)
+                rating_delta = facts.rating - old_rating
+                stash_delta = facts.stash - old_stash
+
+                # Awareness-only action. Materialising a child-spawning default
+                # has a net-zero cost impact (the default is virtual/0-cost, the
+                # direct assignment uses cost_override=0, and child fighters
+                # don't contribute to list cost), so we never charge or refund
+                # credits — even in campaign mode. We still log it so gang
+                # owners see why a new fighter appeared.
+                lst.create_action(
+                    action_type=ListActionType.CONTENT_COST_CHANGE,
+                    description=f"Pack added a default {equipment_name}",
+                    rating_before=old_rating,
+                    stash_before=old_stash,
+                    rating_delta=rating_delta,
+                    stash_delta=stash_delta,
+                    credits_delta=0,
+                    update_credits=False,
+                    skip_apply=["rating", "stash"],
+                )
+        except List.DoesNotExist:
+            continue
+        except Exception as e:
+            logger.error(
+                f"Failed to propagate default {default_assignment_id} "
+                f"to list {list_id}: {e}"
+            )
+
+    logger.info(
+        f"Propagated default {default_assignment_id} to {len(fighters_by_list)} list(s)"
+    )
 
 
 @task

--- a/gyrinx/core/tests/test_propagate_default_child_fighter.py
+++ b/gyrinx/core/tests/test_propagate_default_child_fighter.py
@@ -1,0 +1,434 @@
+"""Tests for issue #1725 — propagate pack default child-fighter assignments
+to existing gangs.
+
+When a pack author adds a ``ContentFighterDefaultAssignment`` whose equipment
+spawns a child fighter (a vehicle / exotic beast via
+``ContentEquipmentFighterProfile``), the child fighter should materialise on
+*every* already-subscribed gang that has a list-fighter of the relevant type —
+not just gangs created after the change.
+
+These tests are written red-first: they describe the desired behaviour before
+the propagation signal + task land.
+
+Cost note: materialising a default child-spawning assignment produces a net
+rating delta of ZERO (the default assignment is virtual/0-cost, the direct
+assignment uses ``cost_override=0``, and child fighters don't contribute to
+list cost). The paired list-action log entry therefore exists for *awareness*
+(a new fighter appeared because the pack author changed content), not to
+reconcile a cost change — it records the true zero delta and charges no
+credits.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from gyrinx.content.models.default_assignment import ContentFighterDefaultAssignment
+from gyrinx.content.models.equipment import (
+    ContentEquipmentFighterProfile,
+)
+from gyrinx.content.models.fighter import ContentFighter
+from gyrinx.core.models.action import ListAction, ListActionType
+from gyrinx.core.models.list import ListFighter, ListFighterEquipmentAssignment
+from gyrinx.core.models.pack import CustomContentPackItem
+from gyrinx.core.tasks import propagate_default_child_fighter_assignment
+
+# Full legacy statline so facts_from_db() can compute on the fly.
+_STATS = dict(
+    movement='5"',
+    weapon_skill="4+",
+    ballistic_skill="4+",
+    strength="3",
+    toughness="3",
+    wounds="1",
+    initiative="4+",
+    attacks="1",
+    leadership="7+",
+    cool="7+",
+    willpower="7+",
+    intelligence="7+",
+)
+
+
+def _register_pack_item(pack, obj):
+    """Register a content object as a pack item (subscriber-visible)."""
+    ct = ContentType.objects.get_for_model(type(obj))
+    return CustomContentPackItem.objects.create(
+        pack=pack,
+        content_type=ct,
+        object_id=obj.pk,
+        owner=pack.owner,
+    )
+
+
+@pytest.fixture
+def child_spawning_setup(pack, content_house, make_content_fighter, make_equipment):
+    """Build the common scenario:
+
+    - ``parent_cf``: a GANGER fighter type, registered as pack content
+    - ``child_cf``: an EXOTIC_BEAST fighter type (the spawned child)
+    - ``equipment``: ContentEquipment with a ContentEquipmentFighterProfile ->
+      child_cf, also registered as pack content
+
+    Returns a dict; the default assignment is NOT created yet (each test
+    decides when/whether to create it).
+    """
+    from gyrinx.content.models.fighter import FighterCategoryChoices
+
+    parent_cf = make_content_fighter(
+        type="Goliath Driver",
+        category=FighterCategoryChoices.GANGER,
+        house=content_house,
+        base_cost=60,
+        **_STATS,
+    )
+    child_cf = make_content_fighter(
+        type="Hive Cur",
+        category=FighterCategoryChoices.EXOTIC_BEAST,
+        house=content_house,
+        base_cost=25,
+        **_STATS,
+    )
+    equipment = make_equipment("Hive Cur", category="Status Items", cost="25")
+    ContentEquipmentFighterProfile.objects.create(
+        equipment=equipment, content_fighter=child_cf
+    )
+
+    _register_pack_item(pack, parent_cf)
+    _register_pack_item(pack, equipment)
+
+    return {
+        "pack": pack,
+        "parent_cf": parent_cf,
+        "child_cf": child_cf,
+        "equipment": equipment,
+    }
+
+
+def _subscribed_list_with_parent(make_list, content_house, pack, parent_cf, user):
+    """A list subscribed to ``pack`` with one hired list-fighter of parent type.
+
+    The list's cached rating is refreshed after the parent is added so it
+    reflects reality (as it would after a normal hire flow). This isolates the
+    later materialisation effect in the action-log assertions.
+    """
+    lst = make_list("Subscribed Gang", content_house=content_house)
+    lst.packs.add(pack)
+    parent = ListFighter.objects.create(
+        list=lst, content_fighter=parent_cf, name="My Driver", owner=user
+    )
+    lst.facts_from_db(update=True)
+    return lst, parent
+
+
+# --- Signal gating -------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_signal_enqueues_only_for_child_spawning_created_default(
+    child_spawning_setup, make_equipment
+):
+    """The post_save signal enqueues the task only when a default is *created*
+    AND its equipment has a ContentEquipmentFighterProfile."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    equipment = child_spawning_setup["equipment"]
+
+    # A plain (non-child-spawning) equipment.
+    plain_equipment = make_equipment("Bolt Pistol", category="Pistols", cost="10")
+
+    with patch(
+        "gyrinx.core.models.list.propagate_default_child_fighter_assignment"
+    ) as mock_task:
+        # Non-child-spawning default -> must NOT enqueue.
+        ContentFighterDefaultAssignment.objects.create(
+            fighter=parent_cf, equipment=plain_equipment
+        )
+        mock_task.enqueue.assert_not_called()
+
+        # Child-spawning default -> must enqueue exactly once.
+        default = ContentFighterDefaultAssignment.objects.create(
+            fighter=parent_cf, equipment=equipment
+        )
+        mock_task.enqueue.assert_called_once_with(default_assignment_id=str(default.pk))
+
+        # Editing the child-spawning default (created=False) -> must NOT re-enqueue.
+        mock_task.enqueue.reset_mock()
+        default.cost = 5
+        default.save()
+        mock_task.enqueue.assert_not_called()
+
+
+# --- Core propagation ----------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_propagation_reaches_existing_subscribed_gang(
+    child_spawning_setup, make_list, content_house, user
+):
+    """Creating a child-spawning default materialises the child fighter on an
+    existing subscribed gang's matching list-fighter."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    child_cf = child_spawning_setup["child_cf"]
+    equipment = child_spawning_setup["equipment"]
+    pack = child_spawning_setup["pack"]
+
+    lst, parent = _subscribed_list_with_parent(
+        make_list, content_house, pack, parent_cf, user
+    )
+
+    # Sanity: no child yet.
+    assert not ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
+
+    ContentFighterDefaultAssignment.objects.create(
+        fighter=parent_cf, equipment=equipment
+    )
+
+    # Child fighter materialised on the existing parent.
+    assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
+    # And a from_default_assignment direct assignment exists on the parent.
+    assert ListFighterEquipmentAssignment.objects.filter(
+        list_fighter=parent,
+        content_equipment=equipment,
+        from_default_assignment__isnull=False,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_idempotent_rerun(child_spawning_setup, make_list, content_house, user):
+    """Re-running the task does not create duplicate child fighters/assignments."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    child_cf = child_spawning_setup["child_cf"]
+    equipment = child_spawning_setup["equipment"]
+    pack = child_spawning_setup["pack"]
+
+    lst, parent = _subscribed_list_with_parent(
+        make_list, content_house, pack, parent_cf, user
+    )
+    default = ContentFighterDefaultAssignment.objects.create(
+        fighter=parent_cf, equipment=equipment
+    )
+
+    children_before = ListFighter.objects.filter(
+        list=lst, content_fighter=child_cf
+    ).count()
+    assignments_before = ListFighterEquipmentAssignment.objects.filter(
+        list_fighter=parent, content_equipment=equipment
+    ).count()
+    assert children_before == 1
+
+    # Run the task again (enqueue runs synchronously under ImmediateBackend).
+    propagate_default_child_fighter_assignment.enqueue(
+        default_assignment_id=str(default.pk)
+    )
+
+    assert (
+        ListFighter.objects.filter(list=lst, content_fighter=child_cf).count()
+        == children_before
+    )
+    assert (
+        ListFighterEquipmentAssignment.objects.filter(
+            list_fighter=parent, content_equipment=equipment
+        ).count()
+        == assignments_before
+    )
+
+
+@pytest.mark.django_db
+def test_existing_materialised_assignment_untouched(
+    child_spawning_setup, make_list, content_house, user
+):
+    """If a list-fighter already has the materialised assignment, propagation
+    leaves it alone (no duplicate, no second action)."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    child_cf = child_spawning_setup["child_cf"]
+    equipment = child_spawning_setup["equipment"]
+    pack = child_spawning_setup["pack"]
+
+    lst, parent = _subscribed_list_with_parent(
+        make_list, content_house, pack, parent_cf, user
+    )
+    # Create the default WITHOUT propagation firing, then materialise once.
+    with patch("gyrinx.core.models.list.propagate_default_child_fighter_assignment"):
+        default = ContentFighterDefaultAssignment.objects.create(
+            fighter=parent_cf, equipment=equipment
+        )
+    # Materialise manually (simulate already-spawned).
+    propagate_default_child_fighter_assignment.enqueue(
+        default_assignment_id=str(default.pk)
+    )
+    assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).count() == 1
+
+    actions_before = ListAction.objects.filter(
+        list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
+    ).count()
+
+    # Run again — nothing new should be created.
+    propagate_default_child_fighter_assignment.enqueue(
+        default_assignment_id=str(default.pk)
+    )
+    assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).count() == 1
+    assert (
+        ListAction.objects.filter(
+            list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
+        ).count()
+        == actions_before
+    )
+
+
+@pytest.mark.django_db
+def test_unsubscribed_gang_unaffected(
+    child_spawning_setup, make_list, content_house, user
+):
+    """A list NOT subscribed to the pack does not receive the child fighter."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    child_cf = child_spawning_setup["child_cf"]
+    equipment = child_spawning_setup["equipment"]
+
+    lst = make_list("Unsubscribed Gang", content_house=content_house)
+    # NOT subscribed to the pack.
+    ListFighter.objects.create(
+        list=lst, content_fighter=parent_cf, name="Lone Driver", owner=user
+    )
+
+    ContentFighterDefaultAssignment.objects.create(
+        fighter=parent_cf, equipment=equipment
+    )
+
+    assert not ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
+
+
+@pytest.mark.django_db
+def test_archived_pack_item_still_propagates_to_subscriber(
+    child_spawning_setup, make_list, content_house, user
+):
+    """Archive semantics: an archived pack item still propagates to gangs that
+    are already subscribed (archived content stays visible to subscribers)."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    child_cf = child_spawning_setup["child_cf"]
+    equipment = child_spawning_setup["equipment"]
+    pack = child_spawning_setup["pack"]
+
+    lst, parent = _subscribed_list_with_parent(
+        make_list, content_house, pack, parent_cf, user
+    )
+
+    # Archive the parent fighter's pack item.
+    ct = ContentType.objects.get_for_model(ContentFighter)
+    item = CustomContentPackItem.objects.get(
+        pack=pack, content_type=ct, object_id=parent_cf.pk
+    )
+    item.archived = True
+    item.save()
+
+    ContentFighterDefaultAssignment.objects.create(
+        fighter=parent_cf, equipment=equipment
+    )
+
+    assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
+
+
+# --- Action log ----------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_action_log_entry_created(child_spawning_setup, make_list, content_house, user):
+    """An awareness action is logged per affected list, referencing the
+    equipment, with a true (zero) rating delta and no credit charge."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    equipment = child_spawning_setup["equipment"]
+    pack = child_spawning_setup["pack"]
+
+    lst, parent = _subscribed_list_with_parent(
+        make_list, content_house, pack, parent_cf, user
+    )
+
+    before = ListAction.objects.filter(
+        list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
+    ).count()
+
+    ContentFighterDefaultAssignment.objects.create(
+        fighter=parent_cf, equipment=equipment
+    )
+
+    actions = ListAction.objects.filter(
+        list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
+    )
+    assert actions.count() == before + 1
+    action = actions.latest("created")
+    assert equipment.name in action.description
+    assert action.rating_delta == 0
+    assert action.credits_delta == 0
+
+
+@pytest.mark.django_db
+def test_campaign_mode_no_credit_charge(
+    child_spawning_setup, make_list, content_house, user
+):
+    """In campaign mode, propagation must not charge or refund credits."""
+    from gyrinx.core.models.list import List
+
+    parent_cf = child_spawning_setup["parent_cf"]
+    child_cf = child_spawning_setup["child_cf"]
+    equipment = child_spawning_setup["equipment"]
+    pack = child_spawning_setup["pack"]
+
+    lst = make_list(
+        "Campaign Gang", content_house=content_house, status=List.CAMPAIGN_MODE
+    )
+    lst.packs.add(pack)
+    lst.credits_current = 100
+    lst.save()
+    ListFighter.objects.create(
+        list=lst, content_fighter=parent_cf, name="Driver", owner=user
+    )
+
+    ContentFighterDefaultAssignment.objects.create(
+        fighter=parent_cf, equipment=equipment
+    )
+
+    lst.refresh_from_db()
+    assert lst.credits_current == 100
+    # Child still materialised.
+    assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
+
+
+@pytest.mark.django_db
+def test_no_action_when_list_has_no_latest_action(
+    child_spawning_setup, make_list, content_house, user
+):
+    """A subscribed list without an initial action still materialises the child
+    but records no CONTENT_COST_CHANGE action."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    child_cf = child_spawning_setup["child_cf"]
+    equipment = child_spawning_setup["equipment"]
+    pack = child_spawning_setup["pack"]
+
+    lst = make_list(
+        "No Initial Action", content_house=content_house, create_initial_action=False
+    )
+    lst.packs.add(pack)
+    ListFighter.objects.create(
+        list=lst, content_fighter=parent_cf, name="Driver", owner=user
+    )
+
+    ContentFighterDefaultAssignment.objects.create(
+        fighter=parent_cf, equipment=equipment
+    )
+
+    # Child still materialised.
+    assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
+    # But no action recorded (no latest_action to anchor it).
+    assert not ListAction.objects.filter(
+        list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
+    ).exists()
+
+
+# Out of scope (not tested here, by design):
+# - Deleting a default does NOT retract already-spawned child fighters — they
+#   are user-owned data once materialised. We add no deletion-propagation, and
+#   the from_default_assignment FK uses on_delete=DO_NOTHING.
+# - Adding a ContentEquipmentFighterProfile to equipment that already has a
+#   default does NOT trigger propagation — the signal fires on default
+#   creation only (see test_signal_enqueues_only_for_child_spawning_created_default,
+#   which asserts created=False saves do not re-enqueue).

--- a/gyrinx/core/tests/test_propagate_default_child_fighter.py
+++ b/gyrinx/core/tests/test_propagate_default_child_fighter.py
@@ -7,9 +7,6 @@ spawns a child fighter (a vehicle / exotic beast via
 *every* already-subscribed gang that has a list-fighter of the relevant type —
 not just gangs created after the change.
 
-These tests are written red-first: they describe the desired behaviour before
-the propagation signal + task land.
-
 Cost note: materialising a default child-spawning assignment produces a net
 rating delta of ZERO (the default assignment is virtual/0-cost, the direct
 assignment uses ``cost_override=0``, and child fighters don't contribute to
@@ -122,12 +119,26 @@ def _subscribed_list_with_parent(make_list, content_house, pack, parent_cf, user
     return lst, parent
 
 
+def _create_default(capture, fighter, equipment):
+    """Create a child-spawning default and run the deferred propagation.
+
+    The post_save signal defers the task enqueue to ``transaction.on_commit``;
+    pytest's wrapping transaction never commits, so we use
+    ``django_capture_on_commit_callbacks(execute=True)`` to fire it (the
+    ImmediateBackend then runs the task synchronously).
+    """
+    with capture(execute=True):
+        return ContentFighterDefaultAssignment.objects.create(
+            fighter=fighter, equipment=equipment
+        )
+
+
 # --- Signal gating -------------------------------------------------------------
 
 
 @pytest.mark.django_db
 def test_signal_enqueues_only_for_child_spawning_created_default(
-    child_spawning_setup, make_equipment
+    child_spawning_setup, make_equipment, django_capture_on_commit_callbacks
 ):
     """The post_save signal enqueues the task only when a default is *created*
     AND its equipment has a ContentEquipmentFighterProfile."""
@@ -141,21 +152,24 @@ def test_signal_enqueues_only_for_child_spawning_created_default(
         "gyrinx.core.models.list.propagate_default_child_fighter_assignment"
     ) as mock_task:
         # Non-child-spawning default -> must NOT enqueue.
-        ContentFighterDefaultAssignment.objects.create(
-            fighter=parent_cf, equipment=plain_equipment
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            ContentFighterDefaultAssignment.objects.create(
+                fighter=parent_cf, equipment=plain_equipment
+            )
         mock_task.enqueue.assert_not_called()
 
-        # Child-spawning default -> must enqueue exactly once.
-        default = ContentFighterDefaultAssignment.objects.create(
-            fighter=parent_cf, equipment=equipment
-        )
+        # Child-spawning default -> must enqueue exactly once (after commit).
+        with django_capture_on_commit_callbacks(execute=True):
+            default = ContentFighterDefaultAssignment.objects.create(
+                fighter=parent_cf, equipment=equipment
+            )
         mock_task.enqueue.assert_called_once_with(default_assignment_id=str(default.pk))
 
         # Editing the child-spawning default (created=False) -> must NOT re-enqueue.
         mock_task.enqueue.reset_mock()
-        default.cost = 5
-        default.save()
+        with django_capture_on_commit_callbacks(execute=True):
+            default.cost = 5
+            default.save()
         mock_task.enqueue.assert_not_called()
 
 
@@ -164,7 +178,11 @@ def test_signal_enqueues_only_for_child_spawning_created_default(
 
 @pytest.mark.django_db
 def test_propagation_reaches_existing_subscribed_gang(
-    child_spawning_setup, make_list, content_house, user
+    child_spawning_setup,
+    make_list,
+    content_house,
+    user,
+    django_capture_on_commit_callbacks,
 ):
     """Creating a child-spawning default materialises the child fighter on an
     existing subscribed gang's matching list-fighter."""
@@ -180,9 +198,7 @@ def test_propagation_reaches_existing_subscribed_gang(
     # Sanity: no child yet.
     assert not ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
 
-    ContentFighterDefaultAssignment.objects.create(
-        fighter=parent_cf, equipment=equipment
-    )
+    _create_default(django_capture_on_commit_callbacks, parent_cf, equipment)
 
     # Child fighter materialised on the existing parent.
     assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
@@ -195,7 +211,13 @@ def test_propagation_reaches_existing_subscribed_gang(
 
 
 @pytest.mark.django_db
-def test_idempotent_rerun(child_spawning_setup, make_list, content_house, user):
+def test_idempotent_rerun(
+    child_spawning_setup,
+    make_list,
+    content_house,
+    user,
+    django_capture_on_commit_callbacks,
+):
     """Re-running the task does not create duplicate child fighters/assignments."""
     parent_cf = child_spawning_setup["parent_cf"]
     child_cf = child_spawning_setup["child_cf"]
@@ -205,9 +227,7 @@ def test_idempotent_rerun(child_spawning_setup, make_list, content_house, user):
     lst, parent = _subscribed_list_with_parent(
         make_list, content_house, pack, parent_cf, user
     )
-    default = ContentFighterDefaultAssignment.objects.create(
-        fighter=parent_cf, equipment=equipment
-    )
+    default = _create_default(django_capture_on_commit_callbacks, parent_cf, equipment)
 
     children_before = ListFighter.objects.filter(
         list=lst, content_fighter=child_cf
@@ -278,7 +298,11 @@ def test_existing_materialised_assignment_untouched(
 
 @pytest.mark.django_db
 def test_unsubscribed_gang_unaffected(
-    child_spawning_setup, make_list, content_house, user
+    child_spawning_setup,
+    make_list,
+    content_house,
+    user,
+    django_capture_on_commit_callbacks,
 ):
     """A list NOT subscribed to the pack does not receive the child fighter."""
     parent_cf = child_spawning_setup["parent_cf"]
@@ -291,16 +315,18 @@ def test_unsubscribed_gang_unaffected(
         list=lst, content_fighter=parent_cf, name="Lone Driver", owner=user
     )
 
-    ContentFighterDefaultAssignment.objects.create(
-        fighter=parent_cf, equipment=equipment
-    )
+    _create_default(django_capture_on_commit_callbacks, parent_cf, equipment)
 
     assert not ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
 
 
 @pytest.mark.django_db
 def test_archived_pack_item_still_propagates_to_subscriber(
-    child_spawning_setup, make_list, content_house, user
+    child_spawning_setup,
+    make_list,
+    content_house,
+    user,
+    django_capture_on_commit_callbacks,
 ):
     """Archive semantics: an archived pack item still propagates to gangs that
     are already subscribed (archived content stays visible to subscribers)."""
@@ -321,9 +347,7 @@ def test_archived_pack_item_still_propagates_to_subscriber(
     item.archived = True
     item.save()
 
-    ContentFighterDefaultAssignment.objects.create(
-        fighter=parent_cf, equipment=equipment
-    )
+    _create_default(django_capture_on_commit_callbacks, parent_cf, equipment)
 
     assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()
 
@@ -332,7 +356,13 @@ def test_archived_pack_item_still_propagates_to_subscriber(
 
 
 @pytest.mark.django_db
-def test_action_log_entry_created(child_spawning_setup, make_list, content_house, user):
+def test_action_log_entry_created(
+    child_spawning_setup,
+    make_list,
+    content_house,
+    user,
+    django_capture_on_commit_callbacks,
+):
     """An awareness action is logged per affected list, referencing the
     equipment, with a true (zero) rating delta and no credit charge."""
     parent_cf = child_spawning_setup["parent_cf"]
@@ -347,9 +377,7 @@ def test_action_log_entry_created(child_spawning_setup, make_list, content_house
         list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
     ).count()
 
-    ContentFighterDefaultAssignment.objects.create(
-        fighter=parent_cf, equipment=equipment
-    )
+    _create_default(django_capture_on_commit_callbacks, parent_cf, equipment)
 
     actions = ListAction.objects.filter(
         list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
@@ -363,7 +391,11 @@ def test_action_log_entry_created(child_spawning_setup, make_list, content_house
 
 @pytest.mark.django_db
 def test_campaign_mode_no_credit_charge(
-    child_spawning_setup, make_list, content_house, user
+    child_spawning_setup,
+    make_list,
+    content_house,
+    user,
+    django_capture_on_commit_callbacks,
 ):
     """In campaign mode, propagation must not charge or refund credits."""
     from gyrinx.core.models.list import List
@@ -383,9 +415,7 @@ def test_campaign_mode_no_credit_charge(
         list=lst, content_fighter=parent_cf, name="Driver", owner=user
     )
 
-    ContentFighterDefaultAssignment.objects.create(
-        fighter=parent_cf, equipment=equipment
-    )
+    _create_default(django_capture_on_commit_callbacks, parent_cf, equipment)
 
     lst.refresh_from_db()
     assert lst.credits_current == 100
@@ -395,7 +425,11 @@ def test_campaign_mode_no_credit_charge(
 
 @pytest.mark.django_db
 def test_no_action_when_list_has_no_latest_action(
-    child_spawning_setup, make_list, content_house, user
+    child_spawning_setup,
+    make_list,
+    content_house,
+    user,
+    django_capture_on_commit_callbacks,
 ):
     """A subscribed list without an initial action still materialises the child
     but records no CONTENT_COST_CHANGE action."""
@@ -412,9 +446,7 @@ def test_no_action_when_list_has_no_latest_action(
         list=lst, content_fighter=parent_cf, name="Driver", owner=user
     )
 
-    ContentFighterDefaultAssignment.objects.create(
-        fighter=parent_cf, equipment=equipment
-    )
+    _create_default(django_capture_on_commit_callbacks, parent_cf, equipment)
 
     # Child still materialised.
     assert ListFighter.objects.filter(list=lst, content_fighter=child_cf).exists()

--- a/gyrinx/tasks/registry.py
+++ b/gyrinx/tasks/registry.py
@@ -35,12 +35,14 @@ def _get_tasks() -> list[TaskRoute]:
     if _tasks is None:
         from gyrinx.core.tasks import (
             hello_world,
+            propagate_default_child_fighter_assignment,
             refresh_list_facts,
             trigger_discord_issue_action,
         )
 
         _tasks = [
             TaskRoute(hello_world),
+            TaskRoute(propagate_default_child_fighter_assignment),
             TaskRoute(refresh_list_facts),
             TaskRoute(trigger_discord_issue_action),
         ]


### PR DESCRIPTION
Closes #1725.

When a pack author adds a `ContentFighterDefaultAssignment` whose equipment spawns a child fighter (a vehicle / exotic beast via `ContentEquipmentFighterProfile`), the child fighter now materialises on every already-subscribed gang that holds a list-fighter of that type — not just gangs created after the change.

## Changes

- Extract `_materialise_child_fighter_defaults()` from the `create_linked_objects` signal so the hire-time path and the new propagation task share one idempotent helper.
- Add a `post_save` signal on `ContentFighterDefaultAssignment` that enqueues propagation only for newly-created, child-spawning defaults.
- Add the `propagate_default_child_fighter_assignment` task: finds list-fighters of the type on pack-subscribed lists (subscriber read path — archived pack content stays visible), materialises the child per-list in its own transaction, and logs one awareness action per affected gang.

## Action log is awareness-only

Tracing the cost model showed that materialising a child-spawning default has a **net-zero rating impact**: the default is virtual/0-cost, the materialised direct assignment uses `cost_override=0`, and child fighters don't contribute to list cost. So the action records the true zero delta and never charges credits (even in campaign mode). It exists so gang owners can see why a new fighter appeared, not to reconcile a cost change. This diverges from the issue's "+25¢" framing, which doesn't match the actual cost model.

## Out of scope

- `legacy_content_fighter` defaults — the helper acts on `content_fighter` only, matching the hire-time path.
- Deletion / archive of a default does not retract already-spawned child fighters.
- Adding a `ContentEquipmentFighterProfile` after the default already exists.
- Lifting the interim UI block that stops pack authors creating these defaults via the picker — filed as follow-up #1803.

## Tests

New `gyrinx/core/tests/test_propagate_default_child_fighter.py` (9 tests): propagation reaches existing subscribers, idempotent re-run, existing assignments untouched, unsubscribed gangs unaffected, archived pack item still propagates, action logged, campaign mode charges no credits, no action without a `latest_action`, signal gating.

Full suite: 2555 passed, 13 skipped.
