### PR TITLE
fix: clear dead-fighter cost_override on all non-resurrect exits (#1782)

### DIFF
--- a/gyrinx/core/handlers/fighter/__init__.py
+++ b/gyrinx/core/handlers/fighter/__init__.py
@@ -29,6 +29,7 @@ from gyrinx.core.handlers.fighter.removal import (
     handle_fighter_deletion,
 )
 from gyrinx.core.handlers.fighter.resurrect import (
+    RESURRECT_TARGET_STATES,
     FighterResurrectResult,
     handle_fighter_resurrect,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "FighterArchiveResult",
     "FighterCloneParams",
     "FighterCloneResult",
+    "RESURRECT_TARGET_STATES",
     "FighterDeletionResult",
     "FighterEditResult",
     "FighterHireResult",

--- a/gyrinx/core/handlers/fighter/resurrect.py
+++ b/gyrinx/core/handlers/fighter/resurrect.py
@@ -42,6 +42,7 @@ def handle_fighter_resurrect(
     fighter: ListFighter,
     target_state: str = ListFighter.ACTIVE,
     create_campaign_action: bool = True,
+    reason: str = "",
 ) -> FighterResurrectResult:
     """
     Bring a dead fighter back out of the DEAD state, restoring their cost.
@@ -71,6 +72,8 @@ def handle_fighter_resurrect(
         create_campaign_action: Whether to log a CampaignAction. Callers that
             already log their own action (e.g. removing the last injury) can
             set this to False to avoid a duplicate log line.
+        reason: Optional free-text reason to append to the CampaignAction
+            description (e.g. from the edit-state form).
 
     Returns:
         FighterResurrectResult with fighter, restored cost, and actions
@@ -150,12 +153,15 @@ def handle_fighter_resurrect(
         else:
             target_display = dict(ListFighter.INJURY_STATE_CHOICES)[target_state]
             outcome = f"{fighter.name} is no longer dead and is now {target_display}."
+        action_description = f"Resurrection: {fighter.name} is no longer dead"
+        if reason:
+            action_description += f" - {reason}"
         campaign_action = CampaignAction.objects.create(
             user=user,
             owner=user,
             campaign=lst.campaign,
             list=lst,
-            description=f"Resurrection: {fighter.name} is no longer dead",
+            description=action_description,
             outcome=outcome,
         )
 

--- a/gyrinx/core/handlers/fighter/resurrect.py
+++ b/gyrinx/core/handlers/fighter/resurrect.py
@@ -12,12 +12,23 @@ from gyrinx.core.models.list import ListFighter
 from gyrinx.tracing import traced
 
 
+# Injury states a dead fighter may be moved into when leaving DEAD. DEAD itself
+# is excluded — resurrection always takes the fighter out of death.
+RESURRECT_TARGET_STATES = (
+    ListFighter.ACTIVE,
+    ListFighter.RECOVERY,
+    ListFighter.CONVALESCENCE,
+    ListFighter.IN_REPAIR,
+)
+
+
 @dataclass
 class FighterResurrectResult:
     """Result of resurrecting a dead fighter."""
 
     fighter: ListFighter
     restored_cost: int
+    target_state: str
     list_action: Optional[ListAction]
     campaign_action: Optional[CampaignAction]
     description: str
@@ -29,18 +40,25 @@ def handle_fighter_resurrect(
     *,
     user,
     fighter: ListFighter,
+    target_state: str = ListFighter.ACTIVE,
+    create_campaign_action: bool = True,
 ) -> FighterResurrectResult:
     """
-    Resurrect a dead fighter, restoring their cost to the list rating.
+    Bring a dead fighter back out of the DEAD state, restoring their cost.
+
+    Killing a fighter sets ``cost_override=0`` alongside ``injury_state=DEAD``.
+    This handler is the single place that clears that override when a fighter
+    leaves DEAD, so any DEAD → non-DEAD transition must route through here
+    rather than saving ``injury_state`` directly (see #1782).
 
     This handler performs the following operations atomically:
     1. Captures before values from the list
     2. Calculates the cost that will be restored
-    3. Sets injury_state to ACTIVE
+    3. Sets injury_state to the target state (default ACTIVE)
     4. Clears cost_override (restores original cost)
     5. Saves the fighter
     6. Creates UPDATE_FIGHTER ListAction to track rating increase
-    7. Creates CampaignAction if in campaign
+    7. Creates CampaignAction if in campaign (unless suppressed)
 
     Note: Equipment is NOT restored - it remains in the stash and must be
     manually re-equipped by the user.
@@ -48,12 +66,18 @@ def handle_fighter_resurrect(
     Args:
         user: The user performing the resurrection
         fighter: The dead fighter to resurrect (must have injury_state=DEAD)
+        target_state: The non-DEAD injury state to move the fighter into.
+            Defaults to ACTIVE.
+        create_campaign_action: Whether to log a CampaignAction. Callers that
+            already log their own action (e.g. removing the last injury) can
+            set this to False to avoid a duplicate log line.
 
     Returns:
         FighterResurrectResult with fighter, restored cost, and actions
 
     Raises:
-        ValueError: If fighter is not dead, is stash, or list not in campaign mode
+        ValueError: If fighter is not dead, is stash, list not in campaign
+            mode, or target_state is not a valid non-DEAD state
     """
     lst = fighter.list
 
@@ -67,6 +91,12 @@ def handle_fighter_resurrect(
     if fighter.injury_state != ListFighter.DEAD:
         raise ValueError("Only dead fighters can be resurrected")
 
+    if target_state not in RESURRECT_TARGET_STATES:
+        raise ValueError(
+            f"Cannot resurrect a fighter into state {target_state!r}; "
+            f"must be one of {RESURRECT_TARGET_STATES}"
+        )
+
     # Capture before values for ListAction
     rating_before = lst.rating_current
     stash_before = lst.stash_current
@@ -77,7 +107,7 @@ def handle_fighter_resurrect(
     restored_cost = fighter._base_cost_before_override()
 
     # Apply mutations
-    fighter.injury_state = ListFighter.ACTIVE
+    fighter.injury_state = target_state
     fighter.cost_override = None  # Restores original cost
     fighter.save(update_fields=["injury_state", "cost_override"])
 
@@ -85,7 +115,14 @@ def handle_fighter_resurrect(
     propagate_from_fighter(fighter, Delta(delta=restored_cost, list=lst))
 
     # Build description
-    description = f"{fighter.name} resurrected (rating +{restored_cost}¢)"
+    if target_state == ListFighter.ACTIVE:
+        description = f"{fighter.name} resurrected (rating +{restored_cost}¢)"
+    else:
+        target_display = dict(ListFighter.INJURY_STATE_CHOICES)[target_state]
+        description = (
+            f"{fighter.name} is no longer dead, now {target_display} "
+            f"(rating +{restored_cost}¢)"
+        )
 
     # Create UPDATE_FIGHTER ListAction
     # The fighter's cost goes from 0 to restored_cost
@@ -107,19 +144,25 @@ def handle_fighter_resurrect(
 
     # Create CampaignAction if this list is part of a campaign
     campaign_action = None
-    if lst.campaign:
+    if lst.campaign and create_campaign_action:
+        if target_state == ListFighter.ACTIVE:
+            outcome = f"{fighter.name} has been returned to the active roster."
+        else:
+            target_display = dict(ListFighter.INJURY_STATE_CHOICES)[target_state]
+            outcome = f"{fighter.name} is no longer dead and is now {target_display}."
         campaign_action = CampaignAction.objects.create(
             user=user,
             owner=user,
             campaign=lst.campaign,
             list=lst,
             description=f"Resurrection: {fighter.name} is no longer dead",
-            outcome=f"{fighter.name} has been returned to the active roster.",
+            outcome=outcome,
         )
 
     return FighterResurrectResult(
         fighter=fighter,
         restored_cost=restored_cost,
+        target_state=target_state,
         list_action=list_action,
         campaign_action=campaign_action,
         description=description,

--- a/gyrinx/core/templates/core/list_fighter_resurrect.html
+++ b/gyrinx/core/templates/core/list_fighter_resurrect.html
@@ -11,6 +11,7 @@
               method="post">
             {% csrf_token %}
             <input type="hidden" name="target_state" value="{{ target_state }}">
+            {% if reason %}<input type="hidden" name="reason" value="{{ reason }}">{% endif %}
             <p>
                 Are you sure you want to resurrect <strong>{{ fighter.name }}</strong>?
             </p>

--- a/gyrinx/core/templates/core/list_fighter_resurrect.html
+++ b/gyrinx/core/templates/core/list_fighter_resurrect.html
@@ -13,11 +13,15 @@
             <input type="hidden" name="target_state" value="{{ target_state }}">
             {% if reason %}<input type="hidden" name="reason" value="{{ reason }}">{% endif %}
             <p>
-                Are you sure you want to resurrect <strong>{{ fighter.name }}</strong>?
+                Are you sure you want to bring <strong>{{ fighter.name }}</strong> back from the dead?
             </p>
             <p>This will:</p>
             <ul>
-                <li>Return them to the gang roster</li>
+                {% if target_state == "active" %}
+                    <li>Return them to the gang roster</li>
+                {% else %}
+                    <li>Return them to the gang roster, in {{ target_state_display }}</li>
+                {% endif %}
                 <li>Set their rating back to its original value, minus equipment</li>
             </ul>
             <div class="alert alert-primary alert-icon mb-0" role="alert">

--- a/gyrinx/core/templates/core/list_fighter_resurrect.html
+++ b/gyrinx/core/templates/core/list_fighter_resurrect.html
@@ -10,6 +10,7 @@
         <form action="{% url 'core:list-fighter-resurrect' list.id fighter.id %}"
               method="post">
             {% csrf_token %}
+            <input type="hidden" name="target_state" value="{{ target_state }}">
             <p>
                 Are you sure you want to resurrect <strong>{{ fighter.name }}</strong>?
             </p>

--- a/gyrinx/core/tests/test_fighter_state_edit.py
+++ b/gyrinx/core/tests/test_fighter_state_edit.py
@@ -284,3 +284,137 @@ def test_fighter_state_edit_no_change(client, user, content_house):
 
     # Check no campaign action was created
     assert CampaignAction.objects.count() == 0
+
+
+# ===== #1782: leaving DEAD via the edit-state form must clear cost_override =====
+
+
+@pytest.mark.django_db
+def test_state_edit_dead_to_recovery_routes_through_resurrect(
+    client, user, list_with_campaign, content_fighter
+):
+    """DEAD -> RECOVERY via the form redirects to resurrect carrying the target state."""
+    lst = list_with_campaign
+    fighter = ListFighter.objects.create(
+        name="Dead Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+    response = client.post(url, {"fighter_state": ListFighter.RECOVERY})
+
+    assert response.status_code == 302
+    expected = reverse("core:list-fighter-resurrect", args=[lst.id, fighter.id])
+    assert response.url == f"{expected}?target_state={ListFighter.RECOVERY}"
+
+    # The bare save must NOT have run - fighter is still dead until resurrect confirms.
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.DEAD
+    assert fighter.cost_override == 0
+
+
+@pytest.mark.django_db
+def test_dead_to_recovery_clears_cost_override(
+    client, user, list_with_campaign, content_fighter
+):
+    """Completing DEAD -> RECOVERY restores cost and reflects it in the list rating (#1782)."""
+    lst = list_with_campaign
+    fighter = ListFighter.objects.create(
+        name="Dead Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+        rating_current=0,
+    )
+    restored_cost = fighter._base_cost_before_override()
+    assert restored_cost > 0
+
+    client.force_login(user)
+    # The state-edit redirect lands on the resurrect view with the target state.
+    resurrect_url = reverse("core:list-fighter-resurrect", args=[lst.id, fighter.id])
+    response = client.post(resurrect_url, {"target_state": ListFighter.RECOVERY})
+    assert response.status_code == 302
+
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.RECOVERY
+    assert fighter.cost_override is None
+    assert fighter.rating_current == restored_cost
+
+    lst.refresh_from_db()
+    assert lst.rating_current >= restored_cost
+
+
+@pytest.mark.django_db
+def test_dead_to_convalescence_then_active(
+    client, user, list_with_campaign, content_fighter
+):
+    """DEAD -> CONVALESCENCE clears the override; a later CONVALESCENCE -> ACTIVE is a plain save (#1782)."""
+    lst = list_with_campaign
+    fighter = ListFighter.objects.create(
+        name="Dead Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+        rating_current=0,
+    )
+    restored_cost = fighter._base_cost_before_override()
+    assert restored_cost > 0
+
+    client.force_login(user)
+
+    # DEAD -> CONVALESCENCE goes through resurrect and clears the override.
+    resurrect_url = reverse("core:list-fighter-resurrect", args=[lst.id, fighter.id])
+    client.post(resurrect_url, {"target_state": ListFighter.CONVALESCENCE})
+
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.CONVALESCENCE
+    assert fighter.cost_override is None
+    assert fighter.rating_current == restored_cost
+
+    # CONVALESCENCE -> ACTIVE is an ordinary non-DEAD transition: plain save, cost unchanged.
+    state_url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+    response = client.post(state_url, {"fighter_state": ListFighter.ACTIVE})
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "core:list-fighter-injuries-edit", args=[lst.id, fighter.id]
+    )
+
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.ACTIVE
+    assert fighter.cost_override is None
+    assert fighter.rating_current == restored_cost
+
+
+@pytest.mark.django_db
+def test_deliberate_free_fighter_survives_state_edit(
+    client, user, list_with_campaign, content_fighter
+):
+    """A live fighter deliberately at cost_override=0 keeps it across a state edit (no save-guard, #1782)."""
+    lst = list_with_campaign
+    fighter = ListFighter.objects.create(
+        name="Free Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.RECOVERY,
+        cost_override=0,
+    )
+
+    client.force_login(user)
+    state_url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+    response = client.post(state_url, {"fighter_state": ListFighter.ACTIVE})
+    assert response.status_code == 302
+
+    # Not a DEAD-origin transition, so cost_override must be left untouched.
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.ACTIVE
+    assert fighter.cost_override == 0

--- a/gyrinx/core/tests/test_fighter_state_edit.py
+++ b/gyrinx/core/tests/test_fighter_state_edit.py
@@ -218,11 +218,14 @@ def test_fighter_state_edit_active_redirects_to_resurrect(client, user, content_
         },
     )
 
-    # Should redirect to resurrect confirmation page
+    # Should redirect to resurrect confirmation page. ACTIVE is the default
+    # target so it isn't added to the query string, but the reason is carried
+    # over so it isn't lost (#1782).
     assert response.status_code == 302
-    assert response.url == reverse(
-        "core:list-fighter-resurrect", args=[lst.id, fighter.id]
-    )
+    base = reverse("core:list-fighter-resurrect", args=[lst.id, fighter.id])
+    assert response.url.startswith(base)
+    assert "target_state=" not in response.url
+    assert "reason=Resurrected" in response.url
 
     # Check state was NOT changed yet (resurrect view should handle it)
     fighter.refresh_from_db()
@@ -316,6 +319,47 @@ def test_state_edit_dead_to_recovery_routes_through_resurrect(
     fighter.refresh_from_db()
     assert fighter.injury_state == ListFighter.DEAD
     assert fighter.cost_override == 0
+
+
+@pytest.mark.django_db
+def test_state_edit_dead_exit_carries_reason_to_resurrect(
+    client, user, list_with_campaign, content_fighter
+):
+    """A reason entered on the state-edit form survives the redirect to resurrect (#1782)."""
+    lst = list_with_campaign
+    fighter = ListFighter.objects.create(
+        name="Dead Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+    )
+
+    client.force_login(user)
+    state_url = reverse("core:list-fighter-state-edit", args=[lst.id, fighter.id])
+    response = client.post(
+        state_url,
+        {"fighter_state": ListFighter.RECOVERY, "reason": "Back from the brink"},
+    )
+
+    # The redirect carries both target_state and the reason.
+    assert response.status_code == 302
+    assert "target_state=recovery" in response.url
+    assert "reason=" in response.url
+
+    # Completing the resurrect records the reason in the CampaignAction.
+    response = client.post(
+        response.url.split("?")[0],
+        {"target_state": ListFighter.RECOVERY, "reason": "Back from the brink"},
+    )
+    assert response.status_code == 302
+
+    action = CampaignAction.objects.filter(
+        description__startswith="Resurrection:"
+    ).last()
+    assert action is not None
+    assert "Back from the brink" in action.description
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_handlers_fighter_lifecycle.py
+++ b/gyrinx/core/tests/test_handlers_fighter_lifecycle.py
@@ -334,6 +334,87 @@ def test_handle_fighter_resurrect_validates_not_stash(
         )
 
 
+@pytest.mark.django_db
+def test_handle_fighter_resurrect_into_recovery_clears_override(
+    user, list_with_campaign, content_fighter
+):
+    """Resurrecting into a non-ACTIVE state still clears cost_override (#1782)."""
+    lst = list_with_campaign
+
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+    )
+    restored_cost = fighter._base_cost_before_override()
+
+    result = handle_fighter_resurrect(
+        user=user,
+        fighter=fighter,
+        target_state=ListFighter.RECOVERY,
+    )
+
+    assert result.target_state == ListFighter.RECOVERY
+
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.RECOVERY
+    assert fighter.cost_override is None
+    assert fighter.cost_int() == restored_cost
+    assert restored_cost > 0
+
+
+@pytest.mark.django_db
+def test_handle_fighter_resurrect_rejects_dead_target(
+    user, list_with_campaign, content_fighter
+):
+    """A resurrection cannot target the DEAD state."""
+    lst = list_with_campaign
+
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+    )
+
+    with pytest.raises(ValueError, match="resurrect"):
+        handle_fighter_resurrect(
+            user=user,
+            fighter=fighter,
+            target_state=ListFighter.DEAD,
+        )
+
+
+@pytest.mark.django_db
+def test_handle_fighter_resurrect_can_suppress_campaign_action(
+    user, list_with_campaign, content_fighter
+):
+    """create_campaign_action=False skips the handler's CampaignAction."""
+    lst = list_with_campaign
+
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+    )
+
+    result = handle_fighter_resurrect(
+        user=user,
+        fighter=fighter,
+        create_campaign_action=False,
+    )
+
+    assert result.campaign_action is None
+
+
 # ===== Stash accounting after kill (regression for stash_current 500) =====
 #
 # Bug: when a fighter is killed, handle_fighter_kill transfers their equipment

--- a/gyrinx/core/tests/test_handlers_fighter_lifecycle.py
+++ b/gyrinx/core/tests/test_handlers_fighter_lifecycle.py
@@ -415,6 +415,32 @@ def test_handle_fighter_resurrect_can_suppress_campaign_action(
     assert result.campaign_action is None
 
 
+@pytest.mark.django_db
+def test_handle_fighter_resurrect_appends_reason_to_campaign_action(
+    user, list_with_campaign, content_fighter
+):
+    """A reason is appended to the CampaignAction description (carried from the form)."""
+    lst = list_with_campaign
+
+    fighter = ListFighter.objects.create(
+        name="Test Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+    )
+
+    result = handle_fighter_resurrect(
+        user=user,
+        fighter=fighter,
+        reason="Patched up by the Doc",
+    )
+
+    assert result.campaign_action is not None
+    assert "Patched up by the Doc" in result.campaign_action.description
+
+
 # ===== Stash accounting after kill (regression for stash_current 500) =====
 #
 # Bug: when a fighter is killed, handle_fighter_kill transfers their equipment

--- a/gyrinx/core/tests/test_injury_views.py
+++ b/gyrinx/core/tests/test_injury_views.py
@@ -629,3 +629,62 @@ def test_non_owner_cannot_manage_injuries(
     # Cannot edit state
     url = reverse("core:list-fighter-state-edit", args=[co_list.id, co_fighter.id])
     assert client.get(url).status_code == 404
+
+
+@pytest.mark.django_db
+def test_remove_last_injury_on_dead_fighter_clears_cost_override(
+    client, user, list_with_campaign, content_fighter
+):
+    """Removing the last injury from a DEAD fighter routes through resurrect (#1782).
+
+    The auto-reset to ACTIVE must clear cost_override (set to 0 on death) and
+    restore the rating, rather than a bare save leaving it stuck at 0.
+
+    Uses ``list_with_campaign`` (which has an initial LIST_CREATE action) so the
+    rating propagation path is exercised, unlike the inline ``create_test_data``
+    helper whose list has no ``latest_action``.
+    """
+    lst = list_with_campaign
+    fighter = ListFighter.objects.create(
+        name="Dead Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+        cost_override=0,
+        rating_current=0,
+    )
+    restored_cost = fighter._base_cost_before_override()
+    assert restored_cost > 0
+
+    injury = ContentInjury.objects.create(
+        name="Test Lingering Injury",
+        description="Recovery",
+        phase=ContentInjuryDefaultOutcome.RECOVERY,
+    )
+    fighter_injury = ListFighterInjury.objects.create(
+        fighter=fighter,
+        injury=injury,
+        owner=user,
+    )
+
+    client.force_login(user)
+    url = reverse(
+        "core:list-fighter-injury-remove", args=[lst.id, fighter.id, fighter_injury.id]
+    )
+    response = client.post(url)
+    assert response.status_code == 302
+
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.ACTIVE
+    assert fighter.cost_override is None
+    assert fighter.rating_current == restored_cost
+
+    lst.refresh_from_db()
+    assert lst.rating_current >= restored_cost
+
+    # The injury-removal CampaignAction is the single log line; the resurrect
+    # handler's own action is suppressed to avoid duplication.
+    actions = CampaignAction.objects.filter(campaign=lst.campaign)
+    assert actions.filter(outcome="Fighter became available").exists()
+    assert not actions.filter(description__startswith="Resurrection:").exists()

--- a/gyrinx/core/tests/test_resurrect_fighter.py
+++ b/gyrinx/core/tests/test_resurrect_fighter.py
@@ -254,6 +254,41 @@ def test_resurrect_fighter_confirmation_page(client, user, content_house):
 
 
 @pytest.mark.django_db
+def test_resurrect_confirmation_reflects_non_active_target_state(
+    client, user, content_house
+):
+    """The confirmation page names the resulting state when it isn't Active (#1782)."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+        status=List.CAMPAIGN_MODE,
+    )
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+    fighter = ListFighter.objects.create(
+        name="Deceased Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        injury_state=ListFighter.DEAD,
+    )
+
+    client.force_login(user)
+    url = reverse("core:list-fighter-resurrect", args=[lst.id, fighter.id])
+    response = client.get(url, {"target_state": ListFighter.RECOVERY})
+
+    assert response.status_code == 200
+    # The hidden field round-trips the target, and the copy names the state.
+    assert b'name="target_state" value="recovery"' in response.content
+    assert b"Recovery" in response.content
+
+
+@pytest.mark.django_db
 def test_resurrect_fighter_creates_campaign_action(client, user, content_house):
     """Test that resurrecting a fighter creates a campaign action."""
     fighter_name = "Deceased Fighter"

--- a/gyrinx/core/views/fighter/crud.py
+++ b/gyrinx/core/views/fighter/crud.py
@@ -571,6 +571,9 @@ def resurrect_list_fighter(request, id, fighter_id):
             "fighter": fighter,
             "list": lst,
             "target_state": target_state,
+            "target_state_display": dict(ListFighter.INJURY_STATE_CHOICES).get(
+                target_state, ""
+            ),
             "reason": reason,
         },
     )

--- a/gyrinx/core/views/fighter/crud.py
+++ b/gyrinx/core/views/fighter/crud.py
@@ -14,6 +14,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from gyrinx import messages
 from gyrinx.core.forms.list import CloneListFighterForm, ListFighterForm
 from gyrinx.core.handlers.fighter import (
+    RESURRECT_TARGET_STATES,
     FighterCloneParams,
     handle_fighter_archive_toggle,
     handle_fighter_clone,
@@ -509,6 +510,14 @@ def resurrect_list_fighter(request, id, fighter_id):
         messages.error(request, "Cannot resurrect the stash.")
         return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
 
+    # The fighter can be brought back into ACTIVE (default) or, when routed here
+    # from the edit-state form, an injured non-DEAD state. Anything invalid
+    # falls back to ACTIVE.
+    source = request.POST if request.method == "POST" else request.GET
+    target_state = source.get("target_state", ListFighter.ACTIVE)
+    if target_state not in RESURRECT_TARGET_STATES:
+        target_state = ListFighter.ACTIVE
+
     if request.method == "POST":
         if fighter.injury_state != ListFighter.DEAD:
             messages.error(request, "Only dead fighters can be resurrected.")
@@ -518,6 +527,7 @@ def resurrect_list_fighter(request, id, fighter_id):
         handle_fighter_resurrect(
             user=request.user,
             fighter=fighter,
+            target_state=target_state,
         )
 
         # Log the resurrection event
@@ -533,17 +543,27 @@ def resurrect_list_fighter(request, id, fighter_id):
             action="resurrected",
         )
 
-        messages.success(
-            request,
-            f"{fighter.name} has been resurrected. They can now be re-equipped from the stash.",
-        )
+        if target_state == ListFighter.ACTIVE:
+            messages.success(
+                request,
+                f"{fighter.name} has been resurrected. They can now be re-equipped from the stash.",
+            )
+        else:
+            target_display = dict(ListFighter.INJURY_STATE_CHOICES)[target_state]
+            messages.success(
+                request,
+                f"{fighter.name} is no longer dead and is now {target_display}. "
+                "They can now be re-equipped from the stash.",
+            )
 
         return HttpResponseRedirect(
             reverse("core:list", args=(lst.id,)) + f"#{str(fighter.id)}"
         )
 
     return render(
-        request, "core/list_fighter_resurrect.html", {"fighter": fighter, "list": lst}
+        request,
+        "core/list_fighter_resurrect.html",
+        {"fighter": fighter, "list": lst, "target_state": target_state},
     )
 
 

--- a/gyrinx/core/views/fighter/crud.py
+++ b/gyrinx/core/views/fighter/crud.py
@@ -517,6 +517,9 @@ def resurrect_list_fighter(request, id, fighter_id):
     target_state = source.get("target_state", ListFighter.ACTIVE)
     if target_state not in RESURRECT_TARGET_STATES:
         target_state = ListFighter.ACTIVE
+    # Optional reason carried over from the edit-state form so it isn't lost
+    # when that flow redirects here.
+    reason = source.get("reason", "")
 
     if request.method == "POST":
         if fighter.injury_state != ListFighter.DEAD:
@@ -528,6 +531,7 @@ def resurrect_list_fighter(request, id, fighter_id):
             user=request.user,
             fighter=fighter,
             target_state=target_state,
+            reason=reason,
         )
 
         # Log the resurrection event
@@ -563,7 +567,12 @@ def resurrect_list_fighter(request, id, fighter_id):
     return render(
         request,
         "core/list_fighter_resurrect.html",
-        {"fighter": fighter, "list": lst, "target_state": target_state},
+        {
+            "fighter": fighter,
+            "list": lst,
+            "target_state": target_state,
+            "reason": reason,
+        },
     )
 
 

--- a/gyrinx/core/views/fighter/state.py
+++ b/gyrinx/core/views/fighter/state.py
@@ -1,5 +1,7 @@
 """Fighter state, injuries, and capture views."""
 
+from urllib.parse import urlencode
+
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.db.models import Q
@@ -9,6 +11,7 @@ from django.urls import reverse
 
 from gyrinx import messages
 from gyrinx.core.forms.list import AddInjuryForm, EditFighterStateForm
+from gyrinx.core.handlers.fighter import handle_fighter_resurrect
 from gyrinx.core.models.events import EventNoun, EventVerb, log_event
 from gyrinx.core.models.list import List, ListFighter, ListFighterInjury
 from gyrinx.core.views.list.common import get_clean_list_or_404
@@ -134,17 +137,17 @@ def list_fighter_state_edit(request, id, fighter_id):
                     return HttpResponseRedirect(
                         reverse("core:list-fighter-kill", args=(lst.id, fighter.id))
                     )
-                # If resurrecting from dead to active, redirect to resurrect confirmation
-                elif (
-                    new_state == ListFighter.ACTIVE
-                    and fighter.injury_state == ListFighter.DEAD
-                ):
-                    # Don't save the state change here - let the resurrect view handle it
-                    return HttpResponseRedirect(
-                        reverse(
-                            "core:list-fighter-resurrect", args=(lst.id, fighter.id)
-                        )
+                # Leaving DEAD for any other state must go through the resurrect
+                # flow so cost_override (set to 0 on death) gets cleared and the
+                # rating restoration is propagated. A bare save here would leave
+                # the fighter active with cost_override=0 stuck (#1782).
+                elif fighter.injury_state == ListFighter.DEAD:
+                    url = reverse(
+                        "core:list-fighter-resurrect", args=(lst.id, fighter.id)
                     )
+                    if new_state != ListFighter.ACTIVE:
+                        url += "?" + urlencode({"target_state": new_state})
+                    return HttpResponseRedirect(url)
 
                 with transaction.atomic():
                     fighter.injury_state = new_state
@@ -495,8 +498,20 @@ def list_fighter_remove_injury(request, id, fighter_id, injury_id):
 
             # If fighter has no more injuries, reset state to active
             if fighter.injuries.count() == 0:
-                fighter.injury_state = ListFighter.ACTIVE
-                fighter.save()
+                if fighter.injury_state == ListFighter.DEAD:
+                    # A dead fighter has cost_override=0; route through the
+                    # resurrect handler so the cost is restored rather than a
+                    # bare save leaving it stuck at 0 (#1782). We log our own
+                    # CampaignAction below, so suppress the handler's.
+                    handle_fighter_resurrect(
+                        user=request.user,
+                        fighter=fighter,
+                        target_state=ListFighter.ACTIVE,
+                        create_campaign_action=False,
+                    )
+                else:
+                    fighter.injury_state = ListFighter.ACTIVE
+                    fighter.save()
                 outcome = "Fighter became available"
             else:
                 outcome = "Injury removed"

--- a/gyrinx/core/views/fighter/state.py
+++ b/gyrinx/core/views/fighter/state.py
@@ -145,8 +145,13 @@ def list_fighter_state_edit(request, id, fighter_id):
                     url = reverse(
                         "core:list-fighter-resurrect", args=(lst.id, fighter.id)
                     )
+                    params = {}
                     if new_state != ListFighter.ACTIVE:
-                        url += "?" + urlencode({"target_state": new_state})
+                        params["target_state"] = new_state
+                    if form.cleaned_data.get("reason"):
+                        params["reason"] = form.cleaned_data["reason"]
+                    if params:
+                        url += "?" + urlencode(params)
                     return HttpResponseRedirect(url)
 
                 with transaction.atomic():
@@ -486,6 +491,15 @@ def list_fighter_remove_injury(request, id, fighter_id, injury_id):
         list=lst,
         owner=lst.owner,
     )
+
+    # Check campaign mode — injuries (and the resurrect path the DEAD branch
+    # below routes through) only make sense for campaign-mode fighters.
+    if lst.status != List.CAMPAIGN_MODE:
+        messages.error(
+            request, "Injuries can only be removed from fighters in campaign mode."
+        )
+        return HttpResponseRedirect(reverse("core:list", args=(lst.id,)))
+
     injury = get_object_or_404(ListFighterInjury, id=injury_id, fighter=fighter)
 
     if request.method == "POST":


### PR DESCRIPTION
Fixes #1782.

A killed fighter is the only entity that gets `cost_override=0` written directly. Leaving DEAD by any path other than `handle_fighter_resurrect` left that override stuck at 0, so `rating_current` stayed 0 and the gang rating was silently understated.

## Changes

- **Generalise `handle_fighter_resurrect`** to accept a `target_state` (default ACTIVE, validated against the non-DEAD injury states, rejects DEAD) and an optional `create_campaign_action` flag. This is the single place that clears `cost_override` when a fighter leaves DEAD.
- **Edit-state form (Path 1):** any DEAD → non-DEAD transition now redirects to the resurrect confirmation view, carrying the target state in the query string, instead of a bare save.
- **Remove-injury auto-reset (Path 2):** a DEAD fighter whose last injury is removed now goes through the handler, with its CampaignAction suppressed so the injury-removal log line stays single.

A deliberate `cost_override=0` on a live fighter is preserved — no save-level guard was added.

## Tests

- DEAD → RECOVERY and DEAD → CONVALESCENCE → ACTIVE via the form clear the override and restore both fighter and list rating.
- Removing the last injury from a DEAD fighter clears the override and restores rating.
- The Resurrect button path is unchanged.
- A deliberate free fighter (`cost_override=0`) survives a normal state edit, proving no save-level guard crept in.

Full suite green (2554 passed).

## Not included

Already-stuck fighters in production are left for a separate, reviewed data-fix step (a read-only `prodshell` report first), since `cost_override=0` alone can't distinguish a stuck-after-kill fighter from a deliberately free one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)