### PR TITLE
feat: lift block on pack default child-spawning equipment (closes #1803)

### DIFF
--- a/gyrinx/core/tests/test_pack_vehicles_beasts.py
+++ b/gyrinx/core/tests/test_pack_vehicles_beasts.py
@@ -8,6 +8,8 @@ These tests are written red-first — they describe the desired outcomes
 before the implementation lands.
 """
 
+from unittest.mock import patch
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -656,7 +658,7 @@ def test_subscribed_list_can_buy_pack_exotic_beast_via_equipment(
 
 
 @pytest.mark.django_db
-def test_default_assignment_picker_excludes_pack_vehicle(
+def test_default_assignment_picker_includes_pack_vehicle(
     client,
     user,
     pack,
@@ -665,13 +667,12 @@ def test_default_assignment_picker_excludes_pack_vehicle(
     vehicle_statline_type,
     vehicles_category,
 ):
-    """Until issue #1725 lands, fighter-linked equipment (vehicles / exotic
-    beasts) must NOT appear in the pack-fighter default-equipment picker.
+    """Fighter-linked equipment (vehicles / exotic beasts) appears in the
+    pack-fighter default-equipment picker.
 
-    Otherwise pack authors could silently configure a default that only
-    materialises for newly-hired list-fighters in subscribed gangs —
-    existing list-fighters of that type would not retroactively receive
-    the child fighter.
+    The interim block that hid such equipment was lifted in issue #1803 now
+    that issue #1725 propagates default child-fighter assignments to existing
+    subscribed gangs.
     """
     client.force_login(user)
     # Create a pack vehicle (auto-makes the equipment)
@@ -712,11 +713,11 @@ def test_default_assignment_picker_excludes_pack_vehicle(
     )
     response = client.get(url)
     assert response.status_code == 200
-    assert b"Goliath Mauler" not in response.content
+    assert b"Goliath Mauler" in response.content
 
 
 @pytest.mark.django_db
-def test_default_assignment_post_rejects_pack_vehicle(
+def test_default_assignment_post_accepts_pack_vehicle(
     client,
     user,
     pack,
@@ -724,9 +725,11 @@ def test_default_assignment_post_rejects_pack_vehicle(
     fighter_statline_type,
     vehicle_statline_type,
     vehicles_category,
+    django_capture_on_commit_callbacks,
 ):
-    """Defence in depth: even with a fabricated POST, the default-equipment
-    handler 404s when the equipment is fighter-linked."""
+    """Posting a fighter-linked equipment to the default-equipment handler
+    creates the default and enqueues propagation (issue #1803, building on
+    #1725)."""
     client.force_login(user)
     _create_pack_fighter_full(
         client,
@@ -765,11 +768,18 @@ def test_default_assignment_post_rejects_pack_vehicle(
     url = reverse(
         "core:pack-fighter-default-gear-add", args=(pack.id, ganger_pack_item.id)
     )
-    response = client.post(url, {"content_equipment": str(vehicle_equipment.id)})
-    assert response.status_code == 404
-    assert not ContentFighterDefaultAssignment.objects.filter(
-        fighter=ganger, equipment=vehicle_equipment
-    ).exists()
+    with patch(
+        "gyrinx.core.models.list.propagate_default_child_fighter_assignment"
+    ) as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(
+                url, {"content_equipment": str(vehicle_equipment.id)}
+            )
+        assert response.status_code == 302
+        default = ContentFighterDefaultAssignment.objects.get(
+            fighter=ganger, equipment=vehicle_equipment
+        )
+        mock_task.enqueue.assert_called_once_with(default_assignment_id=str(default.pk))
 
 
 @pytest.mark.django_db
@@ -786,11 +796,10 @@ def test_default_vehicle_assignment_spawns_child_when_fighter_hired(
     """When a pack fighter has a default vehicle assignment, hiring that
     fighter on a subscribed list automatically spawns the child vehicle.
 
-    The pack default-equipment picker currently blocks creation of such
-    defaults via the UI (see issue #1725 for the retroactive-propagation
-    follow-up). This test creates the default via the ORM directly to
-    document the underlying mechanism — once propagation lands, the UI
-    block lifts and this is the expected user-facing behaviour.
+    This exercises the hire-time materialisation path
+    (``create_linked_objects`` signal on ListFighter). For propagation to
+    existing list-fighters of an already-subscribed gang see the
+    ``test_propagate_default_child_fighter`` module.
     """
     client.force_login(user)
     vehicle_fighter = _create_pack_fighter_full(

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -3957,30 +3957,18 @@ def _get_pack_fighter(pack, item_id):
     return pack_item, content_fighter
 
 
-def _build_default_equipment_choices(
-    pack, is_weapon, search_query=None, exclude_fighter_linked=False
-):
+def _build_default_equipment_choices(pack, is_weapon, search_query=None):
     """Build equipment choices for the default equipment picker.
 
     Returns a queryset of ContentEquipment filtered to the same category
     groups that pack creators can use when adding gear/weapons, with
     weapon profiles correctly loaded (including pack profiles).
-
-    ``exclude_fighter_linked`` filters out equipment with a
-    ``ContentEquipmentFighterProfile`` (i.e. vehicle / exotic-beast
-    spawners). The pack-fighter default-assignment picker passes True so
-    pack authors can't silently configure a default that would only
-    apply to gangs hired AFTER the change. See issue #1725 for the
-    follow-up retroactive-propagation work that will lift this block.
     """
     qs = ContentEquipment.objects.with_packs([pack])
     if is_weapon:
         qs = qs.weapons().filter(category__group="Weapons & Ammo")
     else:
         qs = qs.non_weapons().exclude(category__group__in=["Weapons & Ammo", "Other"])
-
-    if exclude_fighter_linked:
-        qs = qs.filter(contentequipmentfighterprofile__isnull=True)
 
     if search_query:
         qs = search_queryset(qs, search_query, ["name", "category__name"])
@@ -4172,9 +4160,7 @@ def add_pack_fighter_default_weapon(request, id, item_id):
             raise Http404
 
         equipment = get_object_or_404(
-            _build_default_equipment_choices(
-                pack, is_weapon=True, exclude_fighter_linked=True
-            ),
+            _build_default_equipment_choices(pack, is_weapon=True),
             pk=equipment_id,
         )
 
@@ -4226,7 +4212,6 @@ def add_pack_fighter_default_weapon(request, id, item_id):
         pack,
         is_weapon=True,
         search_query=search_q or None,
-        exclude_fighter_linked=True,
     )
 
     # Group by category.
@@ -4273,9 +4258,7 @@ def add_pack_fighter_default_gear(request, id, item_id):
             raise Http404
 
         equipment = get_object_or_404(
-            _build_default_equipment_choices(
-                pack, is_weapon=False, exclude_fighter_linked=True
-            ),
+            _build_default_equipment_choices(pack, is_weapon=False),
             pk=equipment_id,
         )
 
@@ -4318,7 +4301,6 @@ def add_pack_fighter_default_gear(request, id, item_id):
         pack,
         is_weapon=False,
         search_query=search_q or None,
-        exclude_fighter_linked=True,
     )
 
     # Group by category.


### PR DESCRIPTION
## Summary

- Lifts the interim block that hid fighter-linked equipment (vehicles / exotic beasts) from the pack-fighter default-equipment picker.
- The block was added with the #1723 / #1724 vehicles + exotic beasts work and was only ever transitional — its purpose was to prevent pack authors from configuring a default that would only apply to gangs hired AFTER the change. #1725's `propagate_default_child_fighter_assignment` task (signal on `ContentFighterDefaultAssignment` post_save) now propagates such defaults to already-subscribed gangs, so the block is no longer needed.
- Closes #1803.

## Changes

- `gyrinx/core/views/pack.py`: drop the `exclude_fighter_linked` kwarg from `_build_default_equipment_choices` and its four call sites in `add_pack_fighter_default_weapon` / `add_pack_fighter_default_gear`.
- `gyrinx/core/tests/test_pack_vehicles_beasts.py`: invert the two interim-block tests — picker now offers vehicle equipment, POST now creates the default and enqueues the propagation task (mocked + on-commit capture). Updated the docstring on the hire-time materialisation test to reflect that the UI block is gone.

## Notes

- The propagation has a net-zero rating impact (default is virtual/0-cost, materialised assignment uses `cost_override=0`, child fighters don't contribute to list cost). The pack-detail gear template (`fighter_default_equipment.html`) renders only the equipment name + a Remove link with no cost field, so it cannot misleadingly imply a cost.
- The `legacy_content_fighter` gap noted in the issue (#1725's materialisation helper only acts on `content_fighter` defaults) is left as a documented follow-up — out of scope for this unblock.

## Test plan

- [x] Open pack admin, pick a fighter, add a default vehicle / exotic beast as gear — confirm it appears in the picker. *(verified: "+ Add ManualTest Vehicle" button under Vehicles category on `/pack/.../default-equipment/gear/add/?q=ManualTest`)*
- [x] Confirm the new default renders on the pack detail page without implying a cost. *(verified: "ManualTest Vehicle" appears under Gear with only a Remove link, no cost field; runserver log shows POST 302 followed by `propagate_default_child_fighter_assignment` task transitioning RUNNING → SUCCESSFUL)*
- [x] Subscribe an existing list to the pack with a hired ganger of that type; confirm the child fighter propagates after adding the default. *(covered by the propagation task running synchronously in dev under ImmediateBackend; #1725 has end-to-end tests for the propagation behaviour itself)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)