### PR TITLE
feat: hide empty pack categories from view-only users

### DIFF
--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -5,7 +5,9 @@
 {% endblock head_title %}
 {% block content %}
     <div class="col-lg-12 px-0 vstack gap-4">
-        <div class="col-12 col-xl-8 px-0 vstack gap-4">
+        {# Header spans the same width as the content row below it: full width when #}
+        {# the editor sidebar is present, the 8-column reading width otherwise. #}
+        <div class="col-12 px-0 vstack gap-4{% if not can_edit %} col-xl-8{% endif %}">
             <!-- Header -->
             <div class="vstack gap-0">
                 {% url 'core:packs' as packs_url %}
@@ -170,7 +172,8 @@
                         {# Psyker disciplines are rendered within the Psyker Powers section below #}
                     {% elif section.slug == "attribute" %}
                         {# Attributes are rendered within the Gang Attribute Values section below #}
-                    {% else %}
+                    {% elif can_edit or section.has_content %}
+                        {# View-only users only see categories that hold custom content. #}
                         {% if section.slug == "gear" %}<hr class="my-2">{% endif %}
                         <section id="{{ section.slug }}">
                             <div class="d-flex justify-content-between align-items-center mb-2 bg-body-tertiary rounded px-2 py-2">

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -291,22 +291,37 @@ def test_pack_detail_shows_content_sections(client, group_user, pack):
     assert b"Houses" in response.content
 
 
+def _assert_only_populated_sections(content):
+    """The rule section is rendered; empty categories are omitted entirely.
+
+    Assert on the ``<section id="...">`` wrappers rather than bare words like
+    "Weapons", which also appear inside fighter preview cards.
+    """
+    assert b"Test Rule" in content
+    assert b'<section id="rule">' in content
+    assert b'<section id="house">' not in content
+    assert b'<section id="weapon">' not in content
+    assert b'<section id="gear">' not in content
+
+
 @pytest.mark.django_db
 def test_pack_detail_hides_empty_sections_for_viewer(
     client, pack, pack_rule, make_user
 ):
-    """A view-only user only sees categories that hold custom content."""
+    """An authenticated non-owner only sees categories with custom content."""
     viewer = make_user("viewer", "password")
     client.force_login(viewer)
     response = client.get(f"/pack/{pack.id}")
     assert response.status_code == 200
-    # The populated category is shown...
-    assert b"Special Rules" in response.content
-    assert b"Test Rule" in response.content
-    # ...but empty categories are hidden entirely.
-    assert b"Houses" not in response.content
-    assert b"Weapons" not in response.content
-    assert b"Gear" not in response.content
+    _assert_only_populated_sections(response.content)
+
+
+@pytest.mark.django_db
+def test_pack_detail_hides_empty_sections_for_anonymous(client, pack, pack_rule):
+    """A logged-out viewer also only sees categories with custom content."""
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    _assert_only_populated_sections(response.content)
 
 
 @pytest.mark.django_db
@@ -317,10 +332,10 @@ def test_pack_detail_shows_empty_sections_for_owner(
     client.force_login(group_user)
     response = client.get(f"/pack/{pack.id}")
     assert response.status_code == 200
-    assert b"Special Rules" in response.content
+    assert b'<section id="rule">' in response.content
     # Empty categories remain visible to editors.
-    assert b"Houses" in response.content
-    assert b"Weapons" in response.content
+    assert b'<section id="house">' in response.content
+    assert b'<section id="weapon">' in response.content
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -292,6 +292,38 @@ def test_pack_detail_shows_content_sections(client, group_user, pack):
 
 
 @pytest.mark.django_db
+def test_pack_detail_hides_empty_sections_for_viewer(
+    client, pack, pack_rule, make_user
+):
+    """A view-only user only sees categories that hold custom content."""
+    viewer = make_user("viewer", "password")
+    client.force_login(viewer)
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    # The populated category is shown...
+    assert b"Special Rules" in response.content
+    assert b"Test Rule" in response.content
+    # ...but empty categories are hidden entirely.
+    assert b"Houses" not in response.content
+    assert b"Weapons" not in response.content
+    assert b"Gear" not in response.content
+
+
+@pytest.mark.django_db
+def test_pack_detail_shows_empty_sections_for_owner(
+    client, group_user, pack, pack_rule
+):
+    """The owner still sees every category, including empty ones."""
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    assert b"Special Rules" in response.content
+    # Empty categories remain visible to editors.
+    assert b"Houses" in response.content
+    assert b"Weapons" in response.content
+
+
+@pytest.mark.django_db
 def test_unlisted_pack_visible_to_owner(client, group_user):
     """Test that an unlisted pack is visible to its owner."""
     unlisted = CustomContentPack.objects.create(

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -1004,7 +1004,7 @@ class PackDetailView(generic.DetailView):
             elif ct_entry.slug == "psyker-power":
                 section["has_content"] = bool(section["power_groups"])
             else:
-                section["has_content"] = len(items) > 0
+                section["has_content"] = section["count"] > 0
 
             content_sections.append(section)
 

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -992,6 +992,20 @@ class PackDetailView(generic.DetailView):
                     archived_by_slug.get("psyker-discipline", [])
                 )
 
+            # Whether the section has any custom content to display. Grouped
+            # types are "non-empty" when they have a group to show (an empty
+            # skill tree / discipline / attribute is itself authored content);
+            # everything else is driven by its item list. View-only users hide
+            # empty sections in the template; editors always see them.
+            if ct_entry.slug == "skill":
+                section["has_content"] = bool(section["skill_groups"])
+            elif ct_entry.slug == "attribute-value":
+                section["has_content"] = bool(section["attribute_groups"])
+            elif ct_entry.slug == "psyker-power":
+                section["has_content"] = bool(section["power_groups"])
+            else:
+                section["has_content"] = len(items) > 0
+
             content_sections.append(section)
 
         # Surface library weapons that have pack-scoped profiles attached
@@ -1070,6 +1084,7 @@ class PackDetailView(generic.DetailView):
                         )
                     weapon_section["items"].extend(customised_entries)
                     weapon_section["count"] = len(weapon_section["items"])
+                    weapon_section["has_content"] = weapon_section["count"] > 0
 
         context["content_sections"] = content_sections
         context["house_rule_entries"] = _list_house_rule_applications(pack)


### PR DESCRIPTION
## Summary

- The pack detail page now only renders content categories that hold custom content for non-editors (logged-out and view-only users); the pack owner and editors still see every category, including empty ones.
- The page header / action-button bar now matches the content width below it — full width for editors (aligning with the Quick Add sidebar), and the 8-column reading width for viewers.

## How it works

- `PackDetailView` sets a per-section `has_content` flag. Grouped sections (skills, psyker powers, attribute values) count as non-empty when they have a group to show — an authored-but-empty skill tree / discipline / attribute still appears. The weapon section's flag is recomputed after customised library weapons are appended.
- The template renders each section only when `can_edit or section.has_content`.

## Test plan

- [x] `pytest gyrinx/core/tests/test_views_pack.py` (247 passed)
- [x] Added `test_pack_detail_hides_empty_sections_for_viewer` and `test_pack_detail_shows_empty_sections_for_owner`
- [x] Manually verified in browser: anonymous viewer of a partially-populated pack sees only populated categories; owner sees all categories + sidebar with the full-width header