### PR TITLE
refactor: make site-wide form-submit spinner non-destructive

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -356,8 +356,10 @@ setupFilterLinks({ prefix: "status", param: "status", allValues: "all" });
 //
 // Two things keep it well-behaved:
 //   1. It is non-destructive. We keep the clicked button's original label/icon
-//      and add a spinner alongside it plus aria-busy, rather than replacing the
-//      button's innerHTML. Nothing inside the button is thrown away.
+//      in the DOM and set aria-busy, rather than replacing the button's
+//      innerHTML. CSS (button[aria-busy]) then hides that content and shows a
+//      centred spinner over it, so nothing inside the button is thrown away and
+//      the original markup can be restored verbatim.
 //   2. It restores itself from the bfcache. A pageshow handler clears the busy
 //      state when a page is restored after pressing Back, so a form is never
 //      left stuck disabled/spinning.
@@ -373,8 +375,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
             submitButtons.forEach((button) => {
                 // Only add the spinner to the button that was clicked, and do
-                // it non-destructively: keep the existing label/icon and add a
-                // spinner alongside it.
+                // it non-destructively: keep the existing label/icon in place
+                // and let CSS hide it behind a centred spinner.
                 if (button.isSameNode(event.submitter)) {
                     button.setAttribute("aria-busy", "true");
 
@@ -382,8 +384,10 @@ document.addEventListener("DOMContentLoaded", () => {
                     // <button> gets a spinner element prepended.
                     if (button.tagName === "BUTTON") {
                         const spinner = document.createElement("span");
-                        spinner.className =
-                            "spinner-border spinner-border-sm me-2";
+                        // Centred over the button via CSS (button[aria-busy])
+                        // rather than flowed beside the label, so small /
+                        // icon-only buttons collapse to just the spinner.
+                        spinner.className = "spinner-border spinner-border-sm";
                         spinner.setAttribute("role", "status");
                         spinner.setAttribute("aria-hidden", "true");
                         spinner.dataset.submitSpinner = "true";

--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -345,7 +345,22 @@ setupFilterLinks({
 setupFilterLinks({ prefix: "house", param: "house", allValues: "all" });
 setupFilterLinks({ prefix: "status", param: "status", allValues: "all" });
 
-// Add loading spinner to form submit buttons
+// Site-wide form-submit "busy" affordance.
+//
+// This is a deliberate exception to our "JS is for one-off enhancements" rule:
+// it applies to *every* form on submit so the whole app feels responsive on
+// slow POSTs (content-pack saves, large list edits, etc.) and discourages
+// accidental double-submits. It is purely an enhancement — it never calls
+// preventDefault(), so forms still submit natively and redirects are followed
+// as normal even if this script fails to load.
+//
+// Two things keep it well-behaved:
+//   1. It is non-destructive. We keep the clicked button's original label/icon
+//      and add a spinner alongside it plus aria-busy, rather than replacing the
+//      button's innerHTML. Nothing inside the button is thrown away.
+//   2. It restores itself from the bfcache. A pageshow handler clears the busy
+//      state when a page is restored after pressing Back, so a form is never
+//      left stuck disabled/spinning.
 document.addEventListener("DOMContentLoaded", () => {
     const forms = document.querySelectorAll("form");
 
@@ -357,21 +372,62 @@ document.addEventListener("DOMContentLoaded", () => {
             );
 
             submitButtons.forEach((button) => {
-                // Only modify the button if it is the one that was clicked
+                // Only add the spinner to the button that was clicked, and do
+                // it non-destructively: keep the existing label/icon and add a
+                // spinner alongside it.
                 if (button.isSameNode(event.submitter)) {
-                    button.style.width = `${button.offsetWidth}px`;
-                    button.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>`;
+                    button.setAttribute("aria-busy", "true");
+
+                    // <input type="submit"> can't hold child markup, so only
+                    // <button> gets a spinner element prepended.
+                    if (button.tagName === "BUTTON") {
+                        const spinner = document.createElement("span");
+                        spinner.className =
+                            "spinner-border spinner-border-sm me-2";
+                        spinner.setAttribute("role", "status");
+                        spinner.setAttribute("aria-hidden", "true");
+                        spinner.dataset.submitSpinner = "true";
+                        button.prepend(spinner);
+                    }
                 }
 
-                // Disable all the buttons
+                // Disable all the buttons to prevent double-submits. We tag
+                // each one we touch so pageshow can restore exactly these.
                 // This is setTimeout to ensure it runs after the form submission starts so that any
                 // name/value attributes are still submitted.
                 setTimeout(() => {
+                    button.dataset.submitDisabled = "true";
                     button.disabled = true;
                 }, 0);
             });
         });
     });
+});
+
+// Clear the form-submit busy state when a page is restored from the bfcache
+// (e.g. pressing Back after submitting). Without this the restored DOM keeps
+// the disabled buttons and spinners, leaving the form looking permanently busy.
+// We only undo what the submit handler above set, identified by our data-*
+// markers, so buttons disabled for other reasons are left alone.
+window.addEventListener("pageshow", (event) => {
+    if (!event.persisted) {
+        return;
+    }
+
+    document
+        .querySelectorAll('[data-submit-disabled="true"]')
+        .forEach((button) => {
+            button.disabled = false;
+            delete button.dataset.submitDisabled;
+        });
+
+    document.querySelectorAll('[aria-busy="true"]').forEach((button) => {
+        button.removeAttribute("aria-busy");
+    });
+
+    document
+        .querySelectorAll('[data-submit-spinner="true"]')
+        .forEach((spinner) => spinner.remove());
 });
 
 // Find all checkboxes and add change event listeners to any hidden fields

--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -395,8 +395,16 @@ document.addEventListener("DOMContentLoaded", () => {
                     }
                 }
 
-                // Disable all the buttons to prevent double-submits. We tag
-                // each one we touch so pageshow can restore exactly these.
+                // Skip buttons that were already disabled before this submit —
+                // they aren't ours to re-enable on pageshow, so we must not tag
+                // them.
+                if (button.disabled) {
+                    return;
+                }
+
+                // Disable the (previously-enabled) buttons to prevent
+                // double-submits. We tag each one we touch so pageshow can
+                // restore exactly these.
                 // This is setTimeout to ensure it runs after the form submission starts so that any
                 // name/value attributes are still submitted.
                 setTimeout(() => {
@@ -418,16 +426,16 @@ window.addEventListener("pageshow", (event) => {
         return;
     }
 
+    // Only touch buttons we tagged. aria-busy is cleared here too (rather than
+    // via a separate document-wide [aria-busy] sweep) so we never clobber other
+    // UI that legitimately uses aria-busy.
     document
         .querySelectorAll('[data-submit-disabled="true"]')
         .forEach((button) => {
             button.disabled = false;
+            button.removeAttribute("aria-busy");
             delete button.dataset.submitDisabled;
         });
-
-    document.querySelectorAll('[aria-busy="true"]').forEach((button) => {
-        button.removeAttribute("aria-busy");
-    });
 
     document
         .querySelectorAll('[data-submit-spinner="true"]')

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -94,6 +94,47 @@ $font-sizes: map-merge($font-sizes, $custom-font-sizes);
 // Custom styles
 //
 
+// Form-submit busy state (driven by core/js/index.js).
+//
+// The submit handler keeps the clicked button's original label/icon in the DOM
+// (so it can be restored verbatim from the bfcache on Back) and only sets
+// aria-busy + prepends a spinner element. These rules hide the real content and
+// show just the centred spinner, so even small / icon-only buttons collapse to
+// the spinner — the way the old, destructive innerHTML swap looked. Removing
+// aria-busy (on submit-failure restore or pageshow) reverts all of this for
+// free, since every rule is keyed on the attribute.
+button[aria-busy="true"] {
+    position: relative;
+
+    // Snap the label out faster than Bootstrap's default .15s .btn colour
+    // transition, so the content disappears quickly when the spinner appears.
+    // Via the Bootstrap mixin so it still honours prefers-reduced-motion.
+    @include transition(color 0.06s ease-in-out);
+
+    // Hide bare text nodes and icon-font glyphs — both are painted by `color`.
+    // !important is required: the submit handler disables the button a tick
+    // after click, and Bootstrap's `.btn:disabled` / `.btn:hover` / `.btn:active`
+    // colour rules have higher specificity than `button[aria-busy]` and would
+    // otherwise restore the text colour, showing the label under the spinner.
+    color: transparent !important;
+
+    // Hide element children (nested icons, badges, images) without removing
+    // them, so the button keeps its intrinsic width and doesn't collapse.
+    > :not([data-submit-spinner]) {
+        visibility: hidden;
+    }
+
+    // Centre the spinner over the now-empty button and give it back a visible
+    // colour (the button variant's own text colour, since the button itself is
+    // now `color: transparent`).
+    [data-submit-spinner] {
+        position: absolute;
+        inset: 0;
+        margin: auto;
+        color: var(--bs-btn-color, currentColor);
+    }
+}
+
 // Lighten secondary in light mode, darken in dark mode
 :root,
 [data-bs-theme="light"] {

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -126,12 +126,15 @@ button[aria-busy="true"] {
 
     // Centre the spinner over the now-empty button and give it back a visible
     // colour (the button variant's own text colour, since the button itself is
-    // now `color: transparent`).
+    // now `color: transparent`). Fall back to the body colour rather than
+    // currentColor: on a submit <button> without a .btn variant (e.g. a
+    // dropdown-item), --bs-btn-color is unset and currentColor would resolve to
+    // the parent's transparent, hiding the spinner.
     [data-submit-spinner] {
         position: absolute;
         inset: 0;
         margin: auto;
-        color: var(--bs-btn-color, currentColor);
+        color: var(--bs-btn-color, var(--bs-body-color));
     }
 }
 


### PR DESCRIPTION
Reworks the global form-submit busy affordance so it's non-destructive and bfcache-safe, while keeping it on all forms and preserving the original "spinner replaces the button" look.

- On submit, set `aria-busy` and prepend a spinner element instead of replacing the button's `innerHTML`, so nothing inside the button is thrown away.
- CSS (`button[aria-busy="true"]`) hides the original label/icon and centres the spinner over it, so small / icon-only buttons collapse to just the spinner. `color: transparent !important` is needed so it beats Bootstrap's `.btn:disabled`/`:hover` colour (the handler disables the button a tick after click); the label fade-out is sped to 0.06s via Bootstrap's `transition()` mixin, which still honours `prefers-reduced-motion`.
- Spinner colour falls back to `--bs-body-color` (not `currentColor`) so submit `<button>`s without a `.btn` variant (e.g. a `dropdown-item`) still get a visible spinner.
- A `pageshow` handler clears the busy state on bfcache restore (fixes stuck spinner on Back). It only touches buttons it tagged via `data-submit-disabled`, and skips buttons that were already disabled before submit, so it never re-enables or clobbers UI it didn't disable.
- Documents why this site-wide JS is an intentional exception.

Note: every submit control in the codebase is a `<button type="submit">` (no `<input type="submit">`), so the CSS covers 100% of real buttons; the JS input branch is purely defensive.

## Test plan

- [ ] Submit a form (e.g. content-pack save, list edit) — the clicked button collapses to a centred spinner with no label showing through, and gets disabled.
- [ ] Small / icon-only buttons (e.g. filter search) show only the spinner, not spinner + icon.
- [ ] A non-`.btn` submit button (campaign packs "Add to…" gang dropdown) shows a visible spinner, not a blank button.
- [ ] Press Back after submitting — no button is left stuck disabled/spinning, and any button that was already disabled stays disabled.
- [ ] With `prefers-reduced-motion: reduce`, the label swaps instantly (no fade).

Closes #1806

Generated with [Claude Code](https://claude.ai/code)