### PR TITLE
feat: refresh logged-out homepage copy

### DIFF
--- a/gyrinx/core/templates/core/index.html
+++ b/gyrinx/core/templates/core/index.html
@@ -4,7 +4,7 @@
     {% if user.is_authenticated %}
         Home
     {% else %}
-        A new set of tools for the Necromunda community
+        A free set of tools for the Necromunda community
     {% endif %}
 {% endblock head_title %}
 {% block prebody %}
@@ -17,7 +17,7 @@
                     <strong>Welcome</strong> to Gyrinx’s Necromunda tools, <a class="link-light link-underline-opacity-50 link-underline-opacity-100-hover"
     href="{% url 'core:user' user.id %}">{{ user.username }}</a>.
                 {% else %}
-                    <strong>Gyrinx</strong> is a new set of tools for the Necromunda community.
+                    <strong>Gyrinx</strong> is a free set of tools for the Necromunda community.
                 {% endif %}
             </h2>
         </div>
@@ -241,44 +241,6 @@
             </div>
         {% else %}
             <div class="mt-4 vstack gap-4">
-                {% if featured_packs %}
-                    <div>
-                        <div class="d-flex justify-content-between align-items-center mb-3">
-                            <h2 class="h4 mb-0">Featured Content Packs</h2>
-                            <span class="ms-auto fs-7">
-                                <a href="{% url 'core:packs' %}"
-                                   class="link-secondary link-underline-opacity-50 link-underline-opacity-100-hover">Browse all</a>
-                            </span>
-                        </div>
-                        <div class="row g-3">
-                            {% for pack in featured_packs %}
-                                <div class="col-12 col-md-4">{% include "core/includes/featured_pack_card.html" with pack=pack %}</div>
-                            {% endfor %}
-                        </div>
-                    </div>
-                    <hr class="col-1 my-4 align-self-center" />
-                {% endif %}
-                <div class="row">
-                    <div class="col-md-4">
-                        <h2>Build and manage your gangs</h2>
-                        <p>
-                            Gyrinx is a new set of tools for building and running your Necromunda gangs — making the game simpler whatever your level of experience.
-                        </p>
-                    </div>
-                    <div class="col-md-4">
-                        <h2>All the latest content</h2>
-                        <p>
-                            We’re combing the rulebooks so every gang — and anything else you might want to use — will be available from launch. Plus, our content team will keep Gyrinx up-to-date as new rules land.
-                        </p>
-                    </div>
-                    <div class="col-md-4">
-                        <h2>Take the hassle out of arbitration</h2>
-                        <p>
-                            Running a campaign can get complicated. We’ll offer support for managing all the fixed campaign types, and let arbitrators create their own with custom settings.
-                        </p>
-                    </div>
-                </div>
-                <hr class="col-1 my-4 align-self-center" />
                 {% get_page_by_url "/about/" as about_page %}
                 {% settings_value "ACCOUNT_ALLOW_SIGNUPS" as account_signups %}
                 <p class="lead fs-2 text-center">
@@ -297,44 +259,22 @@
                         {% endif %}
                     {% endif %}
                 </p>
-                <hr class="col-1 my-4 align-self-center" />
-                <div class="row justify-content-center align-items-center">
+                <div class="row">
                     <div class="col-md-4">
-                        <img src="{% static 'core/img/content/2daef2fe-5829-4052-93fb-c2007935fc1a.png' %}"
-                             class="img-fluid border rounded-2"
-                             alt="Two fighter cards from the Ironhead Squats gang">
-                    </div>
-                    <div class="col-md-6">
-                        <h2>Simplified gang creation</h2>
+                        <h2>Build and manage your gangs</h2>
                         <p>
-                            Forget the hassle of cards and spreadsheets — hire fighters and kit them out with an intuitive gang building system.
-                        </p>
-                        <p>Our tools are free to use, and we're committed to keeping them that way.</p>
-                    </div>
-                </div>
-                <hr class="col-1 my-4 align-self-center" />
-                <div class="row justify-content-center align-items-center">
-                    <div class="col-md-4 order-2">
-                        <img src="{% static 'core/img/content/1b07c211-5e06-4741-b588-edc2c37c2999.png' %}"
-                             class="img-fluid object-fit-contain border rounded-2"
-                             alt="">
-                    </div>
-                    <div class="col-md-6">
-                        <h2>Get to the rules you need</h2>
-                        <p>
-                            Tooltips for traits, skills and special rules will direct you to the right part of the rulebooks, so you can quickly find the information you need in the heat of battle.
+                            Gyrinx is a powerful set of tools for building and running your Necromunda gangs — making the game simpler whatever your level of experience.
                         </p>
                     </div>
-                </div>
-                <hr class="col-1 my-4 align-self-center" />
-                <div class="row text-center">
-                    <h2>And lots more...</h2>
-                </div>
-                <div class="row justify-content-center align-items-center">
-                    <div class="col-md-10">
-                        <img src="{% static 'core/img/content/773e6bb5-3a76-48bf-bf60-f70ad038c02e.png' %}"
-                             class="img-fluid object-fit-contain border rounded-2"
-                             alt="">
+                    <div class="col-md-4">
+                        <h2>All the latest content</h2>
+                        <p>Gyrinx is kept up to date with the latest Necromunda rules as they drop.</p>
+                    </div>
+                    <div class="col-md-4">
+                        <h2>Take the hassle out of arbitration</h2>
+                        <p>
+                            Running a campaign can get complicated. Gyrinx helps you manage all the key parts of campaigns, and supports custom content and rules.
+                        </p>
                     </div>
                 </div>
             </div>

--- a/gyrinx/core/templates/core/layouts/foundation.html
+++ b/gyrinx/core/templates/core/layouts/foundation.html
@@ -7,7 +7,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description"
-              content="Gyrinx is a new set of tools for the Necromunda community">
+              content="Gyrinx is a free set of tools for the Necromunda community">
         <meta name="author" content="Gyrinx">
         <meta name="keywords" content="Necromunda, Gyrinx">
         <meta name="application-name" content="Gyrinx" />

--- a/gyrinx/core/tests/test_homepage_featured_packs.py
+++ b/gyrinx/core/tests/test_homepage_featured_packs.py
@@ -6,8 +6,8 @@ from gyrinx.core.models.pack import CustomContentPack
 
 
 @pytest.mark.django_db
-def test_homepage_shows_featured_packs_for_anonymous(make_user):
-    """Featured + listed packs appear on the front page for anonymous users."""
+def test_homepage_hides_featured_packs_for_anonymous(make_user):
+    """The logged-out landing page no longer renders the featured packs bar."""
     owner = make_user("packowner", "password")
     CustomContentPack.objects.create(
         name="Prototype Weapons",
@@ -21,8 +21,8 @@ def test_homepage_shows_featured_packs_for_anonymous(make_user):
     response = client.get(reverse("core:index"))
 
     assert response.status_code == 200
-    assert b"Featured Content Packs" in response.content
-    assert b"Prototype Weapons" in response.content
+    assert b"Featured Content Packs" not in response.content
+    assert b"Prototype Weapons" not in response.content
 
 
 @pytest.mark.django_db
@@ -118,7 +118,7 @@ def test_homepage_caps_featured_packs_at_three(make_user):
 
 
 @pytest.mark.django_db
-def test_homepage_featured_description_falls_back_to_summary(make_user):
+def test_homepage_featured_description_falls_back_to_summary(client, user, make_user):
     """When featured_description is blank, the card falls back to summary text."""
     owner = make_user("packowner", "password")
     CustomContentPack.objects.create(
@@ -130,7 +130,7 @@ def test_homepage_featured_description_falls_back_to_summary(make_user):
         owner=owner,
     )
 
-    client = Client()
+    client.force_login(user)
     response = client.get(reverse("core:index"))
 
     assert response.status_code == 200

--- a/gyrinx/templates/500.html
+++ b/gyrinx/templates/500.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description"
-              content="Gyrinx is a new set of tools for the Necromunda community">
+              content="Gyrinx is a free set of tools for the Necromunda community">
         <meta name="author" content="Gyrinx">
         <meta name="keywords" content="Necromunda, Gyrinx">
         <meta name="application-name" content="Gyrinx" />


### PR DESCRIPTION
Refreshes the logged-out landing page copy per #1819:

- "Gyrinx is a new set of tools…" → "Gyrinx is a free set of tools…" (hero, page title, and meta descriptions).
- Remove the featured content packs bar from the anonymous landing page (authenticated dashboard unaffected).
- Move the "Find out more, sign in or sign up." paragraph to sit directly below the hero image.
- Update three-column copy: "Build and manage your gangs" ("new" → "powerful"), "All the latest content" (shorter, evergreen), "Take the hassle out of arbitration" (revised).
- Remove the "Simplified gang creation", "Get to the rules you need", and "And lots more…" sections.

Updates `test_homepage_featured_packs.py` so the anonymous-user test now asserts the bar is hidden, and switches the featured-description-fallback test to an authenticated client.

Closes #1819

Generated with [Claude Code](https://claude.ai/code)