### PR TITLE
feat: carry current page through sign-in/sign-up flow

### DIFF
--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -111,9 +111,21 @@
                             {{ user.username }}
                         </a>
                     {% else %}
-                        <a href="{% url 'account_login' %}" class="btn btn-outline-light">Sign In</a>
+                        {% url 'account_login' as login_url_ %}
                         {% url 'account_signup' as signup_url_ %}
-                        {% if signup_url_ %}<a href="{{ signup_url_ }}" class="btn btn-success">Sign Up</a>{% endif %}
+                        {% if request.path != login_url_ and request.path != signup_url_ %}
+                            {% with next_param=request.get_full_path|urlencode %}
+                                <a href="{{ login_url_ }}?next={{ next_param }}"
+                                   class="btn btn-outline-light">Sign In</a>
+                                {% if signup_url_ %}
+                                    <a href="{{ signup_url_ }}?next={{ next_param }}"
+                                       class="btn btn-success">Sign Up</a>
+                                {% endif %}
+                            {% endwith %}
+                        {% else %}
+                            <a href="{{ login_url_ }}" class="btn btn-outline-light">Sign In</a>
+                            {% if signup_url_ %}<a href="{{ signup_url_ }}" class="btn btn-success">Sign Up</a>{% endif %}
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- Sign In and Sign Up nav buttons now append `?next=<current page>` so users are returned to the page they signed in from after authenticating.
- allauth honours the `next` param via the existing `redirect_field` hidden input in the login/signup templates, so it survives the POST and any switch between the two forms.
- A guard skips appending `next` on the login/signup pages themselves to avoid a redirect loop.

## Test plan

- [ ] From a content page (e.g. `/lists/`), click **Sign In** → URL is `/accounts/login/?next=/lists/`; after logging in you land back on `/lists/`.
- [ ] Same for **Sign Up**.
- [ ] On the login page itself, the nav **Sign In** button does not append `?next=/accounts/login/`.
- [ ] Pages with a query string round-trip correctly (next is url-encoded).