### PR TITLE
feat: enlarge house icons and add them to the design system

### DIFF
--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -120,6 +120,28 @@ Bootstrap Icons only. **Hyphenated format**: `bi-pencil` not `bi bi-pencil`.
 
 Sizes: inherit from parent (default), `fs-7` for compact, `fs-4` for featured.
 
+### House icons
+
+Houses can carry an inline SVG badge rendered next to the house name (gang rows,
+list headers, house filters). Render it with the `{% house_icon house %}` template
+tag — never hand-roll the markup — which emits a sanitised, `currentColor`-filled
+`<svg class="house-icon">`. The icon inherits the surrounding text colour and sits
+inline with the name:
+
+```html
+{% load color_tags %}
+<div>{{ list.content_house_name }}{% house_icon list.content_house_cached %}</div>
+```
+
+`.house-icon` scales the glyph ~25% larger than a Bootstrap Icon and nudges it
+to sit centred on the text, both via a single `transform` (`translateY(...) scale(...)`).
+The transform is deliberate: it is purely visual and never feeds the line-box
+calculation, so the badge does **not** inflate the row's line-height — whereas a larger
+`width`/`height` or a `vertical-align` offset both would, and noticeably so in tight
+(`line-height: 1`) rows. The inline margins reserve horizontal breathing room for the
+visually-larger glyph. The tag is currently gated to the **House Icons Alpha** group and
+renders nothing for houses without an icon or for users outside the group.
+
 ---
 
 ## Containers & Cards
@@ -412,3 +434,4 @@ A `<br>` before the icon in real templates, or a `<div>` wrapper:
 | `.flash-warn` | 2s warning-colour fade animation for new items |
 | `.tooltipped` | Info-underline style with help cursor |
 | `.table-fixed` | `table-layout: fixed` for stat grids |
+| `.house-icon` | Inline house SVG badge; `transform`-scaled ~25% (line-height safe), `currentColor`; emitted by `{% house_icon %}` |

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -434,4 +434,4 @@ A `<br>` before the icon in real templates, or a `<div>` wrapper:
 | `.flash-warn` | 2s warning-colour fade animation for new items |
 | `.tooltipped` | Info-underline style with help cursor |
 | `.table-fixed` | `table-layout: fixed` for stat grids |
-| `.house-icon` | Inline house SVG badge; `transform`-scaled ~25% (line-height safe), `currentColor`; emitted by `{% house_icon %}` |
+| `.house-icon` | Inline house SVG badge; `transform`-scaled ~25% (line-height safe), `currentColor`; emitted by `{% house_icon house %}` |

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -536,14 +536,23 @@ $width-em-sizes: (
     width: 4rem;
 }
 
-// Inline house icons rendered next to house names. Sized and aligned to match
-// Bootstrap Icons (1em, baseline-aligned), and recoloured to the surrounding
-// text via currentColor (set as an attribute on the sanitised SVG).
+// Inline house icons rendered next to house names. Recoloured to the
+// surrounding text via currentColor (set as an attribute on the sanitised SVG).
+//
+// The glyph reads a touch small at 1em, so it's scaled up ~25% and nudged to
+// sit optically centred on the text. Both the size bump and the vertical
+// offset are done with a single `transform`, deliberately: a `transform` is
+// purely visual and never affects layout, whereas a larger width/height or a
+// `vertical-align` offset both feed into the line-box calculation and grow the
+// row's line-height in tight (line-height: 1) contexts like compact list rows.
+// The layout box stays 1em; the inline margins reserve horizontal room so the
+// visually-larger glyph doesn't crowd the surrounding text.
 .house-icon {
     display: inline-block;
     width: 1em;
     height: 1em;
-    vertical-align: -0.125em;
-    margin-inline-start: 0.25em;
+    margin-inline-start: 0.35em;
+    margin-inline-end: 0.1em;
     fill: currentColor;
+    transform: translateY(-0.2em) scale(1.25);
 }

--- a/gyrinx/core/templates/core/debug/design_system.html
+++ b/gyrinx/core/templates/core/debug/design_system.html
@@ -583,11 +583,10 @@
                 examples below show the badge at body and compact (<code>fs-7</code>) sizes.
             </p>
             <div class="d-flex flex-column gap-2">
-                {# djlint:off #}
-                <div>Squat Prospectors<span class="house-icon"><svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 1 1 5.5V15h4.5v-4h5v4H15V5.5L8 1Z" /></svg></span></div>
-                <div class="text-secondary fs-7">House name at <code>fs-7</code><span class="house-icon"><svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 1 1 5.5V15h4.5v-4h5v4H15V5.5L8 1Z" /></svg></span></div>
-                {# djlint:on #}
-                {# djlint:off H021 #}{# restore the file-level H021 suppression re-enabled by djlint:on above #}
+                <div>Squat Prospectors{{ ds_house_icon_svg }}</div>
+                <div class="text-secondary fs-7">
+                    House name at <code>fs-7</code>{{ ds_house_icon_svg }}
+                </div>
             </div>
         </section>
         <!-- ============================================================ -->
@@ -1583,6 +1582,8 @@
                             <span class="tooltipped">hover me</span>
                         {% elif cls == ".table-fixed" %}
                             <span class="text-secondary">(table-layout: fixed)</span>
+                        {% elif cls == ".house-icon" %}
+                            <span>House{{ ds_house_icon_svg }}</span>
                         {% endif %}
                     </td>
                 </tr>

--- a/gyrinx/core/templates/core/debug/design_system.html
+++ b/gyrinx/core/templates/core/debug/design_system.html
@@ -573,6 +573,22 @@
                     </div>
                 {% endfor %}
             </div>
+            <h3 class="h6 caps-label mb-2 mt-4">House icons</h3>
+            <p class="text-secondary fs-7 mb-2">
+                Inline badge rendered next to a house's name (gang rows, list headers, house
+                filters). Emit it with the
+                <code>{% templatetag openblock %} house_icon house {% templatetag closeblock %}</code>
+                template tag; it inherits the surrounding text colour and sits comfortably alongside
+                the name. Currently gated to the <strong>House Icons Alpha</strong> group. The
+                examples below show the badge at body and compact (<code>fs-7</code>) sizes.
+            </p>
+            <div class="d-flex flex-column gap-2">
+                {# djlint:off #}
+                <div>Squat Prospectors<span class="house-icon"><svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 1 1 5.5V15h4.5v-4h5v4H15V5.5L8 1Z" /></svg></span></div>
+                <div class="text-secondary fs-7">House name at <code>fs-7</code><span class="house-icon"><svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 1 1 5.5V15h4.5v-4h5v4H15V5.5L8 1Z" /></svg></span></div>
+                {# djlint:on #}
+                {# djlint:off H021 #}{# restore the file-level H021 suppression re-enabled by djlint:on above #}
+            </div>
         </section>
         <!-- ============================================================ -->
         <!-- 6. CONTAINERS & CARDS -->
@@ -1091,7 +1107,7 @@
             <div class="border rounded p-3 mb-4">
                 <div class="col-lg-12 px-0 vstack gap-4">
                     <div class="vstack gap-0">
-                        {% include "core/includes/breadcrumb.html" with type="List" owner=user name="My Gang" type_url="/lists/" only %}
+                        {% include "core/includes/breadcrumb.html" with type="List" owner=ds_user name="My Gang" type_url="/lists/" only %}
                         <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
                             <h1 class="h2 mb-0">My Gang</h1>
                             <nav class="nav btn-group flex-nowrap ms-md-auto">
@@ -1151,16 +1167,16 @@
                 Sits above the page title on entity detail pages. Shows <code>owner / type / name</code> with optional campaign link.
                 Use <code>
                 {% verbatim %}
-                    {% include "core/includes/breadcrumb.html" with type="List" owner=user name="My Gang" type_url="/lists/" only %}
+                    {% include "core/includes/breadcrumb.html" with type="List" owner=ds_user name="My Gang" type_url="/lists/" only %}
                 {% endverbatim %}
             </code>.
         </p>
         <div class="border rounded p-3 mb-4">
             <div class="vstack gap-1">
-                {% include "core/includes/breadcrumb.html" with type="List" owner=user name="Cawdor Facts" type_url="/lists/" only %}
-                {% include "core/includes/breadcrumb.html" with type="Campaign Gang" owner=user name="Iron Hounds" type_url="/lists/" campaign=ds_campaign only %}
-                {% include "core/includes/breadcrumb.html" with type="Pack" owner=user name="Scavvy Pack" type_url="/packs/" only %}
-                {% include "core/includes/breadcrumb.html" with type="List" owner=user name="My Gang" print=True only %}
+                {% include "core/includes/breadcrumb.html" with type="List" owner=ds_user name="Cawdor Facts" type_url="/lists/" only %}
+                {% include "core/includes/breadcrumb.html" with type="Campaign Gang" owner=ds_user name="Iron Hounds" type_url="/lists/" campaign=ds_campaign only %}
+                {% include "core/includes/breadcrumb.html" with type="Pack" owner=ds_user name="Scavvy Pack" type_url="/packs/" only %}
+                {% include "core/includes/breadcrumb.html" with type="List" owner=ds_user name="My Gang" print=True only %}
             </div>
         </div>
         <p class="text-secondary fs-7 mb-4">
@@ -1171,7 +1187,7 @@
         <p class="text-secondary fs-7 mb-2">Breadcrumb above title. Title left, action buttons right, metadata below.</p>
         <div class="border rounded p-3 mb-4">
             <div class="vstack gap-0">
-                {% include "core/includes/breadcrumb.html" with type="List" owner=user name="Cawdor Facts" type_url="/lists/" only %}
+                {% include "core/includes/breadcrumb.html" with type="List" owner=ds_user name="Cawdor Facts" type_url="/lists/" only %}
                 <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
                     <h1 class="h2 mb-0">Cawdor Facts</h1>
                     <div class="ms-md-auto d-flex gap-1 flex-nowrap">

--- a/gyrinx/core/tests/test_debug_views.py
+++ b/gyrinx/core/tests/test_debug_views.py
@@ -1,0 +1,30 @@
+"""Tests for the development-only debug views."""
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+
+@override_settings(DEBUG=True)
+@pytest.mark.django_db
+def test_design_system_renders_logged_out(client):
+    """The design system reference must render without authentication.
+
+    It previously 500'd for anonymous users because the breadcrumb samples
+    reversed ``{% url 'core:user' %}`` from ``request.user`` (AnonymousUser has
+    no username). The view now supplies a fake breadcrumb owner instead.
+    """
+    response = client.get(reverse("debug_design_system"))
+
+    assert response.status_code == 200
+    # The house icon sample renders the .house-icon class for the CSS preview.
+    assert b"house-icon" in response.content
+
+
+@override_settings(DEBUG=False)
+@pytest.mark.django_db
+def test_design_system_404_when_debug_disabled(client):
+    """Debug views are only reachable in development."""
+    response = client.get(reverse("debug_design_system"))
+
+    assert response.status_code == 404

--- a/gyrinx/core/views/debug.py
+++ b/gyrinx/core/views/debug.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, render
+from django.utils.safestring import mark_safe
 
 from gyrinx.core.models import List
 
@@ -66,6 +67,8 @@ def debug_test_plan_detail(request, filename):
 
 def debug_design_system(request):
     """Design system living reference page."""
+    if not settings.DEBUG:
+        raise Http404("Debug views are only available in development")
 
     theme_colours = [
         ("blue", "#0771ea"),
@@ -150,7 +153,7 @@ def debug_design_system(request):
         (
             ".house-icon",
             "Inline house SVG badge; transform-scaled ~25% (line-height safe), "
-            "currentColor; emitted by {% house_icon %}",
+            "currentColor; emitted by {% house_icon house %}",
         ),
     ]
 
@@ -173,6 +176,17 @@ def debug_design_system(request):
 
     ds_user = _DSUser()
 
+    # Sample house icon for the design system preview. Mirrors the markup that
+    # {% house_icon %} emits (class + fill + role/aria on the <svg> itself) so the
+    # .house-icon CSS can be previewed without the alpha-gated tag or a real
+    # house. Defined here as one source of truth for the section and table cell.
+    # nosec B703 B308 - hardcoded literal SVG, no user input
+    ds_house_icon_svg = mark_safe(  # nosec B703 B308
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" '
+        'class="house-icon" fill="currentColor" role="img" aria-hidden="true">'
+        '<path d="M8 1 1 5.5V15h4.5v-4h5v4H15V5.5L8 1Z" /></svg>'
+    )
+
     return render(
         request,
         "core/debug/design_system.html",
@@ -186,6 +200,7 @@ def debug_design_system(request):
             "custom_classes": custom_classes,
             "ds_campaign": ds_campaign,
             "ds_user": ds_user,
+            "ds_house_icon_svg": ds_house_icon_svg,
         },
     )
 

--- a/gyrinx/core/views/debug.py
+++ b/gyrinx/core/views/debug.py
@@ -147,6 +147,11 @@ def debug_design_system(request):
         (".flash-warn", "2s warning-colour fade animation for new items"),
         (".tooltipped", "Info-underline style with help cursor"),
         (".table-fixed", "table-layout: fixed for stat grids"),
+        (
+            ".house-icon",
+            "Inline house SVG badge; transform-scaled ~25% (line-height safe), "
+            "currentColor; emitted by {% house_icon %}",
+        ),
     ]
 
     # Mock campaign for breadcrumb demo (needs .id and .name)
@@ -155,6 +160,18 @@ def debug_design_system(request):
     ds_campaign = SimpleNamespace(
         id="00000000-0000-0000-0000-000000000000", name="Underhive Wars"
     )
+
+    # Mock owner for breadcrumb demo so the page renders logged-out too. The
+    # breadcrumb reverses {% url 'core:user' owner.username %} and displays
+    # str(owner); a fake object keeps the sample self-contained and avoids
+    # depending on request.user (AnonymousUser has no username when logged out).
+    class _DSUser:
+        username = "underhive-boss"
+
+        def __str__(self):
+            return "Underhive Boss"
+
+    ds_user = _DSUser()
 
     return render(
         request,
@@ -168,6 +185,7 @@ def debug_design_system(request):
             "page_shells": page_shells,
             "custom_classes": custom_classes,
             "ds_campaign": ds_campaign,
+            "ds_user": ds_user,
         },
     )
 


### PR DESCRIPTION
## Summary

- Scale `.house-icon` ~25% via a single `transform` (`translateY(-0.2em) scale(1.25)`) so the badge reads larger and stays centred on the text, with no impact on row line-height (a `transform` doesn't feed the line-box calc; the previous `vertical-align` offset grew line-height in tight `line-height: 1` rows). Inline margins widened to give the larger glyph horizontal space.
- Document the house icon badge in the design system — both the living page (`/_debug/design-system/`) and `docs/DESIGN-SYSTEM.md`.
- Make the design system page render logged-out by supplying a fake breadcrumb owner instead of relying on `request.user` (previously 500'd as `AnonymousUser` for the `{% url 'core:user' %}` reverse).

## Test plan

- [ ] `/_debug/design-system/` renders **logged-out** (was a 500)
- [ ] House icons section shows the badge at body and `fs-7` sizes
- [ ] House badge appears ~25% larger than a Bootstrap Icon next to house names
- [ ] Compact rows (gang/list rows, `fs-7`) show no line-height increase from the icon
- [ ] `.house-icon` row present in the Custom CSS Classes table

Notes: line-height neutrality verified in-browser (0px delta at line-height 1, 1.2, 1.5). The inline SVG samples are wrapped in `{# djlint:off #}` because djlint mis-handles inline SVG; the H021 file-level suppression is restored immediately after.