### PR TITLE
fix: isolate dev session cookies per worktree

### DIFF
--- a/gyrinx/core/widgets.py
+++ b/gyrinx/core/widgets.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from tinymce.widgets import TinyMCE
 
 # Additional TinyMCE configuration for forms
@@ -72,8 +73,9 @@ TINYMCE_UPLOAD_CONFIG = {
                     return tokenField.value;
                 }
 
-                // Fall back to cookie
-                const name = 'csrftoken';
+                // Fall back to cookie (name injected from settings.CSRF_COOKIE_NAME
+                // below, so per-worktree dev cookie renaming doesn't break uploads)
+                const name = '__CSRF_COOKIE_NAME__';
                 const cookies = document.cookie.split(';');
                 for (const cookie of cookies) {
                     const trimmed = cookie.trim();
@@ -114,6 +116,13 @@ TINYMCE_UPLOAD_CONFIG = {
         }
     """,
 }
+
+# Inject the configured CSRF cookie name into the upload handler's cookie-fallback
+# branch. Defaults to "csrftoken", but settings_dev.py renames it per-worktree so
+# concurrent dev servers don't share one cookie jar — the JS must read the same name.
+TINYMCE_UPLOAD_CONFIG["images_upload_handler"] = TINYMCE_UPLOAD_CONFIG[
+    "images_upload_handler"
+].replace("__CSRF_COOKIE_NAME__", settings.CSRF_COOKIE_NAME)
 
 
 class TinyMCEWithUpload(TinyMCE):

--- a/gyrinx/settings_dev.py
+++ b/gyrinx/settings_dev.py
@@ -33,6 +33,15 @@ CSRF_TRUSTED_ORIGINS = [
     f"http://127.0.0.1:{_dev_port}",
 ]
 
+# Per-worktree cookie isolation. Cookies are scoped by domain, not port, so every
+# worktree at localhost:<port> shares one cookie jar. With the default cookie names
+# (sessionid / csrftoken) each worktree's login overwrites the others' — and because
+# each worktree has its own database, the overwritten cookie resolves to a session
+# row that doesn't exist there, logging you out. Suffixing with the port gives each
+# worktree independent cookies so you can stay logged into all of them at once.
+SESSION_COOKIE_NAME = f"gyrinx_sessionid_{_dev_port}"
+CSRF_COOKIE_NAME = f"gyrinx_csrftoken_{_dev_port}"
+
 # Feature flags for development
 FEATURE_LIST_ACTION_CREATE_INITIAL = True
 


### PR DESCRIPTION
## Summary

- Dev servers across worktrees all serve on `localhost:<port>`, but cookies are scoped by domain (not port), so they shared one cookie jar. With the default `sessionid` / `csrftoken` names, logging into one worktree overwrote the others' cookie — and because each worktree has its own database, the overwritten cookie resolved to a session row that doesn't exist there, logging you out. Only one worktree could hold a valid login at a time.
- Suffix `SESSION_COOKIE_NAME` and `CSRF_COOKIE_NAME` with `DJANGO_PORT` (already exported per-worktree) in `settings_dev.py`, so each worktree gets independent cookies.

Dev-settings only — no effect on production.

## Test plan

- [ ] `DJANGO_PORT=8123 DJANGO_SETTINGS_MODULE=gyrinx.settings_dev` resolves cookie names to `gyrinx_sessionid_8123` / `gyrinx_csrftoken_8123` (verified locally)
- [ ] Log into two worktree dev servers on different ports; confirm both stay logged in simultaneously
- [ ] Existing single-worktree login/CSRF flow still works on the default port

## Notes

Each running dev server needs a restart to pick up the new cookie name, and there's one final logout as the old `sessionid` cookie is orphaned — after that, simultaneous logins across worktrees stick.