### PR TITLE
fix: escape user-provided content in templates and guard a debug view

### DIFF
--- a/gyrinx/api/patreon.py
+++ b/gyrinx/api/patreon.py
@@ -1,7 +1,6 @@
 import logging
 
 from allauth.account.models import EmailAddress
-from django.contrib.auth.models import User
 
 from gyrinx.core.badges import rank_for_tier_title
 from gyrinx.core.models.auth import PatreonStatus, UserProfile
@@ -62,12 +61,18 @@ def _extract_tier_title(payload):
 
 
 def _find_user_by_email(email):
-    """Match an email to a Django user, checking allauth EmailAddress first."""
+    """Match an email to a Django user via a verified allauth EmailAddress.
+
+    Only a verified ``EmailAddress`` counts: a match means the user has proven
+    ownership of that address. We deliberately do not fall back to the raw
+    ``User.email`` column, which can be set without verification and would let a
+    Patreon-supplied email attach supporter status to an unproven account.
+    """
     email_obj = EmailAddress.objects.filter(email__iexact=email, verified=True).first()
     if email_obj:
         return email_obj.user
 
-    return User.objects.filter(email__iexact=email).first()
+    return None
 
 
 def process_patreon_webhook(payload, event):

--- a/gyrinx/api/test_patreon.py
+++ b/gyrinx/api/test_patreon.py
@@ -85,15 +85,33 @@ def test_matches_case_insensitive():
 
 
 @pytest.mark.django_db
-def test_falls_back_to_user_email():
+def test_unverified_email_does_not_match():
+    # A user whose email is set on the User row but never verified via a
+    # allauth EmailAddress must NOT be matched — we require proven ownership.
     User.objects.create_user("patron3", email="fallback@example.com", password="test")  # nosec B106
-    # No EmailAddress record — should fall back to User.email
 
     payload = _make_payload("fallback@example.com", "Test Patron")
     result = process_patreon_webhook(payload, "members:create")
 
-    assert result["matched"] is True
-    assert result["user"] == "patron3"
+    assert result["matched"] is False
+    assert result["user"] is None
+
+
+@pytest.mark.django_db
+def test_unverified_email_address_does_not_match():
+    # An EmailAddress that exists but is not verified must not match either.
+    user = User.objects.create_user(
+        "patron4", email="other@example.com", password="test"
+    )  # nosec B106
+    EmailAddress.objects.create(
+        user=user, email="unverified@example.com", verified=False, primary=False
+    )
+
+    payload = _make_payload("unverified@example.com", "Test Patron")
+    result = process_patreon_webhook(payload, "members:create")
+
+    assert result["matched"] is False
+    assert result["user"] is None
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -74,7 +74,7 @@
                     {% endif %}
                 </div>
                 {% if asset_type.description %}
-                    <div class="text-secondary fs-7 mb-3 mb-last-0">{{ asset_type.description|safe }}</div>
+                    <div class="text-secondary fs-7 mb-3 mb-last-0">{{ asset_type.description|safe_rich_text|safe }}</div>
                 {% endif %}
                 {% with assets=asset_type.assets.all %}
                     {% if assets %}
@@ -96,7 +96,7 @@
                                         <td class="ps-0">
                                             <div class="fw-semibold">{{ asset.name }}</div>
                                             {% if asset.description %}
-                                                <div class="fs-7 text-secondary mb-last-0">{{ asset.description|safe }}</div>
+                                                <div class="fs-7 text-secondary mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>
                                             {% endif %}
                                             {% if asset.properties_with_labels %}
                                                 <div class="fs-7 text-secondary">

--- a/gyrinx/core/templates/core/campaign/campaign_resources.html
+++ b/gyrinx/core/templates/core/campaign/campaign_resources.html
@@ -45,7 +45,7 @@
                     {% endif %}
                 </div>
                 {% if resource_type.description %}
-                    <div class="text-secondary fs-7 mb-3 mb-last-0">{{ resource_type.description|safe }}</div>
+                    <div class="text-secondary fs-7 mb-3 mb-last-0">{{ resource_type.description|safe_rich_text|safe }}</div>
                 {% endif %}
                 {% with resources=resource_type.list_resources.all %}
                     {% if resources %}

--- a/gyrinx/core/templates/core/list_fighter_advancement_type.html
+++ b/gyrinx/core/templates/core/list_fighter_advancement_type.html
@@ -83,9 +83,12 @@
     </div>
 {% endblock content %}
 {% block extra_script %}
+    {{ advancement_configs|json_script:"advancement-configs" }}
     <script>
     // Advancement configurations passed from the server
-    const advancementConfigs = {{ advancement_configs_json|safe }};
+    const advancementConfigs = JSON.parse(
+        document.getElementById('advancement-configs').textContent
+    );
 
     // Get references to form elements
     const advancementSelect = document.getElementById('{{ form.advancement_choice.id_for_label }}');

--- a/gyrinx/core/templatetags/color_tags.py
+++ b/gyrinx/core/templatetags/color_tags.py
@@ -2,6 +2,7 @@ from hashlib import sha256
 
 from django import template
 from django.core.cache import cache
+from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 
 from gyrinx.content.svg import sanitize_house_icon_svg
@@ -21,11 +22,17 @@ def theme_square(list_obj, size="0.8em", extra_classes=""):
     theme_color = getattr(list_obj, "theme_color", None)
 
     if theme_color:
-        return mark_safe(
-            f'<span class="d-inline-block rounded {extra_classes}" '
-            f'style="width: {size}; height: {size}; '
-            f"background-color: {theme_color}; "
-            f'border: 1px solid rgba(0,0,0,0.15);"></span>'
+        # theme_color is a validated hex colour and size is internal, but
+        # escape extra_classes for hygiene since it is interpolated into markup.
+        return format_html(
+            '<span class="d-inline-block rounded {}" '
+            'style="width: {}; height: {}; '
+            "background-color: {}; "
+            'border: 1px solid rgba(0,0,0,0.15);"></span>',
+            extra_classes,
+            size,
+            size,
+            theme_color,
         )
     else:
         return ""
@@ -44,9 +51,16 @@ def list_with_theme(list_obj, extra_classes="", square_size="0.8em"):
 
     if theme_color:
         square = theme_square(list_obj, extra_classes="me-1", size=square_size)
-        return mark_safe(f'<span class="{extra_classes}">{square}{name}</span>')
+        # square is already-safe markup from theme_square; escape the
+        # user-controlled name and extra_classes via format_html.
+        return format_html(
+            '<span class="{}">{}{}</span>',
+            extra_classes,
+            conditional_escape(square),
+            name,
+        )
     else:
-        return mark_safe(f'<span class="{extra_classes}">{name}</span>')
+        return format_html('<span class="{}">{}</span>', extra_classes, name)
 
 
 def _house_icon_svg(icon, extra_classes):

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -226,6 +226,47 @@ def test_campaign_assets_view():
 
 
 @pytest.mark.django_db
+def test_campaign_assets_view_sanitizes_descriptions():
+    """Script tags in asset/asset-type descriptions must be stripped on render."""
+    client = Client()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    client.login(username="testuser", password="testpass")
+
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        public=True,
+    )
+
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        description='<script>alert("type")</script><p>Safe type text</p>',
+        owner=user,
+    )
+
+    CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description='<img src=x onerror="alert(1)"><p>Safe asset text</p>',
+        owner=user,
+    )
+
+    response = client.get(reverse("core:campaign-assets", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Sanitised rich text drops the <script> wrapper and the onerror handler so
+    # nothing executes; benign markup/text survives. (bleach keeps inert text
+    # content, and the page has its own legitimate <script> tags, so assert
+    # against the executable constructs rather than substrings like "alert".)
+    assert "<script>alert" not in content
+    assert "onerror" not in content
+    assert "Safe type text" in content
+    assert "Safe asset text" in content
+
+
+@pytest.mark.django_db
 def test_create_asset_type_view():
     """Test creating an asset type through the view."""
     client = Client()

--- a/gyrinx/core/tests/test_campaign_resources.py
+++ b/gyrinx/core/tests/test_campaign_resources.py
@@ -348,6 +348,37 @@ def test_campaign_resources_view():
 
 
 @pytest.mark.django_db
+def test_campaign_resources_view_sanitizes_description():
+    """Script tags in a resource-type description must be stripped on render."""
+    client = Client()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    client.login(username="testuser", password="testpass")
+
+    campaign = Campaign.objects.create(
+        name="Test Campaign",
+        owner=user,
+        public=True,
+    )
+
+    CampaignResourceType.objects.create(
+        campaign=campaign,
+        name="Meat",
+        description="<script>alert(1)</script><p>Safe resource text</p>",
+        default_amount=10,
+        owner=user,
+    )
+
+    response = client.get(reverse("core:campaign-resources", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Sanitised rich text drops the <script> wrapper so nothing executes (bleach
+    # keeps inert text content, and the page has its own legitimate <script>
+    # tags, so assert against the executable construct, not the word "alert").
+    assert "<script>alert" not in content
+    assert "Safe resource text" in content
+
+
+@pytest.mark.django_db
 def test_resource_modify_form_validation(content_house):
     """Test resource modification form validation."""
     user = User.objects.create_user(username="testuser", password="testpass")

--- a/gyrinx/core/tests/test_color_tags.py
+++ b/gyrinx/core/tests/test_color_tags.py
@@ -84,6 +84,8 @@ def test_list_with_theme_escapes_extra_classes():
 
     display = list_with_theme(MockList(), extra_classes='"><script>alert(1)</script>')
     assert "<script>" not in display
+    # The payload must be escaped in place, not silently dropped.
+    assert "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in display
 
 
 def test_theme_square_escapes_extra_classes():
@@ -95,3 +97,5 @@ def test_theme_square_escapes_extra_classes():
 
     square = theme_square(MockList(), extra_classes='"><script>alert(1)</script>')
     assert "<script>" not in square
+    # The payload must be escaped in place, not silently dropped.
+    assert "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in square

--- a/gyrinx/core/tests/test_color_tags.py
+++ b/gyrinx/core/tests/test_color_tags.py
@@ -49,3 +49,49 @@ def test_list_with_theme_no_color():
 
     display = list_with_theme(MockList())
     assert display == '<span class="">Test Gang</span>'
+
+
+def test_list_with_theme_escapes_name():
+    """A malicious list name must be HTML-escaped, not rendered as markup."""
+
+    class MockList:
+        name = "<script>alert(1)</script>"
+        theme_color = "#386b33"
+
+    display = list_with_theme(MockList())
+    assert "<script>" not in display
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in display
+
+
+def test_list_with_theme_escapes_name_no_color():
+    """Name escaping also applies on the no-theme-color branch."""
+
+    class MockList:
+        name = "<script>alert(1)</script>"
+        theme_color = None
+
+    display = list_with_theme(MockList())
+    assert "<script>" not in display
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in display
+
+
+def test_list_with_theme_escapes_extra_classes():
+    """extra_classes is interpolated into markup and must be escaped."""
+
+    class MockList:
+        name = "Test Gang"
+        theme_color = None
+
+    display = list_with_theme(MockList(), extra_classes='"><script>alert(1)</script>')
+    assert "<script>" not in display
+
+
+def test_theme_square_escapes_extra_classes():
+    """extra_classes on theme_square must be escaped."""
+
+    class MockList:
+        name = "Test Gang"
+        theme_color = "#386b33"
+
+    square = theme_square(MockList(), extra_classes='"><script>alert(1)</script>')
+    assert "<script>" not in square

--- a/gyrinx/core/tests/test_debug_views.py
+++ b/gyrinx/core/tests/test_debug_views.py
@@ -4,8 +4,16 @@ import pytest
 from django.test import override_settings
 from django.urls import reverse
 
+# Under DEBUG=True the django-debug-toolbar middleware activates for the test
+# client (its default show callback returns True when REMOTE_ADDR is in
+# INTERNAL_IPS) and then fails to reverse its own ``djdt`` URLs (not installed
+# in the test URLconf). The toolbar's show callback is resolved once and
+# @cache-d, so overriding DEBUG_TOOLBAR_CONFIG is unreliable across tests;
+# clearing INTERNAL_IPS is read fresh per request and reliably keeps it off.
+_no_toolbar = {"INTERNAL_IPS": []}
 
-@override_settings(DEBUG=True)
+
+@override_settings(DEBUG=True, **_no_toolbar)
 @pytest.mark.django_db
 def test_design_system_renders_logged_out(client):
     """The design system reference must render without authentication.
@@ -28,3 +36,60 @@ def test_design_system_404_when_debug_disabled(client):
     response = client.get(reverse("debug_design_system"))
 
     assert response.status_code == 404
+
+
+@override_settings(DEBUG=False)
+@pytest.mark.django_db
+def test_list_actions_404_when_debug_disabled(client, make_list):
+    """The list-actions debug view must 404 in production, even for the owner."""
+    lst = make_list("Test Gang")
+    response = client.get(reverse("debug_list_actions", args=[lst.id]))
+
+    assert response.status_code == 404
+
+
+@override_settings(DEBUG=True, **_no_toolbar)
+@pytest.mark.django_db
+def test_list_actions_404_for_anonymous(client, make_list):
+    """Anonymous users get a 404 (not another user's activity log)."""
+    lst = make_list("Test Gang")
+    response = client.get(reverse("debug_list_actions", args=[lst.id]))
+
+    assert response.status_code == 404
+
+
+@override_settings(DEBUG=True, **_no_toolbar)
+@pytest.mark.django_db
+def test_list_actions_404_for_non_owner(client, make_list, make_user):
+    """A logged-in non-owner cannot view another gang's actions."""
+    lst = make_list("Test Gang")
+    other = make_user("intruder", "password")
+    client.force_login(other)
+    response = client.get(reverse("debug_list_actions", args=[lst.id]))
+
+    assert response.status_code == 404
+
+
+@override_settings(DEBUG=True, **_no_toolbar)
+@pytest.mark.django_db
+def test_list_actions_visible_to_owner(client, user, make_list):
+    """The list owner can view their own actions in development."""
+    lst = make_list("Test Gang")
+    client.force_login(user)
+    response = client.get(reverse("debug_list_actions", args=[lst.id]))
+
+    assert response.status_code == 200
+
+
+@override_settings(DEBUG=True, **_no_toolbar)
+@pytest.mark.django_db
+def test_list_actions_visible_to_staff(client, make_list, make_user):
+    """Staff can view any list's actions in development."""
+    lst = make_list("Test Gang")
+    staff = make_user("admin", "password")
+    staff.is_staff = True
+    staff.save()
+    client.force_login(staff)
+    response = client.get(reverse("debug_list_actions", args=[lst.id]))
+
+    assert response.status_code == 200

--- a/gyrinx/core/tests/test_debug_views.py
+++ b/gyrinx/core/tests/test_debug_views.py
@@ -40,9 +40,10 @@ def test_design_system_404_when_debug_disabled(client):
 
 @override_settings(DEBUG=False)
 @pytest.mark.django_db
-def test_list_actions_404_when_debug_disabled(client, make_list):
+def test_list_actions_404_when_debug_disabled(client, user, make_list):
     """The list-actions debug view must 404 in production, even for the owner."""
     lst = make_list("Test Gang")
+    client.force_login(user)
     response = client.get(reverse("debug_list_actions", args=[lst.id]))
 
     assert response.status_code == 404

--- a/gyrinx/core/views/debug.py
+++ b/gyrinx/core/views/debug.py
@@ -207,7 +207,20 @@ def debug_design_system(request):
 
 def debug_list_actions(request, list_id):
     """Display all actions for a list, sorted newest first."""
-    lst = get_object_or_404(List, id=list_id)
+    if not settings.DEBUG:
+        raise Http404("Debug views are only available in development")
+
+    # Anonymous users (and non-owners) get a 404 rather than another list's
+    # activity log. Anonymous is handled first so we never pass AnonymousUser
+    # as an owner filter value.
+    if not request.user.is_authenticated:
+        raise Http404("List not found")
+
+    # Restrict to the list owner; staff may view any list.
+    if request.user.is_staff:
+        lst = get_object_or_404(List, id=list_id)
+    else:
+        lst = get_object_or_404(List, id=list_id, owner=request.user)
     actions = lst.actions.select_related("user", "list_fighter").order_by("-created")
 
     return render(

--- a/gyrinx/core/views/fighter/advancements.py
+++ b/gyrinx/core/views/fighter/advancements.py
@@ -1,6 +1,5 @@
 """Fighter advancement views."""
 
-import json
 import random
 import uuid
 from typing import Literal, Optional
@@ -588,7 +587,7 @@ def list_fighter_advancement_type(request, id, fighter_id):
             "steps": 3 if is_campaign_mode else 2,
             "current_step": 2 if is_campaign_mode else 1,
             "progress": 66 if is_campaign_mode else 50,
-            "advancement_configs_json": json.dumps(form.get_all_configs_json()),
+            "advancement_configs": form.get_all_configs_json(),
         },
     )
 

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -41,10 +41,14 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 
 # This is handled by the load balancer
 SECURE_SSL_REDIRECT = False
-SECURE_HSTS_SECONDS = 60
+SECURE_HSTS_SECONDS = 31536000  # 1 year
 SESSION_COOKIE_SECURE = True
+# includeSubDomains is left off: we cannot verify that every subdomain serves
+# HTTPS only, so asserting it could break a plain-HTTP subdomain.
 SECURE_HSTS_INCLUDE_SUBDOMAINS = False
-SECURE_HSTS_PRELOAD = True
+# Preload requires includeSubDomains (and is a one-way commitment that is hard
+# to undo), so it stays disabled until that is a deliberate, verified decision.
+SECURE_HSTS_PRELOAD = False
 
 BASE_URL = "https://gyrinx.app"
 


### PR DESCRIPTION
Hardening pass from a security review. Each change is a small, self-contained fix.

- Escape user-provided content in the list/campaign templates: the `list_with_theme`/`theme_square` template tags now escape the list name and class string, and campaign asset/resource descriptions render through the existing `safe_rich_text` bleach filter like every other rich-text field.
- Guard the `debug_list_actions` view with the same `DEBUG`-only check its sibling debug views have, and restrict it to the list owner (staff may view any).
- Raise the production HSTS `max-age` to one year; disable preload (which requires a deliberate `includeSubDomains` decision).
- Require a verified email address when matching Patreon members to accounts, instead of falling back to the unverified `User.email` column.
- Inject advancement config JSON via Django's `json_script` tag instead of raw interpolation into an inline `<script>`; behaviour is unchanged.

Tests added for each behavioural change; full core + api suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
