### PR TITLE
feat: add rich-text (TinyMCE) editor to pack content descriptions

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -34,11 +34,11 @@ def rich_text_description_widget(height="200px"):
     """TinyMCE widget for short rich-text description fields on pack content.
 
     Mirrors the editor used for ``PackForm.summary`` so that custom rules,
-    skills, gear, traits, etc. support formatted text — but with image
-    support removed. These descriptions are short and sit in a dense listing
-    where embedded images render awkwardly, so authors keep text formatting,
-    links, and lists only. Rendered output is sanitised on display via the
-    ``safe_rich_text`` template filter.
+    skills, gear, traits, etc. support rich text formatting — but with image
+    insertion removed (these are short descriptions in a dense listing where
+    embedded images render awkwardly). The rest of the standard toolbar
+    (headings, lists, links, formatting, etc.) is retained. Rendered output is
+    sanitised on display via the ``safe_rich_text`` template filter.
 
     Returns a fresh instance per call so each form owns its own widget.
     """

--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -1,3 +1,5 @@
+import copy
+
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models import Case, When
@@ -26,6 +28,42 @@ from gyrinx.core.models.pack import (
 from gyrinx.core.widgets import TINYMCE_EXTRA_ATTRS, TinyMCEWithUpload
 from gyrinx.forms import group_select
 from gyrinx.models import FighterCategoryChoices, equipment_category_groups
+
+
+def rich_text_description_widget(height="200px"):
+    """TinyMCE widget for short rich-text description fields on pack content.
+
+    Mirrors the editor used for ``PackForm.summary`` so that custom rules,
+    skills, gear, traits, etc. support formatted text — but with image
+    support removed. These descriptions are short and sit in a dense listing
+    where embedded images render awkwardly, so authors keep text formatting,
+    links, and lists only. Rendered output is sanitised on display via the
+    ``safe_rich_text`` template filter.
+
+    Returns a fresh instance per call so each form owns its own widget.
+    """
+    # Drop the image item from the insert menu (deep-copied so the shared
+    # TINYMCE_EXTRA_ATTRS dict used by PackForm is left untouched).
+    menu = copy.deepcopy(TINYMCE_EXTRA_ATTRS["menu"])
+    menu["insert"]["items"] = (
+        "link media addcomment pageembed codesample inserttable | math "
+        "| charmap emoticons hr | pagebreak nonbreaking anchor "
+        "tableofcontents | insertdatetime"
+    )
+    return TinyMCEWithUpload(
+        attrs={"cols": 80, "rows": 5},
+        mce_attrs={
+            **TINYMCE_EXTRA_ATTRS,
+            "menu": menu,
+            "height": height,
+            # No image support: drop the image plugin, its toolbar button,
+            # and the empty-line quick-insert bar (which offers quickimage).
+            "plugins": "autoresize autosave code emoticons fullscreen help link lists quickbars textpattern visualblocks",
+            "toolbar": "undo redo | blocks | bold italic underline link | numlist bullist align | code",
+            "quickbars_insert_toolbar": False,
+        },
+    )
+
 
 # Fighter categories excluded from pack creation.
 # STASH is auto-managed (one per gang); GANG_TERRAIN has its own territory
@@ -469,7 +507,7 @@ class ContentHouseForm(forms.ModelForm):
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+            "description": rich_text_description_widget(),
         }
 
     def clean_name(self):
@@ -498,7 +536,7 @@ class ContentRuleForm(forms.ModelForm):
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 4}),
+            "description": rich_text_description_widget(),
         }
 
     def clean_name(self):
@@ -529,7 +567,7 @@ class ContentWeaponTraitPackForm(forms.ModelForm):
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 4}),
+            "description": rich_text_description_widget(),
         }
 
     def __init__(self, *args, pack=None, **kwargs):
@@ -630,7 +668,7 @@ class ContentWeaponAccessoryPackForm(StandardFieldsMixin, forms.ModelForm):
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+            "description": rich_text_description_widget(),
             "cost": forms.NumberInput(attrs={"class": "form-control"}),
             "rarity": forms.Select(attrs={"class": "form-select"}),
             "rarity_roll": forms.NumberInput(attrs={"class": "form-control"}),
@@ -845,7 +883,7 @@ class ContentSkillPackForm(forms.ModelForm):
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
             "category": forms.Select(attrs={"class": "form-select"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+            "description": rich_text_description_widget(),
         }
 
     def __init__(self, *args, pack=None, **kwargs):
@@ -964,7 +1002,7 @@ class ContentAttributeValuePackForm(forms.ModelForm):
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
             "attribute": forms.Select(attrs={"class": "form-select"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+            "description": rich_text_description_widget(),
         }
 
     def __init__(self, *args, pack=None, **kwargs):
@@ -1287,7 +1325,7 @@ class ContentGearPackForm(forms.ModelForm):
         }
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+            "description": rich_text_description_widget(),
             "category": forms.Select(attrs={"class": "form-select"}),
             "cost": forms.TextInput(attrs={"class": "form-control"}),
             "rarity": forms.Select(attrs={"class": "form-select"}),
@@ -1460,7 +1498,7 @@ class ContentPsykerDisciplinePackForm(forms.ModelForm):
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
             "generic": forms.CheckboxInput(attrs={"class": "form-check-input"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+            "description": rich_text_description_widget(),
         }
 
     def clean_name(self):
@@ -1495,7 +1533,7 @@ class ContentPsykerPowerPackForm(forms.ModelForm):
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
             "discipline": forms.Select(attrs={"class": "form-select"}),
-            "description": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+            "description": rich_text_description_widget(),
         }
 
     def __init__(self, *args, pack=None, **kwargs):

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -257,6 +257,21 @@ a[data-bs-toggle="tooltip"] {
     }
 }
 
+// Danger-coloured `.linked`. Replaces the old
+// `link-danger link-underline-opacity-50 link-underline-opacity-100-hover`.
+// Colour is set directly (not `@extend .link-danger`) for the same reason as
+// `.linked-secondary`: `.link-danger`'s `text-decoration-color: … !important`
+// would override the hover-only underline.
+.linked-danger {
+    @extend .linked;
+    color: var(--bs-danger);
+
+    &:hover,
+    &:focus-visible {
+        color: var(--bs-danger);
+    }
+}
+
 // Bootstrap's `.btn-link` is underlined at rest; give link-style buttons the
 // same underline-only-on-hover/focus treatment as `.linked`.
 .btn-link {

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -396,6 +396,16 @@ img {
     height: auto;
 }
 
+// Rich-text descriptions on pack content (rules, gear, skills, etc.) sit in a
+// dense listing. Image insertion is disabled in the editor, but any legacy
+// embedded images are kept to a small thumbnail so they don't dominate the row.
+.pack-rich-desc img {
+    max-width: 8em;
+    max-height: 8em;
+    width: auto;
+    height: auto;
+}
+
 .img-link-transform img {
     transition:
         transform 0.2s ease,

--- a/gyrinx/core/templates/core/pack/includes/weapon_profiles_display.html
+++ b/gyrinx/core/templates/core/pack/includes/weapon_profiles_display.html
@@ -57,7 +57,7 @@ Cases (from weapon-profiles-display-spec.md):
                         {% if can_edit %}
                             <span class="fs-7"><a href="{% url 'core:pack-customise-weapon-profile-edit' pack.id weapon.id profile.id %}"
    class="linked-secondary">Edit</a> · <a href="{% url 'core:pack-customise-weapon-profile-delete' pack.id weapon.id profile.id %}"
-    class="linked-secondary text-danger">Archive</a></span>
+    class="linked-danger">Archive</a></span>
                         {% endif %}
                     {% elif can_edit and not is_customised %}
                         <span class="text-secondary fs-7">· <a href="{% url 'core:pack-edit-weapon-profile' pack.id pack_item.id profile.id %}"
@@ -100,7 +100,7 @@ Cases (from weapon-profiles-display-spec.md):
                        class="linked-secondary">Edit</a>
                     ·
                     <a href="{% url 'core:pack-delete-item' pack.id pack_item.id %}"
-                       class="linked-secondary text-danger">Archive</a>
+                       class="linked-danger">Archive</a>
                 {% endif %}
             </div>
         </td>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -394,13 +394,8 @@
                                                             <ul class="list-unstyled mb-0">
                                                                 {% for entry in group.skills %}
                                                                     <li class="py-1" id="item-{{ entry.pack_item.id }}">
-                                                                        <div class="d-flex justify-content-between align-items-center">
-                                                                            <div>
-                                                                                <span>{{ entry.content_object.name }}</span>
-                                                                                {% if entry.content_object.description %}
-                                                                                    <div class="text-secondary fs-7">{{ entry.content_object.description|linebreaksbr }}</div>
-                                                                                {% endif %}
-                                                                            </div>
+                                                                        <div class="d-flex justify-content-between align-items-start">
+                                                                            <span>{{ entry.content_object.name }}</span>
                                                                             {% if can_edit %}
                                                                                 <span class="d-flex gap-2">
                                                                                     <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
@@ -410,6 +405,9 @@
                                                                                 </span>
                                                                             {% endif %}
                                                                         </div>
+                                                                        {% if entry.content_object.description %}
+                                                                            <div class="text-secondary fs-7 mb-last-0 pack-rich-desc border rounded p-2 bg-body-tertiary mt-1">{{ entry.content_object.description|safe_rich_text|safe }}</div>
+                                                                        {% endif %}
                                                                     </li>
                                                                 {% endfor %}
                                                             </ul>
@@ -448,26 +446,16 @@
                                                                 {% endif %}
                                                             </span>
                                                         </div>
-                                                        {% if group.discipline.generic or group.discipline.description %}
-                                                            <div class="text-secondary fs-7 mb-1">
-                                                                {% if group.discipline.generic %}
-                                                                    Available to all psykers
-                                                                    {% if group.discipline.description %}·{% endif %}
-                                                                {% endif %}
-                                                                {% if group.discipline.description %}{{ group.discipline.description|linebreaksbr }}{% endif %}
-                                                            </div>
+                                                        {% if group.discipline.generic %}<div class="text-secondary fs-7 mb-1">Available to all psykers</div>{% endif %}
+                                                        {% if group.discipline.description %}
+                                                            <div class="text-secondary fs-7 mb-1 mb-last-0 pack-rich-desc border rounded p-2 bg-body-tertiary">{{ group.discipline.description|safe_rich_text|safe }}</div>
                                                         {% endif %}
                                                         {% if group.powers %}
                                                             <ul class="list-unstyled mb-0">
                                                                 {% for entry in group.powers %}
                                                                     <li class="py-1" id="item-{{ entry.pack_item.id }}">
-                                                                        <div class="d-flex justify-content-between align-items-center">
-                                                                            <div>
-                                                                                <span>{{ entry.content_object.name }}</span>
-                                                                                {% if entry.content_object.description %}
-                                                                                    <div class="text-secondary fs-7">{{ entry.content_object.description|linebreaksbr }}</div>
-                                                                                {% endif %}
-                                                                            </div>
+                                                                        <div class="d-flex justify-content-between align-items-start">
+                                                                            <span>{{ entry.content_object.name }}</span>
                                                                             {% if can_edit %}
                                                                                 <span class="d-flex gap-2">
                                                                                     <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
@@ -477,6 +465,9 @@
                                                                                 </span>
                                                                             {% endif %}
                                                                         </div>
+                                                                        {% if entry.content_object.description %}
+                                                                            <div class="text-secondary fs-7 mb-last-0 pack-rich-desc border rounded p-2 bg-body-tertiary mt-1">{{ entry.content_object.description|safe_rich_text|safe }}</div>
+                                                                        {% endif %}
                                                                     </li>
                                                                 {% endfor %}
                                                             </ul>
@@ -528,13 +519,8 @@
                                                             <ul class="list-unstyled mb-0">
                                                                 {% for entry in group.values %}
                                                                     <li class="py-1" id="item-{{ entry.pack_item.id }}">
-                                                                        <div class="d-flex justify-content-between align-items-center">
-                                                                            <div>
-                                                                                <span>{{ entry.content_object.name }}</span>
-                                                                                {% if entry.content_object.description %}
-                                                                                    <div class="text-secondary fs-7">{{ entry.content_object.description|linebreaksbr }}</div>
-                                                                                {% endif %}
-                                                                            </div>
+                                                                        <div class="d-flex justify-content-between align-items-start">
+                                                                            <span>{{ entry.content_object.name }}</span>
                                                                             {% if can_edit %}
                                                                                 <span class="d-flex gap-2">
                                                                                     <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
@@ -544,6 +530,9 @@
                                                                                 </span>
                                                                             {% endif %}
                                                                         </div>
+                                                                        {% if entry.content_object.description %}
+                                                                            <div class="text-secondary fs-7 mb-last-0 pack-rich-desc border rounded p-2 bg-body-tertiary mt-1">{{ entry.content_object.description|safe_rich_text|safe }}</div>
+                                                                        {% endif %}
                                                                     </li>
                                                                 {% endfor %}
                                                             </ul>
@@ -566,16 +555,11 @@
                                         <ul class="list-unstyled mb-0">
                                             {% for entry in section.items %}
                                                 <li class="py-1" id="item-{{ entry.pack_item.id }}">
-                                                    <div class="d-flex justify-content-between align-items-center">
+                                                    <div class="d-flex justify-content-between align-items-start">
                                                         <div>
                                                             <span>{{ entry.content_object }}</span>
                                                             {% if section.slug == "weapon-accessory" %}
                                                                 <span class="text-secondary fs-7">({{ entry.content_object.cost }}¢)</span>
-                                                            {% endif %}
-                                                            {% if section.slug == "rule" or section.slug == "weapon-trait" or section.slug == "house" or section.slug == "gear" or section.slug == "weapon-accessory" or section.slug == "psyker-discipline" %}
-                                                                {% if entry.content_object.description %}
-                                                                    <div class="text-secondary fs-7">{{ entry.content_object.description|linebreaksbr }}</div>
-                                                                {% endif %}
                                                             {% endif %}
                                                         </div>
                                                         {% if can_edit and not entry.is_auto_equipment %}
@@ -589,6 +573,11 @@
                                                             </span>
                                                         {% endif %}
                                                     </div>
+                                                    {% if section.slug == "rule" or section.slug == "weapon-trait" or section.slug == "house" or section.slug == "gear" or section.slug == "weapon-accessory" or section.slug == "psyker-discipline" %}
+                                                        {% if entry.content_object.description %}
+                                                            <div class="text-secondary fs-7 mb-last-0 pack-rich-desc border rounded p-2 bg-body-tertiary mt-1">{{ entry.content_object.description|safe_rich_text|safe }}</div>
+                                                        {% endif %}
+                                                    {% endif %}
                                                 </li>
                                             {% endfor %}
                                         </ul>

--- a/gyrinx/core/templates/core/pack/pack.html
+++ b/gyrinx/core/templates/core/pack/pack.html
@@ -147,7 +147,7 @@
                                                             <a href="{% url 'core:pack-house-rule-edit' pack.id entry.pack_item.id %}"
                                                                class="linked-secondary fs-7">Edit</a>
                                                             <a href="{% url 'core:pack-house-rule-delete' pack.id entry.pack_item.id %}"
-                                                               class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive</a>
+                                                               class="linked-danger fs-7">Archive</a>
                                                         </span>
                                                     {% endif %}
                                                 </div>
@@ -200,7 +200,7 @@
                                                     {% if can_edit %}
                                                         <span class="d-flex gap-2">
                                                             <a href="{% url 'core:pack-attachment-delete' pack.id attachment.id %}"
-                                                               class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Remove</a>
+                                                               class="linked-danger fs-7">Remove</a>
                                                         </span>
                                                     {% endif %}
                                                 </div>
@@ -385,7 +385,7 @@
                                                                         <a href="{% url 'core:pack-edit-item' pack.id group.pack_item.id %}"
                                                                            class="linked-secondary fs-7">Edit tree</a>
                                                                         <a href="{% url 'core:pack-delete-item' pack.id group.pack_item.id %}"
-                                                                           class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive tree</a>
+                                                                           class="linked-danger fs-7">Archive tree</a>
                                                                     {% endif %}
                                                                 {% endif %}
                                                             </span>
@@ -401,7 +401,7 @@
                                                                                     <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
                                                                                        class="linked-secondary fs-7">Edit</a>
                                                                                     <a href="{% url 'core:pack-delete-item' pack.id entry.pack_item.id %}"
-                                                                                       class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive</a>
+                                                                                       class="linked-danger fs-7">Archive</a>
                                                                                 </span>
                                                                             {% endif %}
                                                                         </div>
@@ -441,7 +441,7 @@
                                                                         <a href="{% url 'core:pack-edit-item' pack.id group.pack_item.id %}"
                                                                            class="linked-secondary fs-7">Edit discipline</a>
                                                                         <a href="{% url 'core:pack-delete-item' pack.id group.pack_item.id %}"
-                                                                           class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive discipline</a>
+                                                                           class="linked-danger fs-7">Archive discipline</a>
                                                                     {% endif %}
                                                                 {% endif %}
                                                             </span>
@@ -461,7 +461,7 @@
                                                                                     <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
                                                                                        class="linked-secondary fs-7">Edit</a>
                                                                                     <a href="{% url 'core:pack-delete-item' pack.id entry.pack_item.id %}"
-                                                                                       class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive</a>
+                                                                                       class="linked-danger fs-7">Archive</a>
                                                                                 </span>
                                                                             {% endif %}
                                                                         </div>
@@ -501,7 +501,7 @@
                                                                         <a href="{% url 'core:pack-edit-item' pack.id group.pack_item.id %}"
                                                                            class="linked-secondary fs-7">Edit attribute</a>
                                                                         <a href="{% url 'core:pack-delete-item' pack.id group.pack_item.id %}"
-                                                                           class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive attribute</a>
+                                                                           class="linked-danger fs-7">Archive attribute</a>
                                                                     {% endif %}
                                                                 {% endif %}
                                                             </span>
@@ -526,7 +526,7 @@
                                                                                     <a href="{% url 'core:pack-edit-item' pack.id entry.pack_item.id %}"
                                                                                        class="linked-secondary fs-7">Edit</a>
                                                                                     <a href="{% url 'core:pack-delete-item' pack.id entry.pack_item.id %}"
-                                                                                       class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive</a>
+                                                                                       class="linked-danger fs-7">Archive</a>
                                                                                 </span>
                                                                             {% endif %}
                                                                         </div>
@@ -569,7 +569,7 @@
                                                                        class="linked-secondary fs-7">Edit</a>
                                                                 {% endif %}
                                                                 <a href="{% url 'core:pack-delete-item' pack.id entry.pack_item.id %}"
-                                                                   class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Archive</a>
+                                                                   class="linked-danger fs-7">Archive</a>
                                                             </span>
                                                         {% endif %}
                                                     </div>

--- a/gyrinx/core/templates/core/pack/pack_item_add.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add.html
@@ -4,6 +4,7 @@
     Add {{ label }} to {{ pack.name }}
 {% endblock head_title %}
 {% block content %}
+    {{ form.media }}
     {% include "core/includes/back.html" with url=back_url text=pack.name %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <h1 class="h3">

--- a/gyrinx/core/templates/core/pack/pack_item_edit.html
+++ b/gyrinx/core/templates/core/pack/pack_item_edit.html
@@ -4,6 +4,7 @@
     Edit {{ label }} - {{ pack.name }}
 {% endblock head_title %}
 {% block content %}
+    {{ form.media }}
     {% include "core/includes/back.html" with url=back_url text=pack.name %}
     {% if is_fighter %}
         <div class="vstack gap-3">

--- a/gyrinx/core/templates/core/pack/pack_item_edit.html
+++ b/gyrinx/core/templates/core/pack/pack_item_edit.html
@@ -68,7 +68,7 @@
     class="linked-secondary">Edit</a>
                                                             {% if can_archive_profiles %}
                                                                 · <a href="{% url 'core:pack-delete-weapon-profile' pack.id pack_item.id profile.id %}"
-    class="linked-secondary text-danger">Archive</a>
+    class="linked-danger">Archive</a>
                                                             {% endif %}
                                                         </span>
                                                     </td>
@@ -146,7 +146,7 @@
     class="linked-secondary">Edit</a>
                                                     {% if can_archive_profiles %}
                                                         · <a href="{% url 'core:pack-delete-weapon-profile' pack.id pack_item.id profile.id %}"
-    class="linked-secondary text-danger">Archive</a>
+    class="linked-danger">Archive</a>
                                                     {% endif %}
                                                 </span>
                                             </td>

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -4534,3 +4534,134 @@ def test_add_gear_duplicate_name_integrity_error(
     assert response.status_code == 200
     content = response.content.decode()
     assert "already exists" in content
+
+
+# --- Rich-text (TinyMCE) description fields (issue #1851) ---
+
+
+def test_pack_content_forms_use_tinymce_for_description():
+    """Pack content forms expose a rich-text editor for ``description``.
+
+    The custom rules editor (and its siblings) should use the TinyMCE
+    widget so authors can format text (bold, lists, links). Image insertion
+    is deliberately disabled for these short descriptions — see
+    ``test_rich_text_description_widget_has_no_image_support``.
+    ``PackAttachmentForm`` is intentionally excluded — its description is a
+    plain caption.
+    """
+    from gyrinx.core.forms.pack import (
+        ContentAttributeValuePackForm,
+        ContentGearPackForm,
+        ContentHouseForm,
+        ContentPsykerDisciplinePackForm,
+        ContentPsykerPowerPackForm,
+        ContentRuleForm,
+        ContentSkillPackForm,
+        ContentWeaponAccessoryPackForm,
+        ContentWeaponTraitPackForm,
+        PackAttachmentForm,
+    )
+    from gyrinx.core.widgets import TinyMCEWithUpload
+
+    rich_text_forms = [
+        ContentRuleForm,
+        ContentWeaponTraitPackForm,
+        ContentWeaponAccessoryPackForm,
+        ContentSkillPackForm,
+        ContentAttributeValuePackForm,
+        ContentGearPackForm,
+        ContentHouseForm,
+        ContentPsykerDisciplinePackForm,
+        ContentPsykerPowerPackForm,
+    ]
+    for form_cls in rich_text_forms:
+        widget = form_cls.base_fields["description"].widget
+        assert isinstance(widget, TinyMCEWithUpload), (
+            f"{form_cls.__name__}.description should use TinyMCEWithUpload, "
+            f"got {type(widget).__name__}"
+        )
+
+    # The attachment caption stays a plain textarea.
+    from django.forms import Textarea
+
+    assert isinstance(PackAttachmentForm.base_fields["description"].widget, Textarea)
+
+
+@pytest.mark.django_db
+def test_pack_rule_description_renders_rich_text(client, group_user, pack):
+    """A rule description containing HTML renders as sanitised rich text.
+
+    Safe markup is preserved (not HTML-escaped) and dangerous markup is
+    stripped, mirroring the pack summary/description rendering.
+    """
+    rule = ContentRule.objects.create(
+        name="Rich Rule",
+        description="<strong>Bold</strong> rule<script>alert(1)</script>",
+    )
+    CustomContentPackItem.objects.create(
+        pack=pack,
+        content_type=ContentType.objects.get_for_model(ContentRule),
+        object_id=rule.pk,
+        owner=group_user,
+    )
+
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}")
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Safe HTML is rendered as markup, not escaped text.
+    assert "<strong>Bold</strong> rule" in content
+    assert "&lt;strong&gt;" not in content
+    # Dangerous markup is stripped by safe_rich_text.
+    assert "<script>alert(1)</script>" not in content
+
+
+@pytest.mark.django_db
+def test_pack_rule_add_page_loads_tinymce_editor(client, group_user, pack):
+    """The add-rule page must emit the TinyMCE media so the editor initialises.
+
+    Regression guard: the widget alone is not enough — the template has to
+    render ``{{ form.media }}`` or the field silently falls back to a plain
+    textarea.
+    """
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}/add/rule/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "tinymce" in content.lower()
+    assert "id_description" in content
+
+
+@pytest.mark.django_db
+def test_pack_rule_edit_page_loads_tinymce_editor(client, group_user, pack):
+    """The edit-rule page must also emit the TinyMCE media."""
+    rule = ContentRule.objects.create(name="Editable Rule", description="<p>Hi</p>")
+    item = CustomContentPackItem.objects.create(
+        pack=pack,
+        content_type=ContentType.objects.get_for_model(ContentRule),
+        object_id=rule.pk,
+        owner=group_user,
+    )
+    client.force_login(group_user)
+    response = client.get(f"/pack/{pack.id}/item/{item.id}/edit/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "tinymce" in content.lower()
+    assert "id_description" in content
+
+
+def test_rich_text_description_widget_has_no_image_support():
+    """The content-description editor must not offer image insertion.
+
+    These descriptions sit in a dense listing where embedded images render
+    awkwardly, so the image plugin, toolbar button, insert-menu item, and
+    empty-line quick-insert bar are all removed.
+    """
+    from gyrinx.core.forms.pack import rich_text_description_widget
+
+    mce = rich_text_description_widget().mce_attrs
+    assert "image" not in mce["plugins"]
+    assert "image" not in mce["toolbar"]
+    assert "image" not in mce["menu"]["insert"]["items"]
+    assert mce["quickbars_insert_toolbar"] is False


### PR DESCRIPTION
## Summary

- Switch all pack content **description** fields from plain textareas to the TinyMCE rich-text editor (special rules, gear, weapons, traits, accessories, skills, attribute values, houses, psyker disciplines/powers) — matching the editor already used for pack summary/description. Authors get text formatting, links, and lists.
- **Image insertion is disabled** in these content-description editors (plugin, toolbar button, insert-menu item, and quick-insert bar removed) — they're short and sit in a dense listing. The main pack summary/description editor still supports images.
- Render those descriptions as sanitised rich text (`safe_rich_text|safe`) on the pack page instead of `linebreaksbr`. Any legacy/embedded images are capped to a small thumbnail (`.pack-rich-desc img { max-width: 8em; max-height: 8em }`), and each description renders in a bordered, tinted, full-width box.
- Fix: the item add/edit templates didn't emit `{{ form.media }}`, so the editor silently fell back to a plain textarea — now added on both.

No model/migration changes — descriptions are already `TextField` and store HTML for pack summary/description today. The `PackAttachment` caption is intentionally left as a plain textarea.

## Test plan

- [x] `pytest gyrinx/core/tests/test_views_pack.py` — widget config, no-image config, sanitised-HTML render, and editor-media presence tests pass
- [x] Manual: add a special rule with bold text → editor renders (no image button), content saves, pack page shows bold (not escaped), `<script>` stripped
- [x] Manual: legacy embedded image renders capped to a thumbnail, not full width
- [x] Manual: edit form loads TinyMCE pre-populated with saved rich content

Closes #1851

🤖 Generated with [Claude Code](https://claude.com/claude-code)