### PR TITLE
feat: add admin action to recompute fighter cost caches from facts

### DIFF
--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -1,5 +1,6 @@
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.db import transaction
 
 from gyrinx.content.models import ContentWeaponProfile
 from gyrinx.core.admin.base import BaseAdmin
@@ -128,9 +129,61 @@ class ListFighterPsykerPowerAssignmentInline(admin.TabularInline):
     fields = ["psyker_power"]
 
 
+@admin.action(description="Recompute cached cost/rating from facts (fix drift)")
+def recompute_cost_caches(modeladmin, request, queryset):
+    """
+    Force-recompute the cached cost/rating chain for the selected fighters
+    straight from the source-of-truth assignments.
+
+    Fixes cached-value drift (e.g. an inflated stash after a fighter death,
+    where a fighter's ``rating_current`` is wrong but ``dirty=False`` so the
+    normal lazy "Refresh Cost" recompute trusts the stale value and never
+    re-derives it). This rebuilds the whole subtree explicitly:
+    assignments -> fighter -> list, ignoring the dirty flags.
+    """
+    changed = []
+    affected_lists = {}
+    fighter_count = 0
+
+    with transaction.atomic():
+        for fighter in queryset.select_related("list", "content_fighter"):
+            fighter_count += 1
+            before = fighter.rating_current
+
+            # Rebuild each real assignment's cache from cost_int()...
+            for assignment in ListFighterEquipmentAssignment.objects.filter(
+                list_fighter=fighter
+            ):
+                assignment.facts_from_db(update=True)
+
+            # ...then the fighter's own cache from the (now-correct) assignments.
+            after = fighter.facts_from_db(update=True).rating
+
+            affected_lists[fighter.list_id] = fighter.list
+            if before != after:
+                changed.append((fighter, before, after))
+
+        # Reconcile each affected list's aggregate caches (rating/stash).
+        for lst in affected_lists.values():
+            lst.facts_from_db(update=True)
+
+    for fighter, before, after in changed:
+        messages.success(
+            request,
+            f"{fighter.name}: rating_current {before} → {after}",
+        )
+
+    messages.info(
+        request,
+        f"Recomputed {fighter_count} fighter(s) across "
+        f"{len(affected_lists)} list(s); {len(changed)} had drift corrected.",
+    )
+
+
 @admin.register(ListFighter)
 class ListFighterAdmin(BaseAdmin):
     form = ListFighterForm
+    actions = [recompute_cost_caches]
     fields = [
         "name",
         "content_fighter",
@@ -146,7 +199,8 @@ class ListFighterAdmin(BaseAdmin):
     ]
     readonly_fields = [cost]
     list_display = ["name", "content_fighter", "list"]
-    search_fields = ["name", "content_fighter__type", "list__name"]
+    # "=id" allows pasting a fighter UUID into the search box for an exact match.
+    search_fields = ["=id", "name", "content_fighter__type", "list__name"]
 
     inlines = [
         ListFighterEquipmentAssignmentInline,

--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -150,10 +150,15 @@ def recompute_cost_caches(modeladmin, request, queryset):
             fighter_count += 1
             before = fighter.rating_current
 
-            # Rebuild each real assignment's cache from cost_int()...
-            for assignment in ListFighterEquipmentAssignment.objects.filter(
-                list_fighter=fighter
-            ):
+            # Rebuild each real assignment's cache from cost_int(). Use
+            # with_related_data() to prefetch the equipment/profiles/accessories/
+            # upgrades that cost_int() touches and avoid N+1 across fighters.
+            assignments = (
+                ListFighterEquipmentAssignment.objects.with_related_data().filter(
+                    list_fighter=fighter
+                )
+            )
+            for assignment in assignments:
                 assignment.facts_from_db(update=True)
 
             # ...then the fighter's own cache from the (now-correct) assignments.

--- a/gyrinx/core/tests/test_admin_list.py
+++ b/gyrinx/core/tests/test_admin_list.py
@@ -1,0 +1,86 @@
+import pytest
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from gyrinx.core.admin.list import ListFighterAdmin, recompute_cost_caches
+from gyrinx.core.models.list import ListFighter
+
+
+def _admin_request():
+    factory = RequestFactory()
+    request = factory.post("/admin/")
+    request.user = User.objects.create_superuser("admin", "admin@test.com", "password")
+    # RequestFactory has no middleware; attach session + message storage so the
+    # action's messages.* calls don't blow up.
+    setattr(request, "session", {})
+    setattr(request, "_messages", FallbackStorage(request))
+    return request
+
+
+@pytest.mark.django_db
+def test_listfighter_admin_has_recompute_action():
+    admin_instance = admin.site._registry[ListFighter]
+    assert isinstance(admin_instance, ListFighterAdmin)
+    assert recompute_cost_caches in admin_instance.actions
+
+
+@pytest.mark.django_db
+def test_listfighter_id_is_searchable():
+    admin_instance = admin.site._registry[ListFighter]
+    assert "=id" in admin_instance.search_fields
+
+
+@pytest.mark.django_db
+def test_recompute_cost_caches_fixes_drift(make_list, make_list_fighter):
+    """A fighter whose cached rating drifted (but is marked clean) is repaired."""
+    lst = make_list("Drifty Gang")
+    fighter = make_list_fighter(lst, "Bozur")
+
+    correct = fighter.cost_int()
+
+    # Simulate the kill-handler drift: cache inflated but clean (dirty=False),
+    # and the list's aggregate caches carry the same inflation.
+    inflated = correct + 45
+    ListFighter.objects.filter(pk=fighter.pk).update(
+        rating_current=inflated, dirty=False
+    )
+    type(lst).objects.filter(pk=lst.pk).update(rating_current=inflated, dirty=False)
+
+    site = AdminSite()
+    admin_instance = ListFighterAdmin(ListFighter, site)
+    request = _admin_request()
+    queryset = ListFighter.objects.filter(pk=fighter.pk)
+
+    recompute_cost_caches(admin_instance, request, queryset)
+
+    fighter.refresh_from_db()
+    lst.refresh_from_db()
+
+    assert fighter.rating_current == correct
+    assert fighter.dirty is False
+    # List aggregate reconciled to the corrected fighter value.
+    assert lst.rating_current == correct
+
+
+@pytest.mark.django_db
+def test_recompute_cost_caches_noop_when_in_sync(make_list, make_list_fighter):
+    """Running on an already-correct fighter leaves the cache untouched."""
+    lst = make_list("Tidy Gang")
+    fighter = make_list_fighter(lst, "Clean")
+    fighter.facts_from_db(update=True)
+    lst.facts_from_db(update=True)
+
+    before = ListFighter.objects.get(pk=fighter.pk).rating_current
+
+    site = AdminSite()
+    admin_instance = ListFighterAdmin(ListFighter, site)
+    request = _admin_request()
+    queryset = ListFighter.objects.filter(pk=fighter.pk)
+
+    recompute_cost_caches(admin_instance, request, queryset)
+
+    fighter.refresh_from_db()
+    assert fighter.rating_current == before

--- a/gyrinx/core/tests/test_admin_list.py
+++ b/gyrinx/core/tests/test_admin_list.py
@@ -66,6 +66,34 @@ def test_recompute_cost_caches_fixes_drift(make_list, make_list_fighter):
 
 
 @pytest.mark.django_db
+def test_recompute_cost_caches_fixes_stash_drift(make_list):
+    """The reported bug: an inflated stash fighter reconciles list.stash_current."""
+    lst = make_list("Stashy Gang")
+    stash = lst.ensure_stash()
+
+    correct = stash.cost_int()
+
+    # Stash fighter's cache inflated but clean, with the same inflation baked
+    # into the list's stash aggregate (the kill-handler drift scenario).
+    inflated = correct + 45
+    ListFighter.objects.filter(pk=stash.pk).update(rating_current=inflated, dirty=False)
+    type(lst).objects.filter(pk=lst.pk).update(stash_current=inflated, dirty=False)
+
+    site = AdminSite()
+    admin_instance = ListFighterAdmin(ListFighter, site)
+    request = _admin_request()
+    queryset = ListFighter.objects.filter(pk=stash.pk)
+
+    recompute_cost_caches(admin_instance, request, queryset)
+
+    stash.refresh_from_db()
+    lst.refresh_from_db()
+
+    assert stash.rating_current == correct
+    assert lst.stash_current == correct
+
+
+@pytest.mark.django_db
 def test_recompute_cost_caches_noop_when_in_sync(make_list, make_list_fighter):
     """Running on an already-correct fighter leaves the cache untouched."""
     lst = make_list("Tidy Gang")


### PR DESCRIPTION
## Summary

- Adds a **ListFighter** admin action — *"Recompute cached cost/rating from facts (fix drift)"* — that force-rebuilds the cached cost/rating chain (`assignment → fighter → list`) straight from source-of-truth, ignoring the `dirty` flags that defeat the normal lazy "Refresh Cost" path.
- Makes the fighter UUID searchable in the changelist (`"=id"`), so you can paste an ID for an exact match or select fighters the usual way.

## Why

Cache drift after a fighter death can leave a fighter's `rating_current` inflated while `dirty=False`. The list-level recompute (`List.facts_from_db`) uses lazy evaluation — it trusts any *clean* fighter cache — so it never re-derives the bad value, and the stash stays permanently inflated (e.g. cached stash 60 vs actual 15 on a real prod list). This action rebuilds the subtree explicitly so the stale-but-clean value gets corrected, then reconciles the list aggregates.

## Test plan

- [x] `pytest gyrinx/core/tests/test_admin_list.py` — 4 pass (action registered, ID searchable, drift corrected, no-op when in sync)
- [x] `pytest gyrinx/core/tests/test_admin_auth.py` — no regression
- [x] `./scripts/fmt.sh` clean; pre-commit hooks pass
- [ ] Smoke-test in admin: search a stash fighter by ID, run the action, confirm `rating_current` and `list.stash_current` reconcile

## Next steps (optional)

- Could add the same action to the **List** admin to fix a whole gang in one go.