### PR TITLE
fix: let staff access debug_list_actions in production

### DIFF
--- a/gyrinx/core/tests/test_debug_views.py
+++ b/gyrinx/core/tests/test_debug_views.py
@@ -49,6 +49,24 @@ def test_list_actions_404_when_debug_disabled(client, user, make_list):
     assert response.status_code == 404
 
 
+@override_settings(DEBUG=False)
+@pytest.mark.django_db
+def test_list_actions_visible_to_staff_in_production(client, make_list, make_user):
+    """Staff retain access in production — the view is admin support tooling.
+
+    Regression test: the original security fix 404'd on DEBUG=False before the
+    staff check ever ran, locking admins out in production.
+    """
+    lst = make_list("Test Gang")
+    staff = make_user("admin", "password")
+    staff.is_staff = True
+    staff.save()
+    client.force_login(staff)
+    response = client.get(reverse("debug_list_actions", args=[lst.id]))
+
+    assert response.status_code == 200
+
+
 @override_settings(DEBUG=True, **_no_toolbar)
 @pytest.mark.django_db
 def test_list_actions_404_for_anonymous(client, make_list):

--- a/gyrinx/core/views/debug.py
+++ b/gyrinx/core/views/debug.py
@@ -207,20 +207,17 @@ def debug_design_system(request):
 
 def debug_list_actions(request, list_id):
     """Display all actions for a list, sorted newest first."""
-    if not settings.DEBUG:
-        raise Http404("Debug views are only available in development")
-
-    # Anonymous users (and non-owners) get a 404 rather than another list's
-    # activity log. Anonymous is handled first so we never pass AnonymousUser
-    # as an owner filter value.
-    if not request.user.is_authenticated:
-        raise Http404("List not found")
-
-    # Restrict to the list owner; staff may view any list.
+    # Staff may view any list's actions in any environment — this doubles as
+    # admin support tooling in production. Everyone else gets the view only in
+    # development, and only for lists they own; anonymous users and non-owners
+    # get a 404 rather than another list's activity log. (AnonymousUser has
+    # is_staff=False, so the staff branch never matches logged-out requests.)
     if request.user.is_staff:
         lst = get_object_or_404(List, id=list_id)
-    else:
+    elif settings.DEBUG and request.user.is_authenticated:
         lst = get_object_or_404(List, id=list_id, owner=request.user)
+    else:
+        raise Http404("List not found")
     actions = lst.actions.select_related("user", "list_fighter").order_by("-created")
 
     return render(


### PR DESCRIPTION
## Summary

The security hardening in #1857 added an unconditional `DEBUG=False` → 404 guard to `debug_list_actions`, which runs before the staff check ever does — so in production the view 404s for everyone, including admins who use it as support tooling.

This reorders the checks:

- **Staff** may view any list's actions in any environment (including production).
- **Non-staff owners** keep development-only access to their own lists.
- **Anonymous users and non-owners** still get a 404.

## Testing

- New regression test: staff access with `DEBUG=False` returns 200.
- All existing debug-view tests still pass (anonymous 404, non-owner 404, owner-in-dev 200, owner-in-prod 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)