### PR TITLE
perf: fix N+1 query explosions in List and ListFighter admin

### DIFF
--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -24,6 +24,10 @@ class ListFighterInline(admin.TabularInline):
     model = ListFighter
     extra = 1
     fields = ["name", "owner", "content_fighter", "cost_override"]
+    # Without autocomplete, every inline row renders a <select> of all users and
+    # all content fighters — and each ContentFighter option label fetches its
+    # house, so a single List change page runs thousands of queries.
+    autocomplete_fields = ["owner", "content_fighter"]
     show_change_link = True
 
 
@@ -64,6 +68,7 @@ class ListAdmin(BaseAdmin):
         "owner__username",
         "owner__email",
     ]
+    autocomplete_fields = ["owner"]
 
     inlines = [ListFighterInline, ListAttributeAssignmentInline]
 
@@ -71,6 +76,19 @@ class ListAdmin(BaseAdmin):
 class ListFighterForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # group_select below iterates every option and renders its label;
+        # ContentFighter.__str__ touches house and ContentSkill groups by
+        # category, so without select_related each option costs a query.
+        for field, related in [
+            ("content_fighter", "house"),
+            ("legacy_content_fighter", "house"),
+            ("skills", "category"),
+        ]:
+            if field in self.fields:
+                self.fields[field].queryset = self.fields[
+                    field
+                ].queryset.select_related(related)
+
         if hasattr(self.instance, "list"):
             if "disabled_default_assignments" in self.fields:
                 self.fields["disabled_default_assignments"].queryset = self.fields[
@@ -112,6 +130,8 @@ class ListFighterEquipmentAssignmentInline(admin.TabularInline):
     extra = 1
     fields = ["content_equipment", weapon_profiles_list, weapon_accessories_list, cost]
     readonly_fields = [weapon_profiles_list, weapon_accessories_list, cost]
+    # Avoid rendering a <select> of the entire equipment catalogue per row.
+    autocomplete_fields = ["content_equipment"]
     show_change_link = True
     fk_name = "list_fighter"
 
@@ -119,6 +139,9 @@ class ListFighterEquipmentAssignmentInline(admin.TabularInline):
 class ListFighterPsykerPowerAssignmentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["psyker_power"].queryset = self.fields[
+            "psyker_power"
+        ].queryset.select_related("discipline")
         group_select(self, "psyker_power", key=lambda x: x.discipline.name)
 
 
@@ -206,6 +229,7 @@ class ListFighterAdmin(BaseAdmin):
     list_display = ["name", "content_fighter", "list"]
     # "=id" allows pasting a fighter UUID into the search box for an exact match.
     search_fields = ["=id", "name", "content_fighter__type", "list__name"]
+    autocomplete_fields = ["list", "owner"]
 
     inlines = [
         ListFighterEquipmentAssignmentInline,
@@ -216,6 +240,19 @@ class ListFighterAdmin(BaseAdmin):
 class ListFighterEquipmentAssignmentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # The group_select keys below reach through FKs (fighter's list,
+        # equipment's category, profile's equipment) — select_related keeps
+        # each grouped dropdown to a single query.
+        for field, related in [
+            ("list_fighter", "list"),
+            ("content_equipment", "category"),
+            ("weapon_profiles_field", "equipment"),
+        ]:
+            if field in self.fields:
+                self.fields[field].queryset = self.fields[
+                    field
+                ].queryset.select_related(related)
+
         exists = ListFighterEquipmentAssignment.objects.filter(
             pk=self.instance.pk
         ).exists()

--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -243,18 +243,19 @@ class ListFighterAdmin(BaseAdmin):
     autocomplete_fields = ["list", "owner"]
 
     def get_search_results(self, request, queryset, search_term):
-        queryset, may_have_duplicates = super().get_search_results(
+        results, may_have_duplicates = super().get_search_results(
             request, queryset, search_term
         )
         # UUIDs can't go in search_fields: a non-UUID term against a UUID
-        # column is a database error, so match exact IDs separately.
+        # column is a database error, so match exact IDs separately. Filter
+        # the incoming queryset so changelist filters still apply.
         try:
             uuid_term = uuid.UUID(search_term.strip())
         except ValueError:
             pass
         else:
-            queryset |= self.model.objects.filter(pk=uuid_term)
-        return queryset, may_have_duplicates
+            results |= queryset.filter(pk=uuid_term)
+        return results, may_have_duplicates
 
     inlines = [
         ListFighterEquipmentAssignmentInline,
@@ -265,18 +266,19 @@ class ListFighterAdmin(BaseAdmin):
 class ListFighterEquipmentAssignmentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # The group_select keys below reach through FKs (fighter's list,
-        # equipment's category, profile's equipment) — select_related keeps
-        # each grouped dropdown to a single query.
+        # The group_select keys and option labels below reach through FKs
+        # (fighter's list and content_fighter via __str__, equipment's
+        # category, profile's equipment) — select_related keeps each grouped
+        # dropdown to a single query.
         for field, related in [
-            ("list_fighter", "list"),
-            ("content_equipment", "category"),
-            ("weapon_profiles_field", "equipment"),
+            ("list_fighter", ("list", "content_fighter")),
+            ("content_equipment", ("category",)),
+            ("weapon_profiles_field", ("equipment",)),
         ]:
             if field in self.fields:
                 self.fields[field].queryset = self.fields[
                     field
-                ].queryset.select_related(related)
+                ].queryset.select_related(*related)
 
         exists = ListFighterEquipmentAssignment.objects.filter(
             pk=self.instance.pk

--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -1,6 +1,10 @@
+import uuid
+
 from django import forms
 from django.contrib import admin, messages
 from django.db import transaction
+from django.urls import reverse
+from django.utils.html import format_html
 
 from gyrinx.content.models import ContentWeaponProfile
 from gyrinx.core.admin.base import BaseAdmin
@@ -208,6 +212,12 @@ def recompute_cost_caches(modeladmin, request, queryset):
     )
 
 
+@admin.display(description="List", ordering="list__name")
+def list_link(obj):
+    url = reverse("admin:core_list_change", args=[obj.list_id])
+    return format_html('<a href="{}">{}</a>', url, obj.list)
+
+
 @admin.register(ListFighter)
 class ListFighterAdmin(BaseAdmin):
     form = ListFighterForm
@@ -226,10 +236,25 @@ class ListFighterAdmin(BaseAdmin):
         "disabled_pskyer_default_powers",
     ]
     readonly_fields = [cost]
-    list_display = ["name", "content_fighter", "list"]
+    list_display = ["name", "content_fighter", list_link]
+    list_select_related = ["content_fighter__house", "list"]
     # "=id" allows pasting a fighter UUID into the search box for an exact match.
     search_fields = ["=id", "name", "content_fighter__type", "list__name"]
     autocomplete_fields = ["list", "owner"]
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, may_have_duplicates = super().get_search_results(
+            request, queryset, search_term
+        )
+        # UUIDs can't go in search_fields: a non-UUID term against a UUID
+        # column is a database error, so match exact IDs separately.
+        try:
+            uuid_term = uuid.UUID(search_term.strip())
+        except ValueError:
+            pass
+        else:
+            queryset |= self.model.objects.filter(pk=uuid_term)
+        return queryset, may_have_duplicates
 
     inlines = [
         ListFighterEquipmentAssignmentInline,


### PR DESCRIPTION
## Summary

- Fix the List and ListFighter admin change forms running thousands of queries: inline rows and `group_select` dropdowns rendered every ContentFighter/user as `<select>` options, and each option label fetched a FK (`ContentFighter.__str__` touches `house`). Switched whole-table dropdowns to `autocomplete_fields` and added `select_related` for the FKs that option labels and `group_select` keys touch.
- ListFighter admin changelist is now searchable by exact fighter UUID (via `get_search_results` — UUID columns can't take arbitrary terms in `search_fields` on Postgres).
- The list column in the ListFighter changelist links to the List admin change page, with `list_select_related` to avoid per-row queries.

Measured locally (small dataset — prod would be worse):

| View | Before | After |
|---|---|---|
| List change form | 8.3s / 9000+ queries | 0.3s / 85 |
| ListFighter change form | 1.7s / 1785 queries | 0.3s / 40 |
| ListFighter changelist | 110 queries | 12 |

## Test plan

- [x] Full test suite passes (2733 passed, 13 skipped)
- [x] `manage check` passes (validates autocomplete/search_fields wiring)
- [x] Smoke-tested via test client: change forms and changelists render (200), ID search returns exactly the matching fighter, name search unchanged, non-UUID search terms don't error, list column links to the List admin page

🤖 Generated with [Claude Code](https://claude.com/claude-code)