### PR TITLE
feat: admin UUID search, list autocomplete filter, change-page actions

### DIFF
--- a/gyrinx/core/admin/base.py
+++ b/gyrinx/core/admin/base.py
@@ -1,4 +1,9 @@
+import uuid
+
+from django.contrib.admin.utils import unquote
+from django.core.exceptions import PermissionDenied
 from django.db import models
+from django.http import HttpResponseRedirect
 from simple_history.admin import SimpleHistoryAdmin
 
 from gyrinx.core.widgets import TinyMCEWithUpload
@@ -8,3 +13,59 @@ class BaseAdmin(SimpleHistoryAdmin):
     formfield_overrides = {
         models.TextField: {"widget": TinyMCEWithUpload},
     }
+
+    # Names of changelist actions (entries in ``actions``) that are also
+    # rendered as buttons on the object's change page, running against just
+    # that object. See admin/gyrinx_change_form.html.
+    object_actions = []
+
+    change_form_template = "admin/gyrinx_change_form.html"
+
+    def get_search_results(self, request, queryset, search_term):
+        results, may_have_duplicates = super().get_search_results(
+            request, queryset, search_term
+        )
+        # Core models all have UUID primary keys, which don't belong in
+        # search_fields (a non-UUID term against a UUID column is a database
+        # error), so match exact IDs separately. Filtering the incoming
+        # queryset keeps any changelist filters applied.
+        try:
+            uuid_term = uuid.UUID(search_term.strip())
+        except ValueError:
+            pass
+        else:
+            results |= queryset.filter(pk=uuid_term)
+        return results, may_have_duplicates
+
+    def get_object_actions(self, request):
+        """The subset of ``actions`` exposed as change-page buttons."""
+        actions = self.get_actions(request)
+        return [
+            {"name": name, "description": actions[name][2]}
+            for name in self.object_actions
+            if name in actions
+        ]
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        if request.method == "POST" and "_object_action" in request.POST:
+            return self._run_object_action(request, object_id)
+        extra_context = {
+            **(extra_context or {}),
+            "object_actions": self.get_object_actions(request),
+        }
+        return super().change_view(request, object_id, form_url, extra_context)
+
+    def _run_object_action(self, request, object_id):
+        name = request.POST["_object_action"]
+        allowed = {action["name"] for action in self.get_object_actions(request)}
+        obj = self.get_object(request, unquote(object_id))
+        if name not in allowed or obj is None:
+            raise PermissionDenied
+        if not self.has_change_permission(request, obj):
+            raise PermissionDenied
+        func = self.get_actions(request)[name][0]
+        queryset = self.get_queryset(request).filter(pk=obj.pk)
+        response = func(self, request, queryset)
+        # Actions usually return None; bounce back to the change page so the
+        # messages they queued are visible.
+        return response or HttpResponseRedirect(request.get_full_path())

--- a/gyrinx/core/admin/filters.py
+++ b/gyrinx/core/admin/filters.py
@@ -1,0 +1,77 @@
+import uuid
+
+from django import forms
+from django.contrib import admin
+from django.contrib.admin.widgets import AutocompleteSelectMultiple
+
+
+class AutocompleteRelatedFilter(admin.SimpleListFilter):
+    """
+    Changelist filter on a FK, rendered as a select2 multi-select autocomplete
+    instead of the default list of links — usable when the related table has
+    thousands of rows.
+
+    Subclasses set ``title``, ``parameter_name``, and ``field_name`` (a FK on
+    the changelist model). The related model's admin must define
+    ``search_fields`` (it backs the autocomplete endpoint), and the ModelAdmin
+    using the filter must include the widget's assets in its media — see
+    ``autocomplete_filter_media``.
+
+    Selected values are carried in the query string as comma-separated UUIDs.
+    """
+
+    template = "admin/gyrinx_autocomplete_filter.html"
+    field_name = None
+
+    def __init__(self, request, params, model, model_admin):
+        self.field = model._meta.get_field(self.field_name)
+        self.admin_site = model_admin.admin_site
+        super().__init__(request, params, model, model_admin)
+
+    def has_output(self):
+        return True
+
+    def lookups(self, request, model_admin):
+        return ()
+
+    def selected_ids(self):
+        ids = []
+        for part in (self.value() or "").split(","):
+            try:
+                ids.append(uuid.UUID(part.strip()))
+            except ValueError:
+                continue
+        return ids
+
+    def queryset(self, request, queryset):
+        ids = self.selected_ids()
+        if ids:
+            return queryset.filter(**{f"{self.field_name}__id__in": ids})
+        return queryset
+
+    def widget_id(self):
+        return f"id_{self.parameter_name}_autocomplete_filter"
+
+    def rendered_widget(self):
+        remote_model = self.field.remote_field.model
+        form_field = forms.ModelMultipleChoiceField(
+            queryset=remote_model._default_manager.all(),
+            widget=AutocompleteSelectMultiple(self.field, self.admin_site),
+            required=False,
+        )
+        return form_field.widget.render(
+            name=f"{self.parameter_name}_select",
+            value=self.selected_ids(),
+            attrs={"id": self.widget_id(), "style": "width: 100%"},
+        )
+
+
+def autocomplete_filter_media(model, field_name, admin_site):
+    """
+    The select2/autocomplete assets an AutocompleteRelatedFilter needs on the
+    changelist page. Changelists don't collect filter media, so the ModelAdmin
+    must add this to its own ``media`` property.
+    """
+    return AutocompleteSelectMultiple(
+        model._meta.get_field(field_name), admin_site
+    ).media

--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django import forms
 from django.contrib import admin, messages
 from django.db import transaction
@@ -8,6 +6,10 @@ from django.utils.html import format_html
 
 from gyrinx.content.models import ContentWeaponProfile
 from gyrinx.core.admin.base import BaseAdmin
+from gyrinx.core.admin.filters import (
+    AutocompleteRelatedFilter,
+    autocomplete_filter_media,
+)
 from gyrinx.forms import group_select
 
 from ..models.list import (
@@ -46,9 +48,27 @@ class ListForm(forms.ModelForm):
     pass
 
 
+@admin.action(description="Recompute cached cost/rating from facts (fix drift)")
+def recompute_list_cost_caches(modeladmin, request, queryset):
+    """
+    List-level wrapper around recompute_cost_caches: rebuild every fighter in
+    the selected lists (including the stash), then reconcile the lists'
+    aggregate caches.
+    """
+    fighters = ListFighter.objects.filter(list__in=queryset)
+    recompute_cost_caches(modeladmin, request, fighters)
+    # recompute_cost_caches only reconciles lists it saw fighters for; cover
+    # fighterless lists too.
+    with transaction.atomic():
+        for lst in queryset:
+            lst.facts_from_db(update=True)
+
+
 @admin.register(List)
 class ListAdmin(BaseAdmin):
     form = ListForm
+    actions = [recompute_list_cost_caches]
+    object_actions = ["recompute_list_cost_caches"]
     fields = [
         "name",
         "content_house",
@@ -218,10 +238,17 @@ def list_link(obj):
     return format_html('<a href="{}">{}</a>', url, obj.list)
 
 
+class ListFilter(AutocompleteRelatedFilter):
+    title = "list"
+    parameter_name = "list_id_in"
+    field_name = "list"
+
+
 @admin.register(ListFighter)
 class ListFighterAdmin(BaseAdmin):
     form = ListFighterForm
     actions = [recompute_cost_caches]
+    object_actions = ["recompute_cost_caches"]
     fields = [
         "name",
         "content_fighter",
@@ -237,25 +264,19 @@ class ListFighterAdmin(BaseAdmin):
     ]
     readonly_fields = [cost]
     list_display = ["name", "content_fighter", list_link]
+    list_filter = [ListFilter]
     list_select_related = ["content_fighter__house", "list"]
-    # "=id" allows pasting a fighter UUID into the search box for an exact match.
-    search_fields = ["=id", "name", "content_fighter__type", "list__name"]
+    # Fighter UUIDs are searchable via BaseAdmin.get_search_results.
+    search_fields = ["name", "content_fighter__type", "list__name"]
     autocomplete_fields = ["list", "owner"]
 
-    def get_search_results(self, request, queryset, search_term):
-        results, may_have_duplicates = super().get_search_results(
-            request, queryset, search_term
+    @property
+    def media(self):
+        # The changelist doesn't collect filter media; ListFilter's select2
+        # widget needs the autocomplete assets.
+        return super().media + autocomplete_filter_media(
+            ListFighter, "list", self.admin_site
         )
-        # UUIDs can't go in search_fields: a non-UUID term against a UUID
-        # column is a database error, so match exact IDs separately. Filter
-        # the incoming queryset so changelist filters still apply.
-        try:
-            uuid_term = uuid.UUID(search_term.strip())
-        except ValueError:
-            pass
-        else:
-            results |= queryset.filter(pk=uuid_term)
-        return results, may_have_duplicates
 
     inlines = [
         ListFighterEquipmentAssignmentInline,

--- a/gyrinx/core/tests/test_admin_list.py
+++ b/gyrinx/core/tests/test_admin_list.py
@@ -4,9 +4,15 @@ from django.contrib.auth.models import User
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
+from django.urls import reverse
 
-from gyrinx.core.admin.list import ListFighterAdmin, recompute_cost_caches
-from gyrinx.core.models.list import ListFighter
+from gyrinx.core.admin.list import (
+    ListAdmin,
+    ListFighterAdmin,
+    recompute_cost_caches,
+    recompute_list_cost_caches,
+)
+from gyrinx.core.models.list import List, ListFighter
 
 
 def _admin_request():
@@ -28,9 +34,130 @@ def test_listfighter_admin_has_recompute_action():
 
 
 @pytest.mark.django_db
-def test_listfighter_id_is_searchable():
-    admin_instance = admin.site._registry[ListFighter]
-    assert "=id" in admin_instance.search_fields
+def test_changelist_search_by_uuid(admin_client, make_list, make_list_fighter):
+    """Pasting an object's UUID into the admin search box finds it (BaseAdmin)."""
+    lst = make_list("UUID Gang")
+    other = make_list("Other Gang")
+    fighter = make_list_fighter(lst, "Bozur")
+    make_list_fighter(other, "Decoy")
+
+    response = admin_client.get(
+        reverse("admin:core_listfighter_changelist"), {"q": str(fighter.id)}
+    )
+    assert response.status_code == 200
+    assert list(response.context["cl"].result_list) == [fighter]
+
+    response = admin_client.get(
+        reverse("admin:core_list_changelist"), {"q": str(lst.id)}
+    )
+    assert response.status_code == 200
+    assert list(response.context["cl"].result_list) == [lst]
+
+    # Plain text search is unaffected.
+    response = admin_client.get(
+        reverse("admin:core_listfighter_changelist"), {"q": "Bozur"}
+    )
+    assert fighter in response.context["cl"].result_list
+
+
+@pytest.mark.django_db
+def test_fighter_changelist_filter_by_list(admin_client, make_list, make_list_fighter):
+    """The autocomplete list filter narrows fighters to the selected list(s)."""
+    lst_one = make_list("Gang One")
+    lst_two = make_list("Gang Two")
+    lst_three = make_list("Gang Three")
+    fighter_one = make_list_fighter(lst_one, "One")
+    fighter_two = make_list_fighter(lst_two, "Two")
+    make_list_fighter(lst_three, "Three")
+
+    url = reverse("admin:core_listfighter_changelist")
+
+    response = admin_client.get(url, {"list_id_in": str(lst_one.id)})
+    assert response.status_code == 200
+    assert list(response.context["cl"].result_list) == [fighter_one]
+
+    # Multi-select carries comma-separated UUIDs.
+    response = admin_client.get(url, {"list_id_in": f"{lst_one.id},{lst_two.id}"})
+    assert set(response.context["cl"].result_list) == {fighter_one, fighter_two}
+
+    # The filter widget and its select2 assets are on the page.
+    assert b"list_id_in" in response.content
+    assert b"admin-autocomplete" in response.content
+    assert b"select2" in response.content
+
+
+@pytest.mark.django_db
+def test_fighter_change_page_has_object_action_button(
+    admin_client, make_list, make_list_fighter
+):
+    lst = make_list("Button Gang")
+    fighter = make_list_fighter(lst, "Btn")
+
+    response = admin_client.get(
+        reverse("admin:core_listfighter_change", args=[fighter.pk])
+    )
+    assert response.status_code == 200
+    assert b'name="_object_action"' in response.content
+    assert b'value="recompute_cost_caches"' in response.content
+
+
+@pytest.mark.django_db
+def test_object_action_recomputes_single_fighter(
+    admin_client, make_list, make_list_fighter
+):
+    """Posting an object action from the change page runs it on just that object."""
+    lst = make_list("Drift Gang")
+    fighter = make_list_fighter(lst, "Drifty")
+    correct = fighter.cost_int()
+    ListFighter.objects.filter(pk=fighter.pk).update(
+        rating_current=correct + 45, dirty=False
+    )
+
+    url = reverse("admin:core_listfighter_change", args=[fighter.pk])
+    response = admin_client.post(url, {"_object_action": "recompute_cost_caches"})
+    assert response.status_code == 302
+    assert response.url == url
+
+    fighter.refresh_from_db()
+    assert fighter.rating_current == correct
+
+
+@pytest.mark.django_db
+def test_object_action_rejects_unlisted_action(
+    admin_client, make_list, make_list_fighter
+):
+    """Only actions named in object_actions can run from the change page."""
+    lst = make_list("Locked Gang")
+    fighter = make_list_fighter(lst, "Lock")
+
+    url = reverse("admin:core_listfighter_change", args=[fighter.pk])
+    response = admin_client.post(url, {"_object_action": "delete_selected"})
+    assert response.status_code == 403
+    assert ListFighter.objects.filter(pk=fighter.pk).exists()
+
+
+@pytest.mark.django_db
+def test_recompute_list_cost_caches_action(make_list, make_list_fighter):
+    """The List-level action rebuilds its fighters and reconciles aggregates."""
+    lst = make_list("Whole Gang")
+    fighter = make_list_fighter(lst, "Member")
+    correct = fighter.cost_int()
+    inflated = correct + 45
+    ListFighter.objects.filter(pk=fighter.pk).update(
+        rating_current=inflated, dirty=False
+    )
+    List.objects.filter(pk=lst.pk).update(rating_current=inflated, dirty=False)
+
+    site = AdminSite()
+    admin_instance = ListAdmin(List, site)
+    request = _admin_request()
+
+    recompute_list_cost_caches(admin_instance, request, List.objects.filter(pk=lst.pk))
+
+    fighter.refresh_from_db()
+    lst.refresh_from_db()
+    assert fighter.rating_current == correct
+    assert lst.rating_current == correct
 
 
 @pytest.mark.django_db

--- a/gyrinx/templates/admin/gyrinx_autocomplete_filter.html
+++ b/gyrinx/templates/admin/gyrinx_autocomplete_filter.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+<details data-filter-title="{{ title }}" open>
+    <summary>{% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}</summary>
+    <style>
+    .gyrinx-autocomplete-filter {
+      padding: 0 15px 10px;
+    }
+    </style>
+    <div class="gyrinx-autocomplete-filter">{{ spec.rendered_widget }}</div>
+    <script>
+    (function () {
+      function init() {
+        var select = document.getElementById("{{ spec.widget_id }}");
+        if (!select || !window.django || !window.django.jQuery) return;
+        // select2 fires change through jQuery, so bind with django.jQuery.
+        django.jQuery(select).on("change", function () {
+          var values = Array.prototype.map.call(
+            select.selectedOptions,
+            function (option) {
+              return option.value;
+            },
+          );
+          var params = new URLSearchParams(window.location.search);
+          if (values.length) {
+            params.set("{{ spec.parameter_name }}", values.join(","));
+          } else {
+            params.delete("{{ spec.parameter_name }}");
+          }
+          window.location.search = params.toString();
+        });
+      }
+      if (document.readyState !== "loading") {
+        init();
+      } else {
+        document.addEventListener("DOMContentLoaded", init);
+      }
+    })();
+    </script>
+</details>

--- a/gyrinx/templates/admin/gyrinx_autocomplete_filter.html
+++ b/gyrinx/templates/admin/gyrinx_autocomplete_filter.html
@@ -26,6 +26,10 @@
           } else {
             params.delete("{{ spec.parameter_name }}");
           }
+          // Changing the filter changes the result set, so the current page
+          // number may be out of range — reset pagination like Django's own
+          // filter links do.
+          params.delete("p");
           window.location.search = params.toString();
         });
       }

--- a/gyrinx/templates/admin/gyrinx_change_form.html
+++ b/gyrinx/templates/admin/gyrinx_change_form.html
@@ -1,0 +1,37 @@
+{% extends "admin/change_form.html" %}
+{% block extrastyle %}
+    {{ block.super }}
+    <style>
+  .object-tools form.gyrinx-object-action {
+    display: inline;
+  }
+  .object-tools form.gyrinx-object-action button {
+    background: var(--object-tools-bg);
+    color: var(--object-tools-fg);
+    border: none;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 0.625rem;
+    font-weight: 400;
+    letter-spacing: 0.5px;
+    padding: 3px 12px;
+    text-transform: uppercase;
+  }
+  .object-tools form.gyrinx-object-action button:hover {
+    background: var(--object-tools-hover-bg);
+  }
+    </style>
+{% endblock extrastyle %}
+{% block object-tools-items %}
+    {% for action in object_actions %}
+        <li>
+            <form method="post" class="gyrinx-object-action">
+                {% csrf_token %}
+                <input type="hidden" name="_object_action" value="{{ action.name }}">
+                <button type="submit">{{ action.description }}</button>
+            </form>
+        </li>
+    {% endfor %}
+    {{ block.super }}
+{% endblock object-tools-items %}

--- a/gyrinx/templates/admin/gyrinx_change_form.html
+++ b/gyrinx/templates/admin/gyrinx_change_form.html
@@ -2,24 +2,30 @@
 {% block extrastyle %}
     {{ block.super }}
     <style>
-  .object-tools form.gyrinx-object-action {
-    display: inline;
+  /* Mirror the .object-tools a rules from admin/css/base.css — buttons don't
+     inherit font or line-height, so set them explicitly. */
+  .object-tools form.gyrinx-object-action,
+  .object-tools form.gyrinx-object-action button {
+    display: block;
+    float: left;
   }
   .object-tools form.gyrinx-object-action button {
+    border: none;
+    cursor: pointer;
+    border-radius: 15px;
+    padding: 3px 12px;
     background: var(--object-tools-bg);
     color: var(--object-tools-fg);
-    border: none;
-    border-radius: 15px;
-    cursor: pointer;
-    display: inline-block;
-    font-size: 0.625rem;
+    font-family: inherit;
     font-weight: 400;
-    letter-spacing: 0.5px;
-    padding: 3px 12px;
+    font-size: 0.6875rem;
+    line-height: inherit;
     text-transform: uppercase;
+    letter-spacing: 0.5px;
   }
+  .object-tools form.gyrinx-object-action button:focus,
   .object-tools form.gyrinx-object-action button:hover {
-    background: var(--object-tools-hover-bg);
+    background-color: var(--object-tools-hover-bg);
   }
     </style>
 {% endblock extrastyle %}
@@ -35,3 +41,20 @@
     {% endfor %}
     {{ block.super }}
 {% endblock object-tools-items %}
+{% block admin_change_form_document_ready %}
+    {{ block.super }}
+    <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      document
+        .querySelectorAll("form.gyrinx-object-action")
+        .forEach(function (form) {
+          form.addEventListener("submit", function (event) {
+            var label = form.querySelector("button").textContent.trim();
+            if (!window.confirm('Run "' + label + '" now?')) {
+              event.preventDefault();
+            }
+          });
+        });
+    });
+    </script>
+{% endblock admin_change_form_document_ready %}


### PR DESCRIPTION
## Summary

- **Search any core admin by UUID** — `BaseAdmin.get_search_results` now matches an exact UUID pasted into the changelist search box, for every core model. Previously only ListFighter had this (and Lists were not findable by ID at all). The ListFighter-specific override and its `=id` search field are removed in favour of the shared implementation.
- **Filter fighters by list** — the ListFighter changelist gains a select2 multi-select autocomplete filter (`AutocompleteRelatedFilter` in `core/admin/filters.py`, backed by the existing admin autocomplete endpoint). Selected lists are carried as comma-separated UUIDs in the query string, so filtered views are linkable.
- **Run actions from the change page** — `BaseAdmin.object_actions` renders named changelist actions as buttons in the object-tools bar of the change page, executing against just that object. Wired up for `recompute_cost_caches` on ListFighter, plus a new list-level `recompute_list_cost_caches` on List (rebuilds all the list's fighters including the stash, then reconciles aggregates).

## Test plan

- [x] `pytest -n auto` — full suite passes (2757 passed)
- [x] New tests: UUID search on both changelists, single/multi list filtering, change-page button rendering, object-action POST (success + rejection of unlisted actions), list-level recompute
- [x] Browser smoke test against the dev server: select2 filter initialises, AJAX search works, selecting one/two lists narrows the changelist and round-trips through the URL, chips re-render preselected, recompute button on a fighter page corrected real drift (stash at −15 → 0) and redirected with messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)