### PR TITLE
fix: enqueue dependabot auto-merge via GitHub App token

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      # Mint a token from a dedicated GitHub App so the enqueue is NOT performed
+      # by GITHUB_TOKEN. Actions triggered by GITHUB_TOKEN do not spawn new
+      # workflow runs, which meant the merge_group event never started the
+      # required `test` / `format-check` runs and the PR was evicted from the
+      # queue after the 60-minute check timeout. An App token enqueues as a
+      # distinct identity so merge_group checks run normally.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
@@ -23,5 +36,5 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-patch'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Why

Dependabot auto-merge PRs were stalling. Two root causes:

1. **Checks never ran in the merge queue.** Auto-merge was enabled with `GITHUB_TOKEN`. Actions triggered by `GITHUB_TOKEN` don't spawn new workflow runs, so when the PR was added to the queue the `merge_group` event never started the required `test` / `format-check` runs. After the ruleset's 60-minute check-response timeout, the PR was evicted from the queue (and lost its auto-merge flag).
2. **Waiting on a human review.** The "Default (Reviews)" ruleset requires a code-owner review, and `CODEOWNERS` is `* @tgvashworth`, so no bot/AI could satisfy it.

## What

- `dependabot-auto-merge.yml` now mints a token from a dedicated GitHub App (`gyrinx-automerge`, Contents R/W + Pull requests R/W) via `actions/create-github-app-token` (pinned) and uses it for `gh pr merge --auto`. The enqueue happens as a distinct identity, so `merge_group` checks run normally.
- The App was added as a bypass actor on the "Default (Reviews)" ruleset, so patch/minor dependabot PRs no longer wait on a human code-owner review.

Required status checks (`test`, `format-check`, CodeQL) live in the separate "Default" ruleset and still gate the merge in the queue — those are unchanged.

Secrets `AUTOMERGE_APP_ID` and `AUTOMERGE_APP_PRIVATE_KEY` are set on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)