### PR TITLE
fix: full-width pack search bar and carry quick-create name through pack selection

### DIFF
--- a/gyrinx/core/templates/core/includes/packs_filter.html
+++ b/gyrinx/core/templates/core/includes/packs_filter.html
@@ -1,5 +1,6 @@
 {% load custom_tags %}
-{% comment %}Filter component for packs, used on the customisation page.
+{% comment %}Filter component for packs. Used on the pack library page and the
+    new-list pack-selection interstitial.
     Parameters:
     - action: The URL to submit the form to
     - name: (optional) a new-list name to preserve across search submissions

--- a/gyrinx/core/templates/core/includes/packs_filter.html
+++ b/gyrinx/core/templates/core/includes/packs_filter.html
@@ -2,6 +2,7 @@
 {% comment %}Filter component for packs, used on the customisation page.
     Parameters:
     - action: The URL to submit the form to
+    - name: (optional) a new-list name to preserve across search submissions
 {% endcomment %}
 <form id="search"
       method="get"
@@ -9,6 +10,7 @@
       class="vstack gap-3">
     <input type="hidden" name="flash" value="search">
     <input type="hidden" name="cb" value="{% cachebuster %}">
+    {% if name %}<input type="hidden" name="name" value="{{ name }}">{% endif %}
     {# Search row #}
     <div>
         <div class="hstack gap-2 align-items-end">

--- a/gyrinx/core/templates/core/list_new_packs.html
+++ b/gyrinx/core/templates/core/list_new_packs.html
@@ -16,7 +16,7 @@
                     <div class="fw-medium">Default Game Content</div>
                     <div class="text-secondary fs-7">Standard fighters, equipment, and rules from the core rulebooks.</div>
                 </div>
-                <a href="{% url 'core:lists-new' %}?skip_packs=1"
+                <a href="{% url 'core:lists-new' %}?skip_packs=1{% if name %}&name={{ name|urlencode }}{% endif %}"
                    class="btn btn-primary ms-auto">Use default content <i class="bi-arrow-right"></i></a>
             </div>
         </div>
@@ -26,8 +26,10 @@
             <span class="text-secondary fs-7">Optionally add content packs</span>
             <hr class="flex-grow-1">
         </div>
-        <!-- Submit button + Filter bar -->
-        <div class="d-flex flex-column flex-xl-row-reverse gap-3 align-items-xl-start">
+        <!-- Filter bar + Submit button -->
+        <div class="vstack gap-3">
+            {% url 'core:lists-new-packs' as action %}
+            {% include "core/includes/packs_filter.html" with action=action name=name %}
             <button type="submit"
                     form="pack-form"
                     class="btn btn-primary align-self-end flex-shrink-0"
@@ -35,16 +37,13 @@
                     disabled>
                 Include selected packs <i class="bi-arrow-right"></i>
             </button>
-            <div class="flex-grow-1">
-                {% url 'core:lists-new-packs' as action %}
-                {% include "core/includes/packs_filter.html" with action=action %}
-            </div>
         </div>
         <!-- Pack list (form wraps only the checkboxes) -->
         <form method="post"
               action="{% url 'core:lists-new-packs' %}"
               id="pack-form">
             {% csrf_token %}
+            {% if name %}<input type="hidden" name="name" value="{{ name }}">{% endif %}
             <div class="vstack gap-2" id="pack-list">
                 {% for pack in available_packs %}
                     <label class="border rounded p-2 d-flex align-items-start gap-2 pack-item">

--- a/gyrinx/core/tests/test_list_packs.py
+++ b/gyrinx/core/tests/test_list_packs.py
@@ -1,5 +1,7 @@
 """Tests for list pack subscription functionality."""
 
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -276,7 +278,7 @@ class TestNewListPacksInterstitial:
         url = reverse("core:lists-new") + "?name=Shadowskin+Spectres"
         response = client.get(url)
         assert response.status_code == 302
-        assert "name=Shadowskin" in response.url
+        assert "name=Shadowskin+Spectres" in response.url
 
     def test_name_rendered_on_interstitial(self, client, cc_user, content_house):
         """The carried name is embedded in the interstitial forms so it survives
@@ -298,7 +300,7 @@ class TestNewListPacksInterstitial:
             url, {"pack_ids": [str(pack.id)], "name": "Shadowskin Spectres"}
         )
         assert response.status_code == 302
-        assert "name=Shadowskin" in response.url
+        assert "name=Shadowskin+Spectres" in response.url
 
         # Following the redirect pre-fills the name on the new-list form
         response = client.get(response.url)
@@ -312,7 +314,20 @@ class TestNewListPacksInterstitial:
         response = client.post(url, {"name": "Shadowskin Spectres"})
         assert response.status_code == 302
         assert "skip_packs=1" in response.url
-        assert "name=Shadowskin" in response.url
+        assert "name=Shadowskin+Spectres" in response.url
+
+    def test_carried_name_capped_to_max_length(self, client, cc_user, content_house):
+        """An over-long name is capped to List.name's max_length before being
+        placed in the redirect URL (avoids oversized URLs / invalid input)."""
+        max_length = List._meta.get_field("name").max_length
+        client.force_login(cc_user)
+        long_name = "x" * (max_length + 50)
+        url = reverse("core:lists-new-packs")
+        response = client.post(url, {"name": long_name})
+        assert response.status_code == 302
+        # The carried name in the redirect is no longer than the field allows
+        carried = parse_qs(urlparse(response.url).query).get("name", [""])[0]
+        assert len(carried) == max_length
 
     def test_packs_interstitial_shows_other_users_preselected_pack(
         self, client, make_user, make_pack

--- a/gyrinx/core/tests/test_list_packs.py
+++ b/gyrinx/core/tests/test_list_packs.py
@@ -267,6 +267,53 @@ class TestNewListPacksInterstitial:
         assert response.status_code == 302
         assert "skip_packs=1" in response.url
 
+    def test_name_carried_to_interstitial_on_redirect(
+        self, client, cc_user, content_house
+    ):
+        """A name typed in the home-page quick-create box survives the redirect
+        to the pack interstitial (regression: name was dropped)."""
+        client.force_login(cc_user)
+        url = reverse("core:lists-new") + "?name=Shadowskin+Spectres"
+        response = client.get(url)
+        assert response.status_code == 302
+        assert "name=Shadowskin" in response.url
+
+    def test_name_rendered_on_interstitial(self, client, cc_user, content_house):
+        """The carried name is embedded in the interstitial forms so it survives
+        search submissions and the final pack selection."""
+        client.force_login(cc_user)
+        url = reverse("core:lists-new-packs") + "?name=Shadowskin+Spectres"
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b'name="name" value="Shadowskin Spectres"' in response.content
+
+    def test_name_carried_through_pack_selection(
+        self, client, cc_user, content_house, pack
+    ):
+        """Posting the interstitial with a name carries it back to the new-list
+        form so it pre-fills the name field."""
+        client.force_login(cc_user)
+        url = reverse("core:lists-new-packs")
+        response = client.post(
+            url, {"pack_ids": [str(pack.id)], "name": "Shadowskin Spectres"}
+        )
+        assert response.status_code == 302
+        assert "name=Shadowskin" in response.url
+
+        # Following the redirect pre-fills the name on the new-list form
+        response = client.get(response.url)
+        assert response.status_code == 200
+        assert b'value="Shadowskin Spectres"' in response.content
+
+    def test_name_carried_through_skip_packs(self, client, cc_user, content_house):
+        """Skipping packs (no selection) still preserves the name."""
+        client.force_login(cc_user)
+        url = reverse("core:lists-new-packs")
+        response = client.post(url, {"name": "Shadowskin Spectres"})
+        assert response.status_code == 302
+        assert "skip_packs=1" in response.url
+        assert "name=Shadowskin" in response.url
+
     def test_packs_interstitial_shows_other_users_preselected_pack(
         self, client, make_user, make_pack
     ):

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -635,9 +635,14 @@ def new_list(request):
 
     skip_packs = request.GET.get("skip_packs") == "1"
 
-    # Users who haven't visited the interstitial yet get redirected there
+    # Users who haven't visited the interstitial yet get redirected there.
+    # Preserve any name typed into the home-page quick-create box.
     if request.method == "GET" and not skip_packs and not pack_ids:
-        return HttpResponseRedirect(reverse("core:lists-new-packs"))
+        packs_url = reverse("core:lists-new-packs")
+        name = request.GET.get("name", "").strip()
+        if name:
+            packs_url += "?" + urlencode({"name": name})
+        return HttpResponseRedirect(packs_url)
 
     # Resolve selected packs
     selected_packs = CustomContentPack.objects.none()
@@ -737,12 +742,15 @@ def new_list_packs(request):
             )
         )
         pack_ids = [pid for pid in sanitised_ids if pid in valid_ids]
-        # Redirect with pack IDs as URL params
+        # Redirect with pack IDs as URL params, preserving any quick-create name
+        name = request.POST.get("name", "").strip()
         url = reverse("core:lists-new")
-        if pack_ids:
-            url = f"{url}?{urlencode([('packs', pid) for pid in pack_ids], doseq=True)}"
-        else:
-            url = f"{url}?{urlencode({'skip_packs': '1'})}"
+        params = (
+            [("packs", pid) for pid in pack_ids] if pack_ids else [("skip_packs", "1")]
+        )
+        if name:
+            params.append(("name", name))
+        url = f"{url}?{urlencode(params, doseq=True)}"
         return safe_redirect(request, url, fallback_url=reverse("core:lists-new"))
 
     # Display filtering for GET requests
@@ -766,6 +774,9 @@ def new_list_packs(request):
             )
         else:
             available_packs = available_packs.filter(owner=request.user)
+
+    # Quick-create name carried through from the home-page box
+    new_list_name = request.GET.get("name", "").strip()
 
     # Search
     search_query = request.GET.get("q", "").strip()
@@ -830,6 +841,7 @@ def new_list_packs(request):
             "available_packs": available_packs,
             "search_query": search_query,
             "preselected_pack_ids": preselected_pack_ids,
+            "name": new_list_name,
         },
     )
 

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -604,6 +604,15 @@ class ListCampaignClonesView(generic.DetailView):
         return context
 
 
+def _carried_list_name(raw):
+    """Normalise a quick-create list name carried through the pack-selection
+    flow: strip whitespace and cap to the model field length so it can't bloat
+    redirect URLs (risking 414s) or exceed what the form would accept anyway.
+    """
+    max_length = List._meta.get_field("name").max_length
+    return (raw or "").strip()[:max_length]
+
+
 @login_required
 def new_list(request):
     """
@@ -639,7 +648,7 @@ def new_list(request):
     # Preserve any name typed into the home-page quick-create box.
     if request.method == "GET" and not skip_packs and not pack_ids:
         packs_url = reverse("core:lists-new-packs")
-        name = request.GET.get("name", "").strip()
+        name = _carried_list_name(request.GET.get("name"))
         if name:
             packs_url += "?" + urlencode({"name": name})
         return HttpResponseRedirect(packs_url)
@@ -743,7 +752,7 @@ def new_list_packs(request):
         )
         pack_ids = [pid for pid in sanitised_ids if pid in valid_ids]
         # Redirect with pack IDs as URL params, preserving any quick-create name
-        name = request.POST.get("name", "").strip()
+        name = _carried_list_name(request.POST.get("name"))
         url = reverse("core:lists-new")
         params = (
             [("packs", pid) for pid in pack_ids] if pack_ids else [("skip_packs", "1")]
@@ -776,7 +785,7 @@ def new_list_packs(request):
             available_packs = available_packs.filter(owner=request.user)
 
     # Quick-create name carried through from the home-page box
-    new_list_name = request.GET.get("name", "").strip()
+    new_list_name = _carried_list_name(request.GET.get("name"))
 
     # Search
     search_query = request.GET.get("q", "").strip()


### PR DESCRIPTION
## Summary

- Restack the new-list pack interstitial so the search filter spans full width, with the submit button on its own row below (previously a shared `flex-row-reverse` with the "Include selected packs" button kept the search bar from reaching full width).
- Preserve the name typed into the home-page quick-create box through the entire pack-selection flow — the redirect to the interstitial, search submissions, the final pack POST, and the "Use default content" link all carry it, so it pre-fills the new-list form.

## Test plan

- [ ] On the home page, type a list name in the quick-create box and click "Get started" — the name survives to the pack interstitial and pre-fills the new-list form after selecting (or skipping) packs.
- [ ] Searching packs / toggling "Your Packs Only" on the interstitial keeps the name.
- [ ] The search bar on the pack interstitial renders full width.
- [x] `pytest gyrinx/core/tests/test_list_packs.py` — 58 passed (4 new tests for name carry-through).