### PR TITLE
feat: responsive list/gang header and collapsible summary cards

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -506,6 +506,39 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
+// Persist collapse open/closed state in the URL.
+//
+// Used by the campaign list summary cards (Actions / Assets / Attributes),
+// which collapse in single-column view. The server renders the initial state
+// from the query param; here we mirror each Bootstrap collapse toggle back into
+// the URL (via replaceState, so it survives reload and is linkable) without a
+// navigation. The slide animation is Bootstrap's; this is purely state-syncing.
+document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("[data-gy-collapse-url]").forEach((el) => {
+        const key = el.getAttribute("data-gy-collapse-url");
+        if (!key) return;
+
+        const setParam = (open) => {
+            const url = new URL(window.location.href);
+            if (open) {
+                url.searchParams.set(key, "1");
+            } else {
+                url.searchParams.delete(key);
+            }
+            window.history.replaceState(null, "", url);
+        };
+
+        // Guard on event.target so we only react to this element's own
+        // transitions, not those of any nested collapse that bubbles up.
+        el.addEventListener("shown.bs.collapse", (event) => {
+            if (event.target === el) setParam(true);
+        });
+        el.addEventListener("hidden.bs.collapse", (event) => {
+            if (event.target === el) setParam(false);
+        });
+    });
+});
+
 // Handle collapse chevron icon rotation
 document.addEventListener("DOMContentLoaded", () => {
     // Find all elements with data-gy-collapse-icon attribute

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -677,3 +677,18 @@ $width-em-sizes: (
         height: 1.5em;
     }
 }
+
+// Campaign list summary cards (Actions / Assets & Resources / Attributes).
+// In single-column view (below lg) each card body collapses behind a chevron
+// toggle in its header (state persisted in the URL). At lg+ the cards sit side
+// by side and are always expanded, so ignore the Bootstrap collapse state and
+// reset any leftover inline height from an in-flight animation.
+@include media-breakpoint-up(lg) {
+    .list-card-collapse {
+        height: auto !important;
+
+        &:not(.show) {
+            display: block;
+        }
+    }
+}

--- a/gyrinx/core/templates/core/campaign/includes/_status_indicator.html
+++ b/gyrinx/core/templates/core/campaign/includes/_status_indicator.html
@@ -1,0 +1,14 @@
+{# Renders a campaign status. With `collapse` set, the pill becomes a coloured dot (with tooltip) below that breakpoint. #}
+{# Params: label (str), color (str — Bootstrap variant), collapse (str breakpoint e.g. "sm", optional) #}
+{% if collapse %}
+    <span class="d-inline-block d-{{ collapse }}-none rounded-circle bg-{{ color }} align-middle"
+          style="width: 0.6rem;
+                 height: 0.6rem"
+          bs-tooltip
+          data-bs-toggle="tooltip"
+          title="{{ label }}"
+          aria-label="{{ label }}"></span>
+    <span class="d-none d-{{ collapse }}-inline-block badge text-bg-{{ color }} align-middle">{{ label }}</span>
+{% else %}
+    <span class="badge text-bg-{{ color }}">{{ label }}</span>
+{% endif %}

--- a/gyrinx/core/templates/core/campaign/includes/_status_indicator.html
+++ b/gyrinx/core/templates/core/campaign/includes/_status_indicator.html
@@ -4,6 +4,8 @@
     <span class="d-inline-block d-{{ collapse }}-none rounded-circle bg-{{ color }} align-middle"
           style="width: 0.6rem;
                  height: 0.6rem"
+          role="img"
+          tabindex="0"
           bs-tooltip
           data-bs-toggle="tooltip"
           title="{{ label }}"

--- a/gyrinx/core/templates/core/campaign/includes/status.html
+++ b/gyrinx/core/templates/core/campaign/includes/status.html
@@ -1,7 +1,8 @@
+{# Campaign status indicator. Optional param: collapse — a breakpoint (e.g. "sm") below which the pill collapses to a coloured dot with a tooltip. #}
 {% if campaign.is_pre_campaign %}
-    <span class="badge text-bg-secondary">Pre-Campaign</span>
+    {% include "core/campaign/includes/_status_indicator.html" with label="Pre-Campaign" color="secondary" collapse=collapse %}
 {% elif campaign.is_in_progress %}
-    <span class="badge text-bg-success">In Progress</span>
+    {% include "core/campaign/includes/_status_indicator.html" with label="In Progress" color="success" collapse=collapse %}
 {% elif campaign.is_post_campaign %}
-    <span class="badge text-bg-secondary">Post-Campaign</span>
+    {% include "core/campaign/includes/_status_indicator.html" with label="Post-Campaign" color="secondary" collapse=collapse %}
 {% endif %}

--- a/gyrinx/core/templates/core/includes/_list_card_toggle.html
+++ b/gyrinx/core/templates/core/includes/_list_card_toggle.html
@@ -1,12 +1,12 @@
 {# Collapse toggle for the campaign list summary cards. Shown only in single-column view (below lg). #}
-{# Params: target (collapse id, no leading #), label (str), open (bool) #}
+{# Params: target (collapse id, no leading #), label (str), open (raw GET value — open only when "1") #}
 <button class="btn btn-link link-body-emphasis p-0 ms-2 lh-1 d-lg-none flex-shrink-0"
         type="button"
         data-bs-toggle="collapse"
         data-bs-target="#{{ target }}"
-        aria-expanded="{{ open|yesno:'true,false' }}"
+        aria-expanded="{% if open == '1' %}true{% else %}false{% endif %}"
         aria-controls="{{ target }}"
         aria-label="Toggle {{ label }}">
-    <i class="bi-chevron-{% if open %}up{% else %}down{% endif %} fs-6"
+    <i class="bi-chevron-{% if open == '1' %}up{% else %}down{% endif %} fs-6"
        data-gy-collapse-icon="{{ target }}"></i>
 </button>

--- a/gyrinx/core/templates/core/includes/_list_card_toggle.html
+++ b/gyrinx/core/templates/core/includes/_list_card_toggle.html
@@ -1,0 +1,12 @@
+{# Collapse toggle for the campaign list summary cards. Shown only in single-column view (below lg). #}
+{# Params: target (collapse id, no leading #), label (str), open (bool) #}
+<button class="btn btn-link link-body-emphasis p-0 ms-2 lh-1 d-lg-none flex-shrink-0"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#{{ target }}"
+        aria-expanded="{{ open|yesno:'true,false' }}"
+        aria-controls="{{ target }}"
+        aria-label="Toggle {{ label }}">
+    <i class="bi-chevron-{% if open %}up{% else %}down{% endif %} fs-6"
+       data-gy-collapse-icon="{{ target }}"></i>
+</button>

--- a/gyrinx/core/templates/core/includes/home/gang_row.html
+++ b/gyrinx/core/templates/core/includes/home/gang_row.html
@@ -10,9 +10,7 @@
             <div class="badge text-bg-primary">{% credits gang.facts_with_fallback.wealth %}</div>
             <div>
                 <a href="{% url 'core:campaign' gang.campaign.id %}"
-                   class="icon-link linked">
-                    <i class="bi-award"></i> {{ gang.campaign.name }}
-                </a>
+                   class="icon-link linked">{{ gang.campaign.name }}</a>
             </div>
         </div>
     </div>

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -13,7 +13,7 @@
     <div class="hstack">
         <div class="vstack flex-grow-1 gap-0 mb-2">
             {% include "core/includes/list_common_header.html" with list=list %}
-            <div class="d-flex flex-column flex-md-row row-gap-1 column-gap-2 align-items-md-center">
+            <div class="d-flex flex-column flex-lg-row row-gap-1 column-gap-2 align-items-lg-center">
                 <div class="d-flex flex-row flex-wrap row-gap-1 column-gap-2 fs-7">
                     {% if not print %}
                         <div>
@@ -89,7 +89,7 @@
                         {% endif %}
                     {% endif %}
                 </div>
-                <div class="flex-shrink-0 ms-md-auto mt-2 mt-md-0">
+                <div class="flex-shrink-0 ms-lg-auto mt-2 mt-lg-0">
                     {% if not print %}
                         <div class="nav hstack gap-1 flex-wrap">
                             {% if list.owner_cached == user and pending_invitations_count > 0 %}

--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -7,7 +7,7 @@
         {% endif %}
     </div>
     <div id="list-card-attributes"
-         class="{% if not print %}collapse list-card-collapse{% if request.GET.attributes_open %} show{% endif %}{% endif %}"
+         class="{% if not print %}collapse list-card-collapse{% if request.GET.attributes_open == '1' %} show{% endif %}{% endif %}"
          data-gy-collapse-url="attributes_open">
         <div class="px-2">
             {% if list.all_attributes %}

--- a/gyrinx/core/templates/core/includes/list_attributes.html
+++ b/gyrinx/core/templates/core/includes/list_attributes.html
@@ -1,89 +1,96 @@
 {% load custom_tags humanize %}
 <div class="g-col-12 {% if print %}g-col-sm-6 g-col-md-3 g-col-xl-2{% else %}g-col-md-12 g-col-lg-6 g-col-xl-4{% endif %}">
-    <div class="bg-body-tertiary rounded px-2 py-2 mb-2">
-        <h3 class="h5 mb-0">Attributes</h3>
+    <div class="bg-body-tertiary rounded px-2 py-2 mb-2 hstack gap-2 align-items-center">
+        <h3 class="h5 mb-0 flex-grow-1">Attributes</h3>
+        {% if not print %}
+            {% include "core/includes/_list_card_toggle.html" with target="list-card-attributes" label="Attributes" open=request.GET.attributes_open %}
+        {% endif %}
     </div>
-    <div class="px-2">
-        {% if list.all_attributes %}
-            {% if list.set_attributes %}
-                <table class="table table-sm table-borderless mb-0 fs-7">
-                    <tbody>
-                        {% for attribute in list.set_attributes %}
-                            <tr>
-                                <td class="ps-0">{{ attribute.name }}</td>
-                                <td>{{ attribute.assignments|join:", " }}</td>
-                                {% if not print %}
-                                    <td class="text-end pe-0">
-                                        {% if list.owner_cached == user and not list.archived %}
-                                            <a href="{% url 'core:list-attribute-edit' list.id attribute.id %}"
-                                               class="icon-link link-secondary fs-7">
-                                                <i class="bi-pencil" aria-hidden="true"></i>
-                                                Edit
-                                            </a>
-                                        {% endif %}
-                                    </td>
-                                {% endif %}
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            {% endif %}
-            {% if not print %}
-                {% if list.owner_cached == user and not list.archived %}
-                    <div class="fs-7 text-end {% if list.set_attributes %}mt-1{% endif %}">
-                        {% with unset=list.unset_attributes unset_count=list.unset_attributes|length %}
-                            {% if unset_count > 0 %}
-                                <span class="text-secondary">
-                                    {% spaceless %}
-                                        <span>Add&nbsp;</span>
-                                        {% for attr in unset|slice:":3" %}
-                                            {% if not forloop.first %}
-                                                {% if forloop.last and unset_count <= 3 %}
-                                                    <span>&nbsp;or&nbsp;</span>
-                                                {% else %}
-                                                    <span>,&nbsp;</span>
-                                                {% endif %}
+    <div id="list-card-attributes"
+         class="{% if not print %}collapse list-card-collapse{% if request.GET.attributes_open %} show{% endif %}{% endif %}"
+         data-gy-collapse-url="attributes_open">
+        <div class="px-2">
+            {% if list.all_attributes %}
+                {% if list.set_attributes %}
+                    <table class="table table-sm table-borderless mb-0 fs-7">
+                        <tbody>
+                            {% for attribute in list.set_attributes %}
+                                <tr>
+                                    <td class="ps-0">{{ attribute.name }}</td>
+                                    <td>{{ attribute.assignments|join:", " }}</td>
+                                    {% if not print %}
+                                        <td class="text-end pe-0">
+                                            {% if list.owner_cached == user and not list.archived %}
+                                                <a href="{% url 'core:list-attribute-edit' list.id attribute.id %}"
+                                                   class="icon-link link-secondary fs-7">
+                                                    <i class="bi-pencil" aria-hidden="true"></i>
+                                                    Edit
+                                                </a>
                                             {% endif %}
-                                            <a href="{% url 'core:list-attribute-edit' list.id attr.id %}"
-                                               class="linked-secondary">{{ attr.name }}</a>
-                                        {% endfor %}
-                                        {% if unset_count > 3 %}<span>&nbsp;or {{ unset_count|add:"-3" }} more...</span>{% endif %}
-                                    {% endspaceless %}
-                                </span>
-                                <span class="text-secondary mx-1">·</span>
-                            {% endif %}
-                        {% endwith %}
-                        <a href="{% url 'core:list-attributes-manage' list.id %}"
-                           class="linked-secondary">Manage</a>
-                    </div>
+                                        </td>
+                                    {% endif %}
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+                {% if not print %}
+                    {% if list.owner_cached == user and not list.archived %}
+                        <div class="fs-7 text-end {% if list.set_attributes %}mt-1{% endif %}">
+                            {% with unset=list.unset_attributes unset_count=list.unset_attributes|length %}
+                                {% if unset_count > 0 %}
+                                    <span class="text-secondary">
+                                        {% spaceless %}
+                                            <span>Add&nbsp;</span>
+                                            {% for attr in unset|slice:":3" %}
+                                                {% if not forloop.first %}
+                                                    {% if forloop.last and unset_count <= 3 %}
+                                                        <span>&nbsp;or&nbsp;</span>
+                                                    {% else %}
+                                                        <span>,&nbsp;</span>
+                                                    {% endif %}
+                                                {% endif %}
+                                                <a href="{% url 'core:list-attribute-edit' list.id attr.id %}"
+                                                   class="linked-secondary">{{ attr.name }}</a>
+                                            {% endfor %}
+                                            {% if unset_count > 3 %}<span>&nbsp;or {{ unset_count|add:"-3" }} more...</span>{% endif %}
+                                        {% endspaceless %}
+                                    </span>
+                                    <span class="text-secondary mx-1">·</span>
+                                {% endif %}
+                            {% endwith %}
+                            <a href="{% url 'core:list-attributes-manage' list.id %}"
+                               class="linked-secondary">Manage</a>
+                        </div>
+                    {% elif not list.set_attributes %}
+                        <p class="text-secondary fs-7 mb-0">No attributes set.</p>
+                    {% endif %}
                 {% elif not list.set_attributes %}
                     <p class="text-secondary fs-7 mb-0">No attributes set.</p>
                 {% endif %}
-            {% elif not list.set_attributes %}
-                <p class="text-secondary fs-7 mb-0">No attributes set.</p>
-            {% endif %}
-            {% if list.fighter_type_summary %}
-                <h4 class="caps-label mb-1 mt-3">Fighters</h4>
-                <table class="table table-borderless table-sm mb-0 fs-7">
-                    <tbody>
-                        {% for item in list.fighter_type_summary.type_totals %}
+                {% if list.fighter_type_summary %}
+                    <h4 class="caps-label mb-1 mt-3">Fighters</h4>
+                    <table class="table table-borderless table-sm mb-0 fs-7">
+                        <tbody>
+                            {% for item in list.fighter_type_summary.type_totals %}
+                                <tr>
+                                    <td class="ps-0">{{ item.type }}</td>
+                                    <td class="text-secondary">{{ item.category }}</td>
+                                    <td class="text-end pe-0">{{ item.count }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                        <tfoot>
                             <tr>
-                                <td class="ps-0">{{ item.type }}</td>
-                                <td class="text-secondary">{{ item.category }}</td>
-                                <td class="text-end pe-0">{{ item.count }}</td>
+                                <td colspan="2" class="ps-0 border-top fw-semibold">Total</td>
+                                <td class="text-end pe-0 border-top fw-semibold">{{ list.fighter_type_summary.total }}</td>
                             </tr>
-                        {% endfor %}
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <td colspan="2" class="ps-0 border-top fw-semibold">Total</td>
-                            <td class="text-end pe-0 border-top fw-semibold">{{ list.fighter_type_summary.total }}</td>
-                        </tr>
-                    </tfoot>
-                </table>
+                        </tfoot>
+                    </table>
+                {% endif %}
+            {% else %}
+                <p class="text-secondary fs-7 mb-0">No attributes available.</p>
             {% endif %}
-        {% else %}
-            <p class="text-secondary fs-7 mb-0">No attributes available.</p>
-        {% endif %}
+        </div>
     </div>
 </div>

--- a/gyrinx/core/templates/core/includes/list_campaign_actions.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_actions.html
@@ -14,7 +14,7 @@
             {% endif %}
         </div>
         <div id="list-card-actions"
-             class="{% if not print %}collapse list-card-collapse{% if request.GET.actions_open %} show{% endif %}{% endif %}"
+             class="{% if not print %}collapse list-card-collapse{% if request.GET.actions_open == '1' %} show{% endif %}{% endif %}"
              data-gy-collapse-url="actions_open">
             <div class="px-2">
                 <p class="text-secondary fs-7 mb-2">

--- a/gyrinx/core/templates/core/includes/list_campaign_actions.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_actions.html
@@ -9,24 +9,31 @@
                     <i class="bi-plus-lg" aria-hidden="true"></i> Log Action
                 </a>
             {% endif %}
-        </div>
-        <div class="px-2">
-            <p class="text-secondary fs-7 mb-2">
-                From <a href="{% url 'core:campaign' list.campaign.id %}" class="linked">{{ list.campaign.name }}</a>
-            </p>
-            {% if recent_actions %}
-                <div class="vstack gap-2">
-                    {% for action in recent_actions %}
-                        {% include "core/includes/campaign_action_item.html" with action=action campaign=list.campaign user=user show_truncated=True show_list_link=False print=print %}
-                    {% endfor %}
-                </div>
-                {% if not print %}
-                    <a href="{% url 'core:campaign-actions' list.campaign.id %}{% querystring gang=list.id %}"
-                       class="fs-7 mt-2 d-inline-block">View all actions →</a>
-                {% endif %}
-            {% else %}
-                <p class="text-secondary fs-7 mb-0">No actions logged yet.</p>
+            {% if not print %}
+                {% include "core/includes/_list_card_toggle.html" with target="list-card-actions" label="Actions" open=request.GET.actions_open %}
             {% endif %}
+        </div>
+        <div id="list-card-actions"
+             class="{% if not print %}collapse list-card-collapse{% if request.GET.actions_open %} show{% endif %}{% endif %}"
+             data-gy-collapse-url="actions_open">
+            <div class="px-2">
+                <p class="text-secondary fs-7 mb-2">
+                    From <a href="{% url 'core:campaign' list.campaign.id %}" class="linked">{{ list.campaign.name }}</a>
+                </p>
+                {% if recent_actions %}
+                    <div class="vstack gap-2">
+                        {% for action in recent_actions %}
+                            {% include "core/includes/campaign_action_item.html" with action=action campaign=list.campaign user=user show_truncated=True show_list_link=False print=print %}
+                        {% endfor %}
+                    </div>
+                    {% if not print %}
+                        <a href="{% url 'core:campaign-actions' list.campaign.id %}{% querystring gang=list.id %}"
+                           class="fs-7 mt-2 d-inline-block">View all actions →</a>
+                    {% endif %}
+                {% else %}
+                    <p class="text-secondary fs-7 mb-0">No actions logged yet.</p>
+                {% endif %}
+            </div>
         </div>
     </div>
 {% endif %}

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -1,97 +1,104 @@
 {% load custom_tags humanize %}
 {% if list.is_campaign_mode and list.campaign %}
     <div class="g-col-12 {% if print %}g-col-sm-6 g-col-md-3 g-col-xl-2{% else %}g-col-md-12 g-col-lg-6 g-col-xl-4{% endif %}">
-        <div class="bg-body-tertiary rounded px-2 py-2 mb-2">
-            <h3 class="h5 mb-0">Assets & Resources</h3>
+        <div class="bg-body-tertiary rounded px-2 py-2 mb-2 hstack gap-2 align-items-center">
+            <h3 class="h5 mb-0 flex-grow-1">Assets & Resources</h3>
+            {% if not print %}
+                {% include "core/includes/_list_card_toggle.html" with target="list-card-assets" label="Assets & Resources" open=request.GET.assets_open %}
+            {% endif %}
         </div>
-        <div class="px-2">
-            <div class="vstack gap-3">
-                {% if held_assets %}
-                    <div>
-                        <h4 class="caps-label mb-1">Assets</h4>
-                        <div class="vstack gap-1">
-                            {% for asset in held_assets %}
-                                <div class="d-flex align-items-center fs-7">
-                                    <div>
-                                        <strong>{{ asset.name }}</strong>
-                                        {% if asset.asset_type.name_singular %}
-                                            <span class="text-secondary">({{ asset.asset_type.name_singular }})</span>
+        <div id="list-card-assets"
+             class="{% if not print %}collapse list-card-collapse{% if request.GET.assets_open %} show{% endif %}{% endif %}"
+             data-gy-collapse-url="assets_open">
+            <div class="px-2">
+                <div class="vstack gap-3">
+                    {% if held_assets %}
+                        <div>
+                            <h4 class="caps-label mb-1">Assets</h4>
+                            <div class="vstack gap-1">
+                                {% for asset in held_assets %}
+                                    <div class="d-flex align-items-center fs-7">
+                                        <div>
+                                            <strong>{{ asset.name }}</strong>
+                                            {% if asset.asset_type.name_singular %}
+                                                <span class="text-secondary">({{ asset.asset_type.name_singular }})</span>
+                                            {% endif %}
+                                        </div>
+                                        {% if list.campaign.is_pre_campaign %}
+                                            <span class="text-secondary fs-7 ms-auto">Campaign not started</span>
+                                        {% elif not list.campaign.archived and not print %}
+                                            <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                               class="icon-link link-secondary fs-7 ms-auto">
+                                                <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
+                                            </a>
                                         {% endif %}
                                     </div>
-                                    {% if list.campaign.is_pre_campaign %}
-                                        <span class="text-secondary fs-7 ms-auto">Campaign not started</span>
-                                    {% elif not list.campaign.archived and not print %}
-                                        <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                           class="icon-link link-secondary fs-7 ms-auto">
-                                            <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
-                                        </a>
-                                    {% endif %}
-                                </div>
-                            {% endfor %}
+                                {% endfor %}
+                            </div>
                         </div>
-                    </div>
-                {% endif %}
-                {% if campaign_resources %}
-                    <div>
-                        <h4 class="caps-label mb-1">Resources</h4>
-                        <table class="table table-sm table-borderless mb-0 fs-7">
-                            <tbody>
-                                {% for resource in campaign_resources %}
-                                    <tr>
-                                        <td class="ps-0">{{ resource.resource_type.name }}</td>
-                                        <td class="text-end">
-                                            {% if list.campaign.is_pre_campaign %}
-                                                <span class="text-secondary">0</span>
-                                            {% else %}
-                                                {{ resource.amount }}
-                                            {% endif %}
-                                        </td>
-                                        <td class="text-end pe-0">
-                                            {% if list.campaign.is_pre_campaign %}
-                                                <span class="text-secondary fs-7">Campaign not started</span>
-                                            {% elif not list.campaign.archived and not print %}
-                                                <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                                   class="icon-link link-secondary fs-7">
-                                                    <i class="bi-pencil" aria-hidden="true"></i> Modify
-                                                </a>
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                {% endif %}
-                {% if captured_fighters %}
-                    <div>
-                        <h4 class="caps-label mb-1">Captured Fighters</h4>
-                        <table class="table table-sm table-borderless mb-0 fs-7">
-                            <tbody>
-                                {% for capture in captured_fighters %}
-                                    <tr>
-                                        <td class="ps-0">
-                                            <strong>{{ capture.fighter.name }}</strong>
-                                            <span class="text-secondary">({{ capture.fighter.list.name }})</span>
-                                        </td>
-                                        <td class="text-end pe-0">
-                                            <a href="{% url 'core:fighter-sell-to-guilders' list.campaign.id capture.fighter.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                               class="link-secondary fs-7">Sell</a>
-                                            ·
-                                            <a href="{% url 'core:fighter-return-to-owner' list.campaign.id capture.fighter.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                               class="link-secondary fs-7">Ransom</a>
-                                            ·
-                                            <a href="{% url 'core:fighter-release' list.campaign.id capture.fighter.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                               class="link-secondary fs-7">Release</a>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                {% endif %}
-                {% if not campaign_resources and not held_assets and not captured_fighters %}
-                    <p class="text-secondary fs-7 mb-0">No assets, resources, or captured fighters held.</p>
-                {% endif %}
+                    {% endif %}
+                    {% if campaign_resources %}
+                        <div>
+                            <h4 class="caps-label mb-1">Resources</h4>
+                            <table class="table table-sm table-borderless mb-0 fs-7">
+                                <tbody>
+                                    {% for resource in campaign_resources %}
+                                        <tr>
+                                            <td class="ps-0">{{ resource.resource_type.name }}</td>
+                                            <td class="text-end">
+                                                {% if list.campaign.is_pre_campaign %}
+                                                    <span class="text-secondary">0</span>
+                                                {% else %}
+                                                    {{ resource.amount }}
+                                                {% endif %}
+                                            </td>
+                                            <td class="text-end pe-0">
+                                                {% if list.campaign.is_pre_campaign %}
+                                                    <span class="text-secondary fs-7">Campaign not started</span>
+                                                {% elif not list.campaign.archived and not print %}
+                                                    <a href="{% url 'core:campaign-resource-modify' list.campaign.id resource.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                       class="icon-link link-secondary fs-7">
+                                                        <i class="bi-pencil" aria-hidden="true"></i> Modify
+                                                    </a>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% endif %}
+                    {% if captured_fighters %}
+                        <div>
+                            <h4 class="caps-label mb-1">Captured Fighters</h4>
+                            <table class="table table-sm table-borderless mb-0 fs-7">
+                                <tbody>
+                                    {% for capture in captured_fighters %}
+                                        <tr>
+                                            <td class="ps-0">
+                                                <strong>{{ capture.fighter.name }}</strong>
+                                                <span class="text-secondary">({{ capture.fighter.list.name }})</span>
+                                            </td>
+                                            <td class="text-end pe-0">
+                                                <a href="{% url 'core:fighter-sell-to-guilders' list.campaign.id capture.fighter.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                   class="link-secondary fs-7">Sell</a>
+                                                ·
+                                                <a href="{% url 'core:fighter-return-to-owner' list.campaign.id capture.fighter.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                   class="link-secondary fs-7">Ransom</a>
+                                                ·
+                                                <a href="{% url 'core:fighter-release' list.campaign.id capture.fighter.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                   class="link-secondary fs-7">Release</a>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% endif %}
+                    {% if not campaign_resources and not held_assets and not captured_fighters %}
+                        <p class="text-secondary fs-7 mb-0">No assets, resources, or captured fighters held.</p>
+                    {% endif %}
+                </div>
             </div>
         </div>
     </div>

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -8,7 +8,7 @@
             {% endif %}
         </div>
         <div id="list-card-assets"
-             class="{% if not print %}collapse list-card-collapse{% if request.GET.assets_open %} show{% endif %}{% endif %}"
+             class="{% if not print %}collapse list-card-collapse{% if request.GET.assets_open == '1' %} show{% endif %}{% endif %}"
              data-gy-collapse-url="assets_open">
             <div class="px-2">
                 <div class="vstack gap-3">

--- a/gyrinx/core/templates/core/includes/list_common_header.html
+++ b/gyrinx/core/templates/core/includes/list_common_header.html
@@ -1,97 +1,100 @@
 {% load custom_tags color_tags %}
-<div class="d-flex flex-column flex-md-row gap-2 column-gap-md-3 {% if link_list %}mb-3 pb-4 border-bottom{% else %}mb-2{% endif %} align-items-md-center break-inside-avoid">
-    <div class="vstack">
-        {% url 'core:lists' as lists_url %}
-        {% if list.is_campaign_mode %}
-            {% include "core/includes/breadcrumb.html" with type="Campaign Gang" owner=list.owner_cached name=list.name type_url=lists_url|add:"?type=gang" campaign=list.campaign print=print %}
-        {% else %}
-            {% include "core/includes/breadcrumb.html" with type="List" owner=list.owner_cached name=list.name type_url=lists_url print=print %}
-        {% endif %}
-        <h2 class="mb-0 h2">
-            {% if link_list %}
-                <a href="{% url 'core:list' list.id %}">{% list_with_theme list %}</a>
-            {% else %}
-                {% list_with_theme list %}
-            {% endif %}
-        </h2>
-    </div>
-    <div class="d-flex flex-row flex-nowrap align-items-center column-gap-3 fs-7 ms-md-auto">
-        <div class="d-flex flex-column align-items-start align-items-md-end text-md-end">
-            <div>{{ list.content_house_name }}{% house_icon list.content_house_cached %}</div>
-            {% if list.campaign %}
-                <div>
-                    {% if print %}
-                        <i class="bi-award"></i> {{ list.campaign.name }}
-                        {% include "core/campaign/includes/status.html" with campaign=list.campaign %}
-                    {% else %}
-                        <a href="{% url 'core:campaign' list.campaign.id %}"
-                           class="icon-link linked">
-                            <i class="bi-award"></i> {{ list.campaign.name }}
-                            {% include "core/campaign/includes/status.html" with campaign=list.campaign %}
-                        </a>
-                    {% endif %}
-                </div>
-            {% endif %}
+<div class="{% if link_list %}mb-3 pb-4 border-bottom{% else %}mb-2{% endif %} break-inside-avoid">
+    {# Breadcrumbs get their own full-width row so they're not squished by the stats block. #}
+    {% url 'core:lists' as lists_url %}
+    {% if list.is_campaign_mode %}
+        {% include "core/includes/breadcrumb.html" with type="Campaign Gang" owner=list.owner_cached name=list.name type_url=lists_url|add:"?type=gang" campaign=list.campaign print=print %}
+    {% else %}
+        {% include "core/includes/breadcrumb.html" with type="List" owner=list.owner_cached name=list.name type_url=lists_url print=print %}
+    {% endif %}
+    <div class="d-flex flex-column flex-xl-row gap-2 column-gap-xl-3 align-items-xl-center">
+        <div class="vstack">
+            <h2 class="mb-0 h2">
+                {% if link_list %}
+                    <a href="{% url 'core:list' list.id %}">{% list_with_theme list %}</a>
+                {% else %}
+                    {% list_with_theme list %}
+                {% endif %}
+            </h2>
         </div>
-        <div class="ms-auto ms-md-0 border-start-md ps-md-2 flex-shrink-0">
-            <table class="table table-sm table-borderless table-responsive text-center mb-0 w-auto">
-                <thead>
-                    <tr class="fs-7 align-middle">
-                        <th class="py-0 bg-transparent"
-                            bs-tooltip
-                            data-bs-toggle="tooltip"
-                            title="Rating"
-                            aria-label="Rating">R</th>
-                        <th class="py-0 bg-transparent"
-                            bs-tooltip
-                            data-bs-toggle="tooltip"
-                            title="Credits"
-                            aria-label="Credits">Cr</th>
-                        <th class="py-0 bg-transparent"
-                            bs-tooltip
-                            data-bs-toggle="tooltip"
-                            title="Stash"
-                            aria-label="Stash">St</th>
-                        <th class="py-0 bg-transparent"
-                            bs-tooltip
-                            data-bs-toggle="tooltip"
-                            title="Wealth"
-                            aria-label="Wealth">W</th>
-                        {% if not print %}
-                            {% if list.owner_cached.id == request.user.id or list.campaign and list.campaign.owner.id == request.user.id %}
-                                <th class="py-0 bg-transparent"></th>
-                            {% endif %}
+        <div class="d-flex flex-row flex-nowrap align-items-center column-gap-3 fs-7 ms-xl-auto">
+            <div class="d-flex flex-column align-items-start align-items-xl-end text-xl-end">
+                <div>{{ list.content_house_name }}{% house_icon list.content_house_cached %}</div>
+                {% if list.campaign %}
+                    <div>
+                        {% if print %}
+                            {{ list.campaign.name }}
+                            {% include "core/campaign/includes/status.html" with campaign=list.campaign %}
+                        {% else %}
+                            <a href="{% url 'core:campaign' list.campaign.id %}"
+                               class="icon-link linked">
+                                {{ list.campaign.name }}
+                                {% include "core/campaign/includes/status.html" with campaign=list.campaign collapse="sm" %}
+                            </a>
                         {% endif %}
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr class="fs-6 align-middle">
-                        <td class="py-0 bg-transparent">{{ list.rating_display }}</td>
-                        <td class="py-0 bg-transparent">{{ list.credits_current_display }}</td>
-                        <td class="py-0 bg-transparent">{{ list.stash_fighter_cost_display }}</td>
-                        <td class="py-0 bg-transparent">{{ list.cost_display }}</td>
-                        {% if not print %}
-                            {% if list.owner_cached.id == request.user.id or list.campaign and list.campaign.owner.id == request.user.id %}
-                                <td class="py-0 bg-transparent align-middle">
-                                    <form method="post"
-                                          action="{% url 'core:list-refresh-cost' list.id %}"
-                                          class="d-inline">
-                                        {% csrf_token %}
-                                        <button type="submit"
-                                                class="btn btn-link btn-sm p-0 text-secondary"
-                                                bs-tooltip
-                                                data-bs-toggle="tooltip"
-                                                title="Refresh rating &amp; wealth"
-                                                aria-label="Refresh rating &amp; wealth">
-                                            <i class="bi-arrow-clockwise"></i>
-                                        </button>
-                                    </form>
-                                </td>
+                    </div>
+                {% endif %}
+            </div>
+            <div class="ms-auto ms-xl-0 border-start-xl ps-xl-2 flex-shrink-0">
+                <table class="table table-sm table-borderless table-responsive text-center mb-0 w-auto">
+                    <thead>
+                        <tr class="fs-7 align-middle">
+                            <th class="py-0 bg-transparent"
+                                bs-tooltip
+                                data-bs-toggle="tooltip"
+                                title="Rating"
+                                aria-label="Rating">R</th>
+                            <th class="py-0 bg-transparent"
+                                bs-tooltip
+                                data-bs-toggle="tooltip"
+                                title="Credits"
+                                aria-label="Credits">Cr</th>
+                            <th class="py-0 bg-transparent"
+                                bs-tooltip
+                                data-bs-toggle="tooltip"
+                                title="Stash"
+                                aria-label="Stash">St</th>
+                            <th class="py-0 bg-transparent"
+                                bs-tooltip
+                                data-bs-toggle="tooltip"
+                                title="Wealth"
+                                aria-label="Wealth">W</th>
+                            {% if not print %}
+                                {% if list.owner_cached.id == request.user.id or list.campaign and list.campaign.owner.id == request.user.id %}
+                                    <th class="py-0 bg-transparent"></th>
+                                {% endif %}
                             {% endif %}
-                        {% endif %}
-                    </tr>
-                </tbody>
-            </table>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr class="fs-6 align-middle">
+                            <td class="py-0 bg-transparent">{{ list.rating_display }}</td>
+                            <td class="py-0 bg-transparent">{{ list.credits_current_display }}</td>
+                            <td class="py-0 bg-transparent">{{ list.stash_fighter_cost_display }}</td>
+                            <td class="py-0 bg-transparent">{{ list.cost_display }}</td>
+                            {% if not print %}
+                                {% if list.owner_cached.id == request.user.id or list.campaign and list.campaign.owner.id == request.user.id %}
+                                    <td class="py-0 bg-transparent align-middle">
+                                        <form method="post"
+                                              action="{% url 'core:list-refresh-cost' list.id %}"
+                                              class="d-inline">
+                                            {% csrf_token %}
+                                            <button type="submit"
+                                                    class="btn btn-link btn-sm p-0 text-secondary"
+                                                    bs-tooltip
+                                                    data-bs-toggle="tooltip"
+                                                    title="Refresh rating &amp; wealth"
+                                                    aria-label="Refresh rating &amp; wealth">
+                                                <i class="bi-arrow-clockwise"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                {% endif %}
+                            {% endif %}
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/gyrinx/core/templates/core/includes/list_row.html
+++ b/gyrinx/core/templates/core/includes/list_row.html
@@ -18,7 +18,7 @@ Expects `list` in context.{% endcomment %}
                 <div>
                     <a href="{% url 'core:campaign' list.campaign.id %}"
                        class="icon-link linked">
-                        <i class="bi-award"></i> {{ list.campaign.name }}
+                        {{ list.campaign.name }}
                         {% include "core/campaign/includes/status.html" with campaign=list.campaign %}
                     </a>
                 </div>

--- a/gyrinx/core/templates/core/pack/pack_lists.html
+++ b/gyrinx/core/templates/core/pack/pack_lists.html
@@ -25,9 +25,7 @@
                                 <div class="hstack column-gap-2 row-gap-1 flex-wrap">
                                     <div>{{ list.content_house }}{% house_icon list.content_house_cached %}</div>
                                     {% if list.status == list.CAMPAIGN_MODE %}
-                                        <div class="badge text-bg-success">
-                                            <i class="bi-award"></i> Campaign: {{ list.campaign.name }}
-                                        </div>
+                                        <div class="badge text-bg-success">Campaign: {{ list.campaign.name }}</div>
                                     {% else %}
                                         <div class="badge text-bg-secondary">
                                             <i class="bi-list-ul"></i> List
@@ -88,9 +86,7 @@
                             <div class="hstack column-gap-2 row-gap-1 flex-wrap">
                                 <div>{{ list.content_house }}{% house_icon list.content_house_cached %}</div>
                                 {% if list.status == list.CAMPAIGN_MODE %}
-                                    <div class="badge text-bg-success">
-                                        <i class="bi-award"></i> Campaign: {{ list.campaign.name }}
-                                    </div>
+                                    <div class="badge text-bg-success">Campaign: {{ list.campaign.name }}</div>
                                 {% else %}
                                     <div class="badge text-bg-secondary">
                                         <i class="bi-list-ul"></i> List

--- a/gyrinx/core/tests/test_list_status.py
+++ b/gyrinx/core/tests/test_list_status.py
@@ -457,5 +457,40 @@ def test_list_with_campaign_mode_but_no_campaign(client):
     # The page should render successfully and contain the list name
     assert b"Campaign List without Campaign" in response.content
 
-    # Should NOT show campaign info since there's no campaign
-    assert b"bi-award" not in response.content  # Campaign icon should not appear
+    # Should NOT show campaign-only UI (the campaign Actions/Assets cards) since
+    # there's no campaign.
+    assert b"list-card-actions" not in response.content
+    assert b"list-card-assets" not in response.content
+
+
+@pytest.mark.django_db
+def test_summary_cards_collapse_state_from_url(client, user, list_with_campaign):
+    """Campaign summary cards collapse by default; they open only for ?<card>_open=1."""
+    client.force_login(user)
+    url = reverse("core:list", args=[list_with_campaign.id])
+
+    # Default: cards present (with URL-sync hooks) but not expanded.
+    html = client.get(url).content.decode()
+    assert 'id="list-card-actions"' in html
+    assert 'data-gy-collapse-url="actions_open"' in html
+    assert "list-card-collapse show" not in html
+
+    # Explicit open via the "1" value.
+    html_open = client.get(url + "?actions_open=1").content.decode()
+    assert "list-card-collapse show" in html_open
+
+    # A non-"1" value must NOT open the card (guards against a truthy-string bug
+    # where ?actions_open=0 would expand it).
+    html_zero = client.get(url + "?actions_open=0").content.decode()
+    assert "list-card-collapse show" not in html_zero
+
+
+@pytest.mark.django_db
+def test_summary_cards_not_collapsible_in_print(client, user, list_with_campaign):
+    """Print output renders the card bodies without a collapse wrapper or toggles."""
+    client.force_login(user)
+    html = client.get(
+        reverse("core:list-print", args=[list_with_campaign.id])
+    ).content.decode()
+    assert "list-card-collapse" not in html
+    assert 'data-bs-toggle="collapse"' not in html


### PR DESCRIPTION
## Summary

- Reworks the list/gang header so it degrades cleanly as the viewport narrows: breadcrumbs get their own full-width row, the title/stats split stays stacked until `xl`, the campaign status pill collapses to a colour-coded dot (with tooltip) below `sm`, and the meta-links-above-buttons stack now holds until `lg`.
- Drops the rosette (`bi-award`) icon from the campaign-membership indicator app-wide (header, list rows, home gang rows, pack-list badges); labelled controls like "Active in Campaigns", the invitations button, and the "Add to… Campaign" menu action keep theirs.
- Makes the campaign **Actions / Assets & Resources / Attributes** summary cards collapsible in single-column view — collapsed by default, state stored in the URL (`?actions_open=1` etc.), Bootstrap slide animation. At `lg`+ the cards sit side-by-side and are always open; print output is unaffected.

## Test plan

- [ ] Open a campaign-mode gang at desktop width — header looks as before; summary cards all expanded with no chevrons.
- [ ] Narrow to tablet/phone — breadcrumbs stay on one row, title/stats stack, status pill becomes a coloured dot below ~576px, meta links sit above the action buttons.
- [ ] On mobile, the three summary cards are collapsed by default; tapping a chevron slides the body open and updates the URL (`?actions_open=1`); reload restores the open state.
- [ ] Print a gang (`/list/<id>/print`) — all three cards render fully expanded with no toggles.
- [ ] Confirm the campaign rosette icon is gone from list rows, home gang rows, and pack-list campaign badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)