### PR TITLE
fix: show pre-campaign gangs on start-campaign form (#1886)

### DIFF
--- a/gyrinx/core/tests/test_campaign_status.py
+++ b/gyrinx/core/tests/test_campaign_status.py
@@ -106,6 +106,41 @@ def test_campaign_status_transitions(client):
 
 
 @pytest.mark.django_db
+def test_campaign_start_page_lists_precampaign_gangs(client):
+    """Regression test for #1886.
+
+    Gangs added during the pre-campaign phase are linked via the `lists` M2M, not
+    the `campaign` FK (which is only set on clones created at start). The start
+    confirmation page must read from the M2M so those gangs are displayed.
+    """
+    user = User.objects.create_user(username="testuser", password="password")
+    client.login(username="testuser", password="password")
+
+    house = ContentHouse.objects.create(name="Test House")
+
+    campaign = Campaign.objects.create_with_user(
+        user=user,
+        name="Test Campaign",
+        owner=user,
+        status=Campaign.PRE_CAMPAIGN,
+    )
+
+    gang = List.objects.create_with_user(
+        user=user,
+        name="Pre-Campaign Gang",
+        owner=user,
+        content_house=house,
+    )
+    # Linked via the pre-campaign M2M only; the `campaign` FK stays unset.
+    campaign.lists.add(gang)
+    assert gang.campaign_id is None
+
+    response = client.get(reverse("core:campaign-start", args=[campaign.id]))
+    assert response.status_code == 200
+    assert b"Pre-Campaign Gang" in response.content
+
+
+@pytest.mark.django_db
 def test_campaign_reopen_functionality(client):
     """Test that ended campaigns can be reopened."""
     owner = User.objects.create_user(username="owner", password="password")

--- a/gyrinx/core/views/campaign/lifecycle.py
+++ b/gyrinx/core/views/campaign/lifecycle.py
@@ -12,7 +12,6 @@ from gyrinx import messages
 from gyrinx.core.handlers.campaign_operations import handle_campaign_start
 from gyrinx.core.models.campaign import Campaign, CampaignAction
 from gyrinx.core.models.events import EventNoun, EventVerb, log_event
-from gyrinx.core.models.list import List
 from gyrinx.core.utils import safe_redirect, toggle_membership
 from gyrinx.tracker import track
 
@@ -75,12 +74,10 @@ def start_campaign(request, id):
         messages.error(request, "This campaign cannot be started.")
         return HttpResponseRedirect(reverse("core:campaign", args=(campaign.id,)))
 
-    # Prefetch lists with latest actions for efficient facts_with_fallback() in template
-    lists = (
-        List.objects.filter(campaign=campaign)
-        .select_related("owner")
-        .with_latest_actions()
-    )
+    # Prefetch lists with latest actions for efficient facts_with_fallback() in template.
+    # Pre-campaign gangs are linked via the `lists` M2M; the `campaign` FK on List is only
+    # populated when clones are created at start, so it must not be used here (see #1886).
+    lists = campaign.lists.select_related("owner").with_latest_actions()
 
     return render(
         request,


### PR DESCRIPTION
Fixes #1886.

## Problem

The start-campaign confirmation page showed no gangs even when gangs had been added during the pre-campaign phase.

## Cause

The view's GET branch queried `List.objects.filter(campaign=campaign)` — the `campaign` **FK** on `List`. That FK is only populated when campaign-mode clones are created *at start*, so during the pre-campaign phase nothing matched and the page rendered an empty list.

Pre-campaign gangs are linked via the `campaign.lists` **M2M** (`related_name="campaigns"`), which is what the start handler (`handle_campaign_start`) and every other campaign view already use. `lifecycle.py` was the lone outlier.

## Fix

Query `campaign.lists` instead. Also removed the now-unused `List` import.

## Test

Added a regression test (`test_campaign_start_page_lists_precampaign_gangs`) that links a gang via the M2M only (FK stays unset) and asserts its name renders on the GET start page. Verified it fails against the old FK query and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)