### PR TITLE
fix: pack-content fighters break content admin inline saves

### DIFF
--- a/gyrinx/conftest.py
+++ b/gyrinx/conftest.py
@@ -631,6 +631,43 @@ def pack_fighter(pack, content_house):
 
 
 @pytest.fixture
+def make_pack_fighter(make_pack, make_content_fighter, user):
+    """Factory fixture to create a fighter that belongs to a content pack.
+
+    Pack content is excluded by the default content manager but surfaced by
+    ``all_content()`` (and so by the content admin inlines).
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    def make_pack_fighter_(
+        house,
+        owner=None,
+        type="Pack Fighter",
+        category=FighterCategoryChoices.GANGER,
+        base_cost=50,
+        **kwargs,
+    ):
+        owner = owner or user
+        fighter = make_content_fighter(
+            type=type,
+            category=category,
+            house=house,
+            base_cost=base_cost,
+            **kwargs,
+        )
+        pack = make_pack(name="Test Pack", owner=owner)
+        CustomContentPackItem.objects.create(
+            pack=pack,
+            content_type=ContentType.objects.get_for_model(ContentFighter),
+            object_id=fighter.pk,
+            owner=pack.owner,
+        )
+        return fighter
+
+    return make_pack_fighter_
+
+
+@pytest.fixture
 def pack_rule(pack, cc_user):
     """A rule in a pack."""
     from gyrinx.content.models import ContentRule

--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -149,7 +149,9 @@ class _AllContentInlineMixin:
     the errors below" with no visible error and the row can never be saved.
 
     To keep the display and validation querysets consistent, ``get_formset``
-    widens the pk field's queryset to ``all_content()`` as well.
+    binds the pk field's queryset to the formset's own queryset (which uses
+    ``all_content()`` and is filtered to the parent instance) instead of the
+    default manager.
     """
 
     show_change_link = True
@@ -177,10 +179,13 @@ class _AllContentInlineMixin:
                 super().add_fields(form, index)
                 pk_field = form.fields.get(pk_name)
                 # The pk field is a ModelChoiceField bound to the default
-                # manager (no pack content). Widen it so pack-content rows that
-                # this inline displays also validate.
+                # manager, which excludes pack content — so pack-content rows
+                # this inline displays would fail validation on their hidden id.
+                # Bind it to the formset's queryset instead: it includes pack
+                # content (all_content()) yet stays scoped to this parent, so a
+                # crafted POST can't smuggle in an unrelated object's pk.
                 if pk_field is not None and hasattr(pk_field, "queryset"):
-                    pk_field.queryset = manager.all_content()
+                    pk_field.queryset = self.get_queryset()
 
         return AllContentFormSet
 

--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -133,7 +133,25 @@ class ContentAdmin(admin.ModelAdmin):
         return fields
 
 
-class ContentTabularInline(admin.TabularInline):
+class _AllContentInlineMixin:
+    """Shared behaviour for content inlines that surface pack content.
+
+    Content managers exclude pack content by default; ``all_content()``
+    bypasses that filter. These inlines display *all* content (including pack
+    items) so it can be managed from the admin.
+
+    The catch: Django builds the inline formset's primary-key field as a
+    ``ModelChoiceField`` whose queryset comes from ``model._default_manager``,
+    which excludes pack content. So a pack-content row renders fine but fails
+    validation on its hidden ``id`` field with "Select a valid choice…". That
+    error is never displayed (the tabular template doesn't render hidden-field
+    errors), yet ``AdminErrorList`` counts it — the page shows "Please correct
+    the errors below" with no visible error and the row can never be saved.
+
+    To keep the display and validation querysets consistent, ``get_formset``
+    widens the pk field's queryset to ``all_content()`` as well.
+    """
+
     show_change_link = True
 
     def get_queryset(self, request):
@@ -146,19 +164,33 @@ class ContentTabularInline(admin.TabularInline):
             return qs
         return super().get_queryset(request)
 
-
-class ContentStackedInline(admin.StackedInline):
-    show_change_link = True
-
-    def get_queryset(self, request):
+    def get_formset(self, request, obj=None, **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
         manager = self.model._default_manager
-        if hasattr(manager, "all_content"):
-            qs = manager.all_content()
-            ordering = self.get_ordering(request)
-            if ordering:
-                qs = qs.order_by(*ordering)
-            return qs
-        return super().get_queryset(request)
+        if not hasattr(manager, "all_content"):
+            return formset
+
+        pk_name = self.model._meta.pk.name
+
+        class AllContentFormSet(formset):
+            def add_fields(self, form, index):
+                super().add_fields(form, index)
+                pk_field = form.fields.get(pk_name)
+                # The pk field is a ModelChoiceField bound to the default
+                # manager (no pack content). Widen it so pack-content rows that
+                # this inline displays also validate.
+                if pk_field is not None and hasattr(pk_field, "queryset"):
+                    pk_field.queryset = manager.all_content()
+
+        return AllContentFormSet
+
+
+class ContentTabularInline(_AllContentInlineMixin, admin.TabularInline):
+    pass
+
+
+class ContentStackedInline(_AllContentInlineMixin, admin.StackedInline):
+    pass
 
 
 class ContentStackedPolymorphicInline(

--- a/gyrinx/content/tests/test_admin_house_inline.py
+++ b/gyrinx/content/tests/test_admin_house_inline.py
@@ -124,8 +124,11 @@ def test_house_inline_formset_pk_field_includes_pack_content(admin_user):
     request = RequestFactory().get(f"/admin/content/contenthouse/{house.pk}/change/")
     request.user = admin_user
     admin = ContentHouseAdmin(ContentHouse, AdminSite())
-    inline = admin.get_inline_instances(request, house)[1]
-    assert isinstance(inline, ContentFighterInline)
+    inline = next(
+        i
+        for i in admin.get_inline_instances(request, house)
+        if isinstance(i, ContentFighterInline)
+    )
 
     fighters = list(inline.get_queryset(request).filter(house=house))
     assert {f.pk for f in fighters} == {normal.pk, pack_fighter.pk}

--- a/gyrinx/content/tests/test_admin_house_inline.py
+++ b/gyrinx/content/tests/test_admin_house_inline.py
@@ -1,7 +1,8 @@
 import pytest
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
-from django.test import RequestFactory
+from django.contrib.contenttypes.models import ContentType
+from django.test import Client, RequestFactory
 
 from gyrinx.content.admin import ContentFighterInline, ContentHouseAdmin
 from gyrinx.content.models import (
@@ -11,8 +12,25 @@ from gyrinx.content.models import (
     ContentSkill,
     ContentSkillCategory,
 )
+from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 
 User = get_user_model()
+
+
+def _make_pack_fighter(house, owner, **kwargs):
+    """Create a fighter and attach it to a pack so it becomes pack content.
+
+    Pack content is excluded by the default content manager but surfaced by
+    ``all_content()`` — which is what the admin inlines display.
+    """
+    fighter = ContentFighter.objects.create(house=house, **kwargs)
+    pack = CustomContentPack.objects.create(name="Test Pack", owner=owner)
+    CustomContentPackItem.objects.create(
+        pack=pack,
+        content_type=ContentType.objects.get_for_model(ContentFighter),
+        object_id=fighter.id,
+    )
+    return fighter
 
 
 @pytest.fixture
@@ -81,3 +99,99 @@ def test_house_change_page_does_not_render_m2m_option_explosion(admin_user):
     assert 'name="contentfighter_set-0-secondary_skill_categories"' not in html
     # The cheap scalar field is present, and the inline still lists the fighters.
     assert 'name="contentfighter_set-0-base_cost"' in html
+
+
+@pytest.mark.django_db
+def test_house_inline_formset_pk_field_includes_pack_content(admin_user):
+    """The inline displays pack-content fighters (via ``all_content()``), so the
+    formset's hidden pk field must validate against ``all_content()`` too.
+
+    Otherwise the pk field's ``ModelChoiceField`` (built from the default
+    manager, which excludes pack content) rejects pack-content rows with a
+    "Select a valid choice…" error on the hidden ``id`` field — counted by
+    ``AdminErrorList`` (so the "Please correct the errors below" banner shows)
+    but never rendered, leaving the house unsaveable. Regression for the silent
+    admin error.
+    """
+    house = ContentHouse.objects.create(name="Packed House")
+    normal = ContentFighter.objects.create(
+        house=house, type="Normal Leader", category="LEADER", base_cost=100
+    )
+    pack_fighter = _make_pack_fighter(
+        house, admin_user, type="Pack Ganger", category="GANGER", base_cost=50
+    )
+
+    request = RequestFactory().get(f"/admin/content/contenthouse/{house.pk}/change/")
+    request.user = admin_user
+    admin = ContentHouseAdmin(ContentHouse, AdminSite())
+    inline = admin.get_inline_instances(request, house)[1]
+    assert isinstance(inline, ContentFighterInline)
+
+    fighters = list(inline.get_queryset(request).filter(house=house))
+    assert {f.pk for f in fighters} == {normal.pk, pack_fighter.pk}
+
+    FormSet = inline.get_formset(request, house)
+    data = {
+        "contentfighter_set-TOTAL_FORMS": str(len(fighters)),
+        "contentfighter_set-INITIAL_FORMS": str(len(fighters)),
+        "contentfighter_set-MIN_NUM_FORMS": "0",
+        "contentfighter_set-MAX_NUM_FORMS": "1000",
+    }
+    for i, f in enumerate(fighters):
+        data[f"contentfighter_set-{i}-id"] = str(f.id)
+        data[f"contentfighter_set-{i}-house"] = str(house.id)
+        data[f"contentfighter_set-{i}-type"] = f.type
+        data[f"contentfighter_set-{i}-category"] = f.category
+        data[f"contentfighter_set-{i}-base_cost"] = str(f.base_cost)
+
+    formset = FormSet(data=data, instance=house, queryset=inline.get_queryset(request))
+    assert formset.is_valid(), formset.errors
+    # No form carries a hidden-field error on its pk.
+    for form in formset.forms:
+        assert "id" not in form.errors
+
+
+@pytest.mark.django_db
+def test_house_change_page_saves_with_pack_content_fighter(admin_user):
+    """End-to-end: saving a house whose inline includes a pack-content fighter
+    must succeed (redirect), not silently fail with the no-error banner.
+    """
+    house = ContentHouse.objects.create(name="Packed House E2E")
+    normal = ContentFighter.objects.create(
+        house=house, type="Normal Leader", category="LEADER", base_cost=100
+    )
+    pack_fighter = _make_pack_fighter(
+        house, admin_user, type="Pack Ganger", category="GANGER", base_cost=50
+    )
+    fighters = [normal, pack_fighter]
+
+    client = Client()
+    client.force_login(admin_user)
+    url = f"/admin/content/contenthouse/{house.pk}/change/"
+
+    data = {
+        "name": house.name,
+        "description": "",
+        "gang_skill_tree_count": "0",
+        "skill_rank_rules-TOTAL_FORMS": "0",
+        "skill_rank_rules-INITIAL_FORMS": "0",
+        "skill_rank_rules-MIN_NUM_FORMS": "0",
+        "skill_rank_rules-MAX_NUM_FORMS": "1000",
+        "contentfighter_set-TOTAL_FORMS": str(len(fighters)),
+        "contentfighter_set-INITIAL_FORMS": str(len(fighters)),
+        "contentfighter_set-MIN_NUM_FORMS": "0",
+        "contentfighter_set-MAX_NUM_FORMS": "1000",
+    }
+    for i, f in enumerate(fighters):
+        data[f"contentfighter_set-{i}-id"] = str(f.id)
+        data[f"contentfighter_set-{i}-house"] = str(house.id)
+        data[f"contentfighter_set-{i}-type"] = f.type
+        data[f"contentfighter_set-{i}-category"] = f.category
+        data[f"contentfighter_set-{i}-base_cost"] = str(f.base_cost)
+
+    response = client.post(url, data)
+    assert response.status_code == 302, (
+        "expected a redirect on successful save; got "
+        f"{response.status_code} with errors banner present="
+        f"{b'Please correct the errors below' in response.content}"
+    )

--- a/gyrinx/content/tests/test_admin_house_inline.py
+++ b/gyrinx/content/tests/test_admin_house_inline.py
@@ -1,7 +1,6 @@
 import pytest
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
 from django.test import Client, RequestFactory
 
 from gyrinx.content.admin import ContentFighterInline, ContentHouseAdmin
@@ -12,25 +11,8 @@ from gyrinx.content.models import (
     ContentSkill,
     ContentSkillCategory,
 )
-from gyrinx.core.models.pack import CustomContentPack, CustomContentPackItem
 
 User = get_user_model()
-
-
-def _make_pack_fighter(house, owner, **kwargs):
-    """Create a fighter and attach it to a pack so it becomes pack content.
-
-    Pack content is excluded by the default content manager but surfaced by
-    ``all_content()`` — which is what the admin inlines display.
-    """
-    fighter = ContentFighter.objects.create(house=house, **kwargs)
-    pack = CustomContentPack.objects.create(name="Test Pack", owner=owner)
-    CustomContentPackItem.objects.create(
-        pack=pack,
-        content_type=ContentType.objects.get_for_model(ContentFighter),
-        object_id=fighter.id,
-    )
-    return fighter
 
 
 @pytest.fixture
@@ -102,7 +84,9 @@ def test_house_change_page_does_not_render_m2m_option_explosion(admin_user):
 
 
 @pytest.mark.django_db
-def test_house_inline_formset_pk_field_includes_pack_content(admin_user):
+def test_house_inline_formset_pk_field_includes_pack_content(
+    admin_user, make_pack_fighter
+):
     """The inline displays pack-content fighters (via ``all_content()``), so the
     formset's hidden pk field must validate against ``all_content()`` too.
 
@@ -117,7 +101,7 @@ def test_house_inline_formset_pk_field_includes_pack_content(admin_user):
     normal = ContentFighter.objects.create(
         house=house, type="Normal Leader", category="LEADER", base_cost=100
     )
-    pack_fighter = _make_pack_fighter(
+    pack_fighter = make_pack_fighter(
         house, admin_user, type="Pack Ganger", category="GANGER", base_cost=50
     )
 
@@ -155,7 +139,9 @@ def test_house_inline_formset_pk_field_includes_pack_content(admin_user):
 
 
 @pytest.mark.django_db
-def test_house_change_page_saves_with_pack_content_fighter(admin_user):
+def test_house_change_page_saves_with_pack_content_fighter(
+    admin_user, make_pack_fighter
+):
     """End-to-end: saving a house whose inline includes a pack-content fighter
     must succeed (redirect), not silently fail with the no-error banner.
     """
@@ -163,7 +149,7 @@ def test_house_change_page_saves_with_pack_content_fighter(admin_user):
     normal = ContentFighter.objects.create(
         house=house, type="Normal Leader", category="LEADER", base_cost=100
     )
-    pack_fighter = _make_pack_fighter(
+    pack_fighter = make_pack_fighter(
         house, admin_user, type="Pack Ganger", category="GANGER", base_cost=50
     )
     fighters = [normal, pack_fighter]


### PR DESCRIPTION
## Problem

The ContentHouse admin change page (and any content admin with an inline) silently fails to save when the inline contains pack-content rows. The page shows *"Please correct the errors below"* with no visible error, and the object can never be saved. This affects e.g. the Venators (AN) house, which has pack-content fighters.

## Cause

`ContentTabularInline`/`ContentStackedInline` display all content including pack items via `all_content()`. But Django builds the inline formset's hidden primary-key field as a `ModelChoiceField` bound to `model._default_manager`, which **excludes pack content**. A pack-content row renders fine but fails validation on its hidden `id` field with "Select a valid choice…". The tabular template doesn't render hidden-field errors, yet `AdminErrorList` counts them — hence the banner with nothing shown.

## Fix

Widen the inline formset's pk field queryset to `all_content()` so the display and validation querysets are consistent. Done in the shared base mixin so it applies to all content inlines.

## Tests

- `test_house_inline_formset_pk_field_includes_pack_content` — the formset validates a pack-content fighter row without an error on the hidden `id` field.
- `test_house_change_page_saves_with_pack_content_fighter` — end-to-end POST of a house with a pack-content fighter redirects (saves) instead of showing the no-error banner.

Both fail without the fix and pass with it. Full content suite (253 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)