### PR TITLE
fix: stop flatpage headings running onto the same line

### DIFF
--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -595,6 +595,17 @@ $width-em-sizes: (
 
 // Flatpage heading link icons - only visible on hover/focus
 // Icons are positioned absolutely so they don't affect layout
+// The wrapping anchor is inline by default, so consecutive short headings can
+// flow onto the same line. Force it to block so each heading occupies its own row.
+.flatpage-content a:has(> h1),
+.flatpage-content a:has(> h2),
+.flatpage-content a:has(> h3),
+.flatpage-content a:has(> h4),
+.flatpage-content a:has(> h5),
+.flatpage-content a:has(> h6) {
+    display: block;
+}
+
 .flatpage-content a > h1,
 .flatpage-content a > h2,
 .flatpage-content a > h3,

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -593,19 +593,15 @@ $width-em-sizes: (
     }
 }
 
-// Flatpage heading link icons - only visible on hover/focus
-// Icons are positioned absolutely so they don't affect layout
-// The wrapping anchor is inline by default, so consecutive short headings can
-// flow onto the same line. Force it to block so each heading occupies its own row.
-.flatpage-content a:has(> h1),
-.flatpage-content a:has(> h2),
-.flatpage-content a:has(> h3),
-.flatpage-content a:has(> h4),
-.flatpage-content a:has(> h5),
-.flatpage-content a:has(> h6) {
+// Flatpage headings are wrapped in an anchor by add_heading_links. That anchor
+// is inline by default, so consecutive short headings can flow onto the same
+// line. Force it to block so each heading occupies its own row.
+.flatpage-content a:has(> :is(h1, h2, h3, h4, h5, h6)) {
     display: block;
 }
 
+// Flatpage heading link icons - only visible on hover/focus
+// Icons are positioned absolutely so they don't affect layout
 .flatpage-content a > h1,
 .flatpage-content a > h2,
 .flatpage-content a > h3,


### PR DESCRIPTION
## Summary

- On help/flatpages, short consecutive headings (e.g. an H3 followed by an H4) could render side-by-side on the same line instead of stacking.
- Each heading is wrapped in an anchor for its "copy link" icon, and that anchor is `display: inline` by default — so two short wrapped headings could flow next to each other within the column width.
- This forces the heading-wrapping anchor to `display: block` so every heading occupies its own row with normal spacing below.

The link-icon-on-hover behaviour is unchanged: the heading itself stays `inline-block`, so the absolutely-positioned link icon still sits immediately after the heading text.

## Test plan

- [ ] Visit a help page with adjacent headings (e.g. `/help/tipsandtricksforlists/`) and confirm each heading is on its own line with space below.
- [ ] Hover a heading and confirm the link icon still appears right after the text, not at the far edge of the row.

Closes #1891