### PR TITLE
fix: index.js bugs + Bootstrap SRI — #1867 Tranche A

### DIFF
--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -202,10 +202,9 @@ document.querySelectorAll("[data-clipboard-text]").forEach((element) => {
 
 // Support syncing two or more form elements
 document.querySelectorAll("[data-gy-sync]").forEach((element) => {
+    const key = element.getAttribute("data-gy-sync");
     const targets = Array.from(
-        document.querySelectorAll(
-            `[data-gy-sync=${element.getAttribute("data-gy-sync")}`,
-        ),
+        document.querySelectorAll(`[data-gy-sync="${CSS.escape(key)}"]`),
     ).filter((target) => target !== element);
 
     if (targets.length === 0) return;
@@ -222,76 +221,11 @@ document.querySelectorAll("[data-gy-sync]").forEach((element) => {
     element.addEventListener("input", dispatch);
 });
 
-// Equipment list filter toggle functionality
-document.addEventListener("DOMContentLoaded", () => {
-    const filterSwitch = document.getElementById("filter-switch");
-
-    // Find the availability button by its ID
-    const availabilityButton = document.getElementById(
-        "availability-dropdown-button",
-    );
-
-    if (filterSwitch && availabilityButton) {
-        filterSwitch.addEventListener("change", (event) => {
-            if (event.target.checked) {
-                // Equipment list is ON - disable availability
-                availabilityButton.classList.add("disabled");
-                availabilityButton.setAttribute("disabled", "");
-                availabilityButton.removeAttribute("data-bs-toggle");
-                availabilityButton.removeAttribute("aria-expanded");
-                availabilityButton.removeAttribute("data-bs-auto-close");
-
-                // Remove existing tooltip if any
-                const existingTooltip = bootstrap.Tooltip.getInstance(
-                    availabilityButton.parentElement,
-                );
-                if (existingTooltip) {
-                    existingTooltip.dispose();
-                }
-
-                // Add tooltip
-                availabilityButton.parentElement.setAttribute(
-                    "data-bs-toggle",
-                    "tooltip",
-                );
-                availabilityButton.parentElement.setAttribute(
-                    "data-bs-placement",
-                    "top",
-                );
-                availabilityButton.parentElement.setAttribute(
-                    "title",
-                    "Availability filters are disabled when Equipment List is toggled on. All equipment on the fighter's equipment list is shown regardless of availability.",
-                );
-                new bootstrap.Tooltip(availabilityButton.parentElement);
-            } else {
-                // Equipment list is OFF - enable availability
-                availabilityButton.classList.remove("disabled");
-                availabilityButton.removeAttribute("disabled");
-                availabilityButton.setAttribute("data-bs-toggle", "dropdown");
-                availabilityButton.setAttribute("aria-expanded", "false");
-                availabilityButton.setAttribute(
-                    "data-bs-auto-close",
-                    "outside",
-                );
-
-                // Remove tooltip
-                const tooltip = bootstrap.Tooltip.getInstance(
-                    availabilityButton.parentElement,
-                );
-                if (tooltip) {
-                    tooltip.dispose();
-                }
-                availabilityButton.parentElement.removeAttribute(
-                    "data-bs-toggle",
-                );
-                availabilityButton.parentElement.removeAttribute(
-                    "data-bs-placement",
-                );
-                availabilityButton.parentElement.removeAttribute("title");
-            }
-        });
-    }
-});
+// The availability dropdown's disabled state + tooltip when the equipment-list
+// filter is on is rendered server-side in
+// core/includes/fighter_gear_filter.html (the filter-switch is a GET
+// navigation, so the server re-renders the correct state on each toggle). No
+// client-side JS is needed to mirror it.
 
 // Generic handler for "All/None" filter links in dropdown menus
 function setupFilterLinks(config) {
@@ -451,26 +385,30 @@ document.addEventListener("DOMContentLoaded", () => {
     );
 
     checkboxes.forEach((checkbox) => {
-        checkbox.addEventListener("change", (event) => {
-            // If this is a checkbox, find any hidden input with the same name in the same form
-            // and disable it when the checkbox is checked
+        // Find any hidden input with the same name in the same form and disable
+        // it when the checkbox is checked, so only one value is submitted.
+        const sync = () => {
             const form = checkbox.form || checkbox.closest("form");
-            if (form) {
-                // The input may not be within (DOM Child) of the form, so we need to use
-                // document.querySelector as a fallback to find it by name and form ID.
-                const hiddenInput =
-                    form.querySelector(
-                        `input[type="hidden"][name="${checkbox.name}"]`,
-                    ) ||
-                    document.querySelector(
-                        `input[type="hidden"][name="${checkbox.name}"][form="${form.id}"]`,
-                    );
-                if (hiddenInput) {
-                    // Set initial state
-                    hiddenInput.disabled = checkbox.checked;
-                }
+            if (!form) return;
+            // The input may not be within (DOM Child) of the form, so we need to use
+            // document.querySelector as a fallback to find it by name and form ID.
+            const hiddenInput =
+                form.querySelector(
+                    `input[type="hidden"][name="${checkbox.name}"]`,
+                ) ||
+                document.querySelector(
+                    `input[type="hidden"][name="${checkbox.name}"][form="${form.id}"]`,
+                );
+            if (hiddenInput) {
+                hiddenInput.disabled = checkbox.checked;
             }
-        });
+        };
+
+        checkbox.addEventListener("change", sync);
+        // Set initial state on load — a pre-checked checkbox must disable its
+        // paired hidden input immediately, otherwise both values submit until
+        // the box is first toggled.
+        sync();
     });
 });
 
@@ -499,8 +437,10 @@ document.addEventListener("DOMContentLoaded", () => {
             }
 
             if (form) {
-                // Submit the form
-                form.submit();
+                // Use requestSubmit() rather than submit() so the form's
+                // submit event fires (busy spinner) and HTML5 constraint
+                // validation runs, matching a real submit-button click.
+                form.requestSubmit();
             }
         });
     });

--- a/gyrinx/core/static/core/js/index.js
+++ b/gyrinx/core/static/core/js/index.js
@@ -440,7 +440,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 // Use requestSubmit() rather than submit() so the form's
                 // submit event fires (busy spinner) and HTML5 constraint
                 // validation runs, matching a real submit-button click.
-                form.requestSubmit();
+                // Fall back to submit() where requestSubmit is unavailable
+                // (e.g. Safari < 16), which would otherwise throw.
+                if (form.requestSubmit) {
+                    form.requestSubmit();
+                } else {
+                    form.submit();
+                }
             }
         });
     });

--- a/gyrinx/core/templates/core/layouts/foundation.html
+++ b/gyrinx/core/templates/core/layouts/foundation.html
@@ -63,8 +63,11 @@
         <link rel="dns-prefetch" href="https://use.typekit.net">
         <link rel="preconnect" href="https://use.typekit.net" crossorigin>
         <link rel="stylesheet" href="https://use.typekit.net/rso6ezl.css">
+        {# bootstrap-icons version is pinned here AND in package.json — bump both together (and the integrity hash). #}
         <link rel="stylesheet"
-              href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+              href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+              integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
+              crossorigin="anonymous">
         {% block stylesheet %}
             <link rel="stylesheet" href="{% static 'core/css/screen.css' %}">
         {% endblock stylesheet %}
@@ -91,7 +94,9 @@
         <!-- End Google Tag Manager (noscript) -->
         {% block base %}
         {% endblock base %}
+        {# bootstrap version is pinned here AND in package.json — bump both together (and the integrity hash). #}
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+                integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
                 crossorigin="anonymous"></script>
         <script type="module" src="{% static 'core/js/index.js' %}"></script>
         {% block extra_script %}

--- a/gyrinx/core/templates/core/layouts/foundation.html
+++ b/gyrinx/core/templates/core/layouts/foundation.html
@@ -63,7 +63,7 @@
         <link rel="dns-prefetch" href="https://use.typekit.net">
         <link rel="preconnect" href="https://use.typekit.net" crossorigin>
         <link rel="stylesheet" href="https://use.typekit.net/rso6ezl.css">
-        {# bootstrap-icons version is pinned here AND in package.json — bump both together (and the integrity hash). #}
+        {# bootstrap-icons is loaded only from this CDN (not a package.json dependency) — bump the version and the integrity hash together here. #}
         <link rel="stylesheet"
               href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
               integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
@@ -94,7 +94,7 @@
         <!-- End Google Tag Manager (noscript) -->
         {% block base %}
         {% endblock base %}
-        {# bootstrap version is pinned here AND in package.json — bump both together (and the integrity hash). #}
+        {# bootstrap JS bundle version + integrity hash are pinned here; package.json carries bootstrap "^5.3.8" for the SCSS build — keep them in sync when bumping. #}
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
                 integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
                 crossorigin="anonymous"></script>

--- a/gyrinx/core/tests/test_gear_filter_availability_state.py
+++ b/gyrinx/core/tests/test_gear_filter_availability_state.py
@@ -1,0 +1,107 @@
+"""Tests for the server-rendered availability-dropdown state on the fighter
+gear/weapons filter.
+
+This state used to be mirrored client-side in ``core/static/core/js/index.js``
+(the "Equipment list filter toggle functionality" block). That JS was removed
+(issue #1867) because the server already renders the complete disabled state
+in ``core/includes/fighter_gear_filter.html``. These tests pin that
+server-rendered behaviour so the deletion stays safe.
+"""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+
+def _availability_button_html(html):
+    """Slice out just the availability dropdown <button ...> element so
+    assertions don't collide with the unrelated theme-switcher dropdown."""
+    start = html.index('id="availability-dropdown-button"')
+    # Walk back to the opening "<button" and forward to the closing ">".
+    open_idx = html.rindex("<button", 0, start)
+    close_idx = html.index(">", start)
+    return html[open_idx : close_idx + 1]
+
+
+@pytest.mark.django_db
+def test_availability_disabled_when_equipment_list_filter_on(
+    make_list, make_list_fighter, user
+):
+    """With ?filter=equipment-list the availability dropdown renders disabled,
+    drops its dropdown trigger, and the parent group carries the tooltip."""
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Test Fighter")
+
+    client = Client()
+    client.force_login(user)
+
+    url = reverse("core:list-fighter-gear-edit", args=[lst.id, fighter.id])
+    response = client.get(url, {"filter": "equipment-list"})
+    assert response.status_code == 200
+    html = response.content.decode()
+    button = _availability_button_html(html)
+    # Collapse runs of whitespace so attribute assertions don't depend on
+    # template indentation / djlint formatting.
+    button_compact = " ".join(button.split())
+
+    # The button is disabled and styled as such: both the `disabled` class
+    # (in the class list) and the bare `disabled` attribute are rendered.
+    assert "dropdown-toggle disabled" in button_compact
+    assert "disabled >" in button_compact
+    # The dropdown trigger is dropped while disabled.
+    assert 'data-bs-toggle="dropdown"' not in button_compact
+    # The parent group carries the explanatory tooltip.
+    assert 'data-bs-toggle="tooltip"' in html
+    assert "Availability filters are disabled" in html
+
+
+@pytest.mark.django_db
+def test_availability_enabled_when_equipment_list_filter_off(
+    make_list, make_list_fighter, user
+):
+    """With ?filter=all the availability dropdown renders enabled with its
+    dropdown trigger and no disabled tooltip."""
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Test Fighter")
+
+    client = Client()
+    client.force_login(user)
+
+    url = reverse("core:list-fighter-gear-edit", args=[lst.id, fighter.id])
+    response = client.get(url, {"filter": "all"})
+    assert response.status_code == 200
+    html = response.content.decode()
+    button_compact = " ".join(_availability_button_html(html).split())
+
+    # Dropdown trigger is present and the button is not marked disabled.
+    assert 'data-bs-toggle="dropdown"' in button_compact
+    assert "dropdown-toggle disabled" not in button_compact
+    assert "Availability filters are disabled" not in html
+
+
+@pytest.mark.django_db
+def test_filter_switch_pairs_checkbox_with_hidden_default(
+    make_list, make_list_fighter, user
+):
+    """The equipment-list filter switch renders a checkbox paired with a hidden
+    ``filter`` default. index.js disables the hidden input when the checkbox is
+    checked so only one value submits; this pins the markup that pairing relies
+    on (issue #1867)."""
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Test Fighter")
+
+    client = Client()
+    client.force_login(user)
+
+    url = reverse("core:list-fighter-gear-edit", args=[lst.id, fighter.id])
+    response = client.get(url, {"filter": "all"})
+    assert response.status_code == 200
+    html = response.content.decode()
+
+    # Hidden default + the toggle checkbox share the name "filter".
+    assert '<input type="hidden" name="filter" value="all"' in html
+    assert 'id="filter-switch"' in html
+    assert 'name="filter"' in html
+    assert 'value="equipment-list"' in html
+    # The switch auto-submits the search form on change.
+    assert 'data-gy-toggle-submit="search"' in html


### PR DESCRIPTION
Tranche A of #1867 — the safe, independent frontend fixes. This does **not** close #1867: the Tranche B template migrations and the documented schema-editor exception remain. Part of #1855.

## Changes

- `index.js`: fix the malformed `data-gy-sync` attribute selector (was missing the closing `]` and quotes; now uses `CSS.escape`)
- `index.js`: the checkbox→hidden-field handler now sets initial state on load, so pre-checked boxes no longer double-submit
- `index.js`: `form.submit()` → `form.requestSubmit()` so the submit event (busy state) and HTML5 validation fire
- `index.js`: delete the duplicated availability-disable / tooltip block — that state is already server-rendered in `fighter_gear_filter.html`
- `foundation.html`: add SRI `integrity` hashes for the Bootstrap JS bundle (5.3.8) and bootstrap-icons CSS (1.11.3), with a comment noting the version is pinned in both `foundation.html` and `package.json`
- new test `test_gear_filter_availability_state.py` pinning the server-rendered filter states

## Verification

- `pytest -n auto`: green (new test included)
- SRI hashes computed from the live jsdelivr files
- Suggested follow-up: a manual browser pass on the `data-gy-toggle-submit` controls. All are required-field-free GET filter forms except one POST "required" toggle; `requestSubmit()` is safe for all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
