### PR TITLE
fix: freeze transferred gear value on death to stop stash cost drift (#1826)

### DIFF
--- a/gyrinx/core/handlers/fighter/kill.py
+++ b/gyrinx/core/handlers/fighter/kill.py
@@ -53,7 +53,11 @@ def handle_fighter_kill(
 
     The fighter's cost goes from X to 0, reducing rating by X.
     Equipment transfers from fighter to stash don't change overall wealth,
-    but equipment is preserved in the stash for potential re-use.
+    but equipment is preserved in the stash for potential re-use. The
+    transferred gear's value is frozen at what it cost on the dying fighter
+    (pinned via ``total_cost_override``) so it doesn't re-price in the stash's
+    context — keeping the value that leaves the rating equal to the value that
+    lands in the stash, and keeping the stash cost cache in sync (issue #1826).
 
     Equipment in a category flagged ``persistent`` (see
     ``ContentEquipmentCategory.persistent``) is the exception: it stays
@@ -116,18 +120,31 @@ def handle_fighter_kill(
 
     equipment_cost = 0
     if to_transfer:
-        # Calculate transferred equipment cost before we delete assignments.
-        # Only the transferred (non-persistent) gear bumps the stash — the
-        # persistent items' value is absorbed into the rating reduction below.
-        equipment_cost = sum(a.cost_int() for a in to_transfer)
-
         for assignment in to_transfer:
-            # Create new assignment for stash with same equipment
+            # Freeze each assignment's value as costed on the *dying* fighter
+            # (issue #1826). cost_int() here is evaluated in the dying fighter's
+            # context — its equipment list, house overrides, expansions. The
+            # same gear re-prices in the stash's context (which has no equipment
+            # list), so without pinning the value the delta we propagate into
+            # the stash cache below would never match the stash fighter's own
+            # recomputed cost_int(), and the cache would drift permanently.
+            # Only the transferred (non-persistent) gear bumps the stash — the
+            # persistent items' value is absorbed into the rating reduction.
+            #
+            # Read before the delete below, while the assignment is still
+            # attached to the dying fighter.
+            frozen_cost = assignment.cost_int()
+            equipment_cost += frozen_cost
+
+            # Create new assignment for stash with same equipment, pinned to the
+            # value it carried on the dying fighter via total_cost_override. The
+            # pin persists through any later reassignment out of the stash — the
+            # gear keeps this price rather than re-pricing to a new fighter.
             new_assignment = ListFighterEquipmentAssignment(
                 list_fighter=stash_fighter,
                 content_equipment=assignment.content_equipment,
                 cost_override=assignment.cost_override,
-                total_cost_override=assignment.total_cost_override,
+                total_cost_override=frozen_cost,
                 from_default_assignment=assignment.from_default_assignment,
             )
             new_assignment.save()

--- a/gyrinx/core/tests/test_kill_fighter.py
+++ b/gyrinx/core/tests/test_kill_fighter.py
@@ -6,10 +6,18 @@ from gyrinx.content.models import (
     ContentEquipment,
     ContentEquipmentCategory,
     ContentFighter,
+    ContentFighterEquipmentListItem,
+)
+from gyrinx.core.handlers.equipment.reassignment import (
+    handle_equipment_reassignment,
 )
 from gyrinx.core.handlers.fighter.kill import handle_fighter_kill
 from gyrinx.core.models.action import ListAction, ListActionType
-from gyrinx.core.models.list import List, ListFighter
+from gyrinx.core.models.list import (
+    List,
+    ListFighter,
+    ListFighterEquipmentAssignment,
+)
 
 User = get_user_model()
 
@@ -195,6 +203,120 @@ def test_kill_fighter_transfers_equipment_to_stash(client, user, content_house):
     stash_assignment = stash.listfighterequipmentassignment_set.first()
     assert stash_assignment.content_equipment == equipment
     assert stash_assignment.cost_int() == 15
+
+
+@pytest.mark.django_db
+def test_kill_freezes_transferred_equipment_value(
+    user, make_list, make_content_fighter, make_list_fighter, content_house
+):
+    """Gear transferred to the stash on death keeps its dying-fighter price.
+
+    Regression for #1826. A weapon priced by the dying fighter's equipment list
+    must not re-price to the stash's context (which has no equipment list).
+    Freezing the value via total_cost_override keeps the cached stash total in
+    sync with the stash fighter's own recomputed cost_int() — no drift.
+    """
+    lst = make_list("Freeze Gang", status=List.CAMPAIGN_MODE)
+    stash = lst.ensure_stash()
+
+    # A fighter whose equipment list discounts the Lasgun to 5¢, while its full
+    # price (what the stash, with no equipment list, would charge) is 15¢.
+    cf = make_content_fighter(
+        type="Ganger",
+        category="GANGER",
+        house=content_house,
+        base_cost=50,
+    )
+    fighter = make_list_fighter(lst, "Bob", content_fighter=cf)
+
+    lasgun = ContentEquipment.objects.create(name="Lasgun", cost=15)
+    ContentFighterEquipmentListItem.objects.create(fighter=cf, equipment=lasgun, cost=5)
+
+    fighter.assign(lasgun)
+
+    # Sanity: the Lasgun costs 5¢ on Bob (equipment-list price), not 15¢.
+    bob_assignment = fighter.listfighterequipmentassignment_set.get()
+    assert bob_assignment.cost_int() == 5
+
+    handle_fighter_kill(user=user, lst=lst, fighter=fighter)
+
+    # The gear moved to the stash pinned at its frozen 5¢ — not re-priced to 15¢.
+    stash_assignment = stash.listfighterequipmentassignment_set.get()
+    assert stash_assignment.total_cost_override == 5
+    assert stash_assignment.cost_int() == 5
+
+    # The cached stash total agrees with a fresh recompute of the stash
+    # fighter's contents: the cache did not drift.
+    lst.refresh_from_db()
+    stash.refresh_from_db()
+    assert stash.cost_int() == 5
+    assert lst.stash_current == 5
+
+
+@pytest.mark.django_db
+def test_frozen_stash_value_survives_reassignment_out(
+    user, make_list, make_content_fighter, make_list_fighter, content_house, campaign
+):
+    """Frozen stash gear keeps its price when re-equipped onto another fighter.
+
+    Confirms the #1826 decision: gear stays frozen through reassignment — it
+    does not re-price to the receiving fighter's equipment list. The
+    reassignment handler moves the existing assignment row, so the
+    total_cost_override pinned on death rides along.
+    """
+    lst = make_list("Freeze Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
+    campaign.lists.add(lst)
+    stash = lst.ensure_stash()
+
+    # Bob's equipment list prices the Lasgun at 5¢.
+    dying_cf = make_content_fighter(
+        type="Ganger", category="GANGER", house=content_house, base_cost=50
+    )
+    fighter = make_list_fighter(lst, "Bob", content_fighter=dying_cf)
+    lasgun = ContentEquipment.objects.create(name="Lasgun", cost=15)
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=dying_cf, equipment=lasgun, cost=5
+    )
+    fighter.assign(lasgun)
+
+    handle_fighter_kill(user=user, lst=lst, fighter=fighter)
+    stash_assignment = stash.listfighterequipmentassignment_set.get()
+    assert stash_assignment.cost_int() == 5  # frozen at Bob's price
+
+    # A new fighter whose own equipment list would price the Lasgun at 12¢.
+    heir_cf = make_content_fighter(
+        type="Champion", category="CHAMPION", house=content_house, base_cost=80
+    )
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=heir_cf, equipment=lasgun, cost=12
+    )
+    heir = make_list_fighter(lst, "Heir", content_fighter=heir_cf)
+
+    # Re-fetch participants so the handler reads current cached values.
+    lst.refresh_from_db()
+    stash = ListFighter.objects.get(pk=stash.pk)
+    stash_assignment = ListFighterEquipmentAssignment.objects.get(
+        pk=stash_assignment.pk
+    )
+
+    result = handle_equipment_reassignment(
+        user=user,
+        lst=lst,
+        from_fighter=stash,
+        to_fighter=heir,
+        assignment=stash_assignment,
+    )
+
+    # Still 5¢ on the heir — not re-priced to the heir's 12¢ list price.
+    assert result.equipment_cost == 5
+    stash_assignment.refresh_from_db()
+    assert stash_assignment.cost_int() == 5
+
+    # Wealth bookkeeping: 5¢ left the stash, 5¢ joined the rating; no drift.
+    lst.refresh_from_db()
+    heir.refresh_from_db()
+    assert lst.stash_current == 0
+    assert heir.cost_int() == 80 + 5
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- When a fighter dies in campaign mode, their non-persistent gear transfers to the stash. The kill handler valued that gear in the **dying fighter's** context (its equipment list, house overrides, expansions) and added that amount to the cached stash total — but the new stash assignment re-priced itself in the **stash's** context, which has no equipment list. The two numbers never matched, nothing marked the stash for recompute, so the cached stash value drifted from reality and stayed wrong.
- This pins each transferred item's value via `total_cost_override` at the price it carried on the dying fighter. The value that leaves the gang's rating now equals the value that lands in the stash, and the stash fighter's own recomputed cost matches the cached total — no drift.
- The pin stays with the item if it's later re-equipped out of the stash, so gear keeps its frozen price rather than re-pricing to whichever fighter picks it up.

## Why

A weapon can cost different amounts depending on who holds it (a fighter's equipment list can discount it). On death the gear moved to the stash but the books were updated with the old price while the stash counted the new one. Freezing the price on transfer keeps a death from silently changing what the gang's gear is worth, and keeps the cached stash total honest.

## Test plan

- [x] `test_kill_freezes_transferred_equipment_value` — a Lasgun priced 5¢ on the fighter's equipment list (15¢ at base) transfers to the stash frozen at 5¢; `list.stash_current` equals the stash fighter's recomputed `cost_int()` (no drift).
- [x] `test_frozen_stash_value_survives_reassignment_out` — re-equipping that frozen item onto a fighter whose list would charge 12¢ keeps it at 5¢; stash and rating totals stay balanced.
- [x] Existing `test_kill_fighter.py` suite green (no-discount gear still transfers at base price).
- [x] Adjacent suites green: admin cost-cache recompute, stash fighter, persistent-stash migration, equipment sell/removal/cost-override, fighter lifecycle, equipment edit, purchases, campaign attributes.
- [x] No schema change (`total_cost_override` already exists); missing-migration check passes.

Closes #1826
