### PR TITLE
refactor: extract PackItemFormMixin for Content*PackForm (#1863 part 3)

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -102,11 +102,16 @@ class PackItemFormMixin:
 
     CRITICAL — archive semantics (see CLAUDE.md "Content packs: archive
     semantics"): every ``CustomContentPackItem`` lookup here filters
-    ``archived=False``. This is a form-validation / unique-constraint write
-    path, and the ``CustomContentPackItem`` unique constraint is itself
-    conditional on ``archived=False`` — so the "live" item lookup MUST match.
-    Do not broaden these to include archived items.
+    ``archived=False``. Archiving is the pack owner's soft-delete, so an
+    archived item must stop reserving its name against its own owner —
+    otherwise they can never reuse a name they archived. Do not broaden these
+    to include archived items.
     """
+
+    # Forms that are never pack-scoped (and so never assign ``self._pack``)
+    # still inherit these helpers; the default keeps their "no pack" branches
+    # working rather than raising AttributeError.
+    _pack = None
 
     def _raise_if_name_taken(self, qs, message):
         """Exclude the current instance, then raise ``ValidationError`` if any

--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -81,6 +81,101 @@ def _append_cost_propagation_help(form, field_name="cost"):
         form.fields[field_name].help_text = existing + COST_PROPAGATION_HELP_SUFFIX
 
 
+class PackItemFormMixin:
+    """Shared helpers for the ``Content*PackForm`` family.
+
+    Collapses three repeated shapes without forcing a single ``clean_name``
+    (the variants genuinely differ — base vs ``all_content()`` manager,
+    extra-field scoping, per-pack uniqueness, and message text). Each form's
+    ``clean_name`` / ``__init__`` calls these helpers with its own specifics:
+
+    - ``_raise_if_name_taken`` — the "exclude self, then raise if any match"
+      tail shared by every uniqueness check. The caller builds the filtered
+      queryset (choosing manager + filters + message).
+    - ``_pack_item_object_ids`` — the canonical ``CustomContentPackItem``
+      object-id lookup for ``self._pack`` and a content model, used by both
+      the per-pack uniqueness check and the Default/Custom choice grouping.
+    - ``_check_name_unique_in_pack`` — the second half of the two-step checks
+      in the weapon-trait / weapon-accessory forms.
+    - ``_apply_grouped_pack_choices`` — the "split choices into Custom (pack)
+      and Default (base)" ``__init__`` block.
+
+    CRITICAL — archive semantics (see CLAUDE.md "Content packs: archive
+    semantics"): every ``CustomContentPackItem`` lookup here filters
+    ``archived=False``. This is a form-validation / unique-constraint write
+    path, and the ``CustomContentPackItem`` unique constraint is itself
+    conditional on ``archived=False`` — so the "live" item lookup MUST match.
+    Do not broaden these to include archived items.
+    """
+
+    def _raise_if_name_taken(self, qs, message):
+        """Exclude the current instance, then raise ``ValidationError`` if any
+        row in ``qs`` still matches. ``qs`` must already be filtered to the
+        candidate duplicates (by name, manager, and any extra scoping)."""
+        if self.instance.pk:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise ValidationError(message)
+
+    def _pack_item_object_ids(self, model):
+        """Object ids of the current pack's (non-archived) items for ``model``.
+
+        ``archived=False`` matches the conditional unique constraint — see the
+        class docstring's archive-semantics note. Returns an empty queryset
+        when the form has no pack.
+        """
+        from django.contrib.contenttypes.models import ContentType
+
+        from gyrinx.core.models.pack import CustomContentPackItem
+
+        if self._pack is None:
+            return CustomContentPackItem.objects.none().values_list(
+                "object_id", flat=True
+            )
+        ct = ContentType.objects.get_for_model(model)
+        return CustomContentPackItem.objects.filter(
+            pack=self._pack, content_type=ct, archived=False
+        ).values_list("object_id", flat=True)
+
+    def _check_name_unique_in_pack(self, model, value, message):
+        """Raise if ``value`` collides with another of the current pack's items.
+
+        No-op when the form has no pack. Mirrors the base-library check but
+        scopes to the pack's (non-archived) items via ``all_content()``.
+        """
+        if self._pack is None:
+            return
+        pack_item_ids = self._pack_item_object_ids(model)
+        qs = model.objects.all_content().filter(
+            pk__in=pack_item_ids, name__iexact=value
+        )
+        self._raise_if_name_taken(qs, message)
+
+    def _apply_grouped_pack_choices(self, field_name, queryset, model):
+        """Group ``field_name``'s choices into "Custom" (this pack's items) and
+        "Default" (base game), matching the existing dropdown grouping.
+
+        No-op when the form has no pack (the plain queryset choices stand).
+        """
+        if self._pack is None:
+            return
+        pack_ids = set(self._pack_item_object_ids(model))
+        default_choices = []
+        custom_choices = []
+        for obj in queryset.order_by("name"):
+            choice = (obj.pk, str(obj))
+            if obj.pk in pack_ids:
+                custom_choices.append(choice)
+            else:
+                default_choices.append(choice)
+        grouped = [("", "---------")]
+        if custom_choices:
+            grouped.append(("Custom", custom_choices))
+        if default_choices:
+            grouped.append(("Default", default_choices))
+        self.fields[field_name].choices = grouped
+
+
 class PackForm(forms.ModelForm):
     class Meta:
         model = CustomContentPack
@@ -132,7 +227,7 @@ class PackAttachmentForm(forms.ModelForm):
         }
 
 
-class ContentFighterPackForm(forms.ModelForm):
+class ContentFighterPackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing fighters in a content pack.
 
     On create (no instance): shows type, category, house, base_cost.
@@ -409,13 +504,10 @@ class ContentFighterPackForm(forms.ModelForm):
 
     def clean_type(self):
         value = self.cleaned_data["type"]
-        qs = ContentFighter.objects.filter(type__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A fighter with this name already exists in the content library."
-            )
+        self._raise_if_name_taken(
+            ContentFighter.objects.filter(type__iexact=value),
+            "A fighter with this name already exists in the content library.",
+        )
         return value
 
     def _save_m2m(self):
@@ -499,7 +591,7 @@ class ContentFighterPackForm(forms.ModelForm):
             )
 
 
-class ContentHouseForm(forms.ModelForm):
+class ContentHouseForm(PackItemFormMixin, forms.ModelForm):
     class Meta:
         model = ContentHouse
         fields = ["name", "description"]
@@ -518,17 +610,14 @@ class ContentHouseForm(forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentHouse.objects.filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A house with this name already exists in the content library."
-            )
+        self._raise_if_name_taken(
+            ContentHouse.objects.filter(name__iexact=value),
+            "A house with this name already exists in the content library.",
+        )
         return value
 
 
-class ContentRuleForm(forms.ModelForm):
+class ContentRuleForm(PackItemFormMixin, forms.ModelForm):
     class Meta:
         model = ContentRule
         fields = ["name", "description"]
@@ -547,17 +636,14 @@ class ContentRuleForm(forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentRule.objects.filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A rule with this name already exists in the content library."
-            )
+        self._raise_if_name_taken(
+            ContentRule.objects.filter(name__iexact=value),
+            "A rule with this name already exists in the content library.",
+        )
         return value
 
 
-class ContentWeaponTraitPackForm(forms.ModelForm):
+class ContentWeaponTraitPackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing weapon traits in a content pack."""
 
     class Meta:
@@ -583,32 +669,16 @@ class ContentWeaponTraitPackForm(forms.ModelForm):
     def clean_name(self):
         value = self.cleaned_data["name"]
         # Check uniqueness among base (non-pack) traits.
-        qs = ContentWeaponTrait.objects.filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A weapon trait with this name already exists in the content library."
-            )
+        self._raise_if_name_taken(
+            ContentWeaponTrait.objects.filter(name__iexact=value),
+            "A weapon trait with this name already exists in the content library.",
+        )
         # Check uniqueness within the current pack.
-        if self._pack is not None:
-            from django.contrib.contenttypes.models import ContentType
-
-            from gyrinx.core.models.pack import CustomContentPackItem
-
-            trait_ct = ContentType.objects.get_for_model(ContentWeaponTrait)
-            pack_trait_ids = CustomContentPackItem.objects.filter(
-                pack=self._pack, content_type=trait_ct, archived=False
-            ).values_list("object_id", flat=True)
-            qs = ContentWeaponTrait.objects.all_content().filter(
-                pk__in=pack_trait_ids, name__iexact=value
-            )
-            if self.instance.pk:
-                qs = qs.exclude(pk=self.instance.pk)
-            if qs.exists():
-                raise ValidationError(
-                    "A weapon trait with this name already exists in this Content Pack."
-                )
+        self._check_name_unique_in_pack(
+            ContentWeaponTrait,
+            value,
+            "A weapon trait with this name already exists in this Content Pack.",
+        )
         return value
 
 
@@ -625,7 +695,9 @@ class StandardFieldsMixin:
             yield self[name]
 
 
-class ContentWeaponAccessoryPackForm(StandardFieldsMixin, forms.ModelForm):
+class ContentWeaponAccessoryPackForm(
+    PackItemFormMixin, StandardFieldsMixin, forms.ModelForm
+):
     """Form for adding/editing weapon accessories in a content pack.
 
     Includes a synthetic mod picker (weapon stat mods + weapon trait mods)
@@ -790,31 +862,15 @@ class ContentWeaponAccessoryPackForm(StandardFieldsMixin, forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentWeaponAccessory.objects.filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A weapon accessory with this name already exists in the content library."
-            )
-        if self._pack is not None:
-            from django.contrib.contenttypes.models import ContentType
-
-            from gyrinx.core.models.pack import CustomContentPackItem
-
-            accessory_ct = ContentType.objects.get_for_model(ContentWeaponAccessory)
-            pack_accessory_ids = CustomContentPackItem.objects.filter(
-                pack=self._pack, content_type=accessory_ct, archived=False
-            ).values_list("object_id", flat=True)
-            qs = ContentWeaponAccessory.objects.all_content().filter(
-                pk__in=pack_accessory_ids, name__iexact=value
-            )
-            if self.instance.pk:
-                qs = qs.exclude(pk=self.instance.pk)
-            if qs.exists():
-                raise ValidationError(
-                    "A weapon accessory with this name already exists in this Content Pack."
-                )
+        self._raise_if_name_taken(
+            ContentWeaponAccessory.objects.filter(name__iexact=value),
+            "A weapon accessory with this name already exists in the content library.",
+        )
+        self._check_name_unique_in_pack(
+            ContentWeaponAccessory,
+            value,
+            "A weapon accessory with this name already exists in this Content Pack.",
+        )
         return value
 
     def _save_m2m(self):
@@ -843,7 +899,7 @@ class ContentWeaponAccessoryPackForm(StandardFieldsMixin, forms.ModelForm):
         instance.modifiers.set(mods)
 
 
-class ContentSkillCategoryPackForm(forms.ModelForm):
+class ContentSkillCategoryPackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing skill categories (skill trees) in a content pack."""
 
     class Meta:
@@ -861,17 +917,14 @@ class ContentSkillCategoryPackForm(forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentSkillCategory.objects.all_content().filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A skill tree with this name already exists in the content library."
-            )
+        self._raise_if_name_taken(
+            ContentSkillCategory.objects.all_content().filter(name__iexact=value),
+            "A skill tree with this name already exists in the content library.",
+        )
         return value
 
 
-class ContentSkillPackForm(forms.ModelForm):
+class ContentSkillPackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing skills in a content pack."""
 
     class Meta:
@@ -903,48 +956,22 @@ class ContentSkillPackForm(forms.ModelForm):
         self.fields["category"].queryset = qs
 
         # Group choices into "Default" (base game) and "Custom" (pack content)
-        if pack is not None:
-            from gyrinx.core.models.pack import CustomContentPackItem
-
-            pack_cat_ids = set(
-                CustomContentPackItem.objects.filter(
-                    pack=pack,
-                    content_type__model="contentskillcategory",
-                    archived=False,
-                ).values_list("object_id", flat=True)
-            )
-            default_choices = []
-            custom_choices = []
-            for cat in qs.order_by("name"):
-                choice = (cat.pk, str(cat))
-                if cat.pk in pack_cat_ids:
-                    custom_choices.append(choice)
-                else:
-                    default_choices.append(choice)
-            grouped = [("", "---------")]
-            if custom_choices:
-                grouped.append(("Custom", custom_choices))
-            if default_choices:
-                grouped.append(("Default", default_choices))
-            self.fields["category"].choices = grouped
+        self._apply_grouped_pack_choices("category", qs, ContentSkillCategory)
 
     def clean_name(self):
         value = self.cleaned_data["name"]
         category = self.cleaned_data.get("category")
         if category:
-            qs = ContentSkill.objects.all_content().filter(
-                name__iexact=value, category=category
+            self._raise_if_name_taken(
+                ContentSkill.objects.all_content().filter(
+                    name__iexact=value, category=category
+                ),
+                "A skill with this name already exists in this skill tree.",
             )
-            if self.instance.pk:
-                qs = qs.exclude(pk=self.instance.pk)
-            if qs.exists():
-                raise ValidationError(
-                    "A skill with this name already exists in this skill tree."
-                )
         return value
 
 
-class ContentAttributePackForm(forms.ModelForm):
+class ContentAttributePackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing gang attributes in a content pack."""
 
     class Meta:
@@ -979,18 +1006,15 @@ class ContentAttributePackForm(forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentAttribute.objects.all_content().filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "An attribute with this name already exists. "
-                "Attribute names are unique across the library and all packs."
-            )
+        self._raise_if_name_taken(
+            ContentAttribute.objects.all_content().filter(name__iexact=value),
+            "An attribute with this name already exists. "
+            "Attribute names are unique across the library and all packs.",
+        )
         return value
 
 
-class ContentAttributeValuePackForm(forms.ModelForm):
+class ContentAttributeValuePackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing gang-attribute values in a content pack."""
 
     class Meta:
@@ -1022,44 +1046,18 @@ class ContentAttributeValuePackForm(forms.ModelForm):
         self.fields["attribute"].queryset = qs
 
         # Group choices into "Default" (base game) and "Custom" (pack content)
-        if pack is not None:
-            from gyrinx.core.models.pack import CustomContentPackItem
-
-            pack_attr_ids = set(
-                CustomContentPackItem.objects.filter(
-                    pack=pack,
-                    content_type__model="contentattribute",
-                    archived=False,
-                ).values_list("object_id", flat=True)
-            )
-            default_choices = []
-            custom_choices = []
-            for attr in qs.order_by("name"):
-                choice = (attr.pk, str(attr))
-                if attr.pk in pack_attr_ids:
-                    custom_choices.append(choice)
-                else:
-                    default_choices.append(choice)
-            grouped = [("", "---------")]
-            if custom_choices:
-                grouped.append(("Custom", custom_choices))
-            if default_choices:
-                grouped.append(("Default", default_choices))
-            self.fields["attribute"].choices = grouped
+        self._apply_grouped_pack_choices("attribute", qs, ContentAttribute)
 
     def clean_name(self):
         value = self.cleaned_data["name"]
         attribute = self.cleaned_data.get("attribute")
         if attribute:
-            qs = ContentAttributeValue.objects.all_content().filter(
-                name__iexact=value, attribute=attribute
+            self._raise_if_name_taken(
+                ContentAttributeValue.objects.all_content().filter(
+                    name__iexact=value, attribute=attribute
+                ),
+                "A value with this name already exists for this attribute.",
             )
-            if self.instance.pk:
-                qs = qs.exclude(pk=self.instance.pk)
-            if qs.exists():
-                raise ValidationError(
-                    "A value with this name already exists for this attribute."
-                )
         return value
 
 
@@ -1308,7 +1306,7 @@ class EquipmentModifiersForm(FighterModPickerMixin, forms.ModelForm):
         fields = []
 
 
-class ContentGearPackForm(forms.ModelForm):
+class ContentGearPackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing gear (non-weapon equipment) in a content pack."""
 
     class Meta:
@@ -1368,17 +1366,14 @@ class ContentGearPackForm(forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentEquipment.objects.filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "Gear with this name already exists in the content library."
-            )
+        self._raise_if_name_taken(
+            ContentEquipment.objects.filter(name__iexact=value),
+            "Gear with this name already exists in the content library.",
+        )
         return value
 
 
-class ContentWeaponPackForm(forms.ModelForm):
+class ContentWeaponPackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing weapons in a content pack.
 
     Filters categories to "Weapons & Ammo" only (inverse of the gear form).
@@ -1422,13 +1417,10 @@ class ContentWeaponPackForm(forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentEquipment.objects.filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A weapon with this name already exists in the content library."
-            )
+        self._raise_if_name_taken(
+            ContentEquipment.objects.filter(name__iexact=value),
+            "A weapon with this name already exists in the content library.",
+        )
         return value
 
 
@@ -1485,7 +1477,7 @@ class ContentWeaponProfilePackForm(forms.ModelForm):
             )
 
 
-class ContentPsykerDisciplinePackForm(forms.ModelForm):
+class ContentPsykerDisciplinePackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing psyker disciplines in a content pack."""
 
     class Meta:
@@ -1513,18 +1505,14 @@ class ContentPsykerDisciplinePackForm(forms.ModelForm):
 
     def clean_name(self):
         value = self.cleaned_data["name"]
-        qs = ContentPsykerDiscipline.objects.all_content().filter(name__iexact=value)
-        if self.instance.pk:
-            qs = qs.exclude(pk=self.instance.pk)
-        if qs.exists():
-            raise ValidationError(
-                "A psyker discipline with this name already exists in the content "
-                "library."
-            )
+        self._raise_if_name_taken(
+            ContentPsykerDiscipline.objects.all_content().filter(name__iexact=value),
+            "A psyker discipline with this name already exists in the content library.",
+        )
         return value
 
 
-class ContentPsykerPowerPackForm(forms.ModelForm):
+class ContentPsykerPowerPackForm(PackItemFormMixin, forms.ModelForm):
     """Form for adding/editing psyker powers in a content pack."""
 
     class Meta:
@@ -1556,44 +1544,18 @@ class ContentPsykerPowerPackForm(forms.ModelForm):
         self.fields["discipline"].queryset = qs
 
         # Group choices into "Custom" (pack content) and "Default" (base game).
-        if pack is not None:
-            from gyrinx.core.models.pack import CustomContentPackItem
-
-            pack_disc_ids = set(
-                CustomContentPackItem.objects.filter(
-                    pack=pack,
-                    content_type__model="contentpsykerdiscipline",
-                    archived=False,
-                ).values_list("object_id", flat=True)
-            )
-            default_choices = []
-            custom_choices = []
-            for disc in qs.order_by("name"):
-                choice = (disc.pk, str(disc))
-                if disc.pk in pack_disc_ids:
-                    custom_choices.append(choice)
-                else:
-                    default_choices.append(choice)
-            grouped = [("", "---------")]
-            if custom_choices:
-                grouped.append(("Custom", custom_choices))
-            if default_choices:
-                grouped.append(("Default", default_choices))
-            self.fields["discipline"].choices = grouped
+        self._apply_grouped_pack_choices("discipline", qs, ContentPsykerDiscipline)
 
     def clean_name(self):
         value = self.cleaned_data["name"]
         discipline = self.cleaned_data.get("discipline")
         if discipline:
-            qs = ContentPsykerPower.objects.all_content().filter(
-                name__iexact=value, discipline=discipline
+            self._raise_if_name_taken(
+                ContentPsykerPower.objects.all_content().filter(
+                    name__iexact=value, discipline=discipline
+                ),
+                "A psyker power with this name already exists in this discipline.",
             )
-            if self.instance.pk:
-                qs = qs.exclude(pk=self.instance.pk)
-            if qs.exists():
-                raise ValidationError(
-                    "A psyker power with this name already exists in this discipline."
-                )
         return value
 
 

--- a/gyrinx/core/tests/test_pack_form_mixin.py
+++ b/gyrinx/core/tests/test_pack_form_mixin.py
@@ -70,7 +70,7 @@ def test_archived_pack_item_does_not_block_the_name(pack, trait_in_pack):
 
 
 @pytest.mark.django_db
-def test_pack_item_object_ids_excludes_archived(pack, trait_in_pack, user):
+def test_pack_item_object_ids_excludes_archived(pack, trait_in_pack):
     """The shared primitive both the uniqueness check and the choice grouping
     build on — archived items are out of scope for both."""
     trait, item = trait_in_pack
@@ -114,7 +114,7 @@ def test_editing_an_object_does_not_collide_with_itself(pack, trait_in_pack):
 
 
 @pytest.mark.django_db
-def test_grouped_choices_put_custom_before_default(pack, trait_in_pack, user):
+def test_grouped_choices_put_custom_before_default(pack, trait_in_pack):
     """The shared grouping helper: a blank sentinel, then this pack's items
     under "Custom", then base-library items under "Default". Pinned because
     three call sites collapsed into this one implementation."""

--- a/gyrinx/core/tests/test_pack_form_mixin.py
+++ b/gyrinx/core/tests/test_pack_form_mixin.py
@@ -8,10 +8,11 @@ resting on thirteen separate implementations.
 """
 
 import pytest
+from django import forms
 from django.contrib.contenttypes.models import ContentType
 
 from gyrinx.content.models import ContentWeaponTrait
-from gyrinx.core.forms.pack import ContentWeaponTraitPackForm
+from gyrinx.core.forms.pack import ContentWeaponTraitPackForm, PackItemFormMixin
 from gyrinx.core.models.pack import CustomContentPackItem
 
 
@@ -42,13 +43,15 @@ def test_duplicate_name_within_the_pack_is_rejected(pack, trait_in_pack):
 def test_archived_pack_item_does_not_block_the_name(pack, trait_in_pack):
     """An archived pack item must not reserve its name.
 
-    `CustomContentPackItem`'s unique constraint is conditional on
-    `archived=False`, so the form's "is this name taken?" lookup has to match
-    it — otherwise the form rejects a name the database would happily accept,
-    and the pack owner can never reuse a name they archived. See CLAUDE.md,
-    "Content packs: archive semantics".
+    Archiving is the pack owner's soft-delete, so an archived item has to stop
+    reserving its name against its own owner — otherwise they can never reuse
+    a name they archived. See CLAUDE.md, "Content packs: archive semantics".
     """
     _trait, item = trait_in_pack
+    # The trait is pack-registered, so the default manager (which excludes
+    # pack content) cannot see it. Asserted so that if that ever changes this
+    # test fails here, rather than silently passing the base-library half.
+    assert not ContentWeaponTrait.objects.filter(name__iexact="Blaze").exists()
     # Same name is rejected while the item is live...
     assert not ContentWeaponTraitPackForm(
         data={"name": "Blaze", "description": ""}, pack=pack
@@ -88,3 +91,75 @@ def test_no_pack_means_no_in_pack_checks():
     # A name that exists in no library at all validates fine.
     form = ContentWeaponTraitPackForm(data={"name": "Novel Trait", "description": ""})
     assert form.is_valid(), form.errors
+
+
+def test_forms_that_are_never_pack_scoped_still_have_a_pack_default():
+    """Six `Content*Form`s inherit the mixin without ever assigning `_pack`.
+    The class default is what keeps their "no pack" branches from raising."""
+    assert PackItemFormMixin._pack is None
+
+
+@pytest.mark.django_db
+def test_editing_an_object_does_not_collide_with_itself(pack, trait_in_pack):
+    """`_raise_if_name_taken` excludes the instance being edited — otherwise
+    every edit form would reject its own current name. This is now the single
+    self-exclusion for all thirteen forms."""
+    trait, _item = trait_in_pack
+    form = ContentWeaponTraitPackForm(
+        data={"name": "Blaze", "description": "Edited"},
+        instance=trait,
+        pack=pack,
+    )
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_grouped_choices_put_custom_before_default(pack, trait_in_pack, user):
+    """The shared grouping helper: a blank sentinel, then this pack's items
+    under "Custom", then base-library items under "Default". Pinned because
+    three call sites collapsed into this one implementation."""
+    in_pack, _item = trait_in_pack
+    base = ContentWeaponTrait.objects.create(name="Ancient")
+
+    class _GroupingForm(PackItemFormMixin, forms.Form):
+        trait = forms.ModelChoiceField(queryset=ContentWeaponTrait.objects.none())
+
+    form = _GroupingForm()
+    form._pack = pack
+    form._apply_grouped_pack_choices(
+        "trait", ContentWeaponTrait.objects.all_content(), ContentWeaponTrait
+    )
+
+    choices = form.fields["trait"].choices
+    assert choices[0] == ("", "---------")
+    assert choices[1][0] == "Custom"
+    assert [label for _pk, label in choices[1][1]] == [str(in_pack)]
+    assert choices[2][0] == "Default"
+    assert [label for _pk, label in choices[2][1]] == [str(base)]
+
+
+@pytest.mark.django_db
+def test_grouping_omits_empty_groups_and_no_ops_without_a_pack(pack):
+    """Empty groups are dropped, and a form with no pack keeps plain choices."""
+    base = ContentWeaponTrait.objects.create(name="Ancient")
+
+    class _GroupingForm(PackItemFormMixin, forms.Form):
+        trait = forms.ModelChoiceField(queryset=ContentWeaponTrait.objects.none())
+
+    # Pack with no items of this type -> sentinel + Default only.
+    form = _GroupingForm()
+    form._pack = pack
+    form._apply_grouped_pack_choices(
+        "trait", ContentWeaponTrait.objects.all_content(), ContentWeaponTrait
+    )
+    groups = [g[0] for g in form.fields["trait"].choices]
+    assert groups == ["", "Default"]
+    assert [label for _pk, label in form.fields["trait"].choices[1][1]] == [str(base)]
+
+    # No pack at all -> helper leaves the field's own choices alone.
+    plain = _GroupingForm()
+    before = list(plain.fields["trait"].choices)
+    plain._apply_grouped_pack_choices(
+        "trait", ContentWeaponTrait.objects.all_content(), ContentWeaponTrait
+    )
+    assert list(plain.fields["trait"].choices) == before

--- a/gyrinx/core/tests/test_pack_form_mixin.py
+++ b/gyrinx/core/tests/test_pack_form_mixin.py
@@ -1,0 +1,90 @@
+"""PackItemFormMixin: the shared pack-item form behaviour (#1863).
+
+The `Content*PackForm` family shares its name-uniqueness checks and its
+Default/Custom choice grouping through `PackItemFormMixin`. Centralising that
+logic means one place now decides how archived pack items are treated across
+all thirteen forms — so the archive-semantics rule is pinned here rather than
+resting on thirteen separate implementations.
+"""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from gyrinx.content.models import ContentWeaponTrait
+from gyrinx.core.forms.pack import ContentWeaponTraitPackForm
+from gyrinx.core.models.pack import CustomContentPackItem
+
+
+@pytest.fixture
+def trait_in_pack(pack, user):
+    """A weapon trait registered to `pack` — returns (trait, pack item)."""
+    trait = ContentWeaponTrait.objects.create(name="Blaze")
+    item = CustomContentPackItem.objects.create(
+        pack=pack,
+        content_type=ContentType.objects.get_for_model(ContentWeaponTrait),
+        object_id=trait.pk,
+        owner=user,
+    )
+    return trait, item
+
+
+@pytest.mark.django_db
+def test_duplicate_name_within_the_pack_is_rejected(pack, trait_in_pack):
+    """The in-pack uniqueness half of the shared check."""
+    form = ContentWeaponTraitPackForm(
+        data={"name": "Blaze", "description": ""}, pack=pack
+    )
+    assert not form.is_valid()
+    assert "already exists in this Content Pack" in str(form.errors["name"])
+
+
+@pytest.mark.django_db
+def test_archived_pack_item_does_not_block_the_name(pack, trait_in_pack):
+    """An archived pack item must not reserve its name.
+
+    `CustomContentPackItem`'s unique constraint is conditional on
+    `archived=False`, so the form's "is this name taken?" lookup has to match
+    it — otherwise the form rejects a name the database would happily accept,
+    and the pack owner can never reuse a name they archived. See CLAUDE.md,
+    "Content packs: archive semantics".
+    """
+    _trait, item = trait_in_pack
+    # Same name is rejected while the item is live...
+    assert not ContentWeaponTraitPackForm(
+        data={"name": "Blaze", "description": ""}, pack=pack
+    ).is_valid()
+
+    # ...and accepted once it is archived. (The trait row stays: registering it
+    # to a pack takes it out of the default manager, so the base-library half
+    # of the check does not see it and only the archive rule is under test.)
+    item.archived = True
+    item.save()
+
+    form = ContentWeaponTraitPackForm(
+        data={"name": "Blaze", "description": ""}, pack=pack
+    )
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_pack_item_object_ids_excludes_archived(pack, trait_in_pack, user):
+    """The shared primitive both the uniqueness check and the choice grouping
+    build on — archived items are out of scope for both."""
+    trait, item = trait_in_pack
+    form = ContentWeaponTraitPackForm(pack=pack)
+
+    assert list(form._pack_item_object_ids(ContentWeaponTrait)) == [trait.pk]
+
+    item.archived = True
+    item.save()
+    assert list(form._pack_item_object_ids(ContentWeaponTrait)) == []
+
+
+@pytest.mark.django_db
+def test_no_pack_means_no_in_pack_checks():
+    """Forms used outside a pack context skip the pack lookups entirely."""
+    form = ContentWeaponTraitPackForm(pack=None)
+    assert list(form._pack_item_object_ids(ContentWeaponTrait)) == []
+    # A name that exists in no library at all validates fine.
+    form = ContentWeaponTraitPackForm(data={"name": "Novel Trait", "description": ""})
+    assert form.is_valid(), form.errors


### PR DESCRIPTION
Part 3 of #1863: extract `PackItemFormMixin` in `core/forms/pack.py`, deduping the repeated `clean_name` uniqueness check + Default/Custom choice-grouping across 13 `Content*PackForm`s. **No behaviour change** (−38 net; the ~95-line mixin offsets removed boilerplate).

- 4 helpers (variants genuinely differ): `_raise_if_name_taken`, `_pack_item_object_ids`, `_check_name_unique_in_pack`, `_apply_grouped_pack_choices`. Each form keeps its own manager (`.filter` vs `.all_content()`), field scoping, and message text.
- **`archived=False` preserved** on every `CustomContentPackItem` lookup (matches the conditional unique constraint per the #1742 archive-semantics rule; documented in the mixin docstring with a CLAUDE.md citation).
- `pytest -n auto`: pack form/view suite 509 passed; full 2813 passed. `manage check` / `makemigrations --check` clean.

⚠️ Overlaps `forms/pack.py` with #1867 B1 (`issue-1867-b1`) — whichever merges second needs a trivial rebase.

Part of #1855.
