### PR TITLE
refactor: make pack fighter statline-override URL-driven (#1867 B1)

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -153,26 +153,18 @@ class ContentFighterPackForm(forms.ModelForm):
 
     Accepts an optional ``pack`` kwarg to filter house/rules querysets
     to include both base library content and pack-specific content.
+
+    Whether the statline-override section is shown is a URL-driven variant:
+    the view reads ``?override_statline=1`` and passes ``override_statline``
+    to this form. When off, the ``statline_type`` field is removed entirely
+    so it can never submit a value (no client-side disabling needed).
     """
 
-    override_statline = forms.BooleanField(
-        required=False,
-        label="Override default statline for this Category?",
-        widget=forms.CheckboxInput(
-            attrs={"class": "form-check-input", "id": "id_override_statline"}
-        ),
-    )
     statline_type = forms.ModelChoiceField(
         queryset=ContentStatlineType.objects.none(),
         required=False,
         label="Statline type",
-        widget=forms.Select(
-            attrs={
-                "class": "form-select",
-                "disabled": "disabled",
-                "id": "id_statline_type",
-            }
-        ),
+        widget=forms.Select(attrs={"class": "form-select"}),
     )
 
     class Meta:
@@ -222,9 +214,10 @@ class ContentFighterPackForm(forms.ModelForm):
             ),
         }
 
-    def __init__(self, *args, pack=None, **kwargs):
+    def __init__(self, *args, pack=None, override_statline=False, **kwargs):
         super().__init__(*args, **kwargs)
         self._pack = pack
+        self._override_statline = override_statline
         _append_cost_propagation_help(self, "base_cost")
 
         # Filter category choices.
@@ -250,18 +243,19 @@ class ContentFighterPackForm(forms.ModelForm):
             pk__in=relevant_ids
         )
         self.fields["statline_type"].empty_label = "Default"
-        # Remove disabled attr when override is checked so the value submits.
-        if self.data.get("override_statline"):
-            del self.fields["statline_type"].widget.attrs["disabled"]
 
-        # Place the override/statline fields right after category.
-        field_order = list(self.fields.keys())
-        cat_idx = field_order.index("category") + 1
-        for name in ("override_statline", "statline_type"):
-            field_order.remove(name)
-        field_order.insert(cat_idx, "override_statline")
-        field_order.insert(cat_idx + 1, "statline_type")
-        self.order_fields(field_order)
+        # URL-driven variant: only include statline_type when overriding.
+        # When the override is off the field is removed so it can never
+        # submit a value, and clean() forces statline_type to None.
+        if self._override_statline:
+            # Place the statline-type field right after category.
+            field_order = list(self.fields.keys())
+            cat_idx = field_order.index("category") + 1
+            field_order.remove("statline_type")
+            field_order.insert(cat_idx, "statline_type")
+            self.order_fields(field_order)
+        else:
+            del self.fields["statline_type"]
 
         # House is required for pack fighters.
         self.fields["house"].required = True
@@ -369,8 +363,7 @@ class ContentFighterPackForm(forms.ModelForm):
                 del self.fields[field_name]
         else:
             # Override statline is only relevant during creation.
-            for field_name in ["override_statline", "statline_type"]:
-                self.fields.pop(field_name, None)
+            self.fields.pop("statline_type", None)
 
             # Psyker discipline picker. Only non-generic disciplines are
             # shown — generic disciplines are pooled and cannot be assigned
@@ -415,8 +408,9 @@ class ContentFighterPackForm(forms.ModelForm):
 
     def clean(self):
         cleaned = super().clean()
-        # Server-side enforcement: ignore statline_type unless override is checked.
-        if not cleaned.get("override_statline"):
+        # Server-side enforcement: ignore statline_type unless the
+        # URL-driven override variant is active.
+        if not self._override_statline:
             cleaned["statline_type"] = None
         return cleaned
 

--- a/gyrinx/core/templates/core/pack/pack_item_add.html
+++ b/gyrinx/core/templates/core/pack/pack_item_add.html
@@ -22,6 +22,25 @@
                 {% include "core/pack/includes/_mod_picker_shared.html" %}
             {% else %}
                 {{ form }}
+                {% if slug == "fighter" %}
+                    {% comment %}
+                        URL-driven statline override: the link flips
+                        ?override_statline=1 (a navigation), and the server
+                        renders the statline_type field accordingly. The hidden
+                        input carries the flag through the create POST. No JS.
+                    {% endcomment %}
+                    {% if override_statline %}
+                        <input type="hidden" name="override_statline" value="1">
+                    {% endif %}
+                    <div>
+                        <a href="{{ override_statline_toggle_url }}"
+                           class="btn btn-sm {% if override_statline %}btn-primary{% else %}btn-outline-secondary{% endif %}"
+                           {% if override_statline %}aria-pressed="true"{% else %}aria-pressed="false"{% endif %}>
+                            <i class="{% if override_statline %}bi-check-square{% else %}bi-square{% endif %} me-1"></i>
+                            Override default statline for this Category
+                        </a>
+                    </div>
+                {% endif %}
             {% endif %}
             {% if slug == "gear" or slug == "weapon" %}
                 <div class="alert alert-secondary alert-icon" role="alert">
@@ -93,24 +112,3 @@
         </form>
     </div>
 {% endblock content %}
-{% block extra_script %}
-    <script>
-        (function () {
-            const checkbox = document.getElementById("id_override_statline");
-            const select = document.getElementById("id_statline_type");
-            if (!checkbox || !select) return;
-
-            function toggle() {
-                if (checkbox.checked) {
-                    select.removeAttribute("disabled");
-                } else {
-                    select.setAttribute("disabled", "disabled");
-                    select.value = "";
-                }
-            }
-
-            checkbox.addEventListener("change", toggle);
-            toggle();
-        })();
-    </script>
-{% endblock extra_script %}

--- a/gyrinx/core/tests/test_views_pack.py
+++ b/gyrinx/core/tests/test_views_pack.py
@@ -1643,7 +1643,8 @@ def test_add_fighter_statline_type_includes_vehicle(pack, fighter_statline_type)
         name="Vehicle", defaults={"default_for_categories": ["VEHICLE"]}
     )
 
-    form = ContentFighterPackForm(pack=pack)
+    # statline_type only exists in the override variant (?override_statline=1).
+    form = ContentFighterPackForm(pack=pack, override_statline=True)
     statline_type_names = {st.name for st in form.fields["statline_type"].queryset}
     assert "Vehicle" in statline_type_names
     assert "Fighter" in statline_type_names
@@ -1721,6 +1722,39 @@ def test_add_fighter_default_statline_no_override(
     )
     assert response.status_code == 302
     assert "statline_type_id" not in response.url
+
+
+@pytest.mark.django_db
+def test_add_fighter_statline_override_is_url_driven(
+    client, group_user, pack, fighter_statline_type, content_house
+):
+    """The statline-override section is a URL-driven variant: the
+    ``statline_type`` field (and its rendered ``<select>``) appears only with
+    ``?override_statline=1``. The page works without JS — no client-side
+    toggle is involved.
+    """
+    client.force_login(group_user)
+    add_url = f"/pack/{pack.id}/add/fighter/"
+
+    # Default variant (no flag): statline_type is absent from the form.
+    response = client.get(add_url)
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "statline_type" not in form.fields
+    assert "id_statline_type" not in response.content.decode()
+    # The toggle is a link that navigates to the override variant.
+    assert response.context["override_statline"] is False
+    assert "override_statline=1" in response.context["override_statline_toggle_url"]
+
+    # Override variant: statline_type is present in the form and rendered.
+    response = client.get(add_url + "?override_statline=1")
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "statline_type" in form.fields
+    assert "id_statline_type" in response.content.decode()
+    assert response.context["override_statline"] is True
+    # The toggle now points back to the default (flag removed).
+    assert "override_statline" not in response.context["override_statline_toggle_url"]
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/views/pack.py
+++ b/gyrinx/core/views/pack.py
@@ -1720,6 +1720,15 @@ def add_pack_item(request, id, content_type_slug):
     is_fighter = entry.model_class is ContentFighter
     is_weapon = content_type_slug == "weapon"
 
+    # URL-driven variant: the statline-override section is shown only when
+    # ``?override_statline=1`` is set (fighters only). Flipping it is a
+    # navigation (a link in the template), not a client-side toggle. Any
+    # non-empty value counts as on, so it round-trips through the create POST.
+    override_statline = is_fighter and bool(
+        request.GET.get("override_statline") or request.POST.get("override_statline")
+    )
+    fighter_form_kwargs = {"override_statline": override_statline} if is_fighter else {}
+
     # Weapons require a profile mode — redirect to mode selection if missing.
     if is_weapon and "profile_mode" not in request.GET and request.method != "POST":
         return HttpResponseRedirect(
@@ -1738,7 +1747,9 @@ def add_pack_item(request, id, content_type_slug):
             )
 
     if request.method == "POST":
-        form = entry.form_class(request.POST, **_form_kwargs(entry, pack))
+        form = entry.form_class(
+            request.POST, **_form_kwargs(entry, pack), **fighter_form_kwargs
+        )
 
         # Validate multi-mode profile names before attempting to save.
         wp_name_errors = []
@@ -1843,7 +1854,7 @@ def add_pack_item(request, id, content_type_slug):
             for err in wp_name_errors:
                 form.add_error(None, err)
     else:
-        form = entry.form_class(**_form_kwargs(entry, pack))
+        form = entry.form_class(**_form_kwargs(entry, pack), **fighter_form_kwargs)
         # Pre-select category from query param (e.g., skill tree → skill)
         if "category" in request.GET and "category" in form.fields:
             form.initial["category"] = request.GET["category"]
@@ -1870,6 +1881,17 @@ def add_pack_item(request, id, content_type_slug):
             "this Fighter — open it from the pack and use Edit."
         )
         context["next_step_button"] = "Next →"
+        context["override_statline"] = override_statline
+        # Link that flips the override flag, preserving other query params.
+        toggle_params = request.GET.copy()
+        toggle_params.pop("override_statline", None)
+        if not override_statline:
+            toggle_params["override_statline"] = "1"
+        toggle_qs = toggle_params.urlencode()
+        toggle_url = reverse("core:pack-add-item", args=(pack.id, "fighter"))
+        if toggle_qs:
+            toggle_url += f"?{toggle_qs}"
+        context["override_statline_toggle_url"] = toggle_url
 
     if is_weapon:
         context["profile_mode"] = profile_mode


### PR DESCRIPTION
#1867 B1: make the pack fighter **statline-override** server-rendered / URL-driven (works without JS). Removes the forbidden checkbox-disables-select inline JS.

- `?override_statline=1` navigation; the view passes the flag to `ContentFighterPackForm`, which includes `statline_type` only when overriding; the template renders an `<a>` toggle + a hidden input to carry the flag through the create POST. Fighter-only feature; the 2-step add flow's Step 2 is unaffected.
- New test: GET with/without `?override_statline=1` asserts `statline_type` present/absent in `form.fields` and rendered HTML; JS-off variants confirmed via test client.
- `pytest` pack suites 354 passed; `manage check` / `makemigrations` / `fmt` clean.

⚠️ Overlaps `forms/pack.py` with #1863 part 3 (`issue-1863-form-mixin`) — whichever merges second needs a trivial rebase.

Part of #1855 (#1867).
