### PR TITLE
refactor: URL-drive advancement-type cost prefill (#1867 B2)

### DIFF
--- a/gyrinx/core/forms/advancement.py
+++ b/gyrinx/core/forms/advancement.py
@@ -235,7 +235,12 @@ class AdvancementTypeForm(forms.Form):
     advancement_choice = forms.ChoiceField(
         # Note that these choices are overridden by __init__()
         choices=ADVANCEMENT_CHOICES,
-        widget=forms.Select(attrs={"class": "form-select"}),
+        # data-gy-toggle-submit auto-submits the (GET) form on change so the
+        # server re-renders with the matching cost defaults; the page still
+        # works without JS via the explicit "Update costs" button.
+        widget=forms.Select(
+            attrs={"class": "form-select", "data-gy-toggle-submit": ""}
+        ),
         help_text="Select the type of advancement for this fighter.",
     )
 
@@ -470,19 +475,25 @@ class AdvancementTypeForm(forms.Form):
         """Get the AdvancementConfig for a given choice."""
         return cls.ADVANCEMENT_CONFIGS.get(advancement_choice)
 
-    def get_all_configs_json(self) -> dict:
-        """Get all advancement configs as JSON-serializable dict."""
-        configs = {}
-        for key, config in self.advancement_configs.items():
-            configs[key] = {
-                "name": config.name,
-                "display_name": config.display_name,
-                "xp_cost": config.xp_cost,
-                "cost_increase": config.cost_increase,
-                "roll": config.roll,
-                "restricted_to_fighter_categories": config.restricted_to_fighter_categories,
-            }
-        return configs
+    def cost_initial_for_choice(self, advancement_choice: str) -> dict:
+        """
+        Return the ``xp_cost``/``cost_increase`` form initial values for a
+        choice, resolved against this form's fighter-specific configs.
+
+        ``__init__`` builds ``self.advancement_configs`` from the static
+        ``ADVANCEMENT_CONFIGS`` plus the dynamic stat and equipment configs for
+        the fighter, so this lookup covers stat advancements that aren't in the
+        static config and equipment advancements whose costs come from
+        ``ContentAdvancementEquipment``. Returns an empty dict for an unknown
+        choice so callers can fall back to their own defaults.
+        """
+        config = self.advancement_configs.get(advancement_choice)
+        if config is None:
+            return {}
+        return {
+            "xp_cost": config.xp_cost,
+            "cost_increase": config.cost_increase,
+        }
 
 
 class StatSelectionForm(forms.Form):

--- a/gyrinx/core/templates/core/list_fighter_advancement_type.html
+++ b/gyrinx/core/templates/core/list_fighter_advancement_type.html
@@ -21,31 +21,51 @@
                 </div>
             </div>
         {% endif %}
-        <form method="post"
-              class="vstack gap-4"
-              aria-label="Select advancement form">
-            {% csrf_token %}
-            {{ form.campaign_action_id }}
+        <div class="vstack gap-4">
             {% if form.non_field_errors %}
                 <div class="alert alert-danger alert-icon mb-last-0 mb-0" role="alert">
                     <i class="bi-exclamation-triangle"></i>
                     <div>{{ form.non_field_errors }}</div>
                 </div>
             {% endif %}
-            <div class="vstack gap-3">
-                <div class="alert alert-secondary alert-icon mb-0" role="alert">
-                    <i class="bi-info-circle"></i>
-                    <div>
-                        Available XP: <span class="badge text-bg-primary">{{ fighter.xp_current }}</span>
-                    </div>
-                </div>
+            <div class="alert alert-secondary alert-icon mb-0" role="alert">
+                <i class="bi-info-circle"></i>
                 <div>
-                    <label class="form-label">Advancement</label>
-                    <div class="vstack gap-2">{{ form.advancement_choice }}</div>
-                    {% if form.advancement_choice.errors %}
-                        <div class="invalid-feedback d-block">{{ form.advancement_choice.errors.0 }}</div>
-                    {% endif %}
+                    Available XP: <span class="badge text-bg-primary">{{ fighter.xp_current }}</span>
                 </div>
+            </div>
+            {# Advancement picker: a GET form that reloads this page with the #}
+            {# chosen advancement so the server can render the matching cost #}
+            {# defaults. Auto-submits on change via data-gy-toggle-submit; the #}
+            {# "Update costs" button covers the no-JS path. #}
+            <form method="get"
+                  class="vstack gap-1"
+                  aria-label="Choose advancement form">
+                {% if form.campaign_action_id.value %}
+                    <input type="hidden"
+                           name="campaign_action_id"
+                           value="{{ form.campaign_action_id.value }}">
+                {% endif %}
+                <label for="{{ form.advancement_choice.id_for_label }}" class="form-label">Advancement</label>
+                <div class="vstack gap-2">{{ form.advancement_choice }}</div>
+                {% if form.advancement_choice.errors %}
+                    <div class="invalid-feedback d-block">{{ form.advancement_choice.errors.0 }}</div>
+                {% endif %}
+                <noscript>
+                    <button type="submit" class="btn btn-secondary btn-sm mt-2 align-self-start">Update costs</button>
+                </noscript>
+            </form>
+            {# Action form: submits the chosen advancement and (editable) costs. #}
+            {# The advancement choice is mirrored as a hidden field so the chosen #}
+            {# value posts even though the visible select lives in the GET form. #}
+            <form method="post"
+                  class="vstack gap-4"
+                  aria-label="Select advancement form">
+                {% csrf_token %}
+                {{ form.campaign_action_id }}
+                <input type="hidden"
+                       name="advancement_choice"
+                       value="{{ form.advancement_choice.value }}">
                 <div class="row">
                     <div class="col-md-6">
                         <label for="{{ form.xp_cost.id_for_label }}" class="form-label">XP Spend</label>
@@ -64,57 +84,21 @@
                         {% endif %}
                     </div>
                 </div>
-            </div>
-            <nav class="vstack gap-3" aria-label="Form navigation">
-                <div class="hstack gap-3">
-                    {% if step > 1 %}
-                        <a href="{% url 'core:list-fighter-advancement-dice-choice' list.id fighter.id %}"
-                           class="icon-link">
-                            <i class="bi-chevron-left"></i> Back
-                        </a>
-                    {% endif %}
-                    <button type="submit" class="btn btn-primary" aria-describedby="nav-help">
-                        Next <i class="bi-arrow-right" aria-hidden="true"></i>
-                    </button>
-                </div>
-                <span id="nav-help" class="visually-hidden">Navigate to the next step of the advancement workflow</span>
-            </nav>
-        </form>
+                <nav class="vstack gap-3" aria-label="Form navigation">
+                    <div class="hstack gap-3">
+                        {% if step > 1 %}
+                            <a href="{% url 'core:list-fighter-advancement-dice-choice' list.id fighter.id %}"
+                               class="icon-link">
+                                <i class="bi-chevron-left"></i> Back
+                            </a>
+                        {% endif %}
+                        <button type="submit" class="btn btn-primary" aria-describedby="nav-help">
+                            Next <i class="bi-arrow-right" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                    <span id="nav-help" class="visually-hidden">Navigate to the next step of the advancement workflow</span>
+                </nav>
+            </form>
+        </div>
     </div>
 {% endblock content %}
-{% block extra_script %}
-    {{ advancement_configs|json_script:"advancement-configs" }}
-    <script>
-    // Advancement configurations passed from the server
-    const advancementConfigs = JSON.parse(
-        document.getElementById('advancement-configs').textContent
-    );
-
-    // Get references to form elements
-    const advancementSelect = document.getElementById('{{ form.advancement_choice.id_for_label }}');
-    const xpCostInput = document.getElementById('{{ form.xp_cost.id_for_label }}');
-    const costIncreaseInput = document.getElementById('{{ form.cost_increase.id_for_label }}');
-
-    // Update costs when advancement type changes
-    function updateCosts() {
-        const selectedValue = advancementSelect.value;
-        const config = advancementConfigs[selectedValue];
-
-        if (config) {
-            // Update XP cost and fighter cost increase
-            xpCostInput.value = config.xp_cost;
-            costIncreaseInput.value = config.cost_increase;
-        }
-    }
-
-    // Listen for changes to the advancement selection
-    if (advancementSelect) {
-        advancementSelect.addEventListener('change', updateCosts);
-
-        // Update costs on page load if a value is already selected
-        if (advancementSelect.value) {
-            updateCosts();
-        }
-    }
-    </script>
-{% endblock extra_script %}

--- a/gyrinx/core/tests/test_advancements.py
+++ b/gyrinx/core/tests/test_advancements.py
@@ -875,3 +875,90 @@ def test_advancement_confirm_warns_on_different_fighter(
         fighter=fighter_with_xp, campaign_action=campaign_action
     )
     assert original_advancements.count() == 1
+
+
+def _input_value(content, name):
+    """Return the ``value`` attribute of the <input name="{name}"> in ``content``."""
+    import re
+
+    match = re.search(
+        r'<input\b[^>]*\bname="' + re.escape(name) + r'"[^>]*>',
+        content,
+    )
+    assert match, f"input name={name!r} not found in rendered page"
+    tag = match.group(0)
+    value_match = re.search(r'\bvalue="([^"]*)"', tag)
+    assert value_match, f"input name={name!r} has no value attribute: {tag}"
+    return value_match.group(1)
+
+
+@pytest.mark.django_db
+def test_advancement_type_url_driven_cost_prefill(client, user, fighter_with_xp):
+    """
+    GET ?advancement_choice=stat_strength renders the matching cost defaults
+    server-side, so the page works without JS rewriting the inputs.
+    """
+    client.login(username="testuser", password="password")
+
+    url = reverse(
+        "core:list-fighter-advancement-type",
+        args=[fighter_with_xp.list.id, fighter_with_xp.id],
+    )
+    response = client.get(url, {"advancement_choice": "stat_strength"})
+
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # stat_strength config: xp_cost=8, cost_increase=30 (ADVANCEMENT_CONFIGS).
+    assert _input_value(content, "xp_cost") == "8"
+    assert _input_value(content, "cost_increase") == "30"
+    # The chosen advancement round-trips into the POST form via a hidden mirror,
+    # so submitting works even without JS keeping the select and form in sync.
+    assert _input_value(content, "advancement_choice") == "stat_strength"
+
+    # The old client-side cost-rewriting JSON blob is gone.
+    assert "advancement-configs" not in content
+
+
+@pytest.mark.django_db
+def test_advancement_type_default_cost_prefill_without_choice(
+    client, user, fighter_with_xp
+):
+    """Without an advancement_choice param, the default action costs render."""
+    client.login(username="testuser", password="password")
+
+    url = reverse(
+        "core:list-fighter-advancement-type",
+        args=[fighter_with_xp.list.id, fighter_with_xp.id],
+    )
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # get_initial_for_action default (no campaign action): stat_willpower 3/5.
+    assert _input_value(content, "advancement_choice") == "stat_willpower"
+    assert _input_value(content, "xp_cost") == "3"
+    assert _input_value(content, "cost_increase") == "5"
+
+
+@pytest.mark.django_db
+def test_advancement_type_invalid_choice_falls_back_to_defaults(
+    client, user, fighter_with_xp
+):
+    """An advancement_choice not in the fighter's choices is ignored."""
+    client.login(username="testuser", password="password")
+
+    url = reverse(
+        "core:list-fighter-advancement-type",
+        args=[fighter_with_xp.list.id, fighter_with_xp.id],
+    )
+    response = client.get(url, {"advancement_choice": "not_a_real_choice"})
+
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Falls back to the default action costs rather than erroring.
+    assert _input_value(content, "advancement_choice") == "stat_willpower"
+    assert _input_value(content, "xp_cost") == "3"
+    assert _input_value(content, "cost_increase") == "5"

--- a/gyrinx/core/views/fighter/advancements.py
+++ b/gyrinx/core/views/fighter/advancements.py
@@ -575,6 +575,22 @@ def list_fighter_advancement_type(request, id, fighter_id):
         }
         form = AdvancementTypeForm(initial=initial, fighter=fighter)
 
+        # URL-driven cost prefill: when the user picks an advancement the select
+        # reloads this view with ?advancement_choice=..., and the server renders
+        # the matching xp_cost/cost_increase as the form's initial values (which
+        # stay editable). cost_initial_for_choice resolves against the form's
+        # fighter-specific configs, so dynamically-generated stat and equipment
+        # choices prefill correctly. An unknown/empty choice leaves the
+        # action-based defaults from get_initial_for_action in place.
+        url_choice = request.GET.get("advancement_choice")
+        if url_choice:
+            valid_choices = {
+                value for value, _ in form.fields["advancement_choice"].choices
+            }
+            if url_choice in valid_choices:
+                form.initial["advancement_choice"] = url_choice
+                form.initial.update(form.cost_initial_for_choice(url_choice))
+
     return render(
         request,
         "core/list_fighter_advancement_type.html",
@@ -587,7 +603,6 @@ def list_fighter_advancement_type(request, id, fighter_id):
             "steps": 3 if is_campaign_mode else 2,
             "current_step": 2 if is_campaign_mode else 1,
             "progress": 66 if is_campaign_mode else 50,
-            "advancement_configs": form.get_all_configs_json(),
         },
     )
 


### PR DESCRIPTION
#1867 B2: URL-drive the advancement-type **cost prefill** (works without JS). Removes the `advancement_configs` JSON blob + the inline change-handler that rewrote cost inputs.

- `advancement_choice` is a GET-submitting select (`?advancement_choice=…`); the view sets the form's `initial` for `xp_cost`/`cost_increase` from the form's instance-level `advancement_configs` (so fighter-filtered stat + equipment advancements prefill correctly). Values stay editable. `<noscript>` button + auto-submit enhancement cover both paths.
- New tests (JS-off): GET `?advancement_choice=stat_strength` renders 8/30; no-param renders defaults; invalid choice falls back. Browser-smoke confirmed the JS path + cost round-trip.
- `pytest` advancement suites 81 passed; `manage check` / `makemigrations` / `fmt` clean.

Part of #1855 (#1867).
