### PR TITLE
refactor: make print-config fighter selection mode URL-driven (#1867 B3)

### DIFF
--- a/gyrinx/core/forms/print_config.py
+++ b/gyrinx/core/forms/print_config.py
@@ -52,9 +52,20 @@ class PrintConfigForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.list_obj = kwargs.pop("list_obj", None)
+        # The selection mode is URL-driven: the view passes the mode selected via
+        # navigation so the form renders the matching variant. The
+        # ``included_fighters`` field is only present when the mode is "specific".
+        self.selection_mode = kwargs.pop("selection_mode", PrintConfig.ALL_FIGHTERS)
         super().__init__(*args, **kwargs)
 
-        if self.list_obj:
+        # Keep the stored mode in sync with the URL-driven variant so the hidden
+        # field that posts the value matches the section being rendered.
+        self.fields["fighter_selection_mode"].initial = self.selection_mode
+
+        if self.selection_mode != PrintConfig.SPECIFIC_FIGHTERS:
+            # Only the "specific" variant shows (and submits) fighter checkboxes.
+            del self.fields["included_fighters"]
+        elif self.list_obj:
             # Filter fighters to only show those belonging to this list
             self.fields["included_fighters"].queryset = ListFighter.objects.filter(
                 list=self.list_obj, archived=False, content_fighter__is_stash=False
@@ -68,7 +79,10 @@ class PrintConfigForm(forms.ModelForm):
     def clean(self):
         """Validate fighter selection and clear included_fighters for non-specific modes."""
         cleaned_data = super().clean()
-        mode = cleaned_data.get("fighter_selection_mode")
+        # The mode the form was built for is the source of truth - it drives which
+        # fields exist. The posted radios can't override the URL-driven variant.
+        mode = self.selection_mode
+        cleaned_data["fighter_selection_mode"] = mode
 
         if mode == PrintConfig.SPECIFIC_FIGHTERS:
             if not cleaned_data.get("included_fighters"):

--- a/gyrinx/core/templates/core/print_config/form.html
+++ b/gyrinx/core/templates/core/print_config/form.html
@@ -49,22 +49,45 @@
             <!-- Fighter Selection Section -->
             <div>
                 <h2 class="h5 mb-3">Fighter Selection</h2>
-                <p class="text-secondary fs-7 mb-3">{{ form.included_fighters.help_text }}</p>
+                <p class="text-secondary fs-7 mb-3">Choose which fighters to include in the print output.</p>
                 <div class="border rounded p-3 overflow-auto">
-                    <div class="vstack gap-2 mb-3 border-bottom pb-3">
-                        {% for choice in form.fighter_selection_mode %}
+                    {# The selection mode is URL-driven: switching it is a navigation #}
+                    {# (a GET submission to this same page) so the server renders the #}
+                    {# matching variant. JS auto-submits on change; without JS the #}
+                    {# "Update" button below performs the same navigation. The chosen #}
+                    {# mode is carried into the main POST form by the hidden field. #}
+                    <form method="get"
+                          class="vstack gap-2 mb-3 border-bottom pb-3"
+                          data-gy-selection-mode-picker>
+                        {% for value, label in form.fields.fighter_selection_mode.choices %}
                             <div class="form-check">
-                                {{ choice.tag }}
-                                <label class="form-check-label" for="{{ choice.id_for_label }}">{{ choice.choice_label }}</label>
+                                <input class="form-check-input"
+                                       type="radio"
+                                       name="fighter_selection_mode"
+                                       id="fighter_selection_mode_{{ value }}"
+                                       value="{{ value }}"
+                                       {% if value == form.selection_mode %}checked{% endif %}>
+                                <label class="form-check-label" for="fighter_selection_mode_{{ value }}">{{ label }}</label>
                             </div>
                         {% endfor %}
-                    </div>
-                    {% if form.included_fighters.field.queryset %}
-                        <div class="vstack gap-2" id="fighter-checkboxes">
-                            {% for choice in form.included_fighters %}{{ choice }}{% endfor %}
-                        </div>
-                    {% else %}
-                        <p class="text-secondary mb-0" id="no-fighters-message">No fighters available.</p>
+                        <noscript>
+                            <button type="submit" class="btn btn-secondary btn-sm align-self-start mt-1">Update selection mode</button>
+                        </noscript>
+                    </form>
+                    {# Mirror the chosen mode into the main POST form so it submits #}
+                    {# with the rest of the configuration. #}
+                    <input type="hidden"
+                           name="fighter_selection_mode"
+                           value="{{ form.selection_mode }}">
+                    {% if form.included_fighters %}
+                        {{ form.included_fighters.errors }}
+                        {% if form.included_fighters.field.queryset %}
+                            <div class="vstack gap-2" id="fighter-checkboxes">
+                                {% for choice in form.included_fighters %}{{ choice }}{% endfor %}
+                            </div>
+                        {% else %}
+                            <p class="text-secondary mb-0" id="no-fighters-message">No fighters available.</p>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>
@@ -120,41 +143,15 @@
         </form>
     </div>
     <script>
+        // Enhancement only: auto-submit the selection-mode picker (a GET form) so
+        // switching mode navigates without an extra click. The page works without
+        // this — the picker's <noscript> submit button performs the same GET.
         document.addEventListener('DOMContentLoaded', () => {
-            const modeRadios = document.querySelectorAll('input[name="fighter_selection_mode"]');
-            const fighterCheckboxes = document.querySelectorAll('#fighter-checkboxes input[type="checkbox"]');
-            const fighterCheckboxesContainer = document.getElementById('fighter-checkboxes');
-
-            function updateFighterCheckboxesState() {
-                const selectedMode = document.querySelector('input[name="fighter_selection_mode"]:checked')?.value;
-
-                if (selectedMode === 'specific') {
-                    // Enable fighter checkboxes
-                    fighterCheckboxes.forEach(checkbox => {
-                        checkbox.disabled = false;
-                    });
-                    if (fighterCheckboxesContainer) {
-                        fighterCheckboxesContainer.style.opacity = '1';
-                    }
-                } else {
-                    // Disable and uncheck fighter checkboxes
-                    fighterCheckboxes.forEach(checkbox => {
-                        checkbox.disabled = true;
-                        checkbox.checked = false;
-                    });
-                    if (fighterCheckboxesContainer) {
-                        fighterCheckboxesContainer.style.opacity = '0.5';
-                    }
-                }
-            }
-
-            // Update state when mode changes
-            modeRadios.forEach(radio => {
-                radio.addEventListener('change', updateFighterCheckboxesState);
+            document.querySelectorAll('[data-gy-selection-mode-picker]').forEach((picker) => {
+                picker.querySelectorAll('input[type="radio"]').forEach((radio) => {
+                    radio.addEventListener('change', () => picker.requestSubmit());
+                });
             });
-
-            // Set initial state
-            updateFighterCheckboxesState();
         });
     </script>
 {% endblock content %}

--- a/gyrinx/core/tests/test_print_config_stash.py
+++ b/gyrinx/core/tests/test_print_config_stash.py
@@ -160,6 +160,8 @@ def test_specific_fighters_requires_selection(test_list_with_stash):
             "blank_vehicle_cards": 0,
         },
         list_obj=test_list,
+        # The variant is URL-driven; the view passes the chosen mode to the form.
+        selection_mode=PrintConfig.SPECIFIC_FIGHTERS,
     )
 
     assert not form.is_valid()
@@ -180,6 +182,8 @@ def test_specific_fighters_valid_with_selection(test_list_with_stash):
             "blank_vehicle_cards": 0,
         },
         list_obj=test_list,
+        # The variant is URL-driven; the view passes the chosen mode to the form.
+        selection_mode=PrintConfig.SPECIFIC_FIGHTERS,
     )
 
     assert form.is_valid()

--- a/gyrinx/core/tests/test_print_config_views.py
+++ b/gyrinx/core/tests/test_print_config_views.py
@@ -1,0 +1,373 @@
+"""Tests for the URL-driven print-configuration create/edit views.
+
+The fighter-selection mode is a server-rendered variant chosen by navigation
+(``?fighter_selection_mode=...``). The ``included_fighters`` section is rendered
+only for the "specific" variant, and the server stays the source of truth for
+clearing it in the other modes. These tests exercise the variants without any
+JavaScript, asserting the right section renders per URL and that posting works
+in each mode.
+"""
+
+import pytest
+from django.urls import reverse
+
+from gyrinx.core.models import PrintConfig
+
+
+def _create_url(list_):
+    return reverse("core:print-config-create", kwargs={"list_id": list_.id})
+
+
+def _edit_url(list_, config):
+    return reverse(
+        "core:print-config-edit",
+        kwargs={"list_id": list_.id, "config_id": config.id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create view — GET variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_get_default_hides_fighter_checkboxes(
+    client, user, make_list, make_list_fighter
+):
+    """Default mode (all) renders no fighter checkbox section."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ganger A")
+    client.force_login(user)
+
+    response = client.get(_create_url(lst))
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "included_fighters" not in form.fields
+    assert 'id="fighter-checkboxes"' not in response.content.decode()
+    # The mode picker is always present so the user can switch variants.
+    assert 'name="fighter_selection_mode"' in response.content.decode()
+    assert fighter.name not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_create_get_specific_shows_fighter_checkboxes(
+    client, user, make_list, make_list_fighter
+):
+    """?fighter_selection_mode=specific renders the fighter checkbox section."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ganger A")
+    client.force_login(user)
+
+    response = client.get(
+        _create_url(lst), {"fighter_selection_mode": PrintConfig.SPECIFIC_FIGHTERS}
+    )
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert "included_fighters" in form.fields
+    content = response.content.decode()
+    assert 'id="fighter-checkboxes"' in content
+    assert fighter.name in content
+
+
+@pytest.mark.django_db
+def test_create_get_none_hides_fighter_checkboxes(
+    client, user, make_list, make_list_fighter
+):
+    """?fighter_selection_mode=none renders no fighter checkbox section."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger A")
+    client.force_login(user)
+
+    response = client.get(
+        _create_url(lst), {"fighter_selection_mode": PrintConfig.NO_FIGHTERS}
+    )
+
+    assert response.status_code == 200
+    assert "included_fighters" not in response.context["form"].fields
+    assert 'id="fighter-checkboxes"' not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_create_get_invalid_mode_falls_back_to_default(client, user, make_list):
+    """An unknown mode value falls back to the default (all) variant."""
+    lst = make_list("Gang")
+    client.force_login(user)
+
+    response = client.get(_create_url(lst), {"fighter_selection_mode": "bogus"})
+
+    assert response.status_code == 200
+    assert response.context["form"].selection_mode == PrintConfig.ALL_FIGHTERS
+    assert "included_fighters" not in response.context["form"].fields
+
+
+# ---------------------------------------------------------------------------
+# Create view — POST variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_post_all_succeeds_without_fighters(client, user, make_list):
+    """Posting in 'all' mode with no fighters creates the config."""
+    lst = make_list("Gang")
+    client.force_login(user)
+
+    response = client.post(
+        _create_url(lst),
+        {
+            "name": "All Fighters Config",
+            "fighter_selection_mode": PrintConfig.ALL_FIGHTERS,
+            "blank_fighter_cards": 0,
+            "blank_vehicle_cards": 0,
+        },
+    )
+
+    assert response.status_code == 302
+    config = PrintConfig.objects.get(list=lst, name="All Fighters Config")
+    assert config.fighter_selection_mode == PrintConfig.ALL_FIGHTERS
+    assert config.included_fighters.count() == 0
+
+
+@pytest.mark.django_db
+def test_create_post_none_succeeds_without_fighters(client, user, make_list):
+    """Posting in 'none' mode with no fighters creates the config."""
+    lst = make_list("Gang")
+    client.force_login(user)
+
+    response = client.post(
+        _create_url(lst),
+        {
+            "name": "No Fighters Config",
+            "fighter_selection_mode": PrintConfig.NO_FIGHTERS,
+            "blank_fighter_cards": 0,
+            "blank_vehicle_cards": 0,
+        },
+    )
+
+    assert response.status_code == 302
+    config = PrintConfig.objects.get(list=lst, name="No Fighters Config")
+    assert config.fighter_selection_mode == PrintConfig.NO_FIGHTERS
+    assert config.included_fighters.count() == 0
+
+
+@pytest.mark.django_db
+def test_create_post_specific_without_fighters_errors(
+    client, user, make_list, make_list_fighter
+):
+    """Posting 'specific' with zero fighters surfaces the validation error."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger A")
+    client.force_login(user)
+
+    response = client.post(
+        _create_url(lst),
+        {
+            "name": "Specific Config",
+            "fighter_selection_mode": PrintConfig.SPECIFIC_FIGHTERS,
+            "blank_fighter_cards": 0,
+            "blank_vehicle_cards": 0,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "included_fighters" in response.context["form"].errors
+    assert not PrintConfig.objects.filter(list=lst, name="Specific Config").exists()
+
+
+@pytest.mark.django_db
+def test_create_post_specific_with_fighters_succeeds(
+    client, user, make_list, make_list_fighter
+):
+    """Posting 'specific' with a fighter selected creates the config."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ganger A")
+    client.force_login(user)
+
+    response = client.post(
+        _create_url(lst),
+        {
+            "name": "Specific Config",
+            "fighter_selection_mode": PrintConfig.SPECIFIC_FIGHTERS,
+            "included_fighters": [str(fighter.id)],
+            "blank_fighter_cards": 0,
+            "blank_vehicle_cards": 0,
+        },
+    )
+
+    assert response.status_code == 302
+    config = PrintConfig.objects.get(list=lst, name="Specific Config")
+    assert config.fighter_selection_mode == PrintConfig.SPECIFIC_FIGHTERS
+    assert list(config.included_fighters.all()) == [fighter]
+
+
+# ---------------------------------------------------------------------------
+# Edit view — GET variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_edit_get_uses_saved_mode_specific(client, user, make_list, make_list_fighter):
+    """Editing a 'specific' config defaults the variant to its saved mode."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ganger A")
+    config = PrintConfig.objects.create(
+        name="Saved Specific",
+        list=lst,
+        owner=user,
+        fighter_selection_mode=PrintConfig.SPECIFIC_FIGHTERS,
+    )
+    config.included_fighters.add(fighter)
+    client.force_login(user)
+
+    response = client.get(_edit_url(lst, config))
+
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert form.selection_mode == PrintConfig.SPECIFIC_FIGHTERS
+    assert "included_fighters" in form.fields
+    assert 'id="fighter-checkboxes"' in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_edit_get_uses_saved_mode_all(client, user, make_list, make_list_fighter):
+    """Editing an 'all' config hides the fighter checkbox section by default."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger A")
+    config = PrintConfig.objects.create(
+        name="Saved All",
+        list=lst,
+        owner=user,
+        fighter_selection_mode=PrintConfig.ALL_FIGHTERS,
+    )
+    client.force_login(user)
+
+    response = client.get(_edit_url(lst, config))
+
+    assert response.status_code == 200
+    assert response.context["form"].selection_mode == PrintConfig.ALL_FIGHTERS
+    assert "included_fighters" not in response.context["form"].fields
+
+
+@pytest.mark.django_db
+def test_edit_get_url_overrides_saved_mode(client, user, make_list, make_list_fighter):
+    """The URL mode wins over the saved mode when switching variants."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ganger A")
+    config = PrintConfig.objects.create(
+        name="Saved All",
+        list=lst,
+        owner=user,
+        fighter_selection_mode=PrintConfig.ALL_FIGHTERS,
+    )
+    client.force_login(user)
+
+    response = client.get(
+        _edit_url(lst, config),
+        {"fighter_selection_mode": PrintConfig.SPECIFIC_FIGHTERS},
+    )
+
+    assert response.status_code == 200
+    assert response.context["form"].selection_mode == PrintConfig.SPECIFIC_FIGHTERS
+    assert "included_fighters" in response.context["form"].fields
+    assert fighter.name in response.content.decode()
+
+
+# ---------------------------------------------------------------------------
+# Edit view — POST variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_edit_post_switch_to_all_clears_fighters(
+    client, user, make_list, make_list_fighter
+):
+    """Switching a saved 'specific' config to 'all' clears included_fighters."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ganger A")
+    config = PrintConfig.objects.create(
+        name="Was Specific",
+        list=lst,
+        owner=user,
+        fighter_selection_mode=PrintConfig.SPECIFIC_FIGHTERS,
+    )
+    config.included_fighters.add(fighter)
+    client.force_login(user)
+
+    response = client.post(
+        _edit_url(lst, config),
+        {
+            "name": "Was Specific",
+            "fighter_selection_mode": PrintConfig.ALL_FIGHTERS,
+            "blank_fighter_cards": 0,
+            "blank_vehicle_cards": 0,
+        },
+    )
+
+    assert response.status_code == 302
+    config.refresh_from_db()
+    assert config.fighter_selection_mode == PrintConfig.ALL_FIGHTERS
+    assert config.included_fighters.count() == 0
+
+
+@pytest.mark.django_db
+def test_edit_post_specific_without_fighters_errors(
+    client, user, make_list, make_list_fighter
+):
+    """Posting 'specific' on edit with zero fighters surfaces the error."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger A")
+    config = PrintConfig.objects.create(
+        name="Cfg",
+        list=lst,
+        owner=user,
+        fighter_selection_mode=PrintConfig.ALL_FIGHTERS,
+    )
+    client.force_login(user)
+
+    response = client.post(
+        _edit_url(lst, config),
+        {
+            "name": "Cfg",
+            "fighter_selection_mode": PrintConfig.SPECIFIC_FIGHTERS,
+            "blank_fighter_cards": 0,
+            "blank_vehicle_cards": 0,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "included_fighters" in response.context["form"].errors
+    config.refresh_from_db()
+    assert config.fighter_selection_mode == PrintConfig.ALL_FIGHTERS
+
+
+@pytest.mark.django_db
+def test_edit_post_switch_to_specific_with_fighters(
+    client, user, make_list, make_list_fighter
+):
+    """Switching to 'specific' on edit with a fighter persists the selection."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ganger A")
+    config = PrintConfig.objects.create(
+        name="Cfg",
+        list=lst,
+        owner=user,
+        fighter_selection_mode=PrintConfig.ALL_FIGHTERS,
+    )
+    client.force_login(user)
+
+    response = client.post(
+        _edit_url(lst, config),
+        {
+            "name": "Cfg",
+            "fighter_selection_mode": PrintConfig.SPECIFIC_FIGHTERS,
+            "included_fighters": [str(fighter.id)],
+            "blank_fighter_cards": 0,
+            "blank_vehicle_cards": 0,
+        },
+    )
+
+    assert response.status_code == 302
+    config.refresh_from_db()
+    assert config.fighter_selection_mode == PrintConfig.SPECIFIC_FIGHTERS
+    assert list(config.included_fighters.all()) == [fighter]

--- a/gyrinx/core/views/print_config.py
+++ b/gyrinx/core/views/print_config.py
@@ -10,6 +10,20 @@ from gyrinx.core.models import List, PrintConfig
 from gyrinx.core.models.events import EventNoun, EventVerb, log_event
 from gyrinx.core.utils import safe_redirect
 
+# Valid fighter-selection modes, used to validate the URL-driven variant.
+_VALID_SELECTION_MODES = {value for value, _ in PrintConfig.FIGHTER_SELECTION_CHOICES}
+
+
+def _resolve_selection_mode(source, default):
+    """Resolve the URL-driven fighter-selection mode from a request dict.
+
+    Falls back to ``default`` when the value is missing or not a valid choice.
+    """
+    mode = source.get("fighter_selection_mode")
+    if mode in _VALID_SELECTION_MODES:
+        return mode
+    return default
+
 
 class PrintConfigIndexView(generic.ListView):
     """
@@ -62,7 +76,12 @@ def print_config_create(request, list_id):
     )
 
     if request.method == "POST":
-        form = PrintConfigForm(request.POST, list_obj=list_obj)
+        # The selection mode is URL-driven: the posted hidden field carries the
+        # variant the form was rendered for, so it stays the source of truth.
+        selection_mode = _resolve_selection_mode(request.POST, PrintConfig.ALL_FIGHTERS)
+        form = PrintConfigForm(
+            request.POST, list_obj=list_obj, selection_mode=selection_mode
+        )
         if form.is_valid():
             with transaction.atomic():
                 print_config = form.save(commit=False)
@@ -96,8 +115,13 @@ def print_config_create(request, list_id):
             "include_dead_fighters": False,
         }
 
+        # The selection mode is chosen by navigation (?fighter_selection_mode=...);
+        # the form renders the matching variant. Default to "all fighters".
+        selection_mode = _resolve_selection_mode(request.GET, PrintConfig.ALL_FIGHTERS)
         # Don't pre-select any fighters since we default to "all fighters"
-        form = PrintConfigForm(initial=initial, list_obj=list_obj)
+        form = PrintConfigForm(
+            initial=initial, list_obj=list_obj, selection_mode=selection_mode
+        )
 
     return render(
         request,
@@ -121,7 +145,17 @@ def print_config_edit(request, list_id, config_id):
     )
 
     if request.method == "POST":
-        form = PrintConfigForm(request.POST, instance=print_config, list_obj=list_obj)
+        # The posted hidden field carries the URL-driven variant; fall back to the
+        # saved mode if it is somehow absent.
+        selection_mode = _resolve_selection_mode(
+            request.POST, print_config.fighter_selection_mode
+        )
+        form = PrintConfigForm(
+            request.POST,
+            instance=print_config,
+            list_obj=list_obj,
+            selection_mode=selection_mode,
+        )
         if form.is_valid():
             with transaction.atomic():
                 old_name = print_config.name
@@ -144,7 +178,16 @@ def print_config_edit(request, list_id, config_id):
                 )
                 return redirect("core:print-config-index", list_id=list_obj.id)
     else:
-        form = PrintConfigForm(instance=print_config, list_obj=list_obj)
+        # On GET the mode comes from the URL when switching variants, otherwise
+        # from the saved configuration.
+        selection_mode = _resolve_selection_mode(
+            request.GET, print_config.fighter_selection_mode
+        )
+        form = PrintConfigForm(
+            instance=print_config,
+            list_obj=list_obj,
+            selection_mode=selection_mode,
+        )
 
     return render(
         request,


### PR DESCRIPTION
#1867 B3: make the print-config **fighter-selection mode** server-rendered / URL-driven (works without JS). Removes the destructive inline JS that disabled + unchecked + dimmed the fighter checkboxes.

- `?fighter_selection_mode=…` navigation; the form is built for the resolved mode and includes `included_fighters` only for `specific`; `clean()` remains the source of truth (clears the M2M for non-specific modes, so switching specific→all on edit clears it even though the field is omitted). `<noscript>` submit + non-destructive auto-submit enhancement. Covers create + edit.
- 13 new view tests (create+edit, GET/POST across modes, incl. specific→all clearing the M2M and zero-fighter validation).
- `pytest` print-config 20 passed; full core suite 2376 passed; `manage check` / `makemigrations` / `fmt` clean.

Part of #1855 (#1867).
