### PR TITLE
fix: tolerate duplicate ContentMod rows in pack mod pickers (#1915)

### DIFF
--- a/gyrinx/core/forms/pack.py
+++ b/gyrinx/core/forms/pack.py
@@ -30,6 +30,21 @@ from gyrinx.forms import group_select
 from gyrinx.models import FighterCategoryChoices, equipment_category_groups
 
 
+def get_or_create_mod(model, **fields):
+    """Duplicate-tolerant ``get_or_create`` for ``ContentMod`` subclasses.
+
+    Production accumulated duplicate modifier rows before any uniqueness
+    constraint existed (#1915), so a plain ``Model.objects.get_or_create``
+    raises ``MultipleObjectsReturned`` when it matches more than one row. Reuse
+    the earliest existing match (ordered by ``pk`` for determinism) instead,
+    creating a row only when none exists.
+    """
+    existing = model.objects.filter(**fields).order_by("pk").first()
+    if existing is not None:
+        return existing
+    return model.objects.create(**fields)
+
+
 def rich_text_description_widget(height="200px"):
     """TinyMCE widget for short rich-text description fields on pack content.
 
@@ -842,16 +857,14 @@ class ContentWeaponAccessoryPackForm(StandardFieldsMixin, forms.ModelForm):
             mode = self.cleaned_data.get(f"stat_mod_{stat_key}_mode")
             value = self.cleaned_data.get(f"stat_mod_{stat_key}_value")
             if mode and value:
-                mod, _created = ContentModStat.objects.get_or_create(
-                    stat=stat_key, mode=mode, value=value
+                mod = get_or_create_mod(
+                    ContentModStat, stat=stat_key, mode=mode, value=value
                 )
                 mods.append(mod)
         for trait in self._traits:
             mode = self.cleaned_data.get(f"trait_mod_{trait.pk}")
             if mode:
-                mod, _created = ContentModTrait.objects.get_or_create(
-                    trait=trait, mode=mode
-                )
+                mod = get_or_create_mod(ContentModTrait, trait=trait, mode=mode)
                 mods.append(mod)
         instance.modifiers.set(mods)
 
@@ -1273,23 +1286,22 @@ class FighterModPickerMixin(StandardFieldsMixin):
             mode = self.cleaned_data.get(f"fmod_stat_{stat.field_name}_mode")
             value = self.cleaned_data.get(f"fmod_stat_{stat.field_name}_value")
             if mode and value:
-                mod, _ = ContentModFighterStat.objects.get_or_create(
-                    stat=stat.field_name, mode=mode, value=value
+                mod = get_or_create_mod(
+                    ContentModFighterStat,
+                    stat=stat.field_name,
+                    mode=mode,
+                    value=value,
                 )
                 new_mods.append(mod)
         for rule in self._fmod_rules:
             mode = self.cleaned_data.get(f"fmod_rule_{rule.pk}")
             if mode:
-                mod, _ = ContentModFighterRule.objects.get_or_create(
-                    rule=rule, mode=mode
-                )
+                mod = get_or_create_mod(ContentModFighterRule, rule=rule, mode=mode)
                 new_mods.append(mod)
         for skill in self._fmod_skills:
             mode = self.cleaned_data.get(f"fmod_skill_{skill.pk}")
             if mode:
-                mod, _ = ContentModFighterSkill.objects.get_or_create(
-                    skill=skill, mode=mode
-                )
+                mod = get_or_create_mod(ContentModFighterSkill, skill=skill, mode=mode)
                 new_mods.append(mod)
 
         # Preserve any existing mods this picker doesn't manage (e.g. skill-tree

--- a/gyrinx/core/tests/test_pack_equipment_mods.py
+++ b/gyrinx/core/tests/test_pack_equipment_mods.py
@@ -174,6 +174,37 @@ def test_modifiers_form_save_attaches_fighter_stat_mod(pack, pack_gear):
 
 
 @pytest.mark.django_db
+def test_modifiers_form_tolerates_preexisting_duplicate_mods(pack, pack_gear):
+    """Regression for #1915: duplicate ContentModFighterStat rows in the library
+    must not crash the modifiers form with MultipleObjectsReturned."""
+    movement = ContentStat.objects.get(field_name="movement")
+    for _ in range(3):
+        ContentModFighterStat.objects.create(
+            stat=movement.field_name, mode="improve", value="1"
+        )
+
+    form = EquipmentModifiersForm(
+        data={
+            f"fmod_stat_{movement.field_name}_mode": "improve",
+            f"fmod_stat_{movement.field_name}_value": "1",
+        },
+        instance=pack_gear,
+        pack=pack,
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save()
+
+    dupes = ContentModFighterStat.objects.filter(
+        stat=movement.field_name, mode="improve", value="1"
+    ).order_by("pk")
+    # Reuses an existing duplicate; no new row created.
+    assert dupes.count() == 3
+    attached = list(obj.modifiers.all())
+    assert len(attached) == 1
+    assert attached[0] == dupes.first()
+
+
+@pytest.mark.django_db
 def test_modifiers_form_save_attaches_rule_and_skill_mods(pack, pack_weapon):
     rule = ContentRule.objects.create(name="Pack Frenzy")
     _add_to_pack(pack, rule)

--- a/gyrinx/core/tests/test_pack_weapon_accessories.py
+++ b/gyrinx/core/tests/test_pack_weapon_accessories.py
@@ -440,6 +440,50 @@ def test_add_accessory_with_trait_mod(client, user, pack):
 
 
 @pytest.mark.django_db
+def test_add_accessory_tolerates_preexisting_duplicate_mods(client, user, pack):
+    """Regression for #1915: production accumulated duplicate ContentMod rows
+    before any uniqueness constraint existed, so the picker's get_or_create
+    raised MultipleObjectsReturned. The form must reuse an existing duplicate
+    instead of crashing."""
+    # Seed duplicate shared mod rows, mirroring the production state.
+    for _ in range(3):
+        ContentModStat.objects.create(stat="damage", mode="improve", value="1")
+    base_trait = ContentWeaponTrait.objects.create(name="Knockback")
+    for _ in range(2):
+        ContentModTrait.objects.create(trait=base_trait, mode="add")
+
+    client.force_login(user)
+    response = client.post(
+        f"/pack/{pack.id}/add/weapon-accessory/",
+        {
+            "name": "Dup Tolerant",
+            "description": "",
+            "cost": "5",
+            "rarity": "C",
+            "rarity_roll": "",
+            "stat_mod_damage_mode": "improve",
+            "stat_mod_damage_value": "1",
+            f"trait_mod_{base_trait.pk}": "add",
+        },
+    )
+    assert response.status_code == 302
+
+    accessory = ContentWeaponAccessory.objects.all_content().get(name="Dup Tolerant")
+    stat_dupes = ContentModStat.objects.filter(
+        stat="damage", mode="improve", value="1"
+    ).order_by("pk")
+    trait_dupes = ContentModTrait.objects.filter(trait=base_trait, mode="add").order_by(
+        "pk"
+    )
+    # An existing duplicate is reused — no new rows created.
+    assert stat_dupes.count() == 3
+    assert trait_dupes.count() == 2
+    # The reused mods are the deterministic earliest (ordered by pk).
+    assert stat_dupes.first() in accessory.modifiers.all()
+    assert trait_dupes.first() in accessory.modifiers.all()
+
+
+@pytest.mark.django_db
 def test_add_accessory_rejects_non_integer_value_for_improve(client, user, pack):
     """Improve/worsen modes must have integer values — anything else would
     crash in ContentModStat.apply() at runtime."""


### PR DESCRIPTION
Fixes #1915.

## Problem

The pack content forms create shared modifier rows (`ContentModStat`, `ContentModTrait`, `ContentModFighterStat/Rule/Skill`) via `get_or_create` on the modifier's distinguishing fields. None of those tables has a uniqueness constraint, and production has accumulated duplicate rows, so `get_or_create`'s internal `get()` raises `MultipleObjectsReturned` and 500s the "add weapon accessory" and fighter-mod flows. Two prod traces hit this on `ContentModStat` (returned 3) and `ContentModTrait` (returned 2).

A read-only prod check found duplicates in 6 of 7 mod tables (38 groups total), with references spread across the duplicates — so this is systemic, not isolated to the two traced tables.

## Change

Replace the five `get_or_create` call sites in `core/forms/pack.py` with a duplicate-tolerant `get_or_create_mod` helper: it reuses the earliest existing match (ordered by `pk` for determinism) and only creates a row when none exists. This stops every variant of the crash while duplicates still exist in the DB.

Regression tests pre-seed duplicate mod rows and assert the picker reuses one instead of crashing.

## Follow-up

A stacked PR will dedup the existing rows and add the missing unique constraints to prevent recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)