### PR TITLE
feat: top-align featured pack cards and show owner badges

### DIFF
--- a/gyrinx/core/templates/core/includes/featured_pack_card.html
+++ b/gyrinx/core/templates/core/includes/featured_pack_card.html
@@ -1,10 +1,10 @@
-{% load custom_tags %}
+{% load custom_tags badge_tags %}
 <a href="{% url 'core:pack' pack.id %}"
-   class="border rounded p-3 d-flex align-items-center gap-3 text-decoration-none h-100">
+   class="border rounded p-3 d-flex align-items-start gap-3 text-decoration-none h-100">
     <div class="flex-grow-1">
         <h2 class="h4 mb-1">{{ pack.name }}</h2>
         <div class="text-secondary fs-7 mb-1">
-            <i class="bi-person"></i> {{ pack.owner.username }}
+            <i class="bi-person"></i> {{ pack.owner.username }}{% user_badge pack.owner %}
         </div>
         {% with pack.featured_description|default:pack.summary as desc %}
             {% if desc %}<p class="text-secondary mb-0">{{ desc|plain_text_truncate:150 }}</p>{% endif %}

--- a/gyrinx/core/views/home.py
+++ b/gyrinx/core/views/home.py
@@ -173,7 +173,7 @@ def index(request):
     # Pick up to 3 random featured packs to showcase on the front page.
     featured_packs = (
         CustomContentPack.objects.filter(featured=True, listed=True, archived=False)
-        .select_related("owner")
+        .select_related("owner", "owner__profile")
         .order_by("?")[:3]
     )
 


### PR DESCRIPTION
Small UI tweaks to the homepage **featured content packs** row.

## Changes
- **Top-align card contents** — switched the card flex row from `align-items-center` to `align-items-start` so titles and usernames line up across cards regardless of description length.
- **Show owner badges** — render the pack owner's supporter/staff badge next to the username via `{% user_badge pack.owner %}`, matching the pack library listing (`pack/packs.html`). Staff owners show the staff badge by default.
- **Prefetch** `owner__profile` in the `featured_packs` query so the badge doesn't add a query per card.

## Verification
- Rendered the include with a saved staff owner: `user-badge` span present with the "Gyrinx staff" label; `align-items-start` applied.
- `pytest gyrinx/core/tests/test_homepage_featured_packs.py gyrinx/core/tests/test_badges.py` — 41 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)