### PR TITLE
fix: component deltas under cost overrides + reassignment re-pricing (#1925, #1826 Phase 2)

### DIFF
--- a/gyrinx/core/handlers/equipment/deltas.py
+++ b/gyrinx/core/handlers/equipment/deltas.py
@@ -1,0 +1,30 @@
+"""Shared delta arithmetic for equipment component handlers.
+
+Part of the cost-pinning programme (#1826); fixes #1925.
+"""
+
+from gyrinx.core.models.list import ListFighterEquipmentAssignment
+
+
+def component_delta(
+    assignment: ListFighterEquipmentAssignment, raw_component_delta: int
+) -> int:
+    """The assignment-level book delta for a component add/remove/change.
+
+    Definitionally equal to ``assignment.cost_int()`` after the mutation minus
+    ``assignment.cost_int()`` before it — computed without a second,
+    staleness-prone ``cost_int()`` call:
+
+    - With no ``total_cost_override``, ``cost_int()`` is the sum of the
+      components, so changing one component moves it by exactly that
+      component's delta.
+    - With a ``total_cost_override`` set, ``cost_int()`` ignores components
+      entirely, so the true book delta is **zero** (#1925): propagating the
+      raw component cost would move the caches while a recompute snaps them
+      back to the override, silently discarding value.
+
+    Credits are a separate, real transaction and are NOT gated by this —
+    a user who buys an accessory onto a fixed-total assignment still pays for
+    it; the fixed total simply doesn't move until they update it.
+    """
+    return 0 if assignment.has_total_cost_override() else raw_component_delta

--- a/gyrinx/core/handlers/equipment/purchase.py
+++ b/gyrinx/core/handlers/equipment/purchase.py
@@ -18,6 +18,7 @@ from gyrinx.content.models import (
     VirtualWeaponProfile,
 )
 from gyrinx.core.cost.propagation import Delta, propagate_from_assignment
+from gyrinx.core.handlers.equipment.deltas import component_delta
 from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.campaign import CampaignAction
 from gyrinx.core.models.list import (
@@ -203,11 +204,15 @@ def handle_accessory_purchase(
     # Calculate the cost of this accessory
     accessory_cost = assignment.accessory_cost_int(accessory)
 
+    # Book delta is 0 when a total_cost_override pins the assignment (#1925);
+    # the credits charge below stays at the accessory's real cost.
+    book_delta = component_delta(assignment, accessory_cost)
+
     # Build these beforehand so we get the credit values right
     is_stash = fighter.is_stash
     la_args = dict(
-        rating_delta=accessory_cost if not is_stash else 0,
-        stash_delta=accessory_cost if is_stash else 0,
+        rating_delta=book_delta if not is_stash else 0,
+        stash_delta=book_delta if is_stash else 0,
         credits_delta=-accessory_cost if lst.is_campaign_mode else 0,
         rating_before=lst.rating_current,
         stash_before=lst.stash_current,
@@ -234,7 +239,7 @@ def handle_accessory_purchase(
 
     description = f"Bought {accessory.name} for {assignment.content_equipment.name} on {fighter.name} ({accessory_cost}¢)"
 
-    propagate_from_assignment(assignment, Delta(delta=accessory_cost, list=lst))
+    propagate_from_assignment(assignment, Delta(delta=book_delta, list=lst))
 
     # Create ListAction to track the accessory addition
     list_action = lst.create_action(
@@ -294,11 +299,14 @@ def handle_weapon_profile_purchase(
     virtual_profile = VirtualWeaponProfile(profile=profile)
     profile_cost = assignment.profile_cost_int(virtual_profile)
 
+    # Book delta is 0 when a total_cost_override pins the assignment (#1925).
+    book_delta = component_delta(assignment, profile_cost)
+
     # Build these beforehand so we get the credit values right
     is_stash = fighter.is_stash
     la_args = dict(
-        rating_delta=profile_cost if not is_stash else 0,
-        stash_delta=profile_cost if is_stash else 0,
+        rating_delta=book_delta if not is_stash else 0,
+        stash_delta=book_delta if is_stash else 0,
         credits_delta=-profile_cost if lst.is_campaign_mode else 0,
         rating_before=lst.rating_current,
         stash_before=lst.stash_current,
@@ -325,7 +333,7 @@ def handle_weapon_profile_purchase(
 
     description = f"Bought {profile.name} for {assignment.content_equipment.name} on {fighter.name} ({profile_cost}¢)"
 
-    propagate_from_assignment(assignment, Delta(delta=profile_cost, list=lst))
+    propagate_from_assignment(assignment, Delta(delta=book_delta, list=lst))
 
     # Create ListAction to track the profile addition
     list_action = lst.create_action(
@@ -401,11 +409,15 @@ def handle_equipment_upgrade(
         cost_difference < 0 and new_upgrade_cost < 0
     )
 
+    # Book delta is 0 when a total_cost_override pins the assignment (#1925);
+    # the credits movement below stays at the real cost difference.
+    book_delta = component_delta(assignment, cost_difference)
+
     # Build these beforehand so we get the credit values right
     is_stash = fighter.is_stash
     la_args = dict(
-        rating_delta=cost_difference if not is_stash else 0,
-        stash_delta=cost_difference if is_stash else 0,
+        rating_delta=book_delta if not is_stash else 0,
+        stash_delta=book_delta if is_stash else 0,
         credits_delta=-cost_difference
         if lst.is_campaign_mode and involves_credits
         else 0,
@@ -461,7 +473,7 @@ def handle_equipment_upgrade(
     else:
         description = f"Removed upgrades from {assignment.content_equipment.name} on {fighter.name}"
 
-    propagate_from_assignment(assignment, Delta(delta=cost_difference, list=lst))
+    propagate_from_assignment(assignment, Delta(delta=book_delta, list=lst))
 
     list_action = lst.create_action(
         user=user,

--- a/gyrinx/core/handlers/equipment/reassignment.py
+++ b/gyrinx/core/handlers/equipment/reassignment.py
@@ -11,7 +11,11 @@ from typing import Optional
 
 from django.db import transaction
 
-from gyrinx.core.cost.propagation import Delta, propagate_from_fighter
+from gyrinx.core.cost.propagation import (
+    Delta,
+    propagate_from_assignment,
+    propagate_from_fighter,
+)
 from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.campaign import CampaignAction
 from gyrinx.core.models.list import (
@@ -72,11 +76,8 @@ def handle_equipment_reassignment(
         Equipment reassignment does not cost credits - credits_delta is always 0.
         However, rating and stash may change depending on fighter types.
     """
-    # Calculate cost BEFORE reassignment
-    # Note: We calculate the equipment cost both before and after reassignment because
-    # the cost may depend on the assigned fighter. This allows us to track if the cost
-    # changes as a result of reassignment. If cost_int() is expensive and the cost rarely
-    # changes, consider optimizing, but both calculations are required for correctness.
+    # Calculate cost BEFORE reassignment. The cost can depend on the holder
+    # (equipment-list pricing), so it must be recomputed after the move too.
     cost_before = assignment.cost_int()
 
     # Propagate to from_fighter BEFORE reassignment (decrease their rating)
@@ -86,32 +87,47 @@ def handle_equipment_reassignment(
     assignment.list_fighter = to_fighter
     assignment.save_with_user(user=user)
 
-    # Calculate cost AFTER reassignment
-    cost_after = assignment.cost_int()
+    # Calculate cost AFTER reassignment on a FRESH instance: cost_int() reads
+    # per-instance cached_property component costs that populated during the
+    # cost_before call and never invalidate, so re-calling it on the same
+    # object would always return cost_before and silently mask re-pricing
+    # (the #1826-class drift this handler used to produce).
+    refreshed = ListFighterEquipmentAssignment.objects.get(pk=assignment.pk)
+    cost_after = refreshed.cost_int()
 
-    # Propagate to to_fighter AFTER reassignment (increase their rating)
-    propagate_from_fighter(to_fighter, Delta(delta=cost_after, list=lst))
+    # The assignment's own cache still holds the old-context value; shift it
+    # by the re-pricing difference. This walks assignment → (new) fighter, so
+    # afterwards the to_fighter needs only the cost_before base.
+    to_fighter_fresh = refreshed.list_fighter
+    propagate_from_assignment(
+        refreshed, Delta(delta=cost_after - cost_before, list=lst)
+    )
+    propagate_from_fighter(to_fighter_fresh, Delta(delta=cost_before, list=lst))
 
     # Use the cost after reassignment for deltas
     equipment_cost = cost_after
     equipment_name = assignment.content_equipment.name
 
-    # Determine deltas based on source and target fighter types
+    # Determine deltas based on source and target fighter types. The value
+    # LEAVING the source is cost_before; the value ARRIVING at the target is
+    # cost_after — when the move re-prices the gear, the difference is a real
+    # book movement and must be recorded, or the caches and the action chain
+    # diverge on the next recompute.
     from_is_stash = from_fighter.is_stash
     to_is_stash = to_fighter.is_stash
 
     if from_is_stash and not to_is_stash:
-        # Stash → Regular: Move from stash to rating
-        rating_delta = equipment_cost
-        stash_delta = -equipment_cost
+        # Stash → Regular
+        rating_delta = cost_after
+        stash_delta = -cost_before
     elif not from_is_stash and to_is_stash:
-        # Regular → Stash: Move from rating to stash
-        rating_delta = -equipment_cost
-        stash_delta = equipment_cost
+        # Regular → Stash
+        rating_delta = -cost_before
+        stash_delta = cost_after
     else:
-        # Regular → Regular or Stash → Stash: No change
-        rating_delta = 0
-        stash_delta = 0
+        # Regular → Regular or Stash → Stash: only the re-pricing moves the book
+        rating_delta = (cost_after - cost_before) if not from_is_stash else 0
+        stash_delta = (cost_after - cost_before) if from_is_stash else 0
 
     # Build ListAction args (credits never change for reassignment)
     la_args = dict(

--- a/gyrinx/core/handlers/equipment/reassignment.py
+++ b/gyrinx/core/handlers/equipment/reassignment.py
@@ -92,7 +92,15 @@ def handle_equipment_reassignment(
     # cost_before call and never invalidate, so re-calling it on the same
     # object would always return cost_before and silently mask re-pricing
     # (the #1826-class drift this handler used to produce).
-    refreshed = ListFighterEquipmentAssignment.objects.get(pk=assignment.pk)
+    #
+    # The refetch MUST use with_related_data(): its accessory prefetch goes
+    # through all_content(), like the instances views hand this handler and
+    # like the canonical recompute path. A plain fetch resolves accessories
+    # through the pack-excluding default manager, so pack-scoped accessories
+    # would vanish from cost_after and book a phantom repricing.
+    refreshed = ListFighterEquipmentAssignment.objects.with_related_data().get(
+        pk=assignment.pk
+    )
     cost_after = refreshed.cost_int()
 
     # The assignment's own cache still holds the old-context value; shift it
@@ -196,7 +204,9 @@ def handle_equipment_reassignment(
         )
 
     return EquipmentReassignmentResult(
-        assignment=assignment,
+        # Return the refreshed instance: its cached rating reflects the
+        # propagation applied above; the original's in-memory state predates it.
+        assignment=refreshed,
         equipment_cost=equipment_cost,
         from_fighter=from_fighter,
         to_fighter=to_fighter,

--- a/gyrinx/core/handlers/equipment/removal.py
+++ b/gyrinx/core/handlers/equipment/removal.py
@@ -23,6 +23,7 @@ from gyrinx.core.cost.propagation import (
     propagate_from_assignment,
     propagate_from_fighter,
 )
+from gyrinx.core.handlers.equipment.deltas import component_delta
 from gyrinx.core.handlers.refund import calculate_refund_credits
 from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.list import (
@@ -228,10 +229,14 @@ def handle_equipment_component_removal(
     else:
         raise ValueError(f"Unknown component_type: {component_type}")
 
+    # Book delta is 0 when a total_cost_override pins the assignment (#1925);
+    # the refund below stays based on the component's real cost.
+    book_delta = component_delta(assignment, component_cost)
+
     # Calculate deltas based on fighter type
     is_stash = fighter.is_stash
-    rating_delta = -component_cost if not is_stash else 0
-    stash_delta = -component_cost if is_stash else 0
+    rating_delta = -book_delta if not is_stash else 0
+    stash_delta = -book_delta if is_stash else 0
 
     # Validate and calculate refund
     credits_delta, refund_applied = calculate_refund_credits(

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -630,12 +630,9 @@ def test_matrix_legacy_raw_fighter_detected_after_recompute(
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True,
-    reason="P1 (#1925): component purchase onto a total_cost_override'd "
-    "assignment propagates a delta that cost_int() ignores; fixed in Phase 2",
-)
 def test_matrix_p1_1925_accessory_onto_overridden_assignment(healthy_list, user):
+    """P1 (#1925), fixed in Phase 2: a component purchase onto a fixed-total
+    assignment moves credits but not the book value — and reconciles."""
     lst, fighter, assignment = healthy_list
     handle_equipment_cost_override(
         user=user,
@@ -649,7 +646,7 @@ def test_matrix_p1_1925_accessory_onto_overridden_assignment(healthy_list, user)
 
     accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
     buy_accessory(user, lst, fighter, assignment, accessory)
-    assert_reconciles(lst)  # FAILS: cache 58, cost_int() pinned at 50
+    assert_reconciles(lst)  # book value stays at the 50 override; credits moved
 
 
 @pytest.mark.django_db
@@ -767,11 +764,6 @@ def test_matrix_p5_bare_form_accessory_removal(healthy_list, user, client):
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True,
-    reason="P6: reassignment computes cost_after on the same instance; "
-    "cached_property staleness masks context re-pricing; fixed in Phase 2",
-)
 def test_matrix_p6_reassign_discounted_gear_reprices(
     campaign_list,
     user,
@@ -801,3 +793,51 @@ def test_matrix_p6_reassign_discounted_gear_reprices(
         assignment=fresh(assignment),
     )
     assert_reconciles(lst)  # FAILS: moved at 5, B's context recomputes to 15
+
+
+@pytest.mark.django_db
+def test_matrix_p6_repricing_telemetry_fires(
+    campaign_list,
+    user,
+    make_content_fighter,
+    content_house,
+    content_fighter,
+    make_equipment,
+    monkeypatch,
+):
+    """The cost-changed-on-reassignment telemetry fires with real values."""
+    from gyrinx.core.handlers.equipment import reassignment as reassignment_module
+
+    events = []
+    monkeypatch.setattr(
+        reassignment_module,
+        "track",
+        lambda name, **kw: events.append((name, kw)),
+    )
+
+    lst, stash = campaign_list
+    cf_a = make_content_fighter(
+        type="Scavvy", category="GANGER", house=content_house, base_cost=50
+    )
+    fighter_a = hire_fighter(user, lst, cf_a, name="Alfa")
+    fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
+    equipment = make_equipment("Lasgun", cost=15)
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=cf_a, equipment=equipment, cost=5
+    )
+    assignment = buy_equipment(user, lst, fighter_a, equipment)
+
+    handle_equipment_reassignment(
+        user=user,
+        lst=fresh(lst),
+        from_fighter=fresh(fighter_a),
+        to_fighter=fresh(fighter_b),
+        assignment=fresh(assignment),
+    )
+
+    reprice_events = [
+        kw for name, kw in events if name == "equipment_cost_changed_on_reassignment"
+    ]
+    assert len(reprice_events) == 1
+    assert reprice_events[0]["cost_before"] == 5
+    assert reprice_events[0]["cost_after"] == 15

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -52,6 +52,12 @@ def fresh(obj):
     view would. Chaining handlers against stale in-memory instances writes
     stale absolute values — a harness artifact, not an app flow.
     """
+    if isinstance(obj, ListFighterEquipmentAssignment):
+        # Views hand handlers assignments fetched via with_related_data(),
+        # whose accessory prefetch (all_content) includes pack-scoped
+        # accessories; a plain fetch would silently drop them and make the
+        # harness blind to pack-gear pricing bugs.
+        return ListFighterEquipmentAssignment.objects.with_related_data().get(pk=obj.pk)
     return type(obj).objects.get(pk=obj.pk)
 
 
@@ -792,7 +798,7 @@ def test_matrix_p6_reassign_discounted_gear_reprices(
         to_fighter=fresh(fighter_b),
         assignment=fresh(assignment),
     )
-    assert_reconciles(lst)  # FAILS: moved at 5, B's context recomputes to 15
+    assert_reconciles(lst)
 
 
 @pytest.mark.django_db
@@ -841,3 +847,45 @@ def test_matrix_p6_repricing_telemetry_fires(
     assert len(reprice_events) == 1
     assert reprice_events[0]["cost_before"] == 5
     assert reprice_events[0]["cost_after"] == 15
+
+
+@pytest.mark.django_db
+def test_matrix_reassign_gear_with_pack_accessory(
+    campaign_list, user, content_fighter, make_equipment, pack
+):
+    """Pack-scoped accessories survive the reassignment repricing math.
+
+    A plain refetch resolves accessories through the pack-excluding default
+    manager, so a pack accessory would vanish from cost_after and the handler
+    would book a phantom repricing. The handler (and this harness's fresh())
+    must fetch with the same semantics the views use.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    from gyrinx.core.models.pack import CustomContentPackItem
+
+    lst, stash = campaign_list
+    lst.packs.add(pack)
+    fighter_a = hire_fighter(user, lst, content_fighter, name="Alfa")
+    fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
+    equipment = make_equipment("Lasgun", cost=15)
+    assignment = buy_equipment(user, lst, fighter_a, equipment)
+
+    accessory = ContentWeaponAccessory.objects.create(name="Pack Scope", cost=8)
+    CustomContentPackItem.objects.create(
+        pack=pack,
+        content_type=ContentType.objects.get_for_model(ContentWeaponAccessory),
+        object_id=accessory.pk,
+        owner=pack.owner,
+    )
+    buy_accessory(user, lst, fighter_a, assignment, accessory)
+    assert_reconciles(lst)
+
+    handle_equipment_reassignment(
+        user=user,
+        lst=fresh(lst),
+        from_fighter=fresh(fighter_a),
+        to_fighter=fresh(fighter_b),
+        assignment=fresh(assignment),
+    )
+    assert_reconciles(lst)


### PR DESCRIPTION
## Summary

Phase 2 of the cost-pinning programme: fixes the two bookkeeping bugs whose expected-failure tests were pinned in the Phase 1 harness (#1927). Both now pass; the harness proves the books add up before and after every affected action.

- **#1925 — add-ons bought under a fixed price vanished from the books.** When a user manually fixes an item's total price and then buys an add-on (accessory, profile, or upgrade), the handlers moved the gang's recorded value by the add-on's cost even though the item's actual price stays pinned — so the next recalculation silently threw the add-on's value away. A new shared helper (`handlers/equipment/deltas.component_delta`) returns the true book movement (zero while a fixed price is set) and is applied at all four purchase/removal sites. Credits are deliberately still charged/refunded at the add-on's real cost: the purchase is a real transaction; the fixed total simply doesn't move until the user updates it.
- **Moving gear between fighters mispriced the move.** Equipment can cost different amounts on different fighters. The reassignment handler tried to detect this by pricing the item before and after the move — but it priced the same in-memory object twice, and Django's `cached_property` meant the second answer always equalled the first. Re-pricing was silently mis-recorded, and the telemetry meant to report it could never fire. The "after" price now comes from a freshly loaded copy; the item's own recorded value is corrected by the difference; and the gang's history records the value leaving the old fighter and the (possibly different) value arriving at the new one.

## Test plan

- [x] The two Phase 1 expected-failure groups (P1, P6) flipped to passing assertions — full reconciliation immediately after each action and after a forced recalculation.
- [x] New test pins the re-pricing telemetry (fires once, `cost_before=5`, `cost_after=15`).
- [x] Remaining known bugs still tracked as expected failures: P2 kill-transfer (Phase 9), P3 sale, P4 stash removal, P5 bare-form endpoint (Phase 3).
- [x] Affected handler suites: 115 passed. Full suite: 2855 passed, 13 skipped, 4 xfailed.

## Next

Phase 3: the sale flow's catalog mispricing, the stash component-removal gap, and deleting the dead accessories-edit form branch — flipping P3, P4, and P5.

Closes #1925
Refs #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)
