### PR TITLE
test: run the balance-sheet matrix across a catalog-vs-pack content axis (#1826)

### DIFF
--- a/.claude/notes/cost-pinning-design.md
+++ b/.claude/notes/cost-pinning-design.md
@@ -54,9 +54,9 @@ stash visibly contains.
 **Cache-vs-recompute divergence (the drift class).** Any mechanism that makes
 `cost_int()` disagree with the delta-accumulated cache is invisible until the next
 recompute snaps the cache to a different number — no error, just wealth jumping.
-Seven producers of this class existed when the harness landed; two (the
-pack-sweep gap and the bare-form endpoint) were fixed in the pack-axis PR,
-leaving five live:
+Eight producers of this class have been found so far; two (the pack-sweep
+gap and the bare-form endpoint) were fixed in the pack-axis PR, leaving six
+live:
 
 - **#1925 — component purchase under `total_cost_override`.** Buy an accessory on an
   assignment that has the override set. The handler computes the accessory's live
@@ -101,6 +101,17 @@ leaving five live:
   cost-change signal treated the save as a new instance — nothing dirtied, no
   audit action, no campaign credits. Fixed by mirroring the task's
   `all_content()` fallback. Found by the pack axis (§5.2).
+- **Pack upgrades book at zero (#1933).** For SINGLE-mode equipment,
+  `ContentEquipmentUpgrade.cost_int()` sums the cumulative stack through the
+  pack-excluding reverse manager, so a pack-registered upgrade is excluded
+  from its own stack sum and prices at 0 — no rating movement, no credits
+  charged, and the recompute path is equally pack-blind (the fighter-level
+  upgrade prefetch and `upgrade_cost_int` don't use `all_content()`), so
+  cache and recompute agree at the wrong number. The same root leaves the
+  assignment-level `with_related_data()` pack-aware for accessories only:
+  reassignment re-prices gear carrying a pack profile without it. Caught only
+  after the healthy cells gained **booked-movement assertions** (§5.1) —
+  reconciliation alone cannot see a bug both paths share.
 - **The accessories-edit bare-form fallback — FIXED (pack-axis PR, deleted).**
   The weapon-accessories edit view carried a fallback POST branch that rewrote
   `weapon_accessories_field` wholesale via `form.save()` with no delta
@@ -933,6 +944,12 @@ first run surfaced producer #1930. Cells whose *expected* behaviour differs by
 side (the price-change sweep cells, the bare-form endpoint) use explicit
 per-side parameters with per-side xfail marks instead of the shared fixture.
 
+**Booked-movement assertions.** Reconciliation is blind to bugs where the
+write path and the recompute path are *identically* wrong — both book the
+wrong number and agree (#1933 was exactly this). Healthy component cells
+therefore also assert the actual movement: after a purchase/removal, the
+list's rating changed by the component's price.
+
 The **holder context changed** column (set/clear `legacy_content_fighter`, change
 fighter type — §4.6) asserts the intended end state: existing gear does *not*
 reprice, and every invariant family holds. On current code these cells expose
@@ -966,6 +983,12 @@ Each live producer (§1.2) is a strict-xfail group owned by a named phase
   family, §3.3).
 - ~~Pack price corrections never sweep (#1930)~~ — fixed in the pack-axis PR;
   both price-change cells now pass on both sides.
+- **Pack upgrades book at zero / assignment-level pack-blind re-pricing
+  (#1933)** — the pack side of the buy-upgrade cell and the
+  reassign-after-pack-profile cell; fixed in Phase 3 by applying the
+  `all_content()` pattern at the stack sum and the profile/upgrade prefetches
+  (the fighter-level prefetch touches the hot path — re-snapshot
+  `performance_view_queries.json`).
 
 Each is marked `xfail(strict=True)`: it documents the bug, proves the harness can see
 it, and strictness forces the mark to be removed in the same change that fixes it.

--- a/.claude/notes/cost-pinning-design.md
+++ b/.claude/notes/cost-pinning-design.md
@@ -54,7 +54,7 @@ stash visibly contains.
 **Cache-vs-recompute divergence (the drift class).** Any mechanism that makes
 `cost_int()` disagree with the delta-accumulated cache is invisible until the next
 recompute snaps the cache to a different number — no error, just wealth jumping.
-There are six live producers of this class today:
+There are seven live producers of this class today:
 
 - **#1925 — component purchase under `total_cost_override`.** Buy an accessory on an
   assignment that has the override set. The handler computes the accessory's live
@@ -93,6 +93,13 @@ There are six live producers of this class today:
   `cost_after == cost_before` always. Context-priced gear moves at the old holder's
   price; the next recompute re-prices it to the new holder's context and the caches
   jump. (The `equipment_cost_changed_on_reassignment` telemetry can never fire.)
+- **Pack-scoped price corrections never sweep (#1930).** `get_old_cost()`
+  (`gyrinx/content/signals.py:28`) reads the pre-save price through the
+  pack-excluding default manager; for a `CustomContentPackItem`-scoped row it
+  gets `DoesNotExist` and every cost-change signal treats the save as a new
+  instance — nothing is marked dirty, no audit action is enqueued, no campaign
+  credits move. (The downstream task is already pack-hardened; the upstream
+  signal never fires.) Found by the pack axis (§5.2).
 - **The accessories-edit bare-form fallback rewrites the accessory set unaudited.**
   The weapon-accessories edit view's fallback POST branch
   (`gyrinx/core/views/fighter/equipment.py:1001-1011`) binds
@@ -109,7 +116,7 @@ A note on the **admin** as a mutation surface: the assignment admin's change for
 writes all three component M2Ms with no delta propagation either. That is *policy*,
 not a bug: admin writes bypass delta propagation by design, are remediated by the
 existing "recompute cost caches" admin action, and are explicitly allowlisted in the
-acquisition-path CI guard (§4.6). The six producers above are user-facing flows and
+acquisition-path CI guard (§4.6). The seven producers above are user-facing flows and
 are bugs.
 
 **Why whole-total freezing cannot be the fix.** The obvious wealth-stability
@@ -917,6 +924,18 @@ xfails below); others would go red under a mis-ordered rollout (e.g. handlers
 becoming price-neutral before the backfill pinned legacy gear). The matrix is the
 tool that catches that ordering mistake mechanically instead of by review.
 
+**The catalog-vs-pack axis.** Every matrix cell that consumes content runs
+twice — once with plain catalog rows, once with identical content scoped to a
+subscribed `CustomContentPack` (parametrized fixtures, not duplicated tests).
+Pack content is invisible to the default `ContentManager` and only surfaced by
+`all_content()`/`with_packs()`, so any cost path that fetches content
+carelessly prices pack gear differently — a class of drift the catalog variant
+can never see. The axis has already earned its place twice: the Phase 2 review
+caught a pack-only regression in the reassignment refetch, and the axis's
+first run surfaced producer #1930. Cells whose *expected* behaviour differs by
+side (the price-change sweep cells, the bare-form endpoint) use explicit
+per-side parameters with per-side xfail marks instead of the shared fixture.
+
 The **holder context changed** column (set/clear `legacy_content_fighter`, change
 fighter type — §4.6) asserts the intended end state: existing gear does *not*
 reprice, and every invariant family holds. On current code these cells expose
@@ -925,10 +944,10 @@ green as amounts land (Phase 5) and the backfill pins legacy rows (Phase 8) — 
 second example of the "green only under the right rollout order" class the matrix
 exists to police.
 
-### 5.3 Known-red cells: six strict-xfail tripwires, not one
+### 5.3 Known-red cells: seven strict-xfail tripwires, not one
 
-Six drift producers are live today (§1.2), so Phase 1 lands **six** strict-xfail
-groups, each owned by a named phase:
+Seven drift producers are live today (§1.2), so the matrix carries **seven**
+strict-xfail groups, each owned by a named phase:
 
 - **#1925 override-purchase divergence** — set `total_cost_override` via its handler,
   buy a component via its handler, reconcile. Fails: cached rating carries the
@@ -951,6 +970,10 @@ groups, each owned by a named phase:
   context prices it differently; the caches take the old-context price, recompute
   takes the new. Fixed in Phase 2 alongside #1925 (same `cached_property` hazard
   family, §3.3).
+- **Pack price corrections never sweep (#1930)** — change a subscribed pack
+  item's cost; nothing is dirtied and no action lands, so caches diverge on the
+  next recompute with no audit trail. Fixed in Phase 3 (mirror the task's
+  `all_content()` pattern in `get_old_cost()`).
 
 Each is marked `xfail(strict=True)`: it documents the bug, proves the harness can see
 it, and strictness forces the mark to be removed in the same change that fixes it.

--- a/.claude/notes/cost-pinning-design.md
+++ b/.claude/notes/cost-pinning-design.md
@@ -54,7 +54,9 @@ stash visibly contains.
 **Cache-vs-recompute divergence (the drift class).** Any mechanism that makes
 `cost_int()` disagree with the delta-accumulated cache is invisible until the next
 recompute snaps the cache to a different number — no error, just wealth jumping.
-There are seven live producers of this class today:
+Seven producers of this class existed when the harness landed; two (the
+pack-sweep gap and the bare-form endpoint) were fixed in the pack-axis PR,
+leaving five live:
 
 - **#1925 — component purchase under `total_cost_override`.** Buy an accessory on an
   assignment that has the override set. The handler computes the accessory's live
@@ -93,31 +95,26 @@ There are seven live producers of this class today:
   `cost_after == cost_before` always. Context-priced gear moves at the old holder's
   price; the next recompute re-prices it to the new holder's context and the caches
   jump. (The `equipment_cost_changed_on_reassignment` telemetry can never fire.)
-- **Pack-scoped price corrections never sweep (#1930).** `get_old_cost()`
-  (`gyrinx/content/signals.py:28`) reads the pre-save price through the
-  pack-excluding default manager; for a `CustomContentPackItem`-scoped row it
-  gets `DoesNotExist` and every cost-change signal treats the save as a new
-  instance — nothing is marked dirty, no audit action is enqueued, no campaign
-  credits move. (The downstream task is already pack-hardened; the upstream
-  signal never fires.) Found by the pack axis (§5.2).
-- **The accessories-edit bare-form fallback rewrites the accessory set unaudited.**
-  The weapon-accessories edit view's fallback POST branch
-  (`gyrinx/core/views/fighter/equipment.py:1001-1011`) binds
-  `ListFighterEquipmentAssignmentAccessoriesForm` and calls `form.save()`, rewriting
-  `weapon_accessories_field` wholesale with no delta propagation, no ListAction, and
-  no credits movement. No template posts to it — the page's only POST forms are
-  per-accessory add forms carrying `accessory_id`, which the first branch consumes —
-  so the branch is UI-dead but **endpoint-live**: any POST without `accessory_id`
-  (crafted request, stale tab, future template change) silently mutates the M2M and
-  drifts every cache above it. The likely fix is simply deleting the branch; until
-  then it is a live producer.
+- **Pack-scoped price corrections never sweep (#1930) — FIXED (pack-axis PR).**
+  `get_old_cost()` (`gyrinx/content/signals.py`) read the pre-save price through
+  the pack-excluding default manager; a pack row raised `DoesNotExist` and every
+  cost-change signal treated the save as a new instance — nothing dirtied, no
+  audit action, no campaign credits. Fixed by mirroring the task's
+  `all_content()` fallback. Found by the pack axis (§5.2).
+- **The accessories-edit bare-form fallback — FIXED (pack-axis PR, deleted).**
+  The weapon-accessories edit view carried a fallback POST branch that rewrote
+  `weapon_accessories_field` wholesale via `form.save()` with no delta
+  propagation, no ListAction, and no credits movement. UI-dead but endpoint-live;
+  it also could not remove pack accessories at all (the M2M rewrite listed
+  current rows through the default manager). A bare POST now falls through to
+  the page render; a both-sides matrix cell pins the inert behaviour.
 
 A note on the **admin** as a mutation surface: the assignment admin's change form
 writes all three component M2Ms with no delta propagation either. That is *policy*,
 not a bug: admin writes bypass delta propagation by design, are remediated by the
 existing "recompute cost caches" admin action, and are explicitly allowlisted in the
-acquisition-path CI guard (§4.6). The seven producers above are user-facing flows and
-are bugs.
+acquisition-path CI guard (§4.6). The producers above are user-facing flows and
+are bugs; the five still live are owned by Phases 2/3/9.
 
 **Why whole-total freezing cannot be the fix.** The obvious wealth-stability
 mechanism — freeze the assignment's *total* at transfer time — is unsound for exactly
@@ -944,10 +941,10 @@ green as amounts land (Phase 5) and the backfill pins legacy rows (Phase 8) — 
 second example of the "green only under the right rollout order" class the matrix
 exists to police.
 
-### 5.3 Known-red cells: seven strict-xfail tripwires, not one
+### 5.3 Known-red cells: strict-xfail tripwires, one group per live producer
 
-Seven drift producers are live today (§1.2), so the matrix carries **seven**
-strict-xfail groups, each owned by a named phase:
+Each live producer (§1.2) is a strict-xfail group owned by a named phase
+(fixed producers' groups have flipped to passing assertions):
 
 - **#1925 override-purchase divergence** — set `total_cost_override` via its handler,
   buy a component via its handler, reconcile. Fails: cached rating carries the
@@ -957,11 +954,8 @@ strict-xfail groups, each owned by a named phase:
   drifts by (cached value − catalog price). Fixed in Phase 3.
 - **Stash component-removal zero-delta** — remove a component from stash gear; the
   assignment/fighter caches keep its value. Fixed in Phase 3.
-- **Accessories bare-form unaudited rewrite** — POST the weapon-accessories edit
-  endpoint without `accessory_id` and with a changed accessory set (a Django test
-  client can; no template does); `form.save()` rewrites the M2M with no
-  propagation, no action, no credits, and every invariant family above it breaks.
-  Fixed — most likely by deleting the branch — in Phase 3.
+- ~~Accessories bare-form unaudited rewrite~~ — branch deleted in the pack-axis
+  PR; a both-sides cell asserts the bare POST is inert.
 - **Death-transfer re-pricing (#1826)** — kill a fighter carrying equipment-list
   discounted gear; the stash caches take the dying-fighter value while the stash
   assignment recomputes at catalog. Fixed by pinning in Phase 9 (price-neutral
@@ -970,10 +964,8 @@ strict-xfail groups, each owned by a named phase:
   context prices it differently; the caches take the old-context price, recompute
   takes the new. Fixed in Phase 2 alongside #1925 (same `cached_property` hazard
   family, §3.3).
-- **Pack price corrections never sweep (#1930)** — change a subscribed pack
-  item's cost; nothing is dirtied and no action lands, so caches diverge on the
-  next recompute with no audit trail. Fixed in Phase 3 (mirror the task's
-  `all_content()` pattern in `get_old_cost()`).
+- ~~Pack price corrections never sweep (#1930)~~ — fixed in the pack-axis PR;
+  both price-change cells now pass on both sides.
 
 Each is marked `xfail(strict=True)`: it documents the bug, proves the harness can see
 it, and strictness forces the mark to be removed in the same change that fixes it.

--- a/gyrinx/content/signals.py
+++ b/gyrinx/content/signals.py
@@ -24,8 +24,18 @@ def get_old_cost(model_class, instance, cost_field="cost"):
     if instance._state.adding or not instance.pk:
         return None
 
+    # Use all_content() where available so pack-scoped rows still resolve —
+    # the default ContentManager excludes pack items, and treating a pack row
+    # as DoesNotExist here made every cost-change signal think it was a new
+    # instance, so pack price corrections never swept (#1930). Mirrors the
+    # same fallback in gyrinx/core/tasks.propagate_content_cost_change.
+    manager = model_class._default_manager
+    base_qs = (
+        manager.all_content() if hasattr(manager, "all_content") else manager.all()
+    )
+
     try:
-        old_instance = model_class.objects.only(cost_field).get(pk=instance.pk)
+        old_instance = base_qs.only(cost_field).get(pk=instance.pk)
         old_value = getattr(old_instance, cost_field)
         # Handle CharField cost fields (e.g., ContentEquipment)
         if isinstance(old_value, str):

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -22,6 +22,7 @@ from gyrinx.content.models import (
     ContentEquipmentUpgrade,
     ContentFighterEquipmentListItem,
     ContentWeaponAccessory,
+    ContentWeaponProfile,
 )
 from gyrinx.core.cost.balance_sheet import build_balance_sheet
 from gyrinx.core.handlers.equipment.cost_override import (
@@ -78,10 +79,11 @@ def fresh(obj):
     stale absolute values — a harness artifact, not an app flow.
     """
     if isinstance(obj, ListFighterEquipmentAssignment):
-        # Views hand handlers assignments fetched via with_related_data(),
-        # whose accessory prefetch (all_content) includes pack-scoped
-        # accessories; a plain fetch would silently drop them and make the
-        # harness blind to pack-gear pricing bugs.
+        # Views hand handlers assignments fetched via with_related_data().
+        # Its accessory prefetch routes through all_content() so pack
+        # accessories survive; note its profile/upgrade prefetches do NOT
+        # (pack-excluding managers) — that divergence is producer P8
+        # (#1933), pinned in the matrix.
         return ListFighterEquipmentAssignment.objects.with_related_data().get(pk=obj.pk)
     return type(obj).objects.get(pk=obj.pk)
 
@@ -184,8 +186,6 @@ def gear(content_source, make_equipment, make_weapon_profile):
     """Content factory building gear on the current side of the axis."""
 
     class Gear:
-        source = content_source
-
         def equipment(self, name="Lasgun", cost=15, **kwargs):
             return content_source.register(make_equipment(name, cost=cost, **kwargs))
 
@@ -423,6 +423,7 @@ def buy_accessory(user, lst, fighter, assignment, accessory):
 @pytest.mark.django_db
 def test_matrix_buy_weapon_profile(healthy_list, user, gear):
     lst, fighter, assignment = healthy_list
+    rating_before = fresh(lst).rating_current
     profile = gear.profile(assignment.content_equipment, name="Hotshot", cost=10)
     handle_weapon_profile_purchase(
         user=user,
@@ -431,21 +432,52 @@ def test_matrix_buy_weapon_profile(healthy_list, user, gear):
         assignment=fresh(assignment),
         profile=profile,
     )
+    # Reconciliation alone cannot see a bug where the write path and the
+    # recompute path are identically blind (both book the wrong number and
+    # agree) — so healthy cells also assert the actual booked movement.
+    assert fresh(lst).rating_current == rating_before + 10
     assert_reconciles(lst)
 
 
 @pytest.mark.django_db
 def test_matrix_buy_accessory(healthy_list, user, gear):
     lst, fighter, assignment = healthy_list
+    rating_before = fresh(lst).rating_current
     accessory = gear.accessory()
     buy_accessory(user, lst, fighter, assignment, accessory)
+    assert fresh(lst).rating_current == rating_before + 8  # booked movement
     assert_reconciles(lst)
 
 
 @pytest.mark.django_db
-def test_matrix_buy_upgrade(healthy_list, user, gear):
-    lst, fighter, assignment = healthy_list
-    upgrade = gear.upgrade(assignment.content_equipment)
+@pytest.mark.parametrize(
+    "side",
+    [
+        "catalog",
+        pytest.param(
+            "pack",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="P8 (#1933): pack upgrades book at zero — the SINGLE-mode "
+                "stack sum excludes pack rows from its own total, and the "
+                "recompute path is equally pack-blind, so reconciliation alone "
+                "cannot see it; fixed in Phase 3",
+            ),
+        ),
+    ],
+)
+def test_matrix_buy_upgrade(
+    side, user, make_list, content_fighter, make_equipment, make_pack
+):
+    lst, fighter, assignment, equipment, source = build_weapon_list(
+        side, user, make_list, content_fighter, make_equipment, make_pack
+    )
+    rating_before = fresh(lst).rating_current
+    upgrade = source.register(
+        ContentEquipmentUpgrade.objects.create(
+            name="Extended mag", equipment=equipment, cost=12
+        )
+    )
     handle_equipment_upgrade(
         user=user,
         lst=fresh(lst),
@@ -453,6 +485,7 @@ def test_matrix_buy_upgrade(healthy_list, user, gear):
         assignment=fresh(assignment),
         new_upgrades=[upgrade],
     )
+    assert fresh(lst).rating_current == rating_before + 12  # booked movement
     assert_reconciles(lst)
 
 
@@ -461,6 +494,7 @@ def test_matrix_remove_accessory_from_fighter(healthy_list, user, gear):
     lst, fighter, assignment = healthy_list
     accessory = gear.accessory()
     buy_accessory(user, lst, fighter, assignment, accessory)
+    rating_before = fresh(lst).rating_current
     handle_equipment_component_removal(
         user=user,
         lst=fresh(lst),
@@ -470,6 +504,7 @@ def test_matrix_remove_accessory_from_fighter(healthy_list, user, gear):
         component=accessory,
         request_refund=False,
     )
+    assert fresh(lst).rating_current == rating_before - 8  # booked movement
     assert_reconciles(lst)
 
 
@@ -961,7 +996,7 @@ def test_matrix_p6_repricing_telemetry_fires(
 
 @pytest.mark.django_db
 def test_matrix_reassign_gear_with_pack_accessory(
-    campaign_list, user, content_fighter, make_equipment, pack
+    campaign_list, user, content_fighter, gear, pack
 ):
     """Pack-scoped accessories survive the reassignment repricing math.
 
@@ -974,7 +1009,9 @@ def test_matrix_reassign_gear_with_pack_accessory(
     lst.packs.add(pack)
     fighter_a = hire_fighter(user, lst, content_fighter, name="Alfa")
     fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
-    equipment = make_equipment("Lasgun", cost=15)
+    # Equipment rides the axis (so this cell is meaningfully doubled); the
+    # accessory deliberately comes from its own separate pack.
+    equipment = gear.equipment("Lasgun", cost=15)
     assignment = buy_equipment(user, lst, fighter_a, equipment)
 
     accessory = ContentWeaponAccessory.objects.create(name="Pack Scope", cost=8)
@@ -995,3 +1032,42 @@ def test_matrix_reassign_gear_with_pack_accessory(
         assignment=fresh(assignment),
     )
     assert_reconciles(lst)
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(
+    strict=True,
+    reason="P8 (#1933): the assignment-level with_related_data() prefetches "
+    "profiles/upgrades through pack-excluding managers (only accessories go "
+    "via all_content()), so reassignment re-prices gear carrying a pack "
+    "profile without it; fixed in Phase 3",
+)
+def test_matrix_p8_reassign_gear_with_pack_profile(
+    user, make_list, content_fighter, make_equipment, make_pack
+):
+    lst, fighter_a, assignment, equipment, source = build_weapon_list(
+        "pack", user, make_list, content_fighter, make_equipment, make_pack
+    )
+    fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
+    profile = source.register(
+        ContentWeaponProfile.objects.create(
+            equipment=equipment, name="Hotshot", cost=10
+        )
+    )
+    handle_weapon_profile_purchase(
+        user=user,
+        lst=fresh(lst),
+        fighter=fresh(fighter_a),
+        assignment=fresh(assignment),
+        profile=profile,
+    )
+    assert_reconciles(lst)  # clean before the move
+
+    handle_equipment_reassignment(
+        user=user,
+        lst=fresh(lst),
+        from_fighter=fresh(fighter_a),
+        to_fighter=fresh(fighter_b),
+        assignment=fresh(assignment),
+    )
+    assert_reconciles(lst)  # FAILS: cost_after misses the pack profile

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -13,18 +13,43 @@ is what catches "cache says X, recompute says Y" divergence.
 """
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
 
+from gyrinx.content.models import (
+    ContentEquipmentUpgrade,
+    ContentFighterEquipmentListItem,
+    ContentWeaponAccessory,
+)
 from gyrinx.core.cost.balance_sheet import build_balance_sheet
-from gyrinx.core.handlers.equipment.purchase import handle_equipment_purchase
+from gyrinx.core.handlers.equipment.cost_override import (
+    handle_equipment_cost_override,
+)
+from gyrinx.core.handlers.equipment.purchase import (
+    handle_accessory_purchase,
+    handle_equipment_purchase,
+    handle_equipment_upgrade,
+    handle_weapon_profile_purchase,
+)
+from gyrinx.core.handlers.equipment.reassignment import (
+    handle_equipment_reassignment,
+)
+from gyrinx.core.handlers.equipment.removal import (
+    handle_equipment_component_removal,
+    handle_equipment_removal,
+)
 from gyrinx.core.handlers.fighter.hire_clone import handle_fighter_hire
-from gyrinx.core.models.action import ListAction
+from gyrinx.core.handlers.fighter.kill import handle_fighter_kill
+from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.list import (
     List,
     ListFighter,
     ListFighterEquipmentAssignment,
 )
+from gyrinx.core.models.pack import CustomContentPackItem
+from gyrinx.core.tasks import propagate_content_cost_change
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -114,12 +139,87 @@ def assert_problems(problems, must_mention, must_not_mention=()):
         )
 
 
+class ContentSource:
+    """The catalog-vs-pack axis for matrix content.
+
+    Every cell that uses the `gear` factory runs twice: once with plain
+    catalog content, once with the identical content scoped to a subscribed
+    CustomContentPack. Pack content is invisible to the default
+    ContentManager and only surfaced by all_content()/with_packs(), so any
+    cost path that fetches content carelessly prices pack gear differently —
+    a class of drift the catalog variant can never see.
+    """
+
+    def __init__(self, pack=None):
+        self.pack = pack
+
+    @property
+    def name(self):
+        return "pack" if self.pack else "catalog"
+
+    def subscribe(self, lst):
+        if self.pack:
+            lst.packs.add(self.pack)
+
+    def register(self, obj):
+        if self.pack:
+            CustomContentPackItem.objects.create(
+                pack=self.pack,
+                content_type=ContentType.objects.get_for_model(type(obj)),
+                object_id=obj.pk,
+                owner=self.pack.owner,
+            )
+        return obj
+
+
+@pytest.fixture(params=["catalog", "pack"])
+def content_source(request, make_pack):
+    if request.param == "pack":
+        return ContentSource(make_pack("Axis Pack"))
+    return ContentSource()
+
+
 @pytest.fixture
-def healthy_list(user, make_list, content_fighter, make_equipment):
-    """A list built entirely through real flows: one fighter, one weapon."""
+def gear(content_source, make_equipment, make_weapon_profile):
+    """Content factory building gear on the current side of the axis."""
+
+    class Gear:
+        source = content_source
+
+        def equipment(self, name="Lasgun", cost=15, **kwargs):
+            return content_source.register(make_equipment(name, cost=cost, **kwargs))
+
+        def accessory(self, name="Scope", cost=8, **kwargs):
+            return content_source.register(
+                ContentWeaponAccessory.objects.create(name=name, cost=cost, **kwargs)
+            )
+
+        def profile(self, equipment, name="Hotshot", cost=10, **kwargs):
+            return content_source.register(
+                make_weapon_profile(equipment, name=name, cost=cost, **kwargs)
+            )
+
+        def upgrade(self, equipment, name="Extended mag", cost=12, **kwargs):
+            return content_source.register(
+                ContentEquipmentUpgrade.objects.create(
+                    name=name, equipment=equipment, cost=cost, **kwargs
+                )
+            )
+
+    return Gear()
+
+
+@pytest.fixture
+def healthy_list(user, make_list, content_fighter, content_source, gear):
+    """A list built entirely through real flows: one fighter, one weapon.
+
+    Parametrized over the catalog-vs-pack axis: everything downstream of
+    this fixture (meta-tests included) runs on both sides.
+    """
     lst = make_list("Balance Gang")
+    content_source.subscribe(lst)
     fighter = hire_fighter(user, lst, content_fighter, name="Bob")
-    equipment = make_equipment("Lasgun", cost=15)
+    equipment = gear.equipment("Lasgun", cost=15)
     assignment = buy_equipment(user, lst, fighter, equipment)
     lst.refresh_from_db()
     return lst, fighter, assignment
@@ -285,39 +385,16 @@ def test_meta_build_is_read_only(healthy_list):
 # .claude/notes/cost-pinning-design.md §6).
 # ---------------------------------------------------------------------------
 
-from django.contrib.contenttypes.models import ContentType  # noqa: E402
-from django.urls import reverse  # noqa: E402
-
-from gyrinx.content.models import (  # noqa: E402
-    ContentEquipmentUpgrade,
-    ContentFighterEquipmentListItem,
-    ContentWeaponAccessory,
-)
-from gyrinx.core.handlers.equipment.cost_override import (  # noqa: E402
-    handle_equipment_cost_override,
-)
-from gyrinx.core.handlers.equipment.purchase import (  # noqa: E402
-    handle_accessory_purchase,
-    handle_equipment_upgrade,
-    handle_weapon_profile_purchase,
-)
-from gyrinx.core.handlers.equipment.reassignment import (  # noqa: E402
-    handle_equipment_reassignment,
-)
-from gyrinx.core.handlers.equipment.removal import (  # noqa: E402
-    handle_equipment_component_removal,
-    handle_equipment_removal,
-)
-from gyrinx.core.handlers.fighter.kill import handle_fighter_kill  # noqa: E402
-from gyrinx.core.models.action import ListActionType  # noqa: E402
-from gyrinx.core.tasks import propagate_content_cost_change  # noqa: E402
-
 
 @pytest.fixture
-def campaign_list(user, make_list, campaign):
-    """A campaign-mode list with a stash and a credit stake, fully chained."""
+def campaign_list(user, make_list, campaign, content_source):
+    """A campaign-mode list with a stash and a credit stake, fully chained.
+
+    Subscribed to the axis pack when the pack side is active.
+    """
     lst = make_list("War Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
     campaign.lists.add(lst)
+    content_source.subscribe(lst)
     stash = lst.ensure_stash()
     lst.create_action(
         user=user,
@@ -344,9 +421,9 @@ def buy_accessory(user, lst, fighter, assignment, accessory):
 
 
 @pytest.mark.django_db
-def test_matrix_buy_weapon_profile(healthy_list, user, make_weapon_profile):
+def test_matrix_buy_weapon_profile(healthy_list, user, gear):
     lst, fighter, assignment = healthy_list
-    profile = make_weapon_profile(assignment.content_equipment, name="Hotshot", cost=10)
+    profile = gear.profile(assignment.content_equipment, name="Hotshot", cost=10)
     handle_weapon_profile_purchase(
         user=user,
         lst=fresh(lst),
@@ -358,19 +435,17 @@ def test_matrix_buy_weapon_profile(healthy_list, user, make_weapon_profile):
 
 
 @pytest.mark.django_db
-def test_matrix_buy_accessory(healthy_list, user):
+def test_matrix_buy_accessory(healthy_list, user, gear):
     lst, fighter, assignment = healthy_list
-    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
+    accessory = gear.accessory()
     buy_accessory(user, lst, fighter, assignment, accessory)
     assert_reconciles(lst)
 
 
 @pytest.mark.django_db
-def test_matrix_buy_upgrade(healthy_list, user):
+def test_matrix_buy_upgrade(healthy_list, user, gear):
     lst, fighter, assignment = healthy_list
-    upgrade = ContentEquipmentUpgrade.objects.create(
-        name="Extended mag", equipment=assignment.content_equipment, cost=12
-    )
+    upgrade = gear.upgrade(assignment.content_equipment)
     handle_equipment_upgrade(
         user=user,
         lst=fresh(lst),
@@ -382,9 +457,9 @@ def test_matrix_buy_upgrade(healthy_list, user):
 
 
 @pytest.mark.django_db
-def test_matrix_remove_accessory_from_fighter(healthy_list, user):
+def test_matrix_remove_accessory_from_fighter(healthy_list, user, gear):
     lst, fighter, assignment = healthy_list
-    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
+    accessory = gear.accessory()
     buy_accessory(user, lst, fighter, assignment, accessory)
     handle_equipment_component_removal(
         user=user,
@@ -440,21 +515,21 @@ def test_matrix_total_override_set_and_clear(healthy_list, user):
 
 
 @pytest.mark.django_db
-def test_matrix_buy_onto_stash(campaign_list, user, make_equipment):
+def test_matrix_buy_onto_stash(campaign_list, user, gear):
     lst, stash = campaign_list
-    equipment = make_equipment("Stash Gun", cost=50)
+    equipment = gear.equipment("Stash Gun", cost=50)
     buy_equipment(user, lst, stash, equipment)
     assert_reconciles(lst)
 
 
 @pytest.mark.django_db
-def test_matrix_reassign_catalog_gear_between_fighters(
-    campaign_list, user, content_fighter, make_equipment
+def test_matrix_reassign_plain_gear_between_fighters(
+    campaign_list, user, content_fighter, gear
 ):
     lst, stash = campaign_list
     fighter_a = hire_fighter(user, lst, content_fighter, name="Alfa")
     fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
-    equipment = make_equipment("Lasgun", cost=15)
+    equipment = gear.equipment("Lasgun", cost=15)
     assignment = buy_equipment(user, lst, fighter_a, equipment)
     assert_reconciles(lst)
 
@@ -479,13 +554,13 @@ def test_matrix_reassign_catalog_gear_between_fighters(
 
 
 @pytest.mark.django_db
-def test_matrix_kill_fighter_with_catalog_gear(
-    campaign_list, user, content_fighter, make_equipment
+def test_matrix_kill_fighter_with_plain_gear(
+    campaign_list, user, content_fighter, gear
 ):
-    """Death transfers catalog-priced gear: same price in both contexts."""
+    """Death transfers undiscounted gear: same price in both contexts."""
     lst, stash = campaign_list
     fighter = hire_fighter(user, lst, content_fighter, name="Bob")
-    equipment = make_equipment("Lasgun", cost=15)
+    equipment = gear.equipment("Lasgun", cost=15)
     buy_equipment(user, lst, fighter, equipment)
     assert_reconciles(lst)
 
@@ -494,13 +569,11 @@ def test_matrix_kill_fighter_with_catalog_gear(
 
 
 @pytest.mark.django_db
-def test_matrix_repeat_death_catalog_gear(
-    campaign_list, user, content_fighter, make_equipment
-):
+def test_matrix_repeat_death_plain_gear(campaign_list, user, content_fighter, gear):
     """Gear survives two deaths: kill A, re-equip to B, kill B."""
     lst, stash = campaign_list
     fighter_a = hire_fighter(user, lst, content_fighter, name="Alfa")
-    equipment = make_equipment("Lasgun", cost=15)
+    equipment = gear.equipment("Lasgun", cost=15)
     buy_equipment(user, lst, fighter_a, equipment)
     handle_fighter_kill(user=user, lst=fresh(lst), fighter=fresh(fighter_a))
     assert_reconciles(lst)
@@ -521,12 +594,10 @@ def test_matrix_repeat_death_catalog_gear(
 
 
 @pytest.mark.django_db
-def test_matrix_sell_catalog_gear_from_stash(
-    campaign_list, user, client, make_equipment
-):
-    """Selling catalog-priced stash gear: view prices catalog == cache."""
+def test_matrix_sell_plain_gear_from_stash(campaign_list, user, client, gear):
+    """Selling undiscounted stash gear: view prices catalog == cache."""
     lst, stash = campaign_list
-    equipment = make_equipment("Stash Gun", cost=50)
+    equipment = gear.equipment("Stash Gun", cost=50)
     assignment = buy_equipment(user, lst, stash, equipment)
     assert_reconciles(lst)
 
@@ -564,20 +635,53 @@ def test_matrix_campaign_budget_grant_reconciles(
     assert_reconciles(cloned)
 
 
+P7_PACK_SWEEP_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason="P7: pack-item price changes never sweep — get_old_cost() reads the "
+    "old price through the pack-excluding default manager, gets DoesNotExist "
+    "for pack rows, and the signal treats the save as a new instance, so "
+    "nothing is marked dirty and no audit action is enqueued; fixed in Phase 3",
+)
+
+
+def build_weapon_list(
+    side, user, make_list, content_fighter, make_equipment, make_pack
+):
+    """A list with one fighter and one weapon on an explicit axis side.
+
+    For cells whose expectations differ per side (per-param xfail marks),
+    which the axis fixture cannot express.
+    """
+    source = ContentSource(make_pack("Axis Pack") if side == "pack" else None)
+    lst = make_list("Sidecar Gang")
+    source.subscribe(lst)
+    fighter = hire_fighter(user, lst, content_fighter, name="Bob")
+    equipment = source.register(make_equipment("Lasgun", cost=15))
+    assignment = buy_equipment(user, lst, fighter, equipment)
+    lst.refresh_from_db()
+    return lst, fighter, assignment, equipment, source
+
+
 # --- Content price change: the async window --------------------------------
 
 
 @pytest.mark.django_db
-def test_matrix_content_price_change_window_is_visible(healthy_list):
+@pytest.mark.parametrize(
+    "side", ["catalog", pytest.param("pack", marks=P7_PACK_SWEEP_XFAIL)]
+)
+def test_matrix_content_price_change_window_is_visible(
+    side, user, make_list, content_fighter, make_equipment, make_pack
+):
     """Mid-window (sweep done, task not yet run): harness sees the gap.
 
     A content price change marks caches dirty synchronously; the audit action
     lands later via the async task. Between recompute and task, the action
     chain legitimately trails the caches — the harness must show that, not
-    hide it.
+    hide it. On the pack side the sweep never fires at all (P7).
     """
-    lst, fighter, assignment = healthy_list
-    equipment = assignment.content_equipment
+    lst, fighter, assignment, equipment, _ = build_weapon_list(
+        side, user, make_list, content_fighter, make_equipment, make_pack
+    )
     equipment.cost = 25  # was 15
     equipment.save()
 
@@ -593,10 +697,16 @@ def test_matrix_content_price_change_window_is_visible(healthy_list):
 
 
 @pytest.mark.django_db
-def test_matrix_content_price_change_full_flow_reconciles(healthy_list):
+@pytest.mark.parametrize(
+    "side", ["catalog", pytest.param("pack", marks=P7_PACK_SWEEP_XFAIL)]
+)
+def test_matrix_content_price_change_full_flow_reconciles(
+    side, user, make_list, content_fighter, make_equipment, make_pack
+):
     """After the async task creates the CONTENT_COST_CHANGE action: clean."""
-    lst, fighter, assignment = healthy_list
-    equipment = assignment.content_equipment
+    lst, fighter, assignment, equipment, _ = build_weapon_list(
+        side, user, make_list, content_fighter, make_equipment, make_pack
+    )
 
     before_snapshots = {str(lst.id): [lst.rating_current, lst.stash_current]}
     equipment.cost = 25
@@ -636,7 +746,7 @@ def test_matrix_legacy_raw_fighter_detected_after_recompute(
 
 
 @pytest.mark.django_db
-def test_matrix_p1_1925_accessory_onto_overridden_assignment(healthy_list, user):
+def test_matrix_p1_1925_accessory_onto_overridden_assignment(healthy_list, user, gear):
     """P1 (#1925), fixed in Phase 2: a component purchase onto a fixed-total
     assignment moves credits but not the book value — and reconciles."""
     lst, fighter, assignment = healthy_list
@@ -650,7 +760,7 @@ def test_matrix_p1_1925_accessory_onto_overridden_assignment(healthy_list, user)
     )
     assert_reconciles(lst)  # clean before the purchase
 
-    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
+    accessory = gear.accessory()
     buy_accessory(user, lst, fighter, assignment, accessory)
     assert_reconciles(lst)  # book value stays at the 50 override; credits moved
 
@@ -662,14 +772,14 @@ def test_matrix_p1_1925_accessory_onto_overridden_assignment(healthy_list, user)
     "context; the stash re-prices it at catalog; fixed by pinning (Phase 9)",
 )
 def test_matrix_p2_1826_kill_fighter_with_discounted_gear(
-    campaign_list, user, make_content_fighter, content_house, make_equipment
+    campaign_list, user, make_content_fighter, content_house, gear
 ):
     lst, stash = campaign_list
     cf = make_content_fighter(
         type="Scavvy", category="GANGER", house=content_house, base_cost=50
     )
     fighter = hire_fighter(user, lst, cf, name="Bob")
-    equipment = make_equipment("Lasgun", cost=15)
+    equipment = gear.equipment("Lasgun", cost=15)
     ContentFighterEquipmentListItem.objects.create(
         fighter=cf, equipment=equipment, cost=5
     )
@@ -686,11 +796,9 @@ def test_matrix_p2_1826_kill_fighter_with_discounted_gear(
     reason="P3: the sale flow prices lines at raw catalog cost, ignoring "
     "overrides; cache decrements diverge from cost_int(); fixed in Phase 3",
 )
-def test_matrix_p3_sell_overridden_gear_from_stash(
-    campaign_list, user, client, make_equipment
-):
+def test_matrix_p3_sell_overridden_gear_from_stash(campaign_list, user, client, gear):
     lst, stash = campaign_list
-    equipment = make_equipment("Stash Gun", cost=50)
+    equipment = gear.equipment("Stash Gun", cost=50)
     assignment = buy_equipment(user, lst, stash, equipment)
     handle_equipment_cost_override(
         user=user,
@@ -725,13 +833,11 @@ def test_matrix_p3_sell_overridden_gear_from_stash(
     reason="P4: stash component removal propagates rating_delta (0 for "
     "stash) instead of the component's value; fixed in Phase 3",
 )
-def test_matrix_p4_remove_accessory_from_stash_gear(
-    campaign_list, user, make_equipment
-):
+def test_matrix_p4_remove_accessory_from_stash_gear(campaign_list, user, gear):
     lst, stash = campaign_list
-    equipment = make_equipment("Stash Gun", cost=50)
+    equipment = gear.equipment("Stash Gun", cost=50)
     assignment = buy_equipment(user, lst, stash, equipment)
-    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
+    accessory = gear.accessory()
     buy_accessory(user, lst, stash, assignment, accessory)
     assert_reconciles(lst)  # clean before the removal
 
@@ -753,8 +859,12 @@ def test_matrix_p4_remove_accessory_from_stash_gear(
     reason="P5: the accessories edit view's bare-form branch rewrites the "
     "M2M with no propagation, action, or credits; removed in Phase 3",
 )
-def test_matrix_p5_bare_form_accessory_removal(healthy_list, user, client):
-    lst, fighter, assignment = healthy_list
+def test_matrix_p5_bare_form_accessory_removal(
+    user, client, make_list, content_fighter, make_equipment, make_pack
+):
+    lst, fighter, assignment, _, _ = build_weapon_list(
+        "catalog", user, make_list, content_fighter, make_equipment, make_pack
+    )
     accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
     buy_accessory(user, lst, fighter, assignment, accessory)
     assert_reconciles(lst)  # clean before the bare POST
@@ -770,13 +880,52 @@ def test_matrix_p5_bare_form_accessory_removal(healthy_list, user, client):
 
 
 @pytest.mark.django_db
+def test_matrix_p5_bare_form_cannot_remove_pack_accessories(
+    user, client, make_list, content_fighter, make_equipment, make_pack
+):
+    """The bare-form branch silently no-ops for pack accessories.
+
+    Its M2M rewrite computes removals by listing current accessories through
+    the pack-excluding default manager, so a pack accessory is invisible to
+    it and survives the clear. The books stay consistent — but the user's
+    submitted removal silently did nothing, which is one more reason the
+    branch is deleted in Phase 3. This cell documents the behaviour and will
+    fail (prompting deletion of the cell) when the branch goes.
+    """
+    lst, fighter, assignment, _, source = build_weapon_list(
+        "pack", user, make_list, content_fighter, make_equipment, make_pack
+    )
+    accessory = source.register(
+        ContentWeaponAccessory.objects.create(name="Pack Scope", cost=8)
+    )
+    buy_accessory(user, lst, fighter, assignment, accessory)
+    assert_reconciles(lst)
+
+    client.force_login(user)
+    url = reverse(
+        "core:list-fighter-weapon-accessories-edit",
+        args=[lst.id, fighter.id, assignment.id],
+    )
+    response = client.post(url, {})
+    assert response.status_code == 302
+
+    # The pack accessory survived the "clear" and the books still agree.
+    assert (
+        ContentWeaponAccessory.objects.all_content()
+        .filter(weapon_accessories=fresh(assignment))
+        .exists()
+    )
+    assert_reconciles(lst)
+
+
+@pytest.mark.django_db
 def test_matrix_p6_reassign_discounted_gear_reprices(
     campaign_list,
     user,
     make_content_fighter,
     content_house,
     content_fighter,
-    make_equipment,
+    gear,
 ):
     lst, stash = campaign_list
     cf_a = make_content_fighter(
@@ -784,7 +933,7 @@ def test_matrix_p6_reassign_discounted_gear_reprices(
     )
     fighter_a = hire_fighter(user, lst, cf_a, name="Alfa")
     fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
-    equipment = make_equipment("Lasgun", cost=15)
+    equipment = gear.equipment("Lasgun", cost=15)
     ContentFighterEquipmentListItem.objects.create(
         fighter=cf_a, equipment=equipment, cost=5
     )
@@ -808,7 +957,7 @@ def test_matrix_p6_repricing_telemetry_fires(
     make_content_fighter,
     content_house,
     content_fighter,
-    make_equipment,
+    gear,
     monkeypatch,
 ):
     """The cost-changed-on-reassignment telemetry fires with real values."""
@@ -827,7 +976,7 @@ def test_matrix_p6_repricing_telemetry_fires(
     )
     fighter_a = hire_fighter(user, lst, cf_a, name="Alfa")
     fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
-    equipment = make_equipment("Lasgun", cost=15)
+    equipment = gear.equipment("Lasgun", cost=15)
     ContentFighterEquipmentListItem.objects.create(
         fighter=cf_a, equipment=equipment, cost=5
     )
@@ -860,10 +1009,6 @@ def test_matrix_reassign_gear_with_pack_accessory(
     would book a phantom repricing. The handler (and this harness's fresh())
     must fetch with the same semantics the views use.
     """
-    from django.contrib.contenttypes.models import ContentType
-
-    from gyrinx.core.models.pack import CustomContentPackItem
-
     lst, stash = campaign_list
     lst.packs.add(pack)
     fighter_a = hire_fighter(user, lst, content_fighter, name="Alfa")

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -635,15 +635,6 @@ def test_matrix_campaign_budget_grant_reconciles(
     assert_reconciles(cloned)
 
 
-P7_PACK_SWEEP_XFAIL = pytest.mark.xfail(
-    strict=True,
-    reason="P7: pack-item price changes never sweep — get_old_cost() reads the "
-    "old price through the pack-excluding default manager, gets DoesNotExist "
-    "for pack rows, and the signal treats the save as a new instance, so "
-    "nothing is marked dirty and no audit action is enqueued; fixed in Phase 3",
-)
-
-
 def build_weapon_list(
     side, user, make_list, content_fighter, make_equipment, make_pack
 ):
@@ -666,9 +657,7 @@ def build_weapon_list(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "side", ["catalog", pytest.param("pack", marks=P7_PACK_SWEEP_XFAIL)]
-)
+@pytest.mark.parametrize("side", ["catalog", "pack"])
 def test_matrix_content_price_change_window_is_visible(
     side, user, make_list, content_fighter, make_equipment, make_pack
 ):
@@ -677,7 +666,8 @@ def test_matrix_content_price_change_window_is_visible(
     A content price change marks caches dirty synchronously; the audit action
     lands later via the async task. Between recompute and task, the action
     chain legitimately trails the caches — the harness must show that, not
-    hide it. On the pack side the sweep never fires at all (P7).
+    hide it. The pack side works identically since the #1930 fix
+    (get_old_cost resolves pack rows via all_content()).
     """
     lst, fighter, assignment, equipment, _ = build_weapon_list(
         side, user, make_list, content_fighter, make_equipment, make_pack
@@ -697,9 +687,7 @@ def test_matrix_content_price_change_window_is_visible(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "side", ["catalog", pytest.param("pack", marks=P7_PACK_SWEEP_XFAIL)]
-)
+@pytest.mark.parametrize("side", ["catalog", "pack"])
 def test_matrix_content_price_change_full_flow_reconciles(
     side, user, make_list, content_fighter, make_equipment, make_pack
 ):
@@ -854,49 +842,23 @@ def test_matrix_p4_remove_accessory_from_stash_gear(campaign_list, user, gear):
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True,
-    reason="P5: the accessories edit view's bare-form branch rewrites the "
-    "M2M with no propagation, action, or credits; removed in Phase 3",
-)
-def test_matrix_p5_bare_form_accessory_removal(
-    user, client, make_list, content_fighter, make_equipment, make_pack
+@pytest.mark.parametrize("side", ["catalog", "pack"])
+def test_matrix_bare_accessory_post_is_inert(
+    side, user, client, make_list, content_fighter, make_equipment, make_pack
 ):
-    lst, fighter, assignment, _, _ = build_weapon_list(
-        "catalog", user, make_list, content_fighter, make_equipment, make_pack
-    )
-    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
-    buy_accessory(user, lst, fighter, assignment, accessory)
-    assert_reconciles(lst)  # clean before the bare POST
+    """A POST without accessory_id changes nothing (P5, fixed).
 
-    client.force_login(user)
-    url = reverse(
-        "core:list-fighter-weapon-accessories-edit",
-        args=[lst.id, fighter.id, assignment.id],
-    )
-    response = client.post(url, {})  # no accessory_id -> bare form branch
-    assert response.status_code == 302
-    assert_reconciles(lst)  # FAILS: M2M cleared, caches and ledger untouched
-
-
-@pytest.mark.django_db
-def test_matrix_p5_bare_form_cannot_remove_pack_accessories(
-    user, client, make_list, content_fighter, make_equipment, make_pack
-):
-    """The bare-form branch silently no-ops for pack accessories.
-
-    Its M2M rewrite computes removals by listing current accessories through
-    the pack-excluding default manager, so a pack accessory is invisible to
-    it and survives the clear. The books stay consistent — but the user's
-    submitted removal silently did nothing, which is one more reason the
-    branch is deleted in Phase 3. This cell documents the behaviour and will
-    fail (prompting deletion of the cell) when the branch goes.
+    The accessories-edit view used to carry a bare-form fallback that rewrote
+    the whole accessory M2M with no cost propagation, no ListAction, and no
+    credits — a live drift producer on the catalog side, and a silent no-op
+    for pack accessories. The branch is deleted; a bare POST now just
+    re-renders, the accessory survives on both sides, and the books agree.
     """
     lst, fighter, assignment, _, source = build_weapon_list(
-        "pack", user, make_list, content_fighter, make_equipment, make_pack
+        side, user, make_list, content_fighter, make_equipment, make_pack
     )
     accessory = source.register(
-        ContentWeaponAccessory.objects.create(name="Pack Scope", cost=8)
+        ContentWeaponAccessory.objects.create(name="Scope", cost=8)
     )
     buy_accessory(user, lst, fighter, assignment, accessory)
     assert_reconciles(lst)
@@ -906,10 +868,9 @@ def test_matrix_p5_bare_form_cannot_remove_pack_accessories(
         "core:list-fighter-weapon-accessories-edit",
         args=[lst.id, fighter.id, assignment.id],
     )
-    response = client.post(url, {})
-    assert response.status_code == 302
+    response = client.post(url, {})  # no accessory_id
+    assert response.status_code == 200  # falls through to the page render
 
-    # The pack accessory survived the "clear" and the books still agree.
     assert (
         ContentWeaponAccessory.objects.all_content()
         .filter(weapon_accessories=fresh(assignment))

--- a/gyrinx/core/views/fighter/equipment.py
+++ b/gyrinx/core/views/fighter/equipment.py
@@ -998,17 +998,13 @@ def edit_list_fighter_weapon_accessories(request, id, fighter_id, assign_id):
                 + query_string
             )
 
-    # Handle removing accessories via form
-    elif request.method == "POST":
-        form = ListFighterEquipmentAssignmentAccessoriesForm(
-            request.POST, instance=assignment
-        )
-        if form.is_valid():
-            form.save()
-
-        return HttpResponseRedirect(
-            reverse("core:list-fighter-weapons-edit", args=(lst.id, fighter.id))
-        )
+    # A POST without accessory_id falls through to the page render below.
+    # There used to be a bare-form branch here that rewrote the whole
+    # accessory M2M via form.save() with no cost propagation, no ListAction,
+    # and no credits movement — no template posted to it, but the endpoint
+    # was live and silently drifted every cache above it (and could not
+    # remove pack accessories at all, since the M2M rewrite listed current
+    # rows through the pack-excluding default manager).
 
     # Get filter parameters
     filter_mode = request.GET.get("filter", "equipment-list")


### PR DESCRIPTION
## Summary

Content that lives in a content pack is fetched differently from catalog content throughout the app — the default manager hides it, and only `all_content()`/`with_packs()` see it. That means every cost path has a pack-shaped way to go wrong that tests using only catalog content can never catch (the previous PR's only blocking review finding was exactly such a bug).

- **Every balance-sheet matrix cell now runs twice** — once with catalog content, once with identical content inside a subscribed content pack — via a parametrized fixture and a small gear factory, not duplicated tests. The calibration meta-tests double too.
- **First run found a real bug (#1930) — fixed here:** changing the price of a pack item did nothing — no gang marked for recalculation, no history entry, no campaign credit adjustment. The pre-save signal read the old price through the pack-excluding manager, concluded the row was new, and stopped. Fixed with the same `all_content()` fallback the async task already uses; both expected-failure tests flipped to passing on both sides.
- **The dead accessories-edit form branch is deleted here too.** It rewrote a weapon's accessories with no cost bookkeeping at all (catalog-side drift), and couldn't remove pack accessories anyway (silent no-op). No template posted to it; a bare POST now just re-renders the page, with a both-sides test pinning the inert behaviour.
- Cells whose *expected* behaviour genuinely differs by side use explicit per-side parameters with per-side expected-failure marks, keeping the strict tripwire discipline intact.
- **The independent review then caught the axis green-stamping a bug** (#1933): pack upgrades are booked at **zero** — the upgrade-stack sum excludes pack rows from its own total, and the recalculation path is equally blind, so the books "agree" at the wrong number and pure reconciliation can't see it. Healthy cells now also assert the **actual booked movement** (rating changed by the component's price); that turned the vacuous green into two strict expected-failure tests (buy-upgrade pack side, and reassignment of gear carrying a pack weapon profile). The fix touches the hot prefetch path and ships with Phase 3.

## Test plan

- [x] Full matrix on both sides: 59 passed, 8 expected failures (P2 kill-transfer, P3 sale, P4 stash removal on both sides; P8 pack-upgrade zero-booking ×2; P5 and P7 fixed and flipped).
- [x] Full suite: 2885 passed, 13 skipped, 8 xfailed. Accessory/signal/pack suites: 313 passed.
- [x] Design doc updated: seventh producer, the axis written into §5.2, counts corrected.

Refs #1826
Refs #1933
Closes #1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)

