### PR TITLE
feat: sweeps maintain pinned amounts (#1826 Phase 6)

### DIFF
--- a/gyrinx/content/models/equipment.py
+++ b/gyrinx/content/models/equipment.py
@@ -707,6 +707,7 @@ class ContentEquipmentUpgrade(CostMixin, Content):
             type(self)
             .objects.all_content()
             .filter(equipment=self.equipment, position__gte=self.position)
+            .select_related("equipment")
         )
 
     def set_dirty(self) -> None:

--- a/gyrinx/content/models/equipment.py
+++ b/gyrinx/content/models/equipment.py
@@ -693,6 +693,22 @@ class ContentEquipmentUpgrade(CostMixin, Content):
     def __str__(self):
         return f"{self.equipment.upgrade_stack_name_display} – {self.name} ({self.equipment.name})"
 
+    def same_stack_from_position(self):
+        """The upgrades a cost change to this rung reprices.
+
+        MULTI mode prices each upgrade independently: just this row. SINGLE
+        mode is cumulative, so this rung and every higher rung on the same
+        equipment reprice. all_content() so pack-scoped rungs aren't hidden
+        by the default manager (#1933).
+        """
+        if self.equipment.upgrade_mode == ContentEquipment.UpgradeMode.MULTI:
+            return type(self).objects.all_content().filter(pk=self.pk)
+        return (
+            type(self)
+            .objects.all_content()
+            .filter(equipment=self.equipment, position__gte=self.position)
+        )
+
     def set_dirty(self) -> None:
         """
         Mark all ListFighterEquipmentAssignments using this upgrade as dirty.
@@ -706,9 +722,15 @@ class ContentEquipmentUpgrade(CostMixin, Content):
             bulk_mark_assignments_dirty,
         )
 
-        # Find all assignments using this equipment upgrade (via M2M)
+        # Find all assignments using this equipment upgrade (via M2M). SINGLE
+        # stacks price cumulatively — cost_int(position) sums every rung at or
+        # below it — so correcting one rung reprices holders of that rung OR
+        # ANY HIGHER one; the same-rung-only filter silently missed them.
+        # Keep in lockstep with the matching branch in
+        # signal_handlers._affected_list_ids (#1826 §4.7).
+        affected_upgrades = self.same_stack_from_position()
         assignments = ListFighterEquipmentAssignment.objects.filter(
-            upgrades_field=self, archived=False
+            upgrades_field__in=affected_upgrades, archived=False
         )
 
         bulk_mark_assignments_dirty(assignments)

--- a/gyrinx/content/models/equipment_list.py
+++ b/gyrinx/content/models/equipment_list.py
@@ -213,12 +213,16 @@ class ContentFighterEquipmentListUpgrade(CostMixin, Content):
 
         # Find assignments with this upgrade on fighters using this content
         # fighter — plus rows PINNED to this override, which may have moved
-        # (#1826 §4.7; mirror of _affected_list_ids).
+        # (#1826 §4.7; mirror of _affected_list_ids). SINGLE stacks price
+        # cumulatively with this override applied PER RUNG (see the
+        # cumulative walk in core assignment resolution), so an override
+        # correction reprices holders of this rung or any HIGHER one — the
+        # same-rung-only filter silently missed them.
         assignments = ListFighterEquipmentAssignment.objects.filter(
             Q(
                 Q(list_fighter__content_fighter=self.fighter)
                 | Q(list_fighter__legacy_content_fighter=self.fighter),
-                upgrades_field=self.upgrade,
+                upgrades_field__in=self.upgrade.same_stack_from_position(),
             )
             | Q(upgrade_rows__pinned_equipment_list_upgrade=self),
             archived=False,

--- a/gyrinx/content/models/equipment_list.py
+++ b/gyrinx/content/models/equipment_list.py
@@ -77,11 +77,20 @@ class ContentFighterEquipmentListItem(CostMixin, Content):
             bulk_mark_assignments_dirty,
         )
 
-        # Find assignments for this equipment on fighters using this content fighter
+        # Find assignments for this equipment on fighters using this content
+        # fighter — plus rows PINNED to this item (base or profile pins),
+        # which may since have moved to holders this row no longer applies
+        # to. Without the pin clauses, a price correction would miss moved
+        # gear entirely (#1826 §4.7). Keep in lockstep with the matching
+        # branch in signal_handlers._affected_list_ids.
         assignments = ListFighterEquipmentAssignment.objects.filter(
-            Q(list_fighter__content_fighter=self.fighter)
-            | Q(list_fighter__legacy_content_fighter=self.fighter),
-            content_equipment=self.equipment,
+            Q(
+                Q(list_fighter__content_fighter=self.fighter)
+                | Q(list_fighter__legacy_content_fighter=self.fighter),
+                content_equipment=self.equipment,
+            )
+            | Q(pinned_equipment_list_item=self)
+            | Q(profile_rows__pinned_equipment_list_item=self),
             archived=False,
         )
 
@@ -137,11 +146,16 @@ class ContentFighterEquipmentListWeaponAccessory(CostMixin, Content):
             bulk_mark_assignments_dirty,
         )
 
-        # Find assignments with this accessory on fighters using this content fighter
+        # Find assignments with this accessory on fighters using this content
+        # fighter — plus rows PINNED to this override, which may have moved
+        # (#1826 §4.7; mirror of _affected_list_ids).
         assignments = ListFighterEquipmentAssignment.objects.filter(
-            Q(list_fighter__content_fighter=self.fighter)
-            | Q(list_fighter__legacy_content_fighter=self.fighter),
-            weapon_accessories_field=self.weapon_accessory,
+            Q(
+                Q(list_fighter__content_fighter=self.fighter)
+                | Q(list_fighter__legacy_content_fighter=self.fighter),
+                weapon_accessories_field=self.weapon_accessory,
+            )
+            | Q(accessory_rows__pinned_equipment_list_accessory=self),
             archived=False,
         )
 
@@ -197,11 +211,16 @@ class ContentFighterEquipmentListUpgrade(CostMixin, Content):
             bulk_mark_assignments_dirty,
         )
 
-        # Find assignments with this upgrade on fighters using this content fighter
+        # Find assignments with this upgrade on fighters using this content
+        # fighter — plus rows PINNED to this override, which may have moved
+        # (#1826 §4.7; mirror of _affected_list_ids).
         assignments = ListFighterEquipmentAssignment.objects.filter(
-            Q(list_fighter__content_fighter=self.fighter)
-            | Q(list_fighter__legacy_content_fighter=self.fighter),
-            upgrades_field=self.upgrade,
+            Q(
+                Q(list_fighter__content_fighter=self.fighter)
+                | Q(list_fighter__legacy_content_fighter=self.fighter),
+                upgrades_field=self.upgrade,
+            )
+            | Q(upgrade_rows__pinned_equipment_list_upgrade=self),
             archived=False,
         )
 

--- a/gyrinx/content/models/expansion.py
+++ b/gyrinx/content/models/expansion.py
@@ -302,16 +302,22 @@ class ContentEquipmentListExpansionItem(Content):
             bulk_mark_assignments_dirty,
         )
 
-        filter_kwargs = {
-            "content_equipment": self.equipment,
-            "archived": False,
-        }
+        from django.db.models import Q
 
+        base_q = Q(content_equipment=self.equipment)
         # If this item has a specific weapon profile, only mark assignments with that profile
         if self.weapon_profile is not None:
-            filter_kwargs["weapon_profiles_field"] = self.weapon_profile
+            base_q &= Q(weapon_profiles_field=self.weapon_profile)
 
-        assignments = ListFighterEquipmentAssignment.objects.filter(**filter_kwargs)
+        # Also reach rows PINNED to this expansion item (base or profile pins)
+        # regardless of current equipment context (#1826 §4.7; mirror of
+        # _affected_list_ids).
+        assignments = ListFighterEquipmentAssignment.objects.filter(
+            base_q
+            | Q(pinned_expansion_item=self)
+            | Q(profile_rows__pinned_expansion_item=self),
+            archived=False,
+        )
 
         bulk_mark_assignments_dirty(assignments)
 

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -267,13 +267,19 @@ def handle_expansion_item_cost_change(sender, instance, **kwargs):
 # =============================================================================
 
 
-def _affected_list_ids(instance) -> list:
+def _affected_list_ids(instance, include_archived: bool = False) -> list:
     """Return the distinct ids of lists affected by a content cost change.
 
     Shared by the synchronous enqueue path (which snapshots each affected list's
     pre-change costs) and the async task (which recalculates and records actions),
     so both agree on exactly which lists a content instance touches. Returns an
     empty list for unknown model types.
+
+    ``include_archived`` widens the set to lists reachable only through
+    archived rows — the amount-rewriting sweep domain (#1826 §4.7: archived
+    rows are swept too, or a later unarchive resurrects a stale amount).
+    The default (live rows only) is the action/dirty domain and stays in
+    lockstep with the model set_dirty() filters.
     """
     from gyrinx.core.models.list import (
         ListFighter,
@@ -281,12 +287,13 @@ def _affected_list_ids(instance) -> list:
     )
 
     model_name = instance.__class__.__name__
+    live = {} if include_archived else {"archived": False}
 
     if model_name == "ContentEquipment":
         # Equipment directly assigned to fighters
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
-                content_equipment=instance, archived=False
+                content_equipment=instance, **live
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -295,7 +302,7 @@ def _affected_list_ids(instance) -> list:
         # Weapon profiles on assignments
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
-                weapon_profiles_field=instance, archived=False
+                weapon_profiles_field=instance, **live
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -304,7 +311,7 @@ def _affected_list_ids(instance) -> list:
         # Weapon accessories on assignments
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
-                weapon_accessories_field=instance, archived=False
+                weapon_accessories_field=instance, **live
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -315,7 +322,7 @@ def _affected_list_ids(instance) -> list:
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
                 upgrades_field__in=instance.same_stack_from_position(),
-                archived=False,
+                **live,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -325,7 +332,7 @@ def _affected_list_ids(instance) -> list:
         list_ids = (
             ListFighter.objects.filter(
                 Q(content_fighter=instance) | Q(legacy_content_fighter=instance),
-                archived=False,
+                **live,
             )
             .values_list("list_id", flat=True)
             .distinct()
@@ -337,7 +344,7 @@ def _affected_list_ids(instance) -> list:
                 Q(content_fighter=instance.fighter)
                 | Q(legacy_content_fighter=instance.fighter),
                 list__content_house=instance.house,
-                archived=False,
+                **live,
             )
             .values_list("list_id", flat=True)
             .distinct()
@@ -355,7 +362,7 @@ def _affected_list_ids(instance) -> list:
                 )
                 | Q(pinned_equipment_list_item=instance)
                 | Q(profile_rows__pinned_equipment_list_item=instance),
-                archived=False,
+                **live,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -371,7 +378,7 @@ def _affected_list_ids(instance) -> list:
                     weapon_accessories_field=instance.weapon_accessory,
                 )
                 | Q(accessory_rows__pinned_equipment_list_accessory=instance),
-                archived=False,
+                **live,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -387,7 +394,7 @@ def _affected_list_ids(instance) -> list:
                     upgrades_field=instance.upgrade,
                 )
                 | Q(upgrade_rows__pinned_equipment_list_upgrade=instance),
-                archived=False,
+                **live,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -405,7 +412,7 @@ def _affected_list_ids(instance) -> list:
                 expansion_q
                 | Q(pinned_expansion_item=instance)
                 | Q(profile_rows__pinned_expansion_item=instance),
-                archived=False,
+                **live,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -481,12 +488,17 @@ def _create_content_cost_change_actions(instance, before_snapshots=None):
     from gyrinx.core.models.action import ListAction, ListActionType
     from gyrinx.core.models.list import List
 
-    # Find affected lists based on the model type
+    # Find affected lists based on the model type. The rewrite domain also
+    # includes lists reachable only through archived rows (their amounts are
+    # rewritten so an unarchive can't resurrect a stale price); actions and
+    # snapshots stay scoped to the live set.
     list_ids = _affected_list_ids(instance)
+    rewrite_list_ids = _affected_list_ids(instance, include_archived=True)
 
-    if not list_ids:
+    if not rewrite_list_ids:
         return  # No affected lists
 
+    live_list_ids = set(list_ids)
     instance_name = _instance_display_name(instance)
 
     # For each list: rewrite pinned amounts, recalculate, create action.
@@ -494,7 +506,7 @@ def _create_content_cost_change_actions(instance, before_snapshots=None):
     # either all changes succeed (amounts rewritten, facts updated, action
     # created, credits applied) or none do (transaction rolls back, list stays
     # dirty — and unrewritten — for a later redelivery).
-    for list_id in list_ids:
+    for list_id in rewrite_list_ids:
         try:
             with transaction.atomic():
                 lst = List.objects.get(id=list_id)
@@ -509,8 +521,10 @@ def _create_content_cost_change_actions(instance, before_snapshots=None):
                 # Only create actions for lists that have an initial action
                 # Lists without latest_action will have dirty flag set via set_dirty()
                 # and will be recalculated when viewed (against the amounts
-                # rewritten above)
-                if not lst.latest_action:
+                # rewritten above). Archived-only lists get the rewrite but no
+                # action processing — nothing cache-visible moved, and the
+                # snapshot fallback has no baseline for them.
+                if list_id not in live_list_ids or not lst.latest_action:
                     continue
 
                 if sweep.use_row_deltas:
@@ -886,6 +900,11 @@ def _orphan_pinned_rows(instance):
     FKs are SET_NULL); the handler clears the FKs itself, making the delete
     collector's SET_NULL a no-op for these rows. The pin edges are walked via
     introspection so a future pin FK is orphaned without new wiring here.
+
+    NOTE (Phase 8): the per-list audit fan-out below runs synchronously in
+    the deleting request. Harmless while pins are sparse; once the backfill
+    pins everything, deleting a popular source touches many lists — flip the
+    states synchronously but move the audit fan-out to a task then.
     """
     from gyrinx.core.models.action import ListActionType
     from gyrinx.core.models.list import (

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -253,7 +253,15 @@ def handle_expansion_item_cost_change(sender, instance, **kwargs):
         return  # New instance, no existing assignments
 
     new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
+    changed = old_cost != new_cost
+    if not changed:
+        # The int helpers coerce None to 0, but on expansion items None means
+        # "use the base price" and 0 means "free" — a 0 <-> None edit DOES
+        # reprice and must sweep. Compare the raw values to catch it.
+        old_raw = get_old_field(sender, instance, "cost")
+        changed = old_raw is not MISSING and old_raw != instance.cost
+
+    if changed:
         instance._cost_changed = True  # Flag for post_save to create actions
         instance.set_dirty()
 
@@ -384,14 +392,16 @@ def _affected_list_ids(instance, include_archived: bool = False) -> list:
             .distinct()
         )
     elif model_name == "ContentFighterEquipmentListUpgrade":
-        # Equipment upgrade cost overrides on specific fighter types, plus
-        # upgrade rows pinned to this override (mirror of its set_dirty).
+        # Equipment upgrade cost overrides on specific fighter types —
+        # applied per rung in SINGLE-stack cumulative pricing, so this rung
+        # and every higher one — plus upgrade rows pinned to this override
+        # (mirror of its set_dirty).
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
                 Q(
                     Q(list_fighter__content_fighter=instance.fighter)
                     | Q(list_fighter__legacy_content_fighter=instance.fighter),
-                    upgrades_field=instance.upgrade,
+                    upgrades_field__in=instance.upgrade.same_stack_from_position(),
                 )
                 | Q(upgrade_rows__pinned_equipment_list_upgrade=instance),
                 **live,
@@ -540,7 +550,11 @@ def _create_content_cost_change_actions(instance, before_snapshots=None):
                     rating_delta = sweep.rating_delta
                     stash_delta = sweep.stash_delta
                     total_delta = rating_delta + stash_delta
-                    if total_delta == 0:
+                    # Check each delta, not the sum: +N rating / -N stash
+                    # cancels to zero while both books moved, and skipping
+                    # here (after facts committed the movement) would break
+                    # the action chain.
+                    if rating_delta == 0 and stash_delta == 0:
                         continue
                     # Chain the action off the recomputed head so anything
                     # that landed in the window keeps its own audit trail.
@@ -599,8 +613,10 @@ def _create_content_cost_change_actions(instance, before_snapshots=None):
 
                     # Skip if no actual cost change (e.g., override in place)
                     # This happens when a base cost changes but a fighter-specific
-                    # override (ContentFighterEquipmentListItem, etc.) takes precedence
-                    if total_delta == 0:
+                    # override (ContentFighterEquipmentListItem, etc.) takes
+                    # precedence. Check each delta, not the sum — +N rating /
+                    # -N stash cancels while both books moved.
+                    if rating_delta == 0 and stash_delta == 0:
                         continue
 
                 # In campaign mode, adjust credits (charge more or refund)
@@ -943,31 +959,47 @@ def _orphan_pinned_rows(instance):
     if not orphaned_by_list:
         return
 
+    # Capture plain values now — the instance is gone by the time the audit
+    # runs.
     name = _instance_display_name(instance)
-    for list_id, count in orphaned_by_list.items():
-        try:
-            with transaction.atomic():
-                lst = List.objects.get(id=list_id)
-                if not lst.latest_action:
-                    continue
-                components = "component" if count == 1 else "components"
-                lst.create_action(
-                    action_type=ListActionType.CONTENT_COST_CHANGE,
-                    description=(
-                        f"{name}: price source deleted; {count} pinned "
-                        f"{components} keep their amounts, attribution cleared"
-                    ),
-                    subject_app=instance._meta.app_label,
-                    subject_type=instance._meta.model_name,
-                    subject_id=instance.pk,
-                    rating_delta=0,
-                    stash_delta=0,
-                    credits_delta=0,
-                )
-        except List.DoesNotExist:
-            continue
-        except Exception:
-            logger.exception("Failed to record pin-orphaning for list %s", list_id)
+    subject_app = instance._meta.app_label
+    subject_type = instance._meta.model_name
+    subject_id = instance.pk
+
+    def _write_orphan_audits():
+        for list_id, count in orphaned_by_list.items():
+            try:
+                with transaction.atomic():
+                    lst = List.objects.get(id=list_id)
+                    if not lst.latest_action:
+                        continue
+                    components = "component" if count == 1 else "components"
+                    lst.create_action(
+                        action_type=ListActionType.CONTENT_COST_CHANGE,
+                        description=(
+                            f"{name}: price source deleted; {count} pinned "
+                            f"{components} keep their amounts, attribution cleared"
+                        ),
+                        subject_app=subject_app,
+                        subject_type=subject_type,
+                        subject_id=subject_id,
+                        rating_delta=0,
+                        stash_delta=0,
+                        credits_delta=0,
+                    )
+            except List.DoesNotExist:
+                continue  # itself deleted in the same cascade
+            except Exception:
+                logger.exception("Failed to record pin-orphaning for list %s", list_id)
+
+    # Deferred past commit: the delete collector fires every pre_delete
+    # BEFORE deleting anything, so writing a ListAction here for a list
+    # that is itself in the same cascade (deleting a ContentHouse cascades
+    # to its fighters' price rows AND to its lists) would insert a row
+    # referencing a doomed List — an IntegrityError at commit that rolls
+    # the whole deletion back. After commit, cascade-deleted lists simply
+    # no longer exist and are skipped.
+    transaction.on_commit(_write_orphan_audits)
 
 
 @receiver(

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -11,7 +11,7 @@ import logging
 
 from django.db import transaction
 from django.db.models import Q
-from django.db.models.signals import post_save, pre_save
+from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
 
 from gyrinx.content.signals import MISSING, get_new_cost, get_old_cost, get_old_field
@@ -310,10 +310,12 @@ def _affected_list_ids(instance) -> list:
             .distinct()
         )
     elif model_name == "ContentEquipmentUpgrade":
-        # Equipment upgrades on assignments
+        # Equipment upgrades on assignments. SINGLE stacks reprice this rung
+        # and every higher rung (mirror of ContentEquipmentUpgrade.set_dirty).
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
-                upgrades_field=instance, archived=False
+                upgrades_field__in=instance.same_stack_from_position(),
+                archived=False,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
@@ -434,6 +436,29 @@ def _snapshot_list_costs(list_ids) -> dict:
     }
 
 
+def _instance_display_name(instance) -> str:
+    """Human-readable name for a content instance in action descriptions.
+
+    Most models have a name field/method, but some need special handling.
+    """
+    model_name = instance.__class__.__name__
+    if model_name == "ContentFighterEquipmentListItem":
+        return instance.equipment.name
+    elif model_name == "ContentFighterEquipmentListWeaponAccessory":
+        return instance.weapon_accessory.name
+    elif model_name == "ContentFighterEquipmentListUpgrade":
+        return instance.upgrade.name
+    elif model_name == "ContentEquipmentListExpansionItem":
+        return instance.equipment.name
+    elif hasattr(instance, "equipment"):
+        # Generic equipment reference (e.g. ContentWeaponProfile,
+        # ContentEquipmentUpgrade)
+        return instance.equipment.name
+    elif hasattr(instance, "name"):
+        return instance.name() if callable(instance.name) else instance.name
+    return str(instance)
+
+
 def _create_content_cost_change_actions(instance, before_snapshots=None):
     """
     Create CONTENT_COST_CHANGE actions for all lists affected by a content cost change.
@@ -452,103 +477,117 @@ def _create_content_cost_change_actions(instance, before_snapshots=None):
             running can't zero out the delta. When omitted, the live cached values
             are used (correct for synchronous/direct callers).
     """
+    from gyrinx.core.cost.pin_sweep import rewrite_pinned_amounts_for_list
     from gyrinx.core.models.action import ListAction, ListActionType
     from gyrinx.core.models.list import List
 
     # Find affected lists based on the model type
-    model_name = instance.__class__.__name__
     list_ids = _affected_list_ids(instance)
 
     if not list_ids:
         return  # No affected lists
 
-    # Get the instance name for the action description
-    # Most models have a name field/method, but some need special handling
-    if model_name == "ContentFighterEquipmentListItem":
-        # This model has equipment FK
-        instance_name = instance.equipment.name
-    elif model_name == "ContentFighterEquipmentListWeaponAccessory":
-        # This model has weapon_accessory FK
-        instance_name = instance.weapon_accessory.name
-    elif model_name == "ContentFighterEquipmentListUpgrade":
-        # This model has upgrade FK
-        instance_name = instance.upgrade.name
-    elif model_name == "ContentEquipmentListExpansionItem":
-        # This model has equipment FK
-        instance_name = instance.equipment.name
-    elif hasattr(instance, "equipment"):
-        # Generic equipment reference (e.g., ContentWeaponProfile, ContentEquipmentUpgrade)
-        instance_name = instance.equipment.name
-    elif hasattr(instance, "name"):
-        instance_name = instance.name() if callable(instance.name) else instance.name
-    else:
-        instance_name = str(instance)
+    instance_name = _instance_display_name(instance)
 
-    # For each list, recalculate and create action
+    # For each list: rewrite pinned amounts, recalculate, create action.
     # Each list is processed in its own transaction for consistency:
-    # either all changes succeed (facts updated, action created, credits applied)
-    # or none do (transaction rolls back, list stays dirty for later recalculation)
+    # either all changes succeed (amounts rewritten, facts updated, action
+    # created, credits applied) or none do (transaction rolls back, list stays
+    # dirty — and unrewritten — for a later redelivery).
     for list_id in list_ids:
         try:
             with transaction.atomic():
                 lst = List.objects.get(id=list_id)
 
+                # Rewrite pinned amounts FIRST (#1826 §4.7 ordering): any
+                # recompute — the facts_from_db below or a later lazy
+                # view recalc — must sum already-updated amounts. Rewriting
+                # after would snap the caches back to the old amounts or
+                # double-count the correction on the next recompute.
+                sweep = rewrite_pinned_amounts_for_list(instance, lst)
+
                 # Only create actions for lists that have an initial action
                 # Lists without latest_action will have dirty flag set via set_dirty()
-                # and will be recalculated when viewed
+                # and will be recalculated when viewed (against the amounts
+                # rewritten above)
                 if not lst.latest_action:
                     continue
 
-                # Capture before state.
-                #
-                # This task runs asynchronously (after commit), so a user may view
-                # the affected list before it runs. Viewing a dirty list lazily
-                # recalculates and writes the *new* values into rating_current/
-                # stash_current (via get_clean_list_or_404 -> facts_from_db) WITHOUT
-                # recording an action — which would make the live rating_current a
-                # zero-delta baseline here, silently dropping the action (and, in
-                # campaign mode, the credit adjustment). So prefer the pre-change
-                # snapshot captured synchronously at enqueue time; fall back to the
-                # live value only when no snapshot was supplied (e.g. direct calls).
-                snapshot = (
-                    before_snapshots.get(str(list_id)) if before_snapshots else None
-                )
-                if snapshot is not None:
-                    old_rating, old_stash = snapshot
+                if sweep.use_row_deltas:
+                    # Per-row amount deltas: Σ(new − old pinned amount) over
+                    # the rows the sweep rewrote. Unlike the snapshot fallback
+                    # below, this is independent of anything else landing on
+                    # the list between enqueue and this task running — a
+                    # racing user purchase used to be folded into this
+                    # action's delta and double-charged in campaign credits.
+                    # Redelivery is naturally idempotent: the second rewrite
+                    # produces a zero delta and skips out here.
+                    facts = lst.facts_from_db(update=True)
+                    rating_delta = sweep.rating_delta
+                    stash_delta = sweep.stash_delta
+                    total_delta = rating_delta + stash_delta
+                    if total_delta == 0:
+                        continue
+                    # Chain the action off the recomputed head so anything
+                    # that landed in the window keeps its own audit trail.
+                    old_rating = facts.rating - rating_delta
+                    old_stash = facts.stash - stash_delta
                 else:
-                    old_rating = lst.rating_current
-                    old_stash = lst.stash_current
-
-                # Idempotency: if this exact change was already recorded for this
-                # list (same content subject + same pre-change baseline), don't
-                # duplicate it. With a frozen snapshot a redelivery would otherwise
-                # recompute a non-zero delta and double-charge campaign credits.
-                if (
-                    ListAction.objects.filter(
-                        list=lst,
-                        action_type=ListActionType.CONTENT_COST_CHANGE,
-                        subject_id=instance.pk,
-                        rating_before=old_rating,
-                        stash_before=old_stash,
+                    # Snapshot fallback: UNPINNED rows reprice live, so their
+                    # movement only exists as recompute-vs-baseline. This is
+                    # today's machinery, race included; it retires per-list as
+                    # the Phase 8 backfill pins rows.
+                    #
+                    # Capture before state.
+                    #
+                    # This task runs asynchronously (after commit), so a user may view
+                    # the affected list before it runs. Viewing a dirty list lazily
+                    # recalculates and writes the *new* values into rating_current/
+                    # stash_current (via get_clean_list_or_404 -> facts_from_db) WITHOUT
+                    # recording an action — which would make the live rating_current a
+                    # zero-delta baseline here, silently dropping the action (and, in
+                    # campaign mode, the credit adjustment). So prefer the pre-change
+                    # snapshot captured synchronously at enqueue time; fall back to the
+                    # live value only when no snapshot was supplied (e.g. direct calls).
+                    snapshot = (
+                        before_snapshots.get(str(list_id)) if before_snapshots else None
                     )
-                    .exclude(applied=False)
-                    .exists()
-                ):
-                    continue
+                    if snapshot is not None:
+                        old_rating, old_stash = snapshot
+                    else:
+                        old_rating = lst.rating_current
+                        old_stash = lst.stash_current
 
-                # Recalculate with the new content costs (clears dirty flags on list and children)
-                facts = lst.facts_from_db(update=True)
+                    # Idempotency: if this exact change was already recorded for this
+                    # list (same content subject + same pre-change baseline), don't
+                    # duplicate it. With a frozen snapshot a redelivery would otherwise
+                    # recompute a non-zero delta and double-charge campaign credits.
+                    if (
+                        ListAction.objects.filter(
+                            list=lst,
+                            action_type=ListActionType.CONTENT_COST_CHANGE,
+                            subject_id=instance.pk,
+                            rating_before=old_rating,
+                            stash_before=old_stash,
+                        )
+                        .exclude(applied=False)
+                        .exists()
+                    ):
+                        continue
 
-                # Compute deltas
-                rating_delta = facts.rating - old_rating
-                stash_delta = facts.stash - old_stash
-                total_delta = rating_delta + stash_delta
+                    # Recalculate with the new content costs (clears dirty flags on list and children)
+                    facts = lst.facts_from_db(update=True)
 
-                # Skip if no actual cost change (e.g., override in place)
-                # This happens when a base cost changes but a fighter-specific
-                # override (ContentFighterEquipmentListItem, etc.) takes precedence
-                if total_delta == 0:
-                    continue
+                    # Compute deltas
+                    rating_delta = facts.rating - old_rating
+                    stash_delta = facts.stash - old_stash
+                    total_delta = rating_delta + stash_delta
+
+                    # Skip if no actual cost change (e.g., override in place)
+                    # This happens when a base cost changes but a fighter-specific
+                    # override (ContentFighterEquipmentListItem, etc.) takes precedence
+                    if total_delta == 0:
+                        continue
 
                 # In campaign mode, adjust credits (charge more or refund)
                 # Positive delta = cost increased = charge credits (negative)
@@ -828,3 +867,125 @@ def create_expansion_item_cost_action(sender, instance, created, **kwargs):
         return
     _enqueue_content_cost_propagation(instance)
     instance._cost_changed = False
+
+
+# =============================================================================
+# Delete-side handlers: orphan pins when a price source is deleted
+# =============================================================================
+
+
+def _orphan_pinned_rows(instance):
+    """Flip rows pinned to a deleted price source to ORPHANED (#1826 §4.7).
+
+    The amounts stand — nothing changes price, so there is no cache movement
+    and no dirty-marking — but the attribution is gone, and ORPHANED is what
+    keeps every later amount-rewriting sweep's hands off these rows. An audit
+    action records the attribution loss per affected list.
+
+    Runs in pre_delete so the rows are still findable by pin-FK equality (the
+    FKs are SET_NULL); the handler clears the FKs itself, making the delete
+    collector's SET_NULL a no-op for these rows. The pin edges are walked via
+    introspection so a future pin FK is orphaned without new wiring here.
+    """
+    from gyrinx.core.models.action import ListActionType
+    from gyrinx.core.models.list import (
+        List,
+        ListFighterEquipmentAssignment,
+        PinState,
+    )
+
+    orphaned_by_list: dict = {}
+    for rel in type(instance)._meta.related_objects:
+        if not rel.field.name.startswith("pinned_"):
+            continue
+        model = rel.related_model
+        if model._meta.model_name.startswith("historical"):
+            continue
+        is_base = model is ListFighterEquipmentAssignment
+        state_field = "pinned_base_state" if is_base else "pin_state"
+        amount_field = "pinned_base_amount" if is_base else "pinned_amount"
+        list_path = (
+            "list_fighter__list_id"
+            if is_base
+            else "listfighterequipmentassignment__list_fighter__list_id"
+        )
+        rows = model.objects.filter(**{rel.field.name: instance})
+        for lid in rows.values_list(list_path, flat=True):
+            orphaned_by_list[lid] = orphaned_by_list.get(lid, 0) + 1
+        # Rows with an amount keep it and become ORPHANED; a half-written row
+        # without one (which nothing should produce) just loses the FK.
+        rows.filter(**{f"{amount_field}__isnull": False}).update(
+            **{rel.field.name: None, state_field: PinState.ORPHANED}
+        )
+        rows.filter(**{f"{amount_field}__isnull": True}).update(
+            **{rel.field.name: None}
+        )
+
+    if not orphaned_by_list:
+        return
+
+    name = _instance_display_name(instance)
+    for list_id, count in orphaned_by_list.items():
+        try:
+            with transaction.atomic():
+                lst = List.objects.get(id=list_id)
+                if not lst.latest_action:
+                    continue
+                components = "component" if count == 1 else "components"
+                lst.create_action(
+                    action_type=ListActionType.CONTENT_COST_CHANGE,
+                    description=(
+                        f"{name}: price source deleted; {count} pinned "
+                        f"{components} keep their amounts, attribution cleared"
+                    ),
+                    subject_app=instance._meta.app_label,
+                    subject_type=instance._meta.model_name,
+                    subject_id=instance.pk,
+                    rating_delta=0,
+                    stash_delta=0,
+                    credits_delta=0,
+                )
+        except List.DoesNotExist:
+            continue
+        except Exception:
+            logger.exception("Failed to record pin-orphaning for list %s", list_id)
+
+
+@receiver(
+    pre_delete,
+    sender=ContentFighterEquipmentListItem,
+    dispatch_uid="orphan_pins_equipment_list_item_delete",
+)
+@traced("signal_orphan_pins_equipment_list_item_delete")
+def orphan_pins_on_equipment_list_item_delete(sender, instance, **kwargs):
+    _orphan_pinned_rows(instance)
+
+
+@receiver(
+    pre_delete,
+    sender=ContentFighterEquipmentListWeaponAccessory,
+    dispatch_uid="orphan_pins_equipment_list_accessory_delete",
+)
+@traced("signal_orphan_pins_equipment_list_accessory_delete")
+def orphan_pins_on_equipment_list_accessory_delete(sender, instance, **kwargs):
+    _orphan_pinned_rows(instance)
+
+
+@receiver(
+    pre_delete,
+    sender=ContentFighterEquipmentListUpgrade,
+    dispatch_uid="orphan_pins_equipment_list_upgrade_delete",
+)
+@traced("signal_orphan_pins_equipment_list_upgrade_delete")
+def orphan_pins_on_equipment_list_upgrade_delete(sender, instance, **kwargs):
+    _orphan_pinned_rows(instance)
+
+
+@receiver(
+    pre_delete,
+    sender=ContentEquipmentListExpansionItem,
+    dispatch_uid="orphan_pins_expansion_item_delete",
+)
+@traced("signal_orphan_pins_expansion_item_delete")
+def orphan_pins_on_expansion_item_delete(sender, instance, **kwargs):
+    _orphan_pinned_rows(instance)

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -14,7 +14,7 @@ from django.db.models import Q
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
-from gyrinx.content.signals import get_new_cost, get_old_cost
+from gyrinx.content.signals import MISSING, get_new_cost, get_old_cost, get_old_field
 from gyrinx.models import format_cost_display
 from gyrinx.tracing import traced
 
@@ -107,14 +107,25 @@ def handle_profile_cost_change(sender, instance, **kwargs):
 @traced("signal_content_accessory_cost_change")
 def handle_accessory_cost_change(sender, instance, **kwargs):
     """
-    Mark affected assignments dirty when ContentWeaponAccessory.cost changes.
+    Mark affected assignments dirty when ContentWeaponAccessory.cost or
+    cost_expression changes.
     """
     old_cost = get_old_cost(sender, instance, "cost")
     if old_cost is None:
         return  # New instance, no existing assignments
 
     new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
+    changed = old_cost != new_cost
+    if not changed:
+        # A cost_expression edit reprices every assignment carrying this
+        # accessory just as surely as a flat-cost edit, but was previously
+        # unwatched: nothing went dirty and no audit action was recorded.
+        old_expression = get_old_field(sender, instance, "cost_expression")
+        changed = (
+            old_expression is not MISSING and old_expression != instance.cost_expression
+        )
+
+    if changed:
         instance._cost_changed = True  # Flag for post_save to create actions
         instance.set_dirty()
 
@@ -330,52 +341,70 @@ def _affected_list_ids(instance) -> list:
             .distinct()
         )
     elif model_name == "ContentFighterEquipmentListItem":
-        # Equipment list items - cost overrides for equipment on specific fighter types
+        # Equipment list items - cost overrides for equipment on specific
+        # fighter types, plus rows pinned to this item (base or profile),
+        # mirroring ContentFighterEquipmentListItem.set_dirty exactly.
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
-                Q(list_fighter__content_fighter=instance.fighter)
-                | Q(list_fighter__legacy_content_fighter=instance.fighter),
-                content_equipment=instance.equipment,
+                Q(
+                    Q(list_fighter__content_fighter=instance.fighter)
+                    | Q(list_fighter__legacy_content_fighter=instance.fighter),
+                    content_equipment=instance.equipment,
+                )
+                | Q(pinned_equipment_list_item=instance)
+                | Q(profile_rows__pinned_equipment_list_item=instance),
                 archived=False,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
         )
     elif model_name == "ContentFighterEquipmentListWeaponAccessory":
-        # Weapon accessory cost overrides on specific fighter types
+        # Weapon accessory cost overrides on specific fighter types, plus
+        # accessory rows pinned to this override (mirror of its set_dirty).
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
-                Q(list_fighter__content_fighter=instance.fighter)
-                | Q(list_fighter__legacy_content_fighter=instance.fighter),
-                weapon_accessories_field=instance.weapon_accessory,
+                Q(
+                    Q(list_fighter__content_fighter=instance.fighter)
+                    | Q(list_fighter__legacy_content_fighter=instance.fighter),
+                    weapon_accessories_field=instance.weapon_accessory,
+                )
+                | Q(accessory_rows__pinned_equipment_list_accessory=instance),
                 archived=False,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
         )
     elif model_name == "ContentFighterEquipmentListUpgrade":
-        # Equipment upgrade cost overrides on specific fighter types
+        # Equipment upgrade cost overrides on specific fighter types, plus
+        # upgrade rows pinned to this override (mirror of its set_dirty).
         list_ids = (
             ListFighterEquipmentAssignment.objects.filter(
-                Q(list_fighter__content_fighter=instance.fighter)
-                | Q(list_fighter__legacy_content_fighter=instance.fighter),
-                upgrades_field=instance.upgrade,
+                Q(
+                    Q(list_fighter__content_fighter=instance.fighter)
+                    | Q(list_fighter__legacy_content_fighter=instance.fighter),
+                    upgrades_field=instance.upgrade,
+                )
+                | Q(upgrade_rows__pinned_equipment_list_upgrade=instance),
                 archived=False,
             )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
         )
     elif model_name == "ContentEquipmentListExpansionItem":
-        # Expansion items - conservatively mark all assignments with this equipment
-        filter_kwargs = {
-            "content_equipment": instance.equipment,
-            "archived": False,
-        }
+        # Expansion items - conservatively mark all assignments with this
+        # equipment, plus rows pinned to this expansion item (base or
+        # profile), mirroring its set_dirty exactly.
+        expansion_q = Q(content_equipment=instance.equipment)
         if instance.weapon_profile is not None:
-            filter_kwargs["weapon_profiles_field"] = instance.weapon_profile
+            expansion_q &= Q(weapon_profiles_field=instance.weapon_profile)
 
         list_ids = (
-            ListFighterEquipmentAssignment.objects.filter(**filter_kwargs)
+            ListFighterEquipmentAssignment.objects.filter(
+                expansion_q
+                | Q(pinned_expansion_item=instance)
+                | Q(profile_rows__pinned_expansion_item=instance),
+                archived=False,
+            )
             .values_list("list_fighter__list_id", flat=True)
             .distinct()
         )

--- a/gyrinx/content/signals.py
+++ b/gyrinx/content/signals.py
@@ -45,6 +45,33 @@ def get_old_cost(model_class, instance, cost_field="cost"):
         return None
 
 
+#: Sentinel distinguishing "row not found in the DB" from a stored None.
+MISSING = object()
+
+
+def get_old_field(model_class, instance, field):
+    """
+    Get the stored (pre-save) value of an arbitrary field, pack-aware.
+
+    Like get_old_cost but without the integer coercion, for change detection
+    on non-numeric fields such as cost_expression. Returns MISSING when the
+    instance is new or the stored row can't be found, so callers can tell
+    that apart from a genuinely-stored None.
+    """
+    if instance._state.adding or not instance.pk:
+        return MISSING
+
+    manager = model_class._default_manager
+    base_qs = (
+        manager.all_content() if hasattr(manager, "all_content") else manager.all()
+    )
+
+    try:
+        return getattr(base_qs.only(field).get(pk=instance.pk), field)
+    except model_class.DoesNotExist:
+        return MISSING
+
+
 def get_new_cost(instance, cost_field="cost"):
     """
     Get the new cost value for an instance being saved.

--- a/gyrinx/core/cost/pin_sweep.py
+++ b/gyrinx/core/cost/pin_sweep.py
@@ -49,6 +49,10 @@ class PinSweep:
 
     pin_capable: bool = False  # the source model participates in pin sweeps
     has_unpinned: bool = False  # live UNPINNED rows affected → snapshot fallback
+    # A rewritten row sits behind a mask the per-row maths can't price
+    # exactly (a from-default assignment frees SOME components, by
+    # membership) → snapshot fallback, which prices precedence exactly.
+    has_masked: bool = False
     rewrote: int = 0  # rows whose amount was rewritten
     rating_delta: int = 0
     stash_delta: int = 0
@@ -58,7 +62,7 @@ class PinSweep:
     @property
     def use_row_deltas(self) -> bool:
         """Whether the audit delta can be the exact per-row amount sum."""
-        return self.pin_capable and not self.has_unpinned
+        return self.pin_capable and not self.has_unpinned and not self.has_masked
 
     @property
     def total_delta(self) -> int:
@@ -135,9 +139,17 @@ def _holder_context_q(fighter, prefix=""):
 
 
 def _bucket(sweep, assignment, delta):
-    """Accumulate a row delta into rating or stash; archived rows move nothing."""
+    """Accumulate a row delta into rating or stash; archived rows move nothing.
+
+    A fixed assignment total masks every component: the resolved value cannot
+    move, so a rewritten amount is provenance, not book movement — booking it
+    would charge campaign credits for a price that never changed and fabricate
+    an unchained baseline.
+    """
     fighter = assignment.list_fighter
     if assignment.archived or fighter.archived:
+        return
+    if assignment.total_cost_override is not None:
         return
     if fighter.content_fighter.is_stash:
         sweep.stash_delta += delta
@@ -161,7 +173,15 @@ def _rewrite_base_rows(qs, new_amount_for, sweep):
         new = new_amount_for(assignment)
         if new is None or new == assignment.pinned_base_amount:
             continue
-        _bucket(sweep, assignment, new - assignment.pinned_base_amount)
+        # cost_override and linked-child-zero outrank the base pin in
+        # resolution: the base contribution is exactly unchanged, so the
+        # amount is rewritten but no movement is booked.
+        base_masked = (
+            assignment.cost_override is not None
+            or assignment.linked_equipment_parent_id is not None
+        )
+        if not base_masked:
+            _bucket(sweep, assignment, new - assignment.pinned_base_amount)
         updates.append((assignment.pk, new))
         changed.append(assignment.pk)
         sweep.touched_assignments.add(assignment.pk)
@@ -170,7 +190,7 @@ def _rewrite_base_rows(qs, new_amount_for, sweep):
     return changed
 
 
-def _rewrite_through_rows(model, qs, new_amount_for, sweep):
+def _rewrite_through_rows(model, qs, new_amount_for, sweep, defaults_can_mask=False):
     updates = []
     for row in qs.select_related(
         "listfighterequipmentassignment__list_fighter__content_fighter"
@@ -178,7 +198,14 @@ def _rewrite_through_rows(model, qs, new_amount_for, sweep):
         new = new_amount_for(row)
         if new is None or new == row.pinned_amount:
             continue
-        _bucket(sweep, row.listfighterequipmentassignment, new - row.pinned_amount)
+        assignment = row.listfighterequipmentassignment
+        if defaults_can_mask and assignment.from_default_assignment_id is not None:
+            # A from-default assignment frees SOME profiles/accessories (by
+            # membership in the default's component sets) — resolution-exact
+            # pricing needs the recompute, so flag for the snapshot fallback.
+            sweep.has_masked = True
+        else:
+            _bucket(sweep, assignment, new - row.pinned_amount)
         updates.append((row.pk, new))
         sweep.touched_assignments.add(row.listfighterequipmentassignment_id)
     _flush(model, updates, "pinned_amount")
@@ -195,9 +222,7 @@ def _rederive_accessory_rows(qs, sweep, require_expression):
     """
     qs = qs.filter(pin_state=PinState.DERIVED)
     if require_expression:
-        qs = qs.exclude(contentweaponaccessory__cost_expression="").exclude(
-            contentweaponaccessory__cost_expression__isnull=True
-        )
+        qs = _expression_rows(qs)
     base_cache = {}
     updates = []
     for row in qs.select_related(
@@ -216,11 +241,20 @@ def _rederive_accessory_rows(qs, sweep, require_expression):
         new = row.contentweaponaccessory.calculate_cost_for_weapon(base)
         if new == row.pinned_amount:
             continue
-        _bucket(sweep, assignment, new - row.pinned_amount)
+        if assignment.from_default_assignment_id is not None:
+            sweep.has_masked = True  # membership-dependent free accessories
+        else:
+            _bucket(sweep, assignment, new - row.pinned_amount)
         updates.append((row.pk, new))
         sweep.touched_assignments.add(assignment.pk)
     _flush(ListFighterEquipmentAssignmentAccessory, updates, "pinned_amount")
     sweep.rewrote += len(updates)
+
+
+def _expression_rows(qs):
+    return qs.exclude(contentweaponaccessory__cost_expression="").exclude(
+        contentweaponaccessory__cost_expression__isnull=True
+    )
 
 
 def _cascade_expression_accessories(lst, changed_assignment_ids, sweep):
@@ -234,6 +268,19 @@ def _cascade_expression_accessories(lst, changed_assignment_ids, sweep):
         sweep,
         require_expression=True,
     )
+    # An UNPINNED expression accessory on a rewritten base reprices live off
+    # the new base amount: its movement is in the recompute but not in the
+    # per-row deltas, so it forces the snapshot fallback like any other
+    # live-repricing UNPINNED row.
+    if _expression_rows(
+        _live_through(
+            _accessory_rows(lst).filter(
+                listfighterequipmentassignment_id__in=changed_assignment_ids,
+                pin_state=PinState.UNPINNED,
+            )
+        )
+    ).exists():
+        sweep.has_unpinned = True
 
 
 # --- Per-source sweeps: catalog models ---------------------------------------
@@ -250,7 +297,7 @@ def _sweep_equipment(instance, lst):
         sweep,
     )
     _cascade_expression_accessories(lst, changed, sweep)
-    sweep.has_unpinned = (
+    sweep.has_unpinned = sweep.has_unpinned or (
         _base_rows(lst)
         .filter(
             content_equipment=instance,
@@ -273,12 +320,16 @@ def _sweep_weapon_profile(instance, lst):
         ),
         lambda r: new,
         sweep,
+        defaults_can_mask=True,
     )
-    sweep.has_unpinned = _live_through(
-        _profile_rows(lst).filter(
-            contentweaponprofile=instance, pin_state=PinState.UNPINNED
-        )
-    ).exists()
+    sweep.has_unpinned = (
+        sweep.has_unpinned
+        or _live_through(
+            _profile_rows(lst).filter(
+                contentweaponprofile=instance, pin_state=PinState.UNPINNED
+            )
+        ).exists()
+    )
     return sweep
 
 
@@ -292,6 +343,7 @@ def _sweep_weapon_accessory(instance, lst):
         ),
         lambda r: new,
         sweep,
+        defaults_can_mask=True,
     )
     # Expression (or flat) re-derivation for DERIVED rows of this accessory —
     # covers both a cost edit and a cost_expression edit.
@@ -300,11 +352,14 @@ def _sweep_weapon_accessory(instance, lst):
         sweep,
         require_expression=False,
     )
-    sweep.has_unpinned = _live_through(
-        _accessory_rows(lst).filter(
-            contentweaponaccessory=instance, pin_state=PinState.UNPINNED
-        )
-    ).exists()
+    sweep.has_unpinned = (
+        sweep.has_unpinned
+        or _live_through(
+            _accessory_rows(lst).filter(
+                contentweaponaccessory=instance, pin_state=PinState.UNPINNED
+            )
+        ).exists()
+    )
     return sweep
 
 
@@ -327,8 +382,15 @@ def _sweep_upgrade(instance, lst):
         # SINGLE stacks price cumulatively: correcting one rung reprices
         # every row holding that rung or a higher one. Those rows are
         # DERIVED (their amount is a sum, not a copy) and re-derive via
-        # cost_int(), which reads the committed new rung cost.
-        cumulative = {u.pk: u.cost_int() for u in instance.same_stack_from_position()}
+        # cost_int(), which reads the committed new rung cost. The map is
+        # list-independent, so memoize it on the instance — the task calls
+        # this once per affected list.
+        cumulative = getattr(instance, "_pin_sweep_cumulative", None)
+        if cumulative is None:
+            cumulative = {
+                u.pk: u.cost_int() for u in instance.same_stack_from_position()
+            }
+            instance._pin_sweep_cumulative = cumulative
         _rewrite_through_rows(
             ListFighterEquipmentAssignmentUpgrade,
             _upgrade_rows(lst).filter(
@@ -339,12 +401,15 @@ def _sweep_upgrade(instance, lst):
             sweep,
         )
         affected_upgrade_ids = list(cumulative)
-    sweep.has_unpinned = _live_through(
-        _upgrade_rows(lst).filter(
-            contentequipmentupgrade__in=affected_upgrade_ids,
-            pin_state=PinState.UNPINNED,
-        )
-    ).exists()
+    sweep.has_unpinned = (
+        sweep.has_unpinned
+        or _live_through(
+            _upgrade_rows(lst).filter(
+                contentequipmentupgrade__in=affected_upgrade_ids,
+                pin_state=PinState.UNPINNED,
+            )
+        ).exists()
+    )
     return sweep
 
 
@@ -368,6 +433,7 @@ def _sweep_equipment_list_item(instance, lst):
         ),
         lambda r: new,
         sweep,
+        defaults_can_mask=True,
     )
     _cascade_expression_accessories(lst, changed, sweep)
 
@@ -380,7 +446,7 @@ def _sweep_equipment_list_item(instance, lst):
         list_fighter__archived=False,
     )
     if instance.weapon_profile_id:
-        sweep.has_unpinned = (
+        sweep.has_unpinned = sweep.has_unpinned or (
             _profile_rows(lst)
             .filter(
                 listfighterequipmentassignment__in=context,
@@ -390,9 +456,10 @@ def _sweep_equipment_list_item(instance, lst):
             .exists()
         )
     else:
-        sweep.has_unpinned = context.filter(
-            pinned_base_state=PinState.UNPINNED
-        ).exists()
+        sweep.has_unpinned = (
+            sweep.has_unpinned
+            or context.filter(pinned_base_state=PinState.UNPINNED).exists()
+        )
     return sweep
 
 
@@ -406,18 +473,22 @@ def _sweep_equipment_list_accessory(instance, lst):
         ),
         lambda r: new,
         sweep,
+        defaults_can_mask=True,
     )
     sweep.has_unpinned = (
-        _live_through(
-            _accessory_rows(lst).filter(
-                _holder_context_q(
-                    instance.fighter, prefix="listfighterequipmentassignment__"
-                ),
-                contentweaponaccessory=instance.weapon_accessory,
-                pin_state=PinState.UNPINNED,
+        sweep.has_unpinned
+        or (
+            _live_through(
+                _accessory_rows(lst).filter(
+                    _holder_context_q(
+                        instance.fighter, prefix="listfighterequipmentassignment__"
+                    ),
+                    contentweaponaccessory=instance.weapon_accessory,
+                    pin_state=PinState.UNPINNED,
+                )
             )
-        )
-    ).exists()
+        ).exists()
+    )
     return sweep
 
 
@@ -436,16 +507,19 @@ def _sweep_equipment_list_upgrade(instance, lst):
         sweep,
     )
     sweep.has_unpinned = (
-        _live_through(
-            _upgrade_rows(lst).filter(
-                _holder_context_q(
-                    instance.fighter, prefix="listfighterequipmentassignment__"
-                ),
-                contentequipmentupgrade=instance.upgrade,
-                pin_state=PinState.UNPINNED,
+        sweep.has_unpinned
+        or (
+            _live_through(
+                _upgrade_rows(lst).filter(
+                    _holder_context_q(
+                        instance.fighter, prefix="listfighterequipmentassignment__"
+                    ),
+                    contentequipmentupgrade=instance.upgrade,
+                    pin_state=PinState.UNPINNED,
+                )
             )
-        )
-    ).exists()
+        ).exists()
+    )
     return sweep
 
 
@@ -476,6 +550,7 @@ def _sweep_expansion_item(instance, lst):
         ),
         lambda r: profile_new,
         sweep,
+        defaults_can_mask=True,
     )
     _cascade_expression_accessories(lst, changed, sweep)
 
@@ -485,7 +560,7 @@ def _sweep_expansion_item(instance, lst):
         list_fighter__archived=False,
     )
     if instance.weapon_profile_id:
-        sweep.has_unpinned = (
+        sweep.has_unpinned = sweep.has_unpinned or (
             _profile_rows(lst)
             .filter(
                 listfighterequipmentassignment__in=context,
@@ -495,9 +570,10 @@ def _sweep_expansion_item(instance, lst):
             .exists()
         )
     else:
-        sweep.has_unpinned = context.filter(
-            pinned_base_state=PinState.UNPINNED
-        ).exists()
+        sweep.has_unpinned = (
+            sweep.has_unpinned
+            or context.filter(pinned_base_state=PinState.UNPINNED).exists()
+        )
     return sweep
 
 

--- a/gyrinx/core/cost/pin_sweep.py
+++ b/gyrinx/core/cost/pin_sweep.py
@@ -1,0 +1,513 @@
+"""Amount-rewriting sweeps for pinned component rows (#1826 Phase 6, §4.7).
+
+When a price-bearing content source changes, rows pinned to it must have
+their cached amounts rewritten to the corrected price — this is how a
+content correction propagates to pinned gear (prices stay at acquisition
+value EXCEPT when the acquisition-time source itself is corrected). The
+caller (`_create_content_cost_change_actions`) runs the rewrite BEFORE any
+recompute or dirty processing, so `facts_from_db` sums already-updated
+amounts; rewriting after would either snap the caches back or double-count.
+
+The sweep domains are partitioned by pin_state (§4.1):
+
+- SOURCE rows are found by pin-FK equality — holder-independent, so gear
+  that has moved away from the context that priced it is still reached.
+- CATALOG rows are found by the component's own content FK (those lookups
+  were holder-independent already).
+- DERIVED rows are re-derived, never amount-copied: expression accessories
+  re-evaluate against the assignment's (possibly just-rewritten) base cost;
+  SINGLE-stack upgrade rows re-sum their cumulative rungs.
+- ORPHANED rows are excluded from every rewrite — frozen by definition.
+- UNPINNED rows have no amount to rewrite; their presence on a list flips
+  that list's audit delta back to the snapshot fallback (`has_unpinned`),
+  because their live repricing can't be expressed as per-row amount deltas.
+
+Deltas are per-row: Σ(new − old amount), split rating/stash by the holding
+fighter. Archived rows are rewritten too — a later unarchive must not
+resurrect a stale amount — but contribute no delta, matching cache
+semantics (facts exclude archived rows).
+"""
+
+from dataclasses import dataclass, field
+
+from django.db.models import Q
+
+from gyrinx.content.signals import get_new_cost
+from gyrinx.core.models.list import (
+    ListFighterEquipmentAssignment,
+    ListFighterEquipmentAssignmentAccessory,
+    ListFighterEquipmentAssignmentProfile,
+    ListFighterEquipmentAssignmentUpgrade,
+    PinState,
+    bulk_mark_assignments_dirty,
+)
+
+
+@dataclass
+class PinSweep:
+    """Outcome of an amount-rewriting sweep for one (source, list) pair."""
+
+    pin_capable: bool = False  # the source model participates in pin sweeps
+    has_unpinned: bool = False  # live UNPINNED rows affected → snapshot fallback
+    rewrote: int = 0  # rows whose amount was rewritten
+    rating_delta: int = 0
+    stash_delta: int = 0
+    # Assignments whose amounts changed, for the post-rewrite dirty-marking.
+    touched_assignments: set = field(default_factory=set)
+
+    @property
+    def use_row_deltas(self) -> bool:
+        """Whether the audit delta can be the exact per-row amount sum."""
+        return self.pin_capable and not self.has_unpinned
+
+    @property
+    def total_delta(self) -> int:
+        return self.rating_delta + self.stash_delta
+
+
+def rewrite_pinned_amounts_for_list(instance, lst) -> PinSweep:
+    """Rewrite pinned amounts on ``lst`` affected by a change to ``instance``.
+
+    Returns a PinSweep carrying the per-row deltas and whether the caller
+    can use them as the audit delta (`use_row_deltas`) or must fall back to
+    the snapshot-vs-recompute computation (UNPINNED rows present, or a
+    source model pins don't apply to).
+    """
+    handler = _SWEEP_HANDLERS.get(type(instance).__name__)
+    if handler is None:
+        return PinSweep()
+    sweep = handler(instance, lst)
+    if sweep.touched_assignments:
+        # Sweeps do two jobs: rewrite amounts, THEN mark dirty (§4.7). The
+        # enqueue-time set_dirty is not enough — an action landing in the
+        # enqueue-to-task window (a purchase, say) refreshes the fighter's
+        # caches from the OLD amounts and clears the dirty flags, so the
+        # recompute that follows this rewrite would lazily skip the fighter
+        # and leave its cache stale against the rewritten amounts.
+        bulk_mark_assignments_dirty(
+            ListFighterEquipmentAssignment.objects.filter(
+                pk__in=sweep.touched_assignments,
+                archived=False,
+                list_fighter__archived=False,
+            )
+        )
+    return sweep
+
+
+# --- Row-set helpers ---------------------------------------------------------
+
+
+def _base_rows(lst):
+    return ListFighterEquipmentAssignment.objects.filter(list_fighter__list=lst)
+
+
+def _profile_rows(lst):
+    return ListFighterEquipmentAssignmentProfile.objects.filter(
+        listfighterequipmentassignment__list_fighter__list=lst
+    )
+
+
+def _accessory_rows(lst):
+    return ListFighterEquipmentAssignmentAccessory.objects.filter(
+        listfighterequipmentassignment__list_fighter__list=lst
+    )
+
+
+def _upgrade_rows(lst):
+    return ListFighterEquipmentAssignmentUpgrade.objects.filter(
+        listfighterequipmentassignment__list_fighter__list=lst
+    )
+
+
+def _live_through(qs):
+    """Through rows whose assignment and fighter are unarchived (cache-visible)."""
+    return qs.filter(
+        listfighterequipmentassignment__archived=False,
+        listfighterequipmentassignment__list_fighter__archived=False,
+    )
+
+
+def _holder_context_q(fighter, prefix=""):
+    """The legacy holder-keyed sweep condition, for the unpinned checks."""
+    return Q(**{f"{prefix}list_fighter__content_fighter": fighter}) | Q(
+        **{f"{prefix}list_fighter__legacy_content_fighter": fighter}
+    )
+
+
+def _bucket(sweep, assignment, delta):
+    """Accumulate a row delta into rating or stash; archived rows move nothing."""
+    fighter = assignment.list_fighter
+    if assignment.archived or fighter.archived:
+        return
+    if fighter.content_fighter.is_stash:
+        sweep.stash_delta += delta
+    else:
+        sweep.rating_delta += delta
+
+
+def _flush(model, updates, field):
+    by_value = {}
+    for pk, new in updates:
+        by_value.setdefault(new, []).append(pk)
+    for value, pks in by_value.items():
+        model.objects.filter(pk__in=pks).update(**{field: value})
+
+
+def _rewrite_base_rows(qs, new_amount_for, sweep):
+    """Rewrite pinned_base_amount; returns ids of assignments that changed."""
+    changed = []
+    updates = []
+    for assignment in qs.select_related("list_fighter__content_fighter"):
+        new = new_amount_for(assignment)
+        if new is None or new == assignment.pinned_base_amount:
+            continue
+        _bucket(sweep, assignment, new - assignment.pinned_base_amount)
+        updates.append((assignment.pk, new))
+        changed.append(assignment.pk)
+        sweep.touched_assignments.add(assignment.pk)
+    _flush(ListFighterEquipmentAssignment, updates, "pinned_base_amount")
+    sweep.rewrote += len(updates)
+    return changed
+
+
+def _rewrite_through_rows(model, qs, new_amount_for, sweep):
+    updates = []
+    for row in qs.select_related(
+        "listfighterequipmentassignment__list_fighter__content_fighter"
+    ):
+        new = new_amount_for(row)
+        if new is None or new == row.pinned_amount:
+            continue
+        _bucket(sweep, row.listfighterequipmentassignment, new - row.pinned_amount)
+        updates.append((row.pk, new))
+        sweep.touched_assignments.add(row.listfighterequipmentassignment_id)
+    _flush(model, updates, "pinned_amount")
+    sweep.rewrote += len(updates)
+
+
+def _rederive_accessory_rows(qs, sweep, require_expression):
+    """Re-derive DERIVED accessory amounts against their assignment's base.
+
+    ``require_expression`` distinguishes the base-rewrite cascade (only
+    expression accessories depend on the base) from a direct accessory
+    change (every DERIVED row for it re-derives — the evaluator falls back
+    to the flat cost when there is no expression).
+    """
+    qs = qs.filter(pin_state=PinState.DERIVED)
+    if require_expression:
+        qs = qs.exclude(contentweaponaccessory__cost_expression="").exclude(
+            contentweaponaccessory__cost_expression__isnull=True
+        )
+    base_cache = {}
+    updates = []
+    for row in qs.select_related(
+        "contentweaponaccessory",
+        "listfighterequipmentassignment__list_fighter__content_fighter",
+    ):
+        assignment = row.listfighterequipmentassignment
+        base = base_cache.get(assignment.pk)
+        if base is None:
+            # Fresh fetch: the base amount may have been rewritten earlier in
+            # this same sweep, and base_cost_int() caches aggressively.
+            base = ListFighterEquipmentAssignment.objects.get(
+                pk=assignment.pk
+            ).base_cost_int()
+            base_cache[assignment.pk] = base
+        new = row.contentweaponaccessory.calculate_cost_for_weapon(base)
+        if new == row.pinned_amount:
+            continue
+        _bucket(sweep, assignment, new - row.pinned_amount)
+        updates.append((row.pk, new))
+        sweep.touched_assignments.add(assignment.pk)
+    _flush(ListFighterEquipmentAssignmentAccessory, updates, "pinned_amount")
+    sweep.rewrote += len(updates)
+
+
+def _cascade_expression_accessories(lst, changed_assignment_ids, sweep):
+    """Base corrections cascade to same-assignment expression accessories."""
+    if not changed_assignment_ids:
+        return
+    _rederive_accessory_rows(
+        _accessory_rows(lst).filter(
+            listfighterequipmentassignment_id__in=changed_assignment_ids
+        ),
+        sweep,
+        require_expression=True,
+    )
+
+
+# --- Per-source sweeps: catalog models ---------------------------------------
+
+
+def _sweep_equipment(instance, lst):
+    sweep = PinSweep(pin_capable=True)
+    new = get_new_cost(instance, "cost")
+    changed = _rewrite_base_rows(
+        _base_rows(lst).filter(
+            content_equipment=instance, pinned_base_state=PinState.CATALOG
+        ),
+        lambda a: new,
+        sweep,
+    )
+    _cascade_expression_accessories(lst, changed, sweep)
+    sweep.has_unpinned = (
+        _base_rows(lst)
+        .filter(
+            content_equipment=instance,
+            pinned_base_state=PinState.UNPINNED,
+            archived=False,
+            list_fighter__archived=False,
+        )
+        .exists()
+    )
+    return sweep
+
+
+def _sweep_weapon_profile(instance, lst):
+    sweep = PinSweep(pin_capable=True)
+    new = get_new_cost(instance, "cost")
+    _rewrite_through_rows(
+        ListFighterEquipmentAssignmentProfile,
+        _profile_rows(lst).filter(
+            contentweaponprofile=instance, pin_state=PinState.CATALOG
+        ),
+        lambda r: new,
+        sweep,
+    )
+    sweep.has_unpinned = _live_through(
+        _profile_rows(lst).filter(
+            contentweaponprofile=instance, pin_state=PinState.UNPINNED
+        )
+    ).exists()
+    return sweep
+
+
+def _sweep_weapon_accessory(instance, lst):
+    sweep = PinSweep(pin_capable=True)
+    new = get_new_cost(instance, "cost")
+    _rewrite_through_rows(
+        ListFighterEquipmentAssignmentAccessory,
+        _accessory_rows(lst).filter(
+            contentweaponaccessory=instance, pin_state=PinState.CATALOG
+        ),
+        lambda r: new,
+        sweep,
+    )
+    # Expression (or flat) re-derivation for DERIVED rows of this accessory —
+    # covers both a cost edit and a cost_expression edit.
+    _rederive_accessory_rows(
+        _accessory_rows(lst).filter(contentweaponaccessory=instance),
+        sweep,
+        require_expression=False,
+    )
+    sweep.has_unpinned = _live_through(
+        _accessory_rows(lst).filter(
+            contentweaponaccessory=instance, pin_state=PinState.UNPINNED
+        )
+    ).exists()
+    return sweep
+
+
+def _sweep_upgrade(instance, lst):
+    from gyrinx.content.models import ContentEquipment
+
+    sweep = PinSweep(pin_capable=True)
+    if instance.equipment.upgrade_mode == ContentEquipment.UpgradeMode.MULTI:
+        new = get_new_cost(instance, "cost")
+        _rewrite_through_rows(
+            ListFighterEquipmentAssignmentUpgrade,
+            _upgrade_rows(lst).filter(
+                contentequipmentupgrade=instance, pin_state=PinState.CATALOG
+            ),
+            lambda r: new,
+            sweep,
+        )
+        affected_upgrade_ids = [instance.pk]
+    else:
+        # SINGLE stacks price cumulatively: correcting one rung reprices
+        # every row holding that rung or a higher one. Those rows are
+        # DERIVED (their amount is a sum, not a copy) and re-derive via
+        # cost_int(), which reads the committed new rung cost.
+        cumulative = {u.pk: u.cost_int() for u in instance.same_stack_from_position()}
+        _rewrite_through_rows(
+            ListFighterEquipmentAssignmentUpgrade,
+            _upgrade_rows(lst).filter(
+                contentequipmentupgrade__in=list(cumulative),
+                pin_state=PinState.DERIVED,
+            ),
+            lambda r: cumulative[r.contentequipmentupgrade_id],
+            sweep,
+        )
+        affected_upgrade_ids = list(cumulative)
+    sweep.has_unpinned = _live_through(
+        _upgrade_rows(lst).filter(
+            contentequipmentupgrade__in=affected_upgrade_ids,
+            pin_state=PinState.UNPINNED,
+        )
+    ).exists()
+    return sweep
+
+
+# --- Per-source sweeps: override sources (pin-FK equality) --------------------
+
+
+def _sweep_equipment_list_item(instance, lst):
+    sweep = PinSweep(pin_capable=True)
+    new = instance.cost
+    changed = _rewrite_base_rows(
+        _base_rows(lst).filter(
+            pinned_equipment_list_item=instance, pinned_base_state=PinState.SOURCE
+        ),
+        lambda a: new,
+        sweep,
+    )
+    _rewrite_through_rows(
+        ListFighterEquipmentAssignmentProfile,
+        _profile_rows(lst).filter(
+            pinned_equipment_list_item=instance, pin_state=PinState.SOURCE
+        ),
+        lambda r: new,
+        sweep,
+    )
+    _cascade_expression_accessories(lst, changed, sweep)
+
+    # Live-repricing UNPINNED rows: current-context assignments this row
+    # still prices, split by whether it prices the base or a profile.
+    context = _base_rows(lst).filter(
+        _holder_context_q(instance.fighter),
+        content_equipment=instance.equipment,
+        archived=False,
+        list_fighter__archived=False,
+    )
+    if instance.weapon_profile_id:
+        sweep.has_unpinned = (
+            _profile_rows(lst)
+            .filter(
+                listfighterequipmentassignment__in=context,
+                contentweaponprofile=instance.weapon_profile,
+                pin_state=PinState.UNPINNED,
+            )
+            .exists()
+        )
+    else:
+        sweep.has_unpinned = context.filter(
+            pinned_base_state=PinState.UNPINNED
+        ).exists()
+    return sweep
+
+
+def _sweep_equipment_list_accessory(instance, lst):
+    sweep = PinSweep(pin_capable=True)
+    new = instance.cost
+    _rewrite_through_rows(
+        ListFighterEquipmentAssignmentAccessory,
+        _accessory_rows(lst).filter(
+            pinned_equipment_list_accessory=instance, pin_state=PinState.SOURCE
+        ),
+        lambda r: new,
+        sweep,
+    )
+    sweep.has_unpinned = (
+        _live_through(
+            _accessory_rows(lst).filter(
+                _holder_context_q(
+                    instance.fighter, prefix="listfighterequipmentassignment__"
+                ),
+                contentweaponaccessory=instance.weapon_accessory,
+                pin_state=PinState.UNPINNED,
+            )
+        )
+    ).exists()
+    return sweep
+
+
+def _sweep_equipment_list_upgrade(instance, lst):
+    sweep = PinSweep(pin_capable=True)
+    # Provisional flat semantics: what Phase 7 pins for a SINGLE-stack rung
+    # priced through this override defines the cumulative story; until a
+    # producer writes such pins, SOURCE rows copy the override cost.
+    new = instance.cost
+    _rewrite_through_rows(
+        ListFighterEquipmentAssignmentUpgrade,
+        _upgrade_rows(lst).filter(
+            pinned_equipment_list_upgrade=instance, pin_state=PinState.SOURCE
+        ),
+        lambda r: new,
+        sweep,
+    )
+    sweep.has_unpinned = (
+        _live_through(
+            _upgrade_rows(lst).filter(
+                _holder_context_q(
+                    instance.fighter, prefix="listfighterequipmentassignment__"
+                ),
+                contentequipmentupgrade=instance.upgrade,
+                pin_state=PinState.UNPINNED,
+            )
+        )
+    ).exists()
+    return sweep
+
+
+def _sweep_expansion_item(instance, lst):
+    sweep = PinSweep(pin_capable=True)
+    # Expansion semantics: a null cost means "use the base cost" — of the
+    # equipment for base pins, of the profile for profile pins.
+    if instance.cost is not None:
+        base_new = profile_new = instance.cost
+    else:
+        base_new = get_new_cost(instance.equipment, "cost")
+        profile_new = (
+            get_new_cost(instance.weapon_profile, "cost")
+            if instance.weapon_profile_id
+            else base_new
+        )
+    changed = _rewrite_base_rows(
+        _base_rows(lst).filter(
+            pinned_expansion_item=instance, pinned_base_state=PinState.SOURCE
+        ),
+        lambda a: base_new,
+        sweep,
+    )
+    _rewrite_through_rows(
+        ListFighterEquipmentAssignmentProfile,
+        _profile_rows(lst).filter(
+            pinned_expansion_item=instance, pin_state=PinState.SOURCE
+        ),
+        lambda r: profile_new,
+        sweep,
+    )
+    _cascade_expression_accessories(lst, changed, sweep)
+
+    context = _base_rows(lst).filter(
+        content_equipment=instance.equipment,
+        archived=False,
+        list_fighter__archived=False,
+    )
+    if instance.weapon_profile_id:
+        sweep.has_unpinned = (
+            _profile_rows(lst)
+            .filter(
+                listfighterequipmentassignment__in=context,
+                contentweaponprofile=instance.weapon_profile,
+                pin_state=PinState.UNPINNED,
+            )
+            .exists()
+        )
+    else:
+        sweep.has_unpinned = context.filter(
+            pinned_base_state=PinState.UNPINNED
+        ).exists()
+    return sweep
+
+
+_SWEEP_HANDLERS = {
+    "ContentEquipment": _sweep_equipment,
+    "ContentWeaponProfile": _sweep_weapon_profile,
+    "ContentWeaponAccessory": _sweep_weapon_accessory,
+    "ContentEquipmentUpgrade": _sweep_upgrade,
+    "ContentFighterEquipmentListItem": _sweep_equipment_list_item,
+    "ContentFighterEquipmentListWeaponAccessory": _sweep_equipment_list_accessory,
+    "ContentFighterEquipmentListUpgrade": _sweep_equipment_list_upgrade,
+    "ContentEquipmentListExpansionItem": _sweep_expansion_item,
+}

--- a/gyrinx/core/cost/pin_sweep.py
+++ b/gyrinx/core/cost/pin_sweep.py
@@ -199,7 +199,12 @@ def _rewrite_through_rows(model, qs, new_amount_for, sweep, defaults_can_mask=Fa
         if new is None or new == row.pinned_amount:
             continue
         assignment = row.listfighterequipmentassignment
-        if defaults_can_mask and assignment.from_default_assignment_id is not None:
+        if assignment.archived or assignment.list_fighter.archived:
+            # Rewrite only: archived rows move no caches and must not mask —
+            # a sticky has_masked from an archived row would force the whole
+            # list back onto the racy snapshot fallback for nothing.
+            pass
+        elif defaults_can_mask and assignment.from_default_assignment_id is not None:
             # A from-default assignment frees SOME profiles/accessories (by
             # membership in the default's component sets) — resolution-exact
             # pricing needs the recompute, so flag for the snapshot fallback.
@@ -241,7 +246,9 @@ def _rederive_accessory_rows(qs, sweep, require_expression):
         new = row.contentweaponaccessory.calculate_cost_for_weapon(base)
         if new == row.pinned_amount:
             continue
-        if assignment.from_default_assignment_id is not None:
+        if assignment.archived or assignment.list_fighter.archived:
+            pass  # rewrite only: no delta, no mask (see _rewrite_through_rows)
+        elif assignment.from_default_assignment_id is not None:
             sweep.has_masked = True  # membership-dependent free accessories
         else:
             _bucket(sweep, assignment, new - row.pinned_amount)
@@ -296,7 +303,16 @@ def _sweep_equipment(instance, lst):
         lambda a: new,
         sweep,
     )
-    _cascade_expression_accessories(lst, changed, sweep)
+    # DERIVED expression rows re-derive whenever their base input changed —
+    # whether the base was a rewritten pin or an UNPINNED base repricing
+    # live off this source. Re-derivation reads the row's true
+    # base_cost_int(), so a base that didn't actually move is a no-op.
+    live_bases = _base_rows(lst).filter(
+        content_equipment=instance, pinned_base_state=PinState.UNPINNED
+    )
+    _cascade_expression_accessories(
+        lst, changed + list(live_bases.values_list("pk", flat=True)), sweep
+    )
     sweep.has_unpinned = sweep.has_unpinned or (
         _base_rows(lst)
         .filter(
@@ -385,6 +401,14 @@ def _sweep_upgrade(instance, lst):
         # cost_int(), which reads the committed new rung cost. The map is
         # list-independent, so memoize it on the instance — the task calls
         # this once per affected list.
+        #
+        # KNOWN IMPRECISION (Phase 7 decides): cost_int() is the raw catalog
+        # sum, but live resolution applies per-rung CFELU overrides inside
+        # the cumulative walk. A rung correction on an override-discounted
+        # stack re-derives to the catalog total, not the override-inclusive
+        # one. What a MOVED cumulative row should re-derive to is a producer
+        # -semantics question — settle it when Phase 7 defines what SINGLE
+        # +override acquisitions pin.
         cumulative = getattr(instance, "_pin_sweep_cumulative", None)
         if cumulative is None:
             cumulative = {
@@ -435,16 +459,25 @@ def _sweep_equipment_list_item(instance, lst):
         sweep,
         defaults_can_mask=True,
     )
-    _cascade_expression_accessories(lst, changed, sweep)
-
     # Live-repricing UNPINNED rows: current-context assignments this row
     # still prices, split by whether it prices the base or a profile.
-    context = _base_rows(lst).filter(
+    context_all = _base_rows(lst).filter(
         _holder_context_q(instance.fighter),
         content_equipment=instance.equipment,
-        archived=False,
-        list_fighter__archived=False,
     )
+    cascade_ids = list(changed)
+    if not instance.weapon_profile_id:
+        # A base-pricing row also moves the live base of UNPINNED
+        # context-matched assignments — their DERIVED expression
+        # accessories must re-derive too (see _sweep_equipment).
+        cascade_ids += list(
+            context_all.filter(pinned_base_state=PinState.UNPINNED).values_list(
+                "pk", flat=True
+            )
+        )
+    _cascade_expression_accessories(lst, cascade_ids, sweep)
+
+    context = context_all.filter(archived=False, list_fighter__archived=False)
     if instance.weapon_profile_id:
         sweep.has_unpinned = sweep.has_unpinned or (
             _profile_rows(lst)
@@ -514,7 +547,9 @@ def _sweep_equipment_list_upgrade(instance, lst):
                     _holder_context_q(
                         instance.fighter, prefix="listfighterequipmentassignment__"
                     ),
-                    contentequipmentupgrade=instance.upgrade,
+                    # Per-rung override in cumulative pricing: this rung and
+                    # every higher one reprice live (mirror of set_dirty).
+                    contentequipmentupgrade__in=instance.upgrade.same_stack_from_position(),
                     pin_state=PinState.UNPINNED,
                 )
             )
@@ -552,13 +587,20 @@ def _sweep_expansion_item(instance, lst):
         sweep,
         defaults_can_mask=True,
     )
-    _cascade_expression_accessories(lst, changed, sweep)
+    context_all = _base_rows(lst).filter(content_equipment=instance.equipment)
+    cascade_ids = list(changed)
+    if not instance.weapon_profile_id:
+        # A base-pricing item also moves the live base of UNPINNED matching
+        # assignments — their DERIVED expression accessories must re-derive
+        # too (see _sweep_equipment).
+        cascade_ids += list(
+            context_all.filter(pinned_base_state=PinState.UNPINNED).values_list(
+                "pk", flat=True
+            )
+        )
+    _cascade_expression_accessories(lst, cascade_ids, sweep)
 
-    context = _base_rows(lst).filter(
-        content_equipment=instance.equipment,
-        archived=False,
-        list_fighter__archived=False,
-    )
+    context = context_all.filter(archived=False, list_fighter__archived=False)
     if instance.weapon_profile_id:
         sweep.has_unpinned = sweep.has_unpinned or (
             _profile_rows(lst)

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -54,11 +54,14 @@ def propagate_content_cost_change(
     can touch thousands of lists, and the recalculation walks each list's full
     fighter suite. Doing it inline in the admin save blew the request budget.
 
-    Idempotent: each created action records the content instance as its subject
-    with the pre-change baseline, and the helper skips a list that already has a
-    matching applied action — so a redelivery doesn't create spurious actions or
-    double-charge credits. References to deleted instances are handled gracefully
-    (the instance lookup returns and the task is a no-op).
+    Idempotent within a delta branch: the per-row path's second rewrite is a
+    zero delta and skips out; the snapshot path skips a list that already has
+    a matching applied action (same subject + same pre-change baseline). A
+    redelivery that FLIPS branches — a mid-window mutation changed which rows
+    are pinned — can still book a second action; robust cross-branch
+    idempotency (a delivery token) lands with the Phase 8 RECONCILE work.
+    References to deleted instances are handled gracefully (the instance
+    lookup returns and the task is a no-op).
     """
     from django.contrib.contenttypes.models import ContentType
 

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -48,6 +48,7 @@ from gyrinx.core.models.list import (
     List,
     ListFighter,
     ListFighterEquipmentAssignment,
+    PinState,
 )
 from gyrinx.core.models.pack import CustomContentPackItem
 from gyrinx.core.tasks import propagate_content_cost_change
@@ -857,6 +858,63 @@ def test_matrix_p4_remove_accessory_from_stash_gear(campaign_list, user, gear):
     # fighter caches by the component's value, and the books reconcile.
     assert stash_before_removal - fresh(lst).stash_current == 8  # booked movement
     assert_reconciles(lst)
+
+
+def _pin_for_clone(assignment):
+    """Hand-write the pins Phase 7's acquisition choke point will produce:
+    a base pin plus a pinned accessory through-row."""
+    accessory = ContentWeaponAccessory.objects.create(name="Clone Scope", cost=8)
+    assignment.weapon_accessories_field.add(accessory)
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        pinned_base_amount=5, pinned_base_state=PinState.SOURCE
+    )
+    assignment.accessory_rows.update(pinned_amount=3, pin_state=PinState.SOURCE)
+
+
+def _assert_pins_survived(clone, equipment):
+    cloned = ListFighterEquipmentAssignment.objects.get(
+        list_fighter__list=clone, content_equipment=equipment
+    )
+    assert cloned.pinned_base_amount == 5
+    assert cloned.pinned_base_state == PinState.SOURCE
+    assert cloned.accessory_rows.get().pinned_amount == 3
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(
+    strict=True,
+    reason="Phase 7 (#1826): List.clone() rebuilds assignments without the "
+    "pin columns, so cloned gear silently reverts to live pricing",
+)
+def test_matrix_clone_preserves_pins(user, make_list, content_fighter, make_equipment):
+    lst = make_list("Clone Source")
+    fighter = hire_fighter(user, lst, content_fighter, name="Bob")
+    equipment = make_equipment("Lasgun", cost=15)
+    assignment = buy_equipment(user, lst, fighter, equipment)
+    _pin_for_clone(assignment)
+
+    clone = fresh(lst).clone(name="Clone Target")
+    _assert_pins_survived(clone, equipment)
+
+
+@pytest.mark.django_db
+@pytest.mark.xfail(
+    strict=True,
+    reason="Phase 7 (#1826): campaign-start cloning goes through the same "
+    "clone path and drops pins the same way",
+)
+def test_matrix_campaign_start_clone_preserves_pins(
+    user, make_list, content_fighter, make_equipment, campaign
+):
+    lst = make_list("Campaign Clone Source")
+    fighter = hire_fighter(user, lst, content_fighter, name="Bob")
+    equipment = make_equipment("Lasgun", cost=15)
+    assignment = buy_equipment(user, lst, fighter, equipment)
+    _pin_for_clone(assignment)
+
+    cloned, created = campaign.add_list_to_campaign(fresh(lst), user=user)
+    assert created
+    _assert_pins_survived(cloned, equipment)
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_pin_sweeps.py
+++ b/gyrinx/core/tests/test_pin_sweeps.py
@@ -167,6 +167,16 @@ def _build_expansion_item(ctx):
     )
 
 
+def _build_cfeli_with_profile(ctx):
+    _attach_profile(ctx)
+    return _build_cfeli(ctx)
+
+
+def _build_expansion_item_with_profile(ctx):
+    _attach_profile(ctx)
+    return _build_expansion_item(ctx)
+
+
 def _build_cfelwa(ctx):
     accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
     ctx["assignment"].weapon_accessories_field.add(accessory)
@@ -225,7 +235,7 @@ PIN_EDGES = {
         source="ContentFighterEquipmentListItem",
         row="ListFighterEquipmentAssignmentProfile",
         fk="pinned_equipment_list_item",
-        build=lambda ctx: (_attach_profile(ctx), _build_cfeli(ctx))[1],
+        build=_build_cfeli_with_profile,
         pin=lambda ctx, source: ctx["assignment"].profile_rows.update(
             pinned_equipment_list_item=source,
             pinned_amount=5,
@@ -243,7 +253,7 @@ PIN_EDGES = {
         source="ContentEquipmentListExpansionItem",
         row="ListFighterEquipmentAssignmentProfile",
         fk="pinned_expansion_item",
-        build=lambda ctx: (_attach_profile(ctx), _build_expansion_item(ctx))[1],
+        build=_build_expansion_item_with_profile,
         pin=lambda ctx, source: ctx["assignment"].profile_rows.update(
             pinned_expansion_item=source,
             pinned_amount=5,

--- a/gyrinx/core/tests/test_pin_sweeps.py
+++ b/gyrinx/core/tests/test_pin_sweeps.py
@@ -569,7 +569,9 @@ def test_base_correction_cascades_to_expression_accessory(sweep_ctx):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("edge_id", PIN_EDGES.keys())
-def test_deleting_price_source_orphans_pins(edge_id, campaign_sweep_ctx):
+def test_deleting_price_source_orphans_pins(
+    edge_id, campaign_sweep_ctx, django_capture_on_commit_callbacks
+):
     """Deleting a price source freezes the rows pinned to it: the amount is
     kept, the FK cleared, the state flips to ORPHANED, an audit action records
     the attribution loss, and no caches move (nothing changed price)."""
@@ -582,7 +584,10 @@ def test_deleting_price_source_orphans_pins(edge_id, campaign_sweep_ctx):
     caches_before = (rf.rating_current, rf.stash_current, rf.credits_current)
     source_pk = source.pk
 
-    source.delete()
+    # The audit is written after commit (the delete collector must not see
+    # new ListAction rows for lists dying in the same cascade).
+    with django_capture_on_commit_callbacks(execute=True):
+        source.delete()
 
     assert edge.read_pin(ctx) == (5, PinState.ORPHANED, None)
     action = ListAction.objects.get(
@@ -897,3 +902,169 @@ def test_expansion_item_blank_cost_rewrites_to_base_price(sweep_ctx):
     _create_content_cost_change_actions(profile_source)
 
     assert profile_edge.read_pin(ctx)[0] == 12
+
+
+# --- Deep-review follow-ups ----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_house_cascade_delete_survives_pin_orphaning(
+    campaign_sweep_ctx, content_house, django_capture_on_commit_callbacks
+):
+    """Deleting a ContentHouse cascades through its fighters' price rows AND
+    its lists. The orphan audit must not insert ledger rows for gangs dying
+    in the same cascade — previously an IntegrityError at commit rolled the
+    whole deletion back."""
+    ctx = campaign_sweep_ctx
+    edge = PIN_EDGES["equipment-list-item->base"]
+    source = edge.build(ctx)
+    edge.pin(ctx, source)
+    lst_id = ctx["lst"].id
+
+    with django_capture_on_commit_callbacks(execute=True):
+        content_house.delete()
+
+    assert not List.objects.filter(id=lst_id).exists()
+    assert not ListAction.objects.filter(list_id=lst_id).exists()
+
+
+@pytest.mark.django_db
+def test_cfelu_lower_rung_override_correction_reaches_higher_rung(sweep_ctx):
+    """A fighter-specific upgrade override applies PER RUNG inside SINGLE
+    cumulative pricing, so correcting it reprices holders of higher rungs —
+    previously missed by the same-rung-only filter (live bug, pins or not).
+    """
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+    rung0 = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Rung 0", position=0, cost=10
+    )
+    rung1 = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Rung 1", position=1, cost=20
+    )
+    assignment.upgrades_field.add(rung1)  # holds only the HIGHER rung
+    override = ContentFighterEquipmentListUpgrade.objects.create(
+        fighter=assignment.list_fighter.content_fighter, upgrade=rung0, cost=5
+    )
+
+    _clear_dirty(ctx)
+    override.cost = 8
+    override.save()
+    assert fresh(assignment).dirty is True
+    assert ctx["lst"].id in _affected_list_ids(override)
+
+
+@pytest.mark.django_db
+def test_derived_expression_on_unpinned_base_rederives(sweep_ctx):
+    """A DERIVED formula accessory on an UNPINNED base must re-derive when
+    the base's catalog price changes: the base reprices live, and resolution
+    would read the stale derived amount forever."""
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Percent Scope", cost=0, cost_expression="ceil(cost_int * 0.5 / 5) * 5"
+    )
+    assignment.weapon_accessories_field.add(accessory)
+    assignment.accessory_rows.update(
+        pinned_amount=10,  # derived from the live 15 base
+        pin_state=PinState.DERIVED,
+    )
+
+    # Saved, not just set in memory: re-derivation resolves the live base
+    # from the database, exactly as the post-commit task does.
+    equipment.cost = "25"
+    equipment.save()
+    sweep = rewrite_pinned_amounts_for_list(equipment, ctx["lst"])
+
+    assert assignment.accessory_rows.get().pinned_amount == 15
+    assert sweep.has_unpinned is True  # unpinned base repriced live
+
+
+@pytest.mark.django_db
+def test_archived_from_default_row_does_not_mask(sweep_ctx):
+    """An archived default-kit row is rewritten but must not stickily force
+    the whole list onto the snapshot fallback — archived rows move nothing
+    and mask nothing."""
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+    profile = ctx["make_weapon_profile"](equipment, name="Hotshot", cost=5)
+    assignment.weapon_profiles_field.add(profile)
+    assignment.profile_rows.update(pinned_amount=5, pin_state=PinState.CATALOG)
+    default = ContentFighterDefaultAssignment.objects.create(
+        fighter=assignment.list_fighter.content_fighter, equipment=equipment
+    )
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        from_default_assignment=default, archived=True
+    )
+
+    profile.cost = 7
+    sweep = rewrite_pinned_amounts_for_list(profile, ctx["lst"])
+
+    assert sweep.has_masked is False
+    assert sweep.use_row_deltas is True
+    assert assignment.profile_rows.get().pinned_amount == 7  # still rewritten
+
+
+@pytest.mark.django_db
+def test_expansion_item_zero_to_blank_sweeps(sweep_ctx):
+    """cost=0 means "free" and blank means "use the base price" — the
+    transition reprices, but both coerce to 0 in the int helpers, so it was
+    previously invisible to change detection."""
+    ctx = sweep_ctx
+    edge = PIN_EDGES["expansion-item->base"]
+    source = edge.build(ctx)
+    ContentEquipmentListExpansionItem.objects.filter(pk=source.pk).update(cost=0)
+    source.refresh_from_db()
+    edge.pin(ctx, source)
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        pinned_base_amount=0
+    )
+
+    _clear_dirty(ctx)
+    source.cost = None
+    source.save()
+    assert fresh(ctx["assignment"]).dirty is True  # the raw-value watch fired
+
+    _create_content_cost_change_actions(source)
+    assert edge.read_pin(ctx)[0] == 20  # blank -> other_equipment's base price
+
+
+@pytest.mark.django_db
+def test_cancelling_rating_and_stash_deltas_still_book(campaign_sweep_ctx):
+    """+2 rating / -2 stash sums to zero but both books moved — the action
+    must still be recorded or the ledger chain breaks silently."""
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    item = _build_cfeli(ctx)  # cost 5
+
+    # Rating-side row pinned below the corrected price (+2)...
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        pinned_base_amount=5,
+        pinned_base_state=PinState.SOURCE,
+        pinned_equipment_list_item=item,
+    )
+    # ...stash-side row pinned above it (-2).
+    stash = lst.ensure_stash()
+    stash_assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash, content_equipment=ctx["equipment"]
+    )
+    ListFighterEquipmentAssignment.objects.filter(pk=stash_assignment.pk).update(
+        pinned_base_amount=9,
+        pinned_base_state=PinState.SOURCE,
+        pinned_equipment_list_item=item,
+    )
+
+    item.cost = 7
+    item.save()
+    _create_content_cost_change_actions(item)
+
+    action = ListAction.objects.get(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=item.pk,
+    )
+    assert (action.rating_delta, action.stash_delta, action.credits_delta) == (
+        2,
+        -2,
+        0,
+    )

--- a/gyrinx/core/tests/test_pin_sweeps.py
+++ b/gyrinx/core/tests/test_pin_sweeps.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 
 from gyrinx.content.models import (
     ContentEquipmentListExpansion,
@@ -27,21 +28,30 @@ from gyrinx.content.models import (
     ContentFighterEquipmentListWeaponAccessory,
     ContentWeaponAccessory,
 )
-from gyrinx.content.models.signal_handlers import _affected_list_ids
+from gyrinx.content.models.signal_handlers import (
+    _affected_list_ids,
+    _create_content_cost_change_actions,
+)
+from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.list import (
+    List,
     ListFighterEquipmentAssignment,
     ListFighterEquipmentAssignmentAccessory,
     ListFighterEquipmentAssignmentProfile,
     ListFighterEquipmentAssignmentUpgrade,
     PinState,
 )
-from gyrinx.core.tests.test_balance_sheet import fresh
+from gyrinx.core.tasks import propagate_content_cost_change
+from gyrinx.core.tests.test_balance_sheet import (
+    assert_reconciles,
+    buy_equipment,
+    fresh,
+    hire_fighter,
+)
 
 
-@pytest.fixture
-def sweep_ctx(
-    user,
-    make_list,
+def _build_sweep_ctx(
+    lst,
     make_list_fighter,
     make_content_fighter,
     content_house,
@@ -55,7 +65,6 @@ def sweep_ctx(
     assignment doesn't hold — so the legacy sweep filters cannot reach this
     row, and only the pin clauses can.
     """
-    lst = make_list("Sweep Gang")
     holder = make_list_fighter(lst, "Holder")
     origin_cf = make_content_fighter(
         type="Origin Digger", category="GANGER", house=content_house, base_cost=50
@@ -73,6 +82,58 @@ def sweep_ctx(
         "other_equipment": other_equipment,
         "make_weapon_profile": make_weapon_profile,
     }
+
+
+@pytest.fixture
+def sweep_ctx(
+    user,
+    make_list,
+    make_list_fighter,
+    make_content_fighter,
+    content_house,
+    make_equipment,
+    make_weapon_profile,
+):
+    return _build_sweep_ctx(
+        make_list("Sweep Gang"),
+        make_list_fighter,
+        make_content_fighter,
+        content_house,
+        make_equipment,
+        make_weapon_profile,
+    )
+
+
+@pytest.fixture
+def campaign_sweep_ctx(
+    user,
+    campaign,
+    make_list,
+    make_list_fighter,
+    make_content_fighter,
+    content_house,
+    make_equipment,
+    make_weapon_profile,
+):
+    """The moved-gear context on a campaign list with a credits stake, so
+    the full task flow (audit action + campaign credits) can be asserted."""
+    lst = make_list("Sweep Campaign Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
+    campaign.lists.add(lst)
+    lst.create_action(
+        user=user,
+        action_type=ListActionType.UPDATE_CREDITS,
+        description="Stake",
+        credits_delta=1000,
+        update_credits=True,
+    )
+    return _build_sweep_ctx(
+        fresh(lst),
+        make_list_fighter,
+        make_content_fighter,
+        content_house,
+        make_equipment,
+        make_weapon_profile,
+    )
 
 
 def _pin_base(ctx, **fk):
@@ -130,6 +191,23 @@ class PinEdge:
     fk: str  # the pin FK field name on the row model
     build: Callable  # create the source (keyed so legacy filters miss)
     pin: Callable  # write the pin on the assignment/through row
+
+    def read_pin(self, ctx):
+        """Read back (amount, state, fk id) for this edge's pinned row."""
+        if self.row == "ListFighterEquipmentAssignment":
+            a = ListFighterEquipmentAssignment.objects.get(pk=ctx["assignment"].pk)
+            return (
+                a.pinned_base_amount,
+                a.pinned_base_state,
+                getattr(a, f"{self.fk}_id"),
+            )
+        accessor = {
+            "ListFighterEquipmentAssignmentProfile": "profile_rows",
+            "ListFighterEquipmentAssignmentAccessory": "accessory_rows",
+            "ListFighterEquipmentAssignmentUpgrade": "upgrade_rows",
+        }[self.row]
+        row = getattr(ctx["assignment"], accessor).get()
+        return (row.pinned_amount, row.pin_state, getattr(row, f"{self.fk}_id"))
 
 
 PIN_EDGES = {
@@ -274,3 +352,232 @@ def test_accessory_cost_expression_change_sweeps(sweep_ctx):
     accessory.cost_expression = "ceil(cost_int * 1.0 / 5) * 5"
     accessory.save()
     assert fresh(assignment).dirty is True
+
+
+# --- Amount rewriting: corrections propagate to pinned rows ------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("edge_id", PIN_EDGES.keys())
+def test_correction_rewrites_pinned_amount_and_books_it(edge_id, campaign_sweep_ctx):
+    """Full flow per pin edge: the source is corrected, the task rewrites the
+    pinned amount, recomputes, and books the per-row delta as an audit action
+    with campaign credits. The caches-match-recompute assertion also pins the
+    rewrite-BEFORE-recompute ordering: rewritten after, the caches would hold
+    the old sum and disagree with the recompute below.
+    """
+    edge = PIN_EDGES[edge_id]
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    source = edge.build(ctx)
+    edge.pin(ctx, source)
+
+    credits_before = fresh(lst).credits_current
+    source.cost = 7  # pinned at 5
+    source.save()
+    _create_content_cost_change_actions(source)
+
+    amount, state, fk_id = edge.read_pin(ctx)
+    assert amount == 7
+    assert fk_id == source.pk
+
+    action = ListAction.objects.get(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=source.pk,
+    )
+    assert action.rating_delta == 2
+    assert action.stash_delta == 0
+    assert action.credits_delta == -2
+
+    rf = fresh(lst)
+    assert rf.credits_current == credits_before - 2
+    facts = rf.facts_from_db(update=False)
+    assert (facts.rating, facts.stash) == (rf.rating_current, rf.stash_current)
+
+
+@pytest.mark.django_db
+def test_purchase_in_enqueue_window_is_not_double_counted(
+    user, campaign, make_list, make_content_fighter, content_house, make_equipment
+):
+    """A user purchase landing between enqueue and the task must keep its own
+    audit trail: per-row amount deltas book exactly the correction, where the
+    old snapshot-vs-recompute delta absorbed the purchase and double-charged
+    campaign credits.
+    """
+    lst = make_list("Race Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
+    campaign.lists.add(lst)
+    lst.create_action(
+        user=user,
+        action_type=ListActionType.UPDATE_CREDITS,
+        description="Stake",
+        credits_delta=1000,
+        update_credits=True,
+    )
+    cf = make_content_fighter(
+        type="Racer", category="GANGER", house=content_house, base_cost=50
+    )
+    fighter = hire_fighter(user, fresh(lst), cf, name="Bob")
+    equipment = make_equipment("Lasgun", cost=15)
+    item = ContentFighterEquipmentListItem.objects.create(
+        fighter=cf, equipment=equipment, cost=5
+    )
+    assignment = buy_equipment(user, fresh(lst), fighter, equipment)
+    # Pin at the booked acquisition price (what Phase 7 will write).
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        pinned_base_amount=5,
+        pinned_base_state=PinState.SOURCE,
+        pinned_equipment_list_item=item,
+    )
+    assert_reconciles(lst)
+
+    # The correction is enqueued with a pre-change snapshot...
+    before = {str(lst.id): [fresh(lst).rating_current, fresh(lst).stash_current]}
+    item.cost = 8
+    item.save()
+
+    # ...and a purchase lands inside the window, before the task runs.
+    other = make_equipment("Autogun", cost=30)
+    buy_equipment(user, fresh(lst), fresh(fighter), other)
+    credits_after_purchase = fresh(lst).credits_current
+
+    ct = ContentType.objects.get_for_model(type(item))
+    propagate_content_cost_change.func(ct.id, str(item.pk), before)
+
+    # Exactly the +3 correction moves; the +30 purchase is not re-booked.
+    assert fresh(lst).credits_current == credits_after_purchase - 3
+    action = ListAction.objects.get(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=item.pk,
+    )
+    assert action.rating_delta == 3
+    assert action.credits_delta == -3
+    assert_reconciles(lst)
+
+
+# --- Sweep-domain partition by pin_state --------------------------------------
+
+
+@pytest.mark.django_db
+def test_orphaned_and_source_rows_ignore_catalog_sweeps(sweep_ctx):
+    """Catalog amount-copy sweeps only touch CATALOG rows: ORPHANED amounts
+    are frozen by definition, and SOURCE amounts belong to their override
+    source, not the catalog price."""
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        pinned_base_amount=5, pinned_base_state=PinState.ORPHANED
+    )
+    equipment.cost = "25"
+    equipment.save()
+    _create_content_cost_change_actions(equipment)
+    a = ListFighterEquipmentAssignment.objects.get(pk=assignment.pk)
+    assert (a.pinned_base_amount, a.pinned_base_state) == (5, PinState.ORPHANED)
+
+    source = _build_cfelwa(ctx)
+    assignment.accessory_rows.update(
+        pinned_equipment_list_accessory=source,
+        pinned_amount=5,
+        pin_state=PinState.SOURCE,
+    )
+    accessory = source.weapon_accessory
+    accessory.cost = 20
+    accessory.save()
+    _create_content_cost_change_actions(accessory)
+    row = assignment.accessory_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (5, PinState.SOURCE)
+
+
+# --- Derived amounts re-derive, never copy ------------------------------------
+
+
+@pytest.mark.django_db
+def test_single_stack_lower_rung_correction_rederives_higher_rung(sweep_ctx):
+    """SINGLE stacks price cumulatively: correcting rung 0 reprices a DERIVED
+    pinned row holding rung 1, and the widened upgrade sweep reaches that
+    holder even though it doesn't hold rung 0 itself."""
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+    rung0 = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Rung 0", position=0, cost=10
+    )
+    rung1 = ContentEquipmentUpgrade.objects.create(
+        equipment=equipment, name="Rung 1", position=1, cost=20
+    )
+    assignment.upgrades_field.add(rung1)
+    assignment.upgrade_rows.update(pinned_amount=30, pin_state=PinState.DERIVED)
+
+    _clear_dirty(ctx)
+    rung0.cost = 20
+    rung0.save()
+    # The rung-1 holder is dirtied by the rung-0 correction...
+    assert fresh(assignment).dirty is True
+    assert ctx["lst"].id in _affected_list_ids(rung0)
+
+    # ...and its cumulative amount re-derives: 20 + 20.
+    _create_content_cost_change_actions(rung0)
+    row = assignment.upgrade_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (40, PinState.DERIVED)
+
+
+@pytest.mark.django_db
+def test_base_correction_cascades_to_expression_accessory(sweep_ctx):
+    """Rewriting a pinned base cascades to same-assignment DERIVED expression
+    accessories, which re-derive from the new base. The list here is outside
+    the action system (no latest_action) — amounts must be rewritten anyway,
+    or a later lazy recompute would read stale prices forever."""
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Percent Scope", cost=0, cost_expression="ceil(cost_int * 0.5 / 5) * 5"
+    )
+    assignment.weapon_accessories_field.add(accessory)
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        pinned_base_amount=15, pinned_base_state=PinState.CATALOG
+    )
+    assignment.accessory_rows.update(
+        pinned_amount=10,  # ceil(15 * 0.5 / 5) * 5
+        pin_state=PinState.DERIVED,
+    )
+
+    equipment.cost = "25"
+    equipment.save()
+    _create_content_cost_change_actions(equipment)
+
+    a = ListFighterEquipmentAssignment.objects.get(pk=assignment.pk)
+    assert a.pinned_base_amount == 25
+    assert assignment.accessory_rows.get().pinned_amount == 15  # ceil(25*0.5/5)*5
+
+
+# --- Delete-side: sources disappear, amounts stand -----------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("edge_id", PIN_EDGES.keys())
+def test_deleting_price_source_orphans_pins(edge_id, campaign_sweep_ctx):
+    """Deleting a price source freezes the rows pinned to it: the amount is
+    kept, the FK cleared, the state flips to ORPHANED, an audit action records
+    the attribution loss, and no caches move (nothing changed price)."""
+    edge = PIN_EDGES[edge_id]
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    source = edge.build(ctx)
+    edge.pin(ctx, source)
+    rf = fresh(lst)
+    caches_before = (rf.rating_current, rf.stash_current, rf.credits_current)
+    source_pk = source.pk
+
+    source.delete()
+
+    assert edge.read_pin(ctx) == (5, PinState.ORPHANED, None)
+    action = ListAction.objects.get(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=source_pk,
+    )
+    assert "price source deleted" in action.description
+    assert (action.rating_delta, action.stash_delta, action.credits_delta) == (0, 0, 0)
+    rf = fresh(lst)
+    assert (rf.rating_current, rf.stash_current, rf.credits_current) == caches_before

--- a/gyrinx/core/tests/test_pin_sweeps.py
+++ b/gyrinx/core/tests/test_pin_sweeps.py
@@ -20,9 +20,11 @@ import pytest
 from django.contrib.contenttypes.models import ContentType
 
 from gyrinx.content.models import (
+    ContentEquipment,
     ContentEquipmentListExpansion,
     ContentEquipmentListExpansionItem,
     ContentEquipmentUpgrade,
+    ContentFighterDefaultAssignment,
     ContentFighterEquipmentListItem,
     ContentFighterEquipmentListUpgrade,
     ContentFighterEquipmentListWeaponAccessory,
@@ -32,6 +34,7 @@ from gyrinx.content.models.signal_handlers import (
     _affected_list_ids,
     _create_content_cost_change_actions,
 )
+from gyrinx.core.cost.pin_sweep import rewrite_pinned_amounts_for_list
 from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.list import (
     List,
@@ -581,3 +584,267 @@ def test_deleting_price_source_orphans_pins(edge_id, campaign_sweep_ctx):
     assert (action.rating_delta, action.stash_delta, action.credits_delta) == (0, 0, 0)
     rf = fresh(lst)
     assert (rf.rating_current, rf.stash_current, rf.credits_current) == caches_before
+
+
+# --- Resolution masks: rewritten amounts that must book NO movement ----------
+
+
+def _assert_no_correction_booked(lst, source, credits_before):
+    assert not ListAction.objects.filter(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=source.pk,
+    ).exists()
+    assert fresh(lst).credits_current == credits_before
+
+
+@pytest.mark.django_db
+def test_total_cost_override_masks_correction_delta(campaign_sweep_ctx):
+    """A fixed assignment total outranks the pin: the amount is rewritten
+    (provenance stays current) but the resolved value never moved, so no
+    action is booked and no credits are charged."""
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    edge = PIN_EDGES["equipment-list-item->base"]
+    source = edge.build(ctx)
+    edge.pin(ctx, source)
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        total_cost_override=10
+    )
+
+    credits_before = fresh(lst).credits_current
+    source.cost = 7
+    source.save()
+    _create_content_cost_change_actions(source)
+
+    assert edge.read_pin(ctx)[0] == 7  # rewritten
+    _assert_no_correction_booked(lst, source, credits_before)
+
+
+@pytest.mark.django_db
+def test_cost_override_masks_base_correction_delta(campaign_sweep_ctx):
+    """A user base override outranks the base pin the same way."""
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    edge = PIN_EDGES["equipment-list-item->base"]
+    source = edge.build(ctx)
+    edge.pin(ctx, source)
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        cost_override=3
+    )
+
+    credits_before = fresh(lst).credits_current
+    source.cost = 7
+    source.save()
+    _create_content_cost_change_actions(source)
+
+    assert edge.read_pin(ctx)[0] == 7
+    _assert_no_correction_booked(lst, source, credits_before)
+
+
+@pytest.mark.django_db
+def test_from_default_component_mask_forces_snapshot_fallback(sweep_ctx):
+    """From-default assignments free SOME components by membership — the
+    per-row maths can't price that, so the sweep flags the snapshot fallback
+    (while still rewriting the amount)."""
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+    profile = ctx["make_weapon_profile"](equipment, name="Hotshot", cost=5)
+    assignment.weapon_profiles_field.add(profile)
+    assignment.profile_rows.update(pinned_amount=5, pin_state=PinState.CATALOG)
+    default = ContentFighterDefaultAssignment.objects.create(
+        fighter=assignment.list_fighter.content_fighter, equipment=equipment
+    )
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        from_default_assignment=default
+    )
+
+    profile.cost = 7
+    sweep = rewrite_pinned_amounts_for_list(profile, ctx["lst"])
+    assert sweep.has_masked is True
+    assert sweep.use_row_deltas is False
+    assert assignment.profile_rows.get().pinned_amount == 7  # still rewritten
+
+
+@pytest.mark.django_db
+def test_unpinned_expression_rider_forces_snapshot_fallback(sweep_ctx):
+    """An UNPINNED expression accessory reprices live off a rewritten base:
+    its movement is invisible to per-row deltas, so it must flip the list to
+    the snapshot fallback."""
+    ctx = sweep_ctx
+    assignment, equipment = ctx["assignment"], ctx["equipment"]
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Percent Scope", cost=0, cost_expression="ceil(cost_int * 0.5 / 5) * 5"
+    )
+    assignment.weapon_accessories_field.add(accessory)
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        pinned_base_amount=15, pinned_base_state=PinState.CATALOG
+    )
+
+    equipment.cost = "25"
+    sweep = rewrite_pinned_amounts_for_list(equipment, ctx["lst"])
+    assert sweep.has_unpinned is True
+    assert sweep.use_row_deltas is False
+    a = ListFighterEquipmentAssignment.objects.get(pk=assignment.pk)
+    assert a.pinned_base_amount == 25  # base still rewritten
+
+
+# --- Archived rows: amounts maintained, caches untouched ----------------------
+
+
+@pytest.mark.django_db
+def test_archived_rows_rewritten_without_cache_movement(campaign_sweep_ctx):
+    """A list reachable only through an archived pinned row still gets the
+    amount rewrite (an unarchive must not resurrect a stale price), but no
+    dirty-marking, no action, and no cache movement."""
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    edge = PIN_EDGES["equipment-list-item->base"]
+    source = edge.build(ctx)
+    edge.pin(ctx, source)
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        archived=True, dirty=False
+    )
+
+    credits_before = fresh(lst).credits_current
+    source.cost = 7
+    source.save()
+    _create_content_cost_change_actions(source)
+
+    assert edge.read_pin(ctx)[0] == 7
+    assert fresh(ctx["assignment"]).dirty is False
+    _assert_no_correction_booked(lst, source, credits_before)
+
+
+# --- Catalog sweeps: the components' own price corrections -------------------
+
+
+def _catalog_profile(ctx):
+    profile = ctx["make_weapon_profile"](ctx["equipment"], name="Hotshot", cost=5)
+    ctx["assignment"].weapon_profiles_field.add(profile)
+    ctx["assignment"].profile_rows.update(pinned_amount=5, pin_state=PinState.CATALOG)
+    return profile, lambda: ctx["assignment"].profile_rows.get().pinned_amount
+
+
+def _catalog_accessory(ctx):
+    accessory = ContentWeaponAccessory.objects.create(name="Flat Scope", cost=5)
+    ctx["assignment"].weapon_accessories_field.add(accessory)
+    ctx["assignment"].accessory_rows.update(pinned_amount=5, pin_state=PinState.CATALOG)
+    return accessory, lambda: ctx["assignment"].accessory_rows.get().pinned_amount
+
+
+def _catalog_multi_upgrade(ctx):
+    multi_equipment = ContentEquipment.objects.create(
+        name="Multi Gun", cost=10, upgrade_mode=ContentEquipment.UpgradeMode.MULTI
+    )
+    multi_assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=ctx["assignment"].list_fighter, content_equipment=multi_equipment
+    )
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=multi_equipment, name="Mag", cost=5
+    )
+    multi_assignment.upgrades_field.add(upgrade)
+    multi_assignment.upgrade_rows.update(pinned_amount=5, pin_state=PinState.CATALOG)
+    return upgrade, lambda: multi_assignment.upgrade_rows.get().pinned_amount
+
+
+CATALOG_KINDS = {
+    "weapon-profile": _catalog_profile,
+    "weapon-accessory": _catalog_accessory,
+    "multi-upgrade": _catalog_multi_upgrade,
+}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("kind", CATALOG_KINDS.keys())
+def test_catalog_correction_rewrites_component_amount_and_books_it(
+    kind, campaign_sweep_ctx
+):
+    """CATALOG-attributed component rows copy their own content price when
+    it is corrected, and the correction books per-row."""
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    source, read_amount = CATALOG_KINDS[kind](ctx)
+
+    credits_before = fresh(lst).credits_current
+    source.cost = 7
+    source.save()
+    _create_content_cost_change_actions(source)
+
+    assert read_amount() == 7
+    action = ListAction.objects.get(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=source.pk,
+    )
+    assert (action.rating_delta, action.stash_delta, action.credits_delta) == (
+        2,
+        0,
+        -2,
+    )
+    assert fresh(lst).credits_current == credits_before - 2
+
+
+@pytest.mark.django_db
+def test_expression_edit_rederives_derived_amount_and_books(campaign_sweep_ctx):
+    """Editing an accessory's cost_expression re-derives DERIVED rows through
+    the full task flow and books the movement."""
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Percent Scope", cost=0, cost_expression="ceil(cost_int * 0.5 / 5) * 5"
+    )
+    ctx["assignment"].weapon_accessories_field.add(accessory)
+    ctx["assignment"].accessory_rows.update(
+        pinned_amount=10,  # ceil(15 * 0.5 / 5) * 5 against the live 15 base
+        pin_state=PinState.DERIVED,
+    )
+
+    credits_before = fresh(lst).credits_current
+    accessory.cost_expression = "ceil(cost_int * 1.0 / 5) * 5"
+    accessory.save()
+    _create_content_cost_change_actions(accessory)
+
+    assert ctx["assignment"].accessory_rows.get().pinned_amount == 15
+    action = ListAction.objects.get(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=accessory.pk,
+    )
+    assert (action.rating_delta, action.credits_delta) == (5, -5)
+    assert fresh(lst).credits_current == credits_before - 5
+
+
+@pytest.mark.django_db
+def test_stash_side_correction_books_stash_delta(campaign_sweep_ctx):
+    """A pinned row held by the stash books its correction as stash movement,
+    not rating movement."""
+    ctx = campaign_sweep_ctx
+    lst = ctx["lst"]
+    stash = lst.ensure_stash()
+    stash_assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=stash, content_equipment=ctx["equipment"]
+    )
+    item = _build_cfeli(ctx)
+    ListFighterEquipmentAssignment.objects.filter(pk=stash_assignment.pk).update(
+        pinned_base_amount=5,
+        pinned_base_state=PinState.SOURCE,
+        pinned_equipment_list_item=item,
+    )
+
+    credits_before = fresh(lst).credits_current
+    item.cost = 7
+    item.save()
+    _create_content_cost_change_actions(item)
+
+    action = ListAction.objects.get(
+        list=lst,
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=item.pk,
+    )
+    assert (action.rating_delta, action.stash_delta, action.credits_delta) == (
+        0,
+        2,
+        -2,
+    )
+    assert fresh(lst).credits_current == credits_before - 2

--- a/gyrinx/core/tests/test_pin_sweeps.py
+++ b/gyrinx/core/tests/test_pin_sweeps.py
@@ -1,0 +1,276 @@
+"""Phase 6 of the cost-pinning programme (#1826): sweeps reach pinned rows.
+
+The legacy cost-change sweeps find affected assignments through their live
+context: the holder's content fighter, or the equipment currently referenced
+by the changed row. Pinned gear breaks that assumption — a pin is an FK to
+the price-setting content object, and the row carrying it may since have
+moved to a holder (or drifted from an equipment context) the legacy filters
+can't see.
+
+Each test here builds exactly that: a row the holder-keyed sweep provably
+misses (the unpinned control beat), pins it to the changed source, and
+asserts the widened sweep now reaches it — both the `set_dirty()` fan-out
+and its `_affected_list_ids` mirror, which must stay in lockstep.
+"""
+
+from dataclasses import dataclass
+from typing import Callable
+
+import pytest
+
+from gyrinx.content.models import (
+    ContentEquipmentListExpansion,
+    ContentEquipmentListExpansionItem,
+    ContentEquipmentUpgrade,
+    ContentFighterEquipmentListItem,
+    ContentFighterEquipmentListUpgrade,
+    ContentFighterEquipmentListWeaponAccessory,
+    ContentWeaponAccessory,
+)
+from gyrinx.content.models.signal_handlers import _affected_list_ids
+from gyrinx.core.models.list import (
+    ListFighterEquipmentAssignment,
+    ListFighterEquipmentAssignmentAccessory,
+    ListFighterEquipmentAssignmentProfile,
+    ListFighterEquipmentAssignmentUpgrade,
+    PinState,
+)
+from gyrinx.core.tests.test_balance_sheet import fresh
+
+
+@pytest.fixture
+def sweep_ctx(
+    user,
+    make_list,
+    make_list_fighter,
+    make_content_fighter,
+    content_house,
+    make_equipment,
+    make_weapon_profile,
+):
+    """A weapon held by a fighter the pin sources do NOT target.
+
+    The pin sources built by each edge all key on ``origin_cf`` (the fighter
+    context the gear was hypothetically acquired in) or on equipment the
+    assignment doesn't hold — so the legacy sweep filters cannot reach this
+    row, and only the pin clauses can.
+    """
+    lst = make_list("Sweep Gang")
+    holder = make_list_fighter(lst, "Holder")
+    origin_cf = make_content_fighter(
+        type="Origin Digger", category="GANGER", house=content_house, base_cost=50
+    )
+    equipment = make_equipment("Lasgun", cost=15)
+    other_equipment = make_equipment("Autogun", cost=20)
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=holder, content_equipment=equipment
+    )
+    return {
+        "lst": lst,
+        "assignment": assignment,
+        "origin_cf": origin_cf,
+        "equipment": equipment,
+        "other_equipment": other_equipment,
+        "make_weapon_profile": make_weapon_profile,
+    }
+
+
+def _pin_base(ctx, **fk):
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        pinned_base_amount=5, pinned_base_state=PinState.SOURCE, **fk
+    )
+
+
+def _attach_profile(ctx):
+    profile = ctx["make_weapon_profile"](ctx["equipment"], name="Hotshot", cost=10)
+    ctx["assignment"].weapon_profiles_field.add(profile)
+
+
+def _build_cfeli(ctx):
+    # Keyed to origin_cf: the holder-keyed legacy filter misses the row.
+    return ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["origin_cf"], equipment=ctx["equipment"], cost=5
+    )
+
+
+def _build_expansion_item(ctx):
+    # Keyed to equipment the assignment doesn't hold — the situation the
+    # equipment-keyed legacy filter can't see (e.g. the item's equipment FK
+    # was re-pointed after acquisition). The pin must still reach the row.
+    expansion = ContentEquipmentListExpansion.objects.create(name="Sweep Expansion")
+    return ContentEquipmentListExpansionItem.objects.create(
+        expansion=expansion, equipment=ctx["other_equipment"], cost=5
+    )
+
+
+def _build_cfelwa(ctx):
+    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
+    ctx["assignment"].weapon_accessories_field.add(accessory)
+    return ContentFighterEquipmentListWeaponAccessory.objects.create(
+        fighter=ctx["origin_cf"], weapon_accessory=accessory, cost=5
+    )
+
+
+def _build_cfelu(ctx):
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        name="Mag", equipment=ctx["equipment"], cost=12
+    )
+    ctx["assignment"].upgrades_field.add(upgrade)
+    return ContentFighterEquipmentListUpgrade.objects.create(
+        fighter=ctx["origin_cf"], upgrade=upgrade, cost=5
+    )
+
+
+@dataclass(frozen=True)
+class PinEdge:
+    """One pin FK: which content source it targets, from which row model."""
+
+    source: str  # content model whose cost change must sweep the pin
+    row: str  # core model carrying the pin FK
+    fk: str  # the pin FK field name on the row model
+    build: Callable  # create the source (keyed so legacy filters miss)
+    pin: Callable  # write the pin on the assignment/through row
+
+
+PIN_EDGES = {
+    "equipment-list-item->base": PinEdge(
+        source="ContentFighterEquipmentListItem",
+        row="ListFighterEquipmentAssignment",
+        fk="pinned_equipment_list_item",
+        build=_build_cfeli,
+        pin=lambda ctx, source: _pin_base(ctx, pinned_equipment_list_item=source),
+    ),
+    "equipment-list-item->profile-row": PinEdge(
+        source="ContentFighterEquipmentListItem",
+        row="ListFighterEquipmentAssignmentProfile",
+        fk="pinned_equipment_list_item",
+        build=lambda ctx: (_attach_profile(ctx), _build_cfeli(ctx))[1],
+        pin=lambda ctx, source: ctx["assignment"].profile_rows.update(
+            pinned_equipment_list_item=source,
+            pinned_amount=5,
+            pin_state=PinState.SOURCE,
+        ),
+    ),
+    "expansion-item->base": PinEdge(
+        source="ContentEquipmentListExpansionItem",
+        row="ListFighterEquipmentAssignment",
+        fk="pinned_expansion_item",
+        build=_build_expansion_item,
+        pin=lambda ctx, source: _pin_base(ctx, pinned_expansion_item=source),
+    ),
+    "expansion-item->profile-row": PinEdge(
+        source="ContentEquipmentListExpansionItem",
+        row="ListFighterEquipmentAssignmentProfile",
+        fk="pinned_expansion_item",
+        build=lambda ctx: (_attach_profile(ctx), _build_expansion_item(ctx))[1],
+        pin=lambda ctx, source: ctx["assignment"].profile_rows.update(
+            pinned_expansion_item=source,
+            pinned_amount=5,
+            pin_state=PinState.SOURCE,
+        ),
+    ),
+    "equipment-list-accessory->accessory-row": PinEdge(
+        source="ContentFighterEquipmentListWeaponAccessory",
+        row="ListFighterEquipmentAssignmentAccessory",
+        fk="pinned_equipment_list_accessory",
+        build=_build_cfelwa,
+        pin=lambda ctx, source: ctx["assignment"].accessory_rows.update(
+            pinned_equipment_list_accessory=source,
+            pinned_amount=5,
+            pin_state=PinState.SOURCE,
+        ),
+    ),
+    "equipment-list-upgrade->upgrade-row": PinEdge(
+        source="ContentFighterEquipmentListUpgrade",
+        row="ListFighterEquipmentAssignmentUpgrade",
+        fk="pinned_equipment_list_upgrade",
+        build=_build_cfelu,
+        pin=lambda ctx, source: ctx["assignment"].upgrade_rows.update(
+            pinned_equipment_list_upgrade=source,
+            pinned_amount=5,
+            pin_state=PinState.SOURCE,
+        ),
+    ),
+}
+
+
+def _clear_dirty(ctx):
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        dirty=False
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("edge_id", PIN_EDGES.keys())
+def test_price_change_sweep_reaches_moved_pinned_rows(edge_id, sweep_ctx):
+    """A cost change on a pin source dirties rows pinned to it — even rows
+    the legacy context-keyed filters can't see — and its `_affected_list_ids`
+    mirror names their list. The unpinned control beat proves the legacy
+    filters genuinely miss this row, so the pin clause is what finds it.
+    """
+    edge = PIN_EDGES[edge_id]
+    ctx = sweep_ctx
+    assignment, lst = ctx["assignment"], ctx["lst"]
+    source = edge.build(ctx)
+
+    # Control beat: unpinned, this row is invisible to the sweep.
+    _clear_dirty(ctx)
+    source.cost = 6
+    source.save()
+    assert fresh(assignment).dirty is False
+    assert lst.id not in _affected_list_ids(source)
+
+    # Pinned, the same cost change reaches it through the pin FK.
+    edge.pin(ctx, source)
+    _clear_dirty(ctx)
+    source.cost = 7
+    source.save()
+    assert fresh(assignment).dirty is True
+    assert lst.id in _affected_list_ids(source)
+
+
+def test_every_pin_fk_has_a_sweep_edge():
+    """Every pinned_* FK on the assignment/through models appears in
+    PIN_EDGES above — so adding a new pin FK without widening the sweeps
+    (and extending this matrix) fails here, not silently in production.
+    """
+    row_models = [
+        ListFighterEquipmentAssignment,
+        ListFighterEquipmentAssignmentProfile,
+        ListFighterEquipmentAssignmentAccessory,
+        ListFighterEquipmentAssignmentUpgrade,
+    ]
+    discovered = {
+        (field.related_model.__name__, model.__name__, field.name)
+        for model in row_models
+        for field in model._meta.get_fields()
+        if field.concrete and field.is_relation and field.name.startswith("pinned_")
+    }
+    declared = {(edge.source, edge.row, edge.fk) for edge in PIN_EDGES.values()}
+    assert discovered == declared
+
+
+# --- The cost_expression watch ----------------------------------------------
+
+
+@pytest.mark.django_db
+def test_accessory_cost_expression_change_sweeps(sweep_ctx):
+    """Editing an accessory's cost_expression reprices every assignment
+    carrying it, so it must dirty them exactly like a flat-cost edit —
+    previously it was unwatched and nothing moved.
+    """
+    ctx = sweep_ctx
+    assignment = ctx["assignment"]
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Percent Scope", cost=0, cost_expression="ceil(cost_int * 0.5 / 5) * 5"
+    )
+    assignment.weapon_accessories_field.add(accessory)
+
+    # Control beat: a save with nothing changed sweeps nothing.
+    _clear_dirty(ctx)
+    accessory.save()
+    assert fresh(assignment).dirty is False
+
+    accessory.cost_expression = "ceil(cost_int * 1.0 / 5) * 5"
+    accessory.save()
+    assert fresh(assignment).dirty is True

--- a/gyrinx/core/tests/test_pin_sweeps.py
+++ b/gyrinx/core/tests/test_pin_sweeps.py
@@ -848,3 +848,42 @@ def test_stash_side_correction_books_stash_delta(campaign_sweep_ctx):
         -2,
     )
     assert fresh(lst).credits_current == credits_before - 2
+
+
+@pytest.mark.django_db
+def test_expansion_item_blank_cost_rewrites_to_base_price(sweep_ctx):
+    """An expansion item's blank cost means "use the base price" — clearing
+    the override must rewrite pinned amounts to the underlying equipment (or
+    profile) price, not to zero."""
+    ctx = sweep_ctx
+    base_edge = PIN_EDGES["expansion-item->base"]
+    source = base_edge.build(ctx)
+    base_edge.pin(ctx, source)
+
+    source.cost = None
+    source.save()
+    _create_content_cost_change_actions(source)
+
+    # The item prices other_equipment (cost 20): blank falls back to that.
+    assert base_edge.read_pin(ctx)[0] == 20
+
+    # Same fallback for a profile-priced expansion pin: blank -> profile cost.
+    profile_edge = PIN_EDGES["expansion-item->profile-row"]
+    profile_source = ContentEquipmentListExpansionItem.objects.create(
+        expansion=source.expansion,
+        equipment=ctx["equipment"],
+        weapon_profile=ctx["make_weapon_profile"](
+            ctx["equipment"], name="Blank Shot", cost=12
+        ),
+        cost=5,
+    )
+    ctx["assignment"].weapon_profiles_field.add(profile_source.weapon_profile)
+    ctx["assignment"].profile_rows.update(
+        pinned_expansion_item=profile_source, pinned_amount=5, pin_state=PinState.SOURCE
+    )
+
+    profile_source.cost = None
+    profile_source.save()
+    _create_content_cost_change_actions(profile_source)
+
+    assert profile_edge.read_pin(ctx)[0] == 12


### PR DESCRIPTION
Part of the cost-pinning programme (#1826), Phase 6 of the design in `.claude/notes/cost-pinning-design.md`. Phases 1–5 are merged: the balance-sheet harness proves the books, the pin schema exists (inert in production — every row is unpinned), and resolution reads pinned amounts when they exist. This phase makes the sweeps *maintain* those amounts, so content corrections keep propagating once Phase 7 starts writing pins.

## What changed

**Price-change sweeps now reach pinned rows.** The old sweeps found affected gear through its live context — the holder's fighter type, or the equipment a row currently references. Pinned gear breaks that assumption: after a reassignment or death-transfer, the row has moved to a holder those filters can't see, so a price correction would silently skip it. All four equipment-list/expansion sweeps gain OR-clauses on the pin FKs, mirrored identically in the audit-side list enumeration (`_affected_list_ids`) so dirty fan-out and audit snapshots agree.

**Corrections rewrite the pinned amounts.** The async cost-change task now rewrites affected pinned amounts *before* recomputing, partitioned by pin state: rows pinned to an override source copy its new price; catalog-pinned rows copy the new catalog price; derived rows re-derive (percentage-priced accessories re-evaluate against the base, cumulative upgrade stacks re-sum); orphaned rows are never touched; unpinned rows are untouched (nothing to rewrite). Rewritten rows are re-marked dirty, because an action landing in the window can refresh a fighter's caches and clear its flags.

**The audit delta closes a double-count race.** When every affected row is pinned, the correction's audit action books the exact sum of per-row amount changes instead of "recompute minus snapshot". The old construction had a race: a user purchase landing between enqueue and the task ran was folded into the correction's delta and double-charged in campaign credits. Lists that still have unpinned affected rows keep today's snapshot behaviour until the Phase 8 backfill.

**Deleting a price source no longer strands pins.** A `pre_delete` handler flips rows pinned to the deleted source to ORPHANED: the amount stands (nothing changes price, no cache movement), the attribution FK is cleared, and an audit action records it per affected list. Source deletes were previously completely unwatched.

**Two pre-existing gaps fixed along the way:**
- Editing a weapon accessory's `cost_expression` reprices every carrier but previously dirtied nothing — now watched like a flat-cost edit.
- SINGLE-mode upgrade stacks price cumulatively, so correcting a lower rung reprices holders of *higher* rungs — the sweep only matched same-rung holders and silently missed them. This was a live bug independent of pins.

## Production impact today

None by design: every production row is unpinned, so the rewrite finds nothing, the per-row delta path never engages, and the delete handlers find no pins. The whole suite (2950 tests) passes unchanged; the strict-xfail cells pinning known drift (P2 death-transfer, and two new cells pinning that cloning drops pins — Phase 7 fixes that) still xfail on schedule.

## How to verify

- `pytest gyrinx/core/tests/test_pin_sweeps.py` — the per-edge sweep matrix (with an unpinned control beat proving the legacy filters genuinely miss moved gear), the full-flow correction cells (amount rewritten, audit action + campaign credits, caches match recompute), the enqueue-window race cell, pin-state partition cells, SINGLE lower-rung and expression-cascade cells, and the per-edge delete-orphaning matrix.
- An introspection tripwire fails CI if a new pin FK is added without sweep coverage.
- `pytest gyrinx/core/tests/test_balance_sheet.py` — the situation matrix stays green.

Refs #1826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh