### PR TITLE
fix: render Modification admin changelist by description, not ctype

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,8 @@ and override the `owner` kwarg on the factory fixtures.
 - After a `stash` then `pull`, run `git stash pop` if necessary
 - This is useful for keeping the claude local file up-to-date
 - When writing PR descriptions, keep it simple and avoid "selling the feature" in the PR
+- At the end of work, when shipping a draft PR, use the `commit-push-draft` skill
+  (rather than committing, pushing, and opening the draft PR by hand)
 - Use conventional commit prefixes for commit messages and PR titles:
   - `feat:` — new feature or capability
   - `fix:` — bug fix

--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -1088,6 +1088,25 @@ class ContentModAdmin(PolymorphicParentModelAdmin, ContentAdmin):
         ContentModPsykerDisciplineAccess,
     )
     list_filter = (PolymorphicChildModelFilter,)
+    list_display_links = ("mod_description",)
+    # Downcast changelist rows to their real subclass (batched per child model
+    # by django-polymorphic) so each renders its own __str__ instead of the base
+    # "Base Modification". Without this the parent admin marks the queryset
+    # .non_polymorphic() for speed and rows come back as base ContentMod.
+    polymorphic_list = True
+
+    @admin.display(description="Modification")
+    def mod_description(self, obj):
+        # obj is downcast (polymorphic_list = True), so str(obj) renders the
+        # mod's own description, e.g. "Add rule Cunning Killers".
+        return str(obj)
+
+    def get_list_display(self, request):
+        # ContentAdmin.__init__ builds list_display from the base model's
+        # fields, which for the polymorphic parent is just ``polymorphic_ctype``
+        # — an unhelpful "Content | Fighter Rule Modifier" label. Lead with the
+        # rendered mod instead, keeping the type and packs columns alongside.
+        return ("mod_description", "polymorphic_ctype", "packs_display")
 
 
 @admin.register(ContentModApplication)

--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -1105,8 +1105,12 @@ class ContentModAdmin(PolymorphicParentModelAdmin, ContentAdmin):
         # ContentAdmin.__init__ builds list_display from the base model's
         # fields, which for the polymorphic parent is just ``polymorphic_ctype``
         # — an unhelpful "Content | Fighter Rule Modifier" label. Lead with the
-        # rendered mod instead, keeping the type and packs columns alongside.
-        return ("mod_description", "polymorphic_ctype", "packs_display")
+        # rendered mod instead, keeping the type column alongside.
+        #
+        # ContentAdmin also appends ``packs_display``, but a ContentMod is never
+        # a CustomContentPackItem (mods attach via M2M / ContentModApplication),
+        # so it would always render "-" while costing a query per row. Drop it.
+        return ("mod_description", "polymorphic_ctype")
 
 
 @admin.register(ContentModApplication)

--- a/gyrinx/content/tests/test_admin_actions.py
+++ b/gyrinx/content/tests/test_admin_actions.py
@@ -588,13 +588,15 @@ def test_contentmod_changelist_renders_mod_string(client, admin_user):
     whose ``__str__`` is "Base Modification". ``polymorphic_list = True`` on the
     admin re-enables downcasting so each row renders its own subclass string.
     """
+    from django.urls import reverse
+
     from gyrinx.content.models import ContentModFighterStat
 
     ContentModFighterStat.objects.create(stat="movement", mode="improve", value="1")
     ContentModFighterStat.objects.create(stat="movement", mode="worsen", value="2")
 
     client.force_login(admin_user)
-    resp = client.get("/admin/content/contentmod/")
+    resp = client.get(reverse("admin:content_contentmod_changelist"))
     assert resp.status_code == 200
 
     html = resp.content.decode()

--- a/gyrinx/content/tests/test_admin_actions.py
+++ b/gyrinx/content/tests/test_admin_actions.py
@@ -576,3 +576,30 @@ def test_copy_selected_to_house_multiple_fighters(
 
     # Total fighters increased by 2
     assert ContentFighter.objects.count() == initial_fighter_count + 2
+
+
+@pytest.mark.django_db
+def test_contentmod_changelist_renders_mod_string(client, admin_user):
+    """The Modifications changelist should show each mod's rendered
+    description rather than the polymorphic ctype / base "Base Modification".
+
+    The polymorphic parent admin marks the changelist queryset
+    ``.non_polymorphic()`` for speed, which returns base ``ContentMod`` rows
+    whose ``__str__`` is "Base Modification". ``polymorphic_list = True`` on the
+    admin re-enables downcasting so each row renders its own subclass string.
+    """
+    from gyrinx.content.models import ContentModFighterStat
+
+    ContentModFighterStat.objects.create(stat="movement", mode="improve", value="1")
+    ContentModFighterStat.objects.create(stat="movement", mode="worsen", value="2")
+
+    client.force_login(admin_user)
+    resp = client.get("/admin/content/contentmod/")
+    assert resp.status_code == 200
+
+    html = resp.content.decode()
+    # Real subclass descriptions are shown...
+    assert "Improve fighter" in html
+    assert "Worsen fighter" in html
+    # ...and the un-downcast base description is not.
+    assert "Base Modification" not in html


### PR DESCRIPTION
## What

The Modifications admin changelist listed each mod by its polymorphic content type (e.g. "Content | Fighter Rule Modifier"), which tells you nothing about what the mod actually does.

Now the list leads with a **Modification** column showing each mod's rendered description — "Add rule Cunning Killers", "Improve fighter Leadership by 1", "Remove from Primary – Tech", etc. — which is also the clickable link to the change form. The polymorphic content-type stays alongside as a secondary type label.

## Why it was showing the ctype

`ContentModAdmin` is a `PolymorphicParentModelAdmin`. For performance, the polymorphic parent admin marks the changelist queryset `.non_polymorphic()`, so rows come back as base `ContentMod` instances whose `__str__` is `"Base Modification"`. `ContentAdmin.__init__` then builds `list_display` purely from the base model's fields, which for the polymorphic parent is just `polymorphic_ctype` — hence the ctype label was the only useful column.

## Fix

- `polymorphic_list = True` — re-enables downcasting so each row becomes its real subclass and renders its own `__str__`. django-polymorphic batches this per child model, so it's a handful of extra queries, not N+1.
- `get_list_display` / `mod_description` — a `Modification` column that renders the mod string, set as the `list_display_links` target.
- Dropped `packs_display` from the mod changelist. `ContentAdmin` appends it to every content admin, but a `ContentMod` is never a `CustomContentPackItem` — mods attach via M2M and are pack-scoped through `ContentModApplication` — so the column always rendered "-" while costing a query per row.

The change form already rendered the `__str__` fine; this only affects the changelist.

## Test

`test_contentmod_changelist_renders_mod_string` renders the changelist as a superuser and asserts the real subclass descriptions appear and `"Base Modification"` does not.

## How to try it

Visit `/admin/content/contentmod/` — the first column now reads e.g. "Add rule Cunning Killers" instead of "Content | Fighter Rule Modifier".
