### PR TITLE
feat: acquisitions write pins; clone carries them (#1826 Phase 7)

### DIFF
--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -60,6 +60,9 @@ def handle_equipment_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -78,6 +81,9 @@ def handle_fighter_base_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "base_cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -96,6 +102,9 @@ def handle_profile_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -127,6 +136,9 @@ def handle_accessory_cost_change(sender, instance, **kwargs):
 
     if changed:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -145,6 +157,9 @@ def handle_upgrade_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -167,6 +182,9 @@ def handle_equipment_list_item_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -189,6 +207,9 @@ def handle_equipment_list_accessory_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -211,6 +232,9 @@ def handle_equipment_list_upgrade_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -233,6 +257,9 @@ def handle_fighter_house_override_cost_change(sender, instance, **kwargs):
     new_cost = get_new_cost(instance, "cost")
     if old_cost != new_cost:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -263,6 +290,9 @@ def handle_expansion_item_cost_change(sender, instance, **kwargs):
 
     if changed:
         instance._cost_changed = True  # Flag for post_save to create actions
+        # The pre-change value rides to the async task: amount-snapshot
+        # (DERIVED) receipts are maintained by delta, which needs it.
+        instance._old_cost_for_propagation = old_cost
         instance.set_dirty()
 
 
@@ -476,7 +506,7 @@ def _instance_display_name(instance) -> str:
     return str(instance)
 
 
-def _create_content_cost_change_actions(instance, before_snapshots=None):
+def _create_content_cost_change_actions(instance, before_snapshots=None, old_cost=None):
     """
     Create CONTENT_COST_CHANGE actions for all lists affected by a content cost change.
 
@@ -526,7 +556,9 @@ def _create_content_cost_change_actions(instance, before_snapshots=None):
                 # view recalc — must sum already-updated amounts. Rewriting
                 # after would snap the caches back to the old amounts or
                 # double-count the correction on the next recompute.
-                sweep = rewrite_pinned_amounts_for_list(instance, lst)
+                sweep = rewrite_pinned_amounts_for_list(
+                    instance, lst, old_cost=old_cost
+                )
 
                 # Only create actions for lists that have an initial action
                 # Lists without latest_action will have dirty flag set via set_dirty()
@@ -693,6 +725,7 @@ def _enqueue_content_cost_propagation(instance):
 
     content_type_id = ContentType.objects.get_for_model(instance.__class__).id
     object_id = str(instance.pk)
+    old_cost = getattr(instance, "_old_cost_for_propagation", None)
 
     # Capture pre-change cost baselines synchronously (pre-commit). pre_save has
     # marked these lists dirty but has not recalculated them, so rating_current /
@@ -705,6 +738,7 @@ def _enqueue_content_cost_propagation(instance):
                 content_type_id=content_type_id,
                 object_id=object_id,
                 before_snapshots=before_snapshots,
+                old_cost=old_cost,
             )
         except Exception:
             logger.exception(

--- a/gyrinx/core/cost/balance_sheet.py
+++ b/gyrinx/core/cost/balance_sheet.py
@@ -38,11 +38,23 @@ KIND_PROFILES = "profiles"
 KIND_ACCESSORIES = "accessories"
 KIND_UPGRADES = "upgrades"
 
-# Pricing provenance. "pinned" arrives with the pin schema; present from day
-# one so downstream consumers don't need a shape change later.
+# Pricing provenance per component line. "pinned" means the amount comes from
+# an acquisition receipt (#1826); "mixed" marks an aggregate line whose rows
+# are only partially pinned (the pre-backfill state).
 PRICING_LIVE = "live"
 PRICING_USER_OVERRIDE = "user_override"
 PRICING_PINNED = "pinned"
+PRICING_MIXED = "mixed"
+
+
+def _rows_pricing(rows) -> str:
+    """Classify an aggregate component line by its through-rows' pins."""
+    pinned = [r.pinned_amount is not None for r in rows]
+    if not pinned or not any(pinned):
+        return PRICING_LIVE
+    if all(pinned):
+        return PRICING_PINNED
+    return PRICING_MIXED
 
 
 @dataclass(frozen=True)
@@ -274,21 +286,36 @@ def _assignment_balance(virtual) -> AssignmentBalance:
     assignment = virtual._assignment
     override = assignment.total_cost_override
 
+    if assignment.cost_override is not None:
+        base_pricing, base_detail = PRICING_USER_OVERRIDE, ""
+    elif assignment.pinned_base_amount is not None:
+        base_pricing = PRICING_PINNED
+        base_detail = assignment.pinned_base_state
+    else:
+        base_pricing, base_detail = PRICING_LIVE, ""
+
     lines = (
         ComponentLine(
             KIND_BASE,
             assignment.base_cost_int(),
-            PRICING_USER_OVERRIDE
-            if assignment.cost_override is not None
-            else PRICING_LIVE,
+            base_pricing,
+            base_detail,
         ),
         ComponentLine(
-            KIND_PROFILES, assignment.weapon_profiles_cost_int(), PRICING_LIVE
+            KIND_PROFILES,
+            assignment.weapon_profiles_cost_int(),
+            _rows_pricing(assignment.profile_rows.all()),
         ),
         ComponentLine(
-            KIND_ACCESSORIES, assignment.weapon_accessories_cost_int(), PRICING_LIVE
+            KIND_ACCESSORIES,
+            assignment.weapon_accessories_cost_int(),
+            _rows_pricing(assignment.accessory_rows.all()),
         ),
-        ComponentLine(KIND_UPGRADES, assignment.upgrade_cost_int(), PRICING_LIVE),
+        ComponentLine(
+            KIND_UPGRADES,
+            assignment.upgrade_cost_int(),
+            _rows_pricing(assignment.upgrade_rows.all()),
+        ),
     )
 
     if override is not None:

--- a/gyrinx/core/cost/pin_sweep.py
+++ b/gyrinx/core/cost/pin_sweep.py
@@ -69,18 +69,29 @@ class PinSweep:
         return self.rating_delta + self.stash_delta
 
 
-def rewrite_pinned_amounts_for_list(instance, lst) -> PinSweep:
+def rewrite_pinned_amounts_for_list(instance, lst, old_cost=None) -> PinSweep:
     """Rewrite pinned amounts on ``lst`` affected by a change to ``instance``.
+
+    ``old_cost`` is the source's pre-change value (captured by the pre_save
+    handler and carried through the task payload). Amount-snapshot DERIVED
+    rows — SINGLE-stack cumulative pins — can only be maintained by DELTA
+    (new − old applied to the receipt): re-deriving them from current
+    catalog values would silently destroy acquisition-time discounts on
+    rungs that were never corrected. Without ``old_cost`` those rows are
+    left untouched and the list is flagged has_masked (snapshot fallback).
 
     Returns a PinSweep carrying the per-row deltas and whether the caller
     can use them as the audit delta (`use_row_deltas`) or must fall back to
-    the snapshot-vs-recompute computation (UNPINNED rows present, or a
-    source model pins don't apply to).
+    the snapshot-vs-recompute computation (UNPINNED rows present, masked
+    rows, or a source model pins don't apply to).
     """
     handler = _SWEEP_HANDLERS.get(type(instance).__name__)
     if handler is None:
         return PinSweep()
-    sweep = handler(instance, lst)
+    if handler in _NEEDS_OLD_COST:
+        sweep = handler(instance, lst, old_cost)
+    else:
+        sweep = handler(instance, lst)
     if sweep.touched_assignments:
         # Sweeps do two jobs: rewrite amounts, THEN mark dirty (§4.7). The
         # enqueue-time set_dirty is not enough — an action landing in the
@@ -379,8 +390,50 @@ def _sweep_weapon_accessory(instance, lst):
     return sweep
 
 
-def _sweep_upgrade(instance, lst):
-    from gyrinx.content.models import ContentEquipment
+def _single_stack_delta_rewrite(
+    lst, sweep, stack_upgrade_ids, delta, masked_fighter_ids
+):
+    """Apply a rung correction to SINGLE-stack DERIVED receipts BY DELTA.
+
+    Amount-snapshot receipts (Phase 7 pins the override-inclusive cumulative
+    walk) can't be re-derived from catalog values without destroying
+    acquisition discounts on uncorrected rungs — the correction moves the
+    receipt by exactly what the corrected contribution moved, nothing else.
+    ``masked_fighter_ids``: holders for whom the corrected contribution is
+    masked (e.g. a per-rung override hides its catalog price) keep their
+    receipt untouched. Moved rows are best-effort: the mask is evaluated
+    against the CURRENT holder (the receipt doesn't record acquisition-time
+    per-rung state — the documented v1 amount-snapshot imprecision; per-rung
+    provenance is the escalation if it bites).
+    """
+    if delta == 0:
+        return
+
+    def new_amount(row):
+        fighter = row.listfighterequipmentassignment.list_fighter
+        if (
+            fighter.content_fighter_id in masked_fighter_ids
+            or fighter.legacy_content_fighter_id in masked_fighter_ids
+        ):
+            return None  # masked for this holder: receipt stands
+        return row.pinned_amount + delta
+
+    _rewrite_through_rows(
+        ListFighterEquipmentAssignmentUpgrade,
+        _upgrade_rows(lst).filter(
+            contentequipmentupgrade__in=stack_upgrade_ids,
+            pin_state=PinState.DERIVED,
+        ),
+        new_amount,
+        sweep,
+    )
+
+
+def _sweep_upgrade(instance, lst, old_cost=None):
+    from gyrinx.content.models import (
+        ContentEquipment,
+        ContentFighterEquipmentListUpgrade,
+    )
 
     sweep = PinSweep(pin_capable=True)
     if instance.equipment.upgrade_mode == ContentEquipment.UpgradeMode.MULTI:
@@ -395,36 +448,38 @@ def _sweep_upgrade(instance, lst):
         )
         affected_upgrade_ids = [instance.pk]
     else:
-        # SINGLE stacks price cumulatively: correcting one rung reprices
-        # every row holding that rung or a higher one. Those rows are
-        # DERIVED (their amount is a sum, not a copy) and re-derive via
-        # cost_int(), which reads the committed new rung cost. The map is
-        # list-independent, so memoize it on the instance — the task calls
-        # this once per affected list.
-        #
-        # KNOWN IMPRECISION (Phase 7 decides): cost_int() is the raw catalog
-        # sum, but live resolution applies per-rung CFELU overrides inside
-        # the cumulative walk. A rung correction on an override-discounted
-        # stack re-derives to the catalog total, not the override-inclusive
-        # one. What a MOVED cumulative row should re-derive to is a producer
-        # -semantics question — settle it when Phase 7 defines what SINGLE
-        # +override acquisitions pin.
-        cumulative = getattr(instance, "_pin_sweep_cumulative", None)
-        if cumulative is None:
-            cumulative = {
-                u.pk: u.cost_int() for u in instance.same_stack_from_position()
-            }
-            instance._pin_sweep_cumulative = cumulative
-        _rewrite_through_rows(
-            ListFighterEquipmentAssignmentUpgrade,
-            _upgrade_rows(lst).filter(
-                contentequipmentupgrade__in=list(cumulative),
-                pin_state=PinState.DERIVED,
-            ),
-            lambda r: cumulative[r.contentequipmentupgrade_id],
-            sweep,
-        )
-        affected_upgrade_ids = list(cumulative)
+        # SINGLE stacks price cumulatively: a rung's catalog correction
+        # moves every DERIVED receipt holding that rung or a higher one by
+        # the rung's own delta — except for holders whose per-rung override
+        # masks the catalog price entirely.
+        stack_ids = [u.pk for u in instance.same_stack_from_position()]
+        if old_cost is None:
+            # No pre-change value (direct caller outside the task path):
+            # the delta is unknowable, so leave the receipts and flag the
+            # snapshot fallback rather than guess.
+            if (
+                _upgrade_rows(lst)
+                .filter(
+                    contentequipmentupgrade__in=stack_ids,
+                    pin_state=PinState.DERIVED,
+                )
+                .exists()
+            ):
+                sweep.has_masked = True
+        else:
+            masked_fighter_ids = set(
+                ContentFighterEquipmentListUpgrade.objects.filter(
+                    upgrade=instance
+                ).values_list("fighter_id", flat=True)
+            )
+            _single_stack_delta_rewrite(
+                lst,
+                sweep,
+                stack_ids,
+                get_new_cost(instance, "cost") - old_cost,
+                masked_fighter_ids,
+            )
+        affected_upgrade_ids = stack_ids
     sweep.has_unpinned = (
         sweep.has_unpinned
         or _live_through(
@@ -525,11 +580,11 @@ def _sweep_equipment_list_accessory(instance, lst):
     return sweep
 
 
-def _sweep_equipment_list_upgrade(instance, lst):
+def _sweep_equipment_list_upgrade(instance, lst, old_cost=None):
+    from gyrinx.content.models import ContentEquipment
+
     sweep = PinSweep(pin_capable=True)
-    # Provisional flat semantics: what Phase 7 pins for a SINGLE-stack rung
-    # priced through this override defines the cumulative story; until a
-    # producer writes such pins, SOURCE rows copy the override cost.
+    # MULTI-mode pins are SOURCE rows carrying this override's FK: flat copy.
     new = instance.cost
     _rewrite_through_rows(
         ListFighterEquipmentAssignmentUpgrade,
@@ -539,6 +594,33 @@ def _sweep_equipment_list_upgrade(instance, lst):
         lambda r: new,
         sweep,
     )
+    # SINGLE-mode pins are DERIVED amount-snapshots with no FK — this
+    # override's contribution is folded into the cumulative receipt of every
+    # holder who uses it, on this rung or any higher one. Corrections reach
+    # them BY DELTA, scoped to holders in this override's fighter context
+    # (a moved row's new holder doesn't use the override — the documented
+    # v1 amount-snapshot imprecision).
+    if instance.upgrade.equipment.upgrade_mode == ContentEquipment.UpgradeMode.SINGLE:
+        stack_ids = [u.pk for u in instance.upgrade.same_stack_from_position()]
+        derived_rows = _upgrade_rows(lst).filter(
+            _holder_context_q(
+                instance.fighter, prefix="listfighterequipmentassignment__"
+            ),
+            contentequipmentupgrade__in=stack_ids,
+            pin_state=PinState.DERIVED,
+        )
+        if old_cost is None:
+            if derived_rows.exists():
+                sweep.has_masked = True  # delta unknowable outside the task path
+        else:
+            delta = instance.cost - old_cost
+            if delta:
+                _rewrite_through_rows(
+                    ListFighterEquipmentAssignmentUpgrade,
+                    derived_rows,
+                    lambda r: r.pinned_amount + delta,
+                    sweep,
+                )
     sweep.has_unpinned = (
         sweep.has_unpinned
         or (
@@ -619,6 +701,10 @@ def _sweep_expansion_item(instance, lst):
     return sweep
 
 
+# Handlers whose amount-snapshot (DERIVED) rewrites need the source's
+# pre-change value to apply corrections by delta.
+_NEEDS_OLD_COST = None  # set below, after the handler definitions
+
 _SWEEP_HANDLERS = {
     "ContentEquipment": _sweep_equipment,
     "ContentWeaponProfile": _sweep_weapon_profile,
@@ -629,3 +715,5 @@ _SWEEP_HANDLERS = {
     "ContentFighterEquipmentListUpgrade": _sweep_equipment_list_upgrade,
     "ContentEquipmentListExpansionItem": _sweep_expansion_item,
 }
+
+_NEEDS_OLD_COST = {_sweep_upgrade, _sweep_equipment_list_upgrade}

--- a/gyrinx/core/cost/pinning.py
+++ b/gyrinx/core/cost/pinning.py
@@ -1,0 +1,245 @@
+"""The resolve-and-pin choke point (#1826 Phase 7, §4.6).
+
+Every acquisition path calls `pin_assignment()` after the assignment and its
+component rows exist. It runs the same lookups live resolution uses — in the
+same precedence order — and writes the acquisition receipt on each row:
+the amount paid, the price-setting source it came from (as an FK, when there
+is one), and the pin state that classifies it:
+
+- expansion item priced it        → SOURCE, FK to the expansion item
+- equipment-list row priced it    → SOURCE, FK to that row
+- catalog priced it               → CATALOG, no FK (the row's own content FK
+                                    is the attribution)
+- the amount is computed, not
+  looked up (formula accessories,
+  cumulative SINGLE-stack rungs)  → DERIVED, evaluated amount, no FK
+
+Rows the §4.2 anchors outrank are deliberately left UNPINNED: a user base
+override, linked-child gear (structurally free), and default-kit components
+(free by membership). A pin on those could never be read, and the CI guard's
+allowlist names their creation paths as zero-anchored.
+
+Idempotent by design: only UNPINNED rows are written, an existing receipt is
+never overwritten — re-pinning would replace the acquisition price with
+today's. That makes the choke point safe to call from any layer (view AND
+handler double-calling is a no-op) and makes each call on a legacy
+assignment a value-neutral early instalment of the Phase 8 backfill: pinning
+at the current live price is exactly what resolution already returns.
+
+Writes use queryset .update() (no signals, no history churn), matching the
+sweep's write semantics (core/cost/pin_sweep.py).
+"""
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentListExpansion,
+    ContentFighterEquipmentListItem,
+    ContentFighterEquipmentListUpgrade,
+    ContentFighterEquipmentListWeaponAccessory,
+    ExpansionRuleInputs,
+)
+from gyrinx.content.signals import get_new_cost
+from gyrinx.core.models.list import (
+    ListFighterEquipmentAssignment,
+    PinState,
+)
+
+
+def pin_assignment(assignment) -> int:
+    """Write acquisition receipts on an assignment and its component rows.
+
+    Accepts any instance (possibly stale or carrying cached cost properties);
+    works on a fresh refetch so live resolution sees true pre-pin state.
+    Returns the number of rows pinned (0 when everything was already pinned
+    or anchored) — callers don't need it, but tests do.
+    """
+    fresh = ListFighterEquipmentAssignment.objects.with_related_data().get(
+        pk=assignment.pk
+    )
+    pinned = 0
+
+    # --- Base -----------------------------------------------------------
+    # base_for_expression must match what resolution's expression branch
+    # reads (base_cost_int): the pinned amount when we write one, the
+    # override/anchor value when we skip.
+    base_for_expression = fresh.base_cost_int()
+    if (
+        fresh.pinned_base_amount is None
+        and fresh.cost_override is None
+        and fresh.linked_equipment_parent_id is None
+    ):
+        expansion_item = _expansion_item(fresh, weapon_profile=None)
+        if expansion_item is not None:
+            amount = expansion_item.cost
+            fields = {
+                "pinned_base_amount": amount,
+                "pinned_base_state": PinState.SOURCE,
+                "pinned_expansion_item": expansion_item,
+            }
+        else:
+            list_item = _equipment_list_item(fresh, weapon_profile=None)
+            if list_item is not None:
+                amount = list_item.cost_int()
+                fields = {
+                    "pinned_base_amount": amount,
+                    "pinned_base_state": PinState.SOURCE,
+                    "pinned_equipment_list_item": list_item,
+                }
+            else:
+                amount = get_new_cost(fresh.content_equipment, "cost")
+                fields = {
+                    "pinned_base_amount": amount,
+                    "pinned_base_state": PinState.CATALOG,
+                }
+        ListFighterEquipmentAssignment.objects.filter(pk=fresh.pk).update(**fields)
+        base_for_expression = amount
+        pinned += 1
+
+    default = fresh.from_default_assignment
+
+    # --- Profiles ---------------------------------------------------------
+    for row in fresh.profile_rows.all():
+        if row.pinned_amount is not None:
+            continue
+        profile = row.contentweaponprofile
+        if default and default.weapon_profiles_field.contains(profile):
+            continue  # default-kit profile: structurally free, stays unpinned
+        expansion_item = _expansion_item(fresh, weapon_profile=profile)
+        if expansion_item is not None:
+            fields = {
+                "pinned_amount": expansion_item.cost,
+                "pin_state": PinState.SOURCE,
+                "pinned_expansion_item": expansion_item,
+            }
+        else:
+            list_item = _equipment_list_item(fresh, weapon_profile=profile)
+            if list_item is not None:
+                fields = {
+                    "pinned_amount": list_item.cost_int(),
+                    "pin_state": PinState.SOURCE,
+                    "pinned_equipment_list_item": list_item,
+                }
+            else:
+                fields = {
+                    "pinned_amount": get_new_cost(profile, "cost"),
+                    "pin_state": PinState.CATALOG,
+                }
+        type(row).objects.filter(pk=row.pk).update(**fields)
+        pinned += 1
+
+    # --- Accessories --------------------------------------------------------
+    for row in fresh.accessory_rows.all():
+        if row.pinned_amount is not None:
+            continue
+        accessory = row.contentweaponaccessory
+        if default and default.weapon_accessories_field.contains(accessory):
+            continue  # default-kit accessory: free by membership
+        if accessory.cost_expression:
+            fields = {
+                "pinned_amount": accessory.calculate_cost_for_weapon(
+                    base_for_expression
+                ),
+                "pin_state": PinState.DERIVED,
+            }
+        else:
+            override = _preferred_override(
+                ContentFighterEquipmentListWeaponAccessory.objects.filter(
+                    fighter__in=fresh.list_fighter.equipment_list_fighters,
+                    weapon_accessory=accessory,
+                ),
+                fresh.list_fighter,
+            )
+            if override is not None:
+                fields = {
+                    "pinned_amount": override.cost_int(),
+                    "pin_state": PinState.SOURCE,
+                    "pinned_equipment_list_accessory": override,
+                }
+            else:
+                fields = {
+                    "pinned_amount": get_new_cost(accessory, "cost"),
+                    "pin_state": PinState.CATALOG,
+                }
+        type(row).objects.filter(pk=row.pk).update(**fields)
+        pinned += 1
+
+    # --- Upgrades -------------------------------------------------------
+    for row in fresh.upgrade_rows.all():
+        if row.pinned_amount is not None:
+            continue
+        upgrade = row.contentequipmentupgrade
+        if upgrade.equipment.upgrade_mode == ContentEquipment.UpgradeMode.SINGLE:
+            # Cumulative stacks pin the whole override-inclusive rung walk
+            # at acquisition; the amount is a sum, so the state is DERIVED
+            # and sweeps re-derive it rather than copying any single source.
+            fields = {
+                "pinned_amount": fresh._upgrade_cost_with_override(upgrade),
+                "pin_state": PinState.DERIVED,
+            }
+        else:
+            override = _preferred_override(
+                ContentFighterEquipmentListUpgrade.objects.filter(
+                    fighter__in=fresh.list_fighter.equipment_list_fighters,
+                    upgrade=upgrade,
+                ),
+                fresh.list_fighter,
+            )
+            if override is not None:
+                fields = {
+                    "pinned_amount": override.cost_int(),
+                    "pin_state": PinState.SOURCE,
+                    "pinned_equipment_list_upgrade": override,
+                }
+            else:
+                fields = {
+                    "pinned_amount": upgrade.cost,
+                    "pin_state": PinState.CATALOG,
+                }
+        type(row).objects.filter(pk=row.pk).update(**fields)
+        pinned += 1
+
+    return pinned
+
+
+# --- Provenance lookups (mirror resolution precedence exactly) ---------------
+
+
+def _expansion_item(assignment, weapon_profile):
+    """The applicable expansion item pricing this equipment/profile, if any.
+
+    Mirrors _get_expansion_cost_override (assignment.py): first applicable
+    item with a non-null cost wins — but returns the ITEM, which is the
+    receipt's attribution FK.
+    """
+    items = ContentEquipmentListExpansion.get_applicable_expansion_items_for_equipment(
+        ExpansionRuleInputs(
+            list=assignment.list_fighter.list, fighter=assignment.list_fighter
+        ),
+        assignment.content_equipment,
+        weapon_profile,
+        cost__isnull=False,
+    )
+    return items[0] if items else None
+
+
+def _equipment_list_item(assignment, weapon_profile):
+    """The equipment-list row pricing this equipment/profile, if any."""
+    return _preferred_override(
+        ContentFighterEquipmentListItem.objects.filter(
+            fighter__in=assignment.list_fighter.equipment_list_fighters,
+            equipment=assignment.content_equipment,
+            weapon_profile=weapon_profile,
+        ),
+        assignment.list_fighter,
+    )
+
+
+def _preferred_override(qs, list_fighter):
+    """First override, preferring the legacy fighter's row when both exist —
+    the same tie-break live resolution applies."""
+    rows = list(qs)
+    if len(rows) > 1 and list_fighter.legacy_content_fighter:
+        for row in rows:
+            if row.fighter_id == list_fighter.legacy_content_fighter_id:
+                return row
+    return rows[0] if rows else None

--- a/gyrinx/core/cost/pinning.py
+++ b/gyrinx/core/cost/pinning.py
@@ -22,9 +22,16 @@ allowlist names their creation paths as zero-anchored.
 Idempotent by design: only UNPINNED rows are written, an existing receipt is
 never overwritten — re-pinning would replace the acquisition price with
 today's. That makes the choke point safe to call from any layer (view AND
-handler double-calling is a no-op) and makes each call on a legacy
-assignment a value-neutral early instalment of the Phase 8 backfill: pinning
-at the current live price is exactly what resolution already returns.
+handler double-calling is a no-op), and for un-anchored rows makes each call
+on a legacy assignment a value-neutral early instalment of the Phase 8
+backfill: their live resolution already returns the price being pinned.
+
+Assignments with a fixed total (total_cost_override) are skipped entirely:
+the frozen value is what the gang actually paid, so a receipt written at
+today's live prices would record a price that was never paid — and, since
+receipts are never overwritten, it would also block the Phase 8 conversion
+from writing the frozen value into those rows when Phase 9 retires the
+freeze.
 
 Writes use queryset .update() (no signals, no history churn), matching the
 sweep's write semantics (core/cost/pin_sweep.py).
@@ -56,6 +63,10 @@ def pin_assignment(assignment) -> int:
     fresh = ListFighterEquipmentAssignment.objects.with_related_data().get(
         pk=assignment.pk
     )
+    if fresh.total_cost_override is not None:
+        # Frozen gear: the override is the paid price. Leave every row
+        # unpinned for the Phase 8 freeze-conversion to receipt correctly.
+        return 0
     pinned = 0
 
     # --- Base -----------------------------------------------------------

--- a/gyrinx/core/handlers/equipment/purchase.py
+++ b/gyrinx/core/handlers/equipment/purchase.py
@@ -18,6 +18,7 @@ from gyrinx.content.models import (
     VirtualWeaponProfile,
 )
 from gyrinx.core.cost.propagation import Delta, propagate_from_assignment
+from gyrinx.core.cost.pinning import pin_assignment
 from gyrinx.core.handlers.equipment.deltas import component_delta
 from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.campaign import CampaignAction
@@ -106,6 +107,10 @@ def handle_equipment_purchase(
     """
     # Refetch to get the full cost including profiles, accessories, and upgrades
     assignment.refresh_from_db()
+    # Acquisition writes the receipt (#1826 Phase 7): pin the base and every
+    # component at their resolved prices. Value-neutral — the cost_int()
+    # below reads back exactly the amounts just pinned.
+    pin_assignment(assignment)
     total_cost = assignment.cost_int()
 
     # Build these beforehand so we get the credit values right
@@ -236,6 +241,8 @@ def handle_accessory_purchase(
 
     # Add the accessory to the assignment
     assignment.weapon_accessories_field.add(accessory)
+    # Receipt for the new accessory row (#1826 Phase 7); existing pins untouched.
+    pin_assignment(assignment)
 
     description = f"Bought {accessory.name} for {assignment.content_equipment.name} on {fighter.name} ({accessory_cost}¢)"
 
@@ -330,6 +337,8 @@ def handle_weapon_profile_purchase(
 
     # Add the profile to the assignment
     assignment.weapon_profiles_field.add(profile)
+    # Receipt for the new profile row (#1826 Phase 7); existing pins untouched.
+    pin_assignment(assignment)
 
     description = f"Bought {profile.name} for {assignment.content_equipment.name} on {fighter.name} ({profile_cost}¢)"
 
@@ -462,6 +471,9 @@ def handle_equipment_upgrade(
 
     # Update the upgrades
     assignment.upgrades_field.set(new_upgrades)
+    # Receipts for the new upgrade rows (#1826 Phase 7); removed rows took
+    # their pins with them.
+    pin_assignment(assignment)
 
     # Create ListAction to track the upgrade change
     if new_upgrades:

--- a/gyrinx/core/handlers/fighter/vehicle.py
+++ b/gyrinx/core/handlers/fighter/vehicle.py
@@ -15,6 +15,7 @@ from gyrinx.content.models import (
     ContentEquipment,
     ContentFighter,
 )
+from gyrinx.core.cost.pinning import pin_assignment
 from gyrinx.core.cost.propagation import (
     Delta,
     propagate_from_assignment,
@@ -123,6 +124,8 @@ def handle_vehicle_purchase(
         list_fighter=crew,
         content_equipment=vehicle_equipment,
     )
+    # Acquisition writes the receipt (#1826 Phase 7).
+    pin_assignment(assignment)
 
     # Propagate to initialize assignment.rating_current and update crew.rating_current
     propagate_from_assignment(assignment, Delta(delta=vehicle_cost, list=lst))

--- a/gyrinx/core/models/list/advancement.py
+++ b/gyrinx/core/models/list/advancement.py
@@ -247,6 +247,11 @@ class ListFighterAdvancement(AppBase):
                 assignment.upgrades_field.set(
                     self.equipment_assignment.upgrades_field.all()
                 )
+
+                # Acquisition writes the receipt (#1826 Phase 7).
+                from gyrinx.core.cost.pinning import pin_assignment
+
+                pin_assignment(assignment)
                 # Recalculate cached values now that upgrades are added
                 assignment.facts_from_db(update=True)
         elif self.advancement_type == self.ADVANCEMENT_OTHER:

--- a/gyrinx/core/models/list/assignment.py
+++ b/gyrinx/core/models/list/assignment.py
@@ -972,24 +972,54 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
         clone = ListFighterEquipmentAssignment.objects.create(
             list_fighter=list_fighter,
             content_equipment=self.content_equipment,
+            # Cloning is not acquisition (#1826 Phase 7): the receipt travels
+            # with the gear verbatim — amount, attribution, and state — so a
+            # cloned gang (including the campaign-start clone) keeps its
+            # prices instead of silently reverting to live pricing.
+            pinned_base_amount=self.pinned_base_amount,
+            pinned_base_state=self.pinned_base_state,
+            pinned_equipment_list_item_id=self.pinned_equipment_list_item_id,
+            pinned_expansion_item_id=self.pinned_expansion_item_id,
         )
 
         # Preserve from_default_assignment if requested
         if preserve_from_default_assignment and self.from_default_assignment:
             clone.from_default_assignment = self.from_default_assignment
 
-        for profile in self.weapon_profiles_field.all():
-            clone.weapon_profiles_field.add(profile)
+        # Copy components by iterating the through rows, carrying each row's
+        # pin fields via through_defaults. Adding by pk also sidesteps the
+        # pack-filtering default managers entirely (the through models have
+        # no pack scoping), so pack-scoped profiles/upgrades are copied too.
+        for row in self.profile_rows.all():
+            clone.weapon_profiles_field.add(
+                row.contentweaponprofile_id,
+                through_defaults={
+                    "pinned_amount": row.pinned_amount,
+                    "pin_state": row.pin_state,
+                    "pinned_equipment_list_item_id": row.pinned_equipment_list_item_id,
+                    "pinned_expansion_item_id": row.pinned_expansion_item_id,
+                },
+            )
 
-        # Use all_content() so pack-scoped accessories are copied too — the
-        # default M2M manager would silently drop them.
-        for accessory in ContentWeaponAccessory.objects.all_content().filter(
-            weapon_accessories=self
-        ):
-            clone.weapon_accessories_field.add(accessory)
+        for row in self.accessory_rows.all():
+            clone.weapon_accessories_field.add(
+                row.contentweaponaccessory_id,
+                through_defaults={
+                    "pinned_amount": row.pinned_amount,
+                    "pin_state": row.pin_state,
+                    "pinned_equipment_list_accessory_id": row.pinned_equipment_list_accessory_id,
+                },
+            )
 
-        for upgrade in self.upgrades_field.all():
-            clone.upgrades_field.add(upgrade)
+        for row in self.upgrade_rows.all():
+            clone.upgrades_field.add(
+                row.contentequipmentupgrade_id,
+                through_defaults={
+                    "pinned_amount": row.pinned_amount,
+                    "pin_state": row.pin_state,
+                    "pinned_equipment_list_upgrade_id": row.pinned_equipment_list_upgrade_id,
+                },
+            )
 
         if self.cost_override is not None:
             clone.cost_override = self.cost_override

--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -1596,6 +1596,12 @@ class ListFighter(AppBase):
             assign.cost_override = cost_override
 
         assign.save()
+
+        # Acquisition writes the receipt (#1826 Phase 7). Lazy import: the
+        # pinning module imports this models package.
+        from gyrinx.core.cost.pinning import pin_assignment
+
+        pin_assignment(assign)
         return assign
 
     @traced("listfighter_direct_assignments")

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -34,7 +34,10 @@ def refresh_list_facts(list_id: str):
 
 @task
 def propagate_content_cost_change(
-    content_type_id: int, object_id: str, before_snapshots: dict | None = None
+    content_type_id: int,
+    object_id: str,
+    before_snapshots: dict | None = None,
+    old_cost: int | None = None,
 ):
     """Recalculate cached costs and create audit actions for a content cost change.
 
@@ -103,7 +106,9 @@ def propagate_content_cost_change(
         )
         return
 
-    _create_content_cost_change_actions(instance, before_snapshots=before_snapshots)
+    _create_content_cost_change_actions(
+        instance, before_snapshots=before_snapshots, old_cost=old_cost
+    )
 
 
 @task

--- a/gyrinx/core/templates/core/debug/list_balance_sheet.html
+++ b/gyrinx/core/templates/core/debug/list_balance_sheet.html
@@ -149,7 +149,10 @@
                                         {{ line.kind }}
                                         {% if line.detail %}<span class="muted">({{ line.detail }})</span>{% endif %}
                                     </td>
-                                    <td>{{ line.pricing }}</td>
+                                    <td>
+                                        {{ line.pricing }}
+                                        {% if line.detail %}<span class="text-secondary">({{ line.detail }})</span>{% endif %}
+                                    </td>
                                     <td class="num">{{ line.amount }}¢</td>
                                     <td class="num muted">—</td>
                                 </tr>

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -681,17 +681,20 @@ def build_weapon_list(
 def test_matrix_content_price_change_window_is_visible(
     side, user, make_list, content_fighter, make_equipment, make_pack
 ):
-    """Mid-window (sweep done, task not yet run): harness sees the gap.
+    """Mid-window (sweep done, task not yet run), for PINNED gear: stable.
 
-    A content price change marks caches dirty synchronously; the audit action
-    lands later via the async task. Between recompute and task, the action
-    chain legitimately trails the caches — the harness must show that, not
-    hide it. The pack side works identically since the #1930 fix
-    (get_old_cost resolves pack rows via all_content()).
+    Acquisition now writes receipts (Phase 7), so a recompute before the
+    task lands reads the pinned amount — the books hold their value and
+    reconcile cleanly; the correction arrives only WITH the task (which
+    rewrites the amount and books the delta — the full-flow cell below).
+    The pre-Phase-7 behaviour (recompute reveals an un-actioned change)
+    remains real for legacy unpinned rows until the Phase 8 backfill and is
+    pinned by the _legacy variant of this cell.
     """
     lst, fighter, assignment, equipment, _ = build_weapon_list(
         side, user, make_list, content_fighter, make_equipment, make_pack
     )
+    rating_before = fresh(lst).rating_current
     equipment.cost = 25  # was 15
     equipment.save()
 
@@ -699,6 +702,34 @@ def test_matrix_content_price_change_window_is_visible(
     sheet = fresh_sheet(lst)
     assert sheet.dirty_rows
     assert sheet.reconcile() == []
+
+    # A recompute before the task reads the receipt: nothing moves.
+    force_recompute(lst)
+    assert fresh(lst).rating_current == rating_before
+    assert fresh_sheet(lst).reconcile() == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("side", ["catalog", "pack"])
+def test_matrix_content_price_change_window_is_visible_legacy(
+    side, user, make_list, content_fighter, make_equipment, make_pack
+):
+    """Mid-window, for LEGACY (unpinned) rows: harness sees the gap.
+
+    Pre-backfill rows reprice live on recompute, so between recompute and
+    task the action chain legitimately trails the caches — the harness must
+    show that, not hide it. Retires with the Phase 8 backfill.
+    """
+    lst, fighter, assignment, equipment, _ = build_weapon_list(
+        side, user, make_list, content_fighter, make_equipment, make_pack
+    )
+    # Simulate a pre-Phase-7 row: strip the acquisition receipt.
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        pinned_base_amount=None,
+        pinned_base_state=PinState.UNPINNED,
+    )
+    equipment.cost = 25  # was 15
+    equipment.save()
 
     # A recompute before the task lands reveals the un-actioned change.
     force_recompute(lst)
@@ -881,11 +912,6 @@ def _assert_pins_survived(clone, equipment):
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True,
-    reason="Phase 7 (#1826): List.clone() rebuilds assignments without the "
-    "pin columns, so cloned gear silently reverts to live pricing",
-)
 def test_matrix_clone_preserves_pins(user, make_list, content_fighter, make_equipment):
     lst = make_list("Clone Source")
     fighter = hire_fighter(user, lst, content_fighter, name="Bob")
@@ -898,11 +924,6 @@ def test_matrix_clone_preserves_pins(user, make_list, content_fighter, make_equi
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True,
-    reason="Phase 7 (#1826): campaign-start cloning goes through the same "
-    "clone path and drops pins the same way",
-)
 def test_matrix_campaign_start_clone_preserves_pins(
     user, make_list, content_fighter, make_equipment, campaign
 ):
@@ -997,7 +1018,12 @@ def test_matrix_p6_repricing_telemetry_fires(
     gear,
     monkeypatch,
 ):
-    """The cost-changed-on-reassignment telemetry fires with real values."""
+    """Reassigning PINNED gear is price-neutral: no reprice telemetry, the
+    discounted price travels to a holder who would price it at catalog, and
+    the books reconcile. This is the programme's signature outcome arriving
+    for newly-acquired gear (acquisition pins since Phase 7); the legacy
+    variant below keeps the pre-backfill repricing path covered.
+    """
     from gyrinx.core.handlers.equipment import reassignment as reassignment_module
 
     events = []
@@ -1018,6 +1044,60 @@ def test_matrix_p6_repricing_telemetry_fires(
         fighter=cf_a, equipment=equipment, cost=5
     )
     assignment = buy_equipment(user, lst, fighter_a, equipment)
+
+    handle_equipment_reassignment(
+        user=user,
+        lst=fresh(lst),
+        from_fighter=fresh(fighter_a),
+        to_fighter=fresh(fighter_b),
+        assignment=fresh(assignment),
+    )
+
+    reprice_events = [
+        kw for name, kw in events if name == "equipment_cost_changed_on_reassignment"
+    ]
+    assert reprice_events == []
+    assert fresh(assignment).cost_int() == 5  # the receipt travelled
+    assert_reconciles(lst)
+
+
+@pytest.mark.django_db
+def test_matrix_p6_repricing_telemetry_fires_for_legacy_rows(
+    campaign_list,
+    user,
+    make_content_fighter,
+    content_house,
+    content_fighter,
+    gear,
+    monkeypatch,
+):
+    """LEGACY (unpinned) gear still reprices on reassignment, and the
+    telemetry fires with real values. Retires with the Phase 8 backfill."""
+    from gyrinx.core.handlers.equipment import reassignment as reassignment_module
+
+    events = []
+    monkeypatch.setattr(
+        reassignment_module,
+        "track",
+        lambda name, **kw: events.append((name, kw)),
+    )
+
+    lst, stash = campaign_list
+    cf_a = make_content_fighter(
+        type="Scavvy", category="GANGER", house=content_house, base_cost=50
+    )
+    fighter_a = hire_fighter(user, lst, cf_a, name="Alfa")
+    fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
+    equipment = gear.equipment("Lasgun", cost=15)
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=cf_a, equipment=equipment, cost=5
+    )
+    assignment = buy_equipment(user, lst, fighter_a, equipment)
+    # Simulate a pre-Phase-7 row: strip the acquisition receipt.
+    ListFighterEquipmentAssignment.objects.filter(pk=assignment.pk).update(
+        pinned_base_amount=None,
+        pinned_base_state=PinState.UNPINNED,
+    )
 
     handle_equipment_reassignment(
         user=user,

--- a/gyrinx/core/tests/test_pin_guard.py
+++ b/gyrinx/core/tests/test_pin_guard.py
@@ -1,0 +1,119 @@
+"""The acquisition-pinning CI guard (#1826 Phase 7, §4.6).
+
+Every way an equipment assignment (or one of its component through-rows) can
+come into existence must either write acquisition receipts via the
+`pin_assignment` choke point, copy them (clone), or be a named exception.
+A missed path fails SILENTLY in production — it just keeps minting
+receipt-less gear that reprices on movement — so this guard turns "someone
+added an acquisition path and forgot to pin" into a CI failure.
+
+It scans non-test source for the three creation shapes (direct
+instantiation, manager create, component M2M writes) and compares the
+result against the labelled inventory below. If you land here because this
+test failed: either your new call site must call
+`gyrinx.core.cost.pinning.pin_assignment(...)` after the rows exist (then
+record it as PINNED), or it is genuinely one of the exception kinds — argue
+that in review, then record it with the right label.
+
+Labels:
+- PINNED    calls pin_assignment (or is a sub-step of a caller that does)
+- COPIES    clone(): receipts are copied verbatim, not re-resolved
+- ANCHORED  zero-anchored gear (default-kit, linked-child): resolution
+            anchors outrank any pin, nothing to record
+- KILL      the death transfer — becomes the clone-with-pins path in
+            Phase 9, unpinned until then (deliberate, tracked by the P2
+            xfail cells in test_balance_sheet.py)
+- ADMIN     staff write surface; bypasses delta propagation by design, the
+            remediation is the recompute action (permanent exception)
+- CONTENT   same field names on ContentFighterDefaultAssignment (a content
+            model) — not a core assignment at all
+"""
+
+import re
+from pathlib import Path
+
+import gyrinx
+
+PATTERNS = {
+    "instantiate": re.compile(r"(?<!\w)(?<!class )ListFighterEquipmentAssignment\("),
+    "manager-create": re.compile(r"ListFighterEquipmentAssignment\.objects\.create"),
+    "m2m-write": re.compile(
+        r"(weapon_profiles_field|weapon_accessories_field|upgrades_field)\.(add|set)\("
+    ),
+}
+
+# (path, pattern) -> (count, label)
+INVENTORY = {
+    # Main purchase view: form creates, handle_equipment_purchase pins.
+    ("core/views/fighter/equipment.py", "instantiate"): (1, "PINNED"),
+    # Component purchase handlers: each add/set is followed by pin_assignment.
+    ("core/handlers/equipment/purchase.py", "m2m-write"): (3, "PINNED"),
+    # Vehicle purchase: creates then pins.
+    ("core/handlers/fighter/vehicle.py", "manager-create"): (1, "PINNED"),
+    # Equipment advancement: creates + sets upgrades, then pins.
+    ("core/models/list/advancement.py", "manager-create"): (1, "PINNED"),
+    ("core/models/list/advancement.py", "m2m-write"): (1, "PINNED"),
+    # ListFighter.assign(): instantiates + adds components, pins at the end.
+    # (The m2m writes are assign()'s own adds; assign_profile is its
+    # sub-step. The create_with_facts is default-kit materialisation.)
+    ("core/models/list/fighter.py", "instantiate"): (1, "PINNED"),
+    ("core/models/list/fighter.py", "m2m-write"): (1, "PINNED"),
+    ("core/models/list/fighter.py", "manager-create"): (1, "ANCHORED"),
+    # clone(): one create + three through-row copies, receipts carried over.
+    # The fourth m2m write is assign_profile (a sub-step of assign()).
+    ("core/models/list/assignment.py", "manager-create"): (1, "COPIES"),
+    ("core/models/list/assignment.py", "m2m-write"): (4, "COPIES"),
+    # Linked-child creation (post-save signal): structurally free.
+    ("core/models/list/signal_handlers.py", "manager-create"): (1, "ANCHORED"),
+    # Death transfer: unpinned until Phase 9 converts it to clone-with-pins.
+    ("core/handlers/fighter/kill.py", "instantiate"): (1, "KILL"),
+    ("core/handlers/fighter/kill.py", "m2m-write"): (3, "KILL"),
+    # Content-side models sharing the M2M field names.
+    ("content/models/fighter.py", "m2m-write"): (2, "CONTENT"),
+    ("core/views/pack.py", "m2m-write"): (1, "CONTENT"),
+}
+# The admin write surface (core/admin/list.py) creates assignments and
+# through rows via ModelAdmin/inline forms, which none of the source-level
+# patterns above match — its ADMIN exception is enforced by policy (the
+# recompute action is the remediation), not by this scan.
+
+
+def _scan():
+    root = Path(gyrinx.__file__).parent
+    found = {}
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(root).as_posix()
+        if (
+            "/tests/" in f"/{rel}"
+            or "/migrations/" in f"/{rel}"
+            or rel.endswith("conftest.py")
+        ):
+            continue
+        text = path.read_text()
+        for name, rx in PATTERNS.items():
+            n = len(rx.findall(text))
+            if n:
+                found[(rel, name)] = n
+    return found
+
+
+def test_every_assignment_creation_site_is_accounted_for():
+    found = _scan()
+    expected = {key: count for key, (count, _label) in INVENTORY.items()}
+
+    new_sites = {k: v for k, v in found.items() if k not in expected}
+    assert not new_sites, (
+        f"Unrecorded assignment-creation site(s): {new_sites}. "
+        "New acquisition paths must call gyrinx.core.cost.pinning."
+        "pin_assignment(...) after the rows exist — then add the site to "
+        "INVENTORY in this test with the PINNED label (see the module "
+        "docstring for the exception kinds)."
+    )
+
+    gone_or_moved = {k: v for k, v in expected.items() if found.get(k) != v}
+    assert not gone_or_moved, (
+        f"Inventory drift (site moved, removed, or count changed): "
+        f"{ {k: (expected[k], found.get(k)) for k in gone_or_moved} }. "
+        "Re-verify the pinning story for each affected site, then update "
+        "INVENTORY."
+    )

--- a/gyrinx/core/tests/test_pin_guard.py
+++ b/gyrinx/core/tests/test_pin_guard.py
@@ -15,6 +15,10 @@ test failed: either your new call site must call
 record it as PINNED), or it is genuinely one of the exception kinds — argue
 that in review, then record it with the right label.
 
+This is a source-level heuristic: aliased imports, getattr dispatch, or
+string-built model access can slip past it. That is acceptable — it exists
+to catch the ordinary way new code gets written, not adversarial evasion.
+
 Labels:
 - PINNED    calls pin_assignment (or is a sub-step of a caller that does)
 - COPIES    clone(): receipts are copied verbatim, not re-resolved
@@ -36,10 +40,31 @@ import gyrinx
 
 PATTERNS = {
     "instantiate": re.compile(r"(?<!\w)(?<!class )ListFighterEquipmentAssignment\("),
-    "manager-create": re.compile(r"ListFighterEquipmentAssignment\.objects\.create"),
+    "manager-create": re.compile(
+        r"ListFighterEquipmentAssignment\.objects\."
+        r"(create|get_or_create|update_or_create|bulk_create)"
+    ),
+    "reverse-create": re.compile(
+        r"listfighterequipmentassignment_set\."
+        r"(create|get_or_create|update_or_create|bulk_create)"
+    ),
+    "through-create": re.compile(
+        r"ListFighterEquipmentAssignment(Profile|Accessory|Upgrade)\.objects\."
+        r"(create|get_or_create|update_or_create|bulk_create)"
+    ),
     "m2m-write": re.compile(
         r"(weapon_profiles_field|weapon_accessories_field|upgrades_field)\.(add|set)\("
     ),
+}
+
+# PINNED files must actually contain the calls their label claims: deleting
+# a pin_assignment(...) line must fail here, not silently unpin a path.
+PIN_CALL_COUNTS = {
+    "core/cost/pinning.py": 2,  # module docstring + the def itself
+    "core/handlers/equipment/purchase.py": 4,  # equipment/accessory/profile/upgrades
+    "core/handlers/fighter/vehicle.py": 1,
+    "core/models/list/advancement.py": 1,
+    "core/models/list/fighter.py": 1,  # assign()
 }
 
 # (path, pattern) -> (count, label)
@@ -78,18 +103,23 @@ INVENTORY = {
 # recompute action is the remediation), not by this scan.
 
 
-def _scan():
+def _scan(extra_files=None):
+    """Scan non-test source for creation shapes. ``extra_files`` lets the
+    guard's own negative test inject a synthetic bypassing call site."""
     root = Path(gyrinx.__file__).parent
+    sources = {
+        path.relative_to(root).as_posix(): path.read_text()
+        for path in sorted(root.rglob("*.py"))
+    }
+    sources.update(extra_files or {})
     found = {}
-    for path in sorted(root.rglob("*.py")):
-        rel = path.relative_to(root).as_posix()
+    for rel, text in sources.items():
         if (
             "/tests/" in f"/{rel}"
             or "/migrations/" in f"/{rel}"
             or rel.endswith("conftest.py")
         ):
             continue
-        text = path.read_text()
         for name, rx in PATTERNS.items():
             n = len(rx.findall(text))
             if n:
@@ -117,3 +147,44 @@ def test_every_assignment_creation_site_is_accounted_for():
         "Re-verify the pinning story for each affected site, then update "
         "INVENTORY."
     )
+
+
+def test_pinned_files_still_call_the_choke_point():
+    """A PINNED label is a claim: the file wires pin_assignment. Deleting
+    the call must fail here, not silently unpin an acquisition path."""
+    root = Path(gyrinx.__file__).parent
+    for rel, expected in PIN_CALL_COUNTS.items():
+        actual = (root / rel).read_text().count("pin_assignment(")
+        assert actual == expected, (
+            f"{rel}: expected {expected} pin_assignment references, found "
+            f"{actual}. If a call site moved or was removed, re-verify the "
+            "pinning story for every creation site in that file, then "
+            "update PIN_CALL_COUNTS."
+        )
+
+
+def test_guard_detects_synthetic_bypass():
+    """The DoD negative case: a new creation site the inventory doesn't
+    know about must be flagged."""
+    found = _scan(
+        extra_files={
+            "core/rogue.py": (
+                "def rogue(fighter, equipment):\n"
+                "    return ListFighterEquipmentAssignment.objects.create(\n"
+                "        list_fighter=fighter, content_equipment=equipment\n"
+                "    )\n"
+            )
+        }
+    )
+    assert found.get(("core/rogue.py", "manager-create")) == 1
+
+    # The wider creation shapes are matched too.
+    for snippet, pattern in [
+        ("ListFighterEquipmentAssignment.objects.get_or_create(", "manager-create"),
+        ("fighter.listfighterequipmentassignment_set.create(", "reverse-create"),
+        (
+            "ListFighterEquipmentAssignmentProfile.objects.bulk_create(",
+            "through-create",
+        ),
+    ]:
+        assert PATTERNS[pattern].search(snippet), (pattern, snippet)

--- a/gyrinx/core/tests/test_pin_sweeps.py
+++ b/gyrinx/core/tests/test_pin_sweeps.py
@@ -529,8 +529,8 @@ def test_single_stack_lower_rung_correction_rederives_higher_rung(sweep_ctx):
     assert fresh(assignment).dirty is True
     assert ctx["lst"].id in _affected_list_ids(rung0)
 
-    # ...and its cumulative amount re-derives: 20 + 20.
-    _create_content_cost_change_actions(rung0)
+    # ...and its cumulative receipt moves by the rung's delta: 30 + 10.
+    _create_content_cost_change_actions(rung0, old_cost=10)
     row = assignment.upgrade_rows.get()
     assert (row.pinned_amount, row.pin_state) == (40, PinState.DERIVED)
 
@@ -1068,3 +1068,101 @@ def test_cancelling_rating_and_stash_deltas_still_book(campaign_sweep_ctx):
         -2,
         0,
     )
+
+
+# --- SINGLE-stack receipts: corrections apply BY DELTA --------------------------
+
+
+@pytest.fixture
+def single_stack_ctx(campaign_sweep_ctx):
+    """A REAL cumulative-stack receipt: rung 0 discounted by a per-rung
+    override (10 -> 6 for the holder's fighter type), the holder owns rung 1
+    (catalog 20), so acquisition pins the override-inclusive walk: 26."""
+    from gyrinx.core.cost.pinning import pin_assignment
+
+    ctx = campaign_sweep_ctx
+    holder_cf = ctx["assignment"].list_fighter.content_fighter
+    rung0 = ContentEquipmentUpgrade.objects.create(
+        equipment=ctx["equipment"], name="Rung 0", position=0, cost=10
+    )
+    override = ContentFighterEquipmentListUpgrade.objects.create(
+        fighter=holder_cf, upgrade=rung0, cost=6
+    )
+    rung1 = ContentEquipmentUpgrade.objects.create(
+        equipment=ctx["equipment"], name="Rung 1", position=1, cost=20
+    )
+    ctx["assignment"].upgrades_field.add(rung1)
+    pin_assignment(ctx["assignment"])
+    row = ctx["assignment"].upgrade_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (26, PinState.DERIVED)
+    ctx.update(rung0=rung0, rung1=rung1, override=override)
+    return ctx
+
+
+@pytest.mark.django_db
+def test_single_stack_catalog_correction_moves_receipt_by_delta(single_stack_ctx):
+    """Correcting rung 1's catalog price (+5) moves the receipt by exactly
+    +5 — it must NOT re-derive to the raw catalog sum, which would destroy
+    the acquisition discount on rung 0 and overbook the change."""
+    ctx = single_stack_ctx
+    ctx["rung1"].cost = 25
+    ctx["rung1"].save()
+    _create_content_cost_change_actions(ctx["rung1"], old_cost=20)
+
+    row = ctx["assignment"].upgrade_rows.get()
+    assert row.pinned_amount == 31  # 26 + 5, NOT 35 (10 + 25)
+    action = ListAction.objects.get(
+        list=ctx["lst"],
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=ctx["rung1"].pk,
+    )
+    assert (action.rating_delta, action.credits_delta) == (5, -5)
+
+
+@pytest.mark.django_db
+def test_single_stack_masked_rung_correction_leaves_receipt(single_stack_ctx):
+    """Correcting the CATALOG price of a rung the holder's override masks
+    changes nothing they pay: the receipt stands and nothing is booked."""
+    ctx = single_stack_ctx
+    ctx["rung0"].cost = 12
+    ctx["rung0"].save()
+    _create_content_cost_change_actions(ctx["rung0"], old_cost=10)
+
+    assert ctx["assignment"].upgrade_rows.get().pinned_amount == 26
+    assert not ListAction.objects.filter(
+        list=ctx["lst"],
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=ctx["rung0"].pk,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_single_stack_override_correction_reaches_receipt_by_delta(single_stack_ctx):
+    """Correcting the per-rung override (6 -> 8) reaches the DERIVED receipt
+    it priced — previously invisible to sweeps (no FK on amount-snapshots)."""
+    ctx = single_stack_ctx
+    ctx["override"].cost = 8
+    ctx["override"].save()
+    _create_content_cost_change_actions(ctx["override"], old_cost=6)
+
+    assert ctx["assignment"].upgrade_rows.get().pinned_amount == 28  # 26 + 2
+    action = ListAction.objects.get(
+        list=ctx["lst"],
+        action_type=ListActionType.CONTENT_COST_CHANGE,
+        subject_id=ctx["override"].pk,
+    )
+    assert (action.rating_delta, action.credits_delta) == (2, -2)
+
+
+@pytest.mark.django_db
+def test_single_stack_without_old_cost_masks_instead_of_guessing(single_stack_ctx):
+    """A direct sweep call with no pre-change value cannot compute the
+    delta: the receipt stands and the list flags the snapshot fallback."""
+    ctx = single_stack_ctx
+    ctx["rung1"].cost = 25
+    ctx["rung1"].save()
+    sweep = rewrite_pinned_amounts_for_list(ctx["rung1"], ctx["lst"])
+
+    assert sweep.has_masked is True
+    assert sweep.use_row_deltas is False
+    assert ctx["assignment"].upgrade_rows.get().pinned_amount == 26

--- a/gyrinx/core/tests/test_pinning.py
+++ b/gyrinx/core/tests/test_pinning.py
@@ -326,3 +326,131 @@ def test_receipts_are_never_overwritten(ctx):
 
     assert pin_assignment(ctx["assignment"]) == 0  # nothing left to pin
     assert _base_pin(ctx["assignment"])[0] == 5  # acquisition price stands
+
+
+# --- Every wired acquisition path writes receipts -------------------------------
+
+
+@pytest.mark.django_db
+def test_purchase_handlers_pin(ctx, user, make_weapon_profile):
+    """The four purchase handlers (equipment, accessory, profile, upgrades)
+    each leave the rows they created carrying receipts."""
+    from gyrinx.core.handlers.equipment.purchase import (
+        handle_accessory_purchase,
+        handle_equipment_purchase,
+        handle_equipment_upgrade,
+        handle_weapon_profile_purchase,
+    )
+
+    handle_equipment_purchase(
+        user=user,
+        lst=ctx["lst"],
+        fighter=ctx["fighter"],
+        assignment=ctx["assignment"],
+    )
+    assert _base_pin(ctx["assignment"])[:2] == (15, PinState.CATALOG)
+
+    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
+    handle_accessory_purchase(
+        user=user,
+        lst=fresh(ctx["lst"]),
+        fighter=fresh(ctx["fighter"]),
+        assignment=fresh(ctx["assignment"]),
+        accessory=accessory,
+    )
+    row = ctx["assignment"].accessory_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (8, PinState.CATALOG)
+
+    profile = make_weapon_profile(ctx["equipment"], name="Hotshot", cost=10)
+    handle_weapon_profile_purchase(
+        user=user,
+        lst=fresh(ctx["lst"]),
+        fighter=fresh(ctx["fighter"]),
+        assignment=fresh(ctx["assignment"]),
+        profile=profile,
+    )
+    row = ctx["assignment"].profile_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (10, PinState.CATALOG)
+
+    upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=ctx["equipment"], name="Rung 0", position=0, cost=12
+    )
+    handle_equipment_upgrade(
+        user=user,
+        lst=fresh(ctx["lst"]),
+        fighter=fresh(ctx["fighter"]),
+        assignment=fresh(ctx["assignment"]),
+        new_upgrades=[upgrade],
+    )
+    row = ctx["assignment"].upgrade_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (12, PinState.DERIVED)  # SINGLE
+
+
+@pytest.mark.django_db
+def test_fighter_assign_pins(ctx, make_equipment):
+    assignment = ctx["fighter"].assign(make_equipment("Autogun", cost=20))
+    assert _base_pin(assignment)[:2] == (20, PinState.CATALOG)
+
+
+@pytest.mark.django_db
+def test_equipment_advancement_pins(ctx, make_equipment):
+    from gyrinx.content.models import (
+        ContentAdvancementAssignment,
+        ContentAdvancementEquipment,
+    )
+    from gyrinx.core.models import ListFighterAdvancement
+
+    advancement_equipment = ContentAdvancementEquipment.objects.create(
+        name="Weapon Advancement", xp_cost=0, enable_chosen=True
+    )
+    equipment = make_equipment("Advanced Weapon", cost=30)
+    content_assignment = ContentAdvancementAssignment.objects.create(
+        advancement=advancement_equipment, equipment=equipment
+    )
+    advancement = ListFighterAdvancement.objects.create(
+        fighter=ctx["fighter"],
+        advancement_type=ListFighterAdvancement.ADVANCEMENT_EQUIPMENT,
+        equipment_assignment=content_assignment,
+        xp_cost=0,
+    )
+    advancement.apply_advancement()
+
+    created = ListFighterEquipmentAssignment.objects.get(
+        list_fighter=ctx["fighter"], content_equipment=equipment
+    )
+    assert _base_pin(created)[:2] == (30, PinState.CATALOG)
+
+
+@pytest.mark.django_db
+def test_vehicle_purchase_pins(
+    ctx, user, make_content_fighter, content_house, make_equipment
+):
+    from gyrinx.core.handlers.fighter.vehicle import handle_vehicle_purchase
+    from gyrinx.models import FighterCategoryChoices
+
+    vehicle_equipment = make_equipment("Ridgehauler", cost=100)
+    vehicle_fighter = make_content_fighter(
+        type="Hauler",
+        category=FighterCategoryChoices.VEHICLE,
+        house=content_house,
+        base_cost=100,
+    )
+    crew_fighter = make_content_fighter(
+        type="Crew",
+        category=FighterCategoryChoices.CREW,
+        house=content_house,
+        base_cost=50,
+    )
+    result = handle_vehicle_purchase(
+        user=user,
+        lst=ctx["lst"],
+        vehicle_equipment=vehicle_equipment,
+        vehicle_fighter=vehicle_fighter,
+        crew_fighter=crew_fighter,
+        crew_name="Test Crew",
+        is_stash=False,
+    )
+    created = ListFighterEquipmentAssignment.objects.get(
+        list_fighter=result.crew_fighter, content_equipment=vehicle_equipment
+    )
+    assert _base_pin(created)[:2] == (100, PinState.CATALOG)

--- a/gyrinx/core/tests/test_pinning.py
+++ b/gyrinx/core/tests/test_pinning.py
@@ -1,0 +1,328 @@
+"""Phase 7 of the cost-pinning programme (#1826): acquisition writes pins.
+
+`pin_assignment` is the resolve-and-pin choke point every acquisition path
+calls. These tests prove, per price source, that it writes the receipt live
+resolution would agree with — amount + attribution FK + state — that the
+§4.2 anchors stay unpinned, that pinning is value-neutral (cost_int() is
+identical before and after), and that a receipt, once written, is never
+overwritten by a later call.
+"""
+
+import pytest
+
+from gyrinx.content.models import (
+    ContentEquipmentListExpansion,
+    ContentEquipmentListExpansionItem,
+    ContentEquipmentListExpansionRuleByHouse,
+    ContentEquipmentUpgrade,
+    ContentFighterDefaultAssignment,
+    ContentFighterEquipmentListItem,
+    ContentFighterEquipmentListUpgrade,
+    ContentFighterEquipmentListWeaponAccessory,
+    ContentWeaponAccessory,
+)
+from gyrinx.core.cost.pinning import pin_assignment
+from gyrinx.core.models.list import (
+    ListFighterEquipmentAssignment,
+    PinState,
+)
+from gyrinx.core.tests.test_balance_sheet import fresh
+
+
+@pytest.fixture
+def ctx(user, make_list, make_list_fighter, make_equipment, make_weapon_profile):
+    lst = make_list("Pinning Gang")
+    fighter = make_list_fighter(lst, "Bob")
+    equipment = make_equipment("Lasgun", cost=15)
+    assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=fighter, content_equipment=equipment
+    )
+    return {
+        "lst": lst,
+        "fighter": fighter,
+        "equipment": equipment,
+        "assignment": assignment,
+        "make_weapon_profile": make_weapon_profile,
+    }
+
+
+def _base_pin(assignment):
+    a = ListFighterEquipmentAssignment.objects.get(pk=assignment.pk)
+    return (
+        a.pinned_base_amount,
+        a.pinned_base_state,
+        a.pinned_equipment_list_item_id,
+        a.pinned_expansion_item_id,
+    )
+
+
+# --- Base provenance ---------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_catalog_base_pins_catalog(ctx):
+    pin_assignment(ctx["assignment"])
+    amount, state, cfeli_id, exp_id = _base_pin(ctx["assignment"])
+    assert (amount, state) == (15, PinState.CATALOG)
+    assert cfeli_id is None and exp_id is None
+
+
+@pytest.mark.django_db
+def test_equipment_list_discount_pins_source(ctx):
+    item = ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"], cost=5
+    )
+    pin_assignment(ctx["assignment"])
+    amount, state, cfeli_id, exp_id = _base_pin(ctx["assignment"])
+    assert (amount, state, cfeli_id) == (5, PinState.SOURCE, item.pk)
+    assert exp_id is None
+
+
+@pytest.mark.django_db
+def test_expansion_price_pins_source_and_outranks_list_item(ctx):
+    """Expansions outrank equipment-list rows in live resolution; the
+    receipt must attribute to the same winner."""
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"], cost=5
+    )
+    rule = ContentEquipmentListExpansionRuleByHouse.objects.create(
+        house=ctx["lst"].content_house
+    )
+    expansion = ContentEquipmentListExpansion.objects.create(name="Pin Expansion")
+    expansion.rules.add(rule)
+    exp_item = ContentEquipmentListExpansionItem.objects.create(
+        expansion=expansion, equipment=ctx["equipment"], cost=4
+    )
+    assert fresh(ctx["assignment"]).base_cost_int() == 4  # expansion wins live
+
+    pin_assignment(ctx["assignment"])
+    amount, state, cfeli_id, exp_id = _base_pin(ctx["assignment"])
+    assert (amount, state, exp_id) == (4, PinState.SOURCE, exp_item.pk)
+    assert cfeli_id is None
+
+
+@pytest.mark.django_db
+def test_legacy_fighter_discount_preferred(ctx, make_content_fighter, content_house):
+    """When base and legacy fighters both price the item, resolution prefers
+    the legacy row — so must the receipt."""
+    legacy_cf = make_content_fighter(
+        type="Legacy Digger", category="GANGER", house=content_house, base_cost=40
+    )
+    ctx["fighter"].legacy_content_fighter = legacy_cf
+    ctx["fighter"].save()
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"], cost=9
+    )
+    legacy_item = ContentFighterEquipmentListItem.objects.create(
+        fighter=legacy_cf, equipment=ctx["equipment"], cost=6
+    )
+    pin_assignment(ctx["assignment"])
+    amount, state, cfeli_id, _ = _base_pin(ctx["assignment"])
+    assert (amount, state, cfeli_id) == (6, PinState.SOURCE, legacy_item.pk)
+
+
+# --- Component provenance ------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_profile_rows_pin_catalog_and_source(ctx):
+    catalog_profile = ctx["make_weapon_profile"](
+        ctx["equipment"], name="Hotshot", cost=10
+    )
+    priced_profile = ctx["make_weapon_profile"](
+        ctx["equipment"], name="Longshot", cost=12
+    )
+    item = ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["fighter"].content_fighter,
+        equipment=ctx["equipment"],
+        weapon_profile=priced_profile,
+        cost=7,
+    )
+    ctx["assignment"].weapon_profiles_field.add(catalog_profile, priced_profile)
+
+    pin_assignment(ctx["assignment"])
+
+    rows = {r.contentweaponprofile_id: r for r in ctx["assignment"].profile_rows.all()}
+    assert (
+        rows[catalog_profile.pk].pinned_amount,
+        rows[catalog_profile.pk].pin_state,
+    ) == (10, PinState.CATALOG)
+    assert (
+        rows[priced_profile.pk].pinned_amount,
+        rows[priced_profile.pk].pin_state,
+        rows[priced_profile.pk].pinned_equipment_list_item_id,
+    ) == (7, PinState.SOURCE, item.pk)
+
+
+@pytest.mark.django_db
+def test_accessory_rows_pin_catalog_source_and_derived(ctx):
+    flat = ContentWeaponAccessory.objects.create(name="Flat Scope", cost=8)
+    priced = ContentWeaponAccessory.objects.create(name="Priced Scope", cost=8)
+    override = ContentFighterEquipmentListWeaponAccessory.objects.create(
+        fighter=ctx["fighter"].content_fighter, weapon_accessory=priced, cost=3
+    )
+    formula = ContentWeaponAccessory.objects.create(
+        name="Percent Scope", cost=0, cost_expression="ceil(cost_int * 0.5 / 5) * 5"
+    )
+    ctx["assignment"].weapon_accessories_field.add(flat, priced, formula)
+
+    pin_assignment(ctx["assignment"])
+
+    rows = {
+        r.contentweaponaccessory_id: r for r in ctx["assignment"].accessory_rows.all()
+    }
+    assert (rows[flat.pk].pinned_amount, rows[flat.pk].pin_state) == (
+        8,
+        PinState.CATALOG,
+    )
+    assert (
+        rows[priced.pk].pinned_amount,
+        rows[priced.pk].pin_state,
+        rows[priced.pk].pinned_equipment_list_accessory_id,
+    ) == (3, PinState.SOURCE, override.pk)
+    # Formula evaluated against the just-pinned 15 base: ceil(15*0.5/5)*5.
+    assert (rows[formula.pk].pinned_amount, rows[formula.pk].pin_state) == (
+        10,
+        PinState.DERIVED,
+    )
+
+
+@pytest.mark.django_db
+def test_upgrade_rows_pin_multi_and_single(ctx, make_equipment):
+    from gyrinx.content.models import ContentEquipment
+
+    multi_equipment = make_equipment(
+        "Multi Gun", cost=10, upgrade_mode=ContentEquipment.UpgradeMode.MULTI
+    )
+    multi_assignment = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=ctx["fighter"], content_equipment=multi_equipment
+    )
+    flat_upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=multi_equipment, name="Mag", cost=5
+    )
+    priced_upgrade = ContentEquipmentUpgrade.objects.create(
+        equipment=multi_equipment, name="Drum", cost=9
+    )
+    override = ContentFighterEquipmentListUpgrade.objects.create(
+        fighter=ctx["fighter"].content_fighter, upgrade=priced_upgrade, cost=4
+    )
+    multi_assignment.upgrades_field.add(flat_upgrade, priced_upgrade)
+
+    # SINGLE stack on the default-mode equipment: rung1 pins the cumulative,
+    # including a per-rung override on rung 0.
+    rung0 = ContentEquipmentUpgrade.objects.create(
+        equipment=ctx["equipment"], name="Rung 0", position=0, cost=10
+    )
+    ContentFighterEquipmentListUpgrade.objects.create(
+        fighter=ctx["fighter"].content_fighter, upgrade=rung0, cost=6
+    )
+    rung1 = ContentEquipmentUpgrade.objects.create(
+        equipment=ctx["equipment"], name="Rung 1", position=1, cost=20
+    )
+    ctx["assignment"].upgrades_field.add(rung1)
+
+    pin_assignment(multi_assignment)
+    pin_assignment(ctx["assignment"])
+
+    multi_rows = {
+        r.contentequipmentupgrade_id: r for r in multi_assignment.upgrade_rows.all()
+    }
+    assert (
+        multi_rows[flat_upgrade.pk].pinned_amount,
+        multi_rows[flat_upgrade.pk].pin_state,
+    ) == (5, PinState.CATALOG)
+    assert (
+        multi_rows[priced_upgrade.pk].pinned_amount,
+        multi_rows[priced_upgrade.pk].pin_state,
+        multi_rows[priced_upgrade.pk].pinned_equipment_list_upgrade_id,
+    ) == (4, PinState.SOURCE, override.pk)
+
+    single_row = ctx["assignment"].upgrade_rows.get()
+    # Cumulative with the rung-0 override applied: 6 + 20.
+    assert (single_row.pinned_amount, single_row.pin_state) == (26, PinState.DERIVED)
+
+
+# --- Anchors stay unpinned ------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_overridden_and_linked_bases_stay_unpinned(ctx, make_equipment):
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        cost_override=3
+    )
+    pin_assignment(ctx["assignment"])
+    assert _base_pin(ctx["assignment"])[1] == PinState.UNPINNED
+
+    child = ListFighterEquipmentAssignment.objects.create(
+        list_fighter=ctx["fighter"],
+        content_equipment=make_equipment("Sidearm", cost=20),
+        linked_equipment_parent=ctx["assignment"],
+    )
+    pin_assignment(child)
+    assert _base_pin(child)[1] == PinState.UNPINNED
+
+
+@pytest.mark.django_db
+def test_default_kit_components_stay_unpinned(ctx, make_weapon_profile):
+    """Default-kit components are free by membership — no receipt to write —
+    while a non-kit component on the same assignment pins normally."""
+    kit_profile = make_weapon_profile(ctx["equipment"], name="Kit Shot", cost=10)
+    bought_profile = make_weapon_profile(ctx["equipment"], name="Extra Shot", cost=12)
+    default = ContentFighterDefaultAssignment.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"]
+    )
+    default.weapon_profiles_field.add(kit_profile)
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        from_default_assignment=default, cost_override=0
+    )
+    ctx["assignment"].weapon_profiles_field.add(kit_profile, bought_profile)
+
+    pin_assignment(ctx["assignment"])
+
+    rows = {r.contentweaponprofile_id: r for r in ctx["assignment"].profile_rows.all()}
+    assert rows[kit_profile.pk].pin_state == PinState.UNPINNED
+    assert rows[kit_profile.pk].pinned_amount is None
+    assert (
+        rows[bought_profile.pk].pinned_amount,
+        rows[bought_profile.pk].pin_state,
+    ) == (
+        12,
+        PinState.CATALOG,
+    )
+
+
+# --- Safety properties -----------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_pinning_is_value_neutral(ctx, make_weapon_profile):
+    """cost_int() must be identical before and after pinning — the receipt
+    records the price, it never changes it."""
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"], cost=5
+    )
+    profile = make_weapon_profile(ctx["equipment"], name="Hotshot", cost=10)
+    accessory = ContentWeaponAccessory.objects.create(
+        name="Percent Scope", cost=0, cost_expression="ceil(cost_int * 0.5 / 5) * 5"
+    )
+    ctx["assignment"].weapon_profiles_field.add(profile)
+    ctx["assignment"].weapon_accessories_field.add(accessory)
+
+    before = fresh(ctx["assignment"]).cost_int()
+    pin_assignment(ctx["assignment"])
+    after = fresh(ctx["assignment"]).cost_int()
+    assert before == after
+
+
+@pytest.mark.django_db
+def test_receipts_are_never_overwritten(ctx):
+    """A second call after a price change must not re-pin at the new price —
+    corrections flow through sweeps, not through re-pinning."""
+    item = ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"], cost=5
+    )
+    assert pin_assignment(ctx["assignment"]) == 1
+    ContentFighterEquipmentListItem.objects.filter(pk=item.pk).update(cost=9)
+
+    assert pin_assignment(ctx["assignment"]) == 0  # nothing left to pin
+    assert _base_pin(ctx["assignment"])[0] == 5  # acquisition price stands

--- a/gyrinx/core/tests/test_pinning.py
+++ b/gyrinx/core/tests/test_pinning.py
@@ -492,3 +492,72 @@ def test_balance_sheet_shows_pinned_pricing(ctx, user):
     assert (lines["base"].pricing, lines["base"].detail) == ("pinned", "source")
     assert lines["accessories"].pricing == "pinned"
     assert lines["profiles"].pricing == "live"  # no rows -> nothing pinned
+
+
+@pytest.mark.django_db
+def test_frozen_total_blocks_all_pinning(ctx, make_weapon_profile):
+    """A fixed assignment total is the paid price: no receipt is written for
+    any row, preserving the Phase 8 freeze-conversion's ability to record
+    the frozen value later."""
+    profile = make_weapon_profile(ctx["equipment"], name="Hotshot", cost=10)
+    ctx["assignment"].weapon_profiles_field.add(profile)
+    ListFighterEquipmentAssignment.objects.filter(pk=ctx["assignment"].pk).update(
+        total_cost_override=40
+    )
+
+    assert pin_assignment(ctx["assignment"]) == 0
+    assert _base_pin(ctx["assignment"])[1] == PinState.UNPINNED
+    row = ctx["assignment"].profile_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (None, PinState.UNPINNED)
+
+
+@pytest.mark.django_db
+def test_expansion_priced_profile_pins_source(ctx, make_weapon_profile):
+    """A profile priced by an expansion item pins SOURCE with the expansion
+    FK on the through row."""
+    profile = make_weapon_profile(ctx["equipment"], name="Hotshot", cost=10)
+    rule = ContentEquipmentListExpansionRuleByHouse.objects.create(
+        house=ctx["lst"].content_house
+    )
+    expansion = ContentEquipmentListExpansion.objects.create(name="Profile Expansion")
+    expansion.rules.add(rule)
+    exp_item = ContentEquipmentListExpansionItem.objects.create(
+        expansion=expansion,
+        equipment=ctx["equipment"],
+        weapon_profile=profile,
+        cost=6,
+    )
+    ctx["assignment"].weapon_profiles_field.add(profile)
+
+    pin_assignment(ctx["assignment"])
+
+    row = ctx["assignment"].profile_rows.get()
+    assert (
+        row.pinned_amount,
+        row.pin_state,
+        row.pinned_expansion_item_id,
+    ) == (6, PinState.SOURCE, exp_item.pk)
+
+
+@pytest.mark.django_db
+def test_convert_default_assignment_stays_unpinned(ctx, make_weapon_profile):
+    """Driving the REAL default-conversion path: the converted assignment is
+    zero-anchored (cost_override=0, kit components free by membership), so
+    nothing gets a receipt."""
+    kit_profile = make_weapon_profile(ctx["equipment"], name="Kit Shot", cost=10)
+    default = ContentFighterDefaultAssignment.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"]
+    )
+    default.weapon_profiles_field.add(kit_profile)
+    ctx["assignment"].delete()  # the fixture's direct assignment is in the way
+
+    fighter = type(ctx["fighter"]).objects.get(pk=ctx["fighter"].pk)
+    fighter.convert_default_assignment(default)
+
+    converted = ListFighterEquipmentAssignment.objects.get(
+        list_fighter=fighter, from_default_assignment=default
+    )
+    assert converted.cost_override == 0
+    assert _base_pin(converted)[1] == PinState.UNPINNED
+    row = converted.profile_rows.get()
+    assert (row.pinned_amount, row.pin_state) == (None, PinState.UNPINNED)

--- a/gyrinx/core/tests/test_pinning.py
+++ b/gyrinx/core/tests/test_pinning.py
@@ -454,3 +454,41 @@ def test_vehicle_purchase_pins(
         list_fighter=result.crew_fighter, content_equipment=vehicle_equipment
     )
     assert _base_pin(created)[:2] == (100, PinState.CATALOG)
+
+
+@pytest.mark.django_db
+def test_balance_sheet_shows_pinned_pricing(ctx, user):
+    """Phase 7 DoD: fresh acquisitions show pricing == "pinned" on the
+    balance sheet, with the pin state as detail."""
+    from gyrinx.core.cost.balance_sheet import build_balance_sheet
+    from gyrinx.core.handlers.equipment.purchase import (
+        handle_accessory_purchase,
+        handle_equipment_purchase,
+    )
+
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=ctx["fighter"].content_fighter, equipment=ctx["equipment"], cost=5
+    )
+    handle_equipment_purchase(
+        user=user, lst=ctx["lst"], fighter=ctx["fighter"], assignment=ctx["assignment"]
+    )
+    accessory = ContentWeaponAccessory.objects.create(name="Scope", cost=8)
+    handle_accessory_purchase(
+        user=user,
+        lst=fresh(ctx["lst"]),
+        fighter=fresh(ctx["fighter"]),
+        assignment=fresh(ctx["assignment"]),
+        accessory=accessory,
+    )
+
+    sheet = build_balance_sheet(fresh(ctx["lst"]))
+    fighter_sheet = next(f for f in sheet.fighters if f.name == "Bob")
+    lines = {
+        line.kind: line
+        for a in fighter_sheet.assignments
+        if a.assignment_id == ctx["assignment"].pk
+        for line in a.lines
+    }
+    assert (lines["base"].pricing, lines["base"].detail) == ("pinned", "source")
+    assert lines["accessories"].pricing == "pinned"
+    assert lines["profiles"].pricing == "live"  # no rows -> nothing pinned


### PR DESCRIPTION
Part of the cost-pinning programme (#1826), Phase 7 of the design in `.claude/notes/cost-pinning-design.md` (§4.6). Phases 1–6 are merged: resolution reads pinned amounts, and sweeps maintain them when content is corrected. Until now, nothing ever *wrote* a pin — all that machinery has been idle. This phase turns it on.

## What changed

**One choke point writes the acquisition receipt.** `pin_assignment()` (new, `gyrinx/core/cost/pinning.py`) runs the same lookups live resolution uses, in the same precedence order, and records on each row: the amount paid, the price-setting source as an FK (expansion item or equipment-list row), and the pin state — SOURCE for override-priced gear, CATALOG for book price, DERIVED for computed amounts (formula accessories, cumulative upgrade stacks). It is idempotent: only unpinned rows are written and an existing receipt is never overwritten, so it is safe to call from any layer, and a call on a legacy assignment is a value-neutral early instalment of the Phase 8 backfill.

**Every live acquisition path calls it**: the equipment purchase handler (covering the buy flow — the view creates the assignment, the handler pins before its first cost read), the accessory/profile/upgrade purchase handlers, `ListFighter.assign()`, equipment advancements, and vehicle purchases. Deliberately *not* wired: default-kit materialisation and linked-child creation (structurally free — the resolution anchors outrank any pin), the admin write surface (permanent policy exception, remediated by the recompute action), and the death transfer (Phase 9 converts it to the clone-with-pins path; the P2 expected-failure cells keep tracking it).

**Cloning carries receipts.** `clone()` now copies the base pin fields and creates component through-rows with their pin fields intact — a cloned gang (including the campaign-start clone) keeps its prices instead of silently reverting to live pricing. The two expected-failure tripwires from Phase 6 flip to real passing assertions. Copying via the through rows also fixes a latent hole where cloning dropped pack-scoped profiles and upgrades (the old loops iterated pack-filtering managers).

**A CI guard makes missed paths loud.** A watchdog test scans non-test source for the three assignment-creation shapes and compares against a labelled inventory (pinned / copies / anchored / kill-until-Phase-9 / admin / content-side). A new acquisition path that forgets to pin fails CI with instructions; verified to trip on a synthetic bypass site.

## Deliberate behaviour changes

Two harness cells asserting pre-pin behaviour split into pinned + legacy variants:

- **Mid-window recomputes are now pin-stable** for newly-bought gear: between a content edit and the async task, a recompute reads the receipt and the books hold their value; the correction lands only with the task, which rewrites the amount and books the delta. (Legacy unpinned rows keep the old visible-gap behaviour until the Phase 8 backfill.)
- **Reassignment is price-neutral for pinned gear** — the programme's signature outcome, arriving for all newly-acquired gear: a discounted lasgun moved to a fighter who would price it at catalog keeps its discounted price, no reprice telemetry fires, and the books reconcile. (Legacy rows still reprice, still covered.)

Death-transfer gear still reprices (kill path unwired until Phase 9), and existing gear stays receipt-less until Phase 8.

## How to verify

- `pytest gyrinx/core/tests/test_pinning.py` — per-source provenance (catalog / equipment-list / expansion / legacy-preference / formula / cumulative), anchors staying unpinned, value-neutrality (`cost_int()` identical before and after pinning), no-overwrite, and one receipt test per wired path.
- `pytest gyrinx/core/tests/test_pin_guard.py` — the watchdog.
- `pytest gyrinx/core/tests/test_balance_sheet.py` — the matrix, including the flipped clone cells and the new pinned/legacy variant pairs.
- Full suite: 2990 passed, 2 xfailed (the P2 death-transfer pair, Phase 9).

Refs #1826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh