### PR TITLE
chore: rename format-check CI workflow to ci-checks (#1844)

### DIFF
--- a/.claude/notes/pr-deploys-infra-research.md
+++ b/.claude/notes/pr-deploys-infra-research.md
@@ -243,7 +243,7 @@ daphne -b 0.0.0.0 -p $PORT "gyrinx.asgi:application"
 ## 11. GitHub Actions / CI
 
 ### Workflows
-- `format-check.yml` - Runs on PRs and pushes to main; checks Python (ruff), templates (djlint), JS/CSS/JSON (prettier), Jupyter notebooks
+- `ci-checks.yml` - Runs on PRs and pushes to main; checks Python (ruff), templates (djlint), JS/CSS/JSON (prettier), Jupyter notebooks
 - `claude.yml` - Claude Code AI workflow
 - `claude-code-review.yml` - AI code review
 - `claude-code-improvement.yml` - AI improvement suggestions

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,4 +1,4 @@
-name: Format Check
+name: CI Checks
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  format-check:
+  ci-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
       # Mint a token from a dedicated GitHub App so the enqueue is NOT performed
       # by GITHUB_TOKEN. Actions triggered by GITHUB_TOKEN do not spawn new
       # workflow runs, which meant the merge_group event never started the
-      # required `test` / `format-check` runs and the PR was evicted from the
+      # required `test` / `ci-checks` runs and the PR was evicted from the
       # queue after the 60-minute check timeout. An App token enqueues as a
       # distinct identity so merge_group checks run normally.
       - name: Generate app token


### PR DESCRIPTION
Closes #1844.

## What

Renames the `format-check` workflow to `ci-checks` so the check name reflects its scope. The workflow runs ruff, djlint, prettier, a **migration-conflict check**, and a Jupyter-notebook strip check — none of which are "formatting". The old name meant a migration conflict (for example) surfaced as a red *format-check*, sending people to the formatter instead of the actual problem.

Changes:

- `.github/workflows/format-check.yml` → `.github/workflows/ci-checks.yml` (tracked as a rename — 2 lines changed)
- workflow `name: Format Check` → `name: CI Checks`
- job id `format-check:` → `ci-checks:`
- updates the two stale references to the old name (a comment in `dependabot-auto-merge.yml`, and a line in `.claude/notes/pr-deploys-infra-research.md`)

`ci-checks` matches the name approved on the issue's plan comment.

Rebased onto `main` — the branch was conflicting because `main` has since rewritten this workflow (the uv/dependency CI work). The rename now sits on top of the current uv-based workflow; the only content difference from `main` is the two renamed lines.

## ⚠️ Required-status-check swap — must be coupled to the merge

The job id is the status-check context, and `format-check` is a **required status check** on the `main` ruleset **"Default"** (id `3408703`), alongside `test`. Renaming the job changes that context to `ci-checks`, so the ruleset must be updated or PRs block on a check that never reports.

**This PR shows as blocked for exactly that reason** — the renamed job runs green as `ci-checks`, but the ruleset still waits for `format-check`, which this branch no longer produces. That is expected, not a failure.

Order that needs no admin bypass — swap first, then merge:

1. **Swap the required check** in the ruleset: Settings → Rules → Rulesets → **Default** → *Require status checks to pass* → replace `format-check` with `ci-checks` (keep `test`). Once swapped, this PR satisfies both required checks and merges normally.
2. **Merge this PR** immediately after, so `main` starts producing `ci-checks`.
3. **Rebase the two other open PRs** (#1913, #1786) onto `main`. They must rebase before merging anyway — the ruleset requires up-to-date branches — so they pick up the renamed workflow as part of that.

Between steps 1 and 2 those two PRs block on a missing `ci-checks`; keeping the two steps back-to-back keeps that window to about a minute.
