### PR TITLE
feat: price-neutral death transfer via clone-with-pins (#1826 Phase 9)

### DIFF
--- a/.claude/notes/cost-pinning-design.md
+++ b/.claude/notes/cost-pinning-design.md
@@ -1171,6 +1171,24 @@ Precondition: the `pin_state` enum (§4.1) is settled — it shapes the columns.
   invariant test (rating + stash + credits unchanged across a kill); no new
   kill-frozen overrides appear in the drift report after deploy; the re-run's
   report shows the window's rows converted and pinned.
+- **Status (built, unmerged — hold for the estate backfill):** `kill.py` now
+  clones each transferred item via the Phase-7 clone-with-pins path
+  (`assignment.clone(list_fighter=stash)`), pinning any `UNPINNED` straggler at
+  the dying fighter's prices first; it constructs nothing directly and is off
+  the CI-guard allowlist (its `pin_assignment` call is tracked in
+  `PIN_CALL_COUNTS`). The P2 headline cell flips to a passing assertion (price
+  held at 5¢, not catalog 15¢) and the full §2.3 lifecycle + a wealth-invariant
+  cell are green on **both** catalog and pack axes. Two findings not in the
+  original spec: (1) the `reassignment.py` §3.3 differential was already fixed
+  in an earlier phase (fresh `with_related_data()` instance for `cost_after`) —
+  no change needed, only coverage; (2) there was no fresh `total_cost_override`
+  freeze left to "drop" — the residual bug was the manual copy failing to carry
+  pins, so the stash re-priced at catalog. The kill path also needed
+  **pack-aware cost reads** (`fighter_cost_before` and the clones' caches),
+  because `cost_int()` on a plain instance resolves components through the
+  default pack-excluding managers and silently drops pack-scoped accessories —
+  the same `#1933` hazard the reassignment handler already guards; both now use
+  `with_related_data()`.
 
 ### Phase 10 — Surfaces: user-facing breakdown and pin editing
 

--- a/.claude/notes/cost-pinning-design.md
+++ b/.claude/notes/cost-pinning-design.md
@@ -1187,8 +1187,14 @@ Precondition: the `pin_state` enum (§4.1) is settled — it shapes the columns.
   **pack-aware cost reads** (`fighter_cost_before` and the clones' caches),
   because `cost_int()` on a plain instance resolves components through the
   default pack-excluding managers and silently drops pack-scoped accessories —
-  the same `#1933` hazard the reassignment handler already guards; both now use
-  `with_related_data()`.
+  the same `#1933` hazard the reassignment handler already guards.
+  `fighter_cost_before` now fetches the dying fighter via `with_related_data()`;
+  the clone-cache half was **fixed at the root**: `assignment.clone()` now
+  recomputes its facts on a `with_related_data()` refetch, so every clone
+  caller (campaign-start clone included) gets a pack-correct cache, not just the
+  kill path. (3) New gangs need no backfill to be pinned — a fresh purchase
+  pins at acquisition and the campaign-start clone carries the pins in; locked
+  by an end-to-end test on both axes (`test_new_gang_gear_is_pinned_end_to_end`).
 
 ### Phase 10 — Surfaces: user-facing breakdown and pin editing
 

--- a/gyrinx/core/handlers/fighter/kill.py
+++ b/gyrinx/core/handlers/fighter/kill.py
@@ -169,22 +169,13 @@ def handle_fighter_kill(
                 )
             )
 
-        # clone() recomputes each new row's cache on a plain instance, which
-        # resolves components through the default (pack-excluding) managers and
-        # drops pack-scoped accessories/profiles/upgrades (#1933). Recompute the
-        # stash rows pack-aware so their caches match the views and the
-        # canonical recompute, and total the corrected values for the stash
-        # bump. With pins this equals the dying fighter's valuation of the same
-        # gear, so the transfer is wealth-neutral. Persistent items are NOT
-        # here: their value is absorbed into the rating reduction below.
-        clone_pks = [clone.pk for clone in clones]
-        equipment_cost = 0
-        for (
-            stash_row
-        ) in ListFighterEquipmentAssignment.objects.with_related_data().filter(
-            pk__in=clone_pks
-        ):
-            equipment_cost += stash_row.facts_from_db(update=True).rating
+        # The stash gains exactly what its new rows cache. clone() recomputes
+        # each in the stash context pack-aware (reading the copied receipts), so
+        # this total equals what a later recompute produces. With pins it also
+        # equals the dying fighter's valuation of the same gear, so the transfer
+        # is wealth-neutral. Persistent items are NOT here: their value is
+        # absorbed into the rating reduction below.
+        equipment_cost = sum(clone.rating_current for clone in clones)
 
         # Delete only the transferred assignments from the dead fighter;
         # persistent assignments stay attached and remain visible on the card.

--- a/gyrinx/core/handlers/fighter/kill.py
+++ b/gyrinx/core/handlers/fighter/kill.py
@@ -5,10 +5,10 @@ from typing import Optional
 
 from django.db import transaction
 
+from gyrinx.core.cost.pinning import pin_assignment
 from gyrinx.core.cost.propagation import Delta, propagate_from_fighter
 from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.campaign import CampaignAction
-from gyrinx.content.models import ContentWeaponAccessory
 from gyrinx.core.models.list import (
     List,
     ListFighter,
@@ -44,7 +44,9 @@ def handle_fighter_kill(
     This handler performs the following operations atomically:
     1. Captures before values for ListAction
     2. Finds stash fighter
-    3. Transfers non-persistent equipment to stash (creates new assignments)
+    3. Transfers non-persistent equipment to stash by cloning each item with
+       its acquisition receipt (pins) intact, so the gear keeps its price in
+       the stash's context rather than re-pricing at catalog (#1826 Phase 9)
     4. Deletes the transferred (non-persistent) assignments
     5. Marks fighter as DEAD
     6. Sets fighter cost_override = 0
@@ -84,8 +86,15 @@ def handle_fighter_kill(
     stash_before = lst.stash_current
     credits_before = lst.credits_current
 
-    # Calculate fighter cost before death (includes equipment)
-    fighter_cost_before = fighter.cost_int()
+    # Calculate fighter cost before death (includes equipment). Fetch
+    # pack-aware: cost_int() on a plain instance resolves accessories/profiles/
+    # upgrades through the default (pack-excluding) managers and would drop
+    # pack-scoped components (#1933), so the reduction below would leave the
+    # dead fighter's cache non-zero. with_related_data() prefetches via
+    # all_content(), matching the cache the propagation deltas maintained.
+    fighter_cost_before = (
+        ListFighter.objects.with_related_data().get(pk=fighter.pk).cost_int()
+    )
 
     # Find the stash fighter for this list
     stash_fighter = lst.listfighter_set.filter(content_fighter__is_stash=True).first()
@@ -134,39 +143,48 @@ def handle_fighter_kill(
 
     equipment_cost = 0
     if to_transfer:
-        # Calculate transferred equipment cost before we delete assignments.
-        # Only the transferred (non-persistent) gear bumps the stash — the
-        # persistent items' value is absorbed into the rating reduction below.
-        equipment_cost = sum(a.cost_int() for a in to_transfer)
-
+        # Move each item to the stash by cloning it with its acquisition
+        # receipt intact (#1826 Phase 9). Two steps per item:
+        #
+        #   1. Belt-and-braces: pin any row still UNPINNED, resolving at the
+        #      DYING fighter's prices — the last moment this acquisition
+        #      context exists. After the Phase 8 backfill this is a no-op, but
+        #      it makes the ordering non-load-bearing.
+        #   2. Clone from a fresh refetch (so the copy carries the just-written
+        #      receipt, not the stale pre-pin instance state). clone() copies
+        #      the amount, attribution, and state verbatim — plus cost/total
+        #      overrides and every component through-row, pack-scoped included.
+        #
+        # Because the receipt travels with the gear, it prices identically on
+        # the stash without any blanket total freeze, so the #1826
+        # death-repricing bug cannot recur.
+        clones = []
         for assignment in to_transfer:
-            # Create new assignment for stash with same equipment
-            new_assignment = ListFighterEquipmentAssignment(
-                list_fighter=stash_fighter,
-                content_equipment=assignment.content_equipment,
-                cost_override=assignment.cost_override,
-                total_cost_override=assignment.total_cost_override,
-                from_default_assignment=assignment.from_default_assignment,
+            pin_assignment(assignment)
+            source = ListFighterEquipmentAssignment.objects.get(pk=assignment.pk)
+            clones.append(
+                source.clone(
+                    list_fighter=stash_fighter,
+                    preserve_from_default_assignment=True,
+                )
             )
-            new_assignment.save()
 
-            # Copy over M2M relationships
-            if assignment.weapon_profiles_field.exists():
-                new_assignment.weapon_profiles_field.set(
-                    assignment.weapon_profiles_field.all()
-                )
-            # Use all_content() so pack-scoped accessories transfer too — the
-            # default M2M manager would silently exclude them. Evaluate once
-            # to avoid two DB round-trips (exists() + set()).
-            pack_aware_accessories = list(
-                ContentWeaponAccessory.objects.all_content().filter(
-                    weapon_accessories=assignment
-                )
-            )
-            if pack_aware_accessories:
-                new_assignment.weapon_accessories_field.set(pack_aware_accessories)
-            if assignment.upgrades_field.exists():
-                new_assignment.upgrades_field.set(assignment.upgrades_field.all())
+        # clone() recomputes each new row's cache on a plain instance, which
+        # resolves components through the default (pack-excluding) managers and
+        # drops pack-scoped accessories/profiles/upgrades (#1933). Recompute the
+        # stash rows pack-aware so their caches match the views and the
+        # canonical recompute, and total the corrected values for the stash
+        # bump. With pins this equals the dying fighter's valuation of the same
+        # gear, so the transfer is wealth-neutral. Persistent items are NOT
+        # here: their value is absorbed into the rating reduction below.
+        clone_pks = [clone.pk for clone in clones]
+        equipment_cost = 0
+        for (
+            stash_row
+        ) in ListFighterEquipmentAssignment.objects.with_related_data().filter(
+            pk__in=clone_pks
+        ):
+            equipment_cost += stash_row.facts_from_db(update=True).rating
 
         # Delete only the transferred assignments from the dead fighter;
         # persistent assignments stay attached and remain visible on the card.

--- a/gyrinx/core/models/list/assignment.py
+++ b/gyrinx/core/models/list/assignment.py
@@ -1029,9 +1029,22 @@ class ListFighterEquipmentAssignment(HistoryMixin, Base, Archived):
 
         clone.save()
 
-        # Always recalculate cached values after cloning
-        # Cloning is not part of the action/propagation system - it needs explicit recalculation
-        clone.facts_from_db(update=True)
+        # Recalculate cached values after cloning. Cloning is not part of the
+        # action/propagation system, so it needs explicit recalculation — and
+        # it must run on a pack-aware refetch. cost_int() on this freshly-built
+        # instance resolves components through the default (pack-excluding)
+        # managers, so a pack-scoped accessory/profile/upgrade would drop out of
+        # the cached rating (#1933) — the clone would under-value pack gear
+        # until the next recompute. with_related_data() prefetches components
+        # via all_content(), matching what the views and the canonical
+        # recompute compute.
+        fresh_clone = ListFighterEquipmentAssignment.objects.with_related_data().get(
+            pk=clone.pk
+        )
+        fresh_clone.facts_from_db(update=True)
+        # Reflect the just-written cache on the instance we hand back.
+        clone.rating_current = fresh_clone.rating_current
+        clone.dirty = False
 
         return clone
 

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -805,14 +805,16 @@ def test_matrix_p1_1925_accessory_onto_overridden_assignment(healthy_list, user,
 
 
 @pytest.mark.django_db
-@pytest.mark.xfail(
-    strict=True,
-    reason="P2 (#1826): kill-transfer values gear in the dying fighter's "
-    "context; the stash re-prices it at catalog; fixed by pinning (Phase 9)",
-)
 def test_matrix_p2_1826_kill_fighter_with_discounted_gear(
     campaign_list, user, make_content_fighter, content_house, gear
 ):
+    """P2 (#1826), fixed in Phase 9 — the programme's headline bug.
+
+    Gear bought at an equipment-list discount (5¢, catalog 15¢) keeps that
+    price when its owner dies and it lands in the stash: the acquisition
+    receipt travels with the clone, so the stash values it at 5¢ instead of
+    re-pricing to catalog. The books reconcile through the death.
+    """
     lst, stash = campaign_list
     cf = make_content_fighter(
         type="Scavvy", category="GANGER", house=content_house, base_cost=50
@@ -826,7 +828,112 @@ def test_matrix_p2_1826_kill_fighter_with_discounted_gear(
     assert_reconciles(lst)  # clean before the death
 
     handle_fighter_kill(user=user, lst=fresh(lst), fighter=fresh(fighter))
-    assert_reconciles(lst)  # FAILS: stash cache +5, stash recomputes to 15
+    assert_reconciles(lst)  # receipt travels: stash caches 5 and recomputes to 5
+
+    stash_assignment = stash.listfighterequipmentassignment_set.get()
+    assert stash_assignment.cost_int() == 5  # discounted price held, not catalog 15
+
+
+@pytest.mark.django_db
+def test_matrix_p2_1826_full_lifecycle_prices_held(
+    campaign_list, user, make_content_fighter, content_house, content_fighter, gear
+):
+    """The programme's headline scenario, end to end (#1826 §2.3).
+
+    A buys a Lasgun at A's 5¢ equipment-list discount (catalog 15¢); A dies
+    and it lands in the stash; B — who has no discount and would pay catalog —
+    re-equips it from the stash; B buys a Scope in B's context; B dies too.
+    The Lasgun holds 5¢ at every hop and the Scope holds its purchase value,
+    on both catalog and pack content, with the books reconciling after each
+    step (immediately and after a forced recompute).
+    """
+    lst, stash = campaign_list
+    cf_a = make_content_fighter(
+        type="Scavvy", category="GANGER", house=content_house, base_cost=50
+    )
+    lasgun = gear.equipment("Lasgun", cost=15)
+    ContentFighterEquipmentListItem.objects.create(
+        fighter=cf_a, equipment=lasgun, cost=5
+    )
+
+    # A buys the Lasgun at the 5¢ discount.
+    fighter_a = hire_fighter(user, lst, cf_a, name="Alfa")
+    assignment = buy_equipment(user, lst, fighter_a, lasgun)
+    assert fresh(assignment).cost_int() == 5
+    assert_reconciles(lst)
+
+    # A dies: the Lasgun moves to the stash, keeping its 5¢ receipt (the stash
+    # on its own would price it at catalog 15).
+    handle_fighter_kill(user=user, lst=fresh(lst), fighter=fresh(fighter_a))
+    stash_assignment = stash.listfighterequipmentassignment_set.get()
+    assert stash_assignment.cost_int() == 5
+    assert_reconciles(lst)
+
+    # B — no discount — re-equips the Lasgun from the stash. The pin holds: B
+    # carries 5, not the 15 B's own context would compute.
+    fighter_b = hire_fighter(user, lst, content_fighter, name="Bravo")
+    handle_equipment_reassignment(
+        user=user,
+        lst=fresh(lst),
+        from_fighter=fresh(stash),
+        to_fighter=fresh(fighter_b),
+        assignment=fresh(stash_assignment),
+    )
+    assert fresh(stash_assignment).cost_int() == 5
+    assert_reconciles(lst)
+
+    # B buys a Scope in B's context; it pins at its purchase price.
+    scope = gear.accessory("Scope", cost=8)
+    buy_accessory(user, lst, fighter_b, stash_assignment, scope)
+    assert fresh(stash_assignment).cost_int() == 13  # 5 Lasgun + 8 Scope
+    assert_reconciles(lst)
+
+    # B dies too: the discounted Lasgun and the Scope both move to the stash at
+    # their held values — a repeat death that stays price-neutral.
+    handle_fighter_kill(user=user, lst=fresh(lst), fighter=fresh(fighter_b))
+    final = fresh(stash.listfighterequipmentassignment_set.get())
+    assert final.cost_int() == 13  # 5 + 8, held through the second death
+    assert_reconciles(lst)
+
+
+@pytest.mark.django_db
+def test_kill_conserves_equipment_value_no_phantom_wealth(
+    campaign_list, user, make_content_fighter, content_house, gear
+):
+    """A death removes the fighter's whole cost from the rating and returns
+    the equipment's HELD value to the stash — no more, no less.
+
+    The #1826 bug was a phantom wealth gain: discounted gear re-pricing to
+    catalog once it sat in the stash. Here the stash gains exactly the 5¢ the
+    gear was worth, credits never move, and total wealth falls by only the
+    fighter's base cost.
+    """
+    lst, stash = campaign_list
+    cf = make_content_fighter(
+        type="Scavvy", category="GANGER", house=content_house, base_cost=50
+    )
+    lasgun = gear.equipment("Lasgun", cost=15)
+    ContentFighterEquipmentListItem.objects.create(fighter=cf, equipment=lasgun, cost=5)
+    fighter = hire_fighter(user, lst, cf, name="Bob")
+    buy_equipment(user, lst, fighter, lasgun)
+
+    before = fresh(lst)
+    rating_before = before.rating_current
+    stash_before = before.stash_current
+    credits_before = before.credits_current
+    fighter_cost = fresh(fighter).cost_int()  # 50 base + 5 gear
+
+    handle_fighter_kill(user=user, lst=fresh(lst), fighter=fresh(fighter))
+
+    after = fresh(lst)
+    assert after.rating_current == rating_before - fighter_cost  # whole cost gone
+    assert after.stash_current == stash_before + 5  # HELD value, not catalog 15
+    assert after.credits_current == credits_before  # deaths never touch credits
+    # Total wealth fell by exactly the base cost; the 5¢ gear was conserved.
+    wealth_before = rating_before + stash_before + credits_before
+    wealth_after = after.rating_current + after.stash_current + after.credits_current
+    assert wealth_before - wealth_after == 50
+    assert_reconciles(lst)
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -1047,6 +1047,37 @@ def test_matrix_campaign_start_clone_preserves_pins(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("side", ["catalog", "pack"])
+def test_new_gang_gear_is_pinned_end_to_end(
+    side, user, make_list, content_fighter, make_equipment, make_pack, campaign
+):
+    """New gangs carry pins without any backfill. A fresh purchase pins at
+    acquisition (Phase 7), and starting a campaign clones those pins in — so a
+    gang built after Phase 7 shipped never relies on the estate backfill (or
+    Phase 9's defensive kill-pin) for gear it bought itself. Proven end to end
+    through the real purchase + campaign-start flows, on both content axes."""
+    source = ContentSource(make_pack("New Gang Pack") if side == "pack" else None)
+    lst = make_list("Fresh Gang")
+    source.subscribe(lst)
+    fighter = hire_fighter(user, lst, content_fighter, name="Bob")
+    lasgun = source.register(make_equipment("Lasgun", cost=15))
+
+    assignment = buy_equipment(user, lst, fighter, lasgun)
+    # The brand-new purchase is pinned at acquisition (no backfill involved).
+    assert fresh(assignment).pinned_base_amount == 15
+    assert fresh(assignment).pinned_base_state == PinState.CATALOG
+
+    # Starting a campaign clones the gang in — the pins travel with it.
+    cloned, created = campaign.add_list_to_campaign(fresh(lst), user=user)
+    assert created
+    clone_row = ListFighterEquipmentAssignment.objects.get(
+        list_fighter__list=cloned, content_equipment=lasgun
+    )
+    assert clone_row.pinned_base_amount == 15
+    assert_reconciles(cloned)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("side", ["catalog", "pack"])
 def test_matrix_bare_accessory_post_is_inert(
     side, user, client, make_list, content_fighter, make_equipment, make_pack
 ):

--- a/gyrinx/core/tests/test_pin_guard.py
+++ b/gyrinx/core/tests/test_pin_guard.py
@@ -24,13 +24,16 @@ Labels:
 - COPIES    clone(): receipts are copied verbatim, not re-resolved
 - ANCHORED  zero-anchored gear (default-kit, linked-child): resolution
             anchors outrank any pin, nothing to record
-- KILL      the death transfer — becomes the clone-with-pins path in
-            Phase 9, unpinned until then (deliberate, tracked by the P2
-            xfail cells in test_balance_sheet.py)
 - ADMIN     staff write surface; bypasses delta propagation by design, the
             remediation is the recompute action (permanent exception)
 - CONTENT   same field names on ContentFighterDefaultAssignment (a content
             model) — not a core assignment at all
+
+The death transfer (kill.py) was labelled KILL until Phase 9. It now clones
+each transferred item with its receipt (COPIES, in assignment.py) and calls
+pin_assignment on any UNPINNED straggler first, so it no longer constructs
+assignments or writes M2Ms directly — it matches no creation pattern and is
+tracked purely by its pin_assignment call in PIN_CALL_COUNTS.
 """
 
 import re
@@ -62,6 +65,7 @@ PATTERNS = {
 PIN_CALL_COUNTS = {
     "core/cost/pinning.py": 2,  # module docstring + the def itself
     "core/handlers/equipment/purchase.py": 4,  # equipment/accessory/profile/upgrades
+    "core/handlers/fighter/kill.py": 1,  # defensive pin before clone-to-stash
     "core/handlers/fighter/vehicle.py": 1,
     "core/models/list/advancement.py": 1,
     "core/models/list/fighter.py": 1,  # assign()
@@ -90,9 +94,9 @@ INVENTORY = {
     ("core/models/list/assignment.py", "m2m-write"): (4, "COPIES"),
     # Linked-child creation (post-save signal): structurally free.
     ("core/models/list/signal_handlers.py", "manager-create"): (1, "ANCHORED"),
-    # Death transfer: unpinned until Phase 9 converts it to clone-with-pins.
-    ("core/handlers/fighter/kill.py", "instantiate"): (1, "KILL"),
-    ("core/handlers/fighter/kill.py", "m2m-write"): (3, "KILL"),
+    # Death transfer (kill.py): as of Phase 9 it clones each item (COPIES,
+    # above) and pins any straggler first (PIN_CALL_COUNTS), so it matches no
+    # creation pattern here.
     # Content-side models sharing the M2M field names.
     ("content/models/fighter.py", "m2m-write"): (2, "CONTENT"),
     ("core/views/pack.py", "m2m-write"): (1, "CONTENT"),


### PR DESCRIPTION
## What this fixes

Killing a fighter in campaign mode used to **re-price its equipment**. When a
fighter died, each item was re-created from scratch onto the gang's stash — so
a lasgun bought at a 5¢ equipment-list discount reappeared in the stash valued
at its 15¢ catalog price. The gang's recorded worth jumped by 10¢ every time
someone died. That is the original bug reported in #1826.

## The change

`kill.py` now moves each transferred item through the existing **clone-with-pins
path** (built in Phase 7) instead of hand-copying its fields:

- The clone carries the item's acquisition **receipt** verbatim — the amount
  paid, where the price came from, and its pin state — so the gear prices
  identically on the stash without any blanket "freeze the total" hack.
- Before cloning, a defensive `pin_assignment()` writes a receipt for any item
  that somehow still lacks one, at the **dying fighter's** prices (the last
  moment that pricing context exists). After the estate backfill this is a
  no-op, but it means the transfer no longer depends on ordering.
- The death's ledger entry books the receipted values, so the balance sheet
  reconciles through a death.

The kill path also now reads costs **pack-aware**. `cost_int()` on a plainly-
fetched instance resolves components through the default managers, which hide
pack-scoped content, so a pack accessory would silently drop out of both the
dead fighter's cost and the stash's gain. Both reads now use
`with_related_data()` (the same guard the reassignment handler already has).

Reassignment needed no change — its equivalent before/after bug was already
fixed in an earlier phase.

## Tests

- The headline scenario is now a passing test on **both** plain catalog and
  subscribed-pack content: buy at a discount → owner dies → someone else
  re-equips it from the stash → they add an accessory → they die too, with
  every price stable at its purchase value and the books clean at each step.
- A wealth-invariant test asserts a death returns exactly the equipment's held
  value to the stash (not its catalog value), credits never move, and total
  worth falls only by the fighter's base cost.
- The previously-expected-failure cell for this bug flips to a passing
  assertion; the kill path moves off the CI-guard's allowlist.

## Test plan

- [x] `pytest -n 4` full `gyrinx/core/tests/` suite green (2583 passed)
- [x] CI-guard test green with kill off the allowlist
- [x] Lifecycle + wealth-invariant cells green on catalog and pack axes

## ⚠️ Do not merge yet

This is intentionally a **draft** and must not merge until the production estate
backfill (reconcile-all, then backfill-all via the Phase 8b admin maintenance
triggers) has run. Phase 9 assumes existing gear is already receipted; merging
ahead of the backfill would rely on the defensive per-death pin for the whole
estate. After this deploys, the two maintenance buttons get pressed once more
to receipt whatever deaths minted during the rollout window.

Refs #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh