### PR TITLE
fix: book clone's real rating at the clone seam, not the source's stale cache

### DIFF
--- a/gyrinx/core/handlers/list/operations.py
+++ b/gyrinx/core/handlers/list/operations.py
@@ -162,8 +162,19 @@ def handle_list_clone(
     # Create ListAction on cloned list if feature flag is enabled
     cloned_action = None
     if settings.FEATURE_LIST_ACTION_CREATE_INITIAL:
-        # The CREATE action represents creating the list from nothing,
-        # so before values are 0 and deltas equal the cloned values.
+        # The CREATE action represents creating the list from nothing, so the
+        # before values are 0 and the deltas are the CLONE's own values.
+        #
+        # Book the clone's freshly-recomputed caches (List.clone() ran
+        # facts_from_db() on it), NOT original_list.rating_current. A
+        # list-building gang's cached rating can be stale — caches drift until
+        # something recomputes them — and the clone can legitimately differ
+        # from its source (e.g. skipped fighters). Recording the source's value
+        # here writes a rating the clone's real cost immediately contradicts:
+        # the very next action, CAMPAIGN_START, prices the gang with a fresh
+        # cost_int(), so a stale source leaves a permanent chain break at the
+        # clone seam. The clone's own caches are the source of truth for what
+        # it actually is.
         cloned_action = ListAction.objects.create(
             user=user,
             owner=owner,
@@ -174,9 +185,9 @@ def handle_list_clone(
             rating_before=0,
             stash_before=0,
             credits_before=0,
-            rating_delta=original_list.rating_current,
-            stash_delta=original_list.stash_current,
-            credits_delta=original_list.credits_current,
+            rating_delta=cloned_list.rating_current,
+            stash_delta=cloned_list.stash_current,
+            credits_delta=cloned_list.credits_current,
         )
 
         # Set up the latest_actions prefetch so that subsequent create_action calls work

--- a/gyrinx/core/tests/test_clone.py
+++ b/gyrinx/core/tests/test_clone.py
@@ -2,11 +2,17 @@ import pytest
 
 from gyrinx.content.models import ContentEquipmentUpgrade
 from gyrinx.core.handlers.list import handle_list_clone
-from gyrinx.core.models.action import ListActionType
+from gyrinx.core.models.action import ListAction, ListActionType
 from gyrinx.core.models.list import (
     List,
     ListFighter,
     VirtualListFighterEquipmentAssignment,
+)
+from gyrinx.core.tests.test_balance_sheet import (
+    assert_reconciles,
+    buy_equipment,
+    fresh,
+    hire_fighter,
 )
 
 
@@ -499,9 +505,13 @@ def test_list_clone_actions_have_correct_deltas(
     """Test that ListActions have correct cost deltas.
 
     Original's CLONE action: zero deltas (recording the clone event, not a cost change).
-    Clone's CREATE action: deltas equal original values (represents creating list from nothing).
+    Clone's CREATE action: deltas equal the CLONE's recalculated values (NOT the
+    source's cached rating, which can be stale — booking it would leave a chain
+    break at the clone seam).
     """
-    # Setup
+    # Setup: the source's rating/stash caches are set to values that do NOT
+    # match its (empty) content — the stale-cache scenario that caused the
+    # clone-seam break in production.
     settings.FEATURE_LIST_ACTION_CREATE_INITIAL = feature_flag_enabled
     original = make_list("Original List")
     original.credits_current = 500
@@ -523,12 +533,15 @@ def test_list_clone_actions_have_correct_deltas(
         assert result.original_action.stash_delta == 0
         assert result.original_action.credits_delta == 0
 
-        # Assert clone's CREATE action has deltas matching original values
-        # (represents creating list from nothing to its current state)
+        # The CREATE action records the CLONE's recalculated values, not the
+        # source's stale caches. The empty clone recalculates rating/stash to
+        # 0; credits are copied (500). Booking the source's 1000/150 here would
+        # contradict the clone's real cost and break the chain at the seam.
         if result.cloned_action:
-            assert result.cloned_action.rating_delta == original.rating_current
-            assert result.cloned_action.stash_delta == original.stash_current
-            assert result.cloned_action.credits_delta == original.credits_current
+            assert result.cloned_list.rating_current == 0
+            assert result.cloned_action.rating_delta == 0
+            assert result.cloned_action.stash_delta == 0
+            assert result.cloned_action.credits_delta == 500
 
 
 @pytest.mark.parametrize("feature_flag_enabled", [True, False])
@@ -756,12 +769,14 @@ def test_handle_list_clone_regular_name_defaults_with_suffix(make_list, user, se
 def test_handle_list_clone_for_campaign_cloned_action_has_correct_deltas(
     make_list, make_campaign, user, settings
 ):
-    """Test that campaign clone's CREATE action has deltas matching original values.
+    """Test that a campaign clone's CREATE action records the CLONE's own values.
 
-    The CREATE action on a cloned list represents creating the list from nothing
-    to its current state, so the deltas should equal the original's current values.
+    The CREATE action represents the clone coming into existence, so its deltas
+    equal the clone's recalculated rating/stash and copied credits — NOT the
+    source's cached rating_current, which can be stale (that would leave a chain
+    break at the clone -> CAMPAIGN_START seam).
     """
-    # Setup
+    # Setup: source caches set to values its (empty) content does not support.
     settings.FEATURE_LIST_ACTION_CREATE_INITIAL = True
     original = make_list("Original List")
     original.credits_current = 500
@@ -787,7 +802,43 @@ def test_handle_list_clone_for_campaign_cloned_action_has_correct_deltas(
     assert result.cloned_action.stash_before == 0
     assert result.cloned_action.credits_before == 0
 
-    # Deltas should match original's current values
-    assert result.cloned_action.rating_delta == original.rating_current
-    assert result.cloned_action.stash_delta == original.stash_current
-    assert result.cloned_action.credits_delta == original.credits_current
+    # Deltas match the CLONE's recalculated values, not the source's stale
+    # caches: the empty clone recalculates rating/stash to 0; credits copied.
+    assert result.cloned_list.rating_current == 0
+    assert result.cloned_action.rating_delta == 0
+    assert result.cloned_action.stash_delta == 0
+    assert result.cloned_action.credits_delta == 500
+
+
+@pytest.mark.django_db
+def test_campaign_clone_books_clone_rating_not_stale_source_cache(
+    user, make_list, make_campaign, content_fighter, make_equipment
+):
+    """The clone-seam bug: the CREATE action must record the CLONE's real
+    rating, not the source gang's cached rating_current — which can be stale
+    (list-building caches drift). Booking the source cache writes a rating the
+    clone's true cost immediately contradicts, because CAMPAIGN_START prices the
+    gang with a fresh cost_int() — leaving a permanent chain break at the clone
+    seam even though the clone itself is fine (seen in prod on IronSkull: source
+    cached 850, true 760, −90 seam break)."""
+    lst = make_list("Source Gang")
+    fighter = hire_fighter(user, lst, content_fighter, name="Bob")
+    buy_equipment(user, lst, fighter, make_equipment("Lasgun", cost=15))
+    true_rating = fresh(lst).cost_int()
+    assert true_rating > 0
+
+    # Corrupt the source's cached rating so it disagrees with reality — exactly
+    # what a drifted list-building gang looks like in production.
+    List.objects.filter(pk=lst.pk).update(rating_current=true_rating + 90)
+
+    campaign = make_campaign("Seam Campaign", status="in_progress", budget=2000)
+    cloned, created = campaign.add_list_to_campaign(fresh(lst), user=user)
+    assert created
+
+    create_action = ListAction.objects.get(
+        list=cloned, action_type=ListActionType.CREATE
+    )
+    # The CREATE records the CLONE's real rating, not the stale source +90.
+    assert create_action.rating_delta == true_rating
+    # And the whole chain reconciles: no clone-seam break.
+    assert_reconciles(cloned)

--- a/gyrinx/core/tests/test_clone.py
+++ b/gyrinx/core/tests/test_clone.py
@@ -824,12 +824,17 @@ def test_campaign_clone_books_clone_rating_not_stale_source_cache(
     lst = make_list("Source Gang")
     fighter = hire_fighter(user, lst, content_fighter, name="Bob")
     buy_equipment(user, lst, fighter, make_equipment("Lasgun", cost=15))
-    true_rating = fresh(lst).cost_int()
+    # The real hire/buy flows leave the source reconciled (dirty=False), so its
+    # freshly-recomputed rating_current is the true rating — the same quantity
+    # rating_delta is booked from (active fighters only, not stash/credits).
+    true_rating = fresh(lst).rating_current
     assert true_rating > 0
 
-    # Corrupt the source's cached rating so it disagrees with reality — exactly
-    # what a drifted list-building gang looks like in production.
-    List.objects.filter(pk=lst.pk).update(rating_current=true_rating + 90)
+    # Corrupt the source's cached rating so it disagrees with reality while
+    # keeping the cache "clean" (dirty=False) — exactly what a drifted
+    # list-building gang looks like in production, where facts() still serves
+    # the stale value instead of recomputing.
+    List.objects.filter(pk=lst.pk).update(rating_current=true_rating + 90, dirty=False)
 
     campaign = make_campaign("Seam Campaign", status="in_progress", budget=2000)
     cloned, created = campaign.add_list_to_campaign(fresh(lst), user=user)


### PR DESCRIPTION
## Summary

When a gang is cloned — most commonly when it's added to a campaign — the "list created" record on the new clone was copying the **source** gang's cached rating and stash, instead of the clone's own freshly-computed values.

The source gang's cached rating is frequently wrong. A gang that's still being built up in list-building mode accumulates cache drift: the cached rating isn't recomputed on every edit, so it lags reality until something forces a recompute. The clone, by contrast, recomputes its caches from scratch as part of cloning. Copying the stale source number onto the clone's first ledger entry writes a rating that the clone's real cost immediately contradicts — and the very next campaign action re-prices the gang from a fresh cost, so the mismatch becomes a permanent break in the balance-sheet audit chain, right at the clone seam.

This was observed on real production gangs. On one (IronSkull), the source's cached rating was 850 while its true cost was 760, producing a −90 break that the debug balance sheet flags for the life of the gang.

## What changed

- `handle_list_clone` now books the **clone's** recomputed rating/stash/credits on its CREATE action, not the source's cached values.
- New regression test that deliberately corrupts a source gang's cached rating, clones it into a campaign, and asserts the clone's ledger reconciles with no seam break.
- Updated two existing clone-action tests that had encoded the old (buggy) "copy the source cache" behaviour.

This is a small, self-contained fix, independent of the cost-pinning work in #1826 — it stands alone on `main`. Note it only affects **new** clones going forward; existing gangs with a historical seam break are unchanged by this and are addressed separately by the estate reconcile.

## Test plan

- [x] `pytest -n 4 gyrinx/core/tests/test_clone.py` — 23 passed
- [x] `pytest -n 4 gyrinx/core/tests/` — 2621 passed, 7 skipped, 2 xfailed

Refs #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh