### PR TITLE
fix: classic print cards on iOS — page-fold slicing, mobile squish, and page mat

### DIFF
--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -20,7 +20,11 @@
     --cc-line-soft: rgba(29, 26, 22, 0.35);
     --cc-hl: rgba(122, 45, 41, 0.16); // mental-stat / highlighted band tint
     --cc-paper: #fff; // base the texture fades onto
-    --cc-fade: 0.5; // white wash over the texture (0 = full-strength texture)
+    // White wash over the texture (0 = full-strength texture, 1 = plain white).
+    // Kept at 1 so the print cards are clean white — the distressed plate
+    // muddied to grey on paper and wasted ink. The dark theme (lab preview
+    // only) overrides this back to 0 to keep its plate.
+    --cc-fade: 1;
 
     // --- geometry (mm) — tune the whole card from here ---------------------
     --cc-w: 100mm;
@@ -696,10 +700,10 @@
     align-content: flex-start;
     justify-content: center;
     padding: var(--sheet-gap);
-    // On-screen preview canvas only — a neutral mat so the light cards read as
-    // physical cards. Print forces this white (see @media print), so it never
-    // reaches paper.
-    background: #3f3d3a;
+    // Plain white behind the cards — the card's own black border gives them
+    // definition, no grey mat. (Print already forces white; this matches it
+    // on screen too.)
+    background: #fff;
 }
 
 // On-screen A4 page preview: constrain to the real printable width so the lab

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -64,6 +64,14 @@
     box-sizing: border-box;
     width: var(--cc-w);
     height: var(--cc-h);
+    // Fixed-size card. As a flex item it defaults to flex-shrink: 1, so any
+    // container narrower than 100mm (every phone screen — and iOS's print
+    // layout viewport, which is derived from the on-screen device width) would
+    // squash the card's *width* while its height stays 110mm. That distorts the
+    // mm-positioned regions and clips content. Pin the flex size so the card
+    // always keeps its intrinsic 100x110mm and the container scrolls / scales
+    // to fit instead of deforming the card.
+    flex: 0 0 auto;
     overflow: hidden;
     color: var(--cc-ink);
     background: var(--cc-paper);
@@ -73,6 +81,11 @@
     font-family: $font-family-sans-serif;
     font-size: 2.5mm;
     line-height: 1.05;
+    // iOS Safari auto-inflates text in fixed-width blocks ("text autosizing"),
+    // which overflows the precisely-sized mm regions and breaks the layout on
+    // mobile. Pin it so the mm type renders at exactly the size we set.
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
 
@@ -733,7 +746,13 @@
     .print-sheet {
         gap: 3mm;
         padding: 0;
-        width: auto;
+        // Pin the sheet to the A4 content width (210mm − 2×3mm @page margin)
+        // rather than `auto`. On iOS the print layout viewport is inherited
+        // from the narrow on-screen device width, so `auto` collapses the sheet
+        // and the cards can no longer tile 2-up (or scale unpredictably). A
+        // fixed 204mm sheet lays the two 100mm cards out deterministically and
+        // lets the browser scale that whole sheet to the paper.
+        width: 204mm;
         margin: 0;
         justify-content: flex-start;
         background: #fff !important;
@@ -741,6 +760,10 @@
 
     .classic-card {
         break-inside: avoid;
+        // Legacy alias — older WebKit / iOS Safari only honour the
+        // page-break-* properties, not the modern break-* ones, so without
+        // this a card can be sliced across the page fold when printing.
+        page-break-inside: avoid;
         outline: none !important;
     }
 

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -712,6 +712,19 @@
     justify-content: flex-start;
 }
 
+// On a screen narrower than one card (small phones), the fixed-size card can't
+// shrink (see .classic-card flex: 0 0 auto), so contain its horizontal overflow
+// to the sheet instead of letting the whole page scroll sideways. Left-align so
+// the card's left edge stays reachable when the strip scrolls (centering would
+// push it off the unscrollable left side). Screen-only — never touches print,
+// where an overflow container could suppress page-break fragmentation.
+@media screen and (max-width: 110mm) {
+    .print-sheet {
+        justify-content: flex-start;
+        overflow-x: auto;
+    }
+}
+
 // Guide overlay: faint reference frame + mm grid to align regions during tuning.
 .classic-card.show-grid::before {
     content: "";

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -20,11 +20,7 @@
     --cc-line-soft: rgba(29, 26, 22, 0.35);
     --cc-hl: rgba(122, 45, 41, 0.16); // mental-stat / highlighted band tint
     --cc-paper: #fff; // base the texture fades onto
-    // White wash over the texture (0 = full-strength texture, 1 = plain white).
-    // Kept at 1 so the print cards are clean white — the distressed plate
-    // muddied to grey on paper and wasted ink. The dark theme (lab preview
-    // only) overrides this back to 0 to keep its plate.
-    --cc-fade: 1;
+    --cc-fade: 0.5; // white wash over the texture (0 = full-strength texture)
 
     // --- geometry (mm) — tune the whole card from here ---------------------
     --cc-w: 100mm;

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -744,27 +744,45 @@
     }
 
     .print-sheet {
-        gap: 3mm;
-        padding: 0;
-        // Pin the sheet to the A4 content width (210mm − 2×3mm @page margin)
-        // rather than `auto`. On iOS the print layout viewport is inherited
-        // from the narrow on-screen device width, so `auto` collapses the sheet
-        // and the cards can no longer tile 2-up (or scale unpredictably). A
-        // fixed 204mm sheet lays the two 100mm cards out deterministically and
-        // lets the browser scale that whole sheet to the paper.
+        // Lay the cards out as inline-blocks in a plain BLOCK container, not a
+        // flex container. Flex items don't take part in WebKit/iOS page
+        // fragmentation, so `break-inside: avoid` on a flex child is silently
+        // ignored and a card gets sliced across the page fold (this is what
+        // cut cards in half on iOS, worst in landscape). A block flow of
+        // inline-blocks fragments normally and honours the page-break rules.
+        display: block;
+        // Pin to the A4 content width (210mm − 2×3mm @page margin) rather than
+        // `auto`: on iOS the print layout viewport is inherited from the narrow
+        // on-screen device width, so `auto` would collapse the sheet to one
+        // card per row. A fixed 204mm width tiles the cards 2-up
+        // deterministically and the browser scales the sheet to the paper.
         width: 204mm;
+        padding: 0;
         margin: 0;
-        justify-content: flex-start;
+        // Collapse the whitespace between inline-block cards so a pair fits one
+        // row (each card resets its own font-size/line-height).
+        font-size: 0;
+        line-height: 0;
         background: #fff !important;
     }
 
     .classic-card {
+        display: inline-block;
+        vertical-align: top;
+        // 3mm gutter between the two columns and between rows. The right column
+        // (every 2nd card) drops its trailing margin so a pair is exactly
+        // 100 + 3 + 100 = 203mm ≤ 204mm and the next card wraps to a new row
+        // instead of overflowing (which would collapse the layout to 1-up).
+        margin: 0 3mm 3mm 0;
+        // Keep each card whole on a single page. WebKit/iOS honour the legacy
+        // page-break-* alias, so set both.
         break-inside: avoid;
-        // Legacy alias — older WebKit / iOS Safari only honour the
-        // page-break-* properties, not the modern break-* ones, so without
-        // this a card can be sliced across the page fold when printing.
         page-break-inside: avoid;
         outline: none !important;
+    }
+
+    .classic-card:nth-child(2n) {
+        margin-right: 0;
     }
 
     // never carry the tuning grid into a real print


### PR DESCRIPTION
## Summary

The classic-mode print cards (the fixed-size 100×110mm Necromunda-style fighter cards) didn't print properly on iOS and looked wrong on mobile. This fixes three separate problems, all CSS-only:

- **Cards were sliced in half across the page fold when printing** (worst on iOS in landscape). The print sheet was a flex container, and WebKit/iOS Safari don't apply page-break rules to flex items — so `break-inside: avoid` on the cards was ignored. The sheet is now a plain block container of `inline-block` cards, which do take part in page fragmentation, so a card that would straddle the fold is pushed whole to the next page. Cards tile 2-up deterministically in the 204mm A4 content width.
- **Cards were squashed on mobile (and in iOS's print layout).** Each card is a flex item that defaulted to `flex-shrink: 1`, so in any container narrower than 100mm — every phone, and iOS's print layout viewport, which it derives from the on-screen device width — the card's width was compressed while its height stayed at 110mm, deforming the precisely positioned regions. Pinned `flex: 0 0 auto` so the card always keeps its true size, plus `-webkit-text-size-adjust: 100%` to stop iOS auto-inflating the fixed-size text.
- **The page behind the cards was a dark grey mat.** Changed to white; the cards keep their distressed background texture, and their black border gives them definition.

## Test plan

- [x] Open a gang's classic-style print (or `/_debug/print-lab/sheet/?source=presets`) on an iOS device/simulator and print/preview: cards are not sliced across pages, in both portrait and landscape.
- [x] View the same page on a phone screen: cards render at their true size (not horizontally squashed), no odd text scaling.
- [x] Cards keep their background texture; the page behind them is white.
- [x] Desktop print preview still tiles cards 4-up per portrait A4 page.

## Notes

- Portrait prints 4 cards/page; landscape prints 2/page (the layout is portrait-optimised, so landscape leaves the right of the page blank). Nothing is cut either way. Optimising landscape density is a possible follow-up.
- Screen layout is unchanged (still flex); the block/inline-block layout applies only under `@media print`.

Refs #1726