### PR TITLE
feat: notify affected owners & arbitrators when their lists are reconciled

### DIFF
--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -64,8 +64,9 @@ def recompute_list_cost_caches(modeladmin, request, queryset):
     aggregate caches.
     """
     fighters = ListFighter.objects.filter(list__in=queryset)
-    # Lists whose cache moved during the fighter rebuild (a player-visible change).
-    moved_ids = set(_recompute_fighter_caches(request, fighters))
+    # {list_id: rating_delta} for lists whose cache moved during the fighter
+    # rebuild (a player-visible change).
+    moved = dict(_recompute_fighter_caches(request, fighters))
     # recompute_cost_caches only reconciles lists it saw fighters for; cover
     # fighterless lists too (audited the same way) without re-reconciling
     # the ones it already handled.
@@ -74,13 +75,13 @@ def recompute_list_cost_caches(modeladmin, request, queryset):
         if lst.pk not in covered:
             result = reconcile_list(lst, user=request.user, rebuild_fighters=False)
             if result.moved:
-                moved_ids.add(lst.pk)
+                moved[lst.pk] = result.rating_after - result.rating_before
 
     # Notify affected owners/arbitrators once each (aggregated), for the lists
     # in this selection that actually changed. System notification (sender=None)
     # — this is maintenance, not a user action end-recipients need to attribute.
     try:
-        owners, arbs = notify_lists_reconciled(moved_ids)
+        owners, arbs = notify_lists_reconciled(moved)
         if owners or arbs:
             messages.info(
                 request,
@@ -204,12 +205,13 @@ class ListFighterPsykerPowerAssignmentInline(admin.TabularInline):
 
 def _recompute_fighter_caches(request, queryset):
     """Rebuild the cost cache chain for the given fighters and reconcile their
-    lists; return the set of list ids whose aggregate cache actually moved.
+    lists; return ``{list_id: rating_delta}`` for lists whose aggregate cache
+    actually moved.
 
     Split out from the admin action so the list-level wrapper can learn which
-    lists changed (to notify their owners/arbs) — an admin action's return value
-    is interpreted as an HTTP response by the object-actions framework, so it
-    must stay ``None``.
+    lists changed, and by how much, to notify their owners/arbs — an admin
+    action's return value is interpreted as an HTTP response by the
+    object-actions framework, so it must stay ``None``.
     """
     changed = []
     affected_lists = {}
@@ -241,11 +243,11 @@ def _recompute_fighter_caches(request, queryset):
         # Reconcile each affected list's aggregate caches (rating/stash),
         # recording any movement as a RECONCILE action so the ledger absorbs
         # the correction instead of silently snapping (#1826 §4.8.2).
-        moved_list_ids = set()
+        moved_list_deltas = {}
         for lst in affected_lists.values():
             result = reconcile_list(lst, user=request.user, rebuild_fighters=False)
             if result.moved:
-                moved_list_ids.add(lst.pk)
+                moved_list_deltas[lst.pk] = result.rating_after - result.rating_before
 
     for fighter, before, after in changed:
         messages.success(
@@ -259,8 +261,9 @@ def _recompute_fighter_caches(request, queryset):
         f"{len(affected_lists)} list(s); {len(changed)} had drift corrected.",
     )
 
-    # Ids of lists whose aggregate cache actually moved (a player-visible change).
-    return moved_list_ids
+    # {list_id: rating_delta} for lists whose aggregate cache actually moved
+    # (a player-visible change).
+    return moved_list_deltas
 
 
 @admin.action(description="Recompute cached cost/rating from facts (fix drift)")

--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -64,8 +64,8 @@ def recompute_list_cost_caches(modeladmin, request, queryset):
     aggregate caches.
     """
     fighters = ListFighter.objects.filter(list__in=queryset)
-    # {list_id: rating_delta} for lists whose cache moved during the fighter
-    # rebuild (a player-visible change).
+    # {list_id: [rating_delta, stash_delta]} for lists whose cache moved during
+    # the fighter rebuild (a player-visible change).
     moved = dict(_recompute_fighter_caches(request, fighters))
     # recompute_cost_caches only reconciles lists it saw fighters for; cover
     # fighterless lists too (audited the same way) without re-reconciling
@@ -75,7 +75,10 @@ def recompute_list_cost_caches(modeladmin, request, queryset):
         if lst.pk not in covered:
             result = reconcile_list(lst, user=request.user, rebuild_fighters=False)
             if result.moved:
-                moved[lst.pk] = result.rating_after - result.rating_before
+                moved[lst.pk] = [
+                    result.rating_after - result.rating_before,
+                    result.stash_after - result.stash_before,
+                ]
 
     # Notify affected owners/arbitrators once each (aggregated), for the lists
     # in this selection that actually changed. System notification (sender=None)
@@ -205,8 +208,8 @@ class ListFighterPsykerPowerAssignmentInline(admin.TabularInline):
 
 def _recompute_fighter_caches(request, queryset):
     """Rebuild the cost cache chain for the given fighters and reconcile their
-    lists; return ``{list_id: rating_delta}`` for lists whose aggregate cache
-    actually moved.
+    lists; return ``{list_id: [rating_delta, stash_delta]}`` for lists whose
+    aggregate cache actually moved.
 
     Split out from the admin action so the list-level wrapper can learn which
     lists changed, and by how much, to notify their owners/arbs — an admin
@@ -247,7 +250,10 @@ def _recompute_fighter_caches(request, queryset):
         for lst in affected_lists.values():
             result = reconcile_list(lst, user=request.user, rebuild_fighters=False)
             if result.moved:
-                moved_list_deltas[lst.pk] = result.rating_after - result.rating_before
+                moved_list_deltas[lst.pk] = [
+                    result.rating_after - result.rating_before,
+                    result.stash_after - result.stash_before,
+                ]
 
     for fighter, before, after in changed:
         messages.success(
@@ -261,8 +267,8 @@ def _recompute_fighter_caches(request, queryset):
         f"{len(affected_lists)} list(s); {len(changed)} had drift corrected.",
     )
 
-    # {list_id: rating_delta} for lists whose aggregate cache actually moved
-    # (a player-visible change).
+    # {list_id: [rating_delta, stash_delta]} for lists whose aggregate cache
+    # actually moved (a player-visible change).
     return moved_list_deltas
 
 

--- a/gyrinx/core/admin/list.py
+++ b/gyrinx/core/admin/list.py
@@ -1,3 +1,5 @@
+import logging
+
 from django import forms
 from django.contrib import admin, messages
 from django.db import transaction
@@ -6,6 +8,7 @@ from django.utils.html import format_html
 
 from gyrinx.core.admin.base import BaseAdmin
 from gyrinx.core.cost.reconcile import reconcile_list
+from gyrinx.core.cost.reconcile_notify import notify_lists_reconciled
 from gyrinx.core.admin.filters import (
     AutocompleteRelatedFilter,
     autocomplete_filter_media,
@@ -22,6 +25,8 @@ from ..models.list import (
     ListFighterEquipmentAssignmentUpgrade,
     ListFighterPsykerPowerAssignment,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @admin.display(description="Cost")
@@ -59,14 +64,30 @@ def recompute_list_cost_caches(modeladmin, request, queryset):
     aggregate caches.
     """
     fighters = ListFighter.objects.filter(list__in=queryset)
-    recompute_cost_caches(modeladmin, request, fighters)
+    # Lists whose cache moved during the fighter rebuild (a player-visible change).
+    moved_ids = set(_recompute_fighter_caches(request, fighters))
     # recompute_cost_caches only reconciles lists it saw fighters for; cover
     # fighterless lists too (audited the same way) without re-reconciling
     # the ones it already handled.
     covered = set(fighters.values_list("list_id", flat=True).distinct())
     for lst in queryset:
         if lst.pk not in covered:
-            reconcile_list(lst, user=request.user, rebuild_fighters=False)
+            result = reconcile_list(lst, user=request.user, rebuild_fighters=False)
+            if result.moved:
+                moved_ids.add(lst.pk)
+
+    # Notify affected owners/arbitrators once each (aggregated), for the lists
+    # in this selection that actually changed. System notification (sender=None)
+    # — this is maintenance, not a user action end-recipients need to attribute.
+    try:
+        owners, arbs = notify_lists_reconciled(moved_ids)
+        if owners or arbs:
+            messages.info(
+                request,
+                f"Notified {owners} owner(s) and {arbs} arbitrator(s) of the changes.",
+            )
+    except Exception:
+        logger.exception("recompute_list_cost_caches: notification fan-out failed")
 
 
 @admin.register(List)
@@ -181,17 +202,14 @@ class ListFighterPsykerPowerAssignmentInline(admin.TabularInline):
     fields = ["psyker_power"]
 
 
-@admin.action(description="Recompute cached cost/rating from facts (fix drift)")
-def recompute_cost_caches(modeladmin, request, queryset):
-    """
-    Force-recompute the cached cost/rating chain for the selected fighters
-    straight from the source-of-truth assignments.
+def _recompute_fighter_caches(request, queryset):
+    """Rebuild the cost cache chain for the given fighters and reconcile their
+    lists; return the set of list ids whose aggregate cache actually moved.
 
-    Fixes cached-value drift (e.g. an inflated stash after a fighter death,
-    where a fighter's ``rating_current`` is wrong but ``dirty=False`` so the
-    normal lazy "Refresh Cost" recompute trusts the stale value and never
-    re-derives it). This rebuilds the whole subtree explicitly:
-    assignments -> fighter -> list, ignoring the dirty flags.
+    Split out from the admin action so the list-level wrapper can learn which
+    lists changed (to notify their owners/arbs) — an admin action's return value
+    is interpreted as an HTTP response by the object-actions framework, so it
+    must stay ``None``.
     """
     changed = []
     affected_lists = {}
@@ -223,8 +241,11 @@ def recompute_cost_caches(modeladmin, request, queryset):
         # Reconcile each affected list's aggregate caches (rating/stash),
         # recording any movement as a RECONCILE action so the ledger absorbs
         # the correction instead of silently snapping (#1826 §4.8.2).
+        moved_list_ids = set()
         for lst in affected_lists.values():
-            reconcile_list(lst, user=request.user, rebuild_fighters=False)
+            result = reconcile_list(lst, user=request.user, rebuild_fighters=False)
+            if result.moved:
+                moved_list_ids.add(lst.pk)
 
     for fighter, before, after in changed:
         messages.success(
@@ -237,6 +258,21 @@ def recompute_cost_caches(modeladmin, request, queryset):
         f"Recomputed {fighter_count} fighter(s) across "
         f"{len(affected_lists)} list(s); {len(changed)} had drift corrected.",
     )
+
+    # Ids of lists whose aggregate cache actually moved (a player-visible change).
+    return moved_list_ids
+
+
+@admin.action(description="Recompute cached cost/rating from facts (fix drift)")
+def recompute_cost_caches(modeladmin, request, queryset):
+    """Force-recompute the cached cost/rating chain for the selected fighters
+    straight from the source-of-truth assignments (fixes cached-value drift).
+
+    Standalone fighter-level action: it does not fan out notifications (that is
+    the list-level ``recompute_list_cost_caches`` wrapper's job). Returns
+    ``None`` — the object-actions framework treats a return value as a response.
+    """
+    _recompute_fighter_caches(request, queryset)
 
 
 @admin.display(description="List", ordering="list__name")

--- a/gyrinx/core/cost/reconcile_notify.py
+++ b/gyrinx/core/cost/reconcile_notify.py
@@ -1,0 +1,176 @@
+"""Aggregated user notifications for cache reconciliation (#1826 + #721).
+
+When we reconcile lists — a single admin action, or the estate-wide backfill
+run — the people affected should hear about it. But a gamer can own many gangs,
+and an arbitrator's campaigns can hold many more, so notifying *per list* would
+bury them under duplicates. Instead we fan out **one notification per affected
+owner** and **one per affected arbitrator**, each carrying links to every gang
+that changed.
+
+This sits on top of the #721 notification service (``notify*`` in
+``models.notification``); it stays out of that generic module so the
+reconcile-specific copy and grouping live with the rest of the #1826 cost code.
+
+"Affected" means the list's cached totals actually *moved* — i.e. the number a
+player sees changed. Callers pass the ids of lists whose
+:class:`~gyrinx.core.cost.reconcile.ReconcileResult` reported ``moved``. That is
+deliberately narrower than "a RECONCILE action was written": reconcile also
+writes an action when only the *ledger head* needed aligning while the cache was
+already correct — nothing a player would notice, so no notification. And it is
+wider than "an action was written": a pure un-audited cache correction moves the
+cache with no action at all, and the player should still be told.
+"""
+
+import logging
+from collections import defaultdict
+
+from django.urls import reverse
+from django.utils.html import format_html, format_html_join
+
+from gyrinx.core.models.list import List
+from gyrinx.core.models.notification import Notification, NotificationType
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["notify_lists_reconciled"]
+
+
+def _owner_subject(n):
+    return (
+        "A gang of yours was recalculated"
+        if n == 1
+        else f"{n} of your gangs were recalculated"
+    )
+
+
+def _arb_subject(n):
+    return (
+        "A gang in your campaign was recalculated"
+        if n == 1
+        else f"{n} gangs in your campaigns were recalculated"
+    )
+
+
+def _gang_links(lists, *, with_campaign=False):
+    """An HTML ``<ul>`` of links to each gang. Names are auto-escaped by
+    ``format_html_join`` (they are user content), and ``safe_rich_text`` — which
+    renders notification bodies — permits ``<ul>``/``<li>``/``<a href>``, so the
+    links render in the inbox and nothing can inject markup."""
+    items = format_html_join(
+        "",
+        '<li><a href="{}">{}</a>{}</li>',
+        (
+            (
+                reverse("core:list", args=[lst.pk]),
+                lst.name,
+                format_html(" — {}", lst.campaign.name)
+                if (with_campaign and lst.campaign_id)
+                else "",
+            )
+            for lst in lists
+        ),
+    )
+    return format_html("<ul>{}</ul>", items)
+
+
+def _owner_content(lists):
+    return format_html(
+        "{}{}",
+        "We corrected some out-of-date cost totals on the gang(s) below. Their "
+        "ratings now reflect what their fighters and equipment actually cost — "
+        "no credits were spent, and nothing was added or removed.",
+        _gang_links(lists),
+    )
+
+
+def _arb_content(lists):
+    return format_html(
+        "{}{}",
+        "We corrected some out-of-date cost totals on gang(s) in campaigns you "
+        "run. Their ratings now reflect what their fighters and equipment "
+        "actually cost — no credits or equipment changed.",
+        _gang_links(lists, with_campaign=True),
+    )
+
+
+def notify_lists_reconciled(list_ids, *, sender=None, batch_size=500):
+    """Fan out aggregated reconcile notifications for the given lists.
+
+    Sends one notification to each affected **owner** (summarising their gangs)
+    and one to each affected **arbitrator** (summarising affected gangs in
+    campaigns they run, excluding gangs they own — those are already covered by
+    their owner notification, mirroring ``notify_list_changed``'s de-dupe).
+
+    Args:
+        list_ids: ids of lists whose caches actually moved (see module docstring).
+        sender: acting User, or ``None`` for a system/Gyrinx notification
+            (the default — reconciliation is background maintenance and players
+            don't need to attribute it to a particular admin).
+        batch_size: bulk-create chunk size.
+
+    Returns:
+        ``(owners_notified, arbitrators_notified)``. Safe: logs and returns
+        ``(0, 0)`` on error rather than raising into the reconcile flow.
+    """
+    list_ids = list(dict.fromkeys(list_ids))  # de-dupe, preserve order
+    if not list_ids:
+        return (0, 0)
+
+    try:
+        lists = list(
+            List.objects.filter(pk__in=list_ids).select_related(
+                "owner", "campaign", "campaign__owner"
+            )
+        )
+
+        by_owner = defaultdict(list)
+        owner_user = {}
+        by_arb = defaultdict(list)
+        arb_user = {}
+        for lst in lists:
+            if lst.owner_id:
+                by_owner[lst.owner_id].append(lst)
+                owner_user[lst.owner_id] = lst.owner
+            if (
+                lst.is_campaign_mode
+                and lst.campaign_id
+                and lst.campaign.owner_id
+                and lst.campaign.owner_id != lst.owner_id
+            ):
+                by_arb[lst.campaign.owner_id].append(lst)
+                arb_user[lst.campaign.owner_id] = lst.campaign.owner
+
+        notifs = []
+        for owner_id, olists in by_owner.items():
+            notifs.append(
+                Notification(
+                    owner=owner_user[owner_id],
+                    sender=sender,
+                    subject=_owner_subject(len(olists)),
+                    content=_owner_content(olists),
+                    notification_type=NotificationType.LIST,
+                    show_as_banner=False,
+                    icon="bi-calculator",
+                )
+            )
+        for arb_id, alists in by_arb.items():
+            notifs.append(
+                Notification(
+                    owner=arb_user[arb_id],
+                    sender=sender,
+                    subject=_arb_subject(len(alists)),
+                    content=_arb_content(alists),
+                    notification_type=NotificationType.CAMPAIGN,
+                    show_as_banner=False,
+                    icon="bi-calculator",
+                )
+            )
+
+        for i in range(0, len(notifs), batch_size):
+            Notification.objects.bulk_create(
+                notifs[i : i + batch_size], batch_size=batch_size
+            )
+        return (len(by_owner), len(by_arb))
+    except Exception:
+        logger.exception("notify_lists_reconciled failed for %s lists", len(list_ids))
+        return (0, 0)

--- a/gyrinx/core/cost/reconcile_notify.py
+++ b/gyrinx/core/cost/reconcile_notify.py
@@ -29,6 +29,7 @@ from django.utils.html import format_html, format_html_join
 
 from gyrinx.core.models.list import List
 from gyrinx.core.models.notification import Notification, NotificationType
+from gyrinx.models import format_cost_display
 
 logger = logging.getLogger(__name__)
 
@@ -51,14 +52,27 @@ def _arb_subject(n):
     )
 
 
-def _gang_links(lists, *, with_campaign=False):
-    """An HTML ``<ul>`` of links to each gang. Names are auto-escaped by
-    ``format_html_join`` (they are user content), and ``safe_rich_text`` — which
-    renders notification bodies — permits ``<ul>``/``<li>``/``<a href>``, so the
-    links render in the inbox and nothing can inject markup."""
+def _rating_change(rating_deltas, lst):
+    """A '(rating +N¢)' suffix for a gang whose rating moved, else ''.
+
+    ``rating_deltas`` is keyed by ``str(list_id)``. A zero (or missing) delta
+    means the rating didn't move — e.g. only the stash was corrected — so we
+    add nothing rather than a meaningless '(+0¢)'."""
+    delta = rating_deltas.get(str(lst.pk), 0)
+    if not delta:
+        return ""
+    return format_html(" (rating {})", format_cost_display(delta, show_sign=True))
+
+
+def _gang_links(lists, rating_deltas, *, with_campaign=False):
+    """An HTML ``<ul>`` of links to each gang, each annotated with how much its
+    rating changed. Names are auto-escaped by ``format_html_join`` (they are
+    user content), and ``safe_rich_text`` — which renders notification bodies —
+    permits ``<ul>``/``<li>``/``<a href>``, so the links render in the inbox and
+    nothing can inject markup."""
     items = format_html_join(
         "",
-        '<li><a href="{}">{}</a>{}</li>',
+        '<li><a href="{}">{}</a>{}{}</li>',
         (
             (
                 reverse("core:list", args=[lst.pk]),
@@ -66,6 +80,7 @@ def _gang_links(lists, *, with_campaign=False):
                 format_html(" — {}", lst.campaign.name)
                 if (with_campaign and lst.campaign_id)
                 else "",
+                _rating_change(rating_deltas, lst),
             )
             for lst in lists
         ),
@@ -73,36 +88,41 @@ def _gang_links(lists, *, with_campaign=False):
     return format_html("<ul>{}</ul>", items)
 
 
-def _owner_content(lists):
+def _owner_content(lists, rating_deltas):
     return format_html(
         "{}{}",
         "We corrected some out-of-date cost totals on the gang(s) below. Their "
         "ratings now reflect what their fighters and equipment actually cost — "
         "no credits were spent, and nothing was added or removed.",
-        _gang_links(lists),
+        _gang_links(lists, rating_deltas),
     )
 
 
-def _arb_content(lists):
+def _arb_content(lists, rating_deltas):
     return format_html(
         "{}{}",
         "We corrected some out-of-date cost totals on gang(s) in campaigns you "
         "run. Their ratings now reflect what their fighters and equipment "
         "actually cost — no credits or equipment changed.",
-        _gang_links(lists, with_campaign=True),
+        _gang_links(lists, rating_deltas, with_campaign=True),
     )
 
 
-def notify_lists_reconciled(list_ids, *, sender=None, batch_size=500):
+def notify_lists_reconciled(rating_deltas, *, sender=None, batch_size=500):
     """Fan out aggregated reconcile notifications for the given lists.
 
     Sends one notification to each affected **owner** (summarising their gangs)
     and one to each affected **arbitrator** (summarising affected gangs in
     campaigns they run, excluding gangs they own — those are already covered by
-    their owner notification, mirroring ``notify_list_changed``'s de-dupe).
+    their owner notification, mirroring ``notify_list_changed``'s de-dupe). Each
+    gang link is annotated with how much its rating changed.
 
     Args:
-        list_ids: ids of lists whose caches actually moved (see module docstring).
+        rating_deltas: a mapping ``{list_id: rating_delta}`` for the lists whose
+            caches actually moved (see module docstring). Keys may be ``str`` or
+            ``UUID``; a delta is ``rating_after - rating_before`` (negative means
+            the shown rating went down). Lists whose only movement was the stash
+            carry a 0 delta and simply appear without a rating annotation.
         sender: acting User, or ``None`` for a system/Gyrinx notification
             (the default — reconciliation is background maintenance and players
             don't need to attribute it to a particular admin).
@@ -112,7 +132,10 @@ def notify_lists_reconciled(list_ids, *, sender=None, batch_size=500):
         ``(owners_notified, arbitrators_notified)``. Safe: logs and returns
         ``(0, 0)`` on error rather than raising into the reconcile flow.
     """
-    list_ids = list(dict.fromkeys(list_ids))  # de-dupe, preserve order
+    # Normalise keys to str so lookups work whether callers pass UUIDs (admin
+    # path) or strings (task kwargs, which must be JSON-serialisable).
+    rating_deltas = {str(k): v for k, v in dict(rating_deltas).items()}
+    list_ids = list(rating_deltas)
     if not list_ids:
         return (0, 0)
 
@@ -141,16 +164,18 @@ def notify_lists_reconciled(list_ids, *, sender=None, batch_size=500):
                 arb_user[lst.campaign.owner_id] = lst.campaign.owner
 
         notifs = []
+        # These are background-maintenance notices (no human sender), so they
+        # use the SYSTEM type — and its default gear icon — rather than the
+        # LIST/CAMPAIGN types a user-driven change would carry.
         for owner_id, olists in by_owner.items():
             notifs.append(
                 Notification(
                     owner=owner_user[owner_id],
                     sender=sender,
                     subject=_owner_subject(len(olists)),
-                    content=_owner_content(olists),
-                    notification_type=NotificationType.LIST,
+                    content=_owner_content(olists, rating_deltas),
+                    notification_type=NotificationType.SYSTEM,
                     show_as_banner=False,
-                    icon="bi-calculator",
                 )
             )
         for arb_id, alists in by_arb.items():
@@ -159,10 +184,9 @@ def notify_lists_reconciled(list_ids, *, sender=None, batch_size=500):
                     owner=arb_user[arb_id],
                     sender=sender,
                     subject=_arb_subject(len(alists)),
-                    content=_arb_content(alists),
-                    notification_type=NotificationType.CAMPAIGN,
+                    content=_arb_content(alists, rating_deltas),
+                    notification_type=NotificationType.SYSTEM,
                     show_as_banner=False,
-                    icon="bi-calculator",
                 )
             )
 

--- a/gyrinx/core/cost/reconcile_notify.py
+++ b/gyrinx/core/cost/reconcile_notify.py
@@ -52,24 +52,29 @@ def _arb_subject(n):
     )
 
 
-def _rating_change(rating_deltas, lst):
-    """A '(rating +N¢)' suffix for a gang whose rating moved, else ''.
+def _change_summary(deltas, lst):
+    """A ' (rating +N¢, stash +M¢)' suffix summarising what moved for a gang,
+    including only the parts that actually changed. Empty if nothing did.
 
-    ``rating_deltas`` is keyed by ``str(list_id)``. A zero (or missing) delta
-    means the rating didn't move — e.g. only the stash was corrected — so we
-    add nothing rather than a meaningless '(+0¢)'."""
-    delta = rating_deltas.get(str(lst.pk), 0)
-    if not delta:
+    ``deltas`` is keyed by ``str(list_id)`` with ``[rating_delta, stash_delta]``
+    values. Mirrors the wording of the RECONCILE ledger action's description."""
+    rating_delta, stash_delta = deltas.get(str(lst.pk), (0, 0))
+    parts = []
+    if rating_delta:
+        parts.append(f"rating {format_cost_display(rating_delta, show_sign=True)}")
+    if stash_delta:
+        parts.append(f"stash {format_cost_display(stash_delta, show_sign=True)}")
+    if not parts:
         return ""
-    return format_html(" (rating {})", format_cost_display(delta, show_sign=True))
+    return format_html(" ({})", ", ".join(parts))
 
 
-def _gang_links(lists, rating_deltas, *, with_campaign=False):
-    """An HTML ``<ul>`` of links to each gang, each annotated with how much its
-    rating changed. Names are auto-escaped by ``format_html_join`` (they are
-    user content), and ``safe_rich_text`` — which renders notification bodies —
-    permits ``<ul>``/``<li>``/``<a href>``, so the links render in the inbox and
-    nothing can inject markup."""
+def _gang_links(lists, deltas, *, with_campaign=False):
+    """An HTML ``<ul>`` of links to each gang, each annotated with a summary of
+    what changed (rating and/or stash). Names are auto-escaped by
+    ``format_html_join`` (they are user content), and ``safe_rich_text`` — which
+    renders notification bodies — permits ``<ul>``/``<li>``/``<a href>``, so the
+    links render in the inbox and nothing can inject markup."""
     items = format_html_join(
         "",
         '<li><a href="{}">{}</a>{}{}</li>',
@@ -80,7 +85,7 @@ def _gang_links(lists, rating_deltas, *, with_campaign=False):
                 format_html(" — {}", lst.campaign.name)
                 if (with_campaign and lst.campaign_id)
                 else "",
-                _rating_change(rating_deltas, lst),
+                _change_summary(deltas, lst),
             )
             for lst in lists
         ),
@@ -88,41 +93,42 @@ def _gang_links(lists, rating_deltas, *, with_campaign=False):
     return format_html("<ul>{}</ul>", items)
 
 
-def _owner_content(lists, rating_deltas):
+def _owner_content(lists, deltas):
     return format_html(
         "{}{}",
         "We corrected some out-of-date cost totals on the gang(s) below. Their "
         "ratings now reflect what their fighters and equipment actually cost — "
         "no credits were spent, and nothing was added or removed.",
-        _gang_links(lists, rating_deltas),
+        _gang_links(lists, deltas),
     )
 
 
-def _arb_content(lists, rating_deltas):
+def _arb_content(lists, deltas):
     return format_html(
         "{}{}",
         "We corrected some out-of-date cost totals on gang(s) in campaigns you "
         "run. Their ratings now reflect what their fighters and equipment "
         "actually cost — no credits or equipment changed.",
-        _gang_links(lists, rating_deltas, with_campaign=True),
+        _gang_links(lists, deltas, with_campaign=True),
     )
 
 
-def notify_lists_reconciled(rating_deltas, *, sender=None, batch_size=500):
+def notify_lists_reconciled(deltas, *, sender=None, batch_size=500):
     """Fan out aggregated reconcile notifications for the given lists.
 
     Sends one notification to each affected **owner** (summarising their gangs)
     and one to each affected **arbitrator** (summarising affected gangs in
     campaigns they run, excluding gangs they own — those are already covered by
     their owner notification, mirroring ``notify_list_changed``'s de-dupe). Each
-    gang link is annotated with how much its rating changed.
+    gang link is annotated with a summary of what moved (rating and/or stash).
 
     Args:
-        rating_deltas: a mapping ``{list_id: rating_delta}`` for the lists whose
-            caches actually moved (see module docstring). Keys may be ``str`` or
-            ``UUID``; a delta is ``rating_after - rating_before`` (negative means
-            the shown rating went down). Lists whose only movement was the stash
-            carry a 0 delta and simply appear without a rating annotation.
+        deltas: a mapping ``{list_id: [rating_delta, stash_delta]}`` for the
+            lists whose caches actually moved (see module docstring). Keys may be
+            ``str`` or ``UUID``; each delta is ``after - before`` (negative means
+            the shown value went down). Only the non-zero parts are surfaced, so
+            a rating-only move shows just the rating, a stash-only move just the
+            stash.
         sender: acting User, or ``None`` for a system/Gyrinx notification
             (the default — reconciliation is background maintenance and players
             don't need to attribute it to a particular admin).
@@ -134,8 +140,8 @@ def notify_lists_reconciled(rating_deltas, *, sender=None, batch_size=500):
     """
     # Normalise keys to str so lookups work whether callers pass UUIDs (admin
     # path) or strings (task kwargs, which must be JSON-serialisable).
-    rating_deltas = {str(k): v for k, v in dict(rating_deltas).items()}
-    list_ids = list(rating_deltas)
+    deltas = {str(k): v for k, v in dict(deltas).items()}
+    list_ids = list(deltas)
     if not list_ids:
         return (0, 0)
 
@@ -173,7 +179,7 @@ def notify_lists_reconciled(rating_deltas, *, sender=None, batch_size=500):
                     owner=owner_user[owner_id],
                     sender=sender,
                     subject=_owner_subject(len(olists)),
-                    content=_owner_content(olists, rating_deltas),
+                    content=_owner_content(olists, deltas),
                     notification_type=NotificationType.SYSTEM,
                     show_as_banner=False,
                 )
@@ -184,7 +190,7 @@ def notify_lists_reconciled(rating_deltas, *, sender=None, batch_size=500):
                     owner=arb_user[arb_id],
                     sender=sender,
                     subject=_arb_subject(len(alists)),
-                    content=_arb_content(alists, rating_deltas),
+                    content=_arb_content(alists, deltas),
                     notification_type=NotificationType.SYSTEM,
                     show_as_banner=False,
                 )

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -409,7 +409,7 @@ def reconcile_all_lists(
     lists_done: int = 0,
     corrected: int = 0,
     clamped: int = 0,
-    moved_ids: list | None = None,
+    moved: list | None = None,
 ):
     """Audited cache reconciliation across every list (#1826 §4.8.2).
 
@@ -420,9 +420,10 @@ def reconcile_all_lists(
     triggering admin via ``user_id``.
 
     Self-re-enqueues with a pk cursor; totals ride the kwargs so the final
-    summary is cumulative. ``moved_ids`` accumulates the ids of lists whose
-    cached totals actually changed (a player-visible change), so that at
-    completion we can notify each affected owner and arbitrator exactly once
+    summary is cumulative. ``moved`` accumulates ``[list_id, rating_delta]``
+    pairs for lists whose cached totals actually changed (a player-visible
+    change), so that at completion we can notify each affected owner and
+    arbitrator exactly once, telling them how much each gang's rating moved
     (#721). It only holds the *corrected* subset — a small fraction of the
     estate — so it stays well within the task payload size limit.
     """
@@ -436,7 +437,7 @@ def reconcile_all_lists(
     if user_id is not None:
         user = get_user_model().objects.filter(pk=user_id).first()
 
-    moved_ids = list(moved_ids or [])
+    moved = list(moved or [])
 
     qs = List.objects.order_by("id")
     if list_id:
@@ -453,10 +454,12 @@ def reconcile_all_lists(
             if result.moved or result.action:
                 corrected += 1
             if result.moved:
-                # Player-visible change: this owner (and arb) get told. An
-                # action without `moved` is a ledger-only alignment nobody sees,
-                # so it is deliberately excluded here.
-                moved_ids.append(str(batch_list_id))
+                # Player-visible change: this owner (and arb) get told, with the
+                # rating delta. An action without `moved` is a ledger-only
+                # alignment nobody sees, so it is deliberately excluded here.
+                moved.append(
+                    [str(batch_list_id), result.rating_after - result.rating_before]
+                )
             if result.clamped:
                 clamped += 1
                 logger.warning(
@@ -496,7 +499,7 @@ def reconcile_all_lists(
             lists_done=lists_done,
             corrected=corrected,
             clamped=clamped,
-            moved_ids=moved_ids,
+            moved=moved,
         )
     else:
         _update_backfill(backfill_id, progress, status=Backfill.Status.DONE)
@@ -514,7 +517,7 @@ def reconcile_all_lists(
         try:
             from gyrinx.core.cost.reconcile_notify import notify_lists_reconciled
 
-            owners, arbs = notify_lists_reconciled(moved_ids)
+            owners, arbs = notify_lists_reconciled(dict(moved))
             logger.info(
                 "reconcile_all_lists: notified %s owner(s), %s arbitrator(s)",
                 owners,

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -409,6 +409,7 @@ def reconcile_all_lists(
     lists_done: int = 0,
     corrected: int = 0,
     clamped: int = 0,
+    moved_ids: list | None = None,
 ):
     """Audited cache reconciliation across every list (#1826 §4.8.2).
 
@@ -419,7 +420,11 @@ def reconcile_all_lists(
     triggering admin via ``user_id``.
 
     Self-re-enqueues with a pk cursor; totals ride the kwargs so the final
-    summary is cumulative.
+    summary is cumulative. ``moved_ids`` accumulates the ids of lists whose
+    cached totals actually changed (a player-visible change), so that at
+    completion we can notify each affected owner and arbitrator exactly once
+    (#721). It only holds the *corrected* subset — a small fraction of the
+    estate — so it stays well within the task payload size limit.
     """
     from django.contrib.auth import get_user_model
 
@@ -430,6 +435,8 @@ def reconcile_all_lists(
     user = None
     if user_id is not None:
         user = get_user_model().objects.filter(pk=user_id).first()
+
+    moved_ids = list(moved_ids or [])
 
     qs = List.objects.order_by("id")
     if list_id:
@@ -445,6 +452,11 @@ def reconcile_all_lists(
             lists_done += 1
             if result.moved or result.action:
                 corrected += 1
+            if result.moved:
+                # Player-visible change: this owner (and arb) get told. An
+                # action without `moved` is a ledger-only alignment nobody sees,
+                # so it is deliberately excluded here.
+                moved_ids.append(str(batch_list_id))
             if result.clamped:
                 clamped += 1
                 logger.warning(
@@ -484,6 +496,7 @@ def reconcile_all_lists(
             lists_done=lists_done,
             corrected=corrected,
             clamped=clamped,
+            moved_ids=moved_ids,
         )
     else:
         _update_backfill(backfill_id, progress, status=Backfill.Status.DONE)
@@ -493,6 +506,25 @@ def reconcile_all_lists(
             corrected,
             clamped,
         )
+        # Tell affected people once, aggregated: one notification per owner and
+        # one per arbitrator, each linking every gang that actually changed
+        # (#721). Runs once, at completion, over the whole run's moved set — so
+        # a player who owns several corrected gangs gets a single message.
+        # Never let a notification failure undo a completed reconcile.
+        try:
+            from gyrinx.core.cost.reconcile_notify import notify_lists_reconciled
+
+            owners, arbs = notify_lists_reconciled(moved_ids)
+            logger.info(
+                "reconcile_all_lists: notified %s owner(s), %s arbitrator(s)",
+                owners,
+                arbs,
+            )
+        except Exception:
+            logger.exception(
+                "reconcile_all_lists: notification fan-out failed (reconcile "
+                "itself completed)"
+            )
 
 
 @task

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -420,12 +420,13 @@ def reconcile_all_lists(
     triggering admin via ``user_id``.
 
     Self-re-enqueues with a pk cursor; totals ride the kwargs so the final
-    summary is cumulative. ``moved`` accumulates ``[list_id, rating_delta]``
-    pairs for lists whose cached totals actually changed (a player-visible
-    change), so that at completion we can notify each affected owner and
-    arbitrator exactly once, telling them how much each gang's rating moved
-    (#721). It only holds the *corrected* subset — a small fraction of the
-    estate — so it stays well within the task payload size limit.
+    summary is cumulative. ``moved`` accumulates
+    ``[list_id, rating_delta, stash_delta]`` rows for lists whose cached totals
+    actually changed (a player-visible change), so that at completion we can
+    notify each affected owner and arbitrator exactly once, summarising how much
+    each gang's rating and stash moved (#721). It only holds the *corrected*
+    subset — a small fraction of the estate — so it stays well within the task
+    payload size limit.
     """
     from django.contrib.auth import get_user_model
 
@@ -455,10 +456,14 @@ def reconcile_all_lists(
                 corrected += 1
             if result.moved:
                 # Player-visible change: this owner (and arb) get told, with the
-                # rating delta. An action without `moved` is a ledger-only
-                # alignment nobody sees, so it is deliberately excluded here.
+                # rating and stash deltas. An action without `moved` is a
+                # ledger-only alignment nobody sees, so it is excluded here.
                 moved.append(
-                    [str(batch_list_id), result.rating_after - result.rating_before]
+                    [
+                        str(batch_list_id),
+                        result.rating_after - result.rating_before,
+                        result.stash_after - result.stash_before,
+                    ]
                 )
             if result.clamped:
                 clamped += 1
@@ -517,7 +522,8 @@ def reconcile_all_lists(
         try:
             from gyrinx.core.cost.reconcile_notify import notify_lists_reconciled
 
-            owners, arbs = notify_lists_reconciled(dict(moved))
+            deltas = {row[0]: [row[1], row[2]] for row in moved}
+            owners, arbs = notify_lists_reconciled(deltas)
             logger.info(
                 "reconcile_all_lists: notified %s owner(s), %s arbitrator(s)",
                 owners,

--- a/gyrinx/core/tests/test_reconcile_notify.py
+++ b/gyrinx/core/tests/test_reconcile_notify.py
@@ -29,7 +29,10 @@ def test_one_notification_per_owner_with_links(make_user, make_list):
     l2 = make_list("Escher Wildcats", owner=alice)
     l3 = make_list("Orlock Arms", owner=bob)
 
-    owners, arbs = notify_lists_reconciled({l1.pk: -10, l2.pk: 5, l3.pk: -3})
+    # [rating_delta, stash_delta] per gang.
+    owners, arbs = notify_lists_reconciled(
+        {l1.pk: [-10, 0], l2.pk: [5, 3], l3.pk: [-3, 0]}
+    )
     assert (owners, arbs) == (2, 0)
 
     # Alice owns two affected gangs → exactly ONE notification naming both.
@@ -40,13 +43,13 @@ def test_one_notification_per_owner_with_links(make_user, make_list):
     assert "2 of your gangs" in n.subject
     assert n.is_system  # sender defaulted to None → Gyrinx system notification
     assert n.show_as_banner is False
-    # Both gangs are linked in the content, each with its rating change.
+    # Both gangs are linked in the content, each with a summary of what changed.
     assert "Goliath Bruisers" in n.content
     assert "Escher Wildcats" in n.content
     assert reverse("core:list", args=[l1.pk]) in n.content
     assert reverse("core:list", args=[l2.pk]) in n.content
-    assert "-10¢" in n.content  # Goliath dropped by 10
-    assert "+5¢" in n.content  # Escher rose by 5
+    assert "rating -10¢" in n.content  # Goliath rating dropped by 10
+    assert "rating +5¢, stash +3¢" in n.content  # Escher: both moved
 
     # Bob owns one → singular subject.
     bob_notif = Notification.objects.get(owner=bob)
@@ -65,7 +68,9 @@ def test_arb_notified_excluding_gangs_they_own(make_user, make_list, make_campai
         "Arbs Own Gang", owner=arb, status=List.CAMPAIGN_MODE, campaign=camp
     )
 
-    owners, arbs = notify_lists_reconciled({l_player.pk: -10, l_arb_own.pk: 5})
+    owners, arbs = notify_lists_reconciled(
+        {l_player.pk: [-10, 4], l_arb_own.pk: [5, 0]}
+    )
     # Two owners (player, arb — each owns one), one arbitrator (arb, for the
     # player's gang only; their own gang is covered by the owner notification).
     assert (owners, arbs) == (2, 1)
@@ -80,7 +85,7 @@ def test_arb_notified_excluding_gangs_they_own(make_user, make_list, make_campai
     assert "Player Gang" in arb_camp.content
     assert "Arbs Own Gang" not in arb_camp.content
     assert camp.name in arb_camp.content  # campaign named for context
-    assert "-10¢" in arb_camp.content  # rating change shown per gang
+    assert "rating -10¢, stash +4¢" in arb_camp.content  # both changes summarised
 
     # The player gets exactly one owner notification.
     assert Notification.objects.filter(owner=player).count() == 1
@@ -93,23 +98,24 @@ def test_empty_is_noop():
 
 
 @pytest.mark.django_db
-def test_stash_only_move_has_no_rating_annotation(make_user, make_list):
+def test_stash_only_move_shows_stash_not_rating(make_user, make_list):
     owner = make_user("stashy", "pw")
     lst = make_list("Stash Mover", owner=owner)
-    # Rating didn't move (delta 0) — only the stash was corrected. The gang is
-    # still listed, but without a meaningless "(rating +0¢)".
-    owners, arbs = notify_lists_reconciled({lst.pk: 0})
+    # Only the stash moved (rating delta 0): summary shows the stash change and
+    # omits the rating part rather than printing a meaningless "rating +0¢".
+    owners, arbs = notify_lists_reconciled({lst.pk: [0, 5]})
     assert (owners, arbs) == (1, 0)
     n = Notification.objects.get(owner=owner)
     assert "Stash Mover" in n.content
-    assert "(rating" not in n.content  # no per-gang delta annotation
+    assert "(stash +5¢)" in n.content
+    assert "rating +0¢" not in n.content
 
 
 @pytest.mark.django_db
 def test_non_campaign_list_has_no_arb(make_user, make_list):
     owner = make_user("solo", "pw")
     lst = make_list("Solo Gang", owner=owner)  # list-building mode, no campaign
-    owners, arbs = notify_lists_reconciled({lst.pk: -10})
+    owners, arbs = notify_lists_reconciled({lst.pk: [-10, 0]})
     assert (owners, arbs) == (1, 0)
 
 
@@ -184,8 +190,10 @@ def test_estate_run_notifies_once_per_owner_and_arb(
     assert "2 of your gangs" in pn.subject
     for lst, _ in lists:
         assert reverse("core:list", args=[lst.pk]) in pn.content
-    # Cache was tampered +10 then corrected back down, so each gang shows -10¢.
-    assert "-10¢" in pn.content
+    # Cache was tampered +10 then corrected back down, so each gang shows the
+    # rating drop (the stash didn't move here, so no stash part).
+    assert "rating -10¢" in pn.content
+    assert "stash" not in pn.content
 
     # Arb: exactly one aggregated campaign notification naming both gangs.
     arb_notifs = Notification.objects.filter(owner=arb)

--- a/gyrinx/core/tests/test_reconcile_notify.py
+++ b/gyrinx/core/tests/test_reconcile_notify.py
@@ -29,22 +29,24 @@ def test_one_notification_per_owner_with_links(make_user, make_list):
     l2 = make_list("Escher Wildcats", owner=alice)
     l3 = make_list("Orlock Arms", owner=bob)
 
-    owners, arbs = notify_lists_reconciled([l1.pk, l2.pk, l3.pk])
+    owners, arbs = notify_lists_reconciled({l1.pk: -10, l2.pk: 5, l3.pk: -3})
     assert (owners, arbs) == (2, 0)
 
     # Alice owns two affected gangs → exactly ONE notification naming both.
     alice_notifs = Notification.objects.filter(owner=alice)
     assert alice_notifs.count() == 1
     n = alice_notifs.get()
-    assert n.notification_type == NotificationType.LIST
+    assert n.notification_type == NotificationType.SYSTEM  # background maintenance
     assert "2 of your gangs" in n.subject
     assert n.is_system  # sender defaulted to None → Gyrinx system notification
     assert n.show_as_banner is False
-    # Both gangs are linked in the content.
+    # Both gangs are linked in the content, each with its rating change.
     assert "Goliath Bruisers" in n.content
     assert "Escher Wildcats" in n.content
     assert reverse("core:list", args=[l1.pk]) in n.content
     assert reverse("core:list", args=[l2.pk]) in n.content
+    assert "-10¢" in n.content  # Goliath dropped by 10
+    assert "+5¢" in n.content  # Escher rose by 5
 
     # Bob owns one → singular subject.
     bob_notif = Notification.objects.get(owner=bob)
@@ -63,20 +65,22 @@ def test_arb_notified_excluding_gangs_they_own(make_user, make_list, make_campai
         "Arbs Own Gang", owner=arb, status=List.CAMPAIGN_MODE, campaign=camp
     )
 
-    owners, arbs = notify_lists_reconciled([l_player.pk, l_arb_own.pk])
+    owners, arbs = notify_lists_reconciled({l_player.pk: -10, l_arb_own.pk: 5})
     # Two owners (player, arb — each owns one), one arbitrator (arb, for the
     # player's gang only; their own gang is covered by the owner notification).
     assert (owners, arbs) == (2, 1)
 
-    # The arb receives two: one as owner (their gang), one as arbitrator.
+    # The arb receives two: one as owner (their gang), one as arbitrator. Both
+    # are SYSTEM notifications, so they're told apart by subject.
     arb_notifs = Notification.objects.filter(owner=arb)
     assert arb_notifs.count() == 2
-    arb_camp = arb_notifs.get(notification_type=NotificationType.CAMPAIGN)
+    arb_camp = arb_notifs.get(subject__icontains="in your campaign")
     # The arbitrator notification links the player's gang, NOT the arb's own
     # (that would double-notify — it's already in their owner notification).
     assert "Player Gang" in arb_camp.content
     assert "Arbs Own Gang" not in arb_camp.content
     assert camp.name in arb_camp.content  # campaign named for context
+    assert "-10¢" in arb_camp.content  # rating change shown per gang
 
     # The player gets exactly one owner notification.
     assert Notification.objects.filter(owner=player).count() == 1
@@ -84,15 +88,28 @@ def test_arb_notified_excluding_gangs_they_own(make_user, make_list, make_campai
 
 @pytest.mark.django_db
 def test_empty_is_noop():
-    assert notify_lists_reconciled([]) == (0, 0)
+    assert notify_lists_reconciled({}) == (0, 0)
     assert Notification.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_stash_only_move_has_no_rating_annotation(make_user, make_list):
+    owner = make_user("stashy", "pw")
+    lst = make_list("Stash Mover", owner=owner)
+    # Rating didn't move (delta 0) — only the stash was corrected. The gang is
+    # still listed, but without a meaningless "(rating +0¢)".
+    owners, arbs = notify_lists_reconciled({lst.pk: 0})
+    assert (owners, arbs) == (1, 0)
+    n = Notification.objects.get(owner=owner)
+    assert "Stash Mover" in n.content
+    assert "(rating" not in n.content  # no per-gang delta annotation
 
 
 @pytest.mark.django_db
 def test_non_campaign_list_has_no_arb(make_user, make_list):
     owner = make_user("solo", "pw")
     lst = make_list("Solo Gang", owner=owner)  # list-building mode, no campaign
-    owners, arbs = notify_lists_reconciled([lst.pk])
+    owners, arbs = notify_lists_reconciled({lst.pk: -10})
     assert (owners, arbs) == (1, 0)
 
 
@@ -163,16 +180,18 @@ def test_estate_run_notifies_once_per_owner_and_arb(
     player_notifs = Notification.objects.filter(owner=player)
     assert player_notifs.count() == 1
     pn = player_notifs.get()
-    assert pn.notification_type == NotificationType.LIST
+    assert pn.notification_type == NotificationType.SYSTEM
     assert "2 of your gangs" in pn.subject
     for lst, _ in lists:
         assert reverse("core:list", args=[lst.pk]) in pn.content
+    # Cache was tampered +10 then corrected back down, so each gang shows -10¢.
+    assert "-10¢" in pn.content
 
     # Arb: exactly one aggregated campaign notification naming both gangs.
     arb_notifs = Notification.objects.filter(owner=arb)
     assert arb_notifs.count() == 1
     an = arb_notifs.get()
-    assert an.notification_type == NotificationType.CAMPAIGN
+    assert an.notification_type == NotificationType.SYSTEM
     assert "2 gangs in your campaigns" in an.subject
 
 

--- a/gyrinx/core/tests/test_reconcile_notify.py
+++ b/gyrinx/core/tests/test_reconcile_notify.py
@@ -1,0 +1,195 @@
+"""Reconcile → aggregated user notifications (#1826 + #721).
+
+One notification per affected owner and one per affected arbitrator, each
+linking every gang that changed — never one-per-list, so a player with many
+gangs isn't buried.
+"""
+
+import pytest
+from django.urls import reverse
+
+from gyrinx.core.cost.reconcile_notify import notify_lists_reconciled
+from gyrinx.core.models.action import ListActionType
+from gyrinx.core.models.backfill import Backfill
+from gyrinx.core.models.campaign import Campaign
+from gyrinx.core.models.list import List, ListFighter
+from gyrinx.core.models.notification import Notification, NotificationType
+from gyrinx.core.tasks import reconcile_all_lists
+from gyrinx.core.tests.test_balance_sheet import buy_equipment, fresh, hire_fighter
+
+
+# --- notify_lists_reconciled: grouping + de-dupe --------------------------------
+
+
+@pytest.mark.django_db
+def test_one_notification_per_owner_with_links(make_user, make_list):
+    alice = make_user("alice", "pw")
+    bob = make_user("bob", "pw")
+    l1 = make_list("Goliath Bruisers", owner=alice)
+    l2 = make_list("Escher Wildcats", owner=alice)
+    l3 = make_list("Orlock Arms", owner=bob)
+
+    owners, arbs = notify_lists_reconciled([l1.pk, l2.pk, l3.pk])
+    assert (owners, arbs) == (2, 0)
+
+    # Alice owns two affected gangs → exactly ONE notification naming both.
+    alice_notifs = Notification.objects.filter(owner=alice)
+    assert alice_notifs.count() == 1
+    n = alice_notifs.get()
+    assert n.notification_type == NotificationType.LIST
+    assert "2 of your gangs" in n.subject
+    assert n.is_system  # sender defaulted to None → Gyrinx system notification
+    assert n.show_as_banner is False
+    # Both gangs are linked in the content.
+    assert "Goliath Bruisers" in n.content
+    assert "Escher Wildcats" in n.content
+    assert reverse("core:list", args=[l1.pk]) in n.content
+    assert reverse("core:list", args=[l2.pk]) in n.content
+
+    # Bob owns one → singular subject.
+    bob_notif = Notification.objects.get(owner=bob)
+    assert "A gang of yours was recalculated" == bob_notif.subject
+
+
+@pytest.mark.django_db
+def test_arb_notified_excluding_gangs_they_own(make_user, make_list, make_campaign):
+    player = make_user("player", "pw")
+    arb = make_user("arb", "pw")
+    camp = make_campaign("Turf War", owner=arb, status=Campaign.IN_PROGRESS)
+    l_player = make_list(
+        "Player Gang", owner=player, status=List.CAMPAIGN_MODE, campaign=camp
+    )
+    l_arb_own = make_list(
+        "Arbs Own Gang", owner=arb, status=List.CAMPAIGN_MODE, campaign=camp
+    )
+
+    owners, arbs = notify_lists_reconciled([l_player.pk, l_arb_own.pk])
+    # Two owners (player, arb — each owns one), one arbitrator (arb, for the
+    # player's gang only; their own gang is covered by the owner notification).
+    assert (owners, arbs) == (2, 1)
+
+    # The arb receives two: one as owner (their gang), one as arbitrator.
+    arb_notifs = Notification.objects.filter(owner=arb)
+    assert arb_notifs.count() == 2
+    arb_camp = arb_notifs.get(notification_type=NotificationType.CAMPAIGN)
+    # The arbitrator notification links the player's gang, NOT the arb's own
+    # (that would double-notify — it's already in their owner notification).
+    assert "Player Gang" in arb_camp.content
+    assert "Arbs Own Gang" not in arb_camp.content
+    assert camp.name in arb_camp.content  # campaign named for context
+
+    # The player gets exactly one owner notification.
+    assert Notification.objects.filter(owner=player).count() == 1
+
+
+@pytest.mark.django_db
+def test_empty_is_noop():
+    assert notify_lists_reconciled([]) == (0, 0)
+    assert Notification.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_non_campaign_list_has_no_arb(make_user, make_list):
+    owner = make_user("solo", "pw")
+    lst = make_list("Solo Gang", owner=owner)  # list-building mode, no campaign
+    owners, arbs = notify_lists_reconciled([lst.pk])
+    assert (owners, arbs) == (1, 0)
+
+
+# --- estate reconcile run: single aggregated notification ----------------------
+
+
+@pytest.mark.django_db
+def test_estate_run_notifies_once_per_owner_and_arb(
+    make_user, make_list, make_campaign, content_fighter, make_equipment
+):
+    """A full reconcile_all_lists run over two drifted gangs owned by the same
+    player, in a campaign someone else arbitrates, sends the player ONE
+    notification and the arb ONE — each naming both gangs.
+
+    The drift here is a pure cache tamper whose ledger head already equals the
+    true value, so reconcile moves the cache but writes NO action — proving the
+    notification keys off ``ReconcileResult.moved``, not the presence of a
+    RECONCILE action.
+    """
+    admin = make_user("admin", "pw")
+    admin.is_staff = admin.is_superuser = True
+    admin.save()
+    player = make_user("player", "pw")
+    arb = make_user("arb", "pw")
+    camp = make_campaign("Border War", owner=arb, status=Campaign.IN_PROGRESS)
+
+    lists = []
+    for name in ("Gang One", "Gang Two"):
+        lst = make_list(name, owner=player, status=List.CAMPAIGN_MODE, campaign=camp)
+        # Campaign mode gates hiring on credits — stake some first.
+        lst.create_action(
+            user=player,
+            action_type=ListActionType.UPDATE_CREDITS,
+            description="Stake",
+            credits_delta=1000,
+            update_credits=True,
+        )
+        fighter = hire_fighter(player, lst, content_fighter, name="F")
+        buy_equipment(player, lst, fighter, make_equipment("Gun", cost=15))
+        true_rating = fresh(lst).rating_current
+        fighter = ListFighter.objects.get(pk=fighter.pk)
+        # Hidden drift: inflate fighter + list caches, flags clean, ledger head
+        # untouched (still equals true) → moved on reconcile, but no action.
+        ListFighter.objects.filter(pk=fighter.pk).update(
+            rating_current=fighter.rating_current + 10, dirty=False
+        )
+        List.objects.filter(pk=lst.pk).update(
+            rating_current=true_rating + 10, dirty=False
+        )
+        lists.append((lst, true_rating))
+
+    record = Backfill.objects.create(
+        operation=Backfill.Operation.RECONCILE_LISTS,
+        triggered_by=admin,
+        status=Backfill.Status.RUNNING,
+    )
+    reconcile_all_lists.func(
+        backfill_id=str(record.id), user_id=admin.pk, batch_size=500
+    )
+
+    record.refresh_from_db()
+    assert record.status == Backfill.Status.DONE
+    # Caches were actually corrected.
+    for lst, true_rating in lists:
+        assert fresh(lst).rating_current == true_rating
+
+    # Player: exactly one aggregated owner notification naming both gangs.
+    player_notifs = Notification.objects.filter(owner=player)
+    assert player_notifs.count() == 1
+    pn = player_notifs.get()
+    assert pn.notification_type == NotificationType.LIST
+    assert "2 of your gangs" in pn.subject
+    for lst, _ in lists:
+        assert reverse("core:list", args=[lst.pk]) in pn.content
+
+    # Arb: exactly one aggregated campaign notification naming both gangs.
+    arb_notifs = Notification.objects.filter(owner=arb)
+    assert arb_notifs.count() == 1
+    an = arb_notifs.get()
+    assert an.notification_type == NotificationType.CAMPAIGN
+    assert "2 gangs in your campaigns" in an.subject
+
+
+@pytest.mark.django_db
+def test_estate_run_no_drift_notifies_nobody(
+    make_user, make_list, content_fighter, make_equipment
+):
+    """A clean run (nothing moved) sends nothing."""
+    player = make_user("player", "pw")
+    lst = make_list("Clean Gang", owner=player)
+    fighter = hire_fighter(player, lst, content_fighter, name="F")
+    buy_equipment(player, lst, fighter, make_equipment("Gun", cost=15))
+
+    record = Backfill.objects.create(
+        operation=Backfill.Operation.RECONCILE_LISTS,
+        status=Backfill.Status.RUNNING,
+    )
+    reconcile_all_lists.func(backfill_id=str(record.id), batch_size=500)
+
+    assert Notification.objects.count() == 0


### PR DESCRIPTION
## What this does

When we reconcile a gang's cost caches — either the estate-wide maintenance run or the per-gang admin action — the people affected now get told, using the notification system that shipped in #721.

The rule is **one notification per person, not per gang**. A player can own many gangs, and an arbitrator's campaigns can hold many more, so a naive per-gang message would bury them. Instead:

- each affected gang **owner** gets a single notification summarising their changed gangs, with a link to each;
- each affected campaign **arbitrator** gets a single notification summarising the changed gangs in campaigns they run — excluding gangs they own, since those are already in their owner notification.

## "Affected" = the number the player sees actually changed

Notifications key off whether the gang's cached rating/stash actually **moved**, not off whether a `RECONCILE` ledger action was written. Those are different:

- Reconcile writes a ledger action when only the audit chain's head needed aligning — the cache (what the player sees) doesn't change, so **no** notification.
- A pure un-audited cache correction moves the cache with **no** action at all — the player should still be told.

Keying off `ReconcileResult.moved` gets both cases right. (There's a regression test that drives the estate run with the "moved but no action" drift shape specifically to lock this in.)

## How it's wired

- **New `gyrinx/core/cost/reconcile_notify.py`** — `notify_lists_reconciled(list_ids)` does the owner/arbitrator grouping and bulk fan-out on top of the #721 `Notification` model. The per-gang links live in the notification body (the inbox renderer permits `<ul>`/`<a href>`). These are system notifications (shown as from "Gyrinx") and inbox-only — an aggregate spanning many gangs has no single page to banner on.
- **Estate task (`reconcile_all_lists`)** accumulates the ids of gangs that moved across its self-re-enqueueing batches (only the corrected subset, so the task payload stays small) and fans out once, at completion. A notification failure can never undo a completed reconcile.
- **Admin recompute action** — the fighter-cache rebuild is extracted into a plain helper that returns which gangs moved, so the list-level action can notify. (The `@admin.action` itself must return `None` — the object-actions framework treats a return value as an HTTP response, which is what the first cut tripped over.)

## Try it

In Django admin → Lists, select one or more gangs with drifted caches and run **"Recompute cached cost/rating from facts"**. Affected owners/arbitrators get an inbox notification; the admin sees a "Notified N owner(s) and M arbitrator(s)" message. The estate-wide run at `/admin/maintenance/` does the same, aggregated across the whole run.

## Test plan

- [x] New `test_reconcile_notify.py` — owner grouping + links, arbitrator grouping with self-owned exclusion, empty no-op, non-campaign has no arb, full estate-run integration (incl. the moved-but-no-action case), and a clean run notifying nobody.
- [x] `pytest -n 4 gyrinx/core/tests/` — 2745 passed, 7 skipped, 2 xfailed.

Refs #1826
Refs #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh