### PR TITLE
fix: reconcile detail page — stray comment rendered, clamp hint always shown

### DIFF
--- a/gyrinx/core/tests/test_maintenance_pin_ops.py
+++ b/gyrinx/core/tests/test_maintenance_pin_ops.py
@@ -139,6 +139,26 @@ def test_reconcile_detail_page_renders_per_list(client, superuser, tracked_list)
     assert lst.name in content
     assert f"{true_rating + 10} → {true_rating}" in content  # rating before → after
     assert "Corrected:" in content
+    # The template comment must not leak into the rendered page.
+    assert "run captured before it stopped" not in content
+    # Nothing clamped here, so the "investigate" hint must not show.
+    assert "computed total was negative" not in content
+
+
+@pytest.mark.django_db
+def test_reconcile_detail_shows_clamp_hint_only_when_clamped(client, superuser):
+    """The 'computed total was negative — investigate' hint appears only when a
+    zero-clamp actually fired."""
+    record = Backfill.objects.create(
+        operation=Backfill.Operation.RECONCILE_LISTS,
+        triggered_by=superuser,
+        status=Backfill.Status.DONE,
+        summary={"lists": 3, "corrected": 1, "clamped": 2, "per_list": []},
+    )
+    client.force_login(superuser)
+    r = client.get(reverse("admin:maintenance_backfill_detail", args=[record.pk]))
+    assert r.status_code == 200
+    assert "computed total was negative" in r.content.decode()  # clamped=2 → shown
 
 
 @pytest.mark.django_db

--- a/gyrinx/maintenance/templates/admin/maintenance/backfill_detail.html
+++ b/gyrinx/maintenance/templates/admin/maintenance/backfill_detail.html
@@ -50,8 +50,10 @@
         <h2>Error</h2>
         <pre class="mt-error">{{ backfill.error }}</pre>
     {% endif %}
-    {# Always show what the run recorded — including the partial detail a failed
-       run captured before it stopped. #}
+    {% comment %}
+    Always show what the run recorded — including the partial detail a failed
+    run captured before it stopped.
+    {% endcomment %}
     {% if is_reconcile %}
         <h2>Summary</h2>
         <ul>
@@ -63,7 +65,9 @@
             </li>
             <li>
                 <strong>Zero-clamped:</strong> {{ backfill.summary.clamped|default:0 }}
-                <span class="mt-hint">(computed total was negative — investigate)</span>
+                {% if backfill.summary.clamped %}
+                    <span class="mt-hint">(computed total was negative — investigate)</span>
+                {% endif %}
             </li>
         </ul>
         <h2>Per-list detail</h2>


### PR DESCRIPTION
## What

Two rendering bugs on the maintenance reconcile detail page (`/admin/maintenance/backfill/<id>/`), spotted on a live canary run:

- A template comment was **printing on the page**. It spanned two lines, and Django's `{# #}` comment syntax is single-line only — so it wasn't treated as a comment and rendered verbatim. Switched to `{% comment %}…{% endcomment %}`.
- The **"(computed total was negative — investigate)"** hint next to *Zero-clamped* showed **always**, so a clean run (Zero-clamped: 0) looked like it needed investigating. It now shows only when a clamp actually fired.

## Test plan

- [x] New assertions: the template comment must not leak into the rendered page; the clamp hint appears only when `clamped > 0`.
- [x] `pytest -n 4 gyrinx/core/tests/ gyrinx/maintenance/tests/` — 2757 passed, 7 skipped, 2 xfailed.

Refs #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh