### PR TITLE
feat: system check that every @task is registered

### DIFF
--- a/gyrinx/tasks/apps.py
+++ b/gyrinx/tasks/apps.py
@@ -30,6 +30,10 @@ class TasksConfig(AppConfig):
         # Import signal handlers to register them (works with any backend)
         from gyrinx.tasks import signals  # noqa: F401
 
+        # Import the system check module so its @register() runs — enforces that
+        # every @task is in the registry, in every environment (#1947).
+        from gyrinx.tasks import checks  # noqa: F401
+
         # Only provision Pub/Sub in Cloud Run environment
         if not os.getenv("K_SERVICE"):
             logger.debug("Not in Cloud Run, skipping task provisioning")

--- a/gyrinx/tasks/checks.py
+++ b/gyrinx/tasks/checks.py
@@ -1,0 +1,92 @@
+"""System check: every ``@task`` in a known module must be registered (#1947).
+
+Declaring a background task is a two-step ritual split across two files with
+nothing coupling them: ``@task`` in the task module, plus a ``TaskRoute`` entry
+in ``gyrinx/tasks/registry.py``. Only the **production** Pub/Sub backend enforces
+the second step (enqueue lookup + topic provisioning) — dev's ImmediateBackend
+never consults the registry and tests call ``.func`` directly. Miss step two and
+everything is green locally while the task is dead on arrival in prod.
+
+This check turns that omission into a red error at check time — ``runserver``,
+``migrate``, ``check --deploy``, CI — seconds after the mistake is made, in the
+author's own terminal. It also flags registry entries that aren't actually
+``@task``-decorated functions.
+"""
+
+import importlib
+
+from django.core.checks import Error, register
+from django.tasks import Task
+
+from gyrinx.tasks.registry import get_all_tasks
+
+# Modules that declare ``@task`` functions. Forgetting to register a task added
+# to one of these is the common trap this check closes. We also scan every
+# module that already owns a registered task (see ``check_tasks_registered``),
+# so a second task added beside a registered one is caught even if the module
+# isn't listed here. A brand-new module with *no* registered task is the rarer
+# case that recommendation 2 in #1947 (declaration-owned registration) closes
+# structurally — add such modules here until then.
+TASK_MODULES = ("gyrinx.core.tasks",)
+
+
+def _declared_tasks(module_paths):
+    """Map ``{task_name: module_path}`` for every ``@task`` defined in the given
+    modules. Tasks merely *imported* into a module (``func.__module__`` differs)
+    are attributed to their own module, not double-counted here."""
+    declared = {}
+    for mod_path in module_paths:
+        module = importlib.import_module(mod_path)
+        for obj in vars(module).values():
+            if isinstance(obj, Task) and obj.func.__module__ == mod_path:
+                declared[obj.func.__name__] = mod_path
+    return declared
+
+
+@register()
+def check_tasks_registered(app_configs, **kwargs):
+    """Cross-check declared ``@task`` functions against the registry, both ways."""
+    errors = []
+    routes = get_all_tasks()
+    registered = {route.name for route in routes}
+
+    # Scan the configured modules plus any module already owning a registered
+    # task, so "added a second task next to a registered one" is always caught.
+    module_paths = set(TASK_MODULES) | {
+        route._underlying_func.__module__ for route in routes
+    }
+    declared = _declared_tasks(module_paths)
+
+    # Forward: a declared @task missing from the registry is dead on arrival in
+    # production (the Pub/Sub backend rejects the enqueue and provisions no topic).
+    for name, mod_path in sorted(declared.items()):
+        if name not in registered:
+            errors.append(
+                Error(
+                    f"Background task '{name}' ({mod_path}) is declared with @task "
+                    f"but not registered.",
+                    hint=(
+                        f"Add `TaskRoute({name})` to the list in "
+                        f"gyrinx/tasks/registry.py. Unregistered tasks pass locally "
+                        f"(dev's ImmediateBackend and .func test calls skip the "
+                        f"registry) but fail on enqueue in production."
+                    ),
+                    id="gyrinx.tasks.E001",
+                )
+            )
+
+    # Reverse: a registry entry must wrap a real @task. A deleted function fails
+    # at import of registry.py already; this catches registering a plain function.
+    for route in routes:
+        if not isinstance(route.func, Task):
+            errors.append(
+                Error(
+                    f"Registry entry '{route.name}' is not a @task-decorated function.",
+                    hint=(
+                        "Every TaskRoute in gyrinx/tasks/registry.py must wrap a "
+                        "function decorated with django.tasks @task."
+                    ),
+                    id="gyrinx.tasks.E002",
+                )
+            )
+    return errors

--- a/gyrinx/tasks/checks.py
+++ b/gyrinx/tasks/checks.py
@@ -22,11 +22,12 @@ from django.tasks import Task
 
 from gyrinx.tasks.registry import get_all_tasks
 
-# Extra modules to scan, for the rare task module NOT named ``<app>.tasks``.
-# Auto-discovery (see ``_task_module_paths``) already covers every first-party
-# ``<app>.tasks`` module and every module that owns a registered task, so this
-# is usually empty — it's an escape hatch for unconventional locations.
-TASK_MODULES = ("gyrinx.core.tasks",)
+# Escape hatch for a task module NOT named ``<app>.tasks`` (an unconventional
+# location auto-discovery in ``_task_module_paths`` wouldn't find). Empty by
+# default: every first-party ``gyrinx.*/tasks.py`` is auto-discovered, as is any
+# module that already owns a registered task, so listing those here would only
+# duplicate the scan.
+TASK_MODULES = ()
 
 
 def _task_module_paths(routes):
@@ -64,10 +65,14 @@ def _declared_tasks(module_paths):
     for mod_path in module_paths:
         try:
             module = importlib.import_module(mod_path)
-        except ImportError:
-            # A discovered <app>.tasks that fails to import surfaces at startup
-            # anyway; don't turn the whole system check into a traceback.
-            continue
+        except ModuleNotFoundError as exc:
+            # Skip only when the target module itself is absent (a typo'd
+            # TASK_MODULES entry, or a removed module) — nothing to scan. A
+            # missing *dependency* of a real module (``exc.name`` is something
+            # else) is genuine breakage and must not be hidden, so let it raise.
+            if exc.name == mod_path or mod_path.startswith(f"{exc.name}."):
+                continue
+            raise
         for obj in vars(module).values():
             if isinstance(obj, Task) and obj.func.__module__ == mod_path:
                 declared[obj.func.__name__] = mod_path

--- a/gyrinx/tasks/checks.py
+++ b/gyrinx/tasks/checks.py
@@ -96,10 +96,11 @@ def check_tasks_registered(app_configs, **kwargs):
                     f"Background task '{name}' ({mod_path}) is declared with @task "
                     f"but not registered.",
                     hint=(
-                        f"Add `TaskRoute({name})` to the list in "
-                        f"gyrinx/tasks/registry.py. Unregistered tasks pass locally "
-                        f"(dev's ImmediateBackend and .func test calls skip the "
-                        f"registry) but fail on enqueue in production."
+                        f"In gyrinx/tasks/registry.py, import it "
+                        f"(`from {mod_path} import {name}`) and add "
+                        f"`TaskRoute({name})` to the list. Unregistered tasks pass "
+                        f"locally (dev's ImmediateBackend and .func test calls skip "
+                        f"the registry) but fail on enqueue in production."
                     ),
                     id="gyrinx.tasks.E001",
                 )

--- a/gyrinx/tasks/checks.py
+++ b/gyrinx/tasks/checks.py
@@ -14,20 +14,46 @@ author's own terminal. It also flags registry entries that aren't actually
 """
 
 import importlib
+import importlib.util
 
+from django.apps import apps as django_apps
 from django.core.checks import Error, register
 from django.tasks import Task
 
 from gyrinx.tasks.registry import get_all_tasks
 
-# Modules that declare ``@task`` functions. Forgetting to register a task added
-# to one of these is the common trap this check closes. We also scan every
-# module that already owns a registered task (see ``check_tasks_registered``),
-# so a second task added beside a registered one is caught even if the module
-# isn't listed here. A brand-new module with *no* registered task is the rarer
-# case that recommendation 2 in #1947 (declaration-owned registration) closes
-# structurally — add such modules here until then.
+# Extra modules to scan, for the rare task module NOT named ``<app>.tasks``.
+# Auto-discovery (see ``_task_module_paths``) already covers every first-party
+# ``<app>.tasks`` module and every module that owns a registered task, so this
+# is usually empty — it's an escape hatch for unconventional locations.
 TASK_MODULES = ("gyrinx.core.tasks",)
+
+
+def _task_module_paths(routes):
+    """Every module worth scanning for ``@task`` functions:
+
+    - the explicit ``TASK_MODULES``;
+    - every module that already owns a registered task (so a second task added
+      beside a registered one is caught);
+    - each first-party ``gyrinx.*`` app's conventional ``<app>.tasks`` module,
+      when it exists — this closes the "brand-new app's first task, never
+      registered" gap without waiting for declaration-owned registration
+      (#1947 rec 2). Restricted to our own apps so a third-party app's task
+      module can't spuriously demand entries in *our* registry.
+    """
+    paths = set(TASK_MODULES)
+    paths |= {route.path.rsplit(".", 1)[0] for route in routes}
+    for app_config in django_apps.get_app_configs():
+        if not app_config.name.startswith("gyrinx."):
+            continue
+        candidate = f"{app_config.name}.tasks"
+        try:
+            spec = importlib.util.find_spec(candidate)
+        except (ImportError, AttributeError, ValueError):
+            spec = None  # parent not importable / not a package — nothing to scan
+        if spec is not None:
+            paths.add(candidate)
+    return paths
 
 
 def _declared_tasks(module_paths):
@@ -36,7 +62,12 @@ def _declared_tasks(module_paths):
     are attributed to their own module, not double-counted here."""
     declared = {}
     for mod_path in module_paths:
-        module = importlib.import_module(mod_path)
+        try:
+            module = importlib.import_module(mod_path)
+        except ImportError:
+            # A discovered <app>.tasks that fails to import surfaces at startup
+            # anyway; don't turn the whole system check into a traceback.
+            continue
         for obj in vars(module).values():
             if isinstance(obj, Task) and obj.func.__module__ == mod_path:
                 declared[obj.func.__name__] = mod_path
@@ -49,13 +80,7 @@ def check_tasks_registered(app_configs, **kwargs):
     errors = []
     routes = get_all_tasks()
     registered = {route.name for route in routes}
-
-    # Scan the configured modules plus any module already owning a registered
-    # task, so "added a second task next to a registered one" is always caught.
-    module_paths = set(TASK_MODULES) | {
-        route._underlying_func.__module__ for route in routes
-    }
-    declared = _declared_tasks(module_paths)
+    declared = _declared_tasks(_task_module_paths(routes))
 
     # Forward: a declared @task missing from the registry is dead on arrival in
     # production (the Pub/Sub backend rejects the enqueue and provisions no topic).

--- a/gyrinx/tasks/tests/test_checks.py
+++ b/gyrinx/tasks/tests/test_checks.py
@@ -3,7 +3,6 @@
 from django.tasks import task
 
 import gyrinx.tasks.checks as checks
-from gyrinx.tasks.checks import check_tasks_registered
 from gyrinx.tasks.registry import get_all_tasks
 from gyrinx.tasks.route import TaskRoute
 
@@ -25,7 +24,7 @@ def sample_unregistered():
 def test_current_registry_passes_the_check():
     """Every @task the app currently declares is registered — no errors. This is
     the guard: if someone lands a new task without a TaskRoute, this goes red."""
-    assert check_tasks_registered(app_configs=None) == []
+    assert checks.check_tasks_registered(app_configs=None) == []
 
 
 def test_unregistered_declared_task_is_flagged(monkeypatch):
@@ -34,7 +33,7 @@ def test_unregistered_declared_task_is_flagged(monkeypatch):
     routes = [r for r in get_all_tasks() if r.name != "hello_world"]
     monkeypatch.setattr(checks, "get_all_tasks", lambda: routes)
 
-    errors = check_tasks_registered(app_configs=None)
+    errors = checks.check_tasks_registered(app_configs=None)
 
     e001 = [e for e in errors if e.id == "gyrinx.tasks.E001"]
     assert len(e001) == 1
@@ -48,7 +47,7 @@ def test_module_owning_a_registered_task_is_scanned(monkeypatch):
     monkeypatch.setattr(checks, "TASK_MODULES", ())
     monkeypatch.setattr(checks, "get_all_tasks", lambda: [TaskRoute(sample_registered)])
 
-    errors = check_tasks_registered(app_configs=None)
+    errors = checks.check_tasks_registered(app_configs=None)
 
     e001 = [e for e in errors if e.id == "gyrinx.tasks.E001"]
     assert any("sample_unregistered" in e.msg for e in e001)
@@ -76,7 +75,7 @@ def test_registry_entry_that_isnt_a_task_is_flagged(monkeypatch):
     monkeypatch.setattr(checks, "_task_module_paths", lambda routes: set())
     monkeypatch.setattr(checks, "get_all_tasks", lambda: [TaskRoute(not_a_task)])
 
-    errors = check_tasks_registered(app_configs=None)
+    errors = checks.check_tasks_registered(app_configs=None)
 
     assert [e.id for e in errors] == ["gyrinx.tasks.E002"]
     assert "not_a_task" in errors[0].msg
@@ -87,7 +86,7 @@ def test_check_is_registered_with_django():
     so it actually runs on manage check / runserver / CI."""
     from django.core.checks.registry import registry as check_registry
 
-    assert check_tasks_registered in check_registry.get_checks()
+    assert checks.check_tasks_registered in check_registry.get_checks()
 
 
 def test_declared_tasks_attributes_tasks_to_their_own_module():

--- a/gyrinx/tasks/tests/test_checks.py
+++ b/gyrinx/tasks/tests/test_checks.py
@@ -1,0 +1,61 @@
+"""The #1947 system check: declared @task functions must be registered."""
+
+import gyrinx.tasks.checks as checks
+from gyrinx.tasks.checks import check_tasks_registered
+from gyrinx.tasks.registry import get_all_tasks
+from gyrinx.tasks.route import TaskRoute
+
+
+def test_current_registry_passes_the_check():
+    """Every @task the app currently declares is registered — no errors. This is
+    the guard: if someone lands a new task without a TaskRoute, this goes red."""
+    assert check_tasks_registered(app_configs=None) == []
+
+
+def test_unregistered_declared_task_is_flagged(monkeypatch):
+    """Drop one real task from the registry view and the check reports E001 for
+    it — the exact mistake #1947 is about (declared, forgotten in registry.py)."""
+    routes = [r for r in get_all_tasks() if r.name != "hello_world"]
+    monkeypatch.setattr(checks, "get_all_tasks", lambda: routes)
+
+    errors = check_tasks_registered(app_configs=None)
+
+    e001 = [e for e in errors if e.id == "gyrinx.tasks.E001"]
+    assert len(e001) == 1
+    assert "hello_world" in e001[0].msg
+    assert "registry.py" in e001[0].hint
+
+
+def test_registry_entry_that_isnt_a_task_is_flagged(monkeypatch):
+    """A TaskRoute wrapping a plain (non-@task) function reports E002."""
+
+    def not_a_task():
+        pass
+
+    monkeypatch.setattr(checks, "TASK_MODULES", ())  # isolate the reverse check
+    monkeypatch.setattr(checks, "get_all_tasks", lambda: [TaskRoute(not_a_task)])
+
+    errors = check_tasks_registered(app_configs=None)
+
+    assert [e.id for e in errors] == ["gyrinx.tasks.E002"]
+    assert "not_a_task" in errors[0].msg
+
+
+def test_check_is_registered_with_django():
+    """The check is wired into Django's system-check framework (not just defined),
+    so it actually runs on manage check / runserver / CI."""
+    from django.core.checks.registry import registry as check_registry
+
+    assert check_tasks_registered in check_registry.get_checks()
+
+
+def test_declared_tasks_attributes_tasks_to_their_own_module():
+    """_declared_tasks only surfaces tasks *defined* in a module — a module with
+    no @task (e.g. checks.py) yields nothing, so re-exports elsewhere can't create
+    phantom 'unregistered' entries."""
+    # checks.py declares no tasks.
+    assert checks._declared_tasks(("gyrinx.tasks.checks",)) == {}
+    # A real task module surfaces its own tasks, keyed to that module.
+    declared = checks._declared_tasks(("gyrinx.core.tasks",))
+    assert "reconcile_all_lists" in declared
+    assert declared["reconcile_all_lists"] == "gyrinx.core.tasks"

--- a/gyrinx/tasks/tests/test_checks.py
+++ b/gyrinx/tasks/tests/test_checks.py
@@ -1,9 +1,25 @@
 """The #1947 system check: declared @task functions must be registered."""
 
+from django.tasks import task
+
 import gyrinx.tasks.checks as checks
 from gyrinx.tasks.checks import check_tasks_registered
 from gyrinx.tasks.registry import get_all_tasks
 from gyrinx.tasks.route import TaskRoute
+
+
+# Module-level @task functions (Django requires module scope) for tests that
+# need a task in a module OTHER than gyrinx.core.tasks. Neither is in the real
+# registry, TASK_MODULES, or a discovered <app>.tasks module, so the live check
+# never scans this module — they're inert outside the tests that reference them.
+@task
+def sample_registered():
+    pass
+
+
+@task
+def sample_unregistered():
+    pass
 
 
 def test_current_registry_passes_the_check():
@@ -26,13 +42,38 @@ def test_unregistered_declared_task_is_flagged(monkeypatch):
     assert "registry.py" in e001[0].hint
 
 
+def test_module_owning_a_registered_task_is_scanned(monkeypatch):
+    """A second @task in a module reached ONLY via a registered task's own module
+    (not TASK_MODULES) is still caught — guards the route-module derivation."""
+    monkeypatch.setattr(checks, "TASK_MODULES", ())
+    monkeypatch.setattr(checks, "get_all_tasks", lambda: [TaskRoute(sample_registered)])
+
+    errors = check_tasks_registered(app_configs=None)
+
+    e001 = [e for e in errors if e.id == "gyrinx.tasks.E001"]
+    assert any("sample_unregistered" in e.msg for e in e001)
+    assert not any("sample_registered" in e.msg for e in e001)
+
+
+def test_app_discovery_reaches_conventional_task_modules(monkeypatch):
+    """With no explicit TASK_MODULES and no registered routes, the scan still
+    reaches gyrinx.core.tasks purely by discovering the gyrinx.core app's
+    conventional <app>.tasks module — this closes the new-app gap."""
+    monkeypatch.setattr(checks, "TASK_MODULES", ())
+
+    paths = checks._task_module_paths([])
+
+    assert "gyrinx.core.tasks" in paths
+
+
 def test_registry_entry_that_isnt_a_task_is_flagged(monkeypatch):
     """A TaskRoute wrapping a plain (non-@task) function reports E002."""
 
     def not_a_task():
         pass
 
-    monkeypatch.setattr(checks, "TASK_MODULES", ())  # isolate the reverse check
+    # Silence the forward scan so only the reverse check runs.
+    monkeypatch.setattr(checks, "_task_module_paths", lambda routes: set())
     monkeypatch.setattr(checks, "get_all_tasks", lambda: [TaskRoute(not_a_task)])
 
     errors = check_tasks_registered(app_configs=None)
@@ -53,9 +94,13 @@ def test_declared_tasks_attributes_tasks_to_their_own_module():
     """_declared_tasks only surfaces tasks *defined* in a module — a module with
     no @task (e.g. checks.py) yields nothing, so re-exports elsewhere can't create
     phantom 'unregistered' entries."""
-    # checks.py declares no tasks.
     assert checks._declared_tasks(("gyrinx.tasks.checks",)) == {}
-    # A real task module surfaces its own tasks, keyed to that module.
     declared = checks._declared_tasks(("gyrinx.core.tasks",))
     assert "reconcile_all_lists" in declared
     assert declared["reconcile_all_lists"] == "gyrinx.core.tasks"
+
+
+def test_declared_tasks_skips_unimportable_module():
+    """A bad module path degrades gracefully (skipped) rather than crashing the
+    whole system check with a traceback."""
+    assert checks._declared_tasks(("gyrinx.tasks.does_not_exist",)) == {}


### PR DESCRIPTION
## Why

Declaring a background task is two steps in two files with nothing coupling them:

1. `@task` in the task module (e.g. `gyrinx/core/tasks.py`), and
2. a `TaskRoute` entry in `gyrinx/tasks/registry.py`.

Only the **production** Pub/Sub backend enforces step 2 (it looks the task up to find its topic, and provisions topics from the registry). Dev's `ImmediateBackend` never consults the registry, and tests call `.func` directly — so a task that's declared but not registered is **green everywhere locally and dead on arrival in prod**. This exactly happened with `backfill_pins` (the Phase 8 cost-pinning backfill), caught in review rather than by any tooling.

## What this adds

A Django system check (`gyrinx/tasks/checks.py`) that runs wherever checks run — `runserver`, `migrate`, `check --deploy`, CI — and:

- **E001** — errors if a function declared with `@task` in a known task module is **not** in the registry. This is the actual mistake, turned into a red error in the author's terminal seconds after they make it.
- **E002** — errors if a registry entry isn't a real `@task`-decorated function.

It scans the configured `TASK_MODULES` **plus** any module that already owns a registered task, so "added a second task beside a registered one" is caught even if the module list wasn't touched. **Zero production behaviour change.**

This is **recommendation 1 of the three** in the issue (the one marked "do first"). Recommendation 2 (a `@gyrinx_task` decorator that registers on declaration) and 3 (dev-backend parity) remain as separate follow-ups.

## Test plan

- [x] `manage check` runs the check and passes against the current registry.
- [x] New tests (`gyrinx/tasks/tests/test_checks.py`): current registry is clean; a dropped registration surfaces E001 for the right task; a non-`@task` registry entry surfaces E002; the check is actually registered with Django; `_declared_tasks` attributes tasks to their defining module.
- [x] `pytest gyrinx/tasks/tests/` — 107 passed.

Refs #1947

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh