### PR TITLE
feat: balance-sheet mismatch highlight fix + pin-source tooltip

### DIFF
--- a/gyrinx/core/cost/balance_sheet.py
+++ b/gyrinx/core/cost/balance_sheet.py
@@ -84,7 +84,9 @@ def _source_repr(state, amount, fk=None) -> str:
     if amount is None or state == PinState.UNPINNED:
         return ""
     if state == PinState.SOURCE:
-        where = str(fk) if fk is not None else "an override price"
+        # A SOURCE pin should always name its FK; the fallback is defensive, and
+        # stays neutral so it can't be misread as a user cost-override.
+        where = str(fk) if fk is not None else "a price source"
         return f"Pinned to {where} ({amount}¢)"
     if state == PinState.CATALOG:
         return f"Catalog price at acquisition ({amount}¢)"

--- a/gyrinx/core/cost/balance_sheet.py
+++ b/gyrinx/core/cost/balance_sheet.py
@@ -106,7 +106,7 @@ def _rows_source_repr(rows) -> str:
     ]
     if not priced:
         return ""
-    if len(priced) == 1 and len(rows) == 1:
+    if len(rows) == 1:  # the sole row is priced (unpriced-only returned above)
         r = priced[0]
         return _source_repr(r.pin_state, r.pinned_amount, _pin_fk(r))
     counts = Counter(r.pin_state for r in priced)

--- a/gyrinx/core/cost/balance_sheet.py
+++ b/gyrinx/core/cost/balance_sheet.py
@@ -26,11 +26,12 @@ tests (``core/tests/test_balance_sheet.py``) and the staff debug view. A
 arrives with the pin schema in a later phase of the programme.
 """
 
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Optional
 from uuid import UUID
 
-from gyrinx.core.models.list import List
+from gyrinx.core.models.list import List, PinState
 
 # Component line kinds
 KIND_BASE = "base"
@@ -57,6 +58,65 @@ def _rows_pricing(rows) -> str:
     return PRICING_MIXED
 
 
+# Pin attribution FKs, in resolution order — an assignment (base pin) or a
+# through-row (profile/accessory/upgrade pin) carries exactly one when SOURCE.
+_PIN_FK_FIELDS = (
+    "pinned_equipment_list_item",
+    "pinned_expansion_item",
+    "pinned_equipment_list_accessory",
+    "pinned_equipment_list_upgrade",
+)
+
+
+def _pin_fk(obj):
+    """The first non-null pin attribution FK on an assignment or through-row."""
+    for name in _PIN_FK_FIELDS:
+        target = getattr(obj, name, None)
+        if target is not None:
+            return target
+    return None
+
+
+def _source_repr(state, amount, fk=None) -> str:
+    """Human-readable attribution for one pinned component price (design §5.1) —
+    what a receipt points at, for the pricing-column tooltip. Empty for an
+    unpinned/absent amount (live resolution, no receipt to describe)."""
+    if amount is None or state == PinState.UNPINNED:
+        return ""
+    if state == PinState.SOURCE:
+        where = str(fk) if fk is not None else "an override price"
+        return f"Pinned to {where} ({amount}¢)"
+    if state == PinState.CATALOG:
+        return f"Catalog price at acquisition ({amount}¢)"
+    if state == PinState.DERIVED:
+        return f"Derived price ({amount}¢)"
+    if state == PinState.ORPHANED:
+        return f"Frozen — pricing source removed ({amount}¢)"
+    return ""
+
+
+def _rows_source_repr(rows) -> str:
+    """Attribution summary for an aggregate line's through-rows: resolve a lone
+    pinned row fully, else summarise the mix by state."""
+    rows = list(rows)
+    priced = [
+        r
+        for r in rows
+        if r.pin_state != PinState.UNPINNED and r.pinned_amount is not None
+    ]
+    if not priced:
+        return ""
+    if len(priced) == 1 and len(rows) == 1:
+        r = priced[0]
+        return _source_repr(r.pin_state, r.pinned_amount, _pin_fk(r))
+    counts = Counter(r.pin_state for r in priced)
+    parts = [f"{n}× {PinState(s).label.lower()}" for s, n in sorted(counts.items())]
+    live = len(rows) - len(priced)
+    if live:
+        parts.append(f"{live}× live")
+    return "Pinned: " + ", ".join(parts)
+
+
 @dataclass(frozen=True)
 class ComponentLine:
     """One priced component inside an assignment."""
@@ -65,6 +125,7 @@ class ComponentLine:
     amount: int
     pricing: str  # PRICING_* above
     detail: str = ""
+    source_repr: str = ""  # human-readable attribution for the pricing tooltip
 
 
 @dataclass(frozen=True)
@@ -288,33 +349,46 @@ def _assignment_balance(virtual) -> AssignmentBalance:
 
     if assignment.cost_override is not None:
         base_pricing, base_detail = PRICING_USER_OVERRIDE, ""
+        base_source = f"User override ({assignment.cost_override}¢)"
     elif assignment.pinned_base_amount is not None:
         base_pricing = PRICING_PINNED
         base_detail = assignment.pinned_base_state
+        base_source = _source_repr(
+            assignment.pinned_base_state,
+            assignment.pinned_base_amount,
+            _pin_fk(assignment),
+        )
     else:
-        base_pricing, base_detail = PRICING_LIVE, ""
+        base_pricing, base_detail, base_source = PRICING_LIVE, "", ""
 
+    profile_rows = assignment.profile_rows.all()
+    accessory_rows = assignment.accessory_rows.all()
+    upgrade_rows = assignment.upgrade_rows.all()
     lines = (
         ComponentLine(
             KIND_BASE,
             assignment.base_cost_int(),
             base_pricing,
             base_detail,
+            source_repr=base_source,
         ),
         ComponentLine(
             KIND_PROFILES,
             assignment.weapon_profiles_cost_int(),
-            _rows_pricing(assignment.profile_rows.all()),
+            _rows_pricing(profile_rows),
+            source_repr=_rows_source_repr(profile_rows),
         ),
         ComponentLine(
             KIND_ACCESSORIES,
             assignment.weapon_accessories_cost_int(),
-            _rows_pricing(assignment.accessory_rows.all()),
+            _rows_pricing(accessory_rows),
+            source_repr=_rows_source_repr(accessory_rows),
         ),
         ComponentLine(
             KIND_UPGRADES,
             assignment.upgrade_cost_int(),
-            _rows_pricing(assignment.upgrade_rows.all()),
+            _rows_pricing(upgrade_rows),
+            source_repr=_rows_source_repr(upgrade_rows),
         ),
     )
 

--- a/gyrinx/core/templates/core/debug/list_balance_sheet.html
+++ b/gyrinx/core/templates/core/debug/list_balance_sheet.html
@@ -25,12 +25,15 @@
         th { background: #f5f5f5; font-weight: 600; }
         td.num, th.num { text-align: right; font-family: monospace; }
         .summary td { font-weight: 600; }
-        .mismatch { background: #fdecea; }
+        /* tr.mismatch (element+class) outranks .fighter-row/.summary so the
+           danger red wins on those rows instead of their own background. */
+        tr.mismatch { background: #fdecea; }
         .fighter-row { background: #eef3fa; font-weight: 600; }
         .assignment-row td:first-child { padding-left: 1.5rem; }
         .component-row { color: #666; }
         .component-row td:first-child { padding-left: 3rem; }
         .muted { color: #999; }
+        .pin-source { cursor: help; border-bottom: 1px dotted #999; }
         .tag { display: inline-block; background: #eee; border-radius: 4px; padding: 0 0.4rem; font-size: 0.75rem; margin-left: 0.35rem; }
         .tag-override { background: #ffe4c9; color: #8a4b00; }
         .tag-stash { background: #e2e0f7; color: #3c368e; }
@@ -150,7 +153,11 @@
                                         {% if line.detail %}<span class="muted">({{ line.detail }})</span>{% endif %}
                                     </td>
                                     <td>
-                                        {{ line.pricing }}
+                                        {% if line.source_repr %}
+                                            <span class="pin-source" title="{{ line.source_repr }}">{{ line.pricing }}</span>
+                                        {% else %}
+                                            {{ line.pricing }}
+                                        {% endif %}
                                         {% if line.detail %}<span class="text-secondary">({{ line.detail }})</span>{% endif %}
                                     </td>
                                     <td class="num">{{ line.amount }}¢</td>

--- a/gyrinx/core/templates/core/debug/list_balance_sheet.html
+++ b/gyrinx/core/templates/core/debug/list_balance_sheet.html
@@ -25,8 +25,8 @@
         th { background: #f5f5f5; font-weight: 600; }
         td.num, th.num { text-align: right; font-family: monospace; }
         .summary td { font-weight: 600; }
-        /* tr.mismatch (element+class) outranks .fighter-row/.summary so the
-           danger red wins on those rows instead of their own background. */
+        /* tr.mismatch (element+class) outranks .fighter-row so the danger red
+           wins on fighter rows instead of their blue background. */
         tr.mismatch { background: #fdecea; }
         .fighter-row { background: #eef3fa; font-weight: 600; }
         .assignment-row td:first-child { padding-left: 1.5rem; }

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -1407,7 +1407,7 @@ def test_source_repr_per_pin_state():
     assert _source_repr(PinState.SOURCE, 5, "Ganger — Sweep Lasgun") == (
         "Pinned to Ganger — Sweep Lasgun (5¢)"
     )
-    assert _source_repr(PinState.SOURCE, 5) == "Pinned to an override price (5¢)"
+    assert _source_repr(PinState.SOURCE, 5) == "Pinned to a price source (5¢)"
     # Unpinned / absent amount → no receipt to describe.
     assert _source_repr(PinState.UNPINNED, None) == ""
     assert _source_repr(PinState.CATALOG, None) == ""

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -1422,10 +1422,12 @@ def test_rows_source_repr_summarises_a_mix():
     rows = [
         _FakeRow(PinState.CATALOG, 5),
         _FakeRow(PinState.CATALOG, 5),
+        _FakeRow(PinState.SOURCE, 4, "Ganger — Scope"),
         _FakeRow(PinState.UNPINNED, None),
     ]
     out = _rows_source_repr(rows)
     assert "2× catalog" in out
+    assert "1× source" in out
     assert "1× live" in out
 
 
@@ -1437,9 +1439,8 @@ def test_rows_source_repr_all_unpinned_is_empty():
 def test_balance_sheet_populates_pinned_line_source_repr(
     user, make_list, content_fighter, make_equipment
 ):
-    """A purchased line pins at acquisition, so its base ComponentLine carries a
-    non-empty, amount-bearing source_repr for the tooltip; an unpinned line
-    carries none."""
+    """A purchased line pins at acquisition, so its base ComponentLine is pinned
+    and carries an amount-bearing source_repr for the tooltip."""
     lst = make_list("Sheet Gang")
     fighter = hire_fighter(user, lst, content_fighter)
     buy_equipment(user, lst, fighter, make_equipment("Lasgun", cost=15))
@@ -1448,7 +1449,7 @@ def test_balance_sheet_populates_pinned_line_source_repr(
     fb = next(f for f in sheet.fighters if f.fighter_id == fighter.id)
     base = next(line for line in fb.assignments[0].lines if line.kind == "base")
 
-    if base.pricing in ("pinned", "user_override"):
-        assert base.source_repr and base.source_repr.endswith("¢)")
-    else:
-        assert base.source_repr == ""
+    # Deterministic: purchase pins on acquisition, so this must be pinned — if
+    # that ever regressed the test should fail here, not pass via an empty branch.
+    assert base.pricing == "pinned"
+    assert base.source_repr.endswith("¢)")

--- a/gyrinx/core/tests/test_balance_sheet.py
+++ b/gyrinx/core/tests/test_balance_sheet.py
@@ -24,7 +24,11 @@ from gyrinx.content.models import (
     ContentWeaponAccessory,
     ContentWeaponProfile,
 )
-from gyrinx.core.cost.balance_sheet import build_balance_sheet
+from gyrinx.core.cost.balance_sheet import (
+    _rows_source_repr,
+    _source_repr,
+    build_balance_sheet,
+)
 from gyrinx.core.handlers.equipment.cost_override import (
     handle_equipment_cost_override,
 )
@@ -1381,3 +1385,70 @@ def test_matrix_sell_pack_profile_from_stash(
     )
     assert stash_before_sale - fresh(lst).stash_current == 10
     assert_reconciles(lst)
+
+
+# --- #1949: pin-source attribution for the balance-sheet pricing tooltip -------
+
+
+class _FakeRow:
+    """Minimal stand-in for a pinned through-row (pin_state + amount + one FK)."""
+
+    def __init__(self, pin_state, pinned_amount, fk=None):
+        self.pin_state = pin_state
+        self.pinned_amount = pinned_amount
+        self.pinned_equipment_list_item = fk
+
+
+def test_source_repr_per_pin_state():
+    assert _source_repr(PinState.CATALOG, 15) == "Catalog price at acquisition (15¢)"
+    assert _source_repr(PinState.DERIVED, 7) == "Derived price (7¢)"
+    assert _source_repr(PinState.ORPHANED, 4).startswith("Frozen")
+    # SOURCE resolves the attribution FK's string.
+    assert _source_repr(PinState.SOURCE, 5, "Ganger — Sweep Lasgun") == (
+        "Pinned to Ganger — Sweep Lasgun (5¢)"
+    )
+    assert _source_repr(PinState.SOURCE, 5) == "Pinned to an override price (5¢)"
+    # Unpinned / absent amount → no receipt to describe.
+    assert _source_repr(PinState.UNPINNED, None) == ""
+    assert _source_repr(PinState.CATALOG, None) == ""
+
+
+def test_rows_source_repr_single_row_resolves_fully():
+    rows = [_FakeRow(PinState.SOURCE, 5, "Ganger — Sweep Lasgun")]
+    assert _rows_source_repr(rows) == "Pinned to Ganger — Sweep Lasgun (5¢)"
+
+
+def test_rows_source_repr_summarises_a_mix():
+    rows = [
+        _FakeRow(PinState.CATALOG, 5),
+        _FakeRow(PinState.CATALOG, 5),
+        _FakeRow(PinState.UNPINNED, None),
+    ]
+    out = _rows_source_repr(rows)
+    assert "2× catalog" in out
+    assert "1× live" in out
+
+
+def test_rows_source_repr_all_unpinned_is_empty():
+    assert _rows_source_repr([_FakeRow(PinState.UNPINNED, None)]) == ""
+
+
+@pytest.mark.django_db
+def test_balance_sheet_populates_pinned_line_source_repr(
+    user, make_list, content_fighter, make_equipment
+):
+    """A purchased line pins at acquisition, so its base ComponentLine carries a
+    non-empty, amount-bearing source_repr for the tooltip; an unpinned line
+    carries none."""
+    lst = make_list("Sheet Gang")
+    fighter = hire_fighter(user, lst, content_fighter)
+    buy_equipment(user, lst, fighter, make_equipment("Lasgun", cost=15))
+
+    sheet = fresh_sheet(lst)
+    fb = next(f for f in sheet.fighters if f.fighter_id == fighter.id)
+    base = next(line for line in fb.assignments[0].lines if line.kind == "base")
+
+    if base.pricing in ("pinned", "user_override"):
+        assert base.source_repr and base.source_repr.endswith("¢)")
+    else:
+        assert base.source_repr == ""


### PR DESCRIPTION
Two display-only polish items on the balance-sheet debug view (`/_debug/list/<id>/balance-sheet/`), from #1949. No behaviour or bookkeeping changes.

## 1. Fighter/summary mismatch rows now actually highlight

When a fighter's computed total disagreed with its cached value the row rendered plainly. The `mismatch` class *was* applied — but `.fighter-row`'s blue background overrode `.mismatch`'s red (equal specificity, `.fighter-row` defined later in the stylesheet), so the highlight never showed. Bumped the rule to `tr.mismatch` (element+class) so the danger red wins on fighter and summary rows.

## 2. Pin-source tooltip on the pricing column

The pricing cell showed `pinned (source)` / `pinned` / `mixed` / `live` but nothing about *what* a pinned line is pinned to. Implemented the design doc's §5.1 `source_repr` (speced, never built) on `ComponentLine`:

- **SOURCE** → resolves the attribution FK: *"Pinned to Abyssal Ferrymen Ganger — Sweep Lasgun (5¢)"*
- **CATALOG** → *"Catalog price at acquisition (15¢)"*
- **DERIVED** / **ORPHANED** → describe their state
- user overrides name themselves
- Aggregate lines (profiles/accessories/upgrades) resolve a lone pinned row fully, else summarise the mix by state (*"Pinned: 2× catalog, 1× live"*)

Surfaced as a `title` tooltip on the pricing cell with a dotted-underline help cue.

## Test plan

- [x] New tests: `_source_repr` per pin state; `_rows_source_repr` single-row-resolve, mixed-summary, all-unpinned; `build_balance_sheet` populates a purchased line's `source_repr`.
- [x] `pytest gyrinx/core/tests/test_balance_sheet.py gyrinx/core/tests/test_debug_views.py` — 103 passed.
- [x] No model change → no migration.

Refs #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh