### PR TITLE
refactor: one read path for list costs (#1860 Stage B)

### DIFF
--- a/docs/fighter-cost-system-reference.md
+++ b/docs/fighter-cost-system-reference.md
@@ -253,28 +253,11 @@ def facts_from_db(self, update: bool = True) -> ListFacts:
     """
 ```
 
-#### facts_with_fallback() - Hybrid Read (List only)
-
-Returns cached facts if clean, otherwise calculates without updating cache:
-
-```python
-def facts_with_fallback(self) -> ListFacts:
-    """
-    Get facts using cache if clean, otherwise calculate.
-    Does NOT update cache - just reads or calculates.
-    """
-    facts = self.facts()
-    if facts is not None:
-        return facts
-    # Calculate without updating cache
-    return self._calculate_facts()
-```
-
 ### When to Use Each Method
 
 | Scenario | Method | Why |
 |----------|--------|-----|
-| Display in views | `facts()` then `facts_with_fallback()` | Fast read, fallback if stale |
+| Display in views | Persisted fields via display methods | O(1) read; dirty lists show last-good numbers |
 | Object creation | `create_with_facts()` | Atomic creation with cache |
 | Handler operations | Don't call - use propagation | Handlers use incremental updates |
 | Manual refresh | `facts_from_db(update=True)` | Full recalculation |
@@ -294,17 +277,25 @@ def create_with_facts(self, **kwargs):
 
 ### Display Methods
 
-Display methods use the facts system internally:
+List display methods read the persisted cache fields directly — dirty or
+not. A dirty list shows its last-good numbers until the write-time heal
+(`set_dirty` enqueues `refresh_list_facts` on commit) or a detail-page view
+(`get_clean_list_or_404`) recomputes them:
 
 ```python
 # List
 def cost_display(self):
+    return format_cost_display(self.wealth_current)
+
+# Similar for rating_display, stash_fighter_cost_display
+
+# ListFighter keeps a live fallback so a card never shows a number known
+# to be stale:
+def cost_display(self):
     facts = self.facts()
     if facts is not None:
-        return format_cost_display(facts.wealth)
-    return format_cost_display(self.facts_with_fallback().wealth)
-
-# Similar for rating_display(), stash_fighter_cost_display()
+        return format_cost_display(facts.rating)
+    return format_cost_display(self.cost_int_cached)
 ```
 
 ### Dirty Flag Management
@@ -316,6 +307,11 @@ The `dirty` flag indicates cached values may be stale:
 assignment.set_dirty(save=True)  # Also marks fighter and list dirty
 fighter.set_dirty(save=True)     # Also marks list dirty
 lst.set_dirty(save=True)         # Only marks list dirty
+
+# List.set_dirty(save=True) also enqueues a background heal
+# (refresh_list_facts) on commit — only for the caller whose UPDATE
+# actually flips the row clean->dirty. Bulk dirty-marking helpers
+# bypass this; the content-cost-change task heals those lists itself.
 
 # Cleared by:
 # - facts_from_db(update=True)
@@ -345,12 +341,13 @@ The system uses several optimizations:
 - Cached properties to avoid repeated calculations
 - Annotation with cost overrides in querysets
 
-### Prefetching for Facts System
+### Prefetching
 
-To enable the facts system's `can_use_facts` property, views must use the appropriate prefetch:
+Display methods need no prefetch — they read persisted fields. The prefetches
+below optimise related-data access and `latest_action` reads:
 
 ```python
-# Enables can_use_facts for list display
+# Latest-action prefetch (create_action / check_wealth_sync reads)
 lists = List.objects.with_latest_actions()
 
 # Full prefetch for detail views
@@ -360,16 +357,13 @@ lst = List.objects.with_related_data().get(pk=pk)
 fighters = ListFighter.objects.with_related_data()
 ```
 
-The `with_latest_actions()` method prefetches the most recent `ListAction`, which is required for the guard condition that enables the facts system.
-
 ## Common Usage Patterns
 
 ### Getting a List's Total Wealth
 
 ```python
-# In views, always use prefetching first
-lst = List.objects.with_latest_actions().get(pk=list_id)
-wealth = lst.facts_with_fallback().wealth  # rating + stash + credits
+lst = List.objects.get(pk=list_id)
+wealth = lst.wealth_current  # rating_current + stash_current + credits_current
 ```
 
 ### Getting a Fighter's Total Cost

--- a/docs/technical-reference/prefetching-strategy.md
+++ b/docs/technical-reference/prefetching-strategy.md
@@ -6,23 +6,25 @@ This document explains the prefetching methods used to optimize cost calculation
 
 The cost system relies on proper prefetching to:
 
-1. Enable the facts system - The `can_use_facts` property requires `with_latest_actions()`
-2. Avoid N+1 queries - List and detail views need related data prefetched
-3. Optimize display methods - `cost_display()`, `rating_display()` use cached facts when available
+1. Avoid N+1 queries - List and detail views need related data prefetched
+2. Keep `latest_action` reads cheap - `create_action()` and `check_wealth_sync()` read the newest ListAction, and `with_latest_actions()` turns that into a prefetch instead of a query per list
+
+Display methods (`cost_display()`, `rating_display()`, `stash_fighter_cost_display`) read the persisted cache fields (`rating_current`, `stash_current`, `credits_current`) directly and need no prefetch at all. A dirty list shows its last-good numbers until the write-time heal (`List.set_dirty` enqueues `refresh_list_facts`) or a detail-page view (`get_clean_list_or_404`) recomputes them.
 
 ## QuerySet Methods
 
 ### List.objects.with_latest_actions()
 
-Lightweight prefetch that enables the facts system:
+Lightweight prefetch for latest-action reads:
 
 ```python
 def with_latest_actions(self):
     """
     Prefetch the latest action for each list.
 
-    This enables the facts system by populating the `latest_actions` attribute,
-    which is checked by the `can_use_facts` property.
+    Populates the `latest_actions` attribute so `latest_action` (used by
+    create_action and check_wealth_sync) reads from the prefetch instead
+    of issuing a query per list.
     """
     return self.prefetch_related(
         Prefetch(
@@ -35,13 +37,11 @@ def with_latest_actions(self):
     )
 ```
 
-When to use: Any view that displays list costs (campaigns, homepage, list index).
+When to use: Any flow that reads `latest_action` for multiple lists (e.g. before creating actions in bulk).
 
 What it enables:
 
-- `list.can_use_facts` returns `True`
-- `list.latest_action` returns the most recent action
-- `list.facts()` can return cached values
+- `list.latest_action` returns the most recent action without an extra query
 
 ### List.objects.with_related_data()
 
@@ -142,41 +142,20 @@ def with_related_data(self):
 
 When to use: Equipment lists, assignment detail views.
 
-## The can_use_facts Property
-
-The facts system is gated by `can_use_facts`:
-
-```python
-@property
-def can_use_facts(self) -> bool:
-    """
-    Check if facts system can be used for display methods.
-
-    Returns True only if:
-    - latest_actions was prefetched via with_latest_actions()
-    - AND there is at least one action (list has action tracking)
-    """
-    if hasattr(self, "latest_actions"):
-        return bool(self.latest_actions)
-    return False
-```
-
-Important: If you skip the prefetch, `can_use_facts` returns `False` and display methods fall back to direct calculation.
-
 ## View Patterns
 
 ### Multi-List Views (Campaigns, Homepage)
 
-Use `with_latest_actions()` for fast cost display:
+Cost display needs no prefetch — the display methods read persisted fields:
 
 ```python
 def campaign_detail(request, pk):
     campaign = get_object_or_404(Campaign, pk=pk)
-    lists = List.objects.filter(campaign=campaign).with_latest_actions()
+    lists = List.objects.filter(campaign=campaign)
 
     return render(request, "campaign_detail.html", {
         "campaign": campaign,
-        "lists": lists,  # Each list can use facts()
+        "lists": lists,  # cost_display/rating_display read cached fields
     })
 ```
 
@@ -242,21 +221,7 @@ This means:
 
 ## Common Mistakes
 
-### 1. Forgetting with_latest_actions()
-
-```python
-# BAD: can_use_facts returns False
-lists = List.objects.filter(campaign=campaign)
-for lst in lists:
-    cost = lst.cost_display()  # Falls back to full calculation
-
-# GOOD: can_use_facts returns True
-lists = List.objects.filter(campaign=campaign).with_latest_actions()
-for lst in lists:
-    cost = lst.cost_display()  # Uses cached facts
-```
-
-### 2. Not using with_fighters for detail views
+### 1. Not using with_fighters for detail views
 
 ```python
 # BAD: N+1 queries when accessing fighters
@@ -270,7 +235,7 @@ for fighter in lst.listfighter_set.all():  # Already loaded
     print(fighter.name)
 ```
 
-### 3. Double prefetching
+### 2. Double prefetching
 
 ```python
 # BAD: Prefetches twice

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -683,17 +683,19 @@ def _create_content_cost_change_actions(instance, before_snapshots=None, old_cos
         except List.DoesNotExist:
             continue
         except Exception as e:
-            # Log error but continue processing other lists. The transaction
-            # rolled back, so the list stays dirty (and unrewritten) for a
-            # later redelivery.
+            # Log error but continue processing other lists. The per-list
+            # transaction rolled back, so the amount rewrite was undone and
+            # no action was recorded.
             logger.error(
                 f"Failed to create CONTENT_COST_CHANGE action for list {list_id}: {e}"
             )
             # Index pages show last-good numbers and never recompute, so give
             # the failed list a background heal rather than waiting for a
-            # detail-page view. This refreshes caches only — the audit action
-            # for this change is still lost (same as the view-heal path) and
-            # a redelivery remains the real recovery.
+            # detail-page view. The heal clears dirty but recomputes against
+            # the UNREWRITTEN (pre-correction) amounts, and the audit action
+            # is still missing — a task redelivery is the real recovery, and
+            # it works regardless of the dirty flag (the sweep re-runs the
+            # rewrite and recompute unconditionally).
             try:
                 refresh_list_facts.enqueue(list_id=str(list_id))
             except Exception:

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -527,6 +527,7 @@ def _create_content_cost_change_actions(instance, before_snapshots=None, old_cos
     from gyrinx.core.cost.pin_sweep import rewrite_pinned_amounts_for_list
     from gyrinx.core.models.action import ListAction, ListActionType
     from gyrinx.core.models.list import List
+    from gyrinx.core.tasks import refresh_list_facts
 
     # Find affected lists based on the model type. The rewrite domain also
     # includes lists reachable only through archived rows (their amounts are
@@ -562,10 +563,11 @@ def _create_content_cost_change_actions(instance, before_snapshots=None, old_cos
 
                 # Only create actions for lists that have an initial action
                 # Lists without latest_action will have dirty flag set via set_dirty()
-                # and will be recalculated when viewed (against the amounts
-                # rewritten above). Archived-only lists get the rewrite but no
-                # action processing — nothing cache-visible moved, and the
-                # snapshot fallback has no baseline for them.
+                # and will be recalculated on their next detail-page view
+                # (against the amounts rewritten above); index pages show the
+                # last-good cached numbers meanwhile. Archived-only lists get
+                # the rewrite but no action processing — nothing cache-visible
+                # moved, and the snapshot fallback has no baseline for them.
                 if list_id not in live_list_ids or not lst.latest_action:
                     continue
 
@@ -681,11 +683,24 @@ def _create_content_cost_change_actions(instance, before_snapshots=None, old_cos
         except List.DoesNotExist:
             continue
         except Exception as e:
-            # Log error but continue processing other lists
-            # The failed list will remain dirty and be recalculated on next view
+            # Log error but continue processing other lists. The transaction
+            # rolled back, so the list stays dirty (and unrewritten) for a
+            # later redelivery.
             logger.error(
                 f"Failed to create CONTENT_COST_CHANGE action for list {list_id}: {e}"
             )
+            # Index pages show last-good numbers and never recompute, so give
+            # the failed list a background heal rather than waiting for a
+            # detail-page view. This refreshes caches only — the audit action
+            # for this change is still lost (same as the view-heal path) and
+            # a redelivery remains the real recovery.
+            try:
+                refresh_list_facts.enqueue(list_id=str(list_id))
+            except Exception:
+                logger.warning(
+                    f"Failed to enqueue facts refresh for list {list_id}",
+                    exc_info=True,
+                )
 
 
 # Post-save signal handlers that create actions after content saves

--- a/gyrinx/content/tests/test_content_cost_signals.py
+++ b/gyrinx/content/tests/test_content_cost_signals.py
@@ -766,12 +766,13 @@ def test_get_clean_list_or_404_skips_clean_list(user, make_list):
 
 
 @pytest.mark.django_db
-def test_get_clean_list_or_404_enables_can_use_facts(user, make_list, content_fighter):
-    """get_clean_list_or_404 should enable can_use_facts for consistent rating display.
+def test_get_clean_list_or_404_prefetches_latest_actions(
+    user, make_list, content_fighter
+):
+    """get_clean_list_or_404 should prefetch latest_actions.
 
-    This test verifies the fix for the cost calculation bug where different views
-    showed different rating values because some views used the facts system
-    (via with_latest_actions prefetch) and others didn't.
+    The prefetch keeps latest_action reads (create_action, check_wealth_sync)
+    from issuing an extra query per list.
     """
     from gyrinx.core.views.list import get_clean_list_or_404
 
@@ -795,16 +796,11 @@ def test_get_clean_list_or_404_enables_can_use_facts(user, make_list, content_fi
     # Now get the list using get_clean_list_or_404 with List model class
     clean_list = get_clean_list_or_404(List, id=lst.id)
 
-    # The returned list should have can_use_facts enabled (via with_latest_actions prefetch)
-    assert clean_list.can_use_facts is True, (
-        "get_clean_list_or_404 should apply with_latest_actions() prefetch "
-        "to enable can_use_facts for consistent rating display"
-    )
-
-    # Verify the latest_actions attribute is populated
+    # Verify the latest_actions attribute is populated via the prefetch
     assert hasattr(clean_list, "latest_actions"), (
         "get_clean_list_or_404 should prefetch latest_actions"
     )
+    assert clean_list.latest_actions
 
 
 @pytest.mark.django_db
@@ -829,8 +825,8 @@ def test_get_clean_list_or_404_with_queryset_preserves_original_behavior(
     # The list should be returned successfully
     assert clean_list.id == lst.id
 
-    # Without the prefetch, can_use_facts will be False (since latest_actions isn't populated)
-    # This is the expected behavior when using a custom queryset
+    # Without the prefetch, latest_actions isn't populated. This is the
+    # expected behavior when using a custom queryset.
     assert not hasattr(clean_list, "latest_actions") or not clean_list.latest_actions
 
 

--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -1113,11 +1113,14 @@ class ListFighter(AppBase):
     @admin.display(description="Total Cost Display")
     @traced("listfighter_cost_display")
     def cost_display(self):
-        """Display the fighter's total cost."""
-        if self.can_use_facts:
-            facts = self.facts()
-            if facts is not None:
-                return format_cost_display(facts.rating)
+        """Display the fighter's total cost.
+
+        Clean fighters read the cached rating; dirty ones fall back to a live
+        per-request compute so a card never shows a number known to be stale.
+        """
+        facts = self.facts()
+        if facts is not None:
+            return format_cost_display(facts.rating)
         return format_cost_display(self.cost_int_cached)
 
     def facts(self) -> Optional[FighterFacts]:
@@ -1131,16 +1134,6 @@ class ListFighter(AppBase):
             return None
 
         return FighterFacts(rating=self.rating_current)
-
-    @property
-    def can_use_facts(self) -> bool:
-        """
-        Check if facts system can be used for display methods.
-
-        Delegates to parent list's can_use_facts property.
-        Relies on list being prefetched via with_related_data().
-        """
-        return self.list.can_use_facts
 
     @property
     def debug_facts_in_sync(self) -> bool:

--- a/gyrinx/core/models/list/list.py
+++ b/gyrinx/core/models/list/list.py
@@ -55,10 +55,11 @@ class ListQuerySet(models.QuerySet):
         """
         Prefetch the latest action for each list.
 
-        This enables the facts system by populating the `latest_actions` attribute,
-        which is checked by the `can_use_facts` property.
+        Populates the `latest_actions` attribute so `latest_action` (used by
+        create_action and check_wealth_sync) reads from the prefetch instead
+        of issuing a query per list.
 
-        Use this lightweight method when only the facts prefetch is needed.
+        Use this lightweight method when only the actions prefetch is needed.
         For full optimization with related data, use `with_related_data()`.
         """
         return self.prefetch_related(
@@ -339,11 +340,13 @@ class List(AppBase):
         return wealth
 
     def cost_display(self):
-        """Display the list's total wealth (rating + stash + credits)."""
-        facts = self.facts()
-        if facts is not None:
-            return format_cost_display(facts.wealth)
-        return format_cost_display(self.facts_with_fallback().wealth)
+        """Display the list's total wealth (rating + stash + credits).
+
+        Reads the persisted cache fields directly, dirty or not: a dirty list
+        shows its last-good numbers until the write-time heal (see set_dirty)
+        or a detail-page view (get_clean_list_or_404) recomputes them.
+        """
+        return format_cost_display(self.wealth_current)
 
     @cached_property
     def rating(self):
@@ -351,12 +354,8 @@ class List(AppBase):
 
     @cached_property
     def rating_display(self):
-        """Display the list's rating (sum of active fighter costs)."""
-        if self.can_use_facts:
-            facts = self.facts()
-            if facts is not None:
-                return format_cost_display(facts.rating)
-        return format_cost_display(self.rating)
+        """Display the list's rating (last-good cached value, dirty or not)."""
+        return format_cost_display(self.rating_current)
 
     # --- Equipment sets: display-only "selected" rating (#1853) --------------
 
@@ -434,12 +433,8 @@ class List(AppBase):
 
     @cached_property
     def stash_fighter_cost_display(self):
-        """Display the stash fighter's cost."""
-        if self.can_use_facts:
-            facts = self.facts()
-            if facts is not None:
-                return format_cost_display(facts.stash)
-        return format_cost_display(self.stash_fighter_cost_int)
+        """Display the stash cost (last-good cached value, dirty or not)."""
+        return format_cost_display(self.stash_current)
 
     @cached_property
     def credits_current_display(self):
@@ -462,57 +457,6 @@ class List(AppBase):
         return ListFacts(
             rating=self.rating_current,
             stash=self.stash_current,
-            credits=self.credits_current,
-        )
-
-    def facts_with_fallback(self) -> ListFacts:
-        """
-        Get facts using cache if clean, otherwise calculate from scratch.
-
-        MIGRATION PERIOD ONLY: This method provides a performance optimization
-        during the rollout of the action system. It returns cached facts when
-        available (dirty=False), falling back to the original calculation when
-        the cache is stale or not yet populated.
-
-        Intended for use in views like the homepage where many lists are
-        displayed and we want to use cached values when available without
-        forcing a full recalculation via facts_from_db().
-
-        Unlike facts_from_db(), this method does NOT update the cache - it
-        simply reads cached values or calculates on the fly without persisting.
-
-        Once all lists have been bootstrapped with initial actions and the
-        action system is fully rolled out, this method should be removed.
-
-        Returns:
-            ListFacts with rating, stash, and credits values.
-
-        Monitoring:
-            Emits 'facts_fallback' track event when fallback is used, allowing
-            operators to monitor rollout progress via log aggregation.
-        """
-        # Try cached facts first (fast path - O(1) field reads)
-        cached = self.facts()
-        if cached is not None:
-            return cached
-
-        # Fallback to calculation (original behavior)
-        track("facts_fallback", list_id=str(self.pk))
-
-        # Enqueue a background refresh (fire-and-forget, doesn't block page loads)
-        if settings.FEATURE_FACTS_FALLBACK_ENQUEUE:
-            try:
-                refresh_list_facts.enqueue(list_id=str(self.pk))
-            except Exception as e:
-                # Task system is new - don't break facts_with_fallback if it fails
-                logger.warning(
-                    f"Failed to enqueue facts refresh for list {self.pk}: {e}"
-                )
-                track("task_enqueue_failed", list_id=str(self.pk), error=str(e))
-
-        return ListFacts(
-            rating=self.rating,
-            stash=self.stash_fighter_cost_int,
             credits=self.credits_current,
         )
 
@@ -541,6 +485,13 @@ class List(AppBase):
 
         This is the terminal propagation point - List does not propagate further.
 
+        Also enqueues a background facts refresh once the surrounding
+        transaction commits, so a list that goes dirty heals without waiting
+        to be viewed (index pages show the last-good cached numbers in the
+        meantime). Bulk dirty-marking (bulk_mark_assignments_dirty etc.)
+        bypasses this on purpose — the content-cost-change task heals those
+        lists itself.
+
         Args:
             save: If True, immediately saves the dirty flag to the database.
                   Uses QuerySet.update() to bypass signals and avoid thrashing.
@@ -549,6 +500,15 @@ class List(AppBase):
             self.dirty = True
             if save:
                 List.objects.filter(pk=self.pk).update(dirty=True)
+                transaction.on_commit(self._enqueue_facts_refresh)
+
+    def _enqueue_facts_refresh(self) -> None:
+        """Fire-and-forget heal for a dirty list; never breaks the caller."""
+        try:
+            refresh_list_facts.enqueue(list_id=str(self.pk))
+        except Exception as e:
+            logger.warning(f"Failed to enqueue facts refresh for list {self.pk}: {e}")
+            track("task_enqueue_failed", list_id=str(self.pk), error=str(e))
 
     @traced("list_facts_from_db")
     def facts_from_db(self, update: bool = True) -> ListFacts:
@@ -1167,27 +1127,6 @@ class List(AppBase):
             return self.latest_actions[0]
 
         return ListAction.objects.latest_for_list(self.id)
-
-    @property
-    def can_use_facts(self) -> bool:
-        """
-        Check if facts system can be used for display methods.
-
-        Returns True only if:
-        - latest_actions was prefetched via with_related_data()
-        - AND there is at least one action (list has action tracking)
-
-        Returns False if:
-        - Not prefetched (to avoid database query)
-        - Or prefetched but empty (no action tracking yet)
-
-        This is used by display methods to avoid expensive cost_int calculations
-        when cached facts are available.
-        """
-        # Only check prefetched data - never query the database
-        if hasattr(self, "latest_actions"):
-            return bool(self.latest_actions)
-        return False
 
     @traced("list_create_action")
     def create_action(

--- a/gyrinx/core/models/list/list.py
+++ b/gyrinx/core/models/list/list.py
@@ -499,8 +499,15 @@ class List(AppBase):
         if not self.dirty:
             self.dirty = True
             if save:
-                List.objects.filter(pk=self.pk).update(dirty=True)
-                transaction.on_commit(self._enqueue_facts_refresh)
+                # Conditional update: only the instance that actually flips the
+                # row False->True enqueues the heal, so concurrent markers (or
+                # several stale instances of the same row) don't queue
+                # duplicate refreshes.
+                transitioned = List.objects.filter(pk=self.pk, dirty=False).update(
+                    dirty=True
+                )
+                if transitioned:
+                    transaction.on_commit(self._enqueue_facts_refresh)
 
     def _enqueue_facts_refresh(self) -> None:
         """Fire-and-forget heal for a dirty list; never breaks the caller."""

--- a/gyrinx/core/models/list/list.py
+++ b/gyrinx/core/models/list/list.py
@@ -352,9 +352,14 @@ class List(AppBase):
     def rating(self):
         return sum([f.cost_int_cached for f in self.active_fighters])
 
-    @cached_property
+    @property
     def rating_display(self):
-        """Display the list's rating (last-good cached value, dirty or not)."""
+        """Display the list's rating (last-good cached value, dirty or not).
+
+        Plain property on purpose: the underlying field is updated in place by
+        facts_from_db(update=True), and a cached formatted string would pin
+        the pre-refresh value for the instance's lifetime.
+        """
         return format_cost_display(self.rating_current)
 
     # --- Equipment sets: display-only "selected" rating (#1853) --------------
@@ -431,17 +436,19 @@ class List(AppBase):
     def stash_fighter_cost_int(self):
         return self.stash_fighter.cost_int() if self.stash_fighter else 0
 
-    @cached_property
+    @property
     def stash_fighter_cost_display(self):
         """Display the stash cost (last-good cached value, dirty or not)."""
         return format_cost_display(self.stash_current)
 
-    @cached_property
+    @property
     def credits_current_display(self):
         return format_cost_display(self.credits_current)
 
-    @cached_property
+    @property
     def wealth_current(self):
+        # Plain property (not cached): the component fields mutate in place
+        # via facts_from_db/create_action, and callers expect a live sum.
         return self.rating_current + self.stash_current + self.credits_current
 
     def facts(self) -> Optional[ListFacts]:
@@ -495,6 +502,8 @@ class List(AppBase):
         Args:
             save: If True, immediately saves the dirty flag to the database.
                   Uses QuerySet.update() to bypass signals and avoid thrashing.
+                  With save=False no heal is enqueued — persisting the flag
+                  (and arranging the refresh) is the caller's responsibility.
         """
         if not self.dirty:
             self.dirty = True

--- a/gyrinx/core/tasks.py
+++ b/gyrinx/core/tasks.py
@@ -20,7 +20,8 @@ def refresh_list_facts(list_id: str):
     """
     Refresh the cached facts for a list by recalculating from database.
 
-    Called asynchronously when facts_with_fallback detects a dirty cache.
+    Enqueued (on commit) by List.set_dirty, so a list that goes dirty heals
+    in the background instead of waiting to be viewed.
     """
     from gyrinx.core.models import List
 

--- a/gyrinx/core/templates/core/campaign/campaign_add_lists.html
+++ b/gyrinx/core/templates/core/campaign/campaign_add_lists.html
@@ -140,9 +140,7 @@
                                         {% else %}
                                             {{ list.owner.username }}
                                         {% endif %}
-                                        {% with facts=list.facts_with_fallback %}
-                                            · R: {% credits facts.rating %} Cr: {% credits facts.credits %} St: {% credits facts.stash %} W: {% credits facts.wealth %}
-                                        {% endwith %}
+                                        · R: {% credits list.rating_current %} Cr: {% credits list.credits_current %} St: {% credits list.stash_current %} W: {% credits list.wealth_current %}
                                     </div>
                                     {% if list.packs.all %}
                                         <div class="fs-7 text-secondary">

--- a/gyrinx/core/templates/core/campaign/campaign_start.html
+++ b/gyrinx/core/templates/core/campaign/campaign_start.html
@@ -27,7 +27,7 @@
                         </div>
                         {% if campaign.budget > 0 %}
                             <div class="badge text-bg-secondary">
-                                {% with credits_to_add=campaign.budget|subtract:list.facts_with_fallback.wealth %}
+                                {% with credits_to_add=campaign.budget|subtract:list.wealth_current %}
                                     {{ credits_to_add|max:0 }}¢
                                 {% endwith %}
                             </div>

--- a/gyrinx/core/templates/core/campaign/includes/list_row.html
+++ b/gyrinx/core/templates/core/campaign/includes/list_row.html
@@ -7,7 +7,5 @@
 </h6>
 <p class="mb-0 text-secondary fs-7">
     <i class="bi-person"></i> {{ list.owner.username }}
-    {% with facts=list.facts_with_fallback %}
-        • R: {% credits facts.rating %} Cr: {% credits facts.credits %} St: {% credits facts.stash %} W: {% credits facts.wealth %}
-    {% endwith %}
+    • R: {% credits list.rating_current %} Cr: {% credits list.credits_current %} St: {% credits list.stash_current %} W: {% credits list.wealth_current %}
 </p>

--- a/gyrinx/core/templates/core/includes/home/gang_row.html
+++ b/gyrinx/core/templates/core/includes/home/gang_row.html
@@ -7,7 +7,7 @@
         </h3>
         <div class="hstack column-gap-2 row-gap-1 flex-wrap home-row-meta">
             <div>{{ gang.content_house.name }}{% house_icon gang.content_house %}</div>
-            <div class="badge text-bg-primary">{% credits gang.facts_with_fallback.wealth %}</div>
+            <div class="badge text-bg-primary">{% credits gang.wealth_current %}</div>
             <div>
                 <a href="{% url 'core:campaign' gang.campaign.id %}"
                    class="icon-link linked">{{ gang.campaign.name }}</a>

--- a/gyrinx/core/templates/core/includes/home/list_row.html
+++ b/gyrinx/core/templates/core/includes/home/list_row.html
@@ -7,7 +7,7 @@
         </h3>
         <div class="hstack column-gap-2 row-gap-1 flex-wrap home-row-meta">
             <div>{{ list.content_house_name }}{% house_icon list.content_house_cached %}</div>
-            <div class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</div>
+            <div class="badge text-bg-primary">{% credits list.wealth_current %}</div>
         </div>
     </div>
     <div class="ms-auto d-md-none">

--- a/gyrinx/core/templates/core/includes/list_row.html
+++ b/gyrinx/core/templates/core/includes/list_row.html
@@ -13,7 +13,7 @@ Expects `list` in context.{% endcomment %}
         </div>
         <div class="hstack column-gap-2 row-gap-1 flex-wrap">
             <div>{{ list.content_house_name }}{% house_icon list.content_house_cached %}</div>
-            <div class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</div>
+            <div class="badge text-bg-primary">{% credits list.wealth_current %}</div>
             {% if list.status == list.CAMPAIGN_MODE and list.campaign %}
                 <div>
                     <a href="{% url 'core:campaign' list.campaign.id %}"

--- a/gyrinx/core/templates/core/user.html
+++ b/gyrinx/core/templates/core/user.html
@@ -39,7 +39,7 @@
                                         </div>
                                         <span class="hstack gap-2 align-items-center">
                                             <span class="text-secondary fs-7" title="Stars"><i class="bi-star{% if list.star_count %}-fill text-warning{% endif %}"></i> {{ list.star_count|default:0 }}</span>
-                                            <span class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</span>
+                                            <span class="badge text-bg-primary">{% credits list.wealth_current %}</span>
                                         </span>
                                     </div>
                                 </li>
@@ -70,7 +70,7 @@
                                     </div>
                                     <span class="hstack gap-2 align-items-center">
                                         <span class="text-secondary fs-7" title="Stars"><i class="bi-star{% if list.star_count %}-fill text-warning{% endif %}"></i> {{ list.star_count|default:0 }}</span>
-                                        <span class="badge text-bg-primary">{% credits list.facts_with_fallback.wealth %}</span>
+                                        <span class="badge text-bg-primary">{% credits list.wealth_current %}</span>
                                     </span>
                                 </div>
                             </li>

--- a/gyrinx/core/templatetags/custom_tags.py
+++ b/gyrinx/core/templatetags/custom_tags.py
@@ -450,7 +450,7 @@ def credits(value, show_sign=False):
         show_sign: If True, show '+' for positive values (default: False)
 
     Usage:
-        {% credits list.facts_with_fallback.wealth %}
+        {% credits list.wealth_current %}
         {% credits delta show_sign=True %}
     """
     return format_cost_display(value, show_sign=show_sign)

--- a/gyrinx/core/tests/test_facts_interface.py
+++ b/gyrinx/core/tests/test_facts_interface.py
@@ -306,71 +306,52 @@ def test_list_facts_returns_cached_when_clean(user, content_house, make_list):
 
 
 @pytest.mark.django_db
-def test_list_facts_with_fallback_returns_cached_when_clean(
-    user, content_house, make_list
-):
-    """Test that facts_with_fallback() returns cached values when dirty=False."""
+def test_list_display_shows_last_good_values_when_dirty(user, make_list):
+    """Dirty lists display their persisted last-good numbers (#1860 Stage B).
+
+    Index pages don't recompute: a dirty list shows the cached fields until
+    the write-time heal or a detail-page view refreshes them.
+    """
     lst = make_list("Test List")
     lst.rating_current = 100
     lst.stash_current = 50
     lst.credits_current = 25
-    lst.dirty = False
-    lst.save()
-
-    # Should return cached values (fast path)
-    facts = lst.facts_with_fallback()
-    assert facts is not None
-    assert isinstance(facts, ListFacts)
-    assert facts.rating == 100
-    assert facts.stash == 50
-    assert facts.credits == 25
-
-
-@pytest.mark.django_db
-def test_list_facts_with_fallback_calculates_when_dirty(
-    user, make_list, content_fighter, settings
-):
-    """Test that facts_with_fallback() calculates and tracks when dirty=True."""
-    from unittest.mock import patch
-
-    from gyrinx.core.models.list import ListFighter
-
-    lst = make_list("Test List")
-    lst.credits_current = 25
     lst.dirty = True
     lst.save()
 
-    # Create a fighter to have some rating
-    fighter = ListFighter.objects.create(
-        name="Test Fighter",
-        content_fighter=content_fighter,
-        list=lst,
-        owner=user,
-    )
+    assert lst.facts() is None  # facts() still signals staleness to heal paths
+    assert lst.wealth_current == 175
+    assert lst.cost_display() == "175¢"
+    assert lst.rating_display == "100¢"
+    assert lst.stash_fighter_cost_display == "50¢"
 
-    # Enable the feature flag for this test
-    settings.FEATURE_FACTS_FALLBACK_ENQUEUE = True
 
-    # Mock track and the background task enqueue
-    # (ImmediateBackend runs tasks synchronously, which would update dirty flag)
-    with (
-        patch("gyrinx.core.models.list.list.track") as mock_track,
-        patch("gyrinx.core.models.list.list.refresh_list_facts") as mock_task,
-    ):
-        # Should calculate and emit track event
-        facts = lst.facts_with_fallback()
-        assert facts is not None
-        assert isinstance(facts, ListFacts)
-        assert facts.rating == fighter.cost_int()
-        assert facts.credits == 25
+@pytest.mark.django_db
+def test_list_set_dirty_enqueues_refresh_on_commit(
+    user, make_list, django_capture_on_commit_callbacks
+):
+    """set_dirty() enqueues the background heal once the transaction commits.
 
-        # Verify track was called
-        mock_track.assert_called_once_with("facts_fallback", list_id=str(lst.pk))
+    The heal moved from read-time (the old facts_with_fallback) to write-time
+    in #1860 Stage B.
+    """
+    from unittest.mock import patch
 
-        # Verify background task was enqueued (when feature is enabled)
+    lst = make_list("Test List")
+    lst.dirty = False
+    lst.save()
+
+    with patch("gyrinx.core.models.list.list.refresh_list_facts") as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            lst.set_dirty()
         mock_task.enqueue.assert_called_once_with(list_id=str(lst.pk))
 
-    # With task mocked, dirty remains True (facts_with_fallback itself doesn't update)
+        # Already-dirty lists don't enqueue again (transition-edge only).
+        mock_task.enqueue.reset_mock()
+        with django_capture_on_commit_callbacks(execute=True):
+            lst.set_dirty()
+        mock_task.enqueue.assert_not_called()
+
     lst.refresh_from_db()
     assert lst.dirty is True
 
@@ -1244,3 +1225,32 @@ def test_list_has_no_deprecated_cost_int_cached():
     assert not hasattr(List, "cost_int_cached")
     assert hasattr(ListFighter, "cost_int_cached")
     assert hasattr(ListFighterEquipmentAssignment, "cost_int_cached")
+
+
+@pytest.mark.django_db
+def test_index_pages_render_last_good_wealth_for_dirty_list(client, user, make_list):
+    """A dirty list's wealth badge shows the persisted last-good number.
+
+    Index pages never recompute (#1860 Stage B): the home and user pages read
+    the cached fields directly, so a dirty list renders its last-known wealth
+    rather than an empty badge or a live recompute. Asserting on rendered
+    content matters here — Django templates swallow missing attributes
+    silently, so a view test that doesn't check the number can't catch a
+    broken badge.
+    """
+    from django.urls import reverse
+
+    lst = make_list("Badge Gang")
+    lst.rating_current = 123
+    lst.stash_current = 7
+    lst.credits_current = 20
+    lst.dirty = True
+    lst.save()
+
+    client.force_login(user)
+
+    home = client.get(reverse("core:index")).content.decode()
+    assert "150¢" in home  # 123 + 7 + 20, from the persisted fields
+
+    userpage = client.get(reverse("core:user", args=(user.username,))).content.decode()
+    assert "150¢" in userpage

--- a/gyrinx/core/tests/test_models_core.py
+++ b/gyrinx/core/tests/test_models_core.py
@@ -1988,6 +1988,9 @@ def test_list_rating_calculation(
 
     # Rating should be the sum of active fighters only (50 + 100 + 30)
     assert lst.rating == 180
+
+    # Displays read the persisted cache (#1860 Stage B), so sync facts first
+    lst.facts_from_db(update=True)
     assert lst.rating_display == "180¢"
 
     # Add a stash fighter - it should NOT count towards rating
@@ -2020,6 +2023,7 @@ def test_list_rating_calculation(
 
     # Rating should now be 50 + 30 = 80
     assert lst.rating == 80
+    lst.facts_from_db(update=True)
     assert lst.rating_display == "80¢"
 
 
@@ -2081,6 +2085,9 @@ def test_stash_fighter_cost_calculation(
 
     # Stash fighter cost should now be 25 + 50 = 75
     assert lst.stash_fighter_cost_int == 75
+
+    # Displays read the persisted cache (#1860 Stage B), so sync facts first
+    lst.facts_from_db(update=True)
     assert lst.stash_fighter_cost_display == "75¢"
 
 
@@ -2125,8 +2132,8 @@ def test_wealth_breakdown_display(
     # Sync facts after adding fighters
     lst.facts_from_db(update=True)
 
-    # Fetch fresh list with proper prefetching so can_use_facts is True
-    lst = List.objects.with_latest_actions().get(id=lst.id)
+    # Fetch a fresh list so the display reads come from persisted fields
+    lst = List.objects.get(id=lst.id)
 
     # Test display methods
     assert lst.credits_current_display == "250¢"

--- a/gyrinx/core/tests/test_propagate_content_cost_change.py
+++ b/gyrinx/core/tests/test_propagate_content_cost_change.py
@@ -219,3 +219,43 @@ def test_idempotent_after_view_race(
 
     assert after_first == 1
     assert after_second == after_first
+
+
+@pytest.mark.django_db
+def test_sweep_failure_enqueues_background_heal(
+    make_list, make_list_fighter, cost_equipment, settings
+):
+    """A list the sweep fails on gets a background heal enqueued (#1860 Stage B).
+
+    Index pages show last-good cached numbers and never recompute, so without
+    this a sweep-failed list would display stale wealth until someone opened
+    its detail page. The heal refreshes caches only — the audit action for the
+    change is still lost, and a redelivery remains the real recovery.
+    """
+    settings.FEATURE_LIST_ACTION_CREATE_INITIAL = True
+    lst = _clean_list_with_equipment(make_list, make_list_fighter, cost_equipment)
+
+    ContentEquipment = cost_equipment.__class__
+    ContentEquipment.objects.filter(pk=cost_equipment.pk).update(cost="150")
+    cost_equipment.refresh_from_db()
+    cost_equipment.set_dirty()
+
+    from gyrinx.content.models.signal_handlers import (
+        _create_content_cost_change_actions,
+    )
+
+    with (
+        patch(
+            "gyrinx.core.cost.pin_sweep.rewrite_pinned_amounts_for_list",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("gyrinx.core.tasks.refresh_list_facts") as mock_task,
+    ):
+        _create_content_cost_change_actions(cost_equipment)
+
+    mock_task.enqueue.assert_called_once_with(list_id=str(lst.pk))
+
+    # The per-list transaction rolled back: no action was recorded.
+    assert not ListAction.objects.filter(
+        list=lst, action_type=ListActionType.CONTENT_COST_CHANGE
+    ).exists()

--- a/gyrinx/core/views/campaign/lifecycle.py
+++ b/gyrinx/core/views/campaign/lifecycle.py
@@ -74,10 +74,9 @@ def start_campaign(request, id):
         messages.error(request, "This campaign cannot be started.")
         return HttpResponseRedirect(reverse("core:campaign", args=(campaign.id,)))
 
-    # Prefetch lists with latest actions for efficient facts_with_fallback() in template.
     # Pre-campaign gangs are linked via the `lists` M2M; the `campaign` FK on List is only
     # populated when clones are created at start, so it must not be used here (see #1886).
-    lists = campaign.lists.select_related("owner").with_latest_actions()
+    lists = campaign.lists.select_related("owner")
 
     return render(
         request,

--- a/gyrinx/core/views/campaign/lists.py
+++ b/gyrinx/core/views/campaign/lists.py
@@ -291,7 +291,7 @@ def campaign_add_lists(request, id):
         disallowed_packs = CustomContentPack.objects.exclude(id__in=campaign_pack_ids)
         lists = lists.exclude(packs__in=disallowed_packs)
 
-    # Exclude and order by name, prefetch latest actions for facts system
+    # Exclude and order by name
     lists = (
         lists.exclude(id__in=excluded_list_ids)
         .with_latest_actions()

--- a/gyrinx/core/views/list/common.py
+++ b/gyrinx/core/views/list/common.py
@@ -27,8 +27,9 @@ def get_clean_list_or_404(model_or_queryset, *args, **kwargs):
         get_clean_list_or_404(List, id=id, owner=request.user)
         get_clean_list_or_404(List.objects.filter(...), id=id)
     """
-    # If passed the List model directly, apply with_latest_actions() prefetch
-    # to enable can_use_facts for consistent rating display
+    # If passed the List model directly, apply the with_latest_actions()
+    # prefetch so latest_action reads (create_action, check_wealth_sync)
+    # don't issue an extra query.
     if model_or_queryset is List:
         model_or_queryset = List.objects.with_latest_actions()
 

--- a/gyrinx/core/views/list/common.py
+++ b/gyrinx/core/views/list/common.py
@@ -13,8 +13,8 @@ def get_clean_list_or_404(model_or_queryset, *args, **kwargs):
     this function will refresh the cached facts before returning.
 
     When passed the List model class directly, this function automatically
-    applies the with_latest_actions() prefetch to enable the facts system
-    for consistent rating display across all views.
+    applies the with_latest_actions() prefetch so latest_action reads
+    (create_action, check_wealth_sync) don't issue an extra query.
 
     Args:
         model_or_queryset: A model class (List) or queryset to filter

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -100,12 +100,6 @@ FEATURE_LIST_ACTION_CREATE_INITIAL = (
     os.getenv("FEATURE_LIST_ACTION_CREATE_INITIAL", "True") == "True"
 )
 
-# Enable background task enqueue in facts_with_fallback
-# Uses fire-and-forget publishing so it doesn't block page loads
-FEATURE_FACTS_FALLBACK_ENQUEUE = (
-    os.getenv("FEATURE_FACTS_FALLBACK_ENQUEUE", "True") == "True"
-)
-
 # Gyrinx debug mode - shows debug info in templates (not the same as Django DEBUG)
 GYRINX_DEBUG = os.getenv("GYRINX_DEBUG", "") == "True"
 


### PR DESCRIPTION
## Summary

- **Display reads one path now.** `List.cost_display`/`rating_display`/`stash_fighter_cost_display` and the index/campaign templates read the persisted cache fields (`wealth_current`, `rating_current`, `stash_current`) unconditionally. A dirty list shows its last-good numbers instead of triggering a live recompute at read time. Fighter cards keep a live fallback when dirty (facts when clean, `cost_int_cached` otherwise) so a card never shows a number known to be stale.
- **Healing moves from read-time to write-time.** `facts_with_fallback()` ("MIGRATION PERIOD ONLY") and its read-time task enqueue are deleted; `List.set_dirty()` now enqueues `refresh_list_facts` on commit, so a list that goes dirty heals in the background without waiting to be viewed. Bulk dirty-marking (content cost sweeps) deliberately bypasses this — the sweep task heals those lists itself. Single-list pages still heal on view via `get_clean_list_or_404`.
- **The prefetch-sniffing forks are gone.** Both `can_use_facts` properties (List + ListFighter) and the display-method forks they gated are deleted, along with the `FEATURE_FACTS_FALLBACK_ENQUEUE` flag and the `facts_fallback` telemetry. `with_latest_actions()` remains — `latest_action` reads (`create_action`, `check_wealth_sync`) still use the prefetch.

Net −64 lines. Safety evidence: every prod list has a bootstrap action (0 of 9,693 without), the estate is fully reconciled (0 dirty lists), and the `facts_fallback` telemetry shows the deleted fallback path had not executed in production since the estate reconcile.

Refs #1860

## Test plan

- [x] Full suite green: 3,250 passed, 13 skipped (`pytest -n auto`)
- [x] New: dirty lists display last-good numbers (model-level and rendered home/user pages — render-level assertion matters because Django templates swallow missing attributes silently)
- [x] New: `set_dirty()` enqueues the heal on commit, transition-edge only
- [x] Balance-sheet situation matrix stays green (both beats); performance query snapshot unchanged

## Next steps

Stage C (ListAction becomes a pure audit record; propagation writes the list-level cache) follows separately per the plan on #1860.