### PR TITLE
feat: bulk post-battle updates editor for a gang (battle flow step 2)

### DIFF
--- a/gyrinx/core/forms/list.py
+++ b/gyrinx/core/forms/list.py
@@ -585,6 +585,43 @@ class EditListFighterNotesForm(forms.ModelForm):
         }
 
 
+def available_injuries_for_fighter(fighter):
+    """Return the ContentInjury queryset applicable to ``fighter``.
+
+    Filters injury groups by the fighter's category (``restricted_to`` /
+    ``unavailable_to``) and house (``restricted_to_house``); ungrouped injuries
+    are always available. Passing ``None`` returns every injury. Shared by
+    :class:`AddInjuryForm` and the bulk post-battle editor so the two can't
+    drift apart.
+    """
+    from django.db.models import Q
+
+    from gyrinx.content.models import ContentInjury, ContentInjuryGroup
+
+    base = ContentInjury.objects.select_related("injury_group")
+    if fighter is None:
+        return base
+
+    fighter_category = fighter.content_fighter.category
+    fighter_house = fighter.equipment_list_fighter.house
+
+    group_query = (
+        Q(restricted_to__isnull=True)
+        | Q(restricted_to="")
+        | Q(restricted_to__contains=fighter_category)
+    )
+    group_query &= ~Q(unavailable_to__contains=fighter_category)
+    if fighter_house:
+        group_query &= Q(restricted_to_house__isnull=True) | Q(
+            restricted_to_house=fighter_house
+        )
+
+    available_groups = ContentInjuryGroup.objects.filter(group_query)
+    return base.filter(
+        Q(injury_group__in=available_groups) | Q(injury_group__isnull=True)
+    )
+
+
 class AddInjuryForm(forms.Form):
     injury = forms.ModelChoiceField(
         queryset=None,  # Will be set in __init__
@@ -609,48 +646,10 @@ class AddInjuryForm(forms.Form):
         # Extract fighter from kwargs if provided
         fighter = kwargs.pop("fighter", None)
         super().__init__(*args, **kwargs)
-        # Import here to avoid circular imports
-        from django.db.models import Q
-
-        from gyrinx.content.models import ContentInjury, ContentInjuryGroup
         from gyrinx.forms import group_select
 
-        # Filter injuries based on fighter category if fighter is provided
-        if fighter:
-            fighter_category = fighter.content_fighter.category
-            fighter_house = fighter.equipment_list_fighter.house
-
-            # Build query for injury groups available to this fighter
-            # Start with groups that have no category restrictions or include this category
-            group_query = (
-                Q(restricted_to__isnull=True)
-                | Q(restricted_to="")
-                | Q(restricted_to__contains=fighter_category)
-            )
-
-            # Exclude groups that are unavailable to this category
-            group_query &= ~Q(unavailable_to__contains=fighter_category)
-
-            # Apply house restrictions if present
-            if fighter_house:
-                # Include groups with no house restrictions or those restricted to this house
-                group_query &= Q(restricted_to_house__isnull=True) | Q(
-                    restricted_to_house=fighter_house
-                )
-
-            available_groups = ContentInjuryGroup.objects.filter(group_query)
-
-            # Filter injuries by available groups
-            self.fields["injury"].queryset = ContentInjury.objects.select_related(
-                "injury_group"
-            ).filter(
-                Q(injury_group__in=available_groups) | Q(injury_group__isnull=True)
-            )
-        else:
-            # If no fighter, show all injuries
-            self.fields["injury"].queryset = ContentInjury.objects.select_related(
-                "injury_group"
-            )
+        # Filter injuries to those applicable to this fighter (shared helper).
+        self.fields["injury"].queryset = available_injuries_for_fighter(fighter)
 
         # Group injuries by their injury_group field
         group_select(

--- a/gyrinx/core/forms/post_battle.py
+++ b/gyrinx/core/forms/post_battle.py
@@ -108,6 +108,7 @@ class PostBattleUpdatesForm(forms.Form):
                         "class": "form-control",
                         "rows": 4,
                         "placeholder": "Private notes (only visible to you)",
+                        "aria-label": f"Private notes for {fighter.name}",
                     }
                 ),
             )

--- a/gyrinx/core/forms/post_battle.py
+++ b/gyrinx/core/forms/post_battle.py
@@ -1,0 +1,125 @@
+"""Form for the bulk post-battle updates editor.
+
+One dynamic form builds a set of per-fighter fields (XP, per-counter deltas,
+injury + reason, private notes) plus a single battle selector. Every field is
+optional; the view acts only on the ones that were filled in or changed. Field
+names are prefixed by fighter pk so a single ``request.POST`` carries the whole
+grid.
+"""
+
+from django import forms
+
+from gyrinx.core.forms.list import available_injuries_for_fighter
+from gyrinx.core.models.battle import Battle
+from gyrinx.forms import group_select
+
+
+class PostBattleUpdatesForm(forms.Form):
+    """Bulk per-fighter post-battle edits for one list.
+
+    Pass the list's fighters via ``fighters`` and the campaign's selectable
+    battles via ``battles``. For each fighter the form gains:
+
+    - ``xp_<pk>`` — XP to add (optional, positive).
+    - ``counter_<pk>_<counter_pk>`` — one per applicable counter, a delta.
+    - ``injury_<pk>`` — an injury to apply (optional), filtered per fighter.
+    - ``injury_reason_<pk>`` — required reason when an injury is chosen.
+    - ``private_notes_<pk>`` — pre-filled private notes (rich text).
+
+    Plus a single ``battle`` selector that links every logged action to a battle.
+    """
+
+    def __init__(self, *args, fighters=None, battles=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fighters = list(fighters or [])
+
+        self.fields["battle"] = forms.ModelChoiceField(
+            required=False,
+            queryset=battles if battles is not None else Battle.objects.none(),
+            empty_label="---",
+            widget=forms.Select(attrs={"class": "form-select"}),
+            label="Link to a battle",
+        )
+
+        for fighter in self.fighters:
+            pk = fighter.pk
+
+            self.fields[f"xp_{pk}"] = forms.IntegerField(
+                required=False,
+                min_value=1,
+                widget=forms.NumberInput(
+                    attrs={
+                        "class": "form-control form-control-sm",
+                        "min": 1,
+                        "placeholder": "+XP",
+                        "aria-label": f"XP to add for {fighter.name}",
+                    }
+                ),
+            )
+
+            for entry in fighter.applicable_counters:
+                counter = entry.counter
+                self.fields[f"counter_{pk}_{counter.pk}"] = forms.IntegerField(
+                    required=False,
+                    widget=forms.NumberInput(
+                        attrs={
+                            "class": "form-control form-control-sm",
+                            "placeholder": "±0",
+                            "aria-label": f"{counter.name} change for {fighter.name}",
+                        }
+                    ),
+                )
+
+            injury_field = f"injury_{pk}"
+            self.fields[injury_field] = forms.ModelChoiceField(
+                required=False,
+                queryset=available_injuries_for_fighter(fighter),
+                empty_label="—",
+                widget=forms.Select(
+                    attrs={
+                        "class": "form-select form-select-sm",
+                        "aria-label": f"Injury for {fighter.name}",
+                    }
+                ),
+            )
+            group_select(
+                self,
+                injury_field,
+                key=lambda x: x.injury_group.name if x.injury_group else "Other",
+            )
+
+            self.fields[f"injury_reason_{pk}"] = forms.CharField(
+                required=False,
+                max_length=255,
+                widget=forms.TextInput(
+                    attrs={
+                        "class": "form-control form-control-sm",
+                        "placeholder": "Reason",
+                        "aria-label": f"Injury reason for {fighter.name}",
+                    }
+                ),
+            )
+
+            self.fields[f"private_notes_{pk}"] = forms.CharField(
+                required=False,
+                initial=fighter.private_notes,
+                widget=forms.Textarea(
+                    attrs={
+                        "class": "form-control",
+                        "rows": 4,
+                        "placeholder": "Private notes (only visible to you)",
+                    }
+                ),
+            )
+
+    def clean(self):
+        cleaned = super().clean()
+        # An injury must come with a reason.
+        for fighter in self.fighters:
+            pk = fighter.pk
+            if (
+                cleaned.get(f"injury_{pk}")
+                and not (cleaned.get(f"injury_reason_{pk}") or "").strip()
+            ):
+                self.add_error(f"injury_reason_{pk}", "Add a reason for this injury.")
+        return cleaned

--- a/gyrinx/core/handlers/fighter/__init__.py
+++ b/gyrinx/core/handlers/fighter/__init__.py
@@ -39,6 +39,14 @@ from gyrinx.core.handlers.fighter.resurrect import (
     FighterResurrectResult,
     handle_fighter_resurrect,
 )
+from gyrinx.core.handlers.fighter.counter import (
+    FighterCounterAdjustResult,
+    handle_fighter_adjust_counter,
+)
+from gyrinx.core.handlers.fighter.injury import (
+    FighterAddInjuryResult,
+    handle_fighter_add_injury,
+)
 from gyrinx.core.handlers.fighter.roll_flow import (
     RollFlowResult,
     RollResultDeletionResult,
@@ -49,14 +57,21 @@ from gyrinx.core.handlers.fighter.vehicle import (
     VehiclePurchaseResult,
     handle_vehicle_purchase,
 )
+from gyrinx.core.handlers.fighter.xp import (
+    FighterAddXPResult,
+    handle_fighter_add_xp,
+)
 
 __all__ = [
     "FieldChange",
+    "FighterAddInjuryResult",
+    "FighterAddXPResult",
     "FighterAdvancementDeletionResult",
     "FighterAdvancementResult",
     "FighterArchiveResult",
     "FighterCloneParams",
     "FighterCloneResult",
+    "FighterCounterAdjustResult",
     "CounterSpendRemovalResult",
     "CounterSpendResult",
     "RESURRECT_TARGET_STATES",
@@ -70,6 +85,9 @@ __all__ = [
     "VehiclePurchaseResult",
     "handle_counter_spend",
     "handle_counter_spend_removal",
+    "handle_fighter_add_injury",
+    "handle_fighter_add_xp",
+    "handle_fighter_adjust_counter",
     "handle_fighter_advancement",
     "handle_fighter_advancement_deletion",
     "handle_fighter_archive_toggle",

--- a/gyrinx/core/handlers/fighter/counter.py
+++ b/gyrinx/core/handlers/fighter/counter.py
@@ -70,7 +70,7 @@ def handle_fighter_adjust_counter(
         fighter_counter.value = new_value
         fighter_counter.save_with_user(user=user)
     else:
-        fighter_counter = ListFighterCounter.objects.create_with_user(
+        ListFighterCounter.objects.create_with_user(
             user=user,
             fighter=fighter,
             counter=counter,

--- a/gyrinx/core/handlers/fighter/counter.py
+++ b/gyrinx/core/handlers/fighter/counter.py
@@ -1,0 +1,100 @@
+"""Handler for adjusting a fighter's counter value by a delta.
+
+Unlike :func:`handle_counter_spend` (a decrement-with-reason that leaves a
+refundable spend record), this is a plain post-battle adjustment: add or
+subtract from the running counter value, clamped at zero, with a CampaignAction
+for the audit trail.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from django.db import transaction
+
+from gyrinx.content.models import ContentCounter
+from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.list import ListFighter, ListFighterCounter
+from gyrinx.tracing import traced
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FighterCounterAdjustResult:
+    """Result of adjusting a fighter's counter value."""
+
+    fighter: ListFighter
+    counter: ContentCounter
+    applied: int
+    new_value: int
+    campaign_action: Optional[CampaignAction]
+
+
+@traced("handle_fighter_adjust_counter")
+@transaction.atomic
+def handle_fighter_adjust_counter(
+    *,
+    user,
+    fighter: ListFighter,
+    counter: ContentCounter,
+    delta: int,
+    battle=None,
+) -> Optional[FighterCounterAdjustResult]:
+    """
+    Adjust a fighter's counter value by ``delta`` (positive or negative),
+    clamped to a minimum of zero. Creates the ``ListFighterCounter`` row on
+    demand and writes a CampaignAction (optionally attached to ``battle``) in
+    campaign mode.
+
+    A ``delta`` that produces no real change (0, or a decrement below an
+    already-zero value) is a no-op and returns ``None``.
+    """
+    if not delta:
+        return None
+
+    lst = fighter.list
+
+    fighter_counter = (
+        ListFighterCounter.objects.select_for_update()
+        .filter(fighter=fighter, counter=counter)
+        .first()
+    )
+    current = fighter_counter.value if fighter_counter else 0
+    new_value = max(0, current + delta)
+    applied = new_value - current
+    if applied == 0:
+        return None
+
+    if fighter_counter:
+        fighter_counter.value = new_value
+        fighter_counter.save_with_user(user=user)
+    else:
+        fighter_counter = ListFighterCounter.objects.create_with_user(
+            user=user,
+            fighter=fighter,
+            counter=counter,
+            value=new_value,
+            owner=lst.owner,
+        )
+
+    campaign_action = None
+    if lst.campaign:
+        verb = "gained" if applied > 0 else "lost"
+        campaign_action = CampaignAction.objects.create(
+            user=user,
+            owner=user,
+            campaign=lst.campaign,
+            list=lst,
+            battle=battle,
+            description=f"{fighter.name} {verb} {abs(applied)} {counter.name}",
+            outcome=f"{counter.name}: {new_value}",
+        )
+
+    return FighterCounterAdjustResult(
+        fighter=fighter,
+        counter=counter,
+        applied=applied,
+        new_value=new_value,
+        campaign_action=campaign_action,
+    )

--- a/gyrinx/core/handlers/fighter/injury.py
+++ b/gyrinx/core/handlers/fighter/injury.py
@@ -1,0 +1,137 @@
+"""Handler for applying a lasting injury to a fighter and its default outcome.
+
+The single-fighter add-injury view relies on client-side JS to pick the
+resulting fighter state and bounces DEAD outcomes to a separate kill
+confirmation. A bulk/headless caller can't do either, so this handler applies
+the injury's default outcome (``ContentInjury.phase``) server-side and routes
+DEAD through the real kill handler.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from django.db import transaction
+
+from gyrinx.content.models import ContentInjury
+from gyrinx.content.models.injury import ContentInjuryDefaultOutcome
+from gyrinx.core.handlers.fighter.kill import handle_fighter_kill
+from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.events import EventNoun, EventVerb, log_event
+from gyrinx.core.models.list import ListFighter, ListFighterInjury
+from gyrinx.tracing import traced
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FighterAddInjuryResult:
+    """Result of applying a lasting injury."""
+
+    fighter: ListFighter
+    injury: ListFighterInjury
+    outcome_state: str
+    killed: bool
+    campaign_action: Optional[CampaignAction]
+
+
+@traced("handle_fighter_add_injury")
+@transaction.atomic
+def handle_fighter_add_injury(
+    *,
+    user,
+    fighter: ListFighter,
+    injury: ContentInjury,
+    notes: str = "",
+    request=None,
+    battle=None,
+) -> FighterAddInjuryResult:
+    """
+    Record a lasting injury on a fighter and apply its default outcome
+    (``ContentInjury.phase``):
+
+    - ``NO_CHANGE`` keeps the fighter's current state.
+    - ``DEAD`` routes through :func:`handle_fighter_kill` so equipment moves to
+      the stash, cost is zeroed and the list rating is propagated (a bare
+      ``injury_state = DEAD`` would skip all of that).
+    - Any other outcome sets ``injury_state`` directly.
+
+    Writes a CampaignAction in campaign mode and logs an event.
+
+    Args:
+        user: The user applying the injury.
+        fighter: The injured fighter.
+        injury: The ContentInjury to apply.
+        notes: Optional notes recorded on the injury and campaign log.
+        request: Optional request, threaded to ``log_event``.
+        battle: Optional Battle to attach the CampaignAction to.
+
+    Returns:
+        FighterAddInjuryResult.
+    """
+    lst = fighter.list
+
+    injury_record = ListFighterInjury.objects.create_with_user(
+        user=user,
+        fighter=fighter,
+        injury=injury,
+        notes=notes or "",
+        owner=lst.owner,
+    )
+
+    killed = False
+    outcome = injury.phase
+    if outcome == ContentInjuryDefaultOutcome.DEAD:
+        # Full kill logic: equipment -> stash, cost 0, rating propagation.
+        handle_fighter_kill(user=user, lst=lst, fighter=fighter)
+        killed = True
+        final_state = ListFighter.DEAD
+    elif outcome and outcome != ContentInjuryDefaultOutcome.NO_CHANGE:
+        fighter.injury_state = outcome
+        fighter.save_with_user(user=user)
+        final_state = outcome
+    else:
+        # NO_CHANGE (or unset): leave the fighter's state as-is.
+        final_state = fighter.injury_state
+
+    campaign_action = None
+    if lst.campaign:
+        description = (
+            f"{fighter.term_injury_singular}: {fighter.name} suffered {injury.name}"
+        )
+        if notes:
+            description = f"{description} - {notes}"
+        state_display = dict(ListFighter.INJURY_STATE_CHOICES).get(
+            final_state, final_state
+        )
+        campaign_action = CampaignAction.objects.create(
+            user=user,
+            owner=user,
+            campaign=lst.campaign,
+            list=lst,
+            battle=battle,
+            description=description,
+            outcome=f"{fighter.name} was put into {state_display}",
+        )
+
+    log_event(
+        user=user,
+        noun=EventNoun.LIST_FIGHTER,
+        verb=EventVerb.UPDATE,
+        object=fighter,
+        request=request,
+        fighter_name=fighter.name,
+        list_id=str(lst.id),
+        list_name=lst.name,
+        action="injury_added",
+        injury_name=injury.name,
+        injury_state=final_state,
+    )
+
+    return FighterAddInjuryResult(
+        fighter=fighter,
+        injury=injury_record,
+        outcome_state=final_state,
+        killed=killed,
+        campaign_action=campaign_action,
+    )

--- a/gyrinx/core/handlers/fighter/injury.py
+++ b/gyrinx/core/handlers/fighter/injury.py
@@ -71,6 +71,13 @@ def handle_fighter_add_injury(
     """
     lst = fighter.list
 
+    # Injuries are a campaign-mode concept (ListFighterInjury.clean() enforces
+    # this, but save_with_user()/create_with_user() don't run full_clean).
+    # Guard here so the handler upholds its own invariant, mirroring
+    # handle_fighter_kill's precondition check.
+    if not lst.is_campaign_mode:
+        raise ValueError("Injuries can only be applied in campaign mode")
+
     injury_record = ListFighterInjury.objects.create_with_user(
         user=user,
         fighter=fighter,

--- a/gyrinx/core/handlers/fighter/injury.py
+++ b/gyrinx/core/handlers/fighter/injury.py
@@ -17,7 +17,6 @@ from gyrinx.content.models import ContentInjury
 from gyrinx.content.models.injury import ContentInjuryDefaultOutcome
 from gyrinx.core.handlers.fighter.kill import handle_fighter_kill
 from gyrinx.core.models.campaign import CampaignAction
-from gyrinx.core.models.events import EventNoun, EventVerb, log_event
 from gyrinx.core.models.list import ListFighter, ListFighterInjury
 from gyrinx.tracing import traced
 
@@ -43,7 +42,6 @@ def handle_fighter_add_injury(
     fighter: ListFighter,
     injury: ContentInjury,
     notes: str = "",
-    request=None,
     battle=None,
 ) -> FighterAddInjuryResult:
     """
@@ -56,15 +54,17 @@ def handle_fighter_add_injury(
       ``injury_state = DEAD`` would skip all of that).
     - Any other outcome sets ``injury_state`` directly.
 
-    Writes a CampaignAction in campaign mode and logs an event.
+    Writes a CampaignAction in campaign mode. Event logging (which needs the
+    HTTP request) is the caller's responsibility, matching the project's
+    view/handler layering.
 
     Args:
         user: The user applying the injury.
         fighter: The injured fighter.
         injury: The ContentInjury to apply.
         notes: Optional notes recorded on the injury and campaign log.
-        request: Optional request, threaded to ``log_event``.
-        battle: Optional Battle to attach the CampaignAction to.
+        battle: Optional Battle to attach the CampaignAction(s) to — including
+            the death action when the outcome is DEAD.
 
     Returns:
         FighterAddInjuryResult.
@@ -82,8 +82,9 @@ def handle_fighter_add_injury(
     killed = False
     outcome = injury.phase
     if outcome == ContentInjuryDefaultOutcome.DEAD:
-        # Full kill logic: equipment -> stash, cost 0, rating propagation.
-        handle_fighter_kill(user=user, lst=lst, fighter=fighter)
+        # Full kill logic: equipment -> stash, cost 0, rating propagation. Pass
+        # the battle so the death CampaignAction also lands on its timeline.
+        handle_fighter_kill(user=user, lst=lst, fighter=fighter, battle=battle)
         killed = True
         final_state = ListFighter.DEAD
     elif outcome and outcome != ContentInjuryDefaultOutcome.NO_CHANGE:
@@ -113,20 +114,6 @@ def handle_fighter_add_injury(
             description=description,
             outcome=f"{fighter.name} was put into {state_display}",
         )
-
-    log_event(
-        user=user,
-        noun=EventNoun.LIST_FIGHTER,
-        verb=EventVerb.UPDATE,
-        object=fighter,
-        request=request,
-        fighter_name=fighter.name,
-        list_id=str(lst.id),
-        list_name=lst.name,
-        action="injury_added",
-        injury_name=injury.name,
-        injury_state=final_state,
-    )
 
     return FighterAddInjuryResult(
         fighter=fighter,

--- a/gyrinx/core/handlers/fighter/kill.py
+++ b/gyrinx/core/handlers/fighter/kill.py
@@ -37,6 +37,7 @@ def handle_fighter_kill(
     user,
     lst: List,
     fighter: ListFighter,
+    battle=None,
 ) -> FighterKillResult:
     """
     Handle fighter death in campaign mode.
@@ -67,6 +68,9 @@ def handle_fighter_kill(
         user: User performing the kill
         lst: List containing the fighter
         fighter: Fighter being killed (must not be stash, must be campaign mode)
+        battle: Optional Battle to attach the death CampaignAction to (e.g. a
+            kill applied from the post-battle editor), so it lands on that
+            battle's timeline.
 
     Returns:
         FighterKillResult with all operation details
@@ -246,6 +250,7 @@ def handle_fighter_kill(
             owner=user,
             campaign=lst.campaign,
             list=lst,
+            battle=battle,
             description=f"Death: {fighter.name} was killed",
             outcome=f"{fighter.name} is permanently dead.{equipment_desc}",
         )

--- a/gyrinx/core/handlers/fighter/xp.py
+++ b/gyrinx/core/handlers/fighter/xp.py
@@ -1,7 +1,8 @@
 """Handler for granting XP to a fighter (post-battle participation, etc.).
 
-Extracted so both the single-fighter XP view and the bulk post-battle editor
-apply the same rules and write the same audit trail.
+Encapsulates the XP-add rules and audit trail used by the bulk post-battle
+editor. The single-fighter XP view still adds XP inline and could adopt this
+handler later to share the same rules.
 """
 
 import logging

--- a/gyrinx/core/handlers/fighter/xp.py
+++ b/gyrinx/core/handlers/fighter/xp.py
@@ -1,0 +1,84 @@
+"""Handler for granting XP to a fighter (post-battle participation, etc.).
+
+Extracted so both the single-fighter XP view and the bulk post-battle editor
+apply the same rules and write the same audit trail.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+
+from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.list import ListFighter
+from gyrinx.tracing import traced
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FighterAddXPResult:
+    """Result of granting XP to a fighter."""
+
+    fighter: ListFighter
+    amount: int
+    campaign_action: Optional[CampaignAction]
+
+
+@traced("handle_fighter_add_xp")
+@transaction.atomic
+def handle_fighter_add_xp(
+    *,
+    user,
+    fighter: ListFighter,
+    amount: int,
+    description: str = "",
+    battle=None,
+) -> FighterAddXPResult:
+    """
+    Grant XP to a fighter, bumping both current (spendable) and total (lifetime)
+    XP, and writing a CampaignAction in campaign mode.
+
+    Args:
+        user: The user granting the XP.
+        fighter: The fighter receiving XP.
+        amount: XP to add (must be a positive whole number).
+        description: Optional note appended to the campaign log entry.
+        battle: Optional Battle to attach the CampaignAction to.
+
+    Returns:
+        FighterAddXPResult.
+
+    Raises:
+        ValidationError: If amount is not positive.
+    """
+    if amount is None or amount < 1:
+        raise ValidationError("XP to add must be a positive whole number.")
+
+    lst = fighter.list
+
+    fighter.xp_current += amount
+    fighter.xp_total += amount
+    fighter.save_with_user(user=user)
+
+    action_desc = f"Added {amount} XP for {fighter.name}"
+    if description:
+        action_desc = f"{action_desc} - {description}"
+
+    campaign_action = None
+    if lst.campaign:
+        campaign_action = CampaignAction.objects.create(
+            user=user,
+            owner=user,
+            campaign=lst.campaign,
+            list=lst,
+            battle=battle,
+            description=action_desc,
+            outcome=f"Current: {fighter.xp_current} XP, Total: {fighter.xp_total} XP",
+        )
+
+    return FighterAddXPResult(
+        fighter=fighter, amount=amount, campaign_action=campaign_action
+    )

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -164,6 +164,17 @@
                                         <i class="bi-three-dots-vertical"></i>
                                     </button>
                                     <ul class="dropdown-menu">
+                                        {% if list.owner_cached == user and list.is_campaign_mode %}
+                                            <li>
+                                                <a href="{% url 'core:list-post-battle' list.id %}"
+                                                   class="dropdown-item icon-link">
+                                                    <i class="bi-clipboard-check"></i> Post-battle updates
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <hr class="dropdown-divider">
+                                            </li>
+                                        {% endif %}
                                         <li>
                                             <a href="{% url 'core:print-config-index' list.id %}"
                                                class="dropdown-item icon-link">

--- a/gyrinx/core/templates/core/includes/list.html
+++ b/gyrinx/core/templates/core/includes/list.html
@@ -164,7 +164,7 @@
                                         <i class="bi-three-dots-vertical"></i>
                                     </button>
                                     <ul class="dropdown-menu">
-                                        {% if list.owner_cached == user and list.is_campaign_mode %}
+                                        {% if is_campaign_arbitrator or list.is_campaign_mode and list.owner_cached == user %}
                                             <li>
                                                 <a href="{% url 'core:list-post-battle' list.id %}"
                                                    class="dropdown-item icon-link">

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -9,8 +9,9 @@
     <div class="col-12 px-0 vstack gap-3">
         <h1 class="h3 mb-0">Post-battle updates</h1>
         <p class="text-secondary mb-0">
-            Record what happened this battle across the whole gang. Every field starts
-            blank — only what you fill in or change is applied, nothing else is touched.
+            Record what happened this battle across the whole gang. The action fields
+            start blank and notes show what's already saved — only what you fill in or
+            change is applied, nothing else is touched.
         </p>
         <form method="post" data-pb-form>
             {% csrf_token %}

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -152,7 +152,7 @@
                      // reserialise the HTML on a blanket triggerSave() and log a
                      // spurious "notes changed" — so leave clean editors' textareas
                      // holding their original server-rendered value.
-                     window.tinymce.editors.forEach(function (ed) {
+                     window.tinymce.get().forEach(function (ed) {
                          if (ed.isDirty()) ed.save();
                      });
                  });

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -62,11 +62,17 @@
                                                 <span class="text-secondary">({{ c.value }})</span>
                                             </label>
                                             {{ c.field }}
+                                            {% for error in c.field.errors %}
+                                                <div class="text-danger fs-7">{{ error }}</div>
+                                            {% endfor %}
                                         </div>
                                     {% endfor %}
                                     <div class="col-12 col-md">
                                         <label class="form-label fs-7 mb-1" for="{{ row.injury.id_for_label }}">Injury</label>
                                         {{ row.injury }}
+                                        {% for error in row.injury.errors %}
+                                            <div class="text-danger fs-7">{{ error }}</div>
+                                        {% endfor %}
                                     </div>
                                     <div class="col-12 col-md">
                                         <label class="form-label fs-7 mb-1"

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -146,7 +146,15 @@
              var form = document.querySelector("form[data-pb-form]");
              if (form) {
                  form.addEventListener("submit", function () {
-                     if (window.tinymce) window.tinymce.triggerSave();
+                     if (!window.tinymce) return;
+                     // Only write back editors the user actually edited. Merely
+                     // opening a fighter's notes mounts TinyMCE, which would
+                     // reserialise the HTML on a blanket triggerSave() and log a
+                     // spurious "notes changed" — so leave clean editors' textareas
+                     // holding their original server-rendered value.
+                     window.tinymce.editors.forEach(function (ed) {
+                         if (ed.isDirty()) ed.save();
+                     });
                  });
              }
          })();

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -1,0 +1,149 @@
+{% extends "core/layouts/base.html" %}
+{% load static custom_tags %}
+{% block head_title %}
+    Post-battle updates - {{ list.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:list' list.id as list_url %}
+    {% include "core/includes/list_common_header.html" with list=list link_list="true" %}
+    <div class="col-12 px-0 vstack gap-3">
+        <h1 class="h3 mb-0">Post-battle updates</h1>
+        <p class="text-secondary mb-0">
+            Record what happened this battle across the whole gang. Every field starts
+            blank — only what you fill in or change is applied, nothing else is touched.
+        </p>
+        <form method="post" data-pb-form>
+            {% csrf_token %}
+            {% if rows %}
+                <div class="vstack gap-4">
+                    {% if form.non_field_errors %}
+                        <div class="alert alert-danger alert-icon" role="alert">
+                            <i class="bi-exclamation-triangle"></i>
+                            <div>{{ form.non_field_errors }}</div>
+                        </div>
+                    {% endif %}
+                    {% if has_battles %}
+                        <div class="col-12 col-md-6 col-lg-4">
+                            <label for="{{ form.battle.id_for_label }}" class="form-label mb-1">
+                                {{ form.battle.label }}
+                                <span class="text-secondary fs-7">(optional)</span>
+                            </label>
+                            {{ form.battle }}
+                            <div class="form-text">Actions logged below will be attached to this battle.</div>
+                        </div>
+                    {% endif %}
+                    <div class="border-top">
+                        {% for row in rows %}
+                            <div class="py-3 border-bottom">
+                                <div class="d-flex flex-wrap align-items-baseline gap-2 mb-2">
+                                    <span class="fw-semibold fs-5">{{ row.fighter.name }}</span>
+                                    <span class="text-secondary fw-normal">{{ row.fighter.get_category_label }}</span>
+                                    {% if row.fighter.is_dead %}
+                                        <span class="badge text-bg-dark">Dead</span>
+                                    {% elif not row.fighter.is_active %}
+                                        <span class="badge text-bg-secondary">{{ row.fighter.get_injury_state_display }}</span>
+                                    {% endif %}
+                                </div>
+                                <div class="row g-2 g-md-3">
+                                    <div class="col-6 col-md-2">
+                                        <label class="form-label fs-7 mb-1" for="{{ row.xp.id_for_label }}">
+                                            Add XP
+                                            <span class="text-secondary">({{ row.fighter.xp_current }})</span>
+                                        </label>
+                                        {{ row.xp }}
+                                        {% for error in row.xp.errors %}
+                                            <div class="text-danger fs-7">{{ error }}</div>
+                                        {% endfor %}
+                                    </div>
+                                    {% for c in row.counters %}
+                                        <div class="col-6 col-md-2">
+                                            <label class="form-label fs-7 mb-1" for="{{ c.field.id_for_label }}">
+                                                {{ c.counter.name }}
+                                                <span class="text-secondary">({{ c.value }})</span>
+                                            </label>
+                                            {{ c.field }}
+                                        </div>
+                                    {% endfor %}
+                                    <div class="col-12 col-md">
+                                        <label class="form-label fs-7 mb-1" for="{{ row.injury.id_for_label }}">Injury</label>
+                                        {{ row.injury }}
+                                    </div>
+                                    <div class="col-12 col-md">
+                                        <label class="form-label fs-7 mb-1"
+                                               for="{{ row.injury_reason.id_for_label }}">Reason</label>
+                                        {{ row.injury_reason }}
+                                        {% for error in row.injury_reason.errors %}
+                                            <div class="text-danger fs-7">{{ error }}</div>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                                <details class="mt-2" data-pb-notes>
+                                    <summary class="fs-7 linked">Private notes</summary>
+                                    <div class="mt-2">{{ row.private_notes }}</div>
+                                </details>
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-success">Apply updates</button>
+                        {% include "core/includes/cancel.html" with url=list_url text="Cancel" %}
+                    </div>
+                </div>
+            {% else %}
+                <div class="border rounded p-2">
+                    <i class="bi-info-circle"></i> This gang has no fighters to update.
+                </div>
+            {% endif %}
+        </form>
+    </div>
+    {% if rows %}
+        <script src="{% static 'tinymce/tinymce.min.js' %}"></script>
+        <script>
+         (function () {
+             function initEditor(ta) {
+                 if (!window.tinymce || ta.dataset.pbInit) return;
+                 ta.dataset.pbInit = "1";
+                 var dark = document.documentElement.getAttribute("data-bs-theme") === "dark";
+                 window.tinymce.init({
+                     target: ta,
+                     menubar: false,
+                     statusbar: false,
+                     plugins: "lists link autolink autoresize",
+                     toolbar: "bold italic underline | bullist numlist | link | removeformat",
+                     min_height: 180,
+                     branding: false,
+                     promotion: false,
+                     skin: dark ? "oxide-dark" : "oxide",
+                     content_css: dark ? "dark" : "default",
+                 });
+             }
+             document.querySelectorAll("details[data-pb-notes]").forEach(function (d) {
+                 d.addEventListener("toggle", function () {
+                     if (d.open) {
+                         var ta = d.querySelector("textarea");
+                         if (ta) initEditor(ta);
+                     }
+                 });
+             });
+             // Reason is only meaningful alongside an injury: keep it disabled
+             // until one is chosen. Server-side validation is the source of
+             // truth; this is just an affordance, so no-JS submits still work.
+             document.querySelectorAll('select[name^="injury_"]').forEach(function (sel) {
+                 var reason = document.querySelector(
+                     '[name="' + sel.name.replace(/^injury_/, "injury_reason_") + '"]'
+                 );
+                 if (!reason) return;
+                 function sync() { reason.disabled = !sel.value; }
+                 sel.addEventListener("change", sync);
+                 sync();
+             });
+             var form = document.querySelector("form[data-pb-form]");
+             if (form) {
+                 form.addEventListener("submit", function () {
+                     if (window.tinymce) window.tinymce.triggerSave();
+                 });
+             }
+         })();
+        </script>
+    {% endif %}
+{% endblock content %}

--- a/gyrinx/core/tests/test_post_battle_updates.py
+++ b/gyrinx/core/tests/test_post_battle_updates.py
@@ -275,6 +275,53 @@ def test_post_battle_battle_url_param_preselects(
 
 
 @pytest.mark.django_db
+def test_post_battle_malformed_battle_param_is_ignored(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    make_list_fighter(list_with_campaign, "F1")
+    # A non-UUID ?battle= must not 500 the lookup — it's simply ignored.
+    resp = client.get(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {"battle": "not-a-uuid"},
+    )
+    assert resp.status_code == 200
+    assert resp.context["form"]["battle"].value() in (None, "")
+
+
+@pytest.mark.django_db
+def test_post_battle_link_visible_to_arbitrator_on_list_page(
+    client, user, make_user, campaign, make_list, make_list_fighter
+):
+    from gyrinx.core.models.list import List
+
+    player = make_user("player_pb_menu", "password")
+    plist = make_list(
+        "Player Gang", owner=player, status=List.CAMPAIGN_MODE, campaign=campaign
+    )
+    campaign.lists.add(plist)
+    post_battle_url = reverse("core:list-post-battle", args=[plist.id])
+
+    # Arbitrator (campaign owner = user) sees the menu item on a gang they
+    # don't own — the view lets them edit, so the link must be discoverable.
+    client.force_login(user)
+    resp = client.get(reverse("core:list", args=[plist.id]))
+    assert resp.status_code == 200
+    assert resp.context["is_campaign_arbitrator"] is True
+    assert post_battle_url in resp.content.decode()
+
+    # An unrelated viewer is not the arbitrator and does not see it.
+    outsider = make_user("outsider_pb_menu", "password")
+    plist.public = True
+    plist.save()
+    client.force_login(outsider)
+    resp = client.get(reverse("core:list", args=[plist.id]))
+    assert resp.status_code == 200
+    assert resp.context["is_campaign_arbitrator"] is False
+    assert post_battle_url not in resp.content.decode()
+
+
+@pytest.mark.django_db
 def test_post_battle_arbitrator_can_edit_and_outsider_cannot(
     client, user, make_user, campaign, content_house, make_list, make_list_fighter
 ):

--- a/gyrinx/core/tests/test_post_battle_updates.py
+++ b/gyrinx/core/tests/test_post_battle_updates.py
@@ -1,0 +1,304 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.urls import reverse
+
+from gyrinx.content.models import ContentCounter, ContentInjury
+from gyrinx.content.models.injury import ContentInjuryDefaultOutcome
+from gyrinx.core.handlers.fighter import (
+    handle_fighter_add_injury,
+    handle_fighter_add_xp,
+    handle_fighter_adjust_counter,
+)
+from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.list import ListFighter, ListFighterCounter, ListFighterInjury
+
+
+# --- Handlers --------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_handle_fighter_add_xp(user, list_with_campaign, make_list_fighter):
+    fighter = make_list_fighter(list_with_campaign, "F1")
+    fighter.xp_current = 2
+    fighter.xp_total = 5
+    fighter.save()
+
+    result = handle_fighter_add_xp(user=user, fighter=fighter, amount=3)
+
+    fighter.refresh_from_db()
+    assert fighter.xp_current == 5
+    assert fighter.xp_total == 8
+    assert result.campaign_action is not None
+    assert CampaignAction.objects.filter(list=list_with_campaign).count() == 1
+
+
+@pytest.mark.django_db
+def test_handle_fighter_add_xp_rejects_nonpositive(
+    user, list_with_campaign, make_list_fighter
+):
+    fighter = make_list_fighter(list_with_campaign, "F1")
+    for bad in (0, -1):
+        with pytest.raises(ValidationError):
+            handle_fighter_add_xp(user=user, fighter=fighter, amount=bad)
+
+
+@pytest.mark.django_db
+def test_handle_fighter_add_injury_applies_outcome(
+    user, list_with_campaign, make_list_fighter
+):
+    fighter = make_list_fighter(list_with_campaign, "F1")
+    injury = ContentInjury.objects.create(
+        name="Spinal Injury", phase=ContentInjuryDefaultOutcome.RECOVERY
+    )
+
+    result = handle_fighter_add_injury(user=user, fighter=fighter, injury=injury)
+
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.RECOVERY
+    assert result.killed is False
+    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 1
+    assert CampaignAction.objects.filter(list=list_with_campaign).count() == 1
+
+
+@pytest.mark.django_db
+def test_handle_fighter_add_injury_no_change_keeps_state(
+    user, list_with_campaign, make_list_fighter
+):
+    fighter = make_list_fighter(list_with_campaign, "F1")
+    assert fighter.injury_state == ListFighter.ACTIVE
+    injury = ContentInjury.objects.create(
+        name="Bruised", phase=ContentInjuryDefaultOutcome.NO_CHANGE
+    )
+
+    handle_fighter_add_injury(user=user, fighter=fighter, injury=injury)
+
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.ACTIVE
+    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 1
+
+
+@pytest.mark.django_db
+def test_handle_fighter_add_injury_dead_routes_through_kill(
+    user, list_with_campaign, make_list_fighter
+):
+    fighter = make_list_fighter(list_with_campaign, "F1")
+    injury = ContentInjury.objects.create(
+        name="Critical", phase=ContentInjuryDefaultOutcome.DEAD
+    )
+
+    result = handle_fighter_add_injury(user=user, fighter=fighter, injury=injury)
+
+    fighter.refresh_from_db()
+    assert result.killed is True
+    assert fighter.injury_state == ListFighter.DEAD
+    assert fighter.is_dead is True
+    # The kill handler zeroes the fighter's cost.
+    assert fighter.cost_int() == 0
+
+
+@pytest.mark.django_db
+def test_handle_fighter_adjust_counter(user, list_with_campaign, make_list_fighter):
+    fighter = make_list_fighter(list_with_campaign, "F1")
+    counter = ContentCounter.objects.create(name="Kill Count")
+    counter.restricted_to_fighters.add(fighter.content_fighter)
+
+    # First adjustment creates the row.
+    result = handle_fighter_adjust_counter(
+        user=user, fighter=fighter, counter=counter, delta=3
+    )
+    assert result.new_value == 3
+    row = ListFighterCounter.objects.get(fighter=fighter, counter=counter)
+    assert row.value == 3
+
+    # Negative delta clamps at zero.
+    handle_fighter_adjust_counter(
+        user=user, fighter=fighter, counter=counter, delta=-10
+    )
+    row.refresh_from_db()
+    assert row.value == 0
+
+    # A no-op delta (already zero) does nothing.
+    assert (
+        handle_fighter_adjust_counter(
+            user=user, fighter=fighter, counter=counter, delta=-1
+        )
+        is None
+    )
+
+
+# --- View ------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_battle_requires_campaign_mode(client, user, make_list):
+    client.force_login(user)
+    lst = make_list("Building Gang")  # LIST_BUILDING by default
+    resp = client.get(reverse("core:list-post-battle", args=[lst.id]))
+    assert resp.status_code == 302
+    assert resp.url == reverse("core:list", args=[lst.id])
+
+
+@pytest.mark.django_db
+def test_post_battle_page_renders(client, user, list_with_campaign, make_list_fighter):
+    client.force_login(user)
+    make_list_fighter(list_with_campaign, "Alpha")
+    make_list_fighter(list_with_campaign, "Beta")
+
+    resp = client.get(reverse("core:list-post-battle", args=[list_with_campaign.id]))
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "Alpha" in content
+    assert "Beta" in content
+    assert "Post-battle updates" in content
+
+
+@pytest.mark.django_db
+def test_post_battle_applies_only_edited_fields(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    f_xp = make_list_fighter(list_with_campaign, "XPGuy")
+    f_injury = make_list_fighter(list_with_campaign, "HurtGuy")
+    f_counter = make_list_fighter(list_with_campaign, "CountGuy")
+    untouched = make_list_fighter(list_with_campaign, "Bystander")
+
+    injury = ContentInjury.objects.create(
+        name="Head Wound", phase=ContentInjuryDefaultOutcome.RECOVERY
+    )
+    counter = ContentCounter.objects.create(name="Kills")
+    counter.restricted_to_fighters.add(f_counter.content_fighter)
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {
+            f"xp_{f_xp.pk}": "2",
+            f"injury_{f_injury.pk}": str(injury.pk),
+            f"injury_reason_{f_injury.pk}": "Took a bad hit",
+            f"counter_{f_counter.pk}_{counter.pk}": "4",
+            f"private_notes_{f_xp.pk}": "Fought bravely",
+        },
+    )
+    assert resp.status_code == 302
+
+    f_xp.refresh_from_db()
+    f_injury.refresh_from_db()
+    f_counter.refresh_from_db()
+    untouched.refresh_from_db()
+
+    # Only the edited fields were applied.
+    assert f_xp.xp_current == 2
+    assert f_xp.private_notes == "Fought bravely"
+    assert f_injury.injury_state == ListFighter.RECOVERY
+    assert ListFighterInjury.objects.filter(fighter=f_injury).count() == 1
+    assert ListFighterCounter.objects.get(fighter=f_counter, counter=counter).value == 4
+
+    # Everyone else is untouched.
+    assert untouched.xp_current == 0
+    assert untouched.injury_state == ListFighter.ACTIVE
+    assert f_xp.injury_state == ListFighter.ACTIVE
+    assert f_injury.xp_current == 0
+
+
+@pytest.mark.django_db
+def test_post_battle_injury_requires_reason(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "HurtGuy")
+    injury = ContentInjury.objects.create(
+        name="Sprain", phase=ContentInjuryDefaultOutcome.RECOVERY
+    )
+
+    # Selecting an injury without a reason is rejected; nothing is applied.
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"injury_{fighter.pk}": str(injury.pk)},
+    )
+    assert resp.status_code == 200  # re-render with errors
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.ACTIVE
+    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 0
+
+
+@pytest.mark.django_db
+def test_post_battle_links_actions_to_selected_battle(
+    client, user, list_with_campaign, make_list_fighter
+):
+    from gyrinx.core.models.battle import Battle
+
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "XPGuy")
+    battle = Battle.objects.create(
+        campaign=list_with_campaign.campaign, mission="Ambush", owner=user
+    )
+    battle.set_participants([list_with_campaign])
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {"battle": str(battle.pk), f"xp_{fighter.pk}": "2"},
+    )
+    assert resp.status_code == 302
+
+    action = CampaignAction.objects.get(list=list_with_campaign)
+    assert action.battle_id == battle.pk
+
+
+@pytest.mark.django_db
+def test_post_battle_battle_url_param_preselects(
+    client, user, list_with_campaign, make_list_fighter
+):
+    from gyrinx.core.models.battle import Battle
+
+    client.force_login(user)
+    make_list_fighter(list_with_campaign, "F1")
+    battle = Battle.objects.create(
+        campaign=list_with_campaign.campaign, mission="Ambush", owner=user
+    )
+    battle.set_participants([list_with_campaign])
+
+    resp = client.get(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {"battle": str(battle.pk)},
+    )
+    assert resp.status_code == 200
+    assert resp.context["form"]["battle"].value() == str(battle.pk)
+
+    # A battle the list didn't fight in is ignored, not preselected.
+    other = Battle.objects.create(
+        campaign=list_with_campaign.campaign, mission="Elsewhere", owner=user
+    )
+    resp = client.get(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {"battle": str(other.pk)},
+    )
+    assert resp.context["form"]["battle"].value() in (None, "")
+
+
+@pytest.mark.django_db
+def test_post_battle_arbitrator_can_edit_and_outsider_cannot(
+    client, user, make_user, campaign, content_house, make_list, make_list_fighter
+):
+    from gyrinx.core.models.list import List
+
+    player = make_user("player_pb", "password")
+    plist = make_list(
+        "Player Gang", owner=player, status=List.CAMPAIGN_MODE, campaign=campaign
+    )
+    campaign.lists.add(plist)
+    fighter = make_list_fighter(plist, "PGang Fighter", owner=player)
+
+    # Arbitrator (campaign owner = user) can apply updates to a list they don't own.
+    client.force_login(user)
+    resp = client.post(
+        reverse("core:list-post-battle", args=[plist.id]),
+        {f"xp_{fighter.pk}": "1"},
+    )
+    assert resp.status_code == 302
+    fighter.refresh_from_db()
+    assert fighter.xp_current == 1
+
+    # An unrelated user gets a 404.
+    outsider = make_user("outsider_pb", "password")
+    client.force_login(outsider)
+    resp = client.get(reverse("core:list-post-battle", args=[plist.id]))
+    assert resp.status_code == 404

--- a/gyrinx/core/tests/test_post_battle_updates.py
+++ b/gyrinx/core/tests/test_post_battle_updates.py
@@ -275,6 +275,26 @@ def test_post_battle_battle_url_param_preselects(
 
 
 @pytest.mark.django_db
+def test_post_battle_omitted_notes_field_does_not_wipe_notes(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "F1")
+    fighter.private_notes = "<p>Keep me</p>"
+    fighter.save()
+
+    # Submit without this fighter's private_notes field (simulating a roster
+    # that drifted between GET and POST). Notes must be left untouched.
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"xp_{fighter.pk}": "1"},
+    )
+    assert resp.status_code == 302
+    fighter.refresh_from_db()
+    assert fighter.private_notes == "<p>Keep me</p>"
+
+
+@pytest.mark.django_db
 def test_post_battle_malformed_battle_param_is_ignored(
     client, user, list_with_campaign, make_list_fighter
 ):

--- a/gyrinx/core/tests/test_post_battle_updates.py
+++ b/gyrinx/core/tests/test_post_battle_updates.py
@@ -61,6 +61,21 @@ def test_handle_fighter_add_injury_applies_outcome(
 
 
 @pytest.mark.django_db
+def test_handle_fighter_add_injury_requires_campaign_mode(
+    user, make_list, make_list_fighter
+):
+    lst = make_list("Building Gang")  # LIST_BUILDING, not campaign mode
+    fighter = make_list_fighter(lst, "F1")
+    injury = ContentInjury.objects.create(
+        name="Scratch", phase=ContentInjuryDefaultOutcome.RECOVERY
+    )
+    with pytest.raises(ValueError):
+        handle_fighter_add_injury(user=user, fighter=fighter, injury=injury)
+    # Nothing was recorded.
+    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 0
+
+
+@pytest.mark.django_db
 def test_handle_fighter_add_injury_no_change_keeps_state(
     user, list_with_campaign, make_list_fighter
 ):

--- a/gyrinx/core/tests/test_post_battle_updates.py
+++ b/gyrinx/core/tests/test_post_battle_updates.py
@@ -275,6 +275,43 @@ def test_post_battle_battle_url_param_preselects(
 
 
 @pytest.mark.django_db
+def test_post_battle_fatal_injury_links_death_action_to_battle(
+    client, user, list_with_campaign, make_list_fighter
+):
+    from gyrinx.core.models.battle import Battle
+
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "Doomed")
+    injury = ContentInjury.objects.create(
+        name="Fatal Blow", phase=ContentInjuryDefaultOutcome.DEAD
+    )
+    battle = Battle.objects.create(
+        campaign=list_with_campaign.campaign, mission="Last Stand", owner=user
+    )
+    battle.set_participants([list_with_campaign])
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {
+            "battle": str(battle.pk),
+            f"injury_{fighter.pk}": str(injury.pk),
+            f"injury_reason_{fighter.pk}": "Took a fatal blow",
+        },
+    )
+    assert resp.status_code == 302
+    fighter.refresh_from_db()
+    assert fighter.is_dead is True
+
+    # Both the injury action and the kill handler's "Death:" action link to the
+    # battle — no action logged by this submit is left off the timeline.
+    actions = CampaignAction.objects.filter(list=list_with_campaign)
+    death = actions.filter(description__startswith="Death:").first()
+    assert death is not None
+    assert death.battle_id == battle.pk
+    assert not actions.filter(battle__isnull=True).exists()
+
+
+@pytest.mark.django_db
 def test_post_battle_omitted_notes_field_does_not_wipe_notes(
     client, user, list_with_campaign, make_list_fighter
 ):

--- a/gyrinx/core/urls/list.py
+++ b/gyrinx/core/urls/list.py
@@ -4,6 +4,7 @@ from ..views import print_config, vehicle
 from ..views import pack as pack_views
 from ..views.list import attributes as list_attributes
 from ..views.list import invitations as list_invitations
+from ..views.list import post_battle as list_post_battle
 from ..views.list import skill_trees as list_skill_trees
 from ..views.list import views as list_views
 
@@ -31,6 +32,11 @@ patterns = [
     path("list/<id>/pin", list_views.toggle_list_pin, name="list-pin"),
     path("list/<id>/star", list_views.toggle_list_star, name="list-star"),
     path("list/<id>/edit", list_views.edit_list, name="list-edit"),
+    path(
+        "list/<id>/post-battle",
+        list_post_battle.post_battle_updates,
+        name="list-post-battle",
+    ),
     path("list/<id>/packs", pack_views.list_packs_manage, name="list-packs"),
     path("list/<id>/credits", list_views.edit_list_credits, name="list-credits-edit"),
     path("list/<id>/clone", list_views.clone_list, name="list-clone"),

--- a/gyrinx/core/views/list/post_battle.py
+++ b/gyrinx/core/views/list/post_battle.py
@@ -1,5 +1,6 @@
 """Bulk post-battle updates editor for a list (campaign mode)."""
 
+import uuid
 from dataclasses import dataclass, field
 
 from django.contrib.auth.decorators import login_required
@@ -195,9 +196,15 @@ def post_battle_updates(request, id):
             return HttpResponseRedirect(default_url)
     else:
         # A ?battle=<id> query param preselects that battle (only if the list
-        # actually fought in it — otherwise it's ignored).
+        # actually fought in it — otherwise it's ignored). Validate the UUID
+        # first so a malformed value is ignored rather than 500ing the lookup.
         initial = {}
         battle_param = request.GET.get("battle")
+        if battle_param:
+            try:
+                uuid.UUID(str(battle_param))
+            except (ValueError, TypeError):
+                battle_param = None
         if battle_param and battles.filter(pk=battle_param).exists():
             initial["battle"] = battle_param
         form = PostBattleUpdatesForm(

--- a/gyrinx/core/views/list/post_battle.py
+++ b/gyrinx/core/views/list/post_battle.py
@@ -148,8 +148,21 @@ def _apply(request, lst, fighters, form):
                     fighter=fighter,
                     injury=injury,
                     notes=(cd.get(f"injury_reason_{pk}") or "").strip(),
-                    request=request,
                     battle=battle,
+                )
+                # The handler stays HTTP-free; the view owns event logging.
+                log_event(
+                    user=user,
+                    noun=EventNoun.LIST_FIGHTER,
+                    verb=EventVerb.UPDATE,
+                    object=fighter,
+                    request=request,
+                    action="injury_added",
+                    fighter_name=fighter.name,
+                    list_id=str(lst.id),
+                    list_name=lst.name,
+                    injury_name=injury.name,
+                    injury_state=result.outcome_state,
                 )
                 summary.injuries += 1
                 if result.killed:

--- a/gyrinx/core/views/list/post_battle.py
+++ b/gyrinx/core/views/list/post_battle.py
@@ -49,9 +49,10 @@ class _ApplySummary:
             parts.append(f"notes for {self.notes} fighter{_s(self.notes)}")
         summary = "Post-battle updates applied: " + ", ".join(parts) + "."
         if self.killed_names:
+            names = ", ".join(self.killed_names)
             summary += (
-                f" {', '.join(self.killed_names)} died — their equipment moved to"
-                " the stash."
+                f" {names} died — any equipment they carried was returned to"
+                " the gang's stash."
             )
         return summary
 

--- a/gyrinx/core/views/list/post_battle.py
+++ b/gyrinx/core/views/list/post_battle.py
@@ -1,0 +1,240 @@
+"""Bulk post-battle updates editor for a list (campaign mode)."""
+
+from dataclasses import dataclass, field
+
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse
+
+from gyrinx import messages
+from gyrinx.core.forms.post_battle import PostBattleUpdatesForm
+from gyrinx.core.handlers.fighter import (
+    handle_fighter_add_injury,
+    handle_fighter_add_xp,
+    handle_fighter_adjust_counter,
+)
+from gyrinx.core.models.battle import Battle
+from gyrinx.core.models.events import EventNoun, EventVerb, log_event
+from gyrinx.core.views.fighter.permissions import get_list_for_edit
+
+
+@dataclass
+class _ApplySummary:
+    """Tally of what a post-battle submit changed, for the flash message."""
+
+    xp: int = 0
+    injuries: int = 0
+    kills: int = 0
+    counters: int = 0
+    notes: int = 0
+    killed_names: list = field(default_factory=list)
+
+    @property
+    def changed(self):
+        return bool(self.xp or self.injuries or self.counters or self.notes)
+
+    @property
+    def message(self):
+        parts = []
+        if self.xp:
+            parts.append(f"XP for {self.xp} fighter{_s(self.xp)}")
+        if self.injuries:
+            parts.append(f"{self.injuries} injur{'ies' if self.injuries != 1 else 'y'}")
+        if self.counters:
+            parts.append(f"{self.counters} counter update{_s(self.counters)}")
+        if self.notes:
+            parts.append(f"notes for {self.notes} fighter{_s(self.notes)}")
+        summary = "Post-battle updates applied: " + ", ".join(parts) + "."
+        if self.killed_names:
+            summary += (
+                f" {', '.join(self.killed_names)} died — their equipment moved to"
+                " the stash."
+            )
+        return summary
+
+
+def _s(n):
+    return "" if n == 1 else "s"
+
+
+def _post_battle_fighters(lst):
+    """Active roster fighters for the grid: no stash, no archived; vehicles,
+    crew and dead fighters are included (post-battle needs them). Counters are
+    prefetched so ``applicable_counters`` doesn't go N+1 across the grid."""
+    return list(
+        lst.fighters()
+        .exclude(content_fighter__is_stash=True)
+        .prefetch_related("content_fighter__counters", "counters")
+    )
+
+
+def _selectable_battles(lst):
+    """Non-archived battles in this list's campaign that the list fought in,
+    for linking the logged actions to a specific battle."""
+    if not lst.campaign_id:
+        return Battle.objects.none()
+    return (
+        lst.campaign.battles.filter(archived=False, participants=lst)
+        .distinct()
+        .select_related("campaign")
+    )
+
+
+def _apply(request, lst, fighters, form):
+    """Apply only the fields that were filled in or changed, per fighter."""
+    user = request.user
+    cd = form.cleaned_data
+    battle = cd.get("battle")
+    summary = _ApplySummary()
+
+    with transaction.atomic():
+        for fighter in fighters:
+            # Cache the parent so the handlers don't re-query fighter.list.
+            fighter.list = lst
+            pk = fighter.pk
+
+            # Notes first: a fatal injury (below) calls the kill handler, which
+            # mutates and saves the fighter — we don't want a later notes save
+            # on a now-stale instance to clobber that.
+            new_private = cd.get(f"private_notes_{pk}", "") or ""
+            if new_private != fighter.private_notes:
+                fighter.private_notes = new_private
+                fighter.save_with_user(user=user)
+                log_event(
+                    user=user,
+                    noun=EventNoun.LIST_FIGHTER,
+                    verb=EventVerb.UPDATE,
+                    object=fighter,
+                    request=request,
+                    action="notes_updated",
+                    fighter_name=fighter.name,
+                    list_id=str(lst.id),
+                    list_name=lst.name,
+                )
+                summary.notes += 1
+
+            xp = cd.get(f"xp_{pk}")
+            if xp:
+                handle_fighter_add_xp(
+                    user=user, fighter=fighter, amount=xp, battle=battle
+                )
+                summary.xp += 1
+
+            for entry in fighter.applicable_counters:
+                delta = cd.get(f"counter_{pk}_{entry.counter.pk}")
+                if delta and handle_fighter_adjust_counter(
+                    user=user,
+                    fighter=fighter,
+                    counter=entry.counter,
+                    delta=delta,
+                    battle=battle,
+                ):
+                    summary.counters += 1
+
+            injury = cd.get(f"injury_{pk}")
+            if injury:
+                result = handle_fighter_add_injury(
+                    user=user,
+                    fighter=fighter,
+                    injury=injury,
+                    notes=(cd.get(f"injury_reason_{pk}") or "").strip(),
+                    request=request,
+                    battle=battle,
+                )
+                summary.injuries += 1
+                if result.killed:
+                    summary.kills += 1
+                    summary.killed_names.append(fighter.name)
+
+    return summary
+
+
+@login_required
+def post_battle_updates(request, id):
+    """
+    Bulk-edit a whole gang's post-battle results in one grid: add XP, adjust
+    counters, apply injuries, and edit notes. Campaign mode only; open to the
+    list owner and the campaign arbitrator.
+
+    **Context**
+
+    ``list``
+        The :model:`core.List` being updated.
+    ``form``
+        A :class:`PostBattleUpdatesForm` bound to the list's fighters.
+    ``rows``
+        Per-fighter rows pairing each fighter with its bound form fields.
+
+    **Template**
+
+    :template:`core/list_post_battle_updates.html`
+    """
+    lst, _perms = get_list_for_edit(request, id)
+
+    default_url = reverse("core:list", args=(lst.id,))
+
+    if not lst.is_campaign_mode:
+        messages.error(
+            request, "Post-battle updates are only available in campaign mode."
+        )
+        return HttpResponseRedirect(default_url)
+
+    fighters = _post_battle_fighters(lst)
+    battles = _selectable_battles(lst)
+
+    if request.method == "POST":
+        form = PostBattleUpdatesForm(request.POST, fighters=fighters, battles=battles)
+        if form.is_valid():
+            summary = _apply(request, lst, fighters, form)
+            if summary.changed:
+                messages.success(request, summary.message)
+            else:
+                messages.info(request, "No post-battle changes were entered.")
+            return HttpResponseRedirect(default_url)
+    else:
+        # A ?battle=<id> query param preselects that battle (only if the list
+        # actually fought in it — otherwise it's ignored).
+        initial = {}
+        battle_param = request.GET.get("battle")
+        if battle_param and battles.filter(pk=battle_param).exists():
+            initial["battle"] = battle_param
+        form = PostBattleUpdatesForm(
+            fighters=fighters, battles=battles, initial=initial
+        )
+
+    rows = _build_rows(fighters, form)
+    return render(
+        request,
+        "core/list_post_battle_updates.html",
+        {"list": lst, "form": form, "rows": rows, "has_battles": battles.exists()},
+    )
+
+
+def _build_rows(fighters, form):
+    """Pair each fighter with its bound fields so the template can render the
+    grid without dynamic field-name lookups."""
+    rows = []
+    for fighter in fighters:
+        pk = fighter.pk
+        counters = [
+            {
+                "counter": entry.counter,
+                "value": entry.value,
+                "warn": entry.warn,
+                "field": form[f"counter_{pk}_{entry.counter.pk}"],
+            }
+            for entry in fighter.applicable_counters
+        ]
+        rows.append(
+            {
+                "fighter": fighter,
+                "xp": form[f"xp_{pk}"],
+                "injury": form[f"injury_{pk}"],
+                "injury_reason": form[f"injury_reason_{pk}"],
+                "counters": counters,
+                "private_notes": form[f"private_notes_{pk}"],
+            }
+        )
+    return rows

--- a/gyrinx/core/views/list/post_battle.py
+++ b/gyrinx/core/views/list/post_battle.py
@@ -99,8 +99,14 @@ def _apply(request, lst, fighters, form):
             # Notes first: a fatal injury (below) calls the kill handler, which
             # mutates and saves the fighter — we don't want a later notes save
             # on a now-stale instance to clobber that.
-            new_private = cd.get(f"private_notes_{pk}", "") or ""
-            if new_private != fighter.private_notes:
+            #
+            # Only touch notes if the field was actually submitted. If the roster
+            # changed between GET and POST (a fighter added/removed), its notes
+            # field is absent from the payload and `cleaned_data` would default
+            # it to "" — writing that back would silently wipe existing notes.
+            notes_field = f"private_notes_{pk}"
+            new_private = cd.get(notes_field, "") or ""
+            if notes_field in form.data and new_private != fighter.private_notes:
                 fighter.private_notes = new_private
                 fighter.save_with_user(user=user)
                 log_event(

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -376,6 +376,17 @@ class ListDetailView(generic.DetailView):
                 self.request.user, list_=list_obj
             )
 
+        # Whether the viewer is the campaign arbitrator (campaign owner) for a
+        # campaign-mode list. Mirrors get_list_for_edit's owner-or-arbitrator
+        # rule so arbitrator-only affordances (e.g. Post-battle updates) show
+        # in the menu even on a gang the arbitrator doesn't own.
+        context["is_campaign_arbitrator"] = bool(
+            self.request.user.is_authenticated
+            and list_obj.is_campaign_mode
+            and list_obj.campaign_id
+            and list_obj.campaign.owner_id == self.request.user.pk
+        )
+
         return context
 
 


### PR DESCRIPTION
## Summary

- Adds a **Post-battle updates** screen, reached from the top of a gang's list dropdown (campaign mode only), for recording a whole gang's results after a battle in one pass instead of editing each fighter one at a time.
- Every field starts blank; only what you fill in or change is applied. Per fighter, in a mobile-first grid: add XP, adjust each applicable counter (e.g. Kill Count) by a delta, apply an injury (filtered to that fighter) with a required reason, and edit private notes in a rich-text editor.
- A battle selector at the top links every campaign action logged by the submit to that battle, so post-battle results show up on that battle's timeline. `?battle=<id>` in the URL preselects it.

## Details

- **What it looks like.** A flat list of fighters with horizontal dividers. Each row shows the fighter's name (with muted category) and its current XP / counter values, then blank inputs for the changes you want to make. The reason box stays disabled until an injury is chosen. Private notes open in a TinyMCE editor that initialises lazily when you expand the disclosure, so a large roster stays fast.
- **Nothing happens to untouched fighters.** The view walks each fighter and acts only on fields that were filled in or changed — a blank grid submits nothing.
- **Fatal injuries are handled correctly.** An injury whose default outcome is "dead" routes through the existing kill handler (equipment moves to the stash, fighter cost zeroed, rating propagated) rather than just flipping a state flag. The bulk submit is treated as the confirmation.
- **Reusable handlers.** Three fighter handlers — add XP, add injury, adjust counter — each write a `CampaignAction` (optionally battle-linked) for the audit trail, and a shared `available_injuries_for_fighter()` helper is used by both the bulk form and the existing single-fighter injury form.
- **Graceful without JS.** The reason-disable behaviour is a progressive enhancement; server-side validation is the source of truth, so submissions still work with JavaScript off.

## Test plan

- [ ] In a campaign-mode gang, open **Post-battle updates** from the list ⋮ menu (top of the dropdown).
- [ ] Add XP to one fighter, a counter delta to another, leave the rest blank → submit → only the edited fighters change; a success message summarises what was applied.
- [ ] Select an injury without a reason → form is rejected with an inline error and nothing is applied; add a reason → it applies.
- [ ] Pick an injury whose outcome is "dead" → fighter is killed, equipment moves to the stash.
- [ ] Choose a battle in the selector (or load with `?battle=<id>`) → the logged actions are tagged with that battle on its timeline.
- [ ] Expand a fighter's private notes → rich-text editor appears; edited notes save on submit.
- [ ] Confirm the page and grid wrap/stack sensibly on mobile.
- [ ] Automated: `pytest gyrinx/core/tests/test_post_battle_updates.py` (13 tests).

Refs #1346
Refs #993
Refs #1810