### PR TITLE
test: campaign view-all-battles page coverage (#1015)

### DIFF
--- a/gyrinx/core/tests/test_campaign_battles_page.py
+++ b/gyrinx/core/tests/test_campaign_battles_page.py
@@ -1,0 +1,69 @@
+"""Tests for the campaign "View all battles" page (#1015).
+
+The campaign overview only shows the most recent battles (capped at
+``battles_limit``) with a "View all N battles" link. These tests cover the
+dedicated page that link points at: it renders and lists *every* non-archived
+battle in the campaign, and the overview link actually targets it.
+"""
+
+import pytest
+from django.urls import reverse
+
+from gyrinx.core.models import Battle
+
+
+def _make_battles(campaign, owner, participant_list, count):
+    """Create ``count`` battles in ``campaign`` with a single participant."""
+    battles = []
+    for i in range(count):
+        battle = Battle.objects.create(
+            campaign=campaign, mission=f"Mission {i}", owner=owner
+        )
+        battle.set_participants([participant_list])
+        battles.append(battle)
+    return battles
+
+
+@pytest.mark.django_db
+def test_campaign_battles_page_lists_all_battles(client, user, campaign, make_list):
+    """The page renders (200) and lists every battle, past the overview cap."""
+    client.force_login(user)
+    gang = make_list("Gang")
+    campaign.lists.add(gang)
+
+    # More than the overview limit (5) so this exercises the "no limit" behaviour.
+    battles = _make_battles(campaign, user, gang, 6)
+
+    resp = client.get(reverse("core:campaign-battles", args=[campaign.id]))
+    assert resp.status_code == 200
+
+    content = resp.content.decode()
+    for battle in battles:
+        assert reverse("core:battle", args=[battle.id]) in content
+
+
+@pytest.mark.django_db
+def test_campaign_overview_links_to_view_all_battles(client, user, campaign, make_list):
+    """The overview's "View all battles" link points at the battles page."""
+    client.force_login(user)
+    gang = make_list("Gang")
+    campaign.lists.add(gang)
+
+    # Need more battles than the overview cap (5) for the link to appear.
+    _make_battles(campaign, user, gang, 6)
+
+    resp = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert resp.status_code == 200
+
+    battles_url = reverse("core:campaign-battles", args=[campaign.id])
+    assert battles_url in resp.content.decode()
+
+
+@pytest.mark.django_db
+def test_campaign_battles_page_empty_state(client, user, campaign):
+    """With no battles the page still renders and shows the empty state."""
+    client.force_login(user)
+
+    resp = client.get(reverse("core:campaign-battles", args=[campaign.id]))
+    assert resp.status_code == 200
+    assert "No battles have been recorded" in resp.content.decode()


### PR DESCRIPTION
The "View all battles" page from #1015 already shipped as part of the stateful Battle work (#1983): the `campaign-battles` URL, the `campaign_battles` view, the `campaign_battles.html` template, and the reusable `battle_summary_card.html` include all exist on `main`, and the campaign overview already links to the page.

The one part of #1015 without dedicated test coverage was the page itself. This PR backfills a focused test module (`gyrinx/core/tests/test_campaign_battles_page.py`) covering:

- the page renders (200) and lists every battle, past the overview's 5-item cap;
- the empty state when a campaign has no battles;
- the campaign overview's "View all battles" link points at the battles page.

No production code changes — the feature was already present, so a `test:` PR rather than `feat:`.

Refs #1015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188LhzUL7R78XTkyaKhF5qr