### PR TITLE
fix: skip child-fighter propagation signal during fixture loading

### DIFF
--- a/gyrinx/core/models/list/signal_handlers.py
+++ b/gyrinx/core/models/list/signal_handlers.py
@@ -51,6 +51,10 @@ def enqueue_propagate_default_child_fighter_assignment(
     and need no materialisation. The work is offloaded to a task because it can
     touch many list-fighters across all subscribed gangs.
     """
+    if kwargs.get("raw"):
+        # Fixture loading (loaddata / loaddata_overwrite): the equipment row may
+        # not be inserted yet, and a bulk content import must not propagate.
+        return
     if not created:
         return
     if not instance.equipment.contentequipmentfighterprofile_set.exists():

--- a/gyrinx/core/tests/test_propagate_default_child_fighter.py
+++ b/gyrinx/core/tests/test_propagate_default_child_fighter.py
@@ -16,10 +16,12 @@ reconcile a cost change — it records the true zero delta and charges no
 credits.
 """
 
+import uuid
 from unittest.mock import patch
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_save
 
 from gyrinx.content.models.default_assignment import ContentFighterDefaultAssignment
 from gyrinx.content.models.equipment import (
@@ -170,6 +172,34 @@ def test_signal_enqueues_only_for_child_spawning_created_default(
         with django_capture_on_commit_callbacks(execute=True):
             default.cost = 5
             default.save()
+        mock_task.enqueue.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_signal_skips_raw_fixture_saves(
+    child_spawning_setup, django_capture_on_commit_callbacks
+):
+    """Fixture loading (``raw=True``, e.g. a ``loaddata_overwrite`` content
+    import) must not enqueue propagation — and must not query the equipment
+    relation, whose row may not be inserted yet mid-fixture."""
+    parent_cf = child_spawning_setup["parent_cf"]
+    # Equipment FK points at a row that does not exist, as happens when the
+    # fixture lists a default assignment before its equipment.
+    instance = ContentFighterDefaultAssignment(
+        id=uuid.uuid4(), fighter=parent_cf, equipment_id=uuid.uuid4()
+    )
+
+    with patch(
+        "gyrinx.core.models.list.signal_handlers.propagate_default_child_fighter_assignment"
+    ) as mock_task:
+        with django_capture_on_commit_callbacks(execute=True):
+            post_save.send(
+                sender=ContentFighterDefaultAssignment,
+                instance=instance,
+                created=True,
+                raw=True,
+                using="default",
+            )
         mock_task.enqueue.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- Importing the production content library locally (`manage loaddata_overwrite latest.json`) crashed with `ContentEquipment.DoesNotExist`: the `post_save` handler on `ContentFighterDefaultAssignment` queries the assignment's equipment, but mid-fixture the equipment row may not have been inserted yet (the dump lists some default assignments before their equipment).
- Add the standard Django `raw=True` guard so the handler skips fixture loads entirely. Beyond the crash, a bulk content re-import should never trigger child-fighter propagation — every row looks "newly created" after the import's truncate-and-reload, and propagating would be wrong.
- Regression test sends the signal with `raw=True` and a dangling equipment FK, reproducing the crash without the guard.

## Test plan

- [x] New test fails without the fix (reproduces `ContentEquipment.DoesNotExist`) and passes with it
- [x] `pytest gyrinx/core/tests/test_propagate_default_child_fighter.py` — 12 passed
- [x] `pytest gyrinx/core/tests/test_pack_vehicles_beasts.py` — 24 passed
- [x] Verified end-to-end: a full `loaddata_overwrite` of today's prod dump (16,466 objects) completes with the handler skipped

Refs #1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)