### PR TITLE
feat: surface asset metadata and text on list and campaign pages

### DIFF
--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -832,3 +832,14 @@ $width-em-sizes: (
         }
     }
 }
+
+// Two-line truncation for compact rich-text previews (campaign asset panels on
+// the list page and campaign dashboard). The full text lives on the asset
+// detail page, linked alongside the preview.
+.text-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -308,8 +308,10 @@
                                                                     {% endfor %}
                                                                 </div>
                                                             {% endif %}
-                                                            <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">Details →</a>
+                                                            {% if request.user.is_authenticated %}
+                                                                <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                                   class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">Details →</a>
+                                                            {% endif %}
                                                         </td>
                                                         <td class="text-end align-top text-nowrap">
                                                             {% if asset.holder %}

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -309,7 +309,7 @@
                                                                 </div>
                                                             {% endif %}
                                                             {% if request.user.is_authenticated %}
-                                                                <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                                <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}"
                                                                    class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">Details →</a>
                                                             {% endif %}
                                                         </td>

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -285,7 +285,7 @@
                                                             <div class="fw-semibold">
                                                                 {% if request.user.is_authenticated %}
                                                                     <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}"
-                                                                       class="link-body-emphasis link-underline-opacity-25 link-underline-opacity-100-hover">{{ asset.name }}</a>
+                                                                       class="linked">{{ asset.name }}</a>
                                                                 {% else %}
                                                                     {{ asset.name }}
                                                                 {% endif %}
@@ -298,9 +298,6 @@
                                                                     Unowned
                                                                 {% endif %}
                                                             </div>
-                                                            {% if asset.description %}
-                                                                <div class="fs-7 text-secondary text-clamp-2 mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>
-                                                            {% endif %}
                                                             {% if asset.properties_with_labels %}
                                                                 <div class="fs-7 text-secondary">
                                                                     {% for label, value in asset.properties_with_labels %}
@@ -322,6 +319,9 @@
                                                                         {% endspaceless %}
                                                                     {% endfor %}
                                                                 </div>
+                                                            {% endif %}
+                                                            {% if asset.description %}
+                                                                <div class="fs-7 text-secondary text-clamp-2 mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>
                                                             {% endif %}
                                                         </td>
                                                         <td class="text-end align-top text-nowrap">

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -283,6 +283,9 @@
                                                     <tr>
                                                         <td class="ps-0">
                                                             <div class="fw-semibold">{{ asset.name }}</div>
+                                                            {% if asset.description %}
+                                                                <div class="fs-7 text-secondary text-clamp-2 mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>
+                                                            {% endif %}
                                                             {% if asset.properties_with_labels %}
                                                                 <div class="fs-7 text-secondary">
                                                                     {% for label, value in asset.properties_with_labels %}
@@ -305,6 +308,8 @@
                                                                     {% endfor %}
                                                                 </div>
                                                             {% endif %}
+                                                            <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">Details →</a>
                                                         </td>
                                                         <td class="text-end align-top text-nowrap">
                                                             {% if asset.holder %}

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -282,7 +282,22 @@
                                                 {% for asset in assets %}
                                                     <tr>
                                                         <td class="ps-0">
-                                                            <div class="fw-semibold">{{ asset.name }}</div>
+                                                            <div class="fw-semibold">
+                                                                {% if request.user.is_authenticated %}
+                                                                    <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}"
+                                                                       class="link-body-emphasis link-underline-opacity-25 link-underline-opacity-100-hover">{{ asset.name }}</a>
+                                                                {% else %}
+                                                                    {{ asset.name }}
+                                                                {% endif %}
+                                                            </div>
+                                                            <div class="fs-7 text-secondary">
+                                                                {% if asset.holder %}
+                                                                    Held by <a href="{% url 'core:list' asset.holder.id %}"
+    class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{% list_with_theme asset.holder %}</a>
+                                                                {% else %}
+                                                                    Unowned
+                                                                {% endif %}
+                                                            </div>
                                                             {% if asset.description %}
                                                                 <div class="fs-7 text-secondary text-clamp-2 mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>
                                                             {% endif %}
@@ -308,21 +323,11 @@
                                                                     {% endfor %}
                                                                 </div>
                                                             {% endif %}
-                                                            {% if request.user.is_authenticated %}
-                                                                <a href="{% url 'core:campaign-asset-detail' campaign.id asset.id %}"
-                                                                   class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover fs-7">Details →</a>
-                                                            {% endif %}
                                                         </td>
                                                         <td class="text-end align-top text-nowrap">
-                                                            {% if asset.holder %}
-                                                                <a href="{% url 'core:list' asset.holder.id %}"
-                                                                   class="link-underline-opacity-50 link-underline-opacity-100-hover">{% list_with_theme asset.holder %}</a>
-                                                            {% else %}
-                                                                <span class="text-secondary">Unowned</span>
-                                                            {% endif %}
                                                             {% if is_owner and not campaign.archived %}
                                                                 <a href="{% url 'core:campaign-asset-transfer' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                                                   class="icon-link linked fs-7 ms-2"><i class="bi-arrow-left-right"></i> Transfer</a>
+                                                                   class="icon-link linked fs-7"><i class="bi-arrow-left-right"></i> Transfer</a>
                                                             {% endif %}
                                                         </td>
                                                     </tr>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
@@ -4,7 +4,7 @@
     {{ asset.name }}
 {% endblock head_title %}
 {% block content %}
-    {% include "core/includes/campaign_common_header.html" with campaign=campaign current=asset.name %}
+    {% include "core/includes/campaign_common_header.html" with campaign=campaign current=asset.name parent=asset.asset_type.name_singular %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <div>
             <div class="caps-label text-secondary mb-1">{{ asset.asset_type.name_singular }}</div>
@@ -28,9 +28,6 @@
                 </span>
             {% endif %}
         </div>
-        {% if asset.description %}
-            <div class="mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>
-        {% endif %}
         {% if asset.properties_with_labels %}
             <div>
                 <div class="caps-label mb-1">Properties</div>
@@ -73,6 +70,7 @@
                 {% endfor %}
             </div>
         {% endif %}
+        {% if asset.description %}<div class="mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>{% endif %}
         {% if asset.asset_type.description %}
             <div class="border-top pt-3">
                 <div class="caps-label mb-1">About {{ asset.asset_type.name_plural }}</div>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
@@ -4,7 +4,7 @@
     {{ asset.name }}
 {% endblock head_title %}
 {% block content %}
-    {% include "core/includes/back.html" with url=return_url text="Back" %}
+    {% include "core/includes/campaign_common_header.html" with campaign=campaign current=asset.name %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <div>
             <div class="caps-label text-secondary mb-1">{{ asset.asset_type.name_singular }}</div>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
@@ -1,0 +1,83 @@
+{% extends "core/layouts/base.html" %}
+{% load custom_tags color_tags %}
+{% block head_title %}
+    {{ asset.name }}
+{% endblock head_title %}
+{% block content %}
+    {% include "core/includes/back.html" with url=return_url text="Back" %}
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <div>
+            <div class="caps-label text-secondary mb-1">{{ asset.asset_type.name_singular }}</div>
+            <h1 class="h3 mb-0">{{ asset.name }}</h1>
+        </div>
+        <div class="hstack gap-2 flex-wrap fs-7">
+            <span class="text-secondary">
+                {% if asset.holder %}
+                    Held by <a href="{% url 'core:list' asset.holder.id %}"
+    class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">{% list_with_theme asset.holder %}</a>
+                {% else %}
+                    Unowned
+                {% endif %}
+            </span>
+            {% if is_owner and not campaign.archived %}
+                <span class="ms-auto d-flex gap-2">
+                    <a href="{% url 'core:campaign-asset-transfer' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                       class="icon-link linked"><i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer</a>
+                    <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
+                       class="icon-link linked"><i class="bi-pencil" aria-hidden="true"></i> Edit</a>
+                </span>
+            {% endif %}
+        </div>
+        {% if asset.description %}
+            <div class="mb-last-0">{{ asset.description|safe_rich_text|safe }}</div>
+        {% endif %}
+        {% if asset.properties_with_labels %}
+            <div>
+                <div class="caps-label mb-1">Properties</div>
+                <table class="table table-sm table-borderless mb-0">
+                    <tbody>
+                        {% for label, value in asset.properties_with_labels %}
+                            <tr>
+                                <td class="ps-0 text-secondary w-em-10">{{ label }}</td>
+                                <td>{{ value }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+        {% if sub_assets_by_type %}
+            <div class="border-top pt-3 vstack gap-3">
+                {% for label, sub_assets in sub_assets_by_type %}
+                    <div>
+                        <div class="caps-label mb-2">{{ label }}</div>
+                        <div class="vstack gap-2">
+                            {% for sub_asset in sub_assets %}
+                                <div>
+                                    <div class="fw-semibold">{{ sub_asset.name }}</div>
+                                    {% if sub_asset.properties_with_labels %}
+                                        <div class="fs-7 text-secondary">
+                                            {% for plabel, pvalue in sub_asset.properties_with_labels %}
+                                                {% spaceless %}
+                                                    <span class="{% property_nowrap_class plabel pvalue %}">{{ plabel }}: {{ pvalue }}
+                                                        {% if not forloop.last %}&nbsp;·&nbsp;{% endif %}
+                                                    </span>
+                                                {% endspaceless %}
+                                            {% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+        {% if asset.asset_type.description %}
+            <div class="border-top pt-3">
+                <div class="caps-label mb-1">About {{ asset.asset_type.name_plural }}</div>
+                <div class="text-secondary fs-7 mb-last-0">{{ asset.asset_type.description|safe_rich_text|safe }}</div>
+            </div>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/includes/breadcrumb.html
+++ b/gyrinx/core/templates/core/includes/breadcrumb.html
@@ -1,6 +1,7 @@
 {# Breadcrumb component — sits above the page title. #}
 {# Required params: type (str), owner (User object), name (str) #}
-{# Optional params: type_url (str), campaign (Campaign object), print (bool) #}
+{# Optional params: type_url (str), campaign (Campaign object), print (bool), #}
+{#   parent (str) + parent_url (str) — an intermediate crumb before name #}
 {% load badge_tags %}
 <div class="fs-7 text-secondary">
     {% if print %}
@@ -20,6 +21,14 @@
             {{ campaign.name }}
         {% else %}
             <a class="linked-secondary" href="{% url 'core:campaign' campaign.id %}">{{ campaign.name }}</a>
+        {% endif %}
+        <span class="mx-1">/</span>
+    {% endif %}
+    {% if parent %}
+        {% if print or not parent_url %}
+            {{ parent }}
+        {% else %}
+            <a class="linked-secondary" href="{{ parent_url }}">{{ parent }}</a>
         {% endif %}
         <span class="mx-1">/</span>
     {% endif %}

--- a/gyrinx/core/templates/core/includes/campaign_common_header.html
+++ b/gyrinx/core/templates/core/includes/campaign_common_header.html
@@ -1,9 +1,10 @@
 {# Campaign context header for pages nested under a campaign (e.g. a battle). #}
-{# Required params: campaign. Optional: current (label for the current page). #}
+{# Required params: campaign. Optional: current (label for the current page), #}
+{#   parent + parent_url (an intermediate breadcrumb crumb before current). #}
 {# Deliberately low-interaction: breadcrumb + campaign name (linking back) + status. #}
 <div class="mb-3 pb-3 border-bottom">
     {% url 'core:campaigns' as campaigns_url %}
-    {% include "core/includes/breadcrumb.html" with type="Campaigns" owner=campaign.owner name=current type_url=campaigns_url campaign=campaign only %}
+    {% include "core/includes/breadcrumb.html" with type="Campaigns" owner=campaign.owner name=current type_url=campaigns_url campaign=campaign parent=parent parent_url=parent_url only %}
     <div class="d-flex flex-column flex-sm-row gap-1 gap-sm-2 align-items-sm-center mt-1">
         <a class="linked fw-semibold"
            href="{% url 'core:campaign' campaign.id %}">

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -17,17 +17,17 @@
                             <h4 class="caps-label mb-1">Assets</h4>
                             <div class="vstack gap-2">
                                 {% for asset in held_assets %}
-                                    <div class="fs-7">
+                                    <div>
                                         <div class="d-flex align-items-center">
                                             <div>
                                                 {% if not print and request.user.is_authenticated %}
                                                     <a href="{% url 'core:campaign-asset-detail' list.campaign.id asset.id %}"
-                                                       class="fw-semibold link-body-emphasis link-underline-opacity-25 link-underline-opacity-100-hover">{{ asset.name }}</a>
+                                                       class="fw-semibold linked">{{ asset.name }}</a>
                                                 {% else %}
                                                     <strong>{{ asset.name }}</strong>
                                                 {% endif %}
                                                 {% if asset.asset_type.name_singular %}
-                                                    <span class="text-secondary">({{ asset.asset_type.name_singular }})</span>
+                                                    <span class="text-secondary fs-7">({{ asset.asset_type.name_singular }})</span>
                                                 {% endif %}
                                             </div>
                                             {% if list.campaign.is_pre_campaign %}
@@ -40,7 +40,7 @@
                                             {% endif %}
                                         </div>
                                         {% if asset.properties_with_labels %}
-                                            <div class="text-secondary">
+                                            <div class="text-secondary fs-7">
                                                 {% for label, value in asset.properties_with_labels %}
                                                     {% spaceless %}
                                                         <span class="{% property_nowrap_class label value %}">{{ label }}: {{ value }}
@@ -51,7 +51,7 @@
                                             </div>
                                         {% endif %}
                                         {% if asset.sub_asset_counts %}
-                                            <div class="text-secondary">
+                                            <div class="text-secondary fs-7">
                                                 {% for label, count in asset.sub_asset_counts %}
                                                     {% spaceless %}
                                                         <span class="{% property_nowrap_class count label %}">{{ count }} {{ label }}
@@ -62,7 +62,7 @@
                                             </div>
                                         {% endif %}
                                         {% if asset.description %}
-                                            <div class="text-secondary mb-last-0 {% if not print %}text-clamp-2{% endif %}">{{ asset.description|safe_rich_text|safe }}</div>
+                                            <div class="text-secondary fs-7 mb-last-0 {% if not print %}text-clamp-2{% endif %}">{{ asset.description|safe_rich_text|safe }}</div>
                                         {% endif %}
                                     </div>
                                 {% endfor %}

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -15,22 +15,53 @@
                     {% if held_assets %}
                         <div>
                             <h4 class="caps-label mb-1">Assets</h4>
-                            <div class="vstack gap-1">
+                            <div class="vstack gap-2">
                                 {% for asset in held_assets %}
-                                    <div class="d-flex align-items-center fs-7">
-                                        <div>
-                                            <strong>{{ asset.name }}</strong>
-                                            {% if asset.asset_type.name_singular %}
-                                                <span class="text-secondary">({{ asset.asset_type.name_singular }})</span>
+                                    <div class="fs-7">
+                                        <div class="d-flex align-items-center">
+                                            <div>
+                                                <strong>{{ asset.name }}</strong>
+                                                {% if asset.asset_type.name_singular %}
+                                                    <span class="text-secondary">({{ asset.asset_type.name_singular }})</span>
+                                                {% endif %}
+                                            </div>
+                                            {% if list.campaign.is_pre_campaign %}
+                                                <span class="text-secondary fs-7 ms-auto">Campaign not started</span>
+                                            {% elif not list.campaign.archived and not print %}
+                                                <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                                   class="icon-link link-secondary fs-7 ms-auto">
+                                                    <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
+                                                </a>
                                             {% endif %}
                                         </div>
-                                        {% if list.campaign.is_pre_campaign %}
-                                            <span class="text-secondary fs-7 ms-auto">Campaign not started</span>
-                                        {% elif not list.campaign.archived and not print %}
-                                            <a href="{% url 'core:campaign-asset-transfer' list.campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
-                                               class="icon-link link-secondary fs-7 ms-auto">
-                                                <i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer
-                                            </a>
+                                        {% if asset.properties_with_labels %}
+                                            <div class="text-secondary">
+                                                {% for label, value in asset.properties_with_labels %}
+                                                    {% spaceless %}
+                                                        <span class="{% property_nowrap_class label value %}">{{ label }}: {{ value }}
+                                                            {% if not forloop.last %}&nbsp;·&nbsp;{% endif %}
+                                                        </span>
+                                                    {% endspaceless %}
+                                                {% endfor %}
+                                            </div>
+                                        {% endif %}
+                                        {% if asset.sub_asset_counts %}
+                                            <div class="text-secondary">
+                                                {% for label, count in asset.sub_asset_counts %}
+                                                    {% spaceless %}
+                                                        <span class="{% property_nowrap_class count label %}">{{ count }} {{ label }}
+                                                            {% if not forloop.last %}&nbsp;·&nbsp;{% endif %}
+                                                        </span>
+                                                    {% endspaceless %}
+                                                {% endfor %}
+                                            </div>
+                                        {% endif %}
+                                        {% if asset.description %}
+                                            <div class="text-secondary mb-last-0 {% if not print %}text-clamp-2{% endif %}">{{ asset.description|safe_rich_text|safe }}</div>
+                                        {% endif %}
+                                        {% if not print %}
+                                            <a href="{% url 'core:campaign-asset-detail' list.campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">Details →</a>
                                         {% endif %}
                                     </div>
                                 {% endfor %}

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -60,7 +60,7 @@
                                             <div class="text-secondary mb-last-0 {% if not print %}text-clamp-2{% endif %}">{{ asset.description|safe_rich_text|safe }}</div>
                                         {% endif %}
                                         {% if not print and request.user.is_authenticated %}
-                                            <a href="{% url 'core:campaign-asset-detail' list.campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
+                                            <a href="{% url 'core:campaign-asset-detail' list.campaign.id asset.id %}"
                                                class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">Details →</a>
                                         {% endif %}
                                     </div>

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -20,7 +20,12 @@
                                     <div class="fs-7">
                                         <div class="d-flex align-items-center">
                                             <div>
-                                                <strong>{{ asset.name }}</strong>
+                                                {% if not print and request.user.is_authenticated %}
+                                                    <a href="{% url 'core:campaign-asset-detail' list.campaign.id asset.id %}"
+                                                       class="fw-semibold link-body-emphasis link-underline-opacity-25 link-underline-opacity-100-hover">{{ asset.name }}</a>
+                                                {% else %}
+                                                    <strong>{{ asset.name }}</strong>
+                                                {% endif %}
                                                 {% if asset.asset_type.name_singular %}
                                                     <span class="text-secondary">({{ asset.asset_type.name_singular }})</span>
                                                 {% endif %}
@@ -58,10 +63,6 @@
                                         {% endif %}
                                         {% if asset.description %}
                                             <div class="text-secondary mb-last-0 {% if not print %}text-clamp-2{% endif %}">{{ asset.description|safe_rich_text|safe }}</div>
-                                        {% endif %}
-                                        {% if not print and request.user.is_authenticated %}
-                                            <a href="{% url 'core:campaign-asset-detail' list.campaign.id asset.id %}"
-                                               class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">Details →</a>
                                         {% endif %}
                                     </div>
                                 {% endfor %}

--- a/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
+++ b/gyrinx/core/templates/core/includes/list_campaign_resources_assets.html
@@ -59,7 +59,7 @@
                                         {% if asset.description %}
                                             <div class="text-secondary mb-last-0 {% if not print %}text-clamp-2{% endif %}">{{ asset.description|safe_rich_text|safe }}</div>
                                         {% endif %}
-                                        {% if not print %}
+                                        {% if not print and request.user.is_authenticated %}
                                             <a href="{% url 'core:campaign-asset-detail' list.campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
                                                class="link-secondary link-underline-opacity-25 link-underline-opacity-100-hover">Details →</a>
                                         {% endif %}

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -8,6 +8,7 @@ from gyrinx.core.models.campaign import (
     CampaignAction,
     CampaignAsset,
     CampaignAssetType,
+    CampaignSubAsset,
 )
 from gyrinx.core.models.list import List
 
@@ -448,4 +449,209 @@ def test_campaign_asset_transfer_to_none(content_house):
     assert (
         action.description
         == "Territory Transfer: The Sump transferred from Test Gang to no one"
+    )
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_view():
+    """The asset detail page shows description, properties, sub-assets and type text."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        description="<p>Territory type blurb</p>",
+        property_schema=[{"key": "boon", "label": "Boon"}],
+        sub_asset_schema={
+            "structure": {
+                "label": "Structure",
+                "label_plural": "Structures",
+                "property_schema": [{"key": "benefit", "label": "Benefit"}],
+            }
+        },
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description="<p>A toxic wasteland at the base of the hive.</p>",
+        properties={"boon": "+D6 income"},
+        owner=user,
+    )
+    CampaignSubAsset.objects.create(
+        parent_asset=asset,
+        sub_asset_type="structure",
+        name="Generator Hall",
+        properties={"benefit": "Free power"},
+        owner=user,
+    )
+
+    response = client.get(
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "The Sump" in content
+    assert "A toxic wasteland at the base of the hive." in content
+    assert "Boon" in content
+    assert "+D6 income" in content
+    assert "Structures" in content
+    assert "Generator Hall" in content
+    assert "Free power" in content
+    assert "Territory type blurb" in content
+    # Owner sees the edit control on their own campaign's asset.
+    assert reverse("core:campaign-asset-edit", args=[campaign.id, asset.id]) in content
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_accessible_to_non_owner():
+    """Any authenticated user can view the read-only page; edit controls are hidden."""
+    owner = User.objects.create_user(username="owner", password="pw")
+    User.objects.create_user(username="member", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=owner, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=owner,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type, name="The Sump", owner=owner
+    )
+
+    client = Client()
+    client.login(username="member", password="pw")
+    response = client.get(
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "The Sump" in content
+    # No owner-only edit control for a non-owner.
+    assert (
+        reverse("core:campaign-asset-edit", args=[campaign.id, asset.id]) not in content
+    )
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_404_for_other_campaign():
+    """An asset belonging to a different campaign 404s under this campaign's URL."""
+    user = User.objects.create_user(username="owner", password="pw")
+    campaign_a = Campaign.objects.create(name="A", owner=user, public=True)
+    campaign_b = Campaign.objects.create(name="B", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign_b,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type, name="The Sump", owner=user
+    )
+
+    client = Client()
+    client.login(username="owner", password="pw")
+    response = client.get(
+        reverse("core:campaign-asset-detail", args=[campaign_a.id, asset.id])
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_requires_login():
+    """Anonymous users are redirected to login."""
+    user = User.objects.create_user(username="owner", password="pw")
+    campaign = Campaign.objects.create(name="Test", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type, name="The Sump", owner=user
+    )
+
+    response = Client().get(
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+    )
+    assert response.status_code == 302
+    assert "login" in response.url
+
+
+@pytest.mark.django_db
+def test_campaign_dashboard_shows_asset_description_and_details_link():
+    """The campaign dashboard links each asset to its detail page and previews text."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description="<p>A toxic wasteland.</p>",
+        owner=user,
+    )
+
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "A toxic wasteland." in content
+    assert (
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id]) in content
+    )
+
+
+@pytest.mark.django_db
+def test_list_page_shows_asset_metadata(client, list_with_campaign, user):
+    """The list page asset panel shows properties, sub-asset counts, text and a link."""
+    campaign = list_with_campaign.campaign
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        property_schema=[{"key": "boon", "label": "Boon"}],
+        sub_asset_schema={
+            "structure": {"label": "Structure", "label_plural": "Structures"}
+        },
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description="<p>A toxic wasteland.</p>",
+        properties={"boon": "+D6 income"},
+        holder=list_with_campaign,
+        owner=user,
+    )
+    CampaignSubAsset.objects.create(
+        parent_asset=asset,
+        sub_asset_type="structure",
+        name="Generator Hall",
+        owner=user,
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("core:list", args=[list_with_campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "The Sump" in content
+    assert "Boon" in content
+    assert "+D6 income" in content
+    assert "1 Structures" in content
+    assert "A toxic wasteland." in content
+    assert (
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id]) in content
     )

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -783,3 +783,98 @@ def test_campaign_dashboard_shows_held_by(content_house):
     content = response.content.decode()
     assert "Held by" in content
     assert "Iron Skulls" in content
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_orders_description_after_structured_data():
+    """On the detail page, properties/sub-assets come before the long description."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        property_schema=[{"key": "boon", "label": "Boon"}],
+        sub_asset_schema={
+            "structure": {"label": "Structure", "label_plural": "Structures"}
+        },
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description="<p>A toxic wasteland.</p>",
+        properties={"boon": "+D6 income"},
+        owner=user,
+    )
+    CampaignSubAsset.objects.create(
+        parent_asset=asset,
+        sub_asset_type="structure",
+        name="Generator Hall",
+        owner=user,
+    )
+
+    response = client.get(
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+    )
+    content = response.content.decode()
+    assert content.index("Boon") < content.index("A toxic wasteland.")
+    assert content.index("Generator Hall") < content.index("A toxic wasteland.")
+
+
+@pytest.mark.django_db
+def test_campaign_dashboard_orders_description_after_properties():
+    """On the dashboard, an asset's properties come before its description."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        property_schema=[{"key": "boon", "label": "Boon"}],
+        owner=user,
+    )
+    CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description="<p>A toxic wasteland.</p>",
+        properties={"boon": "+D6 income"},
+        owner=user,
+    )
+
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    content = response.content.decode()
+    assert content.index("Boon") < content.index("A toxic wasteland.")
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_breadcrumb_includes_type():
+    """The breadcrumb shows the asset type (singular) as an intermediate crumb."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    # Distinct singular/plural so counting the singular is unambiguous.
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Zone",
+        name_plural="Districts",
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type, name="The Pit", owner=user
+    )
+
+    response = client.get(
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+    )
+    content = response.content.decode()
+    # Appears in the caps-label heading and, now, the breadcrumb crumb.
+    assert content.count("Zone") >= 2

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -655,3 +655,102 @@ def test_list_page_shows_asset_metadata(client, list_with_campaign, user):
     assert (
         reverse("core:campaign-asset-detail", args=[campaign.id, asset.id]) in content
     )
+
+
+@pytest.mark.django_db
+def test_campaign_dashboard_details_link_hidden_for_anonymous():
+    """The Details link (login-only page) is not shown to anonymous viewers."""
+    user = User.objects.create_user(username="owner", password="pw")
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="The Sump",
+        description="<p>A toxic wasteland.</p>",
+        owner=user,
+    )
+
+    # Anonymous client viewing the public campaign dashboard.
+    response = Client().get(reverse("core:campaign", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Description preview is still visible...
+    assert "A toxic wasteland." in content
+    # ...but the login-only Details link is not offered.
+    assert (
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+        not in content
+    )
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_shows_campaign_header():
+    """The detail page carries the shared campaign header (name + link back)."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Ashmoot Campaign", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type, name="The Sump", owner=user
+    )
+
+    response = client.get(
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Ashmoot Campaign" in content
+    assert reverse("core:campaign", args=[campaign.id]) in content
+
+
+@pytest.mark.django_db
+def test_campaign_asset_detail_shows_sub_assets_missing_from_schema():
+    """Sub-assets whose type left the schema still render (canonical page)."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        sub_asset_schema={
+            "structure": {"label": "Structure", "label_plural": "Structures"}
+        },
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type, name="The Sump", owner=user
+    )
+    # In-schema and orphaned (schema no longer lists "outpost") sub-assets.
+    CampaignSubAsset.objects.create(
+        parent_asset=asset,
+        sub_asset_type="structure",
+        name="Generator Hall",
+        owner=user,
+    )
+    CampaignSubAsset.objects.create(
+        parent_asset=asset, sub_asset_type="outpost", name="Lost Bunker", owner=user
+    )
+
+    response = client.get(
+        reverse("core:campaign-asset-detail", args=[campaign.id, asset.id])
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Generator Hall" in content
+    # The orphaned sub-asset is not silently dropped.
+    assert "Lost Bunker" in content

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -585,8 +585,8 @@ def test_campaign_asset_detail_requires_login():
 
 
 @pytest.mark.django_db
-def test_campaign_dashboard_shows_asset_description_and_details_link():
-    """The campaign dashboard links each asset to its detail page and previews text."""
+def test_campaign_dashboard_links_asset_name_and_previews_text():
+    """The dashboard links each asset name to its detail page and previews text."""
     client = Client()
     user = User.objects.create_user(username="owner", password="pw")
     client.login(username="owner", password="pw")
@@ -754,3 +754,32 @@ def test_campaign_asset_detail_shows_sub_assets_missing_from_schema():
     assert "Generator Hall" in content
     # The orphaned sub-asset is not silently dropped.
     assert "Lost Bunker" in content
+
+
+@pytest.mark.django_db
+def test_campaign_dashboard_shows_held_by(content_house):
+    """The dashboard shows the holder using the 'Held by X' pattern."""
+    client = Client()
+    user = User.objects.create_user(username="owner", password="pw")
+    client.login(username="owner", password="pw")
+
+    campaign = Campaign.objects.create(name="Test Campaign", owner=user, public=True)
+    gang = List.objects.create(
+        name="Iron Skulls", owner=user, content_house=content_house
+    )
+    campaign.lists.add(gang)
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=user,
+    )
+    CampaignAsset.objects.create(
+        asset_type=asset_type, name="The Sump", holder=gang, owner=user
+    )
+
+    response = client.get(reverse("core:campaign", args=[campaign.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Held by" in content
+    assert "Iron Skulls" in content

--- a/gyrinx/core/urls/campaign.py
+++ b/gyrinx/core/urls/campaign.py
@@ -98,6 +98,11 @@ patterns = [
         name="campaign-assets",
     ),
     path(
+        "campaign/<id>/asset/<asset_id>",
+        campaign_assets.campaign_asset_detail,
+        name="campaign-asset-detail",
+    ),
+    path(
         "campaign/<id>/assets/type/new",
         campaign_assets.campaign_asset_type_new,
         name="campaign-asset-type-new",

--- a/gyrinx/core/utils.py
+++ b/gyrinx/core/utils.py
@@ -253,7 +253,11 @@ def get_list_held_assets(list_obj):
     Returns:
         QuerySet of held assets
     """
-    return list_obj.held_assets.select_related("asset_type")
+    # prefetch_related("sub_assets") because the list-page panel renders
+    # asset.sub_asset_counts, which iterates sub_assets.all() (N+1 otherwise).
+    return list_obj.held_assets.select_related("asset_type").prefetch_related(
+        "sub_assets"
+    )
 
 
 def get_list_recent_campaign_actions(list_obj, limit=5):

--- a/gyrinx/core/views/campaign/assets.py
+++ b/gyrinx/core/views/campaign/assets.py
@@ -98,8 +98,6 @@ def campaign_asset_detail(request, id, asset_id):
         The :model:`core.CampaignAsset` being viewed.
     ``sub_assets_by_type``
         List of ``(label, [sub_asset, ...])`` tuples in schema order.
-    ``return_url``
-        URL for the back button.
     ``is_owner``
         Whether the current user owns the campaign.
 
@@ -107,14 +105,16 @@ def campaign_asset_detail(request, id, asset_id):
 
     :template:`core/campaign/campaign_asset_detail.html`
     """
-    campaign = get_object_or_404(Campaign, id=id)
+    # One query: fetch the asset scoped to the campaign and pull the campaign in
+    # via the asset_type join, rather than a separate Campaign lookup.
     asset = get_object_or_404(
-        CampaignAsset.objects.select_related("asset_type", "holder").prefetch_related(
-            "sub_assets"
-        ),
+        CampaignAsset.objects.select_related(
+            "asset_type", "asset_type__campaign", "holder"
+        ).prefetch_related("sub_assets"),
         id=asset_id,
-        asset_type__campaign=campaign,
+        asset_type__campaign_id=id,
     )
+    campaign = asset.asset_type.campaign
 
     # Group sub-assets by type, in the order the schema declares them. Point
     # each sub-asset's parent_asset FK at the already-loaded asset so
@@ -127,13 +127,16 @@ def campaign_asset_detail(request, id, asset_id):
 
     sub_assets_by_type = []
     for type_key, type_def in sub_asset_schema.items():
-        items = grouped.get(type_key)
+        items = grouped.pop(type_key, None)
         if items:
             label = type_def.get("label_plural", type_def.get("label", type_key))
             sub_assets_by_type.append((label, items))
 
-    default_url = reverse("core:campaign-assets", args=(campaign.id,))
-    return_url = get_return_url(request, default_url)
+    # Any groups left over have types no longer in the schema; show them last,
+    # labelled by their raw type, so the canonical page never drops persisted
+    # sub-assets.
+    for type_key, items in grouped.items():
+        sub_assets_by_type.append((type_key, items))
 
     log_event(
         user=request.user,
@@ -153,7 +156,6 @@ def campaign_asset_detail(request, id, asset_id):
             "campaign": campaign,
             "asset": asset,
             "sub_assets_by_type": sub_assets_by_type,
-            "return_url": return_url,
             "is_owner": request.user == campaign.owner,
         },
     )

--- a/gyrinx/core/views/campaign/assets.py
+++ b/gyrinx/core/views/campaign/assets.py
@@ -133,10 +133,10 @@ def campaign_asset_detail(request, id, asset_id):
             label = type_def.get("label_plural", type_def.get("label", type_key))
             sub_assets_by_type.append((label, items))
 
-    # Any groups left over have types no longer in the schema; show them last,
-    # labelled by their raw type, so the canonical page never drops persisted
-    # sub-assets.
-    for type_key, items in grouped.items():
+    # Any groups left over have types no longer in the schema; show them last
+    # (sorted for deterministic order), labelled by their raw type, so the
+    # canonical page never drops persisted sub-assets.
+    for type_key, items in sorted(grouped.items()):
         sub_assets_by_type.append((type_key, items))
 
     log_event(

--- a/gyrinx/core/views/campaign/assets.py
+++ b/gyrinx/core/views/campaign/assets.py
@@ -82,6 +82,84 @@ def campaign_assets(request, id):
 
 
 @login_required
+def campaign_asset_detail(request, id, asset_id):
+    """
+    Read-only detail page for a single campaign asset.
+
+    Shows the asset's full description, properties, its type's description, and
+    its sub-assets grouped by type. This is the canonical "asset text" page
+    that the compact asset panels (list page, campaign dashboard) link to.
+
+    **Context**
+
+    ``campaign``
+        The :model:`core.Campaign` the asset belongs to.
+    ``asset``
+        The :model:`core.CampaignAsset` being viewed.
+    ``sub_assets_by_type``
+        List of ``(label, [sub_asset, ...])`` tuples in schema order.
+    ``return_url``
+        URL for the back button.
+    ``is_owner``
+        Whether the current user owns the campaign.
+
+    **Template**
+
+    :template:`core/campaign/campaign_asset_detail.html`
+    """
+    campaign = get_object_or_404(Campaign, id=id)
+    asset = get_object_or_404(
+        CampaignAsset.objects.select_related("asset_type", "holder").prefetch_related(
+            "sub_assets"
+        ),
+        id=asset_id,
+        asset_type__campaign=campaign,
+    )
+
+    # Group sub-assets by type, in the order the schema declares them. Point
+    # each sub-asset's parent_asset FK at the already-loaded asset so
+    # properties_with_labels doesn't re-query the parent/asset_type per row.
+    sub_asset_schema = asset.asset_type.sub_asset_schema or {}
+    grouped = {}
+    for sub_asset in asset.sub_assets.all():
+        sub_asset.parent_asset = asset
+        grouped.setdefault(sub_asset.sub_asset_type, []).append(sub_asset)
+
+    sub_assets_by_type = []
+    for type_key, type_def in sub_asset_schema.items():
+        items = grouped.get(type_key)
+        if items:
+            label = type_def.get("label_plural", type_def.get("label", type_key))
+            sub_assets_by_type.append((label, items))
+
+    default_url = reverse("core:campaign-assets", args=(campaign.id,))
+    return_url = get_return_url(request, default_url)
+
+    log_event(
+        user=request.user,
+        noun=EventNoun.CAMPAIGN_ASSET,
+        verb=EventVerb.VIEW,
+        object=asset,
+        request=request,
+        campaign_id=str(campaign.id),
+        campaign_name=campaign.name,
+        asset_name=asset.name,
+    )
+
+    return render(
+        request,
+        "core/campaign/campaign_asset_detail.html",
+        {
+            "campaign": campaign,
+            "asset": asset,
+            "sub_assets_by_type": sub_assets_by_type,
+            "return_url": return_url,
+            "is_owner": request.user == campaign.owner,
+        },
+    )
+
+
+@login_required
 def campaign_asset_type_new(request, id):
     """
     Create a new asset type for a campaign.

--- a/gyrinx/core/views/campaign/assets.py
+++ b/gyrinx/core/views/campaign/assets.py
@@ -105,8 +105,9 @@ def campaign_asset_detail(request, id, asset_id):
 
     :template:`core/campaign/campaign_asset_detail.html`
     """
-    # One query: fetch the asset scoped to the campaign and pull the campaign in
-    # via the asset_type join, rather than a separate Campaign lookup.
+    # Fetch the asset scoped to the campaign and pull the campaign in via the
+    # asset_type join, avoiding a separate Campaign lookup. (sub_assets are
+    # prefetched in one further query.)
     asset = get_object_or_404(
         CampaignAsset.objects.select_related(
             "asset_type", "asset_type__campaign", "holder"

--- a/gyrinx/core/views/campaign/views.py
+++ b/gyrinx/core/views/campaign/views.py
@@ -197,11 +197,14 @@ class CampaignDetailView(generic.DetailView):
         else:
             context["can_log_actions"] = False
 
-        # Get asset types with their assets for the summary
+        # Get asset types with their assets for the summary. prefetch sub_assets
+        # so the dashboard's asset.sub_asset_counts doesn't run N+1 queries.
         context["asset_types"] = campaign.asset_types.prefetch_related(
             models.Prefetch(
                 "assets",
-                queryset=CampaignAsset.objects.select_related("holder", "asset_type"),
+                queryset=CampaignAsset.objects.select_related(
+                    "holder", "asset_type"
+                ).prefetch_related("sub_assets"),
             )
         )
 


### PR DESCRIPTION
## Summary

Campaign assets have gained richer data over time — custom properties, sub-assets, and a rich-text description — but the only place any of it appeared was the Manage Assets management screen. On a gang's list page you saw just the asset's name and type; on the campaign dashboard you saw properties and sub-asset counts but no description text; and there was no single page to read an asset's full text without going through the management UI.

This change surfaces that information where people actually look at their assets:

- **List page (Assets & Resources panel):** each held asset now shows its properties, sub-asset counts, and a two-line preview of its description. The asset **name links** to its detail page.
- **Campaign dashboard:** each asset shows the same two-line description preview, its holder (**"Held by X"**), and the properties/counts it already showed. The asset **name links** to its detail page.
- **New read-only asset page** at `/campaign/<id>/asset/<id>`: a clean, linkable page (with the shared campaign header — breadcrumb, campaign link, status) showing the full description, all properties, sub-assets with their own properties, and the asset type's description. Any signed-in user can view it (same access as Manage Assets); the campaign owner also sees Transfer/Edit shortcuts.

Long descriptions are clamped to two lines in the compact panels (CSS `line-clamp`, no JavaScript) so they don't crowd out resources; the full text lives on the asset page. In print view the list panel renders the description in full, and the name is plain text (no link). The name-as-link is only shown to signed-in users, since the detail page is login-only.

## Implementation notes

- Description previews reuse the project's `safe_rich_text` sanitisation.
- The list-page and dashboard asset queries `prefetch_related("sub_assets")` so rendering sub-asset counts doesn't trigger N+1 queries (the dashboard already rendered counts, so this also fixes a pre-existing latent N+1 there).
- The detail view fetches the asset in a single query (deriving the campaign via the `asset_type` join) and shows sub-assets whose type is no longer in the schema so it never silently drops persisted rows.

## Test plan

- [x] `pytest -n auto` — full suite green
- [x] New tests: asset detail view (owner + non-owner access, 404 for wrong campaign, login required, campaign header, orphaned sub-assets), dashboard name-link + "Held by X" + anonymous-link guard, list-panel metadata
- [x] Performance query-count snapshot unchanged
- [x] Manual browser check: list panel, dashboard, and asset detail page all render correctly (linked names, "Held by X", clamped vs full description)

Closes #1242
Closes #1241