### PR TITLE
fix: skip content/core save signals during fixture loading

### DIFF
--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -814,6 +814,11 @@ def sync_auto_equipment_cost(sender, instance, created, **kwargs):
     companion alone — see #1725-related discussion in the PR for the
     follow-up form-level guard.
     """
+    if kwargs.get("raw"):
+        # Fixture loading (loaddata / loaddata_overwrite): the fixture already
+        # carries consistent companion rows, and writing mid-import could
+        # collide with rows the fixture inserts later.
+        return
     if instance.category not in AUTO_EQUIPMENT_CATEGORY_BY_FIGHTER_CATEGORY:
         return
 

--- a/gyrinx/core/models/list/signal_handlers.py
+++ b/gyrinx/core/models/list/signal_handlers.py
@@ -27,6 +27,10 @@ pylist = list
 @receiver(post_save, sender=ListFighter, dispatch_uid="create_linked_objects")
 @traced("signal_create_linked_objects")
 def create_linked_objects(sender, instance, **kwargs):
+    if kwargs.get("raw"):
+        # Fixture loading: the content_fighter row may not be inserted yet,
+        # and restoring already-consistent data must not materialise defaults.
+        return
     _materialise_child_fighter_defaults(instance)
 
 
@@ -86,6 +90,9 @@ def enqueue_propagate_default_child_fighter_assignment(
 )
 def touch_list_modified_on_fighter_save(sender, instance, **kwargs):
     """Bump the parent list's modified timestamp when any fighter is saved."""
+    if kwargs.get("raw"):
+        # Fixture loading: don't churn timestamps while restoring data.
+        return
     from django.utils import timezone
 
     List.objects.filter(pk=instance.list_id).update(modified=timezone.now())
@@ -98,6 +105,10 @@ def touch_list_modified_on_fighter_save(sender, instance, **kwargs):
 )
 @traced("signal_create_related_objects")
 def create_related_objects(sender, instance, **kwargs):
+    if kwargs.get("raw"):
+        # Fixture loading: the content_equipment row may not be inserted yet,
+        # and restoring already-consistent data must not create child objects.
+        return
     equipment_fighter_profile = ContentEquipmentFighterProfile.objects.filter(
         equipment=instance.content_equipment,
     )
@@ -186,6 +197,11 @@ def clear_fighter_cached_properties_for_assignment(
     sender, instance: ListFighterEquipmentAssignment, **kwargs
 ):
     """Clear the fighter's cached properties that depend on assignments."""
+    if kwargs.get("raw"):
+        # Fixture loading: the list_fighter row may not be inserted yet, and a
+        # freshly-deserialized instance has no cached properties to clear.
+        # post_delete sends no "raw" kwarg, so the delete path is unaffected.
+        return
     fighter = instance.list_fighter
     for prop in [
         "cost_int_cached",

--- a/gyrinx/core/tests/test_pack_vehicles_beasts.py
+++ b/gyrinx/core/tests/test_pack_vehicles_beasts.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_save
 from django.urls import reverse
 
 from gyrinx.content.models.equipment import (
@@ -990,3 +991,46 @@ def test_add_fighter_page_uses_singular_label_override(client, user, pack):
     body = response.content.decode()
     assert "Add Fighter or Vehicle" in body
     assert "Add Fighters & Vehicle" not in body
+
+
+# --- Fixture-loading (raw) guard — issue #1992 ---------------------------------
+
+
+@pytest.mark.django_db
+def test_companion_sync_skips_raw_fixture_saves(content_house):
+    """Fixture loading (``raw=True``, e.g. a ``loaddata_overwrite`` content
+    import) must not rewrite companion equipment or ``get_or_create`` the auto
+    category — the fixture already carries the consistent end state, and a
+    mid-import write can collide with rows the fixture inserts later."""
+    fighter = ContentFighter.objects.create(
+        type="Goliath Mauler",
+        category="VEHICLE",
+        house=content_house,
+        base_cost=150,
+    )
+    plain_category = ContentEquipmentCategory.objects.create(
+        name="Plain Gear", group="Gear"
+    )
+    # Companion whose name/cost/category deliberately disagree with the
+    # fighter, as they transiently can mid-fixture.
+    companion = ContentEquipment.objects.create(
+        name="Stale Name",
+        category=plain_category,
+        cost="99",
+        auto_companion_for_fighter=fighter,
+    )
+    categories_before = ContentEquipmentCategory.objects.count()
+
+    post_save.send(
+        sender=ContentFighter,
+        instance=fighter,
+        created=True,
+        raw=True,
+        using="default",
+    )
+
+    companion.refresh_from_db()
+    assert companion.name == "Stale Name"
+    assert companion.cost == "99"
+    assert companion.category_id == plain_category.pk
+    assert ContentEquipmentCategory.objects.count() == categories_before

--- a/gyrinx/core/tests/test_signal_raw_fixture_guards.py
+++ b/gyrinx/core/tests/test_signal_raw_fixture_guards.py
@@ -1,0 +1,71 @@
+"""Issue #1992 — core model-save signal receivers must skip fixture loads.
+
+``loaddata`` (and ``loaddata_overwrite``) save deserialized rows with
+``raw=True`` while FK checks are disabled, so a receiver that dereferences a
+relation can hit a row that isn't inserted yet, and side effects would corrupt
+data the fixture already carries in its final state. Each test sends the
+signal exactly as loaddata does — ``raw=True`` on an instance with dangling
+FKs — and asserts every receiver on that sender skips cleanly.
+
+The content-side counterparts live in
+``test_pack_vehicles_beasts.test_companion_sync_skips_raw_fixture_saves`` and
+``test_propagate_default_child_fighter.test_signal_skips_raw_fixture_saves``
+(PR #1991, which motivated this sweep).
+"""
+
+import uuid
+
+import pytest
+from django.db.models.signals import post_save
+
+from gyrinx.core.models.list import (
+    ListFighter,
+    ListFighterEquipmentAssignment,
+)
+
+
+@pytest.mark.django_db
+def test_list_fighter_receivers_skip_raw_fixture_saves():
+    """``create_linked_objects`` (dereferences ``content_fighter`` and creates
+    default assignments) and ``touch_list_modified_on_fighter_save`` (writes to
+    the parent list) must both no-op on a raw save with dangling FKs."""
+    fighter = ListFighter(
+        id=uuid.uuid4(),
+        name="Raw Fighter",
+        content_fighter_id=uuid.uuid4(),
+        list_id=uuid.uuid4(),
+        owner_id=uuid.uuid4(),
+    )
+
+    post_save.send(
+        sender=ListFighter,
+        instance=fighter,
+        created=True,
+        raw=True,
+        using="default",
+    )
+
+    assert ListFighterEquipmentAssignment.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_assignment_receivers_skip_raw_fixture_saves():
+    """``create_related_objects`` (dereferences ``content_equipment``, creates
+    child fighters) and ``clear_fighter_cached_properties_for_assignment``
+    (dereferences ``list_fighter``) must both no-op on a raw save with
+    dangling FKs."""
+    assignment = ListFighterEquipmentAssignment(
+        id=uuid.uuid4(),
+        list_fighter_id=uuid.uuid4(),
+        content_equipment_id=uuid.uuid4(),
+    )
+
+    post_save.send(
+        sender=ListFighterEquipmentAssignment,
+        instance=assignment,
+        created=True,
+        raw=True,
+        using="default",
+    )
+
+    assert ListFighter.objects.count() == 0

--- a/gyrinx/core/tests/test_signal_raw_fixture_guards.py
+++ b/gyrinx/core/tests/test_signal_raw_fixture_guards.py
@@ -25,15 +25,22 @@ from gyrinx.core.models.list import (
 
 
 @pytest.mark.django_db
-def test_list_fighter_receivers_skip_raw_fixture_saves():
+def test_list_fighter_receivers_skip_raw_fixture_saves(make_list):
     """``create_linked_objects`` (dereferences ``content_fighter`` and creates
     default assignments) and ``touch_list_modified_on_fighter_save`` (writes to
-    the parent list) must both no-op on a raw save with dangling FKs."""
+    the parent list) must both no-op on a raw save.
+
+    The list is real so the touch handler's ``update()`` would be observable
+    if its guard were removed; the ``content_fighter`` FK dangles, as it can
+    mid-fixture."""
+    lst = make_list("Raw Load Gang")
+    modified_before = lst.modified
+
     fighter = ListFighter(
         id=uuid.uuid4(),
         name="Raw Fighter",
         content_fighter_id=uuid.uuid4(),
-        list_id=uuid.uuid4(),
+        list_id=lst.pk,
         owner_id=uuid.uuid4(),
     )
 
@@ -45,6 +52,8 @@ def test_list_fighter_receivers_skip_raw_fixture_saves():
         using="default",
     )
 
+    lst.refresh_from_db()
+    assert lst.modified == modified_before
     assert ListFighterEquipmentAssignment.objects.count() == 0
 
 


### PR DESCRIPTION
## Summary

- Follow-up to #1991: sweep of every `@receiver` in `gyrinx/content` and `gyrinx/core` for handlers that can crash or write during fixture loading (`loaddata` / `loaddata_overwrite` save rows with `raw=True` while FK checks are disabled, so related rows may not be inserted yet and side effects would fire on already-consistent data).
- Adds the standard `raw` guard to five handlers:
  - **`sync_auto_equipment_cost`** (content) — the live risk: it *writes* during content imports (rewrites companion equipment, `get_or_create`s categories that can collide with rows the fixture inserts later). Today's imports survive only because of favourable dump ordering.
  - **`create_linked_objects`**, **`create_related_objects`** (core) — dangling-FK crashes plus spurious child fighters/assignments on user-data fixture loads.
  - **`clear_fighter_cached_properties_for_assignment`** (core) — dereferences `list_fighter` first thing; found during the sweep, beyond the three named in the issue. Its `post_delete` path is unaffected (no `raw` kwarg on delete signals).
  - **`touch_list_modified_on_fighter_save`** (core) — write-only timestamp churn; guarded since it's one line in the same file.
- Regression tests send `post_save` exactly as loaddata does (`raw=True`, dangling FKs). Grouping by sender means each test also covers *every* receiver on that sender, so a future unguarded handler on these models will show up.

## Deliberately not changed

- The `pre_save`/`post_save` cost-change handlers are already safe: freshly-deserialized rows have `_state.adding=True`, so `get_old_cost` returns `None` / the `created` gate short-circuits, and they never dereference a foreign relation.
- Three write-only handlers in `core/signals.py` (the two `Event` modified-timestamp bumps and `attach_custom_gang_icon_on_pack_item`) can't crash and only matter for hypothetical fixture loads of log/pack data — left unguarded to avoid noise.
- No reflective "sweep all receivers" test: a synthesised generic instance early-returns in `sync_auto_equipment_cost` before its dangerous path, so such a test would pass with or without the guard — false confidence. The targeted tests set up each handler's real dangerous precondition instead.

## Test plan

- [x] All three new tests red-verified without the guards (two `DoesNotExist` crashes, one companion rewrite), green with them
- [x] Full suite: 3,258 passed, 13 skipped
- [x] End-to-end: `manage loaddata_overwrite latest.json` (today's 16,466-object prod dump) completes cleanly on a scratch DB with **all signals connected** — the import that previously required disconnecting a handler by hand

Closes #1992
Refs #1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)