### PR TITLE
feat: manage arbitrators by username on a dedicated page

### DIFF
--- a/gyrinx/core/forms/campaign.py
+++ b/gyrinx/core/forms/campaign.py
@@ -2,9 +2,7 @@ import json
 
 from django import forms
 from django.contrib.auth import get_user_model
-from django.db import models
 
-from gyrinx.core.forms import BsCheckboxSelectMultiple
 
 from gyrinx.core.models.campaign import (
     Campaign,
@@ -142,7 +140,6 @@ class EditCampaignForm(forms.ModelForm):
             "summary",
             "narrative",
             "public",
-            "admins",
             "budget",
             "phase",
             "phase_notes",
@@ -152,7 +149,6 @@ class EditCampaignForm(forms.ModelForm):
             "summary": "Summary",
             "narrative": "Narrative",
             "public": "Public",
-            "admins": "Arbitrators",
             "budget": "Starting Budget",
             "phase": "Phase",
             "phase_notes": "Phase Notes",
@@ -162,10 +158,6 @@ class EditCampaignForm(forms.ModelForm):
             "summary": "A short summary of the campaign (300 characters max). This will be displayed on the campaign list page.",
             "narrative": "A longer narrative description of the campaign. This will be displayed on the campaign detail page.",
             "public": "If checked, this campaign will be visible to all users.",
-            "admins": (
-                "Users who share full administrative control of this campaign. "
-                "Only owners of gangs in the campaign can be added."
-            ),
             "budget": "Starting budget for each gang in credits.",
             "phase": "Current campaign phase (e.g., 'Occupation', 'Takeover', 'Dominion')",
             "phase_notes": "Notes about the current phase - special rules, conditions, etc.",
@@ -180,9 +172,6 @@ class EditCampaignForm(forms.ModelForm):
                 attrs={"cols": 80, "rows": 20}, mce_attrs=TINYMCE_EXTRA_ATTRS
             ),
             "public": forms.CheckboxInput(attrs={"class": "form-check-input"}),
-            "admins": BsCheckboxSelectMultiple(
-                attrs={"class": "form-check-input"},
-            ),
             "budget": forms.NumberInput(attrs={"class": "form-control", "min": 0}),
             "phase": forms.TextInput(
                 attrs={"class": "form-control", "placeholder": "e.g., Occupation"}
@@ -192,26 +181,9 @@ class EditCampaignForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self._old_phase = None
-        self._old_admin_ids = set()
         super().__init__(*args, **kwargs)
         if self.instance and self.instance.pk:
             self._old_phase = self.instance.phase
-            self._old_admin_ids = set(self.instance.admins.values_list("id", flat=True))
-            # Arbitrators can only be picked from campaign participants (gang
-            # owners) plus anyone already granted admin — never the whole user
-            # table, and never the owner (who is always an admin).
-            User = get_user_model()
-            self.fields["admins"].queryset = (
-                User.objects.filter(
-                    models.Q(id__in=self.instance.lists.values("owner_id"))
-                    | models.Q(id__in=self.instance.admins.values("id"))
-                )
-                .exclude(id=self.instance.owner_id)
-                .order_by("username")
-            )
-        else:
-            # Never offer the whole user table on an unbound form.
-            self.fields["admins"].queryset = get_user_model().objects.none()
 
     def save(self, commit=True, user=None):
         instance = super().save(commit=False)
@@ -222,7 +194,6 @@ class EditCampaignForm(forms.ModelForm):
 
         if commit:
             instance.save()
-            self.save_m2m()
 
             # Log phase change if it changed and user is provided
             if phase_changed and user:
@@ -242,37 +213,47 @@ class EditCampaignForm(forms.ModelForm):
                     owner=user,
                 )
 
-            # Log arbitrator roster changes — granting admin is a trust-boundary
-            # change, so keep an audit trail alongside the phase log.
-            if user:
-                new_admin_ids = set(instance.admins.values_list("id", flat=True))
-                added = new_admin_ids - self._old_admin_ids
-                removed = self._old_admin_ids - new_admin_ids
-                if added or removed:
-                    from gyrinx.core.models.campaign import CampaignAction
-
-                    User = get_user_model()
-
-                    def _names(ids):
-                        return ", ".join(
-                            User.objects.filter(id__in=ids)
-                            .order_by("username")
-                            .values_list("username", flat=True)
-                        )
-
-                    parts = []
-                    if added:
-                        parts.append(f"added {_names(added)}")
-                    if removed:
-                        parts.append(f"removed {_names(removed)}")
-                    CampaignAction.objects.create(
-                        campaign=instance,
-                        user=user,
-                        description="Arbitrators updated: " + "; ".join(parts),
-                        owner=user,
-                    )
-
         return instance
+
+
+class AddArbitratorForm(forms.Form):
+    """Grant a user shared admin (arbitrator) rights on a campaign, by username."""
+
+    username = forms.CharField(
+        label="Username",
+        max_length=150,
+        widget=forms.TextInput(
+            attrs={
+                "class": "form-control",
+                "placeholder": "Username",
+                "autocomplete": "off",
+            }
+        ),
+        help_text="The exact username of the person to make an arbitrator.",
+    )
+
+    def __init__(self, *args, campaign=None, **kwargs):
+        self.campaign = campaign
+        self.user_to_add = None
+        super().__init__(*args, **kwargs)
+
+    def clean_username(self):
+        username = self.cleaned_data["username"].strip()
+        User = get_user_model()
+        user = User.objects.filter(username__iexact=username, is_active=True).first()
+        if user is None:
+            raise forms.ValidationError("No user with that username was found.")
+        if self.campaign:
+            if user == self.campaign.owner:
+                raise forms.ValidationError(
+                    "The campaign owner is always an arbitrator."
+                )
+            if self.campaign.admins.filter(id=user.id).exists():
+                raise forms.ValidationError(
+                    f"{user.username} is already an arbitrator."
+                )
+        self.user_to_add = user
+        return username
 
 
 class CampaignAssetTypeForm(forms.ModelForm):

--- a/gyrinx/core/forms/campaign.py
+++ b/gyrinx/core/forms/campaign.py
@@ -229,7 +229,7 @@ class AddArbitratorForm(forms.Form):
                 "autocomplete": "off",
             }
         ),
-        help_text="The exact username of the person to make an arbitrator.",
+        help_text="The username of the person to make an arbitrator.",
     )
 
     def __init__(self, *args, campaign=None, **kwargs):
@@ -240,7 +240,14 @@ class AddArbitratorForm(forms.Form):
     def clean_username(self):
         username = self.cleaned_data["username"].strip()
         User = get_user_model()
-        user = User.objects.filter(username__iexact=username, is_active=True).first()
+        # Exact match wins; otherwise accept a case-insensitive match only when
+        # it is unambiguous (usernames differing only by case are permitted).
+        user = User.objects.filter(username=username, is_active=True).first()
+        if user is None:
+            matches = list(
+                User.objects.filter(username__iexact=username, is_active=True)[:2]
+            )
+            user = matches[0] if len(matches) == 1 else None
         if user is None:
             raise forms.ValidationError("No user with that username was found.")
         if self.campaign:

--- a/gyrinx/core/templates/core/campaign/campaign.html
+++ b/gyrinx/core/templates/core/campaign/campaign.html
@@ -195,6 +195,10 @@
                             {% endfor %}
                         {% endspaceless %}
                     </div>
+                    {% if is_admin %}
+                        <a href="{% url 'core:campaign-arbitrators' campaign.id %}"
+                           class="fs-7 linked">Manage</a>
+                    {% endif %}
                 </div>
                 {% if campaign.phase %}
                     <div class="g-col-6 g-col-md-3">

--- a/gyrinx/core/templates/core/campaign/campaign_arbitrators.html
+++ b/gyrinx/core/templates/core/campaign/campaign_arbitrators.html
@@ -1,0 +1,53 @@
+{% extends "core/layouts/base.html" %}
+{% load custom_tags %}
+{% block head_title %}
+    Arbitrators - {{ campaign.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:campaign' campaign.id as campaign_url %}
+    {% include "core/includes/back.html" with url=campaign_url text="Back to Campaign" %}
+    <div class="col-12 col-xl-6 px-0 vstack gap-4">
+        <div>
+            <h1 class="h3 mb-1">Arbitrators</h1>
+            <p class="text-secondary mb-0">{{ campaign.name }}</p>
+        </div>
+        <p class="mb-0">
+            Arbitrators share full administrative control of the campaign: they can
+            edit its settings, add and remove gangs, manage assets, resources and
+            attributes, run battles, and act on any gang as a referee.
+        </p>
+        <div class="vstack gap-2">
+            <div class="d-flex align-items-center gap-2 border rounded p-2">
+                <a href="{% url 'core:user' campaign.owner.username %}"
+                   class="linked-body">{{ campaign.owner }}</a>
+                <span class="text-secondary fs-7 ms-auto">Owner — always an arbitrator</span>
+            </div>
+            {% for admin in admins %}
+                <div class="d-flex align-items-center gap-2 border rounded p-2">
+                    <a href="{% url 'core:user' admin.username %}" class="linked-body">{{ admin }}</a>
+                    <form method="post"
+                          action="{% url 'core:campaign-arbitrator-remove' campaign.id admin.id %}"
+                          class="ms-auto">
+                        {% csrf_token %}
+                        <button type="submit"
+                                class="btn btn-link btn-sm p-0 link-danger link-underline-opacity-25 link-underline-opacity-100-hover">
+                            Remove
+                        </button>
+                    </form>
+                </div>
+            {% empty %}
+                <p class="text-secondary fs-7 mb-0">
+                    No shared arbitrators yet — the owner runs this campaign alone. Add
+                    someone by username to share control.
+                </p>
+            {% endfor %}
+        </div>
+        <form method="post" class="vstack gap-3">
+            {% csrf_token %}
+            {% include "core/includes/form_field.html" with field=form.username %}
+            <div>
+                <button type="submit" class="btn btn-primary btn-sm">Add Arbitrator</button>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/tests/test_campaign_admins.py
+++ b/gyrinx/core/tests/test_campaign_admins.py
@@ -1,7 +1,7 @@
 """Tests for shared campaign admins ("Arbitrators", #988).
 
 Covers the Campaign.is_admin helper, the admin-gated campaign views, the
-arbitrator permission on fighter views, and the EditCampaignForm admins field.
+arbitrator permission on fighter views, and the arbitrators management page.
 """
 
 from types import SimpleNamespace
@@ -138,7 +138,6 @@ def test_shared_admin_can_open_fighter_injuries_page(
     assert client.get(url).status_code == 404
 
 
-@pytest.mark.django_db
 def test_edit_form_has_no_admins_field():
     assert "admins" not in EditCampaignForm().fields, (
         "The roster is managed on the arbitrators page, not the edit form"

--- a/gyrinx/core/tests/test_campaign_admins.py
+++ b/gyrinx/core/tests/test_campaign_admins.py
@@ -55,13 +55,14 @@ def test_edit_campaign_view_allows_shared_admin(client, shared_admin, make_campa
             "name": "Renamed by Admin",
             "budget": campaign.budget,
             "public": "on",
-            "admins": [str(shared_admin.id)],
         },
     )
     assert response.status_code == 302
     campaign.refresh_from_db()
     assert campaign.name == "Renamed by Admin"
-    assert shared_admin in campaign.admins.all()
+    assert shared_admin in campaign.admins.all(), (
+        "Editing the campaign must not touch the arbitrator roster"
+    )
 
 
 @pytest.mark.django_db
@@ -138,26 +139,108 @@ def test_shared_admin_can_open_fighter_injuries_page(
 
 
 @pytest.mark.django_db
-def test_edit_form_admins_choices_limited_to_participants(
-    user, make_user, make_campaign, make_list
+def test_edit_form_has_no_admins_field():
+    assert "admins" not in EditCampaignForm().fields, (
+        "The roster is managed on the arbitrators page, not the edit form"
+    )
+
+
+@pytest.mark.django_db
+def test_arbitrators_page_add_by_username(client, user, shared_admin, make_campaign):
+    from gyrinx.core.models.campaign import CampaignAction
+
+    campaign = make_campaign("Roster Campaign")
+    client.force_login(user)
+
+    url = reverse("core:campaign-arbitrators", args=[campaign.id])
+    assert client.get(url).status_code == 200
+
+    # shared_admin owns no gang in the campaign — that must not matter.
+    response = client.post(url, {"username": shared_admin.username})
+    assert response.status_code == 302
+    assert shared_admin in campaign.admins.all()
+    action = CampaignAction.objects.get(
+        campaign=campaign, description__startswith="Arbitrator added"
+    )
+    assert shared_admin.username in action.description
+
+
+@pytest.mark.django_db
+def test_arbitrators_page_add_is_case_insensitive(
+    client, user, make_user, make_campaign
 ):
-    campaign = make_campaign("Choosy Campaign")
-    participant = make_user("participant", "password")
-    stranger = make_user("stranger", "password")
-    legacy_admin = make_user("legacy_admin", "password")
+    campaign = make_campaign("Case Campaign")
+    target = make_user("MixedCaseUser", "password")
+    client.force_login(user)
 
-    lst = make_list("Participant Gang", owner=participant)
-    campaign.lists.add(lst)
-    # An admin who no longer has a gang in the campaign must stay selectable,
-    # otherwise saving the form would silently drop them.
-    campaign.admins.add(legacy_admin)
+    response = client.post(
+        reverse("core:campaign-arbitrators", args=[campaign.id]),
+        {"username": "mixedcaseuser"},
+    )
+    assert response.status_code == 302
+    assert target in campaign.admins.all()
 
-    form = EditCampaignForm(instance=campaign)
-    choice_ids = set(form.fields["admins"].queryset.values_list("id", flat=True))
 
-    assert choice_ids == {participant.id, legacy_admin.id}
-    assert user.id not in choice_ids, "The owner is always an admin — not a choice"
-    assert stranger.id not in choice_ids
+@pytest.mark.django_db
+def test_arbitrators_page_add_rejects_bad_usernames(
+    client, user, shared_admin, make_campaign
+):
+    campaign = make_campaign("Picky Campaign")
+    campaign.admins.add(shared_admin)
+    client.force_login(user)
+    url = reverse("core:campaign-arbitrators", args=[campaign.id])
+
+    for username, fragment in [
+        ("no_such_user", "No user with that username"),
+        (user.username, "always an arbitrator"),
+        (shared_admin.username, "already an arbitrator"),
+    ]:
+        response = client.post(url, {"username": username})
+        assert response.status_code == 200, username
+        assert fragment in response.content.decode(), username
+    assert campaign.admins.count() == 1
+
+
+@pytest.mark.django_db
+def test_arbitrators_page_remove(client, user, shared_admin, make_campaign):
+    from gyrinx.core.models.campaign import CampaignAction
+
+    campaign = make_campaign("Revoking Campaign")
+    campaign.admins.add(shared_admin)
+    client.force_login(user)
+
+    response = client.post(
+        reverse("core:campaign-arbitrator-remove", args=[campaign.id, shared_admin.id])
+    )
+    assert response.status_code == 302
+    assert shared_admin not in campaign.admins.all()
+    assert CampaignAction.objects.filter(
+        campaign=campaign, description__startswith="Arbitrator removed"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_arbitrator_can_remove_self(client, shared_admin, make_campaign):
+    campaign = make_campaign("Leaving Campaign")
+    campaign.admins.add(shared_admin)
+    client.force_login(shared_admin)
+
+    response = client.post(
+        reverse("core:campaign-arbitrator-remove", args=[campaign.id, shared_admin.id])
+    )
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaign", args=[campaign.id])
+    assert shared_admin not in campaign.admins.all()
+
+
+@pytest.mark.django_db
+def test_arbitrators_page_404_for_non_admin(client, rando, make_campaign):
+    campaign = make_campaign("Private Roster Campaign")
+    client.force_login(rando)
+    assert (
+        client.get(reverse("core:campaign-arbitrators", args=[campaign.id])).status_code
+        == 404
+    )
 
 
 @pytest.mark.django_db
@@ -173,39 +256,6 @@ def test_new_battle_page_allows_shared_admin(client, shared_admin, rando, campai
     # A user with no gang and no admin rights is turned away.
     client.force_login(rando)
     assert client.get(url).status_code == 302
-
-
-@pytest.mark.django_db
-def test_admin_roster_changes_are_logged(
-    client, user, shared_admin, make_campaign, make_list
-):
-    from gyrinx.core.models.campaign import CampaignAction
-
-    campaign = make_campaign("Audited Campaign")
-    lst = make_list("Admin Gang", owner=shared_admin)
-    campaign.lists.add(lst)
-
-    client.force_login(user)
-    response = client.post(
-        reverse("core:campaign-edit", args=[campaign.id]),
-        {
-            "name": campaign.name,
-            "budget": campaign.budget,
-            "public": "on",
-            "admins": [str(shared_admin.id)],
-        },
-    )
-    assert response.status_code == 302
-    action = CampaignAction.objects.get(
-        campaign=campaign, description__startswith="Arbitrators updated"
-    )
-    assert f"added {shared_admin.username}" in action.description
-
-
-@pytest.mark.django_db
-def test_unbound_edit_form_offers_no_admin_choices(user):
-    form = EditCampaignForm()
-    assert not form.fields["admins"].queryset.exists()
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/urls/campaign.py
+++ b/gyrinx/core/urls/campaign.py
@@ -28,7 +28,7 @@ patterns = [
         name="campaign-arbitrators",
     ),
     path(
-        "campaign/<id>/arbitrator/<user_id>/remove",
+        "campaign/<id>/arbitrator/<int:user_id>/remove",
         campaign_arbitrators.campaign_arbitrator_remove,
         name="campaign-arbitrator-remove",
     ),

--- a/gyrinx/core/urls/campaign.py
+++ b/gyrinx/core/urls/campaign.py
@@ -3,6 +3,7 @@ from django.urls import path
 from ..views import battle
 from ..views import crew as crew_views
 from ..views.campaign import actions as campaign_actions
+from ..views.campaign import arbitrators as campaign_arbitrators
 from ..views.campaign import assets as campaign_assets
 from ..views.campaign import attributes as campaign_attributes
 from ..views.campaign import battles as campaign_battles
@@ -21,6 +22,16 @@ patterns = [
     path("campaigns/new/", campaign_crud.new_campaign, name="campaigns-new"),
     path("campaign/<id>", campaign_views.CampaignDetailView.as_view(), name="campaign"),
     path("campaign/<id>/edit/", campaign_crud.edit_campaign, name="campaign-edit"),
+    path(
+        "campaign/<id>/arbitrators",
+        campaign_arbitrators.campaign_arbitrators,
+        name="campaign-arbitrators",
+    ),
+    path(
+        "campaign/<id>/arbitrator/<user_id>/remove",
+        campaign_arbitrators.campaign_arbitrator_remove,
+        name="campaign-arbitrator-remove",
+    ),
     path(
         "campaign/<id>/lists/add",
         campaign_lists.campaign_add_lists,

--- a/gyrinx/core/views/campaign/arbitrators.py
+++ b/gyrinx/core/views/campaign/arbitrators.py
@@ -1,0 +1,120 @@
+"""Campaign arbitrator (shared admin) management views."""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.views.decorators.http import require_POST
+
+from gyrinx import messages
+from gyrinx.core.forms.campaign import AddArbitratorForm
+from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.events import EventNoun, EventVerb, log_event
+from gyrinx.core.views.campaign.common import get_campaign_admin_or_404
+
+
+@login_required
+def campaign_arbitrators(request, id):
+    """
+    Manage the arbitrators (shared admins) of a campaign.
+
+    Lists the current arbitrators, and lets any campaign admin grant another
+    user admin rights by username or revoke an existing grant. The owner is
+    always an arbitrator and cannot be removed.
+
+    **Context**
+
+    ``campaign``
+        The :model:`core.Campaign` being managed.
+    ``admins``
+        The current shared admins (excluding the owner), ordered by username.
+    ``form``
+        AddArbitratorForm for granting another user admin rights.
+
+    **Template**
+
+    :template:`core/campaign/campaign_arbitrators.html`
+    """
+    campaign = get_campaign_admin_or_404(request, id)
+
+    if request.method == "POST":
+        form = AddArbitratorForm(request.POST, campaign=campaign)
+        if form.is_valid():
+            new_admin = form.user_to_add
+            campaign.admins.add(new_admin)
+
+            CampaignAction.objects.create(
+                campaign=campaign,
+                user=request.user,
+                description=f"Arbitrator added: {new_admin.username}",
+                owner=request.user,
+            )
+            log_event(
+                user=request.user,
+                noun=EventNoun.CAMPAIGN,
+                verb=EventVerb.ASSIGN,
+                object=campaign,
+                request=request,
+                campaign_name=campaign.name,
+                arbitrator_username=new_admin.username,
+            )
+            messages.success(request, f"{new_admin.username} is now an arbitrator.")
+            return HttpResponseRedirect(
+                reverse("core:campaign-arbitrators", args=(campaign.id,))
+            )
+    else:
+        form = AddArbitratorForm(campaign=campaign)
+
+    return render(
+        request,
+        "core/campaign/campaign_arbitrators.html",
+        {
+            "campaign": campaign,
+            "admins": campaign.admins.order_by("username"),
+            "form": form,
+        },
+    )
+
+
+@login_required
+@require_POST
+def campaign_arbitrator_remove(request, id, user_id):
+    """
+    Revoke a user's arbitrator (shared admin) rights on a campaign.
+
+    Any campaign admin may remove an arbitrator, including themselves. The
+    owner is not in ``admins`` and so can never be removed.
+    """
+    campaign = get_campaign_admin_or_404(request, id)
+    User = get_user_model()
+    admin_to_remove = get_object_or_404(
+        User, id=user_id, administered_campaigns=campaign
+    )
+    removing_self = admin_to_remove == request.user
+
+    campaign.admins.remove(admin_to_remove)
+
+    CampaignAction.objects.create(
+        campaign=campaign,
+        user=request.user,
+        description=f"Arbitrator removed: {admin_to_remove.username}",
+        owner=request.user,
+    )
+    log_event(
+        user=request.user,
+        noun=EventNoun.CAMPAIGN,
+        verb=EventVerb.UNASSIGN,
+        object=campaign,
+        request=request,
+        campaign_name=campaign.name,
+        arbitrator_username=admin_to_remove.username,
+    )
+    messages.success(request, f"{admin_to_remove.username} is no longer an arbitrator.")
+
+    # Someone who just removed themselves can no longer see the manage page.
+    if removing_self and campaign.owner != request.user:
+        return HttpResponseRedirect(reverse("core:campaign", args=(campaign.id,)))
+    return HttpResponseRedirect(
+        reverse("core:campaign-arbitrators", args=(campaign.id,))
+    )

--- a/gyrinx/core/views/campaign/arbitrators.py
+++ b/gyrinx/core/views/campaign/arbitrators.py
@@ -2,6 +2,7 @@
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -42,14 +43,16 @@ def campaign_arbitrators(request, id):
         form = AddArbitratorForm(request.POST, campaign=campaign)
         if form.is_valid():
             new_admin = form.user_to_add
-            campaign.admins.add(new_admin)
-
-            CampaignAction.objects.create(
-                campaign=campaign,
-                user=request.user,
-                description=f"Arbitrator added: {new_admin.username}",
-                owner=request.user,
-            )
+            # Granting admin is a trust-boundary change: the grant and its
+            # audit record must land together.
+            with transaction.atomic():
+                campaign.admins.add(new_admin)
+                CampaignAction.objects.create(
+                    campaign=campaign,
+                    user=request.user,
+                    description=f"Arbitrator added: {new_admin.username}",
+                    owner=request.user,
+                )
             log_event(
                 user=request.user,
                 noun=EventNoun.CAMPAIGN,
@@ -71,7 +74,11 @@ def campaign_arbitrators(request, id):
         "core/campaign/campaign_arbitrators.html",
         {
             "campaign": campaign,
-            "admins": campaign.admins.order_by("username"),
+            # The owner should never be in admins, but exclude defensively so
+            # weird data can't render them twice or make them removable.
+            "admins": campaign.admins.exclude(id=campaign.owner_id).order_by(
+                "username"
+            ),
             "form": form,
         },
     )
@@ -88,19 +95,23 @@ def campaign_arbitrator_remove(request, id, user_id):
     """
     campaign = get_campaign_admin_or_404(request, id)
     User = get_user_model()
+    # Excluding the owner keeps them irremovable even if weird data ever put
+    # them in the admins M2M.
     admin_to_remove = get_object_or_404(
-        User, id=user_id, administered_campaigns=campaign
+        User.objects.exclude(id=campaign.owner_id),
+        id=user_id,
+        administered_campaigns=campaign,
     )
     removing_self = admin_to_remove == request.user
 
-    campaign.admins.remove(admin_to_remove)
-
-    CampaignAction.objects.create(
-        campaign=campaign,
-        user=request.user,
-        description=f"Arbitrator removed: {admin_to_remove.username}",
-        owner=request.user,
-    )
+    with transaction.atomic():
+        campaign.admins.remove(admin_to_remove)
+        CampaignAction.objects.create(
+            campaign=campaign,
+            user=request.user,
+            description=f"Arbitrator removed: {admin_to_remove.username}",
+            owner=request.user,
+        )
     log_event(
         user=request.user,
         noun=EventNoun.CAMPAIGN,
@@ -113,7 +124,7 @@ def campaign_arbitrator_remove(request, id, user_id):
     messages.success(request, f"{admin_to_remove.username} is no longer an arbitrator.")
 
     # Someone who just removed themselves can no longer see the manage page.
-    if removing_self and campaign.owner != request.user:
+    if removing_self:
         return HttpResponseRedirect(reverse("core:campaign", args=(campaign.id,)))
     return HttpResponseRedirect(
         reverse("core:campaign-arbitrators", args=(campaign.id,))


### PR DESCRIPTION
Arbitrators (shared campaign admins, added in #1922) could previously only be picked from the owners of gangs in the campaign, via a checkbox list on the Edit Campaign form. That had two problems: a fresh campaign rendered the field as an odd empty state (a label with nothing under it), and a neutral arbitrator — someone refereeing without playing a gang — couldn't be added at all.

- Arbitrators are now managed on a dedicated page (`/campaign/<id>/arbitrators`): the current roster with per-row **Remove**, plus an **add-by-username** form. Any user can be added — eligibility is no longer tied to gang ownership.
- Username lookup is case-insensitive with inline validation (unknown user, the owner, already-an-arbitrator). The owner is always an arbitrator and can't be removed; an arbitrator can remove themselves.
- The checkbox field is gone from Edit Campaign; the campaign header's Arbitrators block gains a **Manage** link for admins. Roster changes are still recorded in the campaign action log.

Refs #988

## Test plan

- [x] View tests in `gyrinx/core/tests/test_campaign_admins.py`: add by username (including a user with no gang), case-insensitive match, rejection paths, remove, self-removal redirect, non-admin 404, and that Edit Campaign no longer exposes the roster
- [x] Full suite passes locally
- [x] Manual browser test: removed and re-added an arbitrator (wrong-case username), checked the inline error for an unknown username, and confirmed the Manage link and the field's removal from Edit Campaign

## How to try it

1. Open a campaign you own → the Arbitrators row in the header → **Manage**.
2. Add any user by username — they don't need a gang in the campaign.
3. Remove them from the same page; check the Action Log records both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
