### PR TITLE
feat: post-battle editor iteration — gang gains, captures, states, multiple injuries, mass XP

### DIFF
--- a/gyrinx/core/forms/post_battle.py
+++ b/gyrinx/core/forms/post_battle.py
@@ -1,37 +1,95 @@
 """Form for the bulk post-battle updates editor.
 
 One dynamic form builds a set of per-fighter fields (XP, per-counter deltas,
-injury + reason, private notes) plus a single battle selector. Every field is
-optional; the view acts only on the ones that were filled in or changed. Field
-names are prefixed by fighter pk so a single ``request.POST`` carries the whole
-grid.
+injuries, captured-by) plus gang-level fields (battle selector, credits gained,
+per-resource deltas, assets claimed). Every field is optional; the view acts
+only on the ones that were filled in. Field names are prefixed by fighter pk so
+a single ``request.POST`` carries the whole grid.
 """
 
 from django import forms
 
 from gyrinx.core.forms.list import available_injuries_for_fighter
 from gyrinx.core.models.battle import Battle
+from gyrinx.core.models.campaign import CampaignAsset
+from gyrinx.core.models.list import List, ListFighter
 from gyrinx.forms import group_select
 
 
-class PostBattleUpdatesForm(forms.Form):
-    """Bulk per-fighter post-battle edits for one list.
+class RepeatedSelect(forms.SelectMultiple):
+    """A ``<select>`` whose name may appear multiple times in the payload.
 
-    Pass the list's fighters via ``fighters`` and the campaign's selectable
-    battles via ``battles``. For each fighter the form gains:
+    Renders as a plain single-value select (no ``multiple`` attribute); the
+    page's JS clones it so users can add several rows, and the values are
+    collected with ``getlist``. Without JS it degrades to one select.
+    """
+
+    allow_multiple_selected = False
+
+
+class RepeatedModelChoiceField(forms.ModelMultipleChoiceField):
+    """Collects repeated single-selects into a list of model instances.
+
+    Unlike the parent, blank rows (untouched cloned selects) are ignored
+    rather than rejected, and duplicates + submission order are preserved —
+    a fighter really can suffer the same lasting injury twice in one battle.
+    """
+
+    widget = RepeatedSelect
+
+    def clean(self, value):
+        values = [v for v in (value or []) if v]
+        by_pk = {str(obj.pk): obj for obj in super().clean(values)}
+        return [by_pk[str(v)] for v in values]
+
+
+def can_be_captured(fighter):
+    """Whether the capture flow applies: alive and not already captured/sold."""
+    return not fighter.is_dead and fighter.captured_state is None
+
+
+class PostBattleUpdatesForm(forms.Form):
+    """Bulk post-battle edits for one list.
+
+    Pass the list's fighters via ``fighters``, the campaign's selectable
+    battles via ``battles``, gangs that could capture a fighter via
+    ``capture_lists``, the list's campaign resources via ``resources`` and
+    claimable campaign assets via ``assets``. Gang-level fields:
+
+    - ``battle`` — links every logged action to a battle.
+    - ``credits_gained`` — credits to add to the gang (optional, positive).
+    - ``resource_<pk>`` — one per campaign resource, a delta.
+    - ``assets_captured`` — campaign assets to claim (repeated select).
+
+    For each fighter the form gains:
 
     - ``xp_<pk>`` — XP to add (optional, positive).
     - ``counter_<pk>_<counter_pk>`` — one per applicable counter, a delta.
-    - ``injury_<pk>`` — an injury to apply (optional), filtered per fighter.
-    - ``injury_reason_<pk>`` — required reason when an injury is chosen.
-    - ``private_notes_<pk>`` — pre-filled private notes (rich text).
-
-    Plus a single ``battle`` selector that links every logged action to a battle.
+    - ``injury_<pk>`` — injuries to apply (repeated select), filtered per
+      fighter.
+    - ``state_<pk>`` — explicit state to put the fighter into (recovery,
+      convalescence, dead, …; only present for fighters not already dead).
+    - ``captured_by_<pk>`` — gang that captured the fighter (only present for
+      fighters that can be captured).
     """
 
-    def __init__(self, *args, fighters=None, battles=None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        fighters=None,
+        battles=None,
+        capture_lists=None,
+        resources=None,
+        assets=None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.fighters = list(fighters or [])
+        self.resources = list(resources or [])
+        capture_lists = (
+            capture_lists if capture_lists is not None else List.objects.none()
+        )
+        assets = assets if assets is not None else CampaignAsset.objects.none()
 
         self.fields["battle"] = forms.ModelChoiceField(
             required=False,
@@ -39,6 +97,50 @@ class PostBattleUpdatesForm(forms.Form):
             empty_label="---",
             widget=forms.Select(attrs={"class": "form-select"}),
             label="Link to a battle",
+        )
+
+        self.fields["credits_gained"] = forms.IntegerField(
+            required=False,
+            min_value=1,
+            widget=forms.NumberInput(
+                attrs={
+                    "class": "form-control form-control-sm",
+                    "min": 1,
+                    "placeholder": "+¢",
+                    "aria-label": "Credits gained by the gang",
+                }
+            ),
+        )
+
+        for resource in self.resources:
+            self.fields[f"resource_{resource.pk}"] = forms.IntegerField(
+                required=False,
+                widget=forms.NumberInput(
+                    attrs={
+                        "class": "form-control form-control-sm",
+                        "placeholder": "±0",
+                        "aria-label": f"{resource.resource_type.name} change",
+                    }
+                ),
+            )
+
+        assets_field = RepeatedModelChoiceField(
+            required=False,
+            queryset=assets,
+            label="Assets claimed",
+        )
+        assets_field.widget.attrs.update(
+            {
+                "class": "form-select form-select-sm",
+                "aria-label": "Asset claimed by the gang",
+            }
+        )
+        assets_field.label_from_instance = _asset_label
+        self.fields["assets_captured"] = assets_field
+        group_select(
+            self,
+            "assets_captured",
+            key=lambda a: a.asset_type.name_plural,
         )
 
         for fighter in self.fighters:
@@ -53,6 +155,7 @@ class PostBattleUpdatesForm(forms.Form):
                         "min": 1,
                         "placeholder": "+XP",
                         "aria-label": f"XP to add for {fighter.name}",
+                        "data-pb-xp": "",
                     }
                 ),
             )
@@ -71,16 +174,15 @@ class PostBattleUpdatesForm(forms.Form):
                 )
 
             injury_field = f"injury_{pk}"
-            self.fields[injury_field] = forms.ModelChoiceField(
+            self.fields[injury_field] = RepeatedModelChoiceField(
                 required=False,
                 queryset=available_injuries_for_fighter(fighter),
-                empty_label="—",
-                widget=forms.Select(
-                    attrs={
-                        "class": "form-select form-select-sm",
-                        "aria-label": f"Injury for {fighter.name}",
-                    }
-                ),
+            )
+            self.fields[injury_field].widget.attrs.update(
+                {
+                    "class": "form-select form-select-sm",
+                    "aria-label": f"Injury for {fighter.name}",
+                }
             )
             group_select(
                 self,
@@ -88,39 +190,50 @@ class PostBattleUpdatesForm(forms.Form):
                 key=lambda x: x.injury_group.name if x.injury_group else "Other",
             )
 
-            self.fields[f"injury_reason_{pk}"] = forms.CharField(
-                required=False,
-                max_length=255,
-                widget=forms.TextInput(
-                    attrs={
-                        "class": "form-control form-control-sm",
-                        "placeholder": "Reason",
-                        "aria-label": f"Injury reason for {fighter.name}",
-                    }
-                ),
-            )
+            if not fighter.is_dead:
+                # Leaving DEAD must go through the resurrect flow (cost
+                # restoration), so already-dead fighters get no state field.
+                self.fields[f"state_{pk}"] = forms.ChoiceField(
+                    required=False,
+                    choices=[("", "—")] + list(ListFighter.INJURY_STATE_CHOICES),
+                    widget=forms.Select(
+                        attrs={
+                            "class": "form-select form-select-sm",
+                            "aria-label": f"State for {fighter.name}",
+                        }
+                    ),
+                )
 
-            self.fields[f"private_notes_{pk}"] = forms.CharField(
-                required=False,
-                initial=fighter.private_notes,
-                widget=forms.Textarea(
-                    attrs={
-                        "class": "form-control",
-                        "rows": 4,
-                        "placeholder": "Private notes (only visible to you)",
-                        "aria-label": f"Private notes for {fighter.name}",
-                    }
-                ),
-            )
+            if can_be_captured(fighter) and capture_lists:
+                self.fields[f"captured_by_{pk}"] = forms.ModelChoiceField(
+                    required=False,
+                    queryset=capture_lists,
+                    empty_label="—",
+                    widget=forms.Select(
+                        attrs={
+                            "class": "form-select form-select-sm",
+                            "aria-label": f"Gang that captured {fighter.name}",
+                        }
+                    ),
+                )
 
     def clean(self):
         cleaned = super().clean()
-        # An injury must come with a reason.
-        for fighter in self.fighters:
-            pk = fighter.pk
-            if (
-                cleaned.get(f"injury_{pk}")
-                and not (cleaned.get(f"injury_reason_{pk}") or "").strip()
-            ):
-                self.add_error(f"injury_reason_{pk}", "Add a reason for this injury.")
+        # Resource losses can't take a resource below zero; validate here so
+        # the whole submit fails cleanly instead of half-applying.
+        for resource in self.resources:
+            field = f"resource_{resource.pk}"
+            delta = cleaned.get(field)
+            if delta and delta < 0 and resource.amount + delta < 0:
+                self.add_error(
+                    field,
+                    f"Cannot reduce {resource.resource_type.name} below zero "
+                    f"(current: {resource.amount}).",
+                )
         return cleaned
+
+
+def _asset_label(asset):
+    if asset.holder:
+        return f"{asset.name} (held by {asset.holder.name})"
+    return f"{asset.name} (unclaimed)"

--- a/gyrinx/core/forms/post_battle.py
+++ b/gyrinx/core/forms/post_battle.py
@@ -8,23 +8,45 @@ a single ``request.POST`` carries the whole grid.
 """
 
 from django import forms
+from django.utils.html import format_html, format_html_join
 
 from gyrinx.core.forms.list import available_injuries_for_fighter
 from gyrinx.core.models.battle import Battle
 from gyrinx.core.models.campaign import CampaignAsset
 from gyrinx.core.models.list import List, ListFighter
 from gyrinx.forms import group_select
+from gyrinx.models import FighterCategoryChoices
 
 
 class RepeatedSelect(forms.SelectMultiple):
     """A ``<select>`` whose name may appear multiple times in the payload.
 
-    Renders as a plain single-value select (no ``multiple`` attribute); the
-    page's JS clones it so users can add several rows, and the values are
-    collected with ``getlist``. Without JS it degrades to one select.
+    Renders one single-value select (no ``multiple`` attribute) per submitted
+    value — each wrapped in a ``data-pb-repeat-item`` row so a bound re-render
+    (validation error) keeps every selection visible. The page's JS clones a
+    row so users can add more; values are collected with ``getlist``. Without
+    JS it degrades to one select.
     """
 
     allow_multiple_selected = False
+
+    def render(self, name, value, attrs=None, renderer=None):
+        values = [v for v in (value or []) if v not in (None, "")]
+        if not values:
+            values = [None]
+        parts = []
+        for i, v in enumerate(values):
+            item_attrs = None if attrs is None else dict(attrs)
+            if i and item_attrs:
+                # Only the first select keeps the id the label points at.
+                item_attrs.pop("id", None)
+            parts.append(
+                format_html(
+                    '<div class="d-flex gap-1 align-items-center" data-pb-repeat-item>{}</div>',
+                    super().render(name, v, item_attrs, renderer),
+                )
+            )
+        return format_html_join("", "{}", ((p,) for p in parts))
 
 
 class RepeatedModelChoiceField(forms.ModelMultipleChoiceField):
@@ -66,9 +88,10 @@ class PostBattleUpdatesForm(forms.Form):
     - ``xp_<pk>`` — XP to add (optional, positive).
     - ``counter_<pk>_<counter_pk>`` — one per applicable counter, a delta.
     - ``injury_<pk>`` — injuries to apply (repeated select), filtered per
-      fighter.
+      fighter (only present for fighters not already dead).
     - ``state_<pk>`` — explicit state to put the fighter into (recovery,
-      convalescence, dead, …; only present for fighters not already dead).
+      convalescence, dead; in repair for vehicles; only present for fighters
+      not already dead).
     - ``captured_by_<pk>`` — gang that captured the fighter (only present for
       fighters that can be captured).
     """
@@ -89,6 +112,7 @@ class PostBattleUpdatesForm(forms.Form):
         capture_lists = (
             capture_lists if capture_lists is not None else List.objects.none()
         )
+        has_capture_lists = capture_lists.exists()
         assets = assets if assets is not None else CampaignAsset.objects.none()
 
         self.fields["battle"] = forms.ModelChoiceField(
@@ -173,29 +197,44 @@ class PostBattleUpdatesForm(forms.Form):
                     ),
                 )
 
-            injury_field = f"injury_{pk}"
-            self.fields[injury_field] = RepeatedModelChoiceField(
-                required=False,
-                queryset=available_injuries_for_fighter(fighter),
-            )
-            self.fields[injury_field].widget.attrs.update(
-                {
-                    "class": "form-select form-select-sm",
-                    "aria-label": f"Injury for {fighter.name}",
-                }
-            )
-            group_select(
-                self,
-                injury_field,
-                key=lambda x: x.injury_group.name if x.injury_group else "Other",
-            )
-
             if not fighter.is_dead:
-                # Leaving DEAD must go through the resurrect flow (cost
-                # restoration), so already-dead fighters get no state field.
+                # Dead fighters get no injury or state fields: a further
+                # injury would re-run (or bypass) the kill flow, and leaving
+                # DEAD must go through the resurrect flow (cost restoration).
+                injury_field = f"injury_{pk}"
+                self.fields[injury_field] = RepeatedModelChoiceField(
+                    required=False,
+                    queryset=available_injuries_for_fighter(fighter),
+                )
+                self.fields[injury_field].widget.attrs.update(
+                    {
+                        "class": "form-select form-select-sm",
+                        "aria-label": f"Injury for {fighter.name}",
+                    }
+                )
+                group_select(
+                    self,
+                    injury_field,
+                    key=lambda x: x.injury_group.name if x.injury_group else "Other",
+                )
+
+                # Mirror EditFighterStateForm: vehicles repair, they don't
+                # recover, convalesce or die.
+                if fighter.content_fighter.category == FighterCategoryChoices.VEHICLE:
+                    state_choices = [
+                        (ListFighter.ACTIVE, "Active"),
+                        (ListFighter.IN_REPAIR, "In Repair"),
+                    ]
+                else:
+                    state_choices = [
+                        (ListFighter.ACTIVE, "Active"),
+                        (ListFighter.RECOVERY, "Recovery"),
+                        (ListFighter.CONVALESCENCE, "Convalescence"),
+                        (ListFighter.DEAD, "Dead"),
+                    ]
                 self.fields[f"state_{pk}"] = forms.ChoiceField(
                     required=False,
-                    choices=[("", "—")] + list(ListFighter.INJURY_STATE_CHOICES),
+                    choices=[("", "—")] + state_choices,
                     widget=forms.Select(
                         attrs={
                             "class": "form-select form-select-sm",
@@ -204,7 +243,7 @@ class PostBattleUpdatesForm(forms.Form):
                     ),
                 )
 
-            if can_be_captured(fighter) and capture_lists:
+            if can_be_captured(fighter) and has_capture_lists:
                 self.fields[f"captured_by_{pk}"] = forms.ModelChoiceField(
                     required=False,
                     queryset=capture_lists,
@@ -216,6 +255,13 @@ class PostBattleUpdatesForm(forms.Form):
                         }
                     ),
                 )
+
+        # A stronger border on every input, matching the steppers' outline
+        # buttons so the grid's controls read as one set.
+        for field in self.fields.values():
+            css = field.widget.attrs.get("class", "")
+            if "border-secondary" not in css:
+                field.widget.attrs["class"] = f"{css} border-secondary".strip()
 
     def clean(self):
         cleaned = super().clean()

--- a/gyrinx/core/handlers/fighter/capture.py
+++ b/gyrinx/core/handlers/fighter/capture.py
@@ -77,6 +77,7 @@ def handle_fighter_capture(
     user,
     fighter: ListFighter,
     capturing_list: List,
+    battle=None,
 ) -> FighterCaptureResult:
     """
     Handle the capture of a fighter by another gang.
@@ -93,6 +94,7 @@ def handle_fighter_capture(
         user: The user performing the capture
         fighter: The fighter being captured
         capturing_list: The gang capturing the fighter
+        battle: Optional Battle to attach the CampaignAction to
 
     Returns:
         FighterCaptureResult with all created objects
@@ -210,6 +212,7 @@ def handle_fighter_capture(
             owner=user,
             campaign=original_list.campaign,
             list=original_list,
+            battle=battle,
             description=description,
             outcome=f"Rating reduced by {total_cost}¢",
         )

--- a/gyrinx/core/handlers/list/credits.py
+++ b/gyrinx/core/handlers/list/credits.py
@@ -36,6 +36,7 @@ def handle_credits_modification(
     operation: Literal["add", "spend", "reduce"],
     amount: int,
     description: str = "",
+    battle=None,
 ) -> CreditsModificationResult:
     """
     Handle modification of credits on a list.
@@ -58,6 +59,7 @@ def handle_credits_modification(
         operation: Type of operation ("add", "spend", "reduce")
         amount: Amount of credits to add/spend/reduce (must be >= 0)
         description: Optional description of the reason for the change
+        battle: Optional Battle to attach the CampaignAction to
 
     Returns:
         CreditsModificationResult with all details
@@ -151,6 +153,7 @@ def handle_credits_modification(
             owner=user,
             campaign=lst.campaign,
             list=lst,
+            battle=battle,
             description=action_desc,
             outcome=outcome,
         )

--- a/gyrinx/core/models/campaign.py
+++ b/gyrinx/core/models/campaign.py
@@ -711,12 +711,13 @@ class CampaignAsset(AppBase):
 
         return result
 
-    def transfer_to(self, new_holder, user):
+    def transfer_to(self, new_holder, user, battle=None):
         """Transfer this asset to a new holder and log the action
 
         Args:
             new_holder: The List that will hold this asset (can be None)
             user: The User performing the transfer (required)
+            battle: Optional Battle to attach the logged action to
         """
         if not user:
             raise ValueError("User is required for asset transfers")
@@ -735,6 +736,7 @@ class CampaignAsset(AppBase):
                 campaign=self.asset_type.campaign,
                 user=user,
                 list=new_holder,
+                battle=battle,
                 description=description,
                 dice_count=0,
                 owner=user,
@@ -813,12 +815,13 @@ class CampaignListResource(AppBase):
     def __str__(self):
         return f"{self.list.name} - {self.resource_type.name}: {self.amount}"
 
-    def modify_amount(self, modification, user):
+    def modify_amount(self, modification, user, battle=None):
         """Modify the resource amount and log the action
 
         Args:
             modification: Integer amount to add (positive) or subtract (negative)
             user: The User performing the modification
+            battle: Optional Battle to attach the logged action to
 
         Raises:
             ValueError: If modification would result in negative amount
@@ -847,6 +850,7 @@ class CampaignListResource(AppBase):
             campaign=self.campaign,
             user=user,
             list=self.list,
+            battle=battle,
             description=description,
             dice_count=0,
             owner=user,

--- a/gyrinx/core/templates/core/includes/number_stepper.html
+++ b/gyrinx/core/templates/core/includes/number_stepper.html
@@ -1,0 +1,23 @@
+{% comment %}
+A compact number input with −/+ nudge buttons.
+
+Pass `field` (a bound IntegerField rendered as a number input) and `label`
+(short name used in the buttons' aria-labels). The page must include the
+shared stepper JS (see list_post_battle_updates.html) to wire the buttons;
+without JS the native number input still works.
+{% endcomment %}
+<div class="input-group input-group-sm flex-nowrap" data-stepper>
+    <button type="button"
+            class="btn btn-outline-secondary px-2"
+            data-step="-1"
+            aria-label="Decrease {{ label|default:'value' }}">
+        <i class="bi-dash-lg"></i>
+    </button>
+    {{ field }}
+    <button type="button"
+            class="btn btn-outline-secondary px-2"
+            data-step="1"
+            aria-label="Increase {{ label|default:'value' }}">
+        <i class="bi-plus-lg"></i>
+    </button>
+</div>

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -1,5 +1,4 @@
 {% extends "core/layouts/base.html" %}
-{% load static custom_tags %}
 {% block head_title %}
     Post-battle updates - {{ list.name }}
 {% endblock head_title %}
@@ -9,11 +8,11 @@
     <div class="col-12 px-0 vstack gap-3">
         <h1 class="h3 mb-0">Post-battle updates</h1>
         <p class="text-secondary mb-0">
-            Record what happened this battle across the whole gang. The action fields
-            start blank and notes show what's already saved — only what you fill in or
-            change is applied, nothing else is touched.
+            Record what happened this battle — what the gang gained at the top, then
+            what happened to each fighter. Everything starts blank and only what you
+            fill in is applied, nothing else is touched.
         </p>
-        <form method="post" data-pb-form>
+        <form method="post">
             {% csrf_token %}
             {% if rows %}
                 <div class="vstack gap-4">
@@ -33,63 +32,190 @@
                             <div class="form-text">Actions logged below will be attached to this battle.</div>
                         </div>
                     {% endif %}
-                    <div class="border-top">
-                        {% for row in rows %}
-                            <div class="py-3 border-bottom">
-                                <div class="d-flex flex-wrap align-items-baseline gap-2 mb-2">
-                                    <span class="fw-semibold fs-5">{{ row.fighter.name }}</span>
-                                    <span class="text-secondary fw-normal">{{ row.fighter.get_category_label }}</span>
-                                    {% if row.fighter.is_dead %}
-                                        <span class="badge text-bg-dark">Dead</span>
-                                    {% elif not row.fighter.is_active %}
-                                        <span class="badge text-bg-secondary">{{ row.fighter.get_injury_state_display }}</span>
-                                    {% endif %}
+                    <div>
+                        <div class="d-flex justify-content-between align-items-center mb-3 bg-body-secondary rounded px-2 py-1">
+                            <h2 class="h5 mb-0">Gang results</h2>
+                        </div>
+                        <div class="px-2 row g-2 g-md-3">
+                            <div class="col-6 col-md-3 col-lg-2">
+                                <label class="form-label fs-7 mb-1"
+                                       for="{{ form.credits_gained.id_for_label }}">
+                                    Credits gained
+                                    <span class="text-secondary">({{ list.credits_current }}¢)</span>
+                                </label>
+                                {% include "core/includes/number_stepper.html" with field=form.credits_gained label="credits gained" %}
+                                {% for error in form.credits_gained.errors %}
+                                    <div class="text-danger fs-7">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            {% for entry in resource_fields %}
+                                <div class="col-6 col-md-3 col-lg-2">
+                                    <label class="form-label fs-7 mb-1" for="{{ entry.field.id_for_label }}">
+                                        {{ entry.resource.resource_type.name }}
+                                        <span class="text-secondary">({{ entry.resource.amount }})</span>
+                                    </label>
+                                    {% include "core/includes/number_stepper.html" with field=entry.field label=entry.resource.resource_type.name %}
+                                    {% for error in entry.field.errors %}
+                                        <div class="text-danger fs-7">{{ error }}</div>
+                                    {% endfor %}
                                 </div>
-                                <div class="row g-2 g-md-3">
-                                    <div class="col-6 col-md-2">
-                                        <label class="form-label fs-7 mb-1" for="{{ row.xp.id_for_label }}">
-                                            Add XP
-                                            <span class="text-secondary">({{ row.fighter.xp_current }})</span>
-                                        </label>
-                                        {{ row.xp }}
-                                        {% for error in row.xp.errors %}
-                                            <div class="text-danger fs-7">{{ error }}</div>
-                                        {% endfor %}
+                            {% endfor %}
+                            {% if has_assets %}
+                                <div class="col-12 col-md-6 col-lg-4">
+                                    <label class="form-label fs-7 mb-1"
+                                           for="{{ form.assets_captured.id_for_label }}">
+                                        Assets claimed
+                                        <span class="text-secondary fs-7">(Territories and other Assets won this battle)</span>
+                                    </label>
+                                    <div class="vstack gap-1" data-pb-repeat>
+                                        <div class="d-flex gap-1 align-items-center" data-pb-repeat-item>{{ form.assets_captured }}</div>
+                                        <div>
+                                            <a href="#" class="fs-7 icon-link linked" data-pb-repeat-add hidden><i class="bi-plus-lg"></i> Add another</a>
+                                        </div>
                                     </div>
-                                    {% for c in row.counters %}
+                                    {% for error in form.assets_captured.errors %}
+                                        <div class="text-danger fs-7">{{ error }}</div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div>
+                        <div class="d-flex justify-content-between align-items-center bg-body-secondary rounded px-2 py-1">
+                            <h2 class="h5 mb-0">Fighters</h2>
+                        </div>
+                        <div class="d-flex flex-wrap align-items-center gap-2 py-2 px-2 border-bottom sticky-top bg-body"
+                             data-pb-jsonly
+                             data-pb-toolbar
+                             hidden>
+                            <div class="form-check mb-0">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       id="pb-select-all"
+                                       data-pb-select-all
+                                       aria-label="Select all fighters">
+                                <label class="form-check-label fs-7" for="pb-select-all">
+                                    <span data-pb-count>0</span> selected
+                                </label>
+                            </div>
+                            <div class="ms-auto d-flex flex-wrap align-items-center gap-2">
+                                <div class="input-group input-group-sm flex-nowrap w-auto"
+                                     data-stepper
+                                     data-stepper-floor>
+                                    <button type="button"
+                                            class="btn btn-outline-secondary px-2"
+                                            data-step="-1"
+                                            aria-label="Decrease XP amount">
+                                        <i class="bi-dash-lg"></i>
+                                    </button>
+                                    {# djlint:off H021 #}
+                                    <input type="number"
+                                           class="form-control form-control-sm text-center"
+                                           style="max-width: 3.5rem"
+                                           min="1"
+                                           value="1"
+                                           data-pb-xp-amount
+                                           aria-label="XP to apply to selected fighters">
+                                    {# djlint:on H021 #}
+                                    <button type="button"
+                                            class="btn btn-outline-secondary px-2"
+                                            data-step="1"
+                                            aria-label="Increase XP amount">
+                                        <i class="bi-plus-lg"></i>
+                                    </button>
+                                </div>
+                                <button type="button"
+                                        class="btn btn-primary btn-sm text-nowrap"
+                                        data-pb-xp-add
+                                        disabled>Add XP to selected</button>
+                                <button type="button"
+                                        class="btn btn-outline-secondary btn-sm text-nowrap"
+                                        data-pb-xp-clear
+                                        disabled>Clear XP</button>
+                            </div>
+                        </div>
+                        <div class="border-top">
+                            {% for row in rows %}
+                                <div class="py-3 border-bottom" data-pb-row>
+                                    <div class="d-flex flex-wrap align-items-baseline gap-2 mb-2">
+                                        <span data-pb-jsonly hidden>
+                                            <input class="form-check-input"
+                                                   type="checkbox"
+                                                   data-pb-select
+                                                   aria-label="Select {{ row.fighter.name }}">
+                                        </span>
+                                        <span class="fw-semibold fs-5">{{ row.fighter.name }}</span>
+                                        <span class="text-secondary fw-normal">{{ row.fighter.get_category_label }}</span>
+                                        {% if row.fighter.is_dead %}
+                                            <span class="badge text-bg-dark">Dead</span>
+                                        {% elif row.fighter.is_captured %}
+                                            <span class="badge text-bg-warning">Captured</span>
+                                        {% elif row.fighter.is_sold_to_guilders %}
+                                            <span class="badge text-bg-secondary">Sold</span>
+                                        {% elif not row.fighter.is_active %}
+                                            <span class="badge text-bg-secondary">{{ row.fighter.get_injury_state_display }}</span>
+                                        {% endif %}
+                                    </div>
+                                    <div class="row g-2 g-md-3">
                                         <div class="col-6 col-md-2">
-                                            <label class="form-label fs-7 mb-1" for="{{ c.field.id_for_label }}">
-                                                {{ c.counter.name }}
-                                                <span class="text-secondary">({{ c.value }})</span>
+                                            <label class="form-label fs-7 mb-1" for="{{ row.xp.id_for_label }}">
+                                                Add XP
+                                                <span class="text-secondary">({{ row.fighter.xp_current }})</span>
                                             </label>
-                                            {{ c.field }}
-                                            {% for error in c.field.errors %}
+                                            {% include "core/includes/number_stepper.html" with field=row.xp label="XP" %}
+                                            {% for error in row.xp.errors %}
                                                 <div class="text-danger fs-7">{{ error }}</div>
                                             {% endfor %}
                                         </div>
-                                    {% endfor %}
-                                    <div class="col-12 col-md">
-                                        <label class="form-label fs-7 mb-1" for="{{ row.injury.id_for_label }}">Injury</label>
-                                        {{ row.injury }}
-                                        {% for error in row.injury.errors %}
-                                            <div class="text-danger fs-7">{{ error }}</div>
+                                        {% for c in row.counters %}
+                                            <div class="col-6 col-md-2">
+                                                <label class="form-label fs-7 mb-1" for="{{ c.field.id_for_label }}">
+                                                    {{ c.counter.name }}
+                                                    <span class="text-secondary">({{ c.value }})</span>
+                                                </label>
+                                                {% include "core/includes/number_stepper.html" with field=c.field label=c.counter.name %}
+                                                {% for error in c.field.errors %}
+                                                    <div class="text-danger fs-7">{{ error }}</div>
+                                                {% endfor %}
+                                            </div>
                                         {% endfor %}
-                                    </div>
-                                    <div class="col-12 col-md">
-                                        <label class="form-label fs-7 mb-1"
-                                               for="{{ row.injury_reason.id_for_label }}">Reason</label>
-                                        {{ row.injury_reason }}
-                                        {% for error in row.injury_reason.errors %}
-                                            <div class="text-danger fs-7">{{ error }}</div>
-                                        {% endfor %}
+                                        <div class="col-12 col-md">
+                                            <label class="form-label fs-7 mb-1" for="{{ row.injury.id_for_label }}">Injuries</label>
+                                            <div class="vstack gap-1" data-pb-repeat>
+                                                <div class="d-flex gap-1 align-items-center" data-pb-repeat-item>{{ row.injury }}</div>
+                                                <div>
+                                                    <a href="#" class="fs-7 icon-link linked" data-pb-repeat-add hidden><i class="bi-plus-lg"></i> Add another injury</a>
+                                                </div>
+                                            </div>
+                                            {% for error in row.injury.errors %}
+                                                <div class="text-danger fs-7">{{ error }}</div>
+                                            {% endfor %}
+                                        </div>
+                                        {% if row.state %}
+                                            <div class="col-6 col-md-2">
+                                                <label class="form-label fs-7 mb-1" for="{{ row.state.id_for_label }}">
+                                                    State
+                                                    <span class="text-secondary">({{ row.fighter.get_injury_state_display }})</span>
+                                                </label>
+                                                {{ row.state }}
+                                                {% for error in row.state.errors %}
+                                                    <div class="text-danger fs-7">{{ error }}</div>
+                                                {% endfor %}
+                                            </div>
+                                        {% endif %}
+                                        {% if row.captured_by %}
+                                            <div class="col-12 col-md-3">
+                                                <label class="form-label fs-7 mb-1" for="{{ row.captured_by.id_for_label }}">Captured by</label>
+                                                {{ row.captured_by }}
+                                                {% for error in row.captured_by.errors %}
+                                                    <div class="text-danger fs-7">{{ error }}</div>
+                                                {% endfor %}
+                                            </div>
+                                        {% endif %}
                                     </div>
                                 </div>
-                                <details class="mt-2" data-pb-notes>
-                                    <summary class="fs-7 linked">Private notes</summary>
-                                    <div class="mt-2">{{ row.private_notes }}</div>
-                                </details>
-                            </div>
-                        {% endfor %}
+                            {% endfor %}
+                        </div>
                     </div>
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-success">Apply updates</button>
@@ -104,60 +230,135 @@
         </form>
     </div>
     {% if rows %}
-        <script src="{% static 'tinymce/tinymce.min.js' %}"></script>
         <script>
          (function () {
-             function initEditor(ta) {
-                 if (!window.tinymce || ta.dataset.pbInit) return;
-                 ta.dataset.pbInit = "1";
-                 var dark = document.documentElement.getAttribute("data-bs-theme") === "dark";
-                 window.tinymce.init({
-                     target: ta,
-                     menubar: false,
-                     statusbar: false,
-                     plugins: "lists link autolink autoresize",
-                     toolbar: "bold italic underline | bullist numlist | link | removeformat",
-                     min_height: 180,
-                     branding: false,
-                     promotion: false,
-                     skin: dark ? "oxide-dark" : "oxide",
-                     content_css: dark ? "dark" : "default",
-                 });
-             }
-             document.querySelectorAll("details[data-pb-notes]").forEach(function (d) {
-                 d.addEventListener("toggle", function () {
-                     if (d.open) {
-                         var ta = d.querySelector("textarea");
-                         if (ta) initEditor(ta);
+             // Reveal JS-only affordances (row checkboxes, mass-XP toolbar).
+             document.querySelectorAll("[data-pb-jsonly]").forEach(function (el) {
+                 el.hidden = false;
+             });
+
+             // --- Steppers: −/+ nudge buttons around number inputs. -------
+             // Below the input's min the value clears back to "no change";
+             // with data-stepper-floor it clamps at min instead (used by the
+             // toolbar's XP amount, where empty makes no sense).
+             document.addEventListener("click", function (e) {
+                 var btn = e.target.closest("[data-step]");
+                 if (!btn) return;
+                 var group = btn.closest("[data-stepper]");
+                 var input = group && group.querySelector("input");
+                 if (!input) return;
+                 var step = parseInt(btn.dataset.step, 10);
+                 var min = input.min === "" ? null : parseInt(input.min, 10);
+                 var floor = group.hasAttribute("data-stepper-floor");
+                 var val = input.value === "" ? null : parseInt(input.value, 10);
+                 var next;
+                 if (val === null || isNaN(val)) {
+                     if (step > 0) {
+                         next = min !== null ? Math.max(min, step) : step;
+                     } else {
+                         next = min !== null ? null : step;
                      }
+                 } else {
+                     next = val + step;
+                     if (min !== null && next < min) next = floor ? min : null;
+                     // For min-less deltas (counters, resources) zero means
+                     // "no change" — clear rather than submit a pointless 0.
+                     if (next === 0 && min === null) next = null;
+                 }
+                 input.value = next === null ? "" : next;
+                 input.dispatchEvent(new Event("change", { bubbles: true }));
+             });
+
+             // --- Repeatable selects: injuries and assets. ----------------
+             // The form field collects repeated names via getlist, so extra
+             // rows are just clones of the original select.
+             document.querySelectorAll("[data-pb-repeat]").forEach(function (wrap) {
+                 var add = wrap.querySelector("[data-pb-repeat-add]");
+                 if (!add) return;
+                 add.hidden = false;
+                 add.addEventListener("click", function (e) {
+                     e.preventDefault();
+                     var first = wrap.querySelector("[data-pb-repeat-item]");
+                     var clone = first.cloneNode(true);
+                     var select = clone.querySelector("select");
+                     select.value = "";
+                     select.removeAttribute("id");
+                     var rm = document.createElement("button");
+                     rm.type = "button";
+                     rm.className = "btn btn-outline-secondary btn-sm px-2";
+                     rm.setAttribute("aria-label", "Remove this row");
+                     var rmIcon = document.createElement("i");
+                     rmIcon.className = "bi-x-lg";
+                     rm.appendChild(rmIcon);
+                     rm.addEventListener("click", function () {
+                         clone.remove();
+                     });
+                     clone.appendChild(rm);
+                     wrap.insertBefore(clone, add.parentElement);
+                     select.focus();
                  });
              });
-             // Reason is only meaningful alongside an injury: keep it disabled
-             // until one is chosen. Server-side validation is the source of
-             // truth; this is just an affordance, so no-JS submits still work.
-             document.querySelectorAll('select[name^="injury_"]').forEach(function (sel) {
-                 var reason = document.querySelector(
-                     '[name="' + sel.name.replace(/^injury_/, "injury_reason_") + '"]'
-                 );
-                 if (!reason) return;
-                 function sync() { reason.disabled = !sel.value; }
-                 sel.addEventListener("change", sync);
+
+             // --- Mass XP: select fighters, apply an amount to all. -------
+             var toolbar = document.querySelector("[data-pb-toolbar]");
+             if (!toolbar) return;
+             var selectAll = toolbar.querySelector("[data-pb-select-all]");
+             var count = toolbar.querySelector("[data-pb-count]");
+             var amountInput = toolbar.querySelector("[data-pb-xp-amount]");
+             var addBtn = toolbar.querySelector("[data-pb-xp-add]");
+             var clearBtn = toolbar.querySelector("[data-pb-xp-clear]");
+             var boxes = Array.prototype.slice.call(
+                 document.querySelectorAll("[data-pb-select]")
+             );
+
+             function selected() {
+                 return boxes.filter(function (b) { return b.checked; });
+             }
+
+             function sync() {
+                 var n = selected().length;
+                 count.textContent = n;
+                 addBtn.disabled = n === 0;
+                 clearBtn.disabled = n === 0;
+                 selectAll.checked = n > 0 && n === boxes.length;
+                 selectAll.indeterminate = n > 0 && n < boxes.length;
+             }
+
+             boxes.forEach(function (b) {
+                 b.addEventListener("change", sync);
+             });
+             selectAll.addEventListener("change", function () {
+                 boxes.forEach(function (b) { b.checked = selectAll.checked; });
                  sync();
              });
-             var form = document.querySelector("form[data-pb-form]");
-             if (form) {
-                 form.addEventListener("submit", function () {
-                     if (!window.tinymce) return;
-                     // Only write back editors the user actually edited. Merely
-                     // opening a fighter's notes mounts TinyMCE, which would
-                     // reserialise the HTML on a blanket triggerSave() and log a
-                     // spurious "notes changed" — so leave clean editors' textareas
-                     // holding their original server-rendered value.
-                     window.tinymce.get().forEach(function (ed) {
-                         if (ed.isDirty()) ed.save();
-                     });
-                 });
+
+             function xpInputFor(box) {
+                 var row = box.closest("[data-pb-row]");
+                 return row && row.querySelector("[data-pb-xp]");
              }
+
+             addBtn.addEventListener("click", function () {
+                 var amount = parseInt(amountInput.value, 10);
+                 if (isNaN(amount) || amount < 1) amount = 1;
+                 selected().forEach(function (box) {
+                     var input = xpInputFor(box);
+                     if (!input) return;
+                     var current = parseInt(input.value, 10);
+                     input.value = (isNaN(current) ? 0 : current) + amount;
+                     input.dispatchEvent(new Event("change", { bubbles: true }));
+                 });
+             });
+
+             clearBtn.addEventListener("click", function () {
+                 selected().forEach(function (box) {
+                     var input = xpInputFor(box);
+                     if (!input) return;
+                     input.value = "";
+                     input.dispatchEvent(new Event("change", { bubbles: true }));
+                 });
+             });
+
+             sync();
          })();
         </script>
     {% endif %}

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -68,7 +68,7 @@
                                         <span class="text-secondary fs-7">(Territories and other Assets won this battle)</span>
                                     </label>
                                     <div class="vstack gap-1" data-pb-repeat>
-                                        <div class="d-flex gap-1 align-items-center" data-pb-repeat-item>{{ form.assets_captured }}</div>
+                                        {{ form.assets_captured }}
                                         <div>
                                             <a href="#" class="fs-7 icon-link linked" data-pb-repeat-add hidden><i class="bi-plus-lg"></i> Add another</a>
                                         </div>
@@ -110,7 +110,7 @@
                                     </button>
                                     {# djlint:off H021 #}
                                     <input type="number"
-                                           class="form-control form-control-sm text-center"
+                                           class="form-control form-control-sm text-center border-secondary"
                                            style="max-width: 3.5rem"
                                            min="1"
                                            value="1"
@@ -179,18 +179,20 @@
                                                 {% endfor %}
                                             </div>
                                         {% endfor %}
-                                        <div class="col-12 col-md">
-                                            <label class="form-label fs-7 mb-1" for="{{ row.injury.id_for_label }}">Injuries</label>
-                                            <div class="vstack gap-1" data-pb-repeat>
-                                                <div class="d-flex gap-1 align-items-center" data-pb-repeat-item>{{ row.injury }}</div>
-                                                <div>
-                                                    <a href="#" class="fs-7 icon-link linked" data-pb-repeat-add hidden><i class="bi-plus-lg"></i> Add another injury</a>
+                                        {% if row.injury %}
+                                            <div class="col-12 col-md">
+                                                <label class="form-label fs-7 mb-1" for="{{ row.injury.id_for_label }}">Injuries</label>
+                                                <div class="vstack gap-1" data-pb-repeat>
+                                                    {{ row.injury }}
+                                                    <div>
+                                                        <a href="#" class="fs-7 icon-link linked" data-pb-repeat-add hidden><i class="bi-plus-lg"></i> Add another injury</a>
+                                                    </div>
                                                 </div>
+                                                {% for error in row.injury.errors %}
+                                                    <div class="text-danger fs-7">{{ error }}</div>
+                                                {% endfor %}
                                             </div>
-                                            {% for error in row.injury.errors %}
-                                                <div class="text-danger fs-7">{{ error }}</div>
-                                            {% endfor %}
-                                        </div>
+                                        {% endif %}
                                         {% if row.state %}
                                             <div class="col-6 col-md-2">
                                                 <label class="form-label fs-7 mb-1" for="{{ row.state.id_for_label }}">
@@ -230,11 +232,48 @@
         </form>
     </div>
     {% if rows %}
+        {{ injury_phases|json_script:"pb-injury-phases" }}
         <script>
          (function () {
              // Reveal JS-only affordances (row checkboxes, mass-XP toolbar).
              document.querySelectorAll("[data-pb-jsonly]").forEach(function (el) {
                  el.hidden = false;
+             });
+
+             // --- Injury -> state sync, mirroring the single add-injury
+             // screen: choosing an injury pre-fills the row's state select
+             // with the injury's default outcome. Only while the state is
+             // untouched (empty or previously auto-filled) — a manual state
+             // choice always wins.
+             var phasesEl = document.getElementById("pb-injury-phases");
+             var injuryPhases = phasesEl ? JSON.parse(phasesEl.textContent) : {};
+             document.addEventListener("change", function (e) {
+                 var target = e.target;
+                 if (target.matches("select[name^='state_']")) {
+                     // A user-driven change; auto-fills below don't dispatch.
+                     delete target.dataset.pbAuto;
+                     return;
+                 }
+                 if (!target.matches("select[name^='injury_']")) return;
+                 var row = target.closest("[data-pb-row]");
+                 var state = row && row.querySelector("select[name^='state_']");
+                 if (!state) return;
+                 var untouched = state.value === "" || state.dataset.pbAuto === "1";
+                 if (!untouched) return;
+                 var phase = injuryPhases[target.value] || "";
+                 var hasOption = Array.prototype.some.call(
+                     state.options,
+                     function (o) { return o.value === phase; }
+                 );
+                 if (phase && phase !== "no_change" && hasOption) {
+                     state.value = phase;
+                     state.dataset.pbAuto = "1";
+                 } else if (state.dataset.pbAuto === "1") {
+                     // The driving injury was cleared or has no outcome:
+                     // drop the auto-filled state rather than submit it.
+                     state.value = "";
+                     delete state.dataset.pbAuto;
+                 }
              });
 
              // --- Steppers: −/+ nudge buttons around number inputs. -------

--- a/gyrinx/core/tests/test_post_battle_updates.py
+++ b/gyrinx/core/tests/test_post_battle_updates.py
@@ -370,6 +370,158 @@ def test_post_battle_fatal_injury_links_death_action_to_battle(
 
 
 @pytest.mark.django_db
+def test_post_battle_dead_fighter_has_no_injury_or_state_fields(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    dead = make_list_fighter(list_with_campaign, "Corpse")
+    dead.injury_state = ListFighter.DEAD
+    dead.save()
+    injury = ContentInjury.objects.create(
+        name="Sprain", phase=ContentInjuryDefaultOutcome.RECOVERY
+    )
+
+    resp = client.get(reverse("core:list-post-battle", args=[list_with_campaign.id]))
+    form = resp.context["form"]
+    assert f"injury_{dead.pk}" not in form.fields
+    assert f"state_{dead.pk}" not in form.fields
+
+    # A POSTed injury for a dead fighter is ignored, not applied — otherwise
+    # a RECOVERY-outcome injury would pull the fighter out of DEAD without
+    # the resurrect flow (stuck cost_override=0), and a DEAD-outcome injury
+    # would re-run the kill handler.
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"injury_{dead.pk}": str(injury.pk)},
+    )
+    assert resp.status_code == 302
+    dead.refresh_from_db()
+    assert dead.injury_state == ListFighter.DEAD
+    assert ListFighterInjury.objects.filter(fighter=dead).count() == 0
+
+
+@pytest.mark.django_db
+def test_post_battle_vehicle_state_choices(
+    client,
+    user,
+    content_house,
+    list_with_campaign,
+    make_content_fighter,
+    make_list_fighter,
+):
+    from gyrinx.models import FighterCategoryChoices
+
+    client.force_login(user)
+    vehicle_cf = make_content_fighter(
+        type="Truck",
+        category=FighterCategoryChoices.VEHICLE,
+        house=content_house,
+        base_cost=100,
+    )
+    vehicle = make_list_fighter(list_with_campaign, "Truck", content_fighter=vehicle_cf)
+    human = make_list_fighter(list_with_campaign, "Human")
+
+    resp = client.get(reverse("core:list-post-battle", args=[list_with_campaign.id]))
+    form = resp.context["form"]
+
+    vehicle_states = [c[0] for c in form.fields[f"state_{vehicle.pk}"].choices]
+    human_states = [c[0] for c in form.fields[f"state_{human.pk}"].choices]
+    assert ListFighter.IN_REPAIR in vehicle_states
+    assert ListFighter.DEAD not in vehicle_states
+    assert ListFighter.IN_REPAIR not in human_states
+    assert ListFighter.DEAD in human_states
+
+
+@pytest.mark.django_db
+def test_post_battle_rerender_preserves_repeated_selections(
+    client, user, list_with_campaign, make_list_fighter
+):
+    from gyrinx.core.models.campaign import (
+        CampaignListResource,
+        CampaignResourceType,
+    )
+
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "HurtGuy")
+    sprain = ContentInjury.objects.create(
+        name="Sprain", phase=ContentInjuryDefaultOutcome.RECOVERY
+    )
+    scar = ContentInjury.objects.create(
+        name="Scar", phase=ContentInjuryDefaultOutcome.NO_CHANGE
+    )
+    rtype = CampaignResourceType.objects.create(
+        campaign=list_with_campaign.campaign, name="Meat", owner=user
+    )
+    resource = CampaignListResource.objects.create(
+        campaign=list_with_campaign.campaign,
+        resource_type=rtype,
+        list=list_with_campaign,
+        amount=5,
+        owner=user,
+    )
+
+    # A validation error elsewhere re-renders the page: both submitted
+    # injuries must come back as two selects, not collapse into one.
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {
+            f"injury_{fighter.pk}": [str(sprain.pk), str(scar.pk)],
+            f"resource_{resource.pk}": "-10",
+        },
+    )
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert content.count(f'name="injury_{fighter.pk}"') == 2
+    assert f'value="{sprain.pk}" selected' in content
+    assert f'value="{scar.pk}" selected' in content
+
+
+@pytest.mark.django_db
+def test_post_battle_resource_race_rolls_back_and_rerenders(
+    client, user, list_with_campaign, make_list_fighter
+):
+    from unittest import mock
+
+    from gyrinx.core.models.campaign import (
+        CampaignListResource,
+        CampaignResourceType,
+    )
+
+    client.force_login(user)
+    make_list_fighter(list_with_campaign, "F1")
+    rtype = CampaignResourceType.objects.create(
+        campaign=list_with_campaign.campaign, name="Meat", owner=user
+    )
+    resource = CampaignListResource.objects.create(
+        campaign=list_with_campaign.campaign,
+        resource_type=rtype,
+        list=list_with_campaign,
+        amount=5,
+        owner=user,
+    )
+
+    # Simulate a concurrent change that pushes the resource below zero after
+    # form validation: the submit must roll back entirely (credits included)
+    # and re-render with a field error, not 500.
+    with mock.patch.object(
+        CampaignListResource,
+        "modify_amount",
+        side_effect=ValueError("Cannot reduce Meat below zero."),
+    ):
+        resp = client.post(
+            reverse("core:list-post-battle", args=[list_with_campaign.id]),
+            {
+                "credits_gained": "10",
+                f"resource_{resource.pk}": "-2",
+            },
+        )
+    assert resp.status_code == 200
+    assert "Cannot reduce Meat below zero." in resp.content.decode()
+    list_with_campaign.refresh_from_db()
+    assert list_with_campaign.credits_current == 0
+
+
+@pytest.mark.django_db
 def test_post_battle_capture(
     client, user, list_with_campaign, make_list, make_list_fighter
 ):

--- a/gyrinx/core/tests/test_post_battle_updates.py
+++ b/gyrinx/core/tests/test_post_battle_updates.py
@@ -188,9 +188,7 @@ def test_post_battle_applies_only_edited_fields(
         {
             f"xp_{f_xp.pk}": "2",
             f"injury_{f_injury.pk}": str(injury.pk),
-            f"injury_reason_{f_injury.pk}": "Took a bad hit",
             f"counter_{f_counter.pk}_{counter.pk}": "4",
-            f"private_notes_{f_xp.pk}": "Fought bravely",
         },
     )
     assert resp.status_code == 302
@@ -202,7 +200,6 @@ def test_post_battle_applies_only_edited_fields(
 
     # Only the edited fields were applied.
     assert f_xp.xp_current == 2
-    assert f_xp.private_notes == "Fought bravely"
     assert f_injury.injury_state == ListFighter.RECOVERY
     assert ListFighterInjury.objects.filter(fighter=f_injury).count() == 1
     assert ListFighterCounter.objects.get(fighter=f_counter, counter=counter).value == 4
@@ -215,24 +212,71 @@ def test_post_battle_applies_only_edited_fields(
 
 
 @pytest.mark.django_db
-def test_post_battle_injury_requires_reason(
+def test_post_battle_multiple_injuries_applied(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "HurtGuy")
+    sprain = ContentInjury.objects.create(
+        name="Sprain", phase=ContentInjuryDefaultOutcome.RECOVERY
+    )
+    scar = ContentInjury.objects.create(
+        name="Scar", phase=ContentInjuryDefaultOutcome.NO_CHANGE
+    )
+
+    # The injury select can be repeated (same name, multiple values); blank
+    # rows from untouched cloned selects are ignored.
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"injury_{fighter.pk}": ["", str(sprain.pk), str(scar.pk)]},
+    )
+    assert resp.status_code == 302
+    fighter.refresh_from_db()
+    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 2
+    # RECOVERY (from Sprain) sticks; Scar is NO_CHANGE.
+    assert fighter.injury_state == ListFighter.RECOVERY
+
+
+@pytest.mark.django_db
+def test_post_battle_same_injury_twice(
     client, user, list_with_campaign, make_list_fighter
 ):
     client.force_login(user)
     fighter = make_list_fighter(list_with_campaign, "HurtGuy")
     injury = ContentInjury.objects.create(
+        name="Humiliated", phase=ContentInjuryDefaultOutcome.NO_CHANGE
+    )
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"injury_{fighter.pk}": [str(injury.pk), str(injury.pk)]},
+    )
+    assert resp.status_code == 302
+    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 2
+
+
+@pytest.mark.django_db
+def test_post_battle_fatal_injury_stops_further_injuries(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "Doomed")
+    fatal = ContentInjury.objects.create(
+        name="Critical", phase=ContentInjuryDefaultOutcome.DEAD
+    )
+    sprain = ContentInjury.objects.create(
         name="Sprain", phase=ContentInjuryDefaultOutcome.RECOVERY
     )
 
-    # Selecting an injury without a reason is rejected; nothing is applied.
     resp = client.post(
         reverse("core:list-post-battle", args=[list_with_campaign.id]),
-        {f"injury_{fighter.pk}": str(injury.pk)},
+        {f"injury_{fighter.pk}": [str(fatal.pk), str(sprain.pk)]},
     )
-    assert resp.status_code == 200  # re-render with errors
+    assert resp.status_code == 302
     fighter.refresh_from_db()
-    assert fighter.injury_state == ListFighter.ACTIVE
-    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 0
+    assert fighter.is_dead is True
+    # Only the fatal injury was recorded; the rest were dropped.
+    assert ListFighterInjury.objects.filter(fighter=fighter).count() == 1
 
 
 @pytest.mark.django_db
@@ -310,7 +354,6 @@ def test_post_battle_fatal_injury_links_death_action_to_battle(
         {
             "battle": str(battle.pk),
             f"injury_{fighter.pk}": str(injury.pk),
-            f"injury_reason_{fighter.pk}": "Took a fatal blow",
         },
     )
     assert resp.status_code == 302
@@ -327,23 +370,220 @@ def test_post_battle_fatal_injury_links_death_action_to_battle(
 
 
 @pytest.mark.django_db
-def test_post_battle_omitted_notes_field_does_not_wipe_notes(
-    client, user, list_with_campaign, make_list_fighter
+def test_post_battle_capture(
+    client, user, list_with_campaign, make_list, make_list_fighter
 ):
-    client.force_login(user)
-    fighter = make_list_fighter(list_with_campaign, "F1")
-    fighter.private_notes = "<p>Keep me</p>"
-    fighter.save()
+    from gyrinx.core.models.battle import Battle
+    from gyrinx.core.models.list import CapturedFighter, List
 
-    # Submit without this fighter's private_notes field (simulating a roster
-    # that drifted between GET and POST). Notes must be left untouched.
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "Snatched")
+    rivals = make_list(
+        "Rivals", status=List.CAMPAIGN_MODE, campaign=list_with_campaign.campaign
+    )
+    battle = Battle.objects.create(
+        campaign=list_with_campaign.campaign, mission="Ambush", owner=user
+    )
+    battle.set_participants([list_with_campaign])
+
     resp = client.post(
         reverse("core:list-post-battle", args=[list_with_campaign.id]),
-        {f"xp_{fighter.pk}": "1"},
+        {
+            "battle": str(battle.pk),
+            f"captured_by_{fighter.pk}": str(rivals.pk),
+        },
+    )
+    assert resp.status_code == 302
+
+    record = CapturedFighter.objects.get(fighter=fighter)
+    assert record.capturing_list == rivals
+    fighter.refresh_from_db()
+    assert fighter.is_captured is True
+    # The capture's campaign log entry lands on the battle timeline.
+    action = CampaignAction.objects.get(description__contains="was captured by")
+    assert action.battle_id == battle.pk
+
+
+@pytest.mark.django_db
+def test_post_battle_capture_skipped_when_killed_same_submit(
+    client, user, list_with_campaign, make_list, make_list_fighter
+):
+    from gyrinx.core.models.list import CapturedFighter, List
+
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "Doomed")
+    rivals = make_list(
+        "Rivals", status=List.CAMPAIGN_MODE, campaign=list_with_campaign.campaign
+    )
+    fatal = ContentInjury.objects.create(
+        name="Critical", phase=ContentInjuryDefaultOutcome.DEAD
+    )
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {
+            f"injury_{fighter.pk}": str(fatal.pk),
+            f"captured_by_{fighter.pk}": str(rivals.pk),
+        },
     )
     assert resp.status_code == 302
     fighter.refresh_from_db()
-    assert fighter.private_notes == "<p>Keep me</p>"
+    assert fighter.is_dead is True
+    # The fatal injury wins; the capture is not applied.
+    assert not CapturedFighter.objects.filter(fighter=fighter).exists()
+
+
+@pytest.mark.django_db
+def test_post_battle_state_change(client, user, list_with_campaign, make_list_fighter):
+    from gyrinx.core.models.battle import Battle
+
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "Winded")
+    battle = Battle.objects.create(
+        campaign=list_with_campaign.campaign, mission="Skirmish", owner=user
+    )
+    battle.set_participants([list_with_campaign])
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {
+            "battle": str(battle.pk),
+            f"state_{fighter.pk}": ListFighter.RECOVERY,
+        },
+    )
+    assert resp.status_code == 302
+    fighter.refresh_from_db()
+    assert fighter.injury_state == ListFighter.RECOVERY
+    action = CampaignAction.objects.get(description__startswith="State Change:")
+    assert action.battle_id == battle.pk
+
+
+@pytest.mark.django_db
+def test_post_battle_state_dead_routes_through_kill(
+    client, user, list_with_campaign, make_list_fighter
+):
+    client.force_login(user)
+    fighter = make_list_fighter(list_with_campaign, "Goner")
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"state_{fighter.pk}": ListFighter.DEAD},
+    )
+    assert resp.status_code == 302
+    fighter.refresh_from_db()
+    assert fighter.is_dead is True
+    # The kill handler zeroes the fighter's cost.
+    assert fighter.cost_int() == 0
+
+
+@pytest.mark.django_db
+def test_post_battle_credits_gained(
+    client, user, list_with_campaign, make_list_fighter
+):
+    from gyrinx.core.models.battle import Battle
+
+    client.force_login(user)
+    make_list_fighter(list_with_campaign, "F1")
+    battle = Battle.objects.create(
+        campaign=list_with_campaign.campaign, mission="Heist", owner=user
+    )
+    battle.set_participants([list_with_campaign])
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {"battle": str(battle.pk), "credits_gained": "55"},
+    )
+    assert resp.status_code == 302
+    list_with_campaign.refresh_from_db()
+    assert list_with_campaign.credits_current == 55
+    assert list_with_campaign.credits_earned == 55
+    action = CampaignAction.objects.get(description__startswith="Added 55¢")
+    assert action.battle_id == battle.pk
+
+
+@pytest.mark.django_db
+def test_post_battle_resource_delta(
+    client, user, list_with_campaign, make_list_fighter
+):
+    from gyrinx.core.models.campaign import (
+        CampaignListResource,
+        CampaignResourceType,
+    )
+
+    client.force_login(user)
+    make_list_fighter(list_with_campaign, "F1")
+    campaign = list_with_campaign.campaign
+    rtype = CampaignResourceType.objects.create(
+        campaign=campaign, name="Meat", owner=user
+    )
+    resource = CampaignListResource.objects.create(
+        campaign=campaign,
+        resource_type=rtype,
+        list=list_with_campaign,
+        amount=5,
+        owner=user,
+    )
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"resource_{resource.pk}": "-2"},
+    )
+    assert resp.status_code == 302
+    resource.refresh_from_db()
+    assert resource.amount == 3
+
+    # A loss below zero is rejected up front; nothing is applied.
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {f"resource_{resource.pk}": "-10"},
+    )
+    assert resp.status_code == 200  # re-render with errors
+    resource.refresh_from_db()
+    assert resource.amount == 3
+
+
+@pytest.mark.django_db
+def test_post_battle_asset_claim(
+    client, user, list_with_campaign, make_list, make_list_fighter
+):
+    from gyrinx.core.models.battle import Battle
+    from gyrinx.core.models.campaign import CampaignAsset, CampaignAssetType
+    from gyrinx.core.models.list import List
+
+    client.force_login(user)
+    make_list_fighter(list_with_campaign, "F1")
+    campaign = list_with_campaign.campaign
+    rivals = make_list("Rivals", status=List.CAMPAIGN_MODE, campaign=campaign)
+    atype = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        owner=user,
+    )
+    held = CampaignAsset.objects.create(
+        asset_type=atype, name="The Sump", holder=rivals, owner=user
+    )
+    unclaimed = CampaignAsset.objects.create(
+        asset_type=atype, name="Old Ruins", holder=None, owner=user
+    )
+    battle = Battle.objects.create(campaign=campaign, mission="Turf War", owner=user)
+    battle.set_participants([list_with_campaign, rivals])
+
+    resp = client.post(
+        reverse("core:list-post-battle", args=[list_with_campaign.id]),
+        {
+            "battle": str(battle.pk),
+            "assets_captured": [str(held.pk), str(unclaimed.pk)],
+        },
+    )
+    assert resp.status_code == 302
+    held.refresh_from_db()
+    unclaimed.refresh_from_db()
+    assert held.holder == list_with_campaign
+    assert unclaimed.holder == list_with_campaign
+    transfers = CampaignAction.objects.filter(description__contains="Transfer")
+    assert transfers.count() == 2
+    assert all(a.battle_id == battle.pk for a in transfers)
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/views/list/post_battle.py
+++ b/gyrinx/core/views/list/post_battle.py
@@ -16,8 +16,17 @@ from gyrinx.core.handlers.fighter import (
     handle_fighter_add_xp,
     handle_fighter_adjust_counter,
 )
+from gyrinx.core.handlers.fighter.capture import handle_fighter_capture
+from gyrinx.core.handlers.fighter.kill import handle_fighter_kill
+from gyrinx.core.handlers.list import handle_credits_modification
 from gyrinx.core.models.battle import Battle
+from gyrinx.core.models.campaign import (
+    CampaignAction,
+    CampaignAsset,
+    CampaignListResource,
+)
 from gyrinx.core.models.events import EventNoun, EventVerb, log_event
+from gyrinx.core.models.list import List, ListFighter
 from gyrinx.core.views.fighter.permissions import get_list_for_edit
 
 
@@ -25,34 +34,61 @@ from gyrinx.core.views.fighter.permissions import get_list_for_edit
 class _ApplySummary:
     """Tally of what a post-battle submit changed, for the flash message."""
 
+    credits: int = 0
+    resources: int = 0
+    assets: int = 0
     xp: int = 0
     injuries: int = 0
     kills: int = 0
     counters: int = 0
-    notes: int = 0
+    states: int = 0
+    captured: int = 0
     killed_names: list = field(default_factory=list)
+    capture_skipped_names: list = field(default_factory=list)
 
     @property
     def changed(self):
-        return bool(self.xp or self.injuries or self.counters or self.notes)
+        return bool(
+            self.credits
+            or self.resources
+            or self.assets
+            or self.xp
+            or self.injuries
+            or self.counters
+            or self.states
+            or self.captured
+        )
 
     @property
     def message(self):
         parts = []
+        if self.credits:
+            parts.append(f"{self.credits}¢ gained")
+        if self.resources:
+            parts.append(f"{self.resources} resource update{_s(self.resources)}")
+        if self.assets:
+            parts.append(f"{self.assets} asset{_s(self.assets)} claimed")
         if self.xp:
             parts.append(f"XP for {self.xp} fighter{_s(self.xp)}")
         if self.injuries:
             parts.append(f"{self.injuries} injur{'ies' if self.injuries != 1 else 'y'}")
         if self.counters:
             parts.append(f"{self.counters} counter update{_s(self.counters)}")
-        if self.notes:
-            parts.append(f"notes for {self.notes} fighter{_s(self.notes)}")
+        if self.states:
+            parts.append(f"{self.states} state change{_s(self.states)}")
+        if self.captured:
+            parts.append(f"{self.captured} fighter{_s(self.captured)} captured")
         summary = "Post-battle updates applied: " + ", ".join(parts) + "."
         if self.killed_names:
             names = ", ".join(self.killed_names)
             summary += (
                 f" {names} died — any equipment they carried was returned to"
                 " the gang's stash."
+            )
+        if self.capture_skipped_names:
+            names = ", ".join(self.capture_skipped_names)
+            summary += (
+                f" {names} died in the same update, so the capture was not applied."
             )
         return summary
 
@@ -63,11 +99,12 @@ def _s(n):
 
 def _post_battle_fighters(lst):
     """Active roster fighters for the grid: no stash, no archived; vehicles,
-    crew and dead fighters are included (post-battle needs them). Counters are
-    prefetched so ``applicable_counters`` doesn't go N+1 across the grid."""
+    crew and dead fighters are included (post-battle needs them). Counters and
+    capture state are prefetched so the grid doesn't go N+1."""
     return list(
         lst.fighters()
         .exclude(content_fighter__is_stash=True)
+        .select_related("capture_info")
         .prefetch_related("content_fighter__counters", "counters")
     )
 
@@ -84,44 +121,116 @@ def _selectable_battles(lst):
     )
 
 
-def _apply(request, lst, fighters, form):
-    """Apply only the fields that were filled in or changed, per fighter."""
+def _capture_lists(lst):
+    """Other campaign-mode gangs in the campaign that could hold a captive."""
+    if not lst.campaign_id:
+        return List.objects.none()
+    return (
+        lst.campaign.campaign_lists.filter(status=List.CAMPAIGN_MODE)
+        .exclude(id=lst.id)
+        .order_by("name")
+    )
+
+
+def _gang_resources(lst):
+    """This gang's campaign resources, for the ± delta fields."""
+    if not lst.campaign_id:
+        return []
+    return list(
+        CampaignListResource.objects.filter(
+            campaign=lst.campaign, list=lst
+        ).select_related("resource_type")
+    )
+
+
+def _claimable_assets(lst):
+    """Campaign assets this gang doesn't already hold. Ordered by asset type
+    (the model Meta), so the grouped select renders one optgroup per type."""
+    if not lst.campaign_id:
+        return CampaignAsset.objects.none()
+    return (
+        CampaignAsset.objects.filter(asset_type__campaign=lst.campaign)
+        .exclude(holder=lst)
+        .select_related("asset_type", "holder")
+    )
+
+
+def _apply(request, lst, fighters, resources, form):
+    """Apply only the fields that were filled in, gang gains then per fighter."""
     user = request.user
     cd = form.cleaned_data
     battle = cd.get("battle")
     summary = _ApplySummary()
 
     with transaction.atomic():
+        credits = cd.get("credits_gained")
+        if credits:
+            result = handle_credits_modification(
+                user=user,
+                lst=lst,
+                operation="add",
+                amount=credits,
+                description="Post-battle winnings",
+                battle=battle,
+            )
+            log_event(
+                user=user,
+                noun=EventNoun.LIST,
+                verb=EventVerb.UPDATE,
+                object=lst,
+                request=request,
+                list_name=lst.name,
+                credit_operation="add",
+                amount=credits,
+                credits_current=result.credits_after,
+                credits_earned=result.credits_earned_after,
+                description="Post-battle winnings",
+            )
+            summary.credits = credits
+
+        for resource in resources:
+            delta = cd.get(f"resource_{resource.pk}")
+            if delta:
+                resource.modify_amount(delta, user=user, battle=battle)
+                log_event(
+                    user=user,
+                    noun=EventNoun.CAMPAIGN_RESOURCE,
+                    verb=EventVerb.UPDATE,
+                    object=resource,
+                    request=request,
+                    campaign_id=str(lst.campaign_id),
+                    campaign_name=lst.campaign.name,
+                    resource_type=resource.resource_type.name,
+                    list_name=lst.name,
+                    modification=delta,
+                    new_amount=resource.amount,
+                )
+                summary.resources += 1
+
+        # dict.fromkeys: the repeated select preserves duplicates for injuries,
+        # but claiming the same asset twice is meaningless.
+        for asset in dict.fromkeys(cd.get("assets_captured") or ()):
+            old_holder = asset.holder
+            asset.transfer_to(lst, user=user, battle=battle)
+            log_event(
+                user=user,
+                noun=EventNoun.CAMPAIGN_ASSET,
+                verb=EventVerb.UPDATE,
+                object=asset,
+                request=request,
+                campaign_id=str(lst.campaign_id),
+                campaign_name=lst.campaign.name,
+                asset_name=asset.name,
+                transfer_from=old_holder.name if old_holder else "Unassigned",
+                transfer_to=lst.name,
+                action="transfer",
+            )
+            summary.assets += 1
+
         for fighter in fighters:
             # Cache the parent so the handlers don't re-query fighter.list.
             fighter.list = lst
             pk = fighter.pk
-
-            # Notes first: a fatal injury (below) calls the kill handler, which
-            # mutates and saves the fighter — we don't want a later notes save
-            # on a now-stale instance to clobber that.
-            #
-            # Only touch notes if the field was actually submitted. If the roster
-            # changed between GET and POST (a fighter added/removed), its notes
-            # field is absent from the payload and `cleaned_data` would default
-            # it to "" — writing that back would silently wipe existing notes.
-            notes_field = f"private_notes_{pk}"
-            new_private = cd.get(notes_field, "") or ""
-            if notes_field in form.data and new_private != fighter.private_notes:
-                fighter.private_notes = new_private
-                fighter.save_with_user(user=user)
-                log_event(
-                    user=user,
-                    noun=EventNoun.LIST_FIGHTER,
-                    verb=EventVerb.UPDATE,
-                    object=fighter,
-                    request=request,
-                    action="notes_updated",
-                    fighter_name=fighter.name,
-                    list_id=str(lst.id),
-                    list_name=lst.name,
-                )
-                summary.notes += 1
 
             xp = cd.get(f"xp_{pk}")
             if xp:
@@ -141,13 +250,12 @@ def _apply(request, lst, fighters, form):
                 ):
                     summary.counters += 1
 
-            injury = cd.get(f"injury_{pk}")
-            if injury:
+            killed_now = False
+            for injury in cd.get(f"injury_{pk}") or ():
                 result = handle_fighter_add_injury(
                     user=user,
                     fighter=fighter,
                     injury=injury,
-                    notes=(cd.get(f"injury_reason_{pk}") or "").strip(),
                     battle=battle,
                 )
                 # The handler stays HTTP-free; the view owns event logging.
@@ -168,6 +276,93 @@ def _apply(request, lst, fighters, form):
                 if result.killed:
                     summary.kills += 1
                     summary.killed_names.append(fighter.name)
+                    killed_now = True
+                    # A dead fighter can't take further injuries.
+                    break
+
+            # An explicit state choice is applied after injuries, so it wins
+            # over an injury's default outcome — unless the fighter just died.
+            new_state = cd.get(f"state_{pk}")
+            if new_state and not killed_now and new_state != fighter.injury_state:
+                if new_state == ListFighter.DEAD:
+                    # Full kill logic: equipment -> stash, cost 0, rating
+                    # propagation — same as a fatal injury.
+                    handle_fighter_kill(
+                        user=user, lst=lst, fighter=fighter, battle=battle
+                    )
+                    log_event(
+                        user=user,
+                        noun=EventNoun.LIST_FIGHTER,
+                        verb=EventVerb.DELETE,
+                        object=fighter,
+                        request=request,
+                        fighter_name=fighter.name,
+                        list_id=str(lst.id),
+                        list_name=lst.name,
+                        action="killed",
+                    )
+                    summary.kills += 1
+                    summary.killed_names.append(fighter.name)
+                    killed_now = True
+                else:
+                    old_state = fighter.get_injury_state_display()
+                    fighter.injury_state = new_state
+                    fighter.save_with_user(user=user)
+                    new_state_display = dict(ListFighter.INJURY_STATE_CHOICES)[
+                        new_state
+                    ]
+                    CampaignAction.objects.create(
+                        user=user,
+                        owner=user,
+                        campaign=lst.campaign,
+                        list=lst,
+                        battle=battle,
+                        description=(
+                            f"State Change: {fighter.name} changed from"
+                            f" {old_state} to {new_state_display}"
+                        ),
+                        outcome=f"{fighter.name} is now {new_state_display}",
+                    )
+                    log_event(
+                        user=user,
+                        noun=EventNoun.LIST_FIGHTER,
+                        verb=EventVerb.UPDATE,
+                        object=fighter,
+                        request=request,
+                        action="state_changed",
+                        fighter_name=fighter.name,
+                        list_id=str(lst.id),
+                        list_name=lst.name,
+                        injury_state=new_state,
+                    )
+                summary.states += 1
+
+            capturing_list = cd.get(f"captured_by_{pk}")
+            if capturing_list:
+                if killed_now:
+                    # A fatal injury in the same submit wins over the capture.
+                    summary.capture_skipped_names.append(fighter.name)
+                else:
+                    handle_fighter_capture(
+                        user=user,
+                        fighter=fighter,
+                        capturing_list=capturing_list,
+                        battle=battle,
+                    )
+                    log_event(
+                        user=user,
+                        noun=EventNoun.LIST_FIGHTER,
+                        verb=EventVerb.UPDATE,
+                        object=fighter,
+                        request=request,
+                        action="captured",
+                        fighter_name=fighter.name,
+                        list_id=str(lst.id),
+                        list_name=lst.name,
+                        capturing_list_name=capturing_list.name,
+                        capturing_list_id=str(capturing_list.id),
+                    )
+                    summary.captured += 1
 
     return summary
 
@@ -175,8 +370,9 @@ def _apply(request, lst, fighters, form):
 @login_required
 def post_battle_updates(request, id):
     """
-    Bulk-edit a whole gang's post-battle results in one grid: add XP, adjust
-    counters, apply injuries, and edit notes. Campaign mode only; open to the
+    Bulk-edit a whole gang's post-battle results in one grid: record gang
+    gains (credits, resources, assets), add XP, adjust counters, apply
+    injuries, and mark fighters captured. Campaign mode only; open to the
     list owner and the campaign arbitrator.
 
     **Context**
@@ -187,6 +383,8 @@ def post_battle_updates(request, id):
         A :class:`PostBattleUpdatesForm` bound to the list's fighters.
     ``rows``
         Per-fighter rows pairing each fighter with its bound form fields.
+    ``resource_fields``
+        Per-resource entries pairing each campaign resource with its field.
 
     **Template**
 
@@ -204,11 +402,22 @@ def post_battle_updates(request, id):
 
     fighters = _post_battle_fighters(lst)
     battles = _selectable_battles(lst)
+    capture_lists = _capture_lists(lst)
+    resources = _gang_resources(lst)
+    assets = _claimable_assets(lst)
+
+    form_kwargs = {
+        "fighters": fighters,
+        "battles": battles,
+        "capture_lists": capture_lists,
+        "resources": resources,
+        "assets": assets,
+    }
 
     if request.method == "POST":
-        form = PostBattleUpdatesForm(request.POST, fighters=fighters, battles=battles)
+        form = PostBattleUpdatesForm(request.POST, **form_kwargs)
         if form.is_valid():
-            summary = _apply(request, lst, fighters, form)
+            summary = _apply(request, lst, fighters, resources, form)
             if summary.changed:
                 messages.success(request, summary.message)
             else:
@@ -227,15 +436,24 @@ def post_battle_updates(request, id):
                 battle_param = None
         if battle_param and battles.filter(pk=battle_param).exists():
             initial["battle"] = battle_param
-        form = PostBattleUpdatesForm(
-            fighters=fighters, battles=battles, initial=initial
-        )
+        form = PostBattleUpdatesForm(initial=initial, **form_kwargs)
 
     rows = _build_rows(fighters, form)
+    resource_fields = [
+        {"resource": resource, "field": form[f"resource_{resource.pk}"]}
+        for resource in resources
+    ]
     return render(
         request,
         "core/list_post_battle_updates.html",
-        {"list": lst, "form": form, "rows": rows, "has_battles": battles.exists()},
+        {
+            "list": lst,
+            "form": form,
+            "rows": rows,
+            "has_battles": battles.exists(),
+            "resource_fields": resource_fields,
+            "has_assets": assets.exists(),
+        },
     )
 
 
@@ -254,14 +472,18 @@ def _build_rows(fighters, form):
             }
             for entry in fighter.applicable_counters
         ]
+        captured_by_name = f"captured_by_{pk}"
+        state_name = f"state_{pk}"
         rows.append(
             {
                 "fighter": fighter,
                 "xp": form[f"xp_{pk}"],
                 "injury": form[f"injury_{pk}"],
-                "injury_reason": form[f"injury_reason_{pk}"],
                 "counters": counters,
-                "private_notes": form[f"private_notes_{pk}"],
+                "state": form[state_name] if state_name in form.fields else None,
+                "captured_by": (
+                    form[captured_by_name] if captured_by_name in form.fields else None
+                ),
             }
         )
     return rows

--- a/gyrinx/core/views/list/post_battle.py
+++ b/gyrinx/core/views/list/post_battle.py
@@ -10,6 +10,7 @@ from django.shortcuts import render
 from django.urls import reverse
 
 from gyrinx import messages
+from gyrinx.content.models import ContentInjury
 from gyrinx.core.forms.post_battle import PostBattleUpdatesForm
 from gyrinx.core.handlers.fighter import (
     handle_fighter_add_injury,
@@ -87,14 +88,22 @@ class _ApplySummary:
             )
         if self.capture_skipped_names:
             names = ", ".join(self.capture_skipped_names)
-            summary += (
-                f" {names} died in the same update, so the capture was not applied."
-            )
+            summary += f" The capture of {names} was therefore not applied."
         return summary
 
 
 def _s(n):
     return "" if n == 1 else "s"
+
+
+class _ResourceApplyError(Exception):
+    """A resource delta failed at apply time (e.g. a concurrent change pushed
+    the resource below zero after the form validated). Carries the field name
+    so the view can surface it as a field error instead of a 500."""
+
+    def __init__(self, field, message):
+        super().__init__(message)
+        self.field = field
 
 
 def _post_battle_fighters(lst):
@@ -191,7 +200,14 @@ def _apply(request, lst, fighters, resources, form):
         for resource in resources:
             delta = cd.get(f"resource_{resource.pk}")
             if delta:
-                resource.modify_amount(delta, user=user, battle=battle)
+                try:
+                    resource.modify_amount(delta, user=user, battle=battle)
+                except ValueError as e:
+                    # The form validated against the amount loaded at bind
+                    # time; a concurrent change can still push the resource
+                    # below zero here. Roll the whole submit back and let the
+                    # view re-render with a field error.
+                    raise _ResourceApplyError(f"resource_{resource.pk}", str(e)) from e
                 log_event(
                     user=user,
                     noun=EventNoun.CAMPAIGN_RESOURCE,
@@ -417,12 +433,17 @@ def post_battle_updates(request, id):
     if request.method == "POST":
         form = PostBattleUpdatesForm(request.POST, **form_kwargs)
         if form.is_valid():
-            summary = _apply(request, lst, fighters, resources, form)
-            if summary.changed:
-                messages.success(request, summary.message)
+            try:
+                summary = _apply(request, lst, fighters, resources, form)
+            except _ResourceApplyError as e:
+                # Everything rolled back; fall through and re-render.
+                form.add_error(e.field, str(e))
             else:
-                messages.info(request, "No post-battle changes were entered.")
-            return HttpResponseRedirect(default_url)
+                if summary.changed:
+                    messages.success(request, summary.message)
+                else:
+                    messages.info(request, "No post-battle changes were entered.")
+                return HttpResponseRedirect(default_url)
     else:
         # A ?battle=<id> query param preselects that battle (only if the list
         # actually fought in it — otherwise it's ignored). Validate the UUID
@@ -443,6 +464,11 @@ def post_battle_updates(request, id):
         {"resource": resource, "field": form[f"resource_{resource.pk}"]}
         for resource in resources
     ]
+    # Injury id -> default outcome, for the JS that mirrors the single-fighter
+    # add-injury screen: picking an injury pre-fills the row's state select.
+    injury_phases = {
+        str(pk): phase for pk, phase in ContentInjury.objects.values_list("id", "phase")
+    }
     return render(
         request,
         "core/list_post_battle_updates.html",
@@ -453,6 +479,7 @@ def post_battle_updates(request, id):
             "has_battles": battles.exists(),
             "resource_fields": resource_fields,
             "has_assets": assets.exists(),
+            "injury_phases": injury_phases,
         },
     )
 
@@ -474,11 +501,12 @@ def _build_rows(fighters, form):
         ]
         captured_by_name = f"captured_by_{pk}"
         state_name = f"state_{pk}"
+        injury_name = f"injury_{pk}"
         rows.append(
             {
                 "fighter": fighter,
                 "xp": form[f"xp_{pk}"],
-                "injury": form[f"injury_{pk}"],
+                "injury": form[injury_name] if injury_name in form.fields else None,
                 "counters": counters,
                 "state": form[state_name] if state_name in form.fields else None,
                 "captured_by": (


### PR DESCRIPTION
## Summary

Iterates on the bulk post-battle updates screen (`/list/<id>/post-battle`) based on feedback from real campaign use:

- **New "Gang results" section** at the top records what the gang gained from the battle: credits, campaign resource changes (± deltas), and campaign assets claimed (e.g. a Territory taken from another gang or an unclaimed one). Everything goes through the existing handlers/model methods and lands on the campaign log, attached to the selected battle.
- **Richer per-fighter results**: multiple injuries per fighter ("Add another injury" repeats the select), an explicit state control (Active / Recovery / Convalescence / Dead — dead routes through the kill handler so equipment moves to the stash and the rating updates), and a "Captured by" select recording capture by another gang. Picking an injury pre-fills the row's State select with the injury's default outcome (mirroring the single add-injury screen) — a manual state choice always wins. Fighters already dead get no injury or state fields, since leaving Dead must go through the resurrect flow.
- **Faster XP entry**: XP and delta inputs get −/+ nudge buttons, and a toolbar lets you tick fighters (with select-all), choose an amount, and add it to all of them at once — a purely client-side convenience that just fills the per-fighter inputs.
- **Removed**: the injury "reason" field and the private-notes editor.
- **Visual**: all inputs carry a stronger secondary border matching the stepper bumper buttons, so the grid's controls read as one set.

The page remains one plain form POST. Without JS it degrades cleanly: repeatable selects become a single select, steppers fall back to native number inputs, and the mass-XP toolbar and row checkboxes don't appear at all.

Notes for review:

- If one submit both fatally injures and captures a fighter, the death wins and the capture is skipped (called out in the flash message).
- Asset claiming lets the gang owner take any campaign asset they don't already hold. That's looser than the single-asset transfer view (current holder or arbitrator only) — battle outcomes are self-reported here like credits/resources, and every claim is logged as a Campaign Action on the battle timeline. Flagging in case you'd rather it be arbitrator-only.
- `handle_fighter_capture`, `handle_credits_modification`, `CampaignAsset.transfer_to` and `CampaignListResource.modify_amount` gain an optional `battle` argument so their campaign log entries attach to the battle; existing callers are unaffected.

## Test plan

- [x] `pytest -n auto` — full suite passes (3358 passed, 13 skipped)
- [x] New view tests: multiple injuries (including the same injury twice, and blank repeated rows), fatal injury stops later injuries, capture, capture skipped when killed in the same submit, state change with battle link, state=dead routes through the kill handler, credits gained with battle link, resource deltas with below-zero rejection, asset claiming with battle link
- [x] Manually exercised in the browser against the dev server: steppers, add-another injury, select-all + mass XP, and a full submit — verified credits/resource/asset/XP/injury/state changes in the database and the flash summary

## How to try it

1. Open a campaign-mode gang and go to "Post-battle updates" (`/list/<id>/post-battle`)
2. Record credits/resources/assets at the top, then per-fighter: XP (try ticking a few fighters and using "Add XP to selected"), injuries ("Add another injury"), state, and captures
3. Apply — the flash message summarises everything, and the campaign log shows the actions attached to the chosen battle

Closes #1810
Refs #1989
Refs #1346
