### PR TITLE
feat: post-battle follow-ups — severity-ranked state auto-fill + battle-page prompt

### DIFF
--- a/gyrinx/core/templates/core/battle/battle.html
+++ b/gyrinx/core/templates/core/battle/battle.html
@@ -70,21 +70,6 @@
                 <span><i class="bi-person"></i> <a class="linked" href="{% url 'core:user' battle.owner.username %}">{{ battle.owner }}</a></span>
             </div>
         </div>
-        <!-- Post-battle prompt: record results for gangs the viewer can edit -->
-        {% if post_battle_lists %}
-            <div class="border rounded p-2 d-flex flex-wrap align-items-center gap-2">
-                <span class="fs-7">
-                    <i class="bi-clipboard-check"></i>
-                    Record what happened to each Gang — XP, injuries, captures and winnings.
-                </span>
-                {% for lst in post_battle_lists %}
-                    <a href="{% url 'core:list-post-battle' lst.id %}?battle={{ battle.id }}"
-                       class="btn btn-primary btn-sm">
-                        Record updates{% if post_battle_lists|length > 1 %}: {{ lst.name }}{% endif %} →
-                    </a>
-                {% endfor %}
-            </div>
-        {% endif %}
         <!-- Two-column layout on wide screens -->
         <div class="row g-4 g-lg-5">
             <!-- Participants + Related Actions -->
@@ -127,6 +112,12 @@
                                                             <i class="bi-trophy-fill text-warning"
                                                                data-bs-toggle="tooltip"
                                                                data-bs-title="Winner"></i>
+                                                        {% endif %}
+                                                        {% if p.can_record_post_battle %}
+                                                            <div>
+                                                                <a href="{% url 'core:list-post-battle' p.list.id %}?battle={{ battle.id }}"
+                                                                   class="linked fs-7">Record updates →</a>
+                                                            </div>
                                                         {% endif %}
                                                     </td>
                                                     <td class="text-end">{% credits p.rating %}</td>

--- a/gyrinx/core/templates/core/battle/battle.html
+++ b/gyrinx/core/templates/core/battle/battle.html
@@ -80,7 +80,7 @@
                 {% for lst in post_battle_lists %}
                     <a href="{% url 'core:list-post-battle' lst.id %}?battle={{ battle.id }}"
                        class="btn btn-primary btn-sm">
-                        Post-battle updates{% if post_battle_lists|length > 1 %}: {{ lst.name }}{% endif %}
+                        Record updates{% if post_battle_lists|length > 1 %}: {{ lst.name }}{% endif %} →
                     </a>
                 {% endfor %}
             </div>

--- a/gyrinx/core/templates/core/battle/battle.html
+++ b/gyrinx/core/templates/core/battle/battle.html
@@ -116,7 +116,7 @@
                                                         {% if p.can_record_post_battle %}
                                                             <div>
                                                                 <a href="{% url 'core:list-post-battle' p.list.id %}?battle={{ battle.id }}"
-                                                                   class="linked fs-7">Record updates →</a>
+                                                                   class="linked fs-7">Record post-battle updates →</a>
                                                             </div>
                                                         {% endif %}
                                                     </td>

--- a/gyrinx/core/templates/core/battle/battle.html
+++ b/gyrinx/core/templates/core/battle/battle.html
@@ -70,6 +70,21 @@
                 <span><i class="bi-person"></i> <a class="linked" href="{% url 'core:user' battle.owner.username %}">{{ battle.owner }}</a></span>
             </div>
         </div>
+        <!-- Post-battle prompt: record results for gangs the viewer can edit -->
+        {% if post_battle_lists %}
+            <div class="border rounded p-2 d-flex flex-wrap align-items-center gap-2">
+                <span class="fs-7">
+                    <i class="bi-clipboard-check"></i>
+                    Record what happened to each Gang — XP, injuries, captures and winnings.
+                </span>
+                {% for lst in post_battle_lists %}
+                    <a href="{% url 'core:list-post-battle' lst.id %}?battle={{ battle.id }}"
+                       class="btn btn-primary btn-sm">
+                        Post-battle updates{% if post_battle_lists|length > 1 %}: {{ lst.name }}{% endif %}
+                    </a>
+                {% endfor %}
+            </div>
+        {% endif %}
         <!-- Two-column layout on wide screens -->
         <div class="row g-4 g-lg-5">
             <!-- Participants + Related Actions -->

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -268,18 +268,20 @@
                      var p = injuryPhases[sel.value];
                      if (p && p !== "no_change") phases.push(p);
                  });
+                 // Most severe outcome that this row's state select can
+                 // actually express — vehicles only offer Active/In Repair,
+                 // so an unavailable severity falls through to the next.
                  var best = "";
-                 for (var i = 0; i < STATE_SEVERITY.length; i++) {
-                     if (phases.indexOf(STATE_SEVERITY[i]) !== -1) {
-                         best = STATE_SEVERITY[i];
-                         break;
-                     }
+                 for (var i = 0; i < STATE_SEVERITY.length && !best; i++) {
+                     var candidate = STATE_SEVERITY[i];
+                     if (phases.indexOf(candidate) === -1) continue;
+                     var available = Array.prototype.some.call(
+                         state.options,
+                         function (o) { return o.value === candidate; }
+                     );
+                     if (available) best = candidate;
                  }
-                 var hasOption = best && Array.prototype.some.call(
-                     state.options,
-                     function (o) { return o.value === best; }
-                 );
-                 if (best && hasOption) {
+                 if (best) {
                      state.value = best;
                      state.dataset.pbAuto = "1";
                  } else if (state.dataset.pbAuto === "1") {

--- a/gyrinx/core/templates/core/list_post_battle_updates.html
+++ b/gyrinx/core/templates/core/list_post_battle_updates.html
@@ -241,12 +241,15 @@
              });
 
              // --- Injury -> state sync, mirroring the single add-injury
-             // screen: choosing an injury pre-fills the row's state select
-             // with the injury's default outcome. Only while the state is
-             // untouched (empty or previously auto-filled) — a manual state
-             // choice always wins.
+             // screen: the row's state select is pre-filled with the most
+             // severe default outcome across ALL of the row's selected
+             // injuries — adding a lighter injury after a worse one must not
+             // downgrade the state. Only while the state is untouched (empty
+             // or previously auto-filled) — a manual state choice always wins.
              var phasesEl = document.getElementById("pb-injury-phases");
              var injuryPhases = phasesEl ? JSON.parse(phasesEl.textContent) : {};
+             // Most severe first.
+             var STATE_SEVERITY = ["dead", "recovery", "convalescence", "in_repair", "active"];
              document.addEventListener("change", function (e) {
                  var target = e.target;
                  if (target.matches("select[name^='state_']")) {
@@ -260,16 +263,27 @@
                  if (!state) return;
                  var untouched = state.value === "" || state.dataset.pbAuto === "1";
                  if (!untouched) return;
-                 var phase = injuryPhases[target.value] || "";
-                 var hasOption = Array.prototype.some.call(
+                 var phases = [];
+                 row.querySelectorAll("select[name^='injury_']").forEach(function (sel) {
+                     var p = injuryPhases[sel.value];
+                     if (p && p !== "no_change") phases.push(p);
+                 });
+                 var best = "";
+                 for (var i = 0; i < STATE_SEVERITY.length; i++) {
+                     if (phases.indexOf(STATE_SEVERITY[i]) !== -1) {
+                         best = STATE_SEVERITY[i];
+                         break;
+                     }
+                 }
+                 var hasOption = best && Array.prototype.some.call(
                      state.options,
-                     function (o) { return o.value === phase; }
+                     function (o) { return o.value === best; }
                  );
-                 if (phase && phase !== "no_change" && hasOption) {
-                     state.value = phase;
+                 if (best && hasOption) {
+                     state.value = best;
                      state.dataset.pbAuto = "1";
                  } else if (state.dataset.pbAuto === "1") {
-                     // The driving injury was cleared or has no outcome:
+                     // No selected injury carries an outcome any more:
                      // drop the auto-filled state rather than submit it.
                      state.value = "";
                      delete state.dataset.pbAuto;
@@ -331,6 +345,12 @@
                      rm.appendChild(rmIcon);
                      rm.addEventListener("click", function () {
                          clone.remove();
+                         // Recompute anything derived from the remaining
+                         // selects (e.g. the injury -> state sync).
+                         var remaining = wrap.querySelector("select");
+                         if (remaining) {
+                             remaining.dispatchEvent(new Event("change", { bubbles: true }));
+                         }
                      });
                      clone.appendChild(rm);
                      wrap.insertBefore(clone, add.parentElement);

--- a/gyrinx/core/tests/test_battle_state_and_roles.py
+++ b/gyrinx/core/tests/test_battle_state_and_roles.py
@@ -390,3 +390,43 @@ def test_participant_cannot_archive(client, user, make_user, campaign, make_list
     client.post(reverse("core:battle-archive", args=[battle.id]), {"archive": "1"})
     battle.refresh_from_db()
     assert battle.archived is False
+
+
+@pytest.mark.django_db
+def test_battle_page_post_battle_prompt(client, user, make_user, campaign, make_list):
+    from gyrinx.core.models.list import List
+
+    player = make_user("pb_prompt_player", "password")
+    mine = make_list("My Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
+    theirs = make_list(
+        "Their Gang", owner=player, status=List.CAMPAIGN_MODE, campaign=campaign
+    )
+    campaign.lists.add(mine, theirs)
+    battle = Battle.objects.create(campaign=campaign, mission="M", owner=user)
+    battle.set_participants([mine, theirs])
+
+    url = reverse("core:battle", args=[battle.id])
+    prompt_mine = (
+        f"{reverse('core:list-post-battle', args=[mine.id])}?battle={battle.id}"
+    )
+    prompt_theirs = (
+        f"{reverse('core:list-post-battle', args=[theirs.id])}?battle={battle.id}"
+    )
+
+    # Before the battle ends there is nothing to record yet.
+    client.force_login(user)
+    assert prompt_mine not in client.get(url).content.decode()
+
+    client.post(reverse("core:battle-start", args=[battle.id]))
+    client.post(reverse("core:battle-end", args=[battle.id]))
+
+    # The arbitrator (campaign owner) is prompted for every participating gang.
+    content = client.get(url).content.decode()
+    assert prompt_mine in content
+    assert prompt_theirs in content
+
+    # A player is prompted only for their own gang.
+    client.force_login(player)
+    content = client.get(url).content.decode()
+    assert prompt_theirs in content
+    assert prompt_mine not in content

--- a/gyrinx/core/tests/test_battle_state_and_roles.py
+++ b/gyrinx/core/tests/test_battle_state_and_roles.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from gyrinx.content.models import ContentBattleRole, ContentBattleRoleOption
 from gyrinx.core.models import Battle, BattleParticipant
+from gyrinx.core.models.list import List
 from gyrinx.core.models.state_machine import InvalidStateTransition
 
 
@@ -394,8 +395,6 @@ def test_participant_cannot_archive(client, user, make_user, campaign, make_list
 
 @pytest.mark.django_db
 def test_battle_page_post_battle_prompt(client, user, make_user, campaign, make_list):
-    from gyrinx.core.models.list import List
-
     player = make_user("pb_prompt_player", "password")
     mine = make_list("My Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
     theirs = make_list(
@@ -430,3 +429,18 @@ def test_battle_page_post_battle_prompt(client, user, make_user, campaign, make_
     content = client.get(url).content.decode()
     assert prompt_theirs in content
     assert prompt_mine not in content
+
+    # An unrelated viewer gets no prompt at all.
+    outsider = make_user("pb_prompt_outsider", "password")
+    client.force_login(outsider)
+    content = client.get(url).content.decode()
+    assert prompt_mine not in content
+    assert prompt_theirs not in content
+
+    # A gang that has left campaign mode no longer gets a button.
+    theirs.status = List.LIST_BUILDING
+    theirs.save()
+    client.force_login(user)
+    content = client.get(url).content.decode()
+    assert prompt_mine in content
+    assert prompt_theirs not in content

--- a/gyrinx/core/tests/test_battle_state_and_roles.py
+++ b/gyrinx/core/tests/test_battle_state_and_roles.py
@@ -412,17 +412,22 @@ def test_battle_page_post_battle_prompt(client, user, make_user, campaign, make_
         f"{reverse('core:list-post-battle', args=[theirs.id])}?battle={battle.id}"
     )
 
-    # Before the battle ends there is nothing to record yet.
+    # Before the battle ends there is nothing to record yet — but crews can
+    # still be added.
     client.force_login(user)
-    assert prompt_mine not in client.get(url).content.decode()
+    content = client.get(url).content.decode()
+    assert prompt_mine not in content
+    assert "Add crew" in content
 
     client.post(reverse("core:battle-start", args=[battle.id]))
     client.post(reverse("core:battle-end", args=[battle.id]))
 
-    # The arbitrator (campaign owner) is prompted for every participating gang.
+    # The arbitrator (campaign owner) is prompted for every participating
+    # gang; a finished battle no longer offers to add crews.
     content = client.get(url).content.decode()
     assert prompt_mine in content
     assert prompt_theirs in content
+    assert "Add crew" not in content
 
     # A player is prompted only for their own gang.
     client.force_login(player)

--- a/gyrinx/core/views/battle.py
+++ b/gyrinx/core/views/battle.py
@@ -51,6 +51,7 @@ class BattleDetailView(generic.DetailView):
             Battle.objects.select_related("campaign", "owner").prefetch_related(
                 "winners",
                 "notes__owner",
+                "participants",
             ),
             id=self.kwargs["id"],
         )
@@ -87,7 +88,7 @@ class BattleDetailView(generic.DetailView):
         context["post_battle_lists"] = []
         if (
             user.is_authenticated
-            and context["state_current"] == "post_battle"
+            and context["state_current"] == Battle.POST_BATTLE
             and not battle.archived
             and not battle.campaign.archived
         ):
@@ -95,7 +96,10 @@ class BattleDetailView(generic.DetailView):
             context["post_battle_lists"] = [
                 lst
                 for lst in battle.participants.all()
-                if is_admin or lst.owner_id == user.id
+                # Only gangs the post-battle editor will actually accept.
+                if lst.is_campaign_mode
+                and not lst.archived
+                and (is_admin or lst.owner_id == user.id)
             ]
 
         # Get all notes ordered by creation date

--- a/gyrinx/core/views/battle.py
+++ b/gyrinx/core/views/battle.py
@@ -51,7 +51,6 @@ class BattleDetailView(generic.DetailView):
             Battle.objects.select_related("campaign", "owner").prefetch_related(
                 "winners",
                 "notes__owner",
-                "participants",
             ),
             id=self.kwargs["id"],
         )
@@ -81,26 +80,6 @@ class BattleDetailView(generic.DetailView):
         context["state_current"] = battle.states.current
         context["can_start"] = context["can_manage"] and battle.can_start()
         context["can_end"] = context["can_manage"] and battle.can_end()
-
-        # Once the battle reaches its post-battle phase, prompt the viewer to
-        # record post-battle updates for each participating gang they may edit
-        # (their own, or all of them for the arbitrator).
-        context["post_battle_lists"] = []
-        if (
-            user.is_authenticated
-            and context["state_current"] == Battle.POST_BATTLE
-            and not battle.archived
-            and not battle.campaign.archived
-        ):
-            is_admin = battle.campaign.is_admin(user)
-            context["post_battle_lists"] = [
-                lst
-                for lst in battle.participants.all()
-                # Only gangs the post-battle editor will actually accept.
-                if lst.is_campaign_mode
-                and not lst.archived
-                and (is_admin or lst.owner_id == user.id)
-            ]
 
         # Get all notes ordered by creation date
         context["notes"] = battle.notes.select_related("owner").order_by("created")
@@ -137,11 +116,26 @@ class BattleDetailView(generic.DetailView):
                 "pending_roll": pending,
             }
 
+        is_over = battle.states.current == Battle.POST_BATTLE
+
         # Whether this user may add a crew to a gang that hasn't got one yet.
-        # The outer guard is a fast-path so anon/archived skip the per-gang work.
-        can_add_any = user.is_authenticated and not (
-            battle.archived or battle.campaign.archived
+        # The outer guard is a fast-path so anon/archived skip the per-gang
+        # work; once the battle is over there is no crew left to pick.
+        can_add_any = (
+            user.is_authenticated
+            and not is_over
+            and not (battle.archived or battle.campaign.archived)
         )
+
+        # Whether this user may record post-battle results for a gang — an
+        # affordance under the gang's name once the battle is over.
+        can_record_any = (
+            user.is_authenticated
+            and is_over
+            and not (battle.archived or battle.campaign.archived)
+        )
+        is_admin = can_record_any and battle.campaign.is_admin(user)
+
         # winners is prefetched in get_object(); read the cache, not a new query.
         winner_ids = {w.id for w in battle.winners.all()}
 
@@ -161,6 +155,13 @@ class BattleDetailView(generic.DetailView):
                             crew is None
                             and can_add_any
                             and Crew.can_manage_new(user, battle, gang)
+                        ),
+                        "can_record_post_battle": (
+                            can_record_any
+                            # Only gangs the post-battle editor will accept.
+                            and gang.is_campaign_mode
+                            and not gang.archived
+                            and (is_admin or gang.owner_id == user.id)
                         ),
                     }
                 )

--- a/gyrinx/core/views/battle.py
+++ b/gyrinx/core/views/battle.py
@@ -81,6 +81,23 @@ class BattleDetailView(generic.DetailView):
         context["can_start"] = context["can_manage"] and battle.can_start()
         context["can_end"] = context["can_manage"] and battle.can_end()
 
+        # Once the battle reaches its post-battle phase, prompt the viewer to
+        # record post-battle updates for each participating gang they may edit
+        # (their own, or all of them for the arbitrator).
+        context["post_battle_lists"] = []
+        if (
+            user.is_authenticated
+            and context["state_current"] == "post_battle"
+            and not battle.archived
+            and not battle.campaign.archived
+        ):
+            is_admin = battle.campaign.is_admin(user)
+            context["post_battle_lists"] = [
+                lst
+                for lst in battle.participants.all()
+                if is_admin or lst.owner_id == user.id
+            ]
+
         # Get all notes ordered by creation date
         context["notes"] = battle.notes.select_related("owner").order_by("created")
 


### PR DESCRIPTION
Two follow-ups to the post-battle editor iteration (#2006):

## Summary

- **Severity-ranked injury→state auto-fill.** The state select was pre-filled from whichever injury select changed most recently, so picking an injury that puts a fighter into Recovery and then one that causes Convalescence would downgrade the state. It now recomputes across all of the row's selected injuries and applies the most severe outcome (Dead > Recovery > Convalescence > In Repair > Active). Removing an injury row also recomputes, so clearing the worst injury downgrades correctly and clearing them all empties the state. Still purely client-side assistance — a manually chosen state always wins.
- **Battle-page prompt.** Once a battle reaches its post-battle phase, each participating gang the viewer can edit (their own gang for players, every gang for the arbitrator) gets a "Record updates →" link under its name in the Participants table, opening the post-battle editor with the battle preselected. "Add crew" is hidden once the battle is over.

## Test plan

- [x] `pytest -n auto` — full suite passes (3363 passed)
- [x] New view test: the prompt appears only after the battle ends, for the arbitrator on every gang and for a player only on their own gang
- [x] Browser-verified: recovery injury holds the state when a convalescence injury is added, downgrades when the recovery injury is cleared, empties when the last injury row is removed; the battle-page buttons link with `?battle=<id>` preselected

## How to try it

1. Open a battle that has ended (`/battle/<id>`) — each editable gang in the Participants table carries a "Record updates →" link
2. Follow a gang's "Record updates →" link; on the editor, add an injury that causes Recovery, then add another that causes Convalescence — State stays Recovery

Refs #1346
