### PR TITLE
fix: template audit — dead back link, hidden form errors, owner gating, N+1 (#2001)

### DIFF
--- a/gyrinx/core/templates/core/layouts/base.html
+++ b/gyrinx/core/templates/core/layouts/base.html
@@ -146,7 +146,7 @@
             {% if messages %}
                 <div>
                     {% for message in messages %}
-                        <div class="alert alert-{% if message.tags == 'debug' %}secondary{% elif message.tags == 'info' %}info{% elif message.tags == 'success' %}success{% elif message.tags == 'warning' %}warning{% elif message.tags == 'error' %}danger{% else %}info{% endif %} alert-dismissible fade show"
+                        <div class="alert alert-{% if message.level_tag == 'debug' %}secondary{% elif message.level_tag == 'info' %}info{% elif message.level_tag == 'success' %}success{% elif message.level_tag == 'warning' %}warning{% elif message.level_tag == 'error' %}danger{% else %}info{% endif %} alert-dismissible fade show"
                              role="alert">
                             {{ message }}
                             <button type="button"

--- a/gyrinx/core/templates/core/list_archived_fighters.html
+++ b/gyrinx/core/templates/core/list_archived_fighters.html
@@ -19,7 +19,7 @@
                     {% for fighter in list.archived_fighters %}
                         <tr class="align-middle">
                             <td>{{ fighter.fully_qualified_name }}</td>
-                            {% if not fighter.source_assignment.exists %}
+                            {% if not fighter.parent_list_fighter %}
                                 <td>
                                     <a href="{% url 'core:list-fighter-restore' list.id fighter.id %}"
                                        class="btn btn-link">Restore</a>
@@ -30,7 +30,7 @@
                                           disabled
                                           bs-tooltip
                                           data-bs-toggle="tooltip"
-                                          title="This fighter is assigned to {{ fighter.source_assignment.get.list_fighter.name }} and cannot be restored directly">
+                                          title="This fighter is assigned to {{ fighter.parent_list_fighter.name }} and cannot be restored directly">
                                         Restore
                                     </span>
                                 </td>
@@ -38,7 +38,7 @@
                         </tr>
                     {% empty %}
                         <tr>
-                            <td colspan="3" class="text-center">No archived fighters</td>
+                            <td colspan="2" class="text-center">No archived fighters</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/gyrinx/core/templates/core/list_fighter_advancements.html
+++ b/gyrinx/core/templates/core/list_fighter_advancements.html
@@ -70,10 +70,12 @@
                 <p class="text-secondary">No advancements yet.</p>
             {% endif %}
             <div class="d-flex align-items-center">
-                <a href="{% url 'core:list-fighter-advancement-start' list.id fighter.id %}"
-                   class="btn btn-primary">
-                    <i class="bi-plus-lg"></i> Add Advancement
-                </a>
+                {% if list.owner_cached == user %}
+                    <a href="{% url 'core:list-fighter-advancement-start' list.id fighter.id %}"
+                       class="btn btn-primary">
+                        <i class="bi-plus-lg"></i> Add Advancement
+                    </a>
+                {% endif %}
                 <a href="{% url 'core:list' list.id %}#{{ fighter.id }}"
                    class="btn btn-link">Cancel</a>
             </div>

--- a/gyrinx/core/templates/core/list_fighter_notes_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_notes_edit.html
@@ -13,21 +13,9 @@
             <input type="hidden" name="return_url" value="{{ return_url }}">
             {{ form.media }}
             <div class="vstack gap-3">
-                <div>
-                    <label for="{{ form.save_roll.id_for_label }}" class="form-label">{{ form.save_roll.label }}</label>
-                    {{ form.save_roll }}
-                    {% if form.save_roll.help_text %}<div class="form-text">{{ form.save_roll.help_text }}</div>{% endif %}
-                </div>
-                <div>
-                    <label for="{{ form.notes.id_for_label }}" class="form-label">{{ form.notes.label }}</label>
-                    {{ form.notes }}
-                    {% if form.notes.help_text %}<div class="form-text">{{ form.notes.help_text }}</div>{% endif %}
-                </div>
-                <div>
-                    <label for="{{ form.private_notes.id_for_label }}" class="form-label">{{ form.private_notes.label }}</label>
-                    {{ form.private_notes }}
-                    {% if form.private_notes.help_text %}<div class="form-text">{{ form.private_notes.help_text }}</div>{% endif %}
-                </div>
+                {% include "core/includes/form_field.html" with field=form.save_roll %}
+                {% include "core/includes/form_field.html" with field=form.notes %}
+                {% include "core/includes/form_field.html" with field=form.private_notes %}
             </div>
             <div class="mt-3">
                 <button type="submit" class="btn btn-success">Save</button>

--- a/gyrinx/core/templates/core/list_new.html
+++ b/gyrinx/core/templates/core/list_new.html
@@ -17,8 +17,7 @@
                 </div>
                 <div>
                     {% for pack in selected_packs %}
-                        {{ pack.name }}
-                        {% if not forloop.last %},{% endif %}
+                        {{ pack.name }}{% if not forloop.last %},{% endif %}
                     {% endfor %}
                 </div>
             </div>

--- a/gyrinx/core/templates/core/print_config/delete.html
+++ b/gyrinx/core/templates/core/print_config/delete.html
@@ -4,7 +4,8 @@
     Delete Print Configuration - {{ print_config.name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
-    {% include "core/includes/back.html" with url="core:print-config-index" url_arg=list.id text="Print Configurations" %}
+    {% url 'core:print-config-index' list.id as back_url %}
+    {% include "core/includes/back.html" with url=back_url text="Print Configurations" %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <h1 class="h3">Delete Print Configuration</h1>
         <form action="{% url 'core:print-config-delete' list.id print_config.id %}"

--- a/gyrinx/core/tests/test_advancements.py
+++ b/gyrinx/core/tests/test_advancements.py
@@ -875,3 +875,26 @@ def test_advancement_confirm_warns_on_different_fighter(
         fighter=fighter_with_xp, campaign_action=campaign_action
     )
     assert original_advancements.count() == 1
+
+
+@pytest.mark.django_db
+def test_advancement_add_button_owner_gated(client, user, make_user, fighter_with_xp):
+    """The Add Advancement button only appears for the list owner."""
+    url = reverse(
+        "core:list-fighter-advancements",
+        args=[fighter_with_xp.list.id, fighter_with_xp.id],
+    )
+    add_url = reverse(
+        "core:list-fighter-advancement-start",
+        args=[fighter_with_xp.list.id, fighter_with_xp.id],
+    )
+
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 200
+    assert add_url in response.content.decode()
+
+    client.force_login(make_user("visitor", "password"))
+    response = client.get(url)
+    assert response.status_code == 200
+    assert add_url not in response.content.decode()

--- a/gyrinx/core/tests/test_notes_page.py
+++ b/gyrinx/core/tests/test_notes_page.py
@@ -439,3 +439,45 @@ def test_fighter_narrative_save_touches_list_modified(make_list, make_list_fight
 
     lst.refresh_from_db()
     assert lst.modified > old_time
+
+
+@pytest.mark.django_db
+def test_fighter_notes_edit_shows_validation_errors(
+    client, user, make_list, make_list_fighter
+):
+    """An invalid submission re-renders the form with field errors visible."""
+    lst = make_list("Test Gang")
+    fighter = make_list_fighter(lst, "Test Fighter")
+    client.force_login(user)
+
+    response = client.post(
+        reverse("core:list-fighter-notes-edit", args=[lst.id, fighter.id]),
+        {"save_roll": "x" * 11},
+    )
+    assert response.status_code == 200
+    assert "Ensure this value has at most 10 characters" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_fighter_notes_edit_rejects_unsafe_return_url(
+    client, user, make_list, make_list_fighter
+):
+    """An unsafe return_url is never rendered into the page or redirected to."""
+    lst = make_list("Test Gang")
+    fighter = make_list_fighter(lst, "Test Fighter")
+    client.force_login(user)
+    url = reverse("core:list-fighter-notes-edit", args=[lst.id, fighter.id])
+    default_url = reverse("core:list-notes", args=[lst.id]) + f"#notes-{fighter.id}"
+
+    response = client.get(f"{url}?return_url=https://evil.example.com/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "evil.example.com" not in content
+    assert default_url in content
+
+    response = client.post(
+        url,
+        {"notes": "<p>Safe.</p>", "return_url": "https://evil.example.com/"},
+    )
+    assert response.status_code == 302
+    assert response.url == default_url

--- a/gyrinx/core/tests/test_print_config_delete.py
+++ b/gyrinx/core/tests/test_print_config_delete.py
@@ -1,0 +1,23 @@
+"""Print configuration delete confirmation page."""
+
+import pytest
+from django.urls import reverse
+
+from gyrinx.core.models import PrintConfig
+
+
+@pytest.mark.django_db
+def test_delete_confirmation_back_link_resolves(client, user, make_list):
+    """The back link resolves the print-config index URL rather than
+    emitting the literal URL name (issue #2001)."""
+    lst = make_list("Test Gang")
+    config = PrintConfig.objects.create(list=lst, owner=user, name="My Config")
+    client.force_login(user)
+
+    response = client.get(reverse("core:print-config-delete", args=[lst.id, config.id]))
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    index_url = reverse("core:print-config-index", args=[lst.id])
+    assert f'href="{index_url}"' in content
+    assert 'href="core:print-config-index"' not in content

--- a/gyrinx/core/tests/test_restore_fighter.py
+++ b/gyrinx/core/tests/test_restore_fighter.py
@@ -3,7 +3,11 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from gyrinx.content.models import ContentFighter
-from gyrinx.core.models.list import List, ListFighter
+from gyrinx.core.models.list import (
+    List,
+    ListFighter,
+    ListFighterEquipmentAssignment,
+)
 
 User = get_user_model()
 
@@ -312,3 +316,51 @@ def test_archived_fighters_page_links_to_restore(client, user, content_house):
     restore_url = reverse("core:list-fighter-restore", args=[lst.id, fighter.id])
     assert restore_url in content
     assert "Restore" in content
+
+
+@pytest.mark.django_db
+def test_archived_fighters_page_disables_restore_for_child_fighters(
+    client, user, content_house, make_equipment
+):
+    """Child fighters (linked via an equipment assignment) get a disabled
+    control naming the parent instead of a restore link."""
+    lst = List.objects.create(
+        name="Test List",
+        owner=user,
+        content_house=content_house,
+    )
+
+    content_fighter = ContentFighter.objects.create(
+        house=content_house,
+        type="Ganger",
+        category="GANGER",
+        base_cost=50,
+    )
+
+    parent = ListFighter.objects.create(
+        name="Parent Fighter",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+    )
+    child = ListFighter.objects.create(
+        name="Beast",
+        content_fighter=content_fighter,
+        list=lst,
+        owner=user,
+        archived=True,
+    )
+    ListFighterEquipmentAssignment.objects.create(
+        list_fighter=parent,
+        content_equipment=make_equipment("Beast Handler Kit", cost="10"),
+        child_fighter=child,
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("core:list-archived-fighters", args=[lst.id]))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "assigned to Parent Fighter" in content
+    restore_url = reverse("core:list-fighter-restore", args=[lst.id, child.id])
+    assert restore_url not in content


### PR DESCRIPTION
A pass over the core templates (issue #2001) turned up a batch of small, independent bugs, all live on main. This fixes the quick ones in a single PR.

## Summary

- **Dead back link**: the print-config delete page passed a URL *name* to `core/includes/back.html`, which renders its `url` param verbatim — the breadcrumb linked to the literal text `core:print-config-index`. The URL is now resolved at the call site (`gyrinx/core/templates/core/print_config/delete.html`), removing the only user of the ignored `url_arg` param.
- **Hidden validation errors**: the fighter notes edit form (`core/list_fighter_notes_edit.html`) never rendered field errors, so an invalid submission re-rendered silently. It now uses the canonical `core/includes/form_field.html` include, which renders label, widget, help text, and errors.
- **Owner gating**: the "Add Advancement" button on `core/list_fighter_advancements.html` showed for every visitor, but the flow behind it 404s non-owners. It's now gated on list ownership like the other actions on that page.
- **Alert styling**: `core/layouts/base.html` matched `message.tags` exactly when picking an alert variant, so any message carrying `extra_tags` would fall through to `info`. Now uses `message.level_tag`.
- **Archived fighters page**: replaced per-row `source_assignment.exists` / `.get` calls (two queries per fighter, bypassing the prefetch cache) with the prefetch-safe `parent_list_fighter` property; also fixed the empty-state `colspan` (3 in a 2-column table).
- **Cosmetic**: pack names on the new-list page rendered as "Pack A , Pack B" — comma now hugs the name.

## return_url hardening

The issue also flagged `return_url` being rendered unvalidated into `href`s. On inspection, every view that puts `return_url` into template context already routes it through the validating `get_return_url()` helper (`gyrinx/core/utils.py`), which is exactly the URL-returning sibling of `safe_redirect` the issue asked for — so no plumbing change was needed. This PR adds rendering-level test coverage proving an unsafe `return_url` is never emitted into the page and never redirected to.

## Test plan

- [x] New test: print-config delete page renders a resolved back-link href
- [x] New test: invalid fighter notes submission shows the field error
- [x] New test: "Add Advancement" visible to owner, hidden from other users
- [x] New test: archived child fighter shows disabled control naming its parent, no restore link
- [x] New test: unsafe `return_url` is not rendered and POST falls back to the default URL
- [x] Full suite: 3368 passed, 13 skipped

## How to try it

Open a list's print configurations, delete one — the "Print Configurations" breadcrumb on the confirmation page now navigates back instead of being a dead link. On a fighter's Notes page, submit a save roll longer than 10 characters to see the validation error.

Refs #2001 — this addresses all the checkbox items; the "larger follow-ups" section (JS-required flows, a11y) stays with the issue to be split out separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)