### PR TITLE
feat: notify gang owners when their gang is added to a battle

### DIFF
--- a/gyrinx/core/handlers/battle.py
+++ b/gyrinx/core/handlers/battle.py
@@ -7,18 +7,25 @@ apart. Everything else in the battle flow is simple CRUD and stays in the views.
 """
 
 import logging
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Optional
 
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.urls import reverse
+from django.utils.html import format_html, format_html_join
 
 from gyrinx.core.handlers.crew import snapshot_played_crew_ratings
 from gyrinx.core.models.battle import Battle
 from gyrinx.core.models.campaign import CampaignAction
+from gyrinx.core.models.notification import NotificationType, notify
 from gyrinx.tracing import traced
 
 logger = logging.getLogger(__name__)
+
+User = get_user_model()
 
 
 @dataclass
@@ -103,3 +110,97 @@ def handle_battle_end(*, user, battle: Battle, winners, is_draw) -> BattleEndRes
         winners=winners,
         campaign_action=campaign_action,
     )
+
+
+def _join_gang_names(gangs):
+    """A natural-language join of gang names ('A', 'A and B', 'A, B and C').
+
+    Names are user content, so each is HTML-escaped by ``format_html*``.
+    """
+    if len(gangs) == 1:
+        return format_html("{}", gangs[0].name)
+    if len(gangs) == 2:
+        return format_html("{} and {}", gangs[0].name, gangs[1].name)
+    head = format_html_join(", ", "{}", ((g.name,) for g in gangs[:-1]))
+    return format_html("{} and {}", head, gangs[-1].name)
+
+
+def notify_battle_participants(*, user, battle, added_lists):
+    """Notify each added gang's owner that their gang is taking part in a battle.
+
+    Fans out **one notification per owner**, not per gang: a player who fields
+    two gangs in the same battle gets a single notification naming both. This
+    mirrors the per-owner aggregation in
+    :func:`gyrinx.core.cost.reconcile_notify.notify_lists_reconciled` and keeps
+    the inbox free of near-duplicate rows.
+
+    The acting user is never notified about their own action — an arbitrator
+    adding another player's gang notifies that player, while a player adding
+    their own gang notifies nobody about it (other players are still notified).
+
+    Uses ``NotificationType.LIST``: the notification is about one of the
+    recipient's own lists (their gang), links to it, and lands in that list
+    owner's inbox — "something changed on your list". ``CAMPAIGN`` is framed for
+    the arbitrator's perspective ("something in a campaign you arbitrate"), which
+    is not who receives this. Creation goes through the safe ``notify()`` helper,
+    so a notification failure can never break battle creation or editing.
+
+    Args:
+        user: the acting User (creator/editor), never notified about their own action.
+        battle: the :class:`~gyrinx.core.models.battle.Battle` (with ``campaign``).
+        added_lists: the gangs newly added to the battle (List instances).
+
+    Returns:
+        The number of owners notified.
+    """
+    # Only other players' gangs, and only those with a real owner.
+    lists = [lst for lst in added_lists if lst.owner_id and lst.owner_id != user.id]
+    if not lists:
+        return 0
+
+    by_owner = defaultdict(list)
+    for lst in lists:
+        by_owner[lst.owner_id].append(lst)
+
+    # One query for the recipient User objects rather than a lazy .owner per gang.
+    owners = {u.id: u for u in User.objects.filter(pk__in=by_owner.keys())}
+
+    campaign = battle.campaign
+    battle_url = reverse("core:battle", args=[battle.id])
+
+    notified = 0
+    for owner_id, gangs in by_owner.items():
+        owner = owners.get(owner_id)
+        if owner is None:
+            continue
+        gangs = sorted(gangs, key=lambda g: g.name)
+        multiple = len(gangs) > 1
+        if multiple:
+            subject = "Your gangs have been added to a battle"
+            lead = format_html("Your gangs {} are", _join_gang_names(gangs))
+        else:
+            subject = "Your gang has been added to a battle"
+            lead = format_html("Your gang {} is", gangs[0].name)
+        content = format_html(
+            '{} taking part in <a href="{}">{}</a>, a battle in the {} campaign.',
+            lead,
+            battle_url,
+            battle.mission,
+            campaign.name,
+        )
+        n = notify(
+            recipient=owner,
+            subject=subject,
+            content=content,
+            sender=user,
+            notification_type=NotificationType.LIST,
+            # A single-gang notification links straight to that gang; a
+            # multi-gang one has no single list to point at, so it falls back to
+            # the campaign (via related_campaign) for its inbox link.
+            related_list=None if multiple else gangs[0],
+            related_campaign=campaign,
+        )
+        if n is not None:
+            notified += 1
+
+    return notified

--- a/gyrinx/core/templates/core/includes/notification_list_item.html
+++ b/gyrinx/core/templates/core/includes/notification_list_item.html
@@ -3,8 +3,9 @@
     A single inbox row. Expects `notification` in context. The select checkbox is
     associated with the standalone bulk form via the HTML5 `form` attribute so it
     can live outside that form (no nested forms). Unread rows carry a left accent
-    border; the title is semi-bold. Row actions follow the design-system
-    inline-action-menu pattern (link-styled buttons, dot separators).
+    border; the title is semi-bold and links through the "open" proxy, which
+    marks the row read before redirecting to its target. Row actions follow the
+    design-system inline-action-menu pattern (link-styled buttons, dot separators).
 {% endcomment %}
 <div class="p-2 vstack gap-1{% if not first %} border-top{% endif %}"
      style="border-left: 3px solid {% if notification.is_read %}transparent{% else %}var(--bs-primary){% endif %}">
@@ -20,7 +21,7 @@
     </div>
     <div class="fw-semibold">
         {% if notification.target_url %}
-            <a href="{{ notification.target_url }}"
+            <a href="{% url 'core:notification-open' notification.id %}"
                class="link-body-emphasis link-underline-opacity-25 link-underline-opacity-100-hover">{{ notification.subject }}</a>
         {% else %}
             {{ notification.subject }}

--- a/gyrinx/core/tests/test_battle_invite_notifications.py
+++ b/gyrinx/core/tests/test_battle_invite_notifications.py
@@ -1,0 +1,205 @@
+"""Tests for battle-invite notifications.
+
+When a gang is added to a battle, its owner should hear about it in their inbox.
+These cover the two entry points (creating and editing a battle) and the rules
+in :func:`gyrinx.core.handlers.battle.notify_battle_participants`: never notify
+the acting user, one notification per owner, and only newly added gangs on edit.
+"""
+
+import pytest
+from django.urls import reverse
+
+from gyrinx.core.models import Battle, Campaign
+from gyrinx.core.models.notification import Notification, NotificationType
+
+
+def _campaign(make_campaign, owner):
+    return make_campaign("Battle Camp", owner=owner, status=Campaign.IN_PROGRESS)
+
+
+@pytest.mark.django_db
+def test_new_battle_notifies_each_other_owner(
+    client, make_user, make_campaign, make_list
+):
+    """An arbitrator (owning no gang) creates a battle between two players'
+    gangs. Each player is notified exactly once; the arbitrator is not."""
+    arbitrator = make_user("arbitrator", "password")
+    owner_a = make_user("player_a", "password")
+    owner_b = make_user("player_b", "password")
+
+    campaign = _campaign(make_campaign, arbitrator)
+    gang_a = make_list("Ratspike", owner=owner_a)
+    gang_b = make_list("Cold Blooded", owner=owner_b)
+    campaign.lists.add(gang_a, gang_b)
+
+    client.force_login(arbitrator)
+    response = client.post(
+        reverse("core:battle-new", args=[campaign.id]),
+        {
+            "date": "2025-02-01",
+            "mission": "Ambush",
+            "participants": [str(gang_a.id), str(gang_b.id)],
+        },
+    )
+    assert response.status_code == 302
+
+    battle = Battle.objects.get()
+
+    # The arbitrator acted, so gets nothing.
+    assert Notification.objects.filter(owner=arbitrator).count() == 0
+
+    for gang, owner in [(gang_a, owner_a), (gang_b, owner_b)]:
+        notes = Notification.objects.filter(owner=owner)
+        assert notes.count() == 1
+        n = notes.get()
+        assert n.notification_type == NotificationType.LIST
+        assert n.sender == arbitrator
+        assert n.related_list == gang
+        assert n.related_campaign == campaign
+        assert n.subject == "Your gang has been added to a battle"
+        # Content names the gang, the battle mission and the campaign.
+        assert gang.name in n.content
+        assert battle.mission in n.content
+        assert campaign.name in n.content
+
+
+@pytest.mark.django_db
+def test_new_battle_does_not_self_notify_actor(
+    client, make_user, make_campaign, make_list
+):
+    """A player who owns a participating gang creates the battle: they are not
+    notified about their own gang, but the other player still is."""
+    owner_a = make_user("player_a", "password")
+    owner_b = make_user("player_b", "password")
+
+    # Campaign owned by someone else; owner_a has create permission via their gang.
+    arbitrator = make_user("arbitrator", "password")
+    campaign = _campaign(make_campaign, arbitrator)
+    gang_a = make_list("Ratspike", owner=owner_a)
+    gang_b = make_list("Cold Blooded", owner=owner_b)
+    campaign.lists.add(gang_a, gang_b)
+
+    client.force_login(owner_a)
+    response = client.post(
+        reverse("core:battle-new", args=[campaign.id]),
+        {
+            "mission": "Ambush",
+            "participants": [str(gang_a.id), str(gang_b.id)],
+        },
+    )
+    assert response.status_code == 302
+
+    # The actor (owner_a) is never notified about their own action.
+    assert Notification.objects.filter(owner=owner_a).count() == 0
+    # The other player is notified once.
+    assert Notification.objects.filter(owner=owner_b).count() == 1
+
+
+@pytest.mark.django_db
+def test_new_battle_one_owner_two_gangs_gets_single_notification(
+    client, make_user, make_campaign, make_list
+):
+    """A player fielding two gangs in one battle gets a single notification that
+    names both — one per owner, not one per gang."""
+    arbitrator = make_user("arbitrator", "password")
+    owner = make_user("player", "password")
+
+    campaign = _campaign(make_campaign, arbitrator)
+    gang_1 = make_list("Alpha Crew", owner=owner)
+    gang_2 = make_list("Bravo Crew", owner=owner)
+    campaign.lists.add(gang_1, gang_2)
+
+    client.force_login(arbitrator)
+    response = client.post(
+        reverse("core:battle-new", args=[campaign.id]),
+        {
+            "mission": "Ambush",
+            "participants": [str(gang_1.id), str(gang_2.id)],
+        },
+    )
+    assert response.status_code == 302
+
+    notes = Notification.objects.filter(owner=owner)
+    assert notes.count() == 1
+    n = notes.get()
+    assert n.subject == "Your gangs have been added to a battle"
+    assert gang_1.name in n.content
+    assert gang_2.name in n.content
+    # A multi-gang notification has no single gang to link to, so it falls back
+    # to the campaign for its inbox link.
+    assert n.related_list is None
+    assert n.related_campaign == campaign
+
+
+@pytest.mark.django_db
+def test_edit_battle_notifies_only_newly_added(
+    client, make_user, make_campaign, make_list
+):
+    """Editing a battle to add a third gang notifies only that gang's owner —
+    existing participants are not re-notified."""
+    arbitrator = make_user("arbitrator", "password")
+    owner_a = make_user("player_a", "password")
+    owner_b = make_user("player_b", "password")
+    owner_c = make_user("player_c", "password")
+
+    campaign = _campaign(make_campaign, arbitrator)
+    gang_a = make_list("Ratspike", owner=owner_a)
+    gang_b = make_list("Cold Blooded", owner=owner_b)
+    gang_c = make_list("Iron Fangs", owner=owner_c)
+    campaign.lists.add(gang_a, gang_b, gang_c)
+
+    # Battle already has A and B; no notifications from this direct setup.
+    battle = Battle.objects.create(campaign=campaign, mission="Raid", owner=arbitrator)
+    battle.set_participants([gang_a, gang_b])
+    assert Notification.objects.count() == 0
+
+    client.force_login(arbitrator)
+    response = client.post(
+        reverse("core:battle-edit", args=[battle.id]),
+        {
+            "mission": "Raid",
+            "participants": [str(gang_a.id), str(gang_b.id), str(gang_c.id)],
+        },
+    )
+    assert response.status_code == 302
+
+    # Only the newly added gang's owner is notified.
+    assert Notification.objects.filter(owner=owner_c).count() == 1
+    assert Notification.objects.filter(owner=owner_a).count() == 0
+    assert Notification.objects.filter(owner=owner_b).count() == 0
+    assert Notification.objects.filter(owner=arbitrator).count() == 0
+
+    n = Notification.objects.get(owner=owner_c)
+    assert n.related_list == gang_c
+    assert n.notification_type == NotificationType.LIST
+
+
+@pytest.mark.django_db
+def test_edit_battle_no_new_participants_notifies_nobody(
+    client, make_user, make_campaign, make_list
+):
+    """Editing a battle without adding anyone (e.g. changing the mission)
+    produces no notifications."""
+    arbitrator = make_user("arbitrator", "password")
+    owner_a = make_user("player_a", "password")
+    owner_b = make_user("player_b", "password")
+
+    campaign = _campaign(make_campaign, arbitrator)
+    gang_a = make_list("Ratspike", owner=owner_a)
+    gang_b = make_list("Cold Blooded", owner=owner_b)
+    campaign.lists.add(gang_a, gang_b)
+
+    battle = Battle.objects.create(campaign=campaign, mission="Raid", owner=arbitrator)
+    battle.set_participants([gang_a, gang_b])
+
+    client.force_login(arbitrator)
+    response = client.post(
+        reverse("core:battle-edit", args=[battle.id]),
+        {
+            "mission": "Raid renamed",
+            "participants": [str(gang_a.id), str(gang_b.id)],
+        },
+    )
+    assert response.status_code == 302
+
+    assert Notification.objects.count() == 0

--- a/gyrinx/core/tests/test_views_notifications.py
+++ b/gyrinx/core/tests/test_views_notifications.py
@@ -115,6 +115,49 @@ def test_notification_unread_action(client, user):
 
 
 @pytest.mark.django_db
+def test_notification_open_marks_read_and_redirects_to_target(client, user, make_list):
+    lst = make_list("Gang")
+    n = notify(recipient=user, subject="x", related_list=lst)
+    client.force_login(user)
+    resp = client.get(reverse("core:notification-open", args=[n.id]))
+    assert resp.status_code == 302
+    assert resp.url == reverse("core:list", args=[lst.id])
+    n.refresh_from_db()
+    assert n.is_read is True
+
+
+@pytest.mark.django_db
+def test_notification_open_without_target_redirects_to_inbox(client, user):
+    n = notify(recipient=user, subject="x")
+    client.force_login(user)
+    resp = client.get(reverse("core:notification-open", args=[n.id]))
+    assert resp.status_code == 302
+    assert resp.url == reverse("core:notifications")
+    n.refresh_from_db()
+    assert n.is_read is True
+
+
+@pytest.mark.django_db
+def test_notification_open_other_users_is_404(client, user, make_user):
+    other = make_user("other", "password")
+    n = notify(recipient=other, subject="theirs")
+    client.force_login(user)
+    resp = client.get(reverse("core:notification-open", args=[n.id]))
+    assert resp.status_code == 404
+    n.refresh_from_db()
+    assert n.is_read is False
+
+
+@pytest.mark.django_db
+def test_inbox_title_links_through_open_proxy(client, user, make_list):
+    lst = make_list("Gang")
+    n = notify_list_owner(lst, subject="list-note")
+    client.force_login(user)
+    resp = client.get(reverse("core:notifications"))
+    assert reverse("core:notification-open", args=[n.id]) in resp.content.decode()
+
+
+@pytest.mark.django_db
 def test_notification_archive_and_delete_actions(client, user):
     n = notify(recipient=user, subject="x")
     client.force_login(user)

--- a/gyrinx/core/urls/notification.py
+++ b/gyrinx/core/urls/notification.py
@@ -7,6 +7,7 @@ from ..views import notification as v
 patterns = [
     path("notifications/", v.NotificationInboxView.as_view(), name="notifications"),
     path("notifications/bulk", v.notifications_bulk, name="notifications-bulk"),
+    path("notification/<uuid:id>/open", v.notification_open, name="notification-open"),
     path("notification/<uuid:id>/read", v.notification_read, name="notification-read"),
     path(
         "notification/<uuid:id>/unread",

--- a/gyrinx/core/views/battle.py
+++ b/gyrinx/core/views/battle.py
@@ -13,7 +13,10 @@ from gyrinx.core.forms.battle import (
     BattleNoteForm,
     BattleRolesForm,
 )
-from gyrinx.core.handlers.battle import handle_battle_end
+from gyrinx.core.handlers.battle import (
+    handle_battle_end,
+    notify_battle_participants,
+)
 from gyrinx.core.handlers.crew import crew_spread_rating
 from gyrinx.core.models import Battle, Campaign, CampaignAction
 from gyrinx.core.models.crew import Crew
@@ -304,6 +307,15 @@ def new_battle(request, campaign_id):
                 owner=request.user,
             )
 
+            # Tell the owners of the other participating gangs their gang is in
+            # a battle. Every participant is newly added here, so pass them all;
+            # the handler skips the acting user's own gangs.
+            notify_battle_participants(
+                user=request.user,
+                battle=battle,
+                added_lists=form.cleaned_data["participants"],
+            )
+
             messages.success(request, f"Battle '{battle.name}' created successfully!")
             return HttpResponseRedirect(reverse("core:battle", args=[battle.id]))
     else:
@@ -337,9 +349,25 @@ def edit_battle(request, id):
         if form.is_valid():
             if "result" in form.cleaned_data:
                 battle.result = form.cleaned_data["result"]
+            # Capture the current participants before syncing so we can notify
+            # only the gangs newly added by this edit (removals get nothing).
+            existing_participant_ids = set(
+                battle.participants.values_list("pk", flat=True)
+            )
             form.save()
             battle.set_participants(form.cleaned_data["participants"])
             battle.winners.set(form.cleaned_data.get("winners") or [])
+
+            newly_added = [
+                lst
+                for lst in form.cleaned_data["participants"]
+                if lst.pk not in existing_participant_ids
+            ]
+            notify_battle_participants(
+                user=request.user,
+                battle=battle,
+                added_lists=newly_added,
+            )
 
             # Log the battle update event
             log_event(

--- a/gyrinx/core/views/notification.py
+++ b/gyrinx/core/views/notification.py
@@ -1,8 +1,10 @@
 """Notification inbox views and per-row / bulk actions.
 
 All state (bucket, read/unread filter, type, search) is URL-driven via the query
-string; the server renders the right subset. All mutations are POST + CSRF; the
-row title link is a plain GET so navigating never silently marks something read.
+string; the server renders the right subset. All mutations are POST + CSRF, with
+one deliberate exception: the row title link is a GET "open" proxy that marks
+the notification read before redirecting to its target — following a
+notification is itself the act of reading it.
 """
 
 import uuid
@@ -11,6 +13,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
@@ -96,6 +99,21 @@ def _back(request):
         request.POST.get("next"),
         fallback_url=reverse("core:notifications"),
     )
+
+
+@login_required
+def notification_open(request, id):
+    """Title-click proxy: mark the notification read, then follow its link.
+
+    A GET mutation is acceptable here because it is owner-scoped, idempotent,
+    and benign — the worst a forged or prefetched request can do is mark the
+    user's own notification read. The redirect target is the server-derived
+    ``target_url`` (never user input), falling back to the inbox for rows with
+    no related object.
+    """
+    n = _get_owned(request, id)
+    n.mark_read()
+    return HttpResponseRedirect(n.target_url or reverse("core:notifications"))
 
 
 @login_required


### PR DESCRIPTION
Playtest feedback: "we should notify users when one of their lists has been invited to a battle."

When a battle is created — or a battle's participants are edited to add a gang — each added gang's owner now gets an inbox notification naming their gang, the battle (linked), and the campaign. The acting user is never notified about their own action, and an owner fielding two gangs in the same battle gets one notification naming both rather than near-duplicates.

Uses the existing notification system's safe `notify()` helper, so a notification failure can never break battle creation. No schema changes. Removing a participant deliberately notifies nobody (kept out of scope).

Originally stacked on #2011 (now merged); rebased onto main.

Also in this PR: clicking a notification's title in the inbox now marks it read before following the link. The title links through a small proxy URL (`/notification/<id>/open`) that marks the row read and redirects to the notification's server-derived target (or the inbox when there is no target). This deliberately reverses the earlier "a plain GET never marks read" stance for this one case — following a notification is itself the act of reading it. Explicit Mark read/unread actions are unchanged.

## Test plan

- [x] Full suite: 3479 passed, 13 skipped
- [x] 5 integration tests POSTing through the real forms: multi-owner fan-out, no self-notification, edit-adds-only, per-owner dedupe, no-op edit notifies nobody
- [x] Browser-verified: recipient's inbox shows the unread badge and the rendered row with a working battle link

Refs #1346


