### PR TITLE
fix: show always-included fighters on a draft crew's overview

### DIFF
--- a/gyrinx/core/handlers/crew.py
+++ b/gyrinx/core/handlers/crew.py
@@ -334,6 +334,37 @@ def crew_whole_gang_projection(crew: Crew):
     return {"rows": rows, "total": total}
 
 
+@traced("crew_included_forecast")
+def crew_included_forecast(crew: Crew):
+    """The always-included fighters that will join ``crew`` when it's confirmed
+    but aren't members yet — a draft only enrols them (as ``INCLUDED``) at lock.
+
+    Lets the crew overview forecast them alongside the chosen picks / the draw,
+    so a hired gun (or anyone marked *Included*) is visible before the crew is
+    locked. Each is costed at its whole kit (Default), which is what the lock
+    enrols them with, matching :func:`crew_whole_gang_projection`. The whole-gang
+    forecast already includes them, so callers use this only when *not* showing
+    that; once locked they are real attendees and this isn't used.
+    """
+    rows = []
+    total = 0
+    for fighter in always_included_crew_fighters(
+        crew.list,
+        included=crew.included_categories,
+        overrides=crew.eligibility_overrides,
+    ).with_related_data():
+        rating = fighter.cost_int_for_equipment_set(None)
+        total += rating
+        rows.append(
+            {
+                "name": fighter.name,
+                "category": fighter.content_fighter.get_category_display(),
+                "rating": rating,
+            }
+        )
+    return {"rows": rows, "total": total}
+
+
 def crew_spread_rating(crew: Crew) -> tuple[Optional[int], bool]:
     """What a crew is worth *right now* for spread/underdog comparison, and
     whether that figure is provisional. Returns ``(rating, is_provisional)``.

--- a/gyrinx/core/templates/core/crew/crew.html
+++ b/gyrinx/core/templates/core/crew/crew.html
@@ -239,6 +239,42 @@
                             {% if receipt.has_free %}<td></td>{% endif %}
                         </tr>
                     {% endif %}
+                    {% if included_forecast %}
+                        {% comment %}
+                        Always-included fighters (hired guns, anyone marked
+                        Included) are only enrolled at lock, so forecast them on
+                        the draft overview — otherwise they're invisible until the
+                        crew is confirmed.
+                        {% endcomment %}
+                        {% for f in included_forecast.rows %}
+                            <tr>
+                                <td>
+                                    <strong>{{ f.name }}</strong>
+                                    <span class="text-secondary fs-7">· {{ f.category }}</span>
+                                    <span class="badge text-bg-secondary ms-1"
+                                          data-bs-toggle="tooltip"
+                                          data-bs-title="Joins regardless of the selection method">Always included</span>
+                                    <span class="text-secondary fs-7">· Default</span>
+                                </td>
+                                <td class="text-end text-secondary">{{ f.rating }}¢</td>
+                                <td></td>
+                                <td></td>
+                                {% if receipt.has_free %}
+                                    <td></td>
+                                {% endif %}
+                            </tr>
+                        {% endfor %}
+                        <tr>
+                            <td colspan="{% if receipt.has_free %}5{% else %}4{% endif %}">
+                                <div class="border rounded p-2 fs-7 text-secondary">
+                                    <i class="bi-info-circle"></i>
+                                    <strong>Always included.</strong>
+                                    These fighters join regardless of the selection method — they're
+                                    enrolled when the crew is confirmed.
+                                </div>
+                            </td>
+                        </tr>
+                    {% endif %}
                     <tr>
                         <td colspan="{% if receipt.has_free %}5{% else %}4{% endif %}"
                             class="pt-3">
@@ -313,7 +349,9 @@
                             </td>
                             <td></td>
                             <td></td>
-                            {% if receipt.has_free %}<td></td>{% endif %}
+                            {% if receipt.has_free %}
+                                <td></td>
+                            {% endif %}
                         </tr>
                         <tr>
                             <td class="text-secondary">Credits</td>
@@ -327,7 +365,9 @@
                             <td></td>
                             <td></td>
                             <td class="text-end">{{ receipt.allowance_total }}¢</td>
-                            {% if receipt.has_free %}<td></td>{% endif %}
+                            {% if receipt.has_free %}
+                                <td></td>
+                            {% endif %}
                         </tr>
                         {% if receipt.has_free %}
                             <tr>
@@ -350,6 +390,9 @@
                                 <span bs-tooltip
                                       data-bs-toggle="tooltip"
                                       title="Unknown until you roll for selection">?</span>
+                            {% elif included_forecast %}
+                                {{ provisional_total }}¢
+                                <span class="fs-7 fw-normal text-secondary">provisional</span>
                             {% else %}
                                 {{ receipt.total }}¢
                             {% endif %}

--- a/gyrinx/core/tests/test_crew.py
+++ b/gyrinx/core/tests/test_crew.py
@@ -963,6 +963,104 @@ def test_selection_screen_shows_always_included_fighters(
     assert "Merc" in content
 
 
+@pytest.mark.django_db
+def test_crew_overview_forecasts_always_included_on_a_draft(
+    client, crew_setup, make_content_fighter, make_list_fighter
+):
+    """A hired gun (always-included) is only enrolled at lock, so it must be
+    forecast on a draft crew's overview — the reported bug was it going missing
+    on a hybrid draft with picks."""
+    _fighter_of_category(
+        crew_setup,
+        make_content_fighter,
+        make_list_fighter,
+        FighterCategoryChoices.HIRED_GUN,
+        "Merc",
+        base_cost=120,
+    )
+    crew = Crew.objects.create(
+        battle=crew_setup["battle"],
+        list=crew_setup["gang"],
+        owner=crew_setup["user"],
+        selection_method=Crew.HYBRID,
+        custom_count=1,
+        random_spec="D3",
+    )
+    add_chosen(crew, crew_setup["fighters"][:1])
+    client.force_login(crew_setup["user"])
+
+    resp = client.get(reverse("core:crew", args=[crew.battle_id, crew.id]))
+
+    forecast = resp.context["included_forecast"]
+    assert forecast is not None
+    assert [r["name"] for r in forecast["rows"]] == ["Merc"]
+    assert forecast["total"] == 120
+    content = resp.content.decode()
+    assert "Merc" in content
+    assert "Always included" in content
+
+
+@pytest.mark.django_db
+def test_crew_overview_no_included_forecast_once_locked(
+    client, crew_setup, make_content_fighter, make_list_fighter
+):
+    """Once locked, always-included fighters are real attendees, so there's no
+    separate forecast (it would double them up)."""
+    _fighter_of_category(
+        crew_setup,
+        make_content_fighter,
+        make_list_fighter,
+        FighterCategoryChoices.HIRED_GUN,
+        "Merc",
+    )
+    crew = Crew.objects.create(
+        battle=crew_setup["battle"],
+        list=crew_setup["gang"],
+        owner=crew_setup["user"],
+        selection_method=Crew.CUSTOM,
+        custom_count=1,
+    )
+    add_chosen(crew, crew_setup["fighters"][:1])
+    handle_crew_lock(user=crew_setup["user"], crew=crew)
+    client.force_login(crew_setup["user"])
+
+    resp = client.get(reverse("core:crew", args=[crew.battle_id, crew.id]))
+
+    assert resp.context["included_forecast"] is None
+    # The hired gun is now a real attendee instead.
+    assert crew.members.filter(source=CrewMember.INCLUDED).exists()
+    assert "Merc" in resp.content.decode()
+
+
+@pytest.mark.django_db
+def test_crew_overview_whole_gang_draft_has_no_separate_included_forecast(
+    client, crew_setup, make_content_fighter, make_list_fighter
+):
+    """The whole-gang projection already lists always-included fighters, so the
+    separate forecast isn't used (no double-listing)."""
+    _fighter_of_category(
+        crew_setup,
+        make_content_fighter,
+        make_list_fighter,
+        FighterCategoryChoices.HIRED_GUN,
+        "Merc",
+    )
+    crew = Crew.objects.create(
+        battle=crew_setup["battle"],
+        list=crew_setup["gang"],
+        owner=crew_setup["user"],
+        selection_method=Crew.CUSTOM,  # no count + no picks = whole gang
+    )
+    client.force_login(crew_setup["user"])
+
+    resp = client.get(reverse("core:crew", args=[crew.battle_id, crew.id]))
+
+    assert resp.context["included_forecast"] is None
+    assert resp.context["projection"] is not None
+    # Still shown, via the whole-gang projection.
+    assert "Merc" in resp.content.decode()
+
+
 # --- Eligibility screen (per-fighter defaults + overrides) ------------------
 #
 # The eligibility step computes a default state per fighter (eligible /

--- a/gyrinx/core/views/crew.py
+++ b/gyrinx/core/views/crew.py
@@ -33,6 +33,7 @@ from gyrinx.core.forms.crew import (
 from gyrinx.core.handlers.crew import (
     TOGGLEABLE_CREW_CATEGORIES,
     crew_battle_spread,
+    crew_included_forecast,
     crew_whole_gang_projection,
     eligible_crew_fighters_for_loadouts,
     handle_crew_archive,
@@ -280,6 +281,20 @@ def crew_detail(request, battle_id, crew_id):
         # The receipt's own total is extras-only while there are no attendees.
         provisional_total = projection["total"] + receipt["total"]
 
+    # Always-included fighters (hired guns, anyone marked Included) are only
+    # enrolled at lock, so a draft's receipt misses them — forecast them here so
+    # they show on the overview alongside the picks / the draw. The whole-gang
+    # projection already covers them, so only when it isn't shown.
+    included_forecast = None
+    if not crew.is_locked and projection is None:
+        forecast = crew_included_forecast(crew)
+        if forecast["rows"]:
+            included_forecast = forecast
+            # A random/hybrid draw is still unknown, so the total stays "?" (the
+            # template keeps that); a custom draft can show a provisional total.
+            if not crew.pending_roll:
+                provisional_total = receipt["total"] + forecast["total"]
+
     # Informational only: how far this crew sits below the highest crew in the
     # battle, in credits. Just the number — the humans decide what, if anything,
     # it entitles them to. None when the gap can't be worked out (no opponent
@@ -299,6 +314,7 @@ def crew_detail(request, battle_id, crew_id):
             "show_rating_note": bool(note and note["differs"]),
             "rating_note": note,
             "projection": projection,
+            "included_forecast": included_forecast,
             "provisional_total": provisional_total,
             "can_edit_loadouts": bool(projection and can_manage),
             "rating_gap": rating_gap,


### PR DESCRIPTION
## Problem

Fighters marked **Included** on the eligibility screen — hired guns and the
like, or anyone a player forces in — don't appear on a **draft** crew's overview
(the main crew page). Reported after a hybrid selection: the included hanger-on
wasn't listed among the crew's fighters until the crew was confirmed.

## Cause

Always-included fighters are only enrolled as `CrewMember`s (source `INCLUDED`)
at **lock** time, via `sync_included_crew_members`. The overview's fighter table
is built from the crew's members, so on a draft it shows the chosen picks but
not the always-included ones. The whole-gang forecast already covered them, but
only for a *whole-gang* draft (no picks) — a hybrid/custom draft with picks fell
through.

## Fix

`crew_included_forecast(crew)` forecasts the always-included fighters on a draft
overview, mirroring the existing whole-gang forecast: each shown read-only under
an **"Always included"** note, costed at its Default kit (what the lock enrols),
with the total marked *provisional* — or **"?"** while a random/hybrid draw is
still pending. Only used when the whole-gang forecast isn't (which already lists
them) and never once locked (they're real attendees then).

## Test plan

- [x] `test_crew_overview_forecasts_always_included_on_a_draft` — the reported
      case: hybrid draft + picks + hired gun → hired gun shown on the overview
- [x] No separate forecast once locked (real attendee instead)
- [x] No separate forecast on a whole-gang draft (shown via the whole-gang forecast)
- [x] Full crew suite green (206)

Refs #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
