### PR TITLE
feat: Part-of-the-Crew hangers default eligible; show fighter status on the crew setup screen

### DIFF
--- a/gyrinx/core/forms/crew.py
+++ b/gyrinx/core/forms/crew.py
@@ -22,6 +22,7 @@ from gyrinx.core.handlers.crew import (
     always_included_crew_fighters,
     compute_crew_eligibility,
     eligible_crew_fighters,
+    fighter_crew_status,
 )
 from gyrinx.core.models.crew import (
     Crew,
@@ -436,6 +437,7 @@ class CrewSetupForm(forms.Form):
                     "effective": row["effective"],
                     "category": fighter.content_fighter.get_category_display(),
                     "cost": fighter.cost_int_cached,
+                    "status": fighter_crew_status(fighter),
                 }
             )
         return out

--- a/gyrinx/core/handlers/crew.py
+++ b/gyrinx/core/handlers/crew.py
@@ -100,6 +100,26 @@ CREW_ALWAYS_INCLUDED = "included"  # joins regardless of method, on top
 CREW_NOT_ELIGIBLE = "excluded"  # not in the crew
 CREW_ELIGIBILITY_STATES = (CREW_ELIGIBLE, CREW_ALWAYS_INCLUDED, CREW_NOT_ELIGIBLE)
 
+# The "Part of the Crew" special rule makes a hanger-on fight — and be selected —
+# like a regular Ganger (Core Rulebook: "may be chosen or randomly selected …
+# just like any other Ganger"), so it joins the pick/draw *pool* rather than
+# staying benched with the other hangers-on. That is CREW_ELIGIBLE, NOT the
+# hired-gun "always included on top" treatment. Ragnir Gunnstein's identical rule
+# is titled "Gang Fighter", so both names count. These names are content-defined
+# (they live in the production DB, not here), so detection is by name — a miss
+# just means a wrong default the player overrides on the eligibility screen.
+PART_OF_THE_CREW_RULE_NAMES = frozenset({"Part of the Crew", "Gang Fighter"})
+
+
+def fighter_is_part_of_the_crew(fighter):
+    """Whether ``fighter``'s type carries the "Part of the Crew" rule (or Ragnir's
+    "Gang Fighter" variant). Reads ``content_fighter.rules`` — callers must have
+    ``content_fighter__rules`` prefetched to keep it off the N+1 path."""
+    return any(
+        rule.name in PART_OF_THE_CREW_RULE_NAMES
+        for rule in fighter.content_fighter.rules.all()
+    )
+
 
 def default_crew_eligibility_state(fighter, *, included_categories):
     """The default eligibility state for ``fighter`` before per-crew overrides.
@@ -113,6 +133,10 @@ def default_crew_eligibility_state(fighter, *, included_categories):
     Recovery keeps a fighter out of the next battle, but Convalescence does not
     (it only bars post-battle actions — Core Rulebook), so a convalescing fighter
     defaults to eligible.
+
+    A hanger-on with the "Part of the Crew" rule is the exception to the
+    hangers-on-are-excluded default: it fights like a Ganger, so it defaults to
+    eligible (in the pool) even without the category being opted in.
     """
     if (
         fighter.is_captured
@@ -126,8 +150,34 @@ def default_crew_eligibility_state(fighter, *, included_categories):
     if category in DEFAULT_EXCLUDED_CREW_CATEGORIES and category not in set(
         included_categories
     ):
+        # "Part of the Crew" fights like a regular Ganger — eligible to be picked
+        # or drawn — so it's in the pool despite its excluded-by-default category.
+        if fighter_is_part_of_the_crew(fighter):
+            return CREW_ELIGIBLE
         return CREW_NOT_ELIGIBLE
     return CREW_ELIGIBLE
+
+
+def fighter_crew_status(fighter):
+    """A short status label for a fighter on the eligibility screen — the
+    conditions that bear on whether they can take part (captured / sold /
+    injured), so a player can see *why* someone defaults to not-eligible and
+    change it. ``None`` when the fighter is active and unremarkable.
+
+    Reads ``capture_info`` (for the captured / sold checks), so the fighters
+    must be loaded with it prefetched (the setup form uses ``with_related_data``).
+    """
+    if fighter.is_captured:
+        return "Captured"
+    if fighter.is_sold_to_guilders:
+        return "Sold to guilders"
+    if fighter.injury_state == ListFighter.RECOVERY:
+        return "In recovery"
+    if fighter.injury_state == ListFighter.CONVALESCENCE:
+        return "Convalescing"
+    if fighter.injury_state == ListFighter.DEAD:
+        return "Dead"
+    return None
 
 
 def _selectable_gang_fighters(lst):
@@ -140,7 +190,8 @@ def _selectable_gang_fighters(lst):
     via :func:`sync_linked_crew_members` when their owner is picked. The Crew that
     operate a vehicle *are* shown (opt-in). ``capture_info`` is selected so the
     captured / sold checks don't fan out into a query per fighter on the draw
-    path.
+    path, and ``content_fighter__rules`` is prefetched for the "Part of the Crew"
+    check.
     """
     return (
         ListFighter.objects.filter(
@@ -151,6 +202,7 @@ def _selectable_gang_fighters(lst):
         )
         .exclude(_effective_category_in(EQUIPMENT_CREW_CATEGORIES))
         .select_related("content_fighter", "capture_info")
+        .prefetch_related("content_fighter__rules")
     )
 
 

--- a/gyrinx/core/templates/core/crew/crew_setup.html
+++ b/gyrinx/core/templates/core/crew/crew_setup.html
@@ -87,7 +87,12 @@
                         {% for row in form.fighter_rows %}
                             <div class="border rounded p-2 d-flex flex-column flex-sm-row gap-1 gap-sm-3 align-items-start align-items-sm-center">
                                 <div class="me-sm-auto">
-                                    <div class="fw-semibold">{{ row.fighter.name }}</div>
+                                    <div class="fw-semibold">
+                                        {{ row.fighter.name }}
+                                        {% if row.status %}
+                                            <span class="badge text-bg-secondary fw-normal ms-1">{{ row.status }}</span>
+                                        {% endif %}
+                                    </div>
                                     <div class="fs-7 text-secondary">{{ row.category }} · {{ row.cost }}¢</div>
                                 </div>
                                 <div class="hstack gap-3 flex-wrap">

--- a/gyrinx/core/tests/test_crew.py
+++ b/gyrinx/core/tests/test_crew.py
@@ -1230,6 +1230,114 @@ def test_ally_defaults_to_always_included(
     assert ally not in set(eligible_crew_fighters(crew_setup["gang"]))
 
 
+def _hanger_with_rule(
+    crew_setup, make_content_fighter, make_list_fighter, name, rule_name
+):
+    """A hanger-on whose content fighter carries ``rule_name``."""
+    from gyrinx.content.models import ContentRule
+
+    hanger = _fighter_of_category(
+        crew_setup,
+        make_content_fighter,
+        make_list_fighter,
+        FighterCategoryChoices.HANGER_ON,
+        name,
+    )
+    rule, _ = ContentRule.objects.get_or_create(name=rule_name)
+    hanger.content_fighter.rules.add(rule)
+    return hanger
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("rule_name", ["Part of the Crew", "Gang Fighter"])
+def test_part_of_the_crew_hanger_defaults_to_eligible(
+    crew_setup, make_content_fighter, make_list_fighter, rule_name
+):
+    """A hanger-on with the 'Part of the Crew' rule (or Ragnir's 'Gang Fighter'
+    variant) fights like a Ganger: it defaults to *eligible* — in the pick/draw
+    pool — not excluded, and NOT always-included on top."""
+    hanger = _hanger_with_rule(
+        crew_setup, make_content_fighter, make_list_fighter, "Ragnir", rule_name
+    )
+    crew = Crew.objects.create(
+        battle=crew_setup["battle"], list=crew_setup["gang"], owner=crew_setup["user"]
+    )
+
+    states = {row["fighter"].id: row["effective"] for row in crew_eligibility(crew)}
+    assert states[hanger.id] == CREW_ELIGIBLE
+    assert hanger in set(eligible_crew_fighters(crew_setup["gang"]))
+    assert hanger not in set(always_included_crew_fighters(crew_setup["gang"]))
+
+
+@pytest.mark.django_db
+def test_plain_hanger_without_the_rule_is_still_excluded(
+    crew_setup, make_content_fighter, make_list_fighter
+):
+    """A normal hanger-on (no 'Part of the Crew' rule) still defaults to excluded,
+    and an unrelated rule doesn't trigger it."""
+    hanger = _hanger_with_rule(
+        crew_setup, make_content_fighter, make_list_fighter, "Rogue Doc", "Medicae"
+    )
+    crew = Crew.objects.create(
+        battle=crew_setup["battle"], list=crew_setup["gang"], owner=crew_setup["user"]
+    )
+
+    states = {row["fighter"].id: row["effective"] for row in crew_eligibility(crew)}
+    assert states[hanger.id] == CREW_NOT_ELIGIBLE
+
+
+@pytest.mark.django_db
+def test_part_of_the_crew_still_benched_when_in_recovery(
+    crew_setup, make_content_fighter, make_list_fighter
+):
+    """Condition wins over the rule: a Part-of-the-Crew hanger in recovery is
+    still not eligible (normal availability rules apply)."""
+    hanger = _hanger_with_rule(
+        crew_setup,
+        make_content_fighter,
+        make_list_fighter,
+        "Ragnir",
+        "Part of the Crew",
+    )
+    hanger.injury_state = ListFighter.RECOVERY
+    hanger.save()
+    crew = Crew.objects.create(
+        battle=crew_setup["battle"], list=crew_setup["gang"], owner=crew_setup["user"]
+    )
+
+    states = {row["fighter"].id: row["effective"] for row in crew_eligibility(crew)}
+    assert states[hanger.id] == CREW_NOT_ELIGIBLE
+
+
+@pytest.mark.django_db
+def test_eligibility_screen_shows_fighter_status(client, crew_setup, make_list):
+    """Captured / in-recovery fighters show their status on the setup screen so a
+    player can see why they default to not-eligible."""
+    from gyrinx.core.models.list import CapturedFighter
+
+    fighters = crew_setup["fighters"]
+    fighters[0].injury_state = ListFighter.RECOVERY
+    fighters[0].save()
+    rivals = make_list(
+        "Rivals", status=List.CAMPAIGN_MODE, campaign=crew_setup["campaign"]
+    )
+    CapturedFighter.objects.create(fighter=fighters[1], capturing_list=rivals)
+    crew = Crew.objects.create(
+        battle=crew_setup["battle"], list=crew_setup["gang"], owner=crew_setup["user"]
+    )
+    client.force_login(crew_setup["user"])
+
+    resp = client.get(reverse("core:crew-setup", args=[crew.battle_id, crew.id]))
+
+    rows = {r["fighter"].id: r["status"] for r in resp.context["form"].fighter_rows()}
+    assert rows[fighters[0].id] == "In recovery"
+    assert rows[fighters[1].id] == "Captured"
+    assert rows[fighters[2].id] is None  # active, no status
+    content = resp.content.decode()
+    assert "In recovery" in content
+    assert "Captured" in content
+
+
 @pytest.mark.django_db
 def test_override_drops_a_ganger_from_the_pool(crew_setup):
     """An 'excluded' override removes an otherwise-eligible fighter from the


### PR DESCRIPTION
Two follow-ups to the crew eligibility screen.

## Part of the Crew

A hanger-on with the **"Part of the Crew"** special rule fights — and is selected
— like a regular Ganger. Per the Core Rulebook it "may be chosen or randomly
selected as part of the gang's starting crew just like any other Ganger", so it
now defaults to **Eligible** (in the pick/draw pool) instead of being benched
with the other hangers-on.

**Note on interpretation:** the rules make it *Eligible* (in the pool, can be
picked or missed by a random draw), **not** "always included on top" (the
hired-gun / You-Get-What-You-Pay-For treatment). Verified against the rulebook.
If you specifically wanted always-included instead, it's a one-line change — say
so.

- Ragnir Gunnstein's identical rule is titled **"Gang Fighter"**, so both names
  are matched.
- Detection is by rule name on the fighter's content type. Those names live in
  the production DB (there's no such rule in the repo), so matching is name-based
  — a miss just means a wrong default the player overrides on the screen.
- Normal availability still wins: a Part-of-the-Crew fighter who is captured or
  in recovery is still not eligible.

## Fighter status on the setup screen

Each fighter row now shows a status badge — **Captured / Sold to guilders / In
recovery / Convalescing / Dead** — so a player can see *why* someone defaults to
not-eligible (and change it if they want). Active fighters show nothing.
`content_fighter__rules` is prefetched on the eligibility roster so the rule
check stays off the N+1 path.

## Test plan

- [x] Part-of-the-Crew hanger (both "Part of the Crew" and "Gang Fighter" rule
      names) defaults to Eligible — in the pool, not always-included
- [x] A plain hanger-on (or one with an unrelated rule) is still Excluded
- [x] A Part-of-the-Crew hanger in recovery is still not eligible
- [x] Captured and in-recovery fighters show their status on the setup screen
- [x] Full crew suite green (211); battle+crew suite green (305)

Refs #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
