### PR TITLE
feat: clarify the crew eligibility control — "Always included", moved rightmost

### DIFF
--- a/gyrinx/core/forms/crew.py
+++ b/gyrinx/core/forms/crew.py
@@ -290,19 +290,15 @@ class CrewForm(forms.Form):
         return cleaned
 
 
-# The eligibility screen's per-fighter control. Order runs definitely-in →
-# maybe → out. Values are the states from handlers.crew.
+# The eligibility screen's per-fighter control. The common pair (Eligible /
+# Excluded) comes first; "Always included" sits rightmost so it doesn't read as
+# "tick to pick" — it's a standing state (hired guns et al. come by default,
+# regardless of the crew selected). Values are the states from handlers.crew.
 ELIGIBILITY_CHOICES = [
-    (CREW_ALWAYS_INCLUDED, "Included"),
     (CREW_ELIGIBLE, "Eligible"),
     (CREW_NOT_ELIGIBLE, "Excluded"),
+    (CREW_ALWAYS_INCLUDED, "Always included"),
 ]
-
-ELIGIBILITY_HELP = {
-    CREW_ALWAYS_INCLUDED: "Joins the crew regardless of the selection method.",
-    CREW_ELIGIBLE: "May be picked or drawn using the selection method.",
-    CREW_NOT_ELIGIBLE: "Not part of this crew.",
-}
 
 
 def eligibility_field_name(fighter_id):

--- a/gyrinx/core/templates/core/crew/crew_setup.html
+++ b/gyrinx/core/templates/core/crew/crew_setup.html
@@ -78,9 +78,10 @@
             <div>
                 <div class="form-label mb-1">Eligibility</div>
                 <div class="fs-7 text-secondary mb-2">
-                    <span class="fw-semibold">Included</span> fighters always join ·
                     <span class="fw-semibold">Eligible</span> fighters may be picked or drawn ·
-                    <span class="fw-semibold">Excluded</span> fighters sit this one out.
+                    <span class="fw-semibold">Excluded</span> fighters sit this one out ·
+                    <span class="fw-semibold">Always included</span> fighters are those like hired guns and
+                    house agents, who come by default regardless of the crew selected.
                 </div>
                 {% if form.fighter_rows %}
                     <div class="vstack gap-2">


### PR DESCRIPTION
Expert feedback on the crew eligibility screen: leading each fighter's radio
with "Included" read as "tick to pick this fighter".

## Changes

- The per-fighter control now runs **Eligible / Excluded / Always included** —
  the common pair first, the standing state moved to the right-hand column.
- The label is **"Always included"** (was "Included"), matching the Choose
  screen's "Always included" section and the crew page's forecast badge — one
  vocabulary across all three places.
- The legend above the table now explains it in the expert's words: *"Always
  included fighters are those like hired guns and house agents, who come by
  default regardless of the crew selected."*

Display only — stored values (`eligible` / `excluded` / `included`) are
unchanged, so existing crews and overrides are unaffected. Also removes the
unused `ELIGIBILITY_HELP` dict.

## Test plan

- [x] Full crew suite green (211)

Refs #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
