### PR TITLE
fix: crew setup status badges match the fighter card's presentation

### DIFF
--- a/gyrinx/core/forms/crew.py
+++ b/gyrinx/core/forms/crew.py
@@ -22,7 +22,7 @@ from gyrinx.core.handlers.crew import (
     always_included_crew_fighters,
     compute_crew_eligibility,
     eligible_crew_fighters,
-    fighter_crew_status,
+    fighter_crew_status_badges,
 )
 from gyrinx.core.models.crew import (
     Crew,
@@ -433,7 +433,7 @@ class CrewSetupForm(forms.Form):
                     "effective": row["effective"],
                     "category": fighter.content_fighter.get_category_display(),
                     "cost": fighter.cost_int_cached,
-                    "status": fighter_crew_status(fighter),
+                    "status_badges": fighter_crew_status_badges(fighter),
                 }
             )
         return out

--- a/gyrinx/core/handlers/crew.py
+++ b/gyrinx/core/handlers/crew.py
@@ -158,26 +158,31 @@ def default_crew_eligibility_state(fighter, *, included_categories):
     return CREW_ELIGIBLE
 
 
-def fighter_crew_status(fighter):
-    """A short status label for a fighter on the eligibility screen — the
-    conditions that bear on whether they can take part (captured / sold /
-    injured), so a player can see *why* someone defaults to not-eligible and
-    change it. ``None`` when the fighter is active and unremarkable.
+def fighter_crew_status_badges(fighter):
+    """Status badges for a fighter on the eligibility screen — the conditions
+    that bear on whether they can take part, so a player can see *why* someone
+    defaults to not-eligible and change it. Empty when active and unremarkable.
 
-    Reads ``capture_info`` (for the captured / sold checks), so the fighters
-    must be loaded with it prefetched (the setup form uses ``with_related_data``).
+    ``[{"label", "badge"}]``, matching the fighter card's presentation exactly
+    (labels and colour classes — see ``fighter_card_content.html``): the injury
+    state's own display name in warning (or danger when dead), plus Captured
+    (warning) / Sold to Guilders (secondary). Reads ``capture_info``, so the
+    fighters must be loaded with it prefetched (the setup form uses
+    ``with_related_data``).
     """
+    badges = []
+    if fighter.injury_state != ListFighter.ACTIVE:
+        badges.append(
+            {
+                "label": fighter.get_injury_state_display(),
+                "badge": "text-bg-danger" if fighter.is_dead else "text-bg-warning",
+            }
+        )
     if fighter.is_captured:
-        return "Captured"
-    if fighter.is_sold_to_guilders:
-        return "Sold to guilders"
-    if fighter.injury_state == ListFighter.RECOVERY:
-        return "In recovery"
-    if fighter.injury_state == ListFighter.CONVALESCENCE:
-        return "Convalescing"
-    if fighter.injury_state == ListFighter.DEAD:
-        return "Dead"
-    return None
+        badges.append({"label": "Captured", "badge": "text-bg-warning"})
+    elif fighter.is_sold_to_guilders:
+        badges.append({"label": "Sold to Guilders", "badge": "text-bg-secondary"})
+    return badges
 
 
 def _selectable_gang_fighters(lst):

--- a/gyrinx/core/templates/core/crew/crew_setup.html
+++ b/gyrinx/core/templates/core/crew/crew_setup.html
@@ -90,9 +90,9 @@
                                 <div class="me-sm-auto">
                                     <div class="fw-semibold">
                                         {{ row.fighter.name }}
-                                        {% if row.status %}
-                                            <span class="badge text-bg-secondary fw-normal ms-1">{{ row.status }}</span>
-                                        {% endif %}
+                                        {% for badge in row.status_badges %}
+                                            <span class="badge {{ badge.badge }} ms-1">{{ badge.label }}</span>
+                                        {% endfor %}
                                     </div>
                                     <div class="fs-7 text-secondary">{{ row.category }} · {{ row.cost }}¢</div>
                                 </div>

--- a/gyrinx/core/tests/test_crew.py
+++ b/gyrinx/core/tests/test_crew.py
@@ -1329,13 +1329,18 @@ def test_eligibility_screen_shows_fighter_status(client, crew_setup, make_list):
 
     resp = client.get(reverse("core:crew-setup", args=[crew.battle_id, crew.id]))
 
-    rows = {r["fighter"].id: r["status"] for r in resp.context["form"].fighter_rows()}
-    assert rows[fighters[0].id] == "In recovery"
-    assert rows[fighters[1].id] == "Captured"
-    assert rows[fighters[2].id] is None  # active, no status
+    rows = {
+        r["fighter"].id: [b["label"] for b in r["status_badges"]]
+        for r in resp.context["form"].fighter_rows()
+    }
+    # Labels and colours match the fighter card's presentation exactly.
+    assert rows[fighters[0].id] == ["Recovery"]
+    assert rows[fighters[1].id] == ["Captured"]
+    assert rows[fighters[2].id] == []  # active, no badges
     content = resp.content.decode()
-    assert "In recovery" in content
+    assert "Recovery" in content
     assert "Captured" in content
+    assert "text-bg-warning" in content  # the normal colour-coding
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Expert feedback on the crew setup screen's fighter-status bubbles: they lacked
the normal colour-coding, and Convalescence showed as "Convalescing". There's no
reason for them to differ from the main list pages.

## Changes

The badges now mirror the fighter card's presentation exactly
(`fighter_card_content.html`):

- **Labels** come from the injury state's own display name — "Recovery",
  "Convalescence", "Dead", "In Repair" — no bespoke wording.
- **Colours** match: warning yellow for injured states, danger red for dead,
  warning for Captured, secondary for "Sold to Guilders".
- A fighter can carry **both** an injury badge and a Captured/Sold badge, as on
  the card.

## Test plan

- [x] Recovery shows as "Recovery" (warning), Captured as "Captured" (warning),
      active fighters show nothing
- [x] Full crew suite green (211)

Refs #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
