### PR TITLE
feat: crew Print button offers Default or Classic card styles

### DIFF
--- a/gyrinx/core/templates/core/crew/crew.html
+++ b/gyrinx/core/templates/core/crew/crew.html
@@ -24,8 +24,28 @@
                         the whole gang — hide it rather than mislead.
                         {% endcomment %}
                         {% if not crew.archived %}
-                            <a href="{% url 'core:list-print' crew.list.id %}?crew={{ crew.id }}"
-                               class="btn btn-secondary btn-sm"><i class="bi-printer"></i> Print</a>
+                            <div class="btn-group" role="group">
+                                <button type="button"
+                                        class="btn btn-secondary btn-sm dropdown-toggle"
+                                        data-bs-toggle="dropdown"
+                                        aria-expanded="false">
+                                    <i class="bi-printer"></i> Print
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li>
+                                        <a class="dropdown-item"
+                                           href="{% url 'core:list-print' crew.list.id %}?crew={{ crew.id }}">
+                                            Default cards
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item"
+                                           href="{% url 'core:list-print' crew.list.id %}?crew={{ crew.id }}&style=classic">
+                                            Classic cards
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
                         {% endif %}
                         {% if can_manage %}
                             {% if not crew.is_locked %}

--- a/gyrinx/core/tests/test_print_config_classic.py
+++ b/gyrinx/core/tests/test_print_config_classic.py
@@ -224,3 +224,89 @@ def test_classic_appends_blank_cards(client, user, make_list, make_list_fighter)
     # 1 real fighter card + 3 blank cards
     assert body.count('class="classic-card') == 4
     assert body.count('data-kind="blank"') == 3
+
+
+# ---------------------------------------------------------------------------
+# ?style= URL override (the crew page's Print dropdown)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_style_param_selects_classic_without_a_config(
+    client, user, make_list, make_list_fighter
+):
+    """?style=classic renders the classic sheet with no PrintConfig at all —
+    how the crew page's Print dropdown offers the classic cards."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger")
+    client.force_login(user)
+
+    resp = client.get(_print_url(lst) + "?style=classic")
+
+    assert resp.status_code == 200
+    assert "core/list_print_classic.html" in [t.name for t in resp.templates]
+    assert len(resp.context["classic_cards"]) == 1  # the fighter, no blanks
+
+
+@pytest.mark.django_db
+def test_style_param_overrides_a_classic_config_back_to_default(
+    client, user, make_list, make_list_fighter
+):
+    """An explicit ?style=default wins over a classic config."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger")
+    config = _classic_config(lst, user)
+    client.force_login(user)
+
+    resp = client.get(_print_url(lst, config) + "&style=default")
+
+    assert resp.status_code == 200
+    assert "core/list_print_classic.html" not in [t.name for t in resp.templates]
+
+
+@pytest.mark.django_db
+def test_crew_print_dropdown_offers_both_styles(client, user, make_list, campaign):
+    """The crew page's Print control links both card styles for the crew."""
+    from gyrinx.core.models import Battle, List
+    from gyrinx.core.models.crew import Crew
+
+    lst = make_list("Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
+    campaign.lists.add(lst)
+    battle = Battle.objects.create(campaign=campaign, mission="Test", owner=user)
+    battle.set_participants([lst])
+    crew = Crew.objects.create(battle=battle, list=lst, owner=user)
+    client.force_login(user)
+
+    resp = client.get(reverse("core:crew", args=[battle.id, crew.id]))
+
+    content = resp.content.decode()
+    assert f"?crew={crew.id}" in content
+    assert f"?crew={crew.id}&style=classic" in content
+
+
+@pytest.mark.django_db
+def test_crew_classic_print_renders_crew_fighters(
+    client, user, make_list, make_list_fighter, campaign
+):
+    """A crew print in classic style shows the crew's fighters as classic cards."""
+    from gyrinx.core.models import Battle, List
+    from gyrinx.core.models.crew import Crew, CrewMember
+
+    lst = make_list("Gang", status=List.CAMPAIGN_MODE, campaign=campaign)
+    campaign.lists.add(lst)
+    picked = make_list_fighter(lst, "Picked")
+    make_list_fighter(lst, "Benched")
+    battle = Battle.objects.create(campaign=campaign, mission="Test", owner=user)
+    battle.set_participants([lst])
+    crew = Crew.objects.create(battle=battle, list=lst, owner=user, status=Crew.LOCKED)
+    CrewMember.objects.create(
+        crew=crew, list_fighter=picked, source=CrewMember.CHOSEN, owner=user
+    )
+    client.force_login(user)
+
+    resp = client.get(_print_url(lst) + f"?crew={crew.id}&style=classic")
+
+    assert resp.status_code == 200
+    assert "core/list_print_classic.html" in [t.name for t in resp.templates]
+    names = [c.name for c in resp.context["classic_cards"]]
+    assert names == ["Picked"]  # crew-narrowed, no bench

--- a/gyrinx/core/tests/test_print_config_classic.py
+++ b/gyrinx/core/tests/test_print_config_classic.py
@@ -279,6 +279,7 @@ def test_crew_print_dropdown_offers_both_styles(client, user, make_list, campaig
 
     resp = client.get(reverse("core:crew", args=[battle.id, crew.id]))
 
+    assert resp.status_code == 200
     content = resp.content.decode()
     assert f"?crew={crew.id}" in content
     assert f"?crew={crew.id}&style=classic" in content
@@ -310,3 +311,37 @@ def test_crew_classic_print_renders_crew_fighters(
     assert "core/list_print_classic.html" in [t.name for t in resp.templates]
     names = [c.name for c in resp.context["classic_cards"]]
     assert names == ["Picked"]  # crew-narrowed, no bench
+
+
+@pytest.mark.django_db
+def test_unrecognised_style_falls_back_to_the_config(
+    client, user, make_list, make_list_fighter
+):
+    """?style=bogus is a navigation accident: the config's style still applies."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger")
+    config = _classic_config(lst, user)
+    client.force_login(user)
+
+    resp = client.get(_print_url(lst, config) + "&style=bogus")
+
+    assert resp.status_code == 200
+    assert "core/list_print_classic.html" in [t.name for t in resp.templates]
+
+
+@pytest.mark.django_db
+def test_style_classic_with_a_config_keeps_its_blank_cards(
+    client, user, make_list, make_list_fighter
+):
+    """?style=classic alongside a config still appends the config's blanks."""
+    lst = make_list("Gang")
+    make_list_fighter(lst, "Ganger")
+    config = _classic_config(lst, user, blank_fighter_cards=2)
+    client.force_login(user)
+
+    resp = client.get(_print_url(lst, config) + "&style=classic")
+
+    assert resp.status_code == 200
+    cards = resp.context["classic_cards"]
+    assert len(cards) == 3  # the fighter + 2 blanks
+    assert [c.kind for c in cards].count("blank") == 2

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -564,6 +564,19 @@ class ListPrintView(generic.DetailView):
         self.print_config = print_config
         context["print_config"] = print_config
 
+        # Card style: normally part of a saved PrintConfig, but a crew print has
+        # no config, so ?style= picks it straight from the URL (the crew page's
+        # Print dropdown offers Default and Classic). An explicit param wins over
+        # the config either way; anything unrecognised falls back to the config.
+        style = self.request.GET.get("style")
+        if style in ("classic", "default"):
+            use_classic = style == "classic"
+        else:
+            use_classic = bool(
+                print_config and print_config.card_style == PrintConfig.CLASSIC
+            )
+        self.use_classic = use_classic
+
         # A crew print (?crew=<id>) narrows the sheet to one battle crew's
         # fighters. Scoped to this gang so it can't leak another gang's crew.
         crew_id = self.request.GET.get("crew")
@@ -661,9 +674,9 @@ class ListPrintView(generic.DetailView):
 
         # Classic-mode cards: render the grimdark fixed-size cards instead of the
         # web cards. Reuses the already-filtered fighter queryset, then appends
-        # the configured blank cards. Fighter cards only (assets/attributes/etc.
-        # don't apply to the classic sheet).
-        if print_config and print_config.card_style == PrintConfig.CLASSIC:
+        # the configured blank cards (none without a config). Fighter cards only
+        # (assets/attributes/etc. don't apply to the classic sheet).
+        if use_classic:
             from gyrinx.core.print_cards import blank_classic_card, card_from_fighter
 
             # Fighter cards only — the stash is not a classic card (it has no
@@ -674,24 +687,23 @@ class ListPrintView(generic.DetailView):
                 if card.kind == "stash":
                     continue
                 cards.append(card)
-            cards += [
-                blank_classic_card("fighter")
-                for _ in range(print_config.blank_fighter_cards)
-            ]
-            cards += [
-                blank_classic_card("vehicle")
-                for _ in range(print_config.blank_vehicle_cards)
-            ]
+            if print_config:
+                cards += [
+                    blank_classic_card("fighter")
+                    for _ in range(print_config.blank_fighter_cards)
+                ]
+                cards += [
+                    blank_classic_card("vehicle")
+                    for _ in range(print_config.blank_vehicle_cards)
+                ]
             context["classic_cards"] = cards
 
         return context
 
     def get_template_names(self):
-        """Classic-style configs render the fixed-size grimdark sheet."""
-        from gyrinx.core.models import PrintConfig
-
-        pc = getattr(self, "print_config", None)
-        if pc and pc.card_style == PrintConfig.CLASSIC:
+        """Classic style (config- or ?style=-selected) renders the fixed-size
+        grimdark sheet."""
+        if getattr(self, "use_classic", False):
             return ["core/list_print_classic.html"]
         return [self.template_name]
 

--- a/gyrinx/core/views/list/views.py
+++ b/gyrinx/core/views/list/views.py
@@ -651,21 +651,25 @@ class ListPrintView(generic.DetailView):
 
         context["fighters_with_groups"] = fighters_qs
 
-        # Add attributes if configured to be included
-        if not print_config or print_config.include_attributes:
-            context["attributes"] = get_list_attributes(list_obj)
+        # Attributes / assets / actions only exist on the web sheet — the classic
+        # template renders classic_cards alone, so skip their DB work entirely
+        # when the classic style is selected.
+        if not use_classic:
+            # Add attributes if configured to be included
+            if not print_config or print_config.include_attributes:
+                context["attributes"] = get_list_attributes(list_obj)
 
-        # Add assets and campaign resources if configured to be included
-        if not print_config or print_config.include_assets:
-            # Get campaign resources
-            context["campaign_resources"] = get_list_campaign_resources(list_obj)
+            # Add assets and campaign resources if configured to be included
+            if not print_config or print_config.include_assets:
+                # Get campaign resources
+                context["campaign_resources"] = get_list_campaign_resources(list_obj)
 
-            # Get assets held by this list
-            context["held_assets"] = get_list_held_assets(list_obj)
+                # Get assets held by this list
+                context["held_assets"] = get_list_held_assets(list_obj)
 
-        # Add recent campaign actions if configured to be included
-        if not print_config or print_config.include_actions:
-            context["recent_actions"] = get_list_recent_campaign_actions(list_obj)
+            # Add recent campaign actions if configured to be included
+            if not print_config or print_config.include_actions:
+                context["recent_actions"] = get_list_recent_campaign_actions(list_obj)
 
         # Add blank card ranges if print_config exists
         if print_config:


### PR DESCRIPTION
People want to print crews with the classic cards. The crew page's **Print**
button is now a dropdown offering both card styles:

- **Default cards** — the web-style sheet, exactly as before.
- **Classic cards** — the grimdark fixed-size sheet (4 per A4).

Classic was previously only reachable through a saved PrintConfig, which a crew
print doesn't have. The print view now also accepts a `?style=` querystring
(`classic` / `default`): an explicit param wins over any config, anything
unrecognised falls back to the config as before, and blank-card padding still
comes only from a config. Crew narrowing (`?crew=`) composes with it, so a
classic crew print shows just the crew's cards — including the linked cards of
brought stash items.

Classic prints also skip the web sheet's attributes/assets/actions context
entirely (it renders cards alone), saving that DB work — including on
config-driven classic prints.

## Test plan

- [x] `?style=classic` renders the classic sheet with no config
- [x] `?style=default` overrides a classic config; unrecognised values fall
      back to the config; `?style=classic` + config keeps its blank cards
- [x] Crew page renders both links; classic crew print shows only the crew's
      fighters
- [x] Existing config-driven classic tests untouched and green (print + crew
      suites: 287)
- [x] Browser-verified: dropdown on the crew page; classic sheet loads and
      auto-opens the print dialog

Refs #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
