### PR TITLE
feat: indicative pick count with over-selection warning; tidier crew sheet; stash copy

### DIFF
--- a/gyrinx/core/forms/crew.py
+++ b/gyrinx/core/forms/crew.py
@@ -231,6 +231,16 @@ class CrewForm(forms.Form):
                 if field is not None:
                     field.initial = member.equipment_set_id
 
+    @property
+    def over_selected_note(self):
+        """The over-selection callout body, or ``None`` when within the count."""
+        if self.custom_count and self.saved_pick_count > self.custom_count:
+            return (
+                f"{self.saved_pick_count} of {self.custom_count} — every pick is "
+                "kept; trim the selection if you want to match the scenario."
+            )
+        return None
+
     def fighter_rows(self):
         """One row per eligible fighter for the template: the checkbox, the
         equipment-set select for fighters that have named sets (``None``

--- a/gyrinx/core/forms/crew.py
+++ b/gyrinx/core/forms/crew.py
@@ -216,9 +216,13 @@ class CrewForm(forms.Form):
                 )
         self.has_eligible_fighters = self.eligible_count > 0
 
-        # Initials from the existing chosen members.
+        # Initials from the existing chosen members. The saved pick count feeds
+        # the server-rendered over-selection warning (the scenario's count is
+        # indicative, never blocking).
+        self.saved_pick_count = 0
         if crew is not None and crew.pk and self.shows_picks:
             chosen = list(crew.members.filter(source=CrewMember.CHOSEN))
+            self.saved_pick_count = len(chosen)
             self.fields["chosen_fighters"].initial = [m.list_fighter_id for m in chosen]
             for member in chosen:
                 field = self.fields.get(
@@ -267,26 +271,9 @@ class CrewForm(forms.Form):
             for fighter in picks
         }
 
-        # The pick count is validated against the crew's stored count (set on
-        # setup): Custom picks exactly that many, Hybrid picks that many and the
-        # rest are drawn. Custom with no count is whole-gang — any number is fine.
-        count = self.custom_count
-        if count is None:
-            return cleaned
-
-        # A scenario can ask for more fighters than the gang can field; then the
-        # most it can send is everyone.
-        required = min(count, self.eligible_count)
-        if len(picks) != required:
-            message = (
-                f"Choose exactly {required} fighters — you've chosen {len(picks)}."
-            )
-            if count > self.eligible_count:
-                message += (
-                    f" This gang only has {self.eligible_count} fighters available."
-                )
-            self.add_error("chosen_fighters", message)
-
+        # The scenario's pick count is indicative, not enforced: every tick is
+        # saved regardless, and over-picking is surfaced as a warning on the
+        # screen rather than a rejection that would throw the selection away.
         return cleaned
 
 

--- a/gyrinx/core/forms/crew.py
+++ b/gyrinx/core/forms/crew.py
@@ -234,7 +234,7 @@ class CrewForm(forms.Form):
     @property
     def over_selected_note(self):
         """The over-selection callout body, or ``None`` when within the count."""
-        if self.custom_count and self.saved_pick_count > self.custom_count:
+        if self.custom_count is not None and self.saved_pick_count > self.custom_count:
             return (
                 f"{self.saved_pick_count} of {self.custom_count} — every pick is "
                 "kept; trim the selection if you want to match the scenario."

--- a/gyrinx/core/handlers/crew.py
+++ b/gyrinx/core/handlers/crew.py
@@ -353,6 +353,7 @@ def crew_whole_gang_projection(crew: Crew):
                 "name": fighter.name,
                 "category": fighter.content_fighter.get_category_display(),
                 "loadout": equipment_set.name if equipment_set else None,
+                "has_sets": bool(fighter.equipment_sets.all()),
                 "rating": rating,
             }
         )
@@ -378,6 +379,7 @@ def crew_whole_gang_projection(crew: Crew):
                 "name": child.name,
                 "category": child.content_fighter.get_category_display(),
                 "loadout": None,
+                "has_sets": bool(child.equipment_sets.all()),
                 "rating": rating,
             }
         )
@@ -398,6 +400,7 @@ def crew_whole_gang_projection(crew: Crew):
                 "name": fighter.name,
                 "category": fighter.content_fighter.get_category_display(),
                 "loadout": None,
+                "has_sets": bool(fighter.equipment_sets.all()),
                 "rating": rating,
             }
         )
@@ -429,6 +432,7 @@ def crew_included_forecast(crew: Crew):
             {
                 "name": fighter.name,
                 "category": fighter.content_fighter.get_category_display(),
+                "has_sets": bool(fighter.equipment_sets.all()),
                 "rating": rating,
             }
         )

--- a/gyrinx/core/models/crew.py
+++ b/gyrinx/core/models/crew.py
@@ -330,6 +330,14 @@ class Crew(AppBase):
         )
 
     @property
+    def over_picked(self):
+        """More chosen fighters than the scenario's count. Indicative only — the
+        count is a guideline, so this drives warnings, never blocking."""
+        return bool(self.custom_count) and (
+            self.members.filter(source=CrewMember.CHOSEN).count() > self.custom_count
+        )
+
+    @property
     def is_whole_gang(self):
         """Custom Selection with no number in brackets: the whole gang may take
         part, so a crew with no picks means everyone attends."""

--- a/gyrinx/core/models/crew.py
+++ b/gyrinx/core/models/crew.py
@@ -547,6 +547,11 @@ class Crew(AppBase):
                 if fighter is not None
                 else 0
             )
+            # Whether this fighter actually has a choice of equipment sets —
+            # the sheet only names the card when there were options.
+            has_sets = (
+                bool(fighter.equipment_sets.all()) if fighter is not None else False
+            )
             cost = (
                 member.rating_played if member.rating_played is not None else live_cost
             )
@@ -563,6 +568,7 @@ class Crew(AppBase):
                         ),
                         "fighter_id": member.list_fighter_id,
                         "loadout": equipment_set.name if equipment_set else None,
+                        "has_sets": has_sets,
                         "is_random": member.source == CrewMember.DRAWN,
                         "member_id": member.id,
                     },

--- a/gyrinx/core/models/crew.py
+++ b/gyrinx/core/models/crew.py
@@ -333,7 +333,7 @@ class Crew(AppBase):
     def over_picked(self):
         """More chosen fighters than the scenario's count. Indicative only — the
         count is a guideline, so this drives warnings, never blocking."""
-        return bool(self.custom_count) and (
+        return self.custom_count is not None and (
             self.members.filter(source=CrewMember.CHOSEN).count() > self.custom_count
         )
 

--- a/gyrinx/core/templates/core/crew/crew.html
+++ b/gyrinx/core/templates/core/crew/crew.html
@@ -171,7 +171,7 @@
                                 {% endif %}
                                 {% if a.has_sets %}
                                     {# Only name the card when the fighter actually had options. #}
-                                    <span class="text-secondary fs-7">· <i class="bi-collection"></i>
+                                    <span class="text-secondary fs-7">· <i class="bi-collection" aria-hidden="true"></i>
                                         {% if a.loadout %}
                                             {{ a.loadout }}
                                         {% else %}
@@ -195,7 +195,7 @@
                                         <strong>{{ p.name }}</strong>
                                         <span class="text-secondary fs-7">· {{ p.category }}</span>
                                         {% if p.has_sets %}
-                                            <span class="text-secondary fs-7">· <i class="bi-collection"></i>
+                                            <span class="text-secondary fs-7">· <i class="bi-collection" aria-hidden="true"></i>
                                                 {% if p.loadout %}
                                                     {{ p.loadout }}
                                                 {% else %}
@@ -278,7 +278,7 @@
                                     <span class="badge text-bg-secondary ms-1"
                                           data-bs-toggle="tooltip"
                                           data-bs-title="Joins regardless of the selection method">Always included</span>
-                                    {% if f.has_sets %}<span class="text-secondary fs-7">· <i class="bi-collection"></i> Default</span>{% endif %}
+                                    {% if f.has_sets %}<span class="text-secondary fs-7">· <i class="bi-collection" aria-hidden="true"></i> Default</span>{% endif %}
                                 </td>
                                 <td class="text-end text-secondary">{{ f.rating }}¢</td>
                                 <td></td>

--- a/gyrinx/core/templates/core/crew/crew.html
+++ b/gyrinx/core/templates/core/crew/crew.html
@@ -169,14 +169,16 @@
                                           data-bs-toggle="tooltip"
                                           data-bs-title="Drawn at random">Random</span>
                                 {% endif %}
-                                <span class="text-secondary fs-7">
-                                    {% if a.loadout %}
-                                        · {{ a.loadout }}
-                                    {% else %}
-                                        {# Say so on drafts too: the card is part of selection and changes the rating. #}
-                                        · Default
-                                    {% endif %}
-                                </span>
+                                {% if a.has_sets %}
+                                    {# Only name the card when the fighter actually had options. #}
+                                    <span class="text-secondary fs-7">· <i class="bi-collection"></i>
+                                        {% if a.loadout %}
+                                            {{ a.loadout }}
+                                        {% else %}
+                                            Default
+                                        {% endif %}
+                                    </span>
+                                {% endif %}
                             </td>
                             <td class="text-end">{{ a.rating }}¢</td>
                             <td></td>
@@ -192,13 +194,15 @@
                                     <td>
                                         <strong>{{ p.name }}</strong>
                                         <span class="text-secondary fs-7">· {{ p.category }}</span>
-                                        <span class="text-secondary fs-7">
-                                            {% if p.loadout %}
-                                                · {{ p.loadout }}
-                                            {% else %}
-                                                · Default
-                                            {% endif %}
-                                        </span>
+                                        {% if p.has_sets %}
+                                            <span class="text-secondary fs-7">· <i class="bi-collection"></i>
+                                                {% if p.loadout %}
+                                                    {{ p.loadout }}
+                                                {% else %}
+                                                    Default
+                                                {% endif %}
+                                            </span>
+                                        {% endif %}
                                     </td>
                                     <td class="text-end text-secondary">{{ p.rating }}¢</td>
                                     <td></td>
@@ -274,26 +278,14 @@
                                     <span class="badge text-bg-secondary ms-1"
                                           data-bs-toggle="tooltip"
                                           data-bs-title="Joins regardless of the selection method">Always included</span>
-                                    <span class="text-secondary fs-7">· Default</span>
+                                    {% if f.has_sets %}<span class="text-secondary fs-7">· <i class="bi-collection"></i> Default</span>{% endif %}
                                 </td>
                                 <td class="text-end text-secondary">{{ f.rating }}¢</td>
                                 <td></td>
                                 <td></td>
-                                {% if receipt.has_free %}
-                                    <td></td>
-                                {% endif %}
+                                {% if receipt.has_free %}<td></td>{% endif %}
                             </tr>
                         {% endfor %}
-                        <tr>
-                            <td colspan="{% if receipt.has_free %}5{% else %}4{% endif %}">
-                                <div class="border rounded p-2 fs-7 text-secondary">
-                                    <i class="bi-info-circle"></i>
-                                    <strong>Always included.</strong>
-                                    These fighters join regardless of the selection method — they're
-                                    enrolled when the crew is confirmed.
-                                </div>
-                            </td>
-                        </tr>
                     {% endif %}
                     <tr>
                         <td colspan="{% if receipt.has_free %}5{% else %}4{% endif %}"

--- a/gyrinx/core/templates/core/crew/crew_form.html
+++ b/gyrinx/core/templates/core/crew/crew_form.html
@@ -17,7 +17,7 @@
                 {% csrf_token %}
                 {{ form.non_field_errors }}
                 {% if form.over_selected_note %}
-                    {% include "core/includes/alert.html" with variant="warning" heading="More fighters chosen than the scenario allows " message=form.over_selected_note %}
+                    {% include "core/includes/alert.html" with variant="warning" heading="More fighters chosen than the scenario allows" message=form.over_selected_note %}
                 {% endif %}
                 <div>
                     <label class="form-label">{{ form.chosen_fighters.label }}</label>

--- a/gyrinx/core/templates/core/crew/crew_form.html
+++ b/gyrinx/core/templates/core/crew/crew_form.html
@@ -16,13 +16,8 @@
             <form method="post" class="vstack gap-3">
                 {% csrf_token %}
                 {{ form.non_field_errors }}
-                {% if form.custom_count and form.saved_pick_count > form.custom_count %}
-                    <div class="border rounded p-2 fs-7">
-                        <i class="bi-exclamation-triangle text-warning"></i>
-                        <strong>More fighters chosen than the scenario allows</strong> —
-                        {{ form.saved_pick_count }} of {{ form.custom_count }}. Every pick is kept;
-                        trim the selection if you want to match the scenario.
-                    </div>
+                {% if form.over_selected_note %}
+                    {% include "core/includes/alert.html" with variant="warning" heading="More fighters chosen than the scenario allows " message=form.over_selected_note %}
                 {% endif %}
                 <div>
                     <label class="form-label">{{ form.chosen_fighters.label }}</label>

--- a/gyrinx/core/templates/core/crew/crew_form.html
+++ b/gyrinx/core/templates/core/crew/crew_form.html
@@ -16,6 +16,14 @@
             <form method="post" class="vstack gap-3">
                 {% csrf_token %}
                 {{ form.non_field_errors }}
+                {% if form.custom_count and form.saved_pick_count > form.custom_count %}
+                    <div class="border rounded p-2 fs-7">
+                        <i class="bi-exclamation-triangle text-warning"></i>
+                        <strong>More fighters chosen than the scenario allows</strong> —
+                        {{ form.saved_pick_count }} of {{ form.custom_count }}. Every pick is kept;
+                        trim the selection if you want to match the scenario.
+                    </div>
+                {% endif %}
                 <div>
                     <label class="form-label">{{ form.chosen_fighters.label }}</label>
                     {% if form.has_eligible_fighters %}
@@ -37,6 +45,7 @@
                         reveals it and keeps it current as boxes are ticked.
                         {% endcomment %}
                         <div class="js-crew-total fs-7 text-secondary mt-1 d-none"
+                             data-allowed="{{ form.custom_count|default_if_none:'' }}"
                              role="status"
                              aria-live="polite"></div>
                         <div class="form-text">
@@ -102,6 +111,8 @@
                 const out = document.querySelector('.js-crew-total');
                 if (!rows.length || !out) return;
 
+                const allowed = parseInt(out.dataset.allowed, 10) || 0;
+
                 function update() {
                     let count = 0;
                     let total = 0;
@@ -112,8 +123,18 @@
                             total += parseInt(row.dataset.cost, 10) || 0;
                         }
                     });
-                    const noun = count === 1 ? 'fighter' : 'fighters';
-                    out.textContent = count + ' ' + noun + ' selected · ' + total + '¢';
+                    if (allowed) {
+                        // The scenario's count is indicative: warn, never block.
+                        const over = count > allowed;
+                        out.textContent =
+                            count + '/' + allowed + ' selected · ' + total + '¢' + (over ? ' ⚠️' : '');
+                        out.classList.toggle('text-warning', over);
+                        out.classList.toggle('fw-semibold', over);
+                        out.classList.toggle('text-secondary', !over);
+                    } else {
+                        const noun = count === 1 ? 'fighter' : 'fighters';
+                        out.textContent = count + ' ' + noun + ' selected · ' + total + '¢';
+                    }
                 }
 
                 rows.forEach(function (row) {

--- a/gyrinx/core/templates/core/crew/crew_form.html
+++ b/gyrinx/core/templates/core/crew/crew_form.html
@@ -106,7 +106,10 @@
                 const out = document.querySelector('.js-crew-total');
                 if (!rows.length || !out) return;
 
-                const allowed = parseInt(out.dataset.allowed, 10) || 0;
+                // Empty = no scenario count; zero is a real limit (matches the
+                // server-side `is not None` checks).
+                const allowedRaw = out.dataset.allowed;
+                const allowed = allowedRaw === '' ? null : parseInt(allowedRaw, 10);
 
                 function update() {
                     let count = 0;
@@ -118,7 +121,7 @@
                             total += parseInt(row.dataset.cost, 10) || 0;
                         }
                     });
-                    if (allowed) {
+                    if (allowed !== null && !Number.isNaN(allowed)) {
                         // The scenario's count is indicative: warn, never block.
                         const over = count > allowed;
                         out.textContent =

--- a/gyrinx/core/templates/core/crew/crew_stash.html
+++ b/gyrinx/core/templates/core/crew/crew_stash.html
@@ -13,6 +13,7 @@
         {% include "core/crew/includes/crew_tabs.html" %}
         <p class="text-secondary mb-0">
             Choose which of {{ gang.name }}'s stash equipment comes to the battle.
+            You can use this to include things like booby traps and gang terrain.
             {% if crew.is_locked %}
                 The crew is confirmed, but the stash can still change — gang terrain and the like are
                 often picked after the draw.

--- a/gyrinx/core/templates/core/crew/includes/crew_tabs.html
+++ b/gyrinx/core/templates/core/crew/includes/crew_tabs.html
@@ -16,8 +16,10 @@
                     2. Choose
                     {% if crew.over_picked %}
                         <i class="bi-exclamation-triangle text-warning"
+                           aria-hidden="true"
                            data-bs-toggle="tooltip"
                            data-bs-title="More fighters chosen than the scenario allows"></i>
+                        <span class="visually-hidden">More fighters chosen than the scenario allows</span>
                     {% endif %}
                 </a>
             </li>

--- a/gyrinx/core/templates/core/crew/includes/crew_tabs.html
+++ b/gyrinx/core/templates/core/crew/includes/crew_tabs.html
@@ -12,7 +12,14 @@
             <li class="nav-item" role="presentation">
                 <a class="nav-link {% if active_tab == 'choose' %}active{% endif %}"
                    href="{% url 'core:crew-edit' battle.id crew.id %}"
-                   {% if active_tab == 'choose' %}aria-current="page"{% endif %}>2. Choose</a>
+                   {% if active_tab == 'choose' %}aria-current="page"{% endif %}>
+                    2. Choose
+                    {% if crew.over_picked %}
+                        <i class="bi-exclamation-triangle text-warning"
+                           data-bs-toggle="tooltip"
+                           data-bs-title="More fighters chosen than the scenario allows"></i>
+                    {% endif %}
+                </a>
             </li>
         {% endif %}
         <li class="nav-item" role="presentation">

--- a/gyrinx/core/tests/test_crew.py
+++ b/gyrinx/core/tests/test_crew.py
@@ -2748,8 +2748,16 @@ def test_pick_count_is_indicative_and_selections_always_persist(client, crew_set
     resp = client.get(edit_url)
     form = resp.context["form"]
     assert form.saved_pick_count == 4
-    assert "More fighters chosen than the scenario allows" in resp.content.decode()
+    content = resp.content.decode()
+    assert "More fighters chosen than the scenario allows" in content
     assert [c.data["selected"] for c in form["chosen_fighters"]].count(True) == 4
+    # The warning surfaces on the tab title too, and clears once within count.
+    crew.refresh_from_db()
+    assert crew.over_picked is True
+    assert "alert-warning" in content  # the design-system callout
+    client.post(edit_url, {"chosen_fighters": [str(f.id) for f in fighters[:2]]})
+    crew.refresh_from_db()
+    assert crew.over_picked is False
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_crew.py
+++ b/gyrinx/core/tests/test_crew.py
@@ -4980,3 +4980,25 @@ def test_stash_tab_post_drops_malformed_ids(client, crew_setup, make_equipment):
     assert set(crew.stash_items.values_list("assignment_id", flat=True)) == {
         gear["Ammo Cache"].id
     }
+
+
+@pytest.mark.django_db
+def test_sheet_names_the_set_only_when_the_fighter_has_options(
+    client, crew_setup, equipped_fighter
+):
+    """A fighter with named sets shows the card marker; one without shows no
+    '· Default' noise."""
+    battle, gang = crew_setup["battle"], crew_setup["gang"]
+    with_sets, _ = equipped_fighter(gang)
+    crew = Crew.objects.create(
+        battle=battle, list=gang, owner=crew_setup["user"], custom_count=2
+    )
+    add_chosen(crew, [with_sets, crew_setup["fighters"][0]])
+    client.force_login(crew_setup["user"])
+
+    resp = client.get(reverse("core:crew", args=[battle.id, crew.id]))
+
+    lines = {a["name"]: a for a in resp.context["receipt"]["attendees"]}
+    assert lines[with_sets.name]["has_sets"] is True
+    assert lines[crew_setup["fighters"][0].name]["has_sets"] is False
+    assert "bi-collection" in resp.content.decode()

--- a/gyrinx/core/tests/test_crew.py
+++ b/gyrinx/core/tests/test_crew.py
@@ -2724,27 +2724,32 @@ def test_edit_without_method_keeps_the_stored_one(client, crew_setup):
 
 
 @pytest.mark.django_db
-def test_custom_requires_exactly_the_bracket_number(client, crew_setup):
+def test_pick_count_is_indicative_and_selections_always_persist(client, crew_setup):
+    """The scenario's count never blocks a save: fewer picks save (work in
+    progress), more picks save too (kept, warned about) — nothing is thrown
+    away or silently trimmed."""
     client.force_login(crew_setup["user"])
     fighters = crew_setup["fighters"]
-    # Set up a Custom crew that must pick exactly 3.
     crew = _create_crew(client, crew_setup, method=Crew.CUSTOM, custom_count="3")
     assert crew.custom_count == 3
     edit_url = reverse("core:crew-edit", args=[crew.battle_id, crew.id])
 
-    # Picking too few is rejected on the selection screen; nothing saved.
+    # Fewer than the count saves fine.
     resp = client.post(edit_url, {"chosen_fighters": [str(fighters[0].id)]})
-    assert resp.status_code == 200
-    assert resp.context["form"].errors["chosen_fighters"] == [
-        "Choose exactly 3 fighters — you've chosen 1."
-    ]
-    assert crew.members.count() == 0
-
-    # Picking exactly 3 succeeds.
-    resp = client.post(edit_url, {"chosen_fighters": [str(f.id) for f in fighters[:3]]})
     assert resp.status_code == 302
-    crew.refresh_from_db()
-    assert crew.members.count() == 3
+    assert crew.members.count() == 1
+
+    # More than the count saves too — all four picks are kept...
+    resp = client.post(edit_url, {"chosen_fighters": [str(f.id) for f in fighters[:4]]})
+    assert resp.status_code == 302
+    assert crew.members.count() == 4
+
+    # ...and re-opening the screen warns without dropping anything.
+    resp = client.get(edit_url)
+    form = resp.context["form"]
+    assert form.saved_pick_count == 4
+    assert "More fighters chosen than the scenario allows" in resp.content.decode()
+    assert [c.data["selected"] for c in form["chosen_fighters"]].count(True) == 4
 
 
 @pytest.mark.django_db
@@ -2777,20 +2782,18 @@ def test_custom_blank_count_with_no_picks_is_the_whole_gang(client, crew_setup):
 
 
 @pytest.mark.django_db
-def test_count_over_roster_requires_every_eligible_fighter(client, crew_setup):
+def test_count_over_roster_saves_whatever_is_picked(client, crew_setup):
+    """A scenario can ask for more fighters than the gang can field — any number
+    of picks saves, no exactness demanded."""
     client.force_login(crew_setup["user"])
     fighters = crew_setup["fighters"]
     crew = _create_crew(client, crew_setup, method=Crew.CUSTOM, custom_count="8")
     edit_url = reverse("core:crew-edit", args=[crew.battle_id, crew.id])
 
     resp = client.post(edit_url, {"chosen_fighters": [str(f.id) for f in fighters[:3]]})
-    assert resp.status_code == 200
-    assert resp.context["form"].errors["chosen_fighters"] == [
-        "Choose exactly 5 fighters — you've chosen 3. "
-        "This gang only has 5 fighters available."
-    ]
+    assert resp.status_code == 302
+    assert crew.members.count() == 3
 
-    # Sending everyone is accepted, even though the scenario asked for more.
     resp = client.post(edit_url, {"chosen_fighters": [str(f.id) for f in fighters]})
     assert resp.status_code == 302
     crew.refresh_from_db()

--- a/gyrinx/core/views/crew.py
+++ b/gyrinx/core/views/crew.py
@@ -363,13 +363,13 @@ def crew_edit(request, battle_id, crew_id):
                 equipment_sets=form.cleaned_data.get("equipment_sets"),
                 included_categories=crew.included_categories,
             )
-            if crew.over_picked:
-                # The crew page has no tabs, so carry the over-pick state there.
+            # The crew page has no tabs, so carry the over-pick state there.
+            chosen_count = crew.members.filter(source=CrewMember.CHOSEN).count()
+            if crew.custom_count is not None and chosen_count > crew.custom_count:
                 messages.warning(
                     request,
                     "Crew updated — more fighters are chosen than the scenario "
-                    f"allows ({crew.members.filter(source=CrewMember.CHOSEN).count()} "
-                    f"of {crew.custom_count}).",
+                    f"allows ({chosen_count} of {crew.custom_count}).",
                 )
             else:
                 messages.success(request, "Crew updated.")

--- a/gyrinx/core/views/crew.py
+++ b/gyrinx/core/views/crew.py
@@ -363,7 +363,16 @@ def crew_edit(request, battle_id, crew_id):
                 equipment_sets=form.cleaned_data.get("equipment_sets"),
                 included_categories=crew.included_categories,
             )
-            messages.success(request, "Crew updated.")
+            if crew.over_picked:
+                # The crew page has no tabs, so carry the over-pick state there.
+                messages.warning(
+                    request,
+                    "Crew updated — more fighters are chosen than the scenario "
+                    f"allows ({crew.members.filter(source=CrewMember.CHOSEN).count()} "
+                    f"of {crew.custom_count}).",
+                )
+            else:
+                messages.success(request, "Crew updated.")
             return _redirect_crew(crew)
     else:
         form = CrewForm(crew=crew)


### PR DESCRIPTION
Four bits of expert feedback on the crew flow.

## Pick count is indicative, never blocking

Previously the Choose tab demanded exactly the scenario's number of fighters —
over-picking was rejected, which threw the selection away (tick 4 with a count
of 3, save, and your picks vanished). Now **every tick saves**, fewer or more:

- A warning note appears when over: *"More fighters chosen than the scenario
  allows — 4 of 3. Every pick is kept; trim the selection if you want to match
  the scenario."*
- The running total becomes **"x/y selected · cost"**, turning warning-yellow
  with a ⚠️ when x > y (plain "x fighters selected" when the scenario sets no
  number).

This also matches the table reality that the bracket number is a scenario
guideline, not something the app should police.

## Tidier crew sheet

- A fighter's equipment set is only named when they actually have options — a
  card icon (the set switcher's `bi-collection`) marks it. Fighters with no
  named sets no longer show a meaningless "· Default".
- The "Always included." explanatory box is gone: the badge's mouseover tooltip
  already carries that information.

## Stash tab copy

The description now reads: *"Choose which of the gang's stash equipment comes to
the battle. You can use this to include things like booby traps and gang
terrain."*

## Test plan

- [x] Fewer-than-count and more-than-count picks both save; reopening warns and
      keeps all picks ticked
- [x] Count-over-roster saves whatever is picked
- [x] Full crew/battle/print suites green (373)
- [x] Browser-verified: warning box + "2/1 selected · 590¢ ⚠️" on an over-picked
      crew; crew sheet without "· Default" noise

Refs #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
