### PR TITLE
perf: stop the equipment admin page rebuilding its dropdowns per row

### DIFF
--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -1,3 +1,5 @@
+import operator
+from functools import reduce
 from itertools import groupby
 
 from django import forms
@@ -100,6 +102,105 @@ def fighter_house_name(fighter):
         return fighter.house.name if fighter.house else "No House"
     except ContentHouse.DoesNotExist:
         return "No House"
+
+
+def grouped_fighter_choices(field):
+    """Build house-grouped ``<optgroup>`` choices for a fighter select.
+
+    ``group_select`` does the same job, but it runs inside a form's ``__init__``
+    — so on an inline it re-iterates every fighter once per row and issues an
+    N+1 query for each fighter's house. Building the choices once, with
+    ``select_related("house")``, and sharing the resulting list across rows
+    turns thousands of queries into one. See
+    ``share_grouped_fighter_choices``.
+    """
+    label = field.label_from_instance
+    fighters = field.queryset.select_related("house").order_by("house__name", "type")
+    return [("", "---------")] + [
+        (house_name, [(fighter.pk, label(fighter)) for fighter in items])
+        for house_name, items in groupby(fighters, key=fighter_house_name)
+    ]
+
+
+def share_field_choices(formset, field_name, build_choices):
+    """Give every row of ``formset`` the same precomputed choices for a field.
+
+    Inline formsets build one form per existing row plus an empty template
+    form. A field whose option list is expensive to assemble — a fighter select
+    grouped by house, a polymorphic modifications select — would otherwise be
+    rebuilt from scratch by each of those forms, so the page's cost grows with
+    the number of rows.
+    """
+    choices = build_choices(formset.form.base_fields[field_name])
+    original_form = formset.form
+
+    class FormWithSharedChoices(original_form):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.fields[field_name].widget.choices = choices
+
+    formset.form = FormWithSharedChoices
+    return formset
+
+
+def share_grouped_fighter_choices(formset, field_name):
+    """Share one house-grouped fighter option list across every inline row."""
+    return share_field_choices(formset, field_name, grouped_fighter_choices)
+
+
+def _fighter_stat_mods(queryset):
+    mods = list(queryset)
+    ContentModFighterStat.prime_stat_definitions(mods)
+    return mods
+
+
+# How to load each concrete modification type so its label costs no further
+# queries. A polymorphic queryset can't ``select_related`` a child model's
+# field, so labelling modifications one at a time costs a query each — see
+# ``modifier_choices``.
+MODIFIER_LABEL_LOADERS = {
+    ContentModStat: list,
+    ContentModFighterStat: _fighter_stat_mods,
+    ContentModTrait: lambda qs: list(qs.select_related("trait")),
+    ContentModFighterRule: lambda qs: list(qs.select_related("rule")),
+    ContentModFighterSkill: lambda qs: list(qs.select_related("skill")),
+    ContentModSkillTreeAccess: lambda qs: list(qs.select_related("skill_category")),
+    ContentModPsykerDisciplineAccess: lambda qs: list(qs.select_related("discipline")),
+}
+
+# The subset that changes something on the fighter rather than a weapon.
+FIGHTER_MODIFIER_TYPES = (
+    ContentModFighterStat,
+    ContentModFighterRule,
+    ContentModFighterSkill,
+    ContentModSkillTreeAccess,
+    ContentModPsykerDisciplineAccess,
+)
+
+
+def modifier_choices(field):
+    """Build the option list for a modifications field in one query per type.
+
+    Django asks each modification for its label, and a polymorphic instance
+    fetches its own related objects — so a list of N modifications costs N
+    queries, repeated for every form on the page. Fetching each concrete type
+    separately lets ``select_related`` do that work up front.
+    """
+    pks = list(field.queryset.non_polymorphic().values_list("pk", flat=True))
+    mods = []
+    for model, load in MODIFIER_LABEL_LOADERS.items():
+        mods.extend(load(model.objects.filter(pk__in=pks)))
+
+    label = field.label_from_instance
+    return sorted(((mod.pk, label(mod)) for mod in mods), key=lambda choice: choice[1])
+
+
+def restrict_to_fighter_modifiers(field):
+    """Limit a modifications field to the types that affect fighters."""
+    field.queryset = reduce(
+        operator.or_,
+        (field.queryset.instance_of(model) for model in FIGHTER_MODIFIER_TYPES),
+    )
 
 
 class ContentAdmin(admin.ModelAdmin):
@@ -294,34 +395,20 @@ class ContentFighterEquipmentCategoryLimitInline(ContentTabularInline):
             Formset class with shared grouped choices and parent instance access
         """
         formset = super().get_formset(request, obj, **kwargs)
-
-        fighter_field = formset.form.base_fields["fighter"]
-        label = fighter_field.label_from_instance
-        fighters = ContentFighter.objects.select_related("house").order_by(
-            "house__name", "type"
-        )
-        grouped_choices = [("", "---------")] + [
-            (house_name, [(fighter.pk, label(fighter)) for fighter in items])
-            for house_name, items in groupby(fighters, key=fighter_house_name)
-        ]
+        formset = share_grouped_fighter_choices(formset, "fighter")
 
         original_form = formset.form
         parent_instance = obj
 
-        class FormWithGroupedFighters(original_form):
-            """
-            Form wrapper that reuses the precomputed grouped fighter choices and
-            exposes the parent equipment category for validation.
-            """
+        class FormWithParentInstance(original_form):
+            """Expose the parent equipment category to the form for validation."""
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 if parent_instance is not None:
                     self.parent_instance = parent_instance
-                # Reuse the shared grouped choices; no per-row requery / N+1.
-                self.fields["fighter"].widget.choices = grouped_choices
 
-        formset.form = FormWithGroupedFighters
+        formset.form = FormWithParentInstance
         return formset
 
 
@@ -346,26 +433,29 @@ class ContentWeaponProfileInline(ContentStackedInline):
     model = ContentWeaponProfile
     extra = 0
 
+    def get_queryset(self, request):
+        # Each row lists its traits; without this that is a query per profile.
+        return super().get_queryset(request).prefetch_related("traits")
+
 
 class ContentWeaponAccessoryInline(ContentTabularInline):
     model = ContentWeaponAccessory
     extra = 0
 
 
-class ContentEquipmentFighterProfileAdminForm(forms.ModelForm):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        group_select(self, "content_fighter", key=fighter_house_name)
-
-    class Meta:
-        model = ContentEquipmentFighterProfile
-        fields = "__all__"
-
-
 class ContentEquipmentFighterProfileInline(ContentTabularInline):
     model = ContentEquipmentFighterProfile
-    form = ContentEquipmentFighterProfileAdminForm
     extra = 0
+
+    def get_formset(self, request, obj=None, **kwargs):
+        """Render the fighter select grouped by house, built once per page.
+
+        This inline used to group the choices in each row's form ``__init__``,
+        which re-walked every fighter (and queried its house) once per row —
+        the single biggest cost in rendering the equipment change page.
+        """
+        formset = super().get_formset(request, obj, **kwargs)
+        return share_grouped_fighter_choices(formset, "content_fighter")
 
 
 class ContentEquipmentEquipmentProfileInline(ContentTabularInline):
@@ -377,6 +467,21 @@ class ContentEquipmentEquipmentProfileInline(ContentTabularInline):
 class ContentEquipmentUpgradeInline(ContentTabularInline):
     model = ContentEquipmentUpgrade
     extra = 0
+
+    def get_queryset(self, request):
+        # Each row shows the modifications it already has selected; without
+        # this that is a query per row.
+        return super().get_queryset(request).prefetch_related("modifiers")
+
+    def get_formset(self, request, obj=None, **kwargs):
+        """Build the modifications option list once for all upgrade rows.
+
+        Equipment with many upgrades (Unborn has 18) rendered the full
+        polymorphic modifications list once per row, at a query per
+        modification per row.
+        """
+        formset = super().get_formset(request, obj, **kwargs)
+        return share_field_choices(formset, "modifiers", modifier_choices)
 
 
 class ContentEquipmentAdminForm(forms.ModelForm):
@@ -402,26 +507,17 @@ class ContentEquipmentAdminForm(forms.ModelForm):
             ),
             "name",
         )
-        # Filter the queryset for modifiers to only include those that change things
-        # on the fighter.
-        mod_qs = self.fields["modifiers"].queryset
-        self.fields["modifiers"].queryset = (
-            mod_qs.instance_of(
-                ContentModFighterStat,
-            )
-            | mod_qs.instance_of(
-                ContentModFighterRule,
-            )
-            | mod_qs.instance_of(
-                ContentModFighterSkill,
-            )
-            | mod_qs.instance_of(
-                ContentModSkillTreeAccess,
-            )
-            | mod_qs.instance_of(
-                ContentModPsykerDisciplineAccess,
-            )
-        )
+        # Only offer modifications that change things on the fighter.
+        modifiers_field = self.fields["modifiers"]
+        restrict_to_fighter_modifiers(modifiers_field)
+        modifiers_field.widget.choices = modifier_choices(modifiers_field)
+
+        # Every fighter is rendered as an option here, and a fighter's label
+        # includes its house — without select_related that is one query per
+        # fighter.
+        companion_field = self.fields.get("auto_companion_for_fighter")
+        if companion_field is not None:
+            companion_field.queryset = companion_field.queryset.select_related("house")
 
         group_select(self, "category", key=lambda x: x.group)
 

--- a/gyrinx/content/admin.py
+++ b/gyrinx/content/admin.py
@@ -1,9 +1,11 @@
 import operator
+from collections import defaultdict
 from functools import reduce
 from itertools import groupby
 
 from django import forms
 from django.contrib import admin, messages
+from django.contrib.contenttypes.models import ContentType
 from django.db import models, transaction
 from django.db.models import Case, When
 from django.db.models.functions import Cast
@@ -131,6 +133,10 @@ def share_field_choices(formset, field_name, build_choices):
     rebuilt from scratch by each of those forms, so the page's cost grows with
     the number of rows.
     """
+    # A field listed in readonly_fields is not on the form at all.
+    if field_name not in formset.form.base_fields:
+        return formset
+
     choices = build_choices(formset.form.base_fields[field_name])
     original_form = formset.form
 
@@ -158,6 +164,11 @@ def _fighter_stat_mods(queryset):
 # queries. A polymorphic queryset can't ``select_related`` a child model's
 # field, so labelling modifications one at a time costs a query each — see
 # ``modifier_choices``.
+#
+# This is an optimisation, not an allow-list: a type missing from here still
+# gets its options, just at a query per row. ``modifier_choices`` drives off
+# what is actually in the queryset so a new subclass can never silently lose
+# its <option> (and with it, the selection, on the next save).
 MODIFIER_LABEL_LOADERS = {
     ContentModStat: list,
     ContentModFighterStat: _fighter_stat_mods,
@@ -183,12 +194,25 @@ def modifier_choices(field):
 
     Django asks each modification for its label, and a polymorphic instance
     fetches its own related objects — so a list of N modifications costs N
-    queries, repeated for every form on the page. Fetching each concrete type
-    separately lets ``select_related`` do that work up front.
+    queries, repeated for every form on the page. Grouping the queryset by
+    concrete type lets ``select_related`` do that work up front.
+
+    Every type present is loaded, whether or not ``MODIFIER_LABEL_LOADERS``
+    knows about it. A modification with no ``<option>`` cannot be submitted, so
+    dropping one here would quietly clear it from the field on the next save.
     """
-    pks = list(field.queryset.non_polymorphic().values_list("pk", flat=True))
+    pks_by_type = defaultdict(list)
+    for pk, ctype_id in field.queryset.non_polymorphic().values_list(
+        "pk", "polymorphic_ctype_id"
+    ):
+        pks_by_type[ctype_id].append(pk)
+
     mods = []
-    for model, load in MODIFIER_LABEL_LOADERS.items():
+    for ctype_id, pks in pks_by_type.items():
+        model = ContentType.objects.get_for_id(ctype_id).model_class()
+        if model is None:
+            continue
+        load = MODIFIER_LABEL_LOADERS.get(model, list)
         mods.extend(load(model.objects.filter(pk__in=pks)))
 
     label = field.label_from_instance
@@ -434,8 +458,14 @@ class ContentWeaponProfileInline(ContentStackedInline):
     extra = 0
 
     def get_queryset(self, request):
-        # Each row lists its traits; without this that is a query per profile.
-        return super().get_queryset(request).prefetch_related("traits")
+        # Each row lists its traits and names its equipment; without this that
+        # is two queries per profile.
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("equipment")
+            .prefetch_related("traits")
+        )
 
 
 class ContentWeaponAccessoryInline(ContentTabularInline):
@@ -446,6 +476,15 @@ class ContentWeaponAccessoryInline(ContentTabularInline):
 class ContentEquipmentFighterProfileInline(ContentTabularInline):
     model = ContentEquipmentFighterProfile
     extra = 0
+
+    def get_queryset(self, request):
+        # Each row names its equipment and fighter, and a fighter's name
+        # includes its house.
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("equipment", "content_fighter__house")
+        )
 
     def get_formset(self, request, obj=None, **kwargs):
         """Render the fighter select grouped by house, built once per page.
@@ -469,9 +508,14 @@ class ContentEquipmentUpgradeInline(ContentTabularInline):
     extra = 0
 
     def get_queryset(self, request):
-        # Each row shows the modifications it already has selected; without
-        # this that is a query per row.
-        return super().get_queryset(request).prefetch_related("modifiers")
+        # Each row shows the modifications it already has selected and names
+        # its equipment; without this that is two queries per row.
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("equipment")
+            .prefetch_related("modifiers")
+        )
 
     def get_formset(self, request, obj=None, **kwargs):
         """Build the modifications option list once for all upgrade rows.
@@ -507,7 +551,9 @@ class ContentEquipmentAdminForm(forms.ModelForm):
             ),
             "name",
         )
-        # Only offer modifications that change things on the fighter.
+        # Only offer modifications that change things on the fighter. Order
+        # matters: assigning a field's queryset resets its widget choices, so
+        # the restriction has to happen before the choices are built.
         modifiers_field = self.fields["modifiers"]
         restrict_to_fighter_modifiers(modifiers_field)
         modifiers_field.widget.choices = modifier_choices(modifiers_field)

--- a/gyrinx/content/models/modifier.py
+++ b/gyrinx/content/models/modifier.py
@@ -20,6 +20,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.functional import cached_property
 from polymorphic.models import PolymorphicModel
 from simple_history.models import HistoricalRecords
 
@@ -273,11 +274,29 @@ class ContentModFighterStat(ContentMod, ContentModStatApplyMixin):
     )
     value = models.CharField(max_length=5)
 
-    def __str__(self):
+    @cached_property
+    def stat_definition(self):
+        """The ContentStat this targets, or None if no stat by that name exists."""
         from .statline import ContentStat
 
+        return ContentStat.objects.filter(field_name=self.stat).first()
+
+    @classmethod
+    def prime_stat_definitions(cls, mods):
+        """Resolve ``stat_definition`` for many modifications in a single query.
+
+        Each modification otherwise looks its own stat up, so rendering a list
+        of them — an admin select, say — costs a query apiece.
+        """
+        from .statline import ContentStat
+
+        definitions = {stat.field_name: stat for stat in ContentStat.objects.all()}
+        for mod in mods:
+            mod.__dict__["stat_definition"] = definitions.get(mod.stat)
+
+    def __str__(self):
         mode_choices = dict(self._meta.get_field("mode").choices)
-        stat = ContentStat.objects.filter(field_name=self.stat).first()
+        stat = self.stat_definition
         verb = "to" if self.mode == "set" else "by"
         return f"{mode_choices[self.mode]} fighter {stat.full_name if stat else f'`{self.stat}`'} {verb} {self.value}"
 

--- a/gyrinx/content/tests/test_admin_equipment_change_page.py
+++ b/gyrinx/content/tests/test_admin_equipment_change_page.py
@@ -17,11 +17,14 @@ from gyrinx.content.models import (
     ContentEquipmentCategory,
     ContentEquipmentFighterProfile,
     ContentEquipmentUpgrade,
+    ContentMod,
     ContentModFighterRule,
     ContentModFighterStat,
     ContentModStat,
+    ContentModTrait,
     ContentRule,
     ContentStat,
+    ContentWeaponTrait,
 )
 from gyrinx.query import capture_queries
 
@@ -89,14 +92,15 @@ def _make_fighter_mods(count):
 
 @pytest.mark.django_db
 def test_change_page_query_count_does_not_scale_with_rows(
-    admin_user, equipment, content_house, make_content_fighter
+    admin_user, equipment_category, content_house, make_content_fighter
 ):
     """Regression: the page must not rebuild its option lists per inline row.
 
     Fighter selects, and the modifications select on every upgrade row, used to
     be assembled inside each row's form — one pass over every fighter (with an
     N+1 on house) and every modification (with an N+1 on each modification's
-    related objects) for each row on the page.
+    related objects) for each row on the page. Rendering the same content with
+    more rows should therefore cost the same number of queries.
     """
     fighters = [
         make_content_fighter(
@@ -109,24 +113,36 @@ def test_change_page_query_count_does_not_scale_with_rows(
     ]
     mods = _make_fighter_mods(10)
 
-    # Several inline rows of each kind, all of which used to multiply the cost.
-    for i, fighter in enumerate(fighters[:5]):
-        ContentEquipmentFighterProfile.objects.create(
-            equipment=equipment, content_fighter=fighter
+    def build(name, rows):
+        equipment = ContentEquipment.objects.create(
+            name=name, category=equipment_category, cost="10"
         )
-    for i in range(8):
-        upgrade = ContentEquipmentUpgrade.objects.create(
-            equipment=equipment, name=f"Upgrade {i}", position=i, cost=5
-        )
-        upgrade.modifiers.set(mods[:4])
-    equipment.modifiers.set(mods[:3])
+        for fighter in fighters[:rows]:
+            ContentEquipmentFighterProfile.objects.create(
+                equipment=equipment, content_fighter=fighter
+            )
+        for i in range(rows):
+            upgrade = ContentEquipmentUpgrade.objects.create(
+                equipment=equipment, name=f"Upgrade {i}", position=i, cost=5
+            )
+            upgrade.modifiers.set(mods[:4])
+        equipment.modifiers.set(mods[:3])
+        return equipment
 
-    _, info = capture_queries(lambda: _render_change_page(admin_user, equipment))
+    small = build("Few Rows", 2)
+    large = build("Many Rows", 8)
 
-    # Before: ~30 fighters x 6 fighter-profile forms, plus ~20 modifications x
-    # 9 upgrade forms, each a query. A generous flat ceiling catches a
-    # regression without being brittle about the exact count.
-    assert info.count < 100, f"too many queries: {info.count}"
+    _, small_info = capture_queries(lambda: _render_change_page(admin_user, small))
+    _, large_info = capture_queries(lambda: _render_change_page(admin_user, large))
+
+    # Four times the rows must not mean four times the queries: the option
+    # lists are built once, and the rows themselves are select_related /
+    # prefetched, so the count should be flat but for a little slack.
+    assert large_info.count <= small_info.count + 2, (
+        f"queries scale with rows: {small_info.count} at 2 rows, "
+        f"{large_info.count} at 8 rows"
+    )
+    assert large_info.count < 100, f"too many queries: {large_info.count}"
 
 
 @pytest.mark.django_db
@@ -219,3 +235,37 @@ def test_prime_stat_definitions_avoids_a_query_per_modification():
     assert len(labels) == 5
     assert all("Movement" in label for label in labels)
     assert info.count == 1, f"expected a single stat query, got {info.count}"
+
+
+@pytest.mark.django_db
+def test_every_modification_type_gets_an_option():
+    """A modification with no <option> would be silently cleared on save.
+
+    ``MODIFIER_LABEL_LOADERS`` is an optimisation, so the choice builder must
+    cover every concrete type in the queryset — including any added later that
+    nobody remembered to list there.
+    """
+    from django import forms
+
+    from gyrinx.content.admin import MODIFIER_LABEL_LOADERS, modifier_choices
+
+    _make_fighter_mods(2)
+    ContentModStat.objects.create(stat="strength", mode="improve", value="1")
+    ContentModTrait.objects.create(
+        trait=ContentWeaponTrait.objects.create(name="Unwieldy"), mode="add"
+    )
+
+    field = forms.ModelMultipleChoiceField(queryset=ContentMod.objects.all())
+    offered = {str(pk) for pk, _label in modifier_choices(field)}
+    everything = {str(pk) for pk in ContentMod.objects.values_list("pk", flat=True)}
+
+    assert offered == everything
+
+    # And the loader map itself should stay in step with the model hierarchy,
+    # so the common path keeps its select_related.
+    def concrete_subclasses(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from concrete_subclasses(sub)
+
+    assert set(concrete_subclasses(ContentMod)) == set(MODIFIER_LABEL_LOADERS)

--- a/gyrinx/content/tests/test_admin_equipment_change_page.py
+++ b/gyrinx/content/tests/test_admin_equipment_change_page.py
@@ -1,0 +1,221 @@
+"""Tests for the ContentEquipment admin change page.
+
+The page renders several selects over the whole content library — every
+fighter, every modification — once per inline row. Building those option lists
+per row made the page issue thousands of queries; these tests pin the flat
+behaviour down.
+"""
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from gyrinx.content.admin import ContentEquipmentAdmin
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentCategory,
+    ContentEquipmentFighterProfile,
+    ContentEquipmentUpgrade,
+    ContentModFighterRule,
+    ContentModFighterStat,
+    ContentModStat,
+    ContentRule,
+    ContentStat,
+)
+from gyrinx.query import capture_queries
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_superuser(
+        username="admin", email="admin@test.com", password="testpass"
+    )
+
+
+@pytest.fixture
+def equipment_category(db):
+    return ContentEquipmentCategory.objects.create(name="Test Gear", group="Gear")
+
+
+@pytest.fixture
+def equipment(equipment_category):
+    return ContentEquipment.objects.create(
+        name="Test Equipment", category=equipment_category, cost="10"
+    )
+
+
+def _equipment_form_class(admin_user, equipment):
+    """The model form the admin actually builds (ContentEquipmentAdminForm is a
+    mixin over a generated ModelForm, so it has no model of its own)."""
+    request = RequestFactory().get("/")
+    request.user = admin_user
+    admin = ContentEquipmentAdmin(ContentEquipment, AdminSite())
+    return admin.get_form(request, equipment)
+
+
+def _render_change_page(admin_user, equipment):
+    request = RequestFactory().get(
+        f"/admin/content/contentequipment/{equipment.pk}/change/"
+    )
+    request.user = admin_user
+
+    admin = ContentEquipmentAdmin(ContentEquipment, AdminSite())
+    response = admin.change_view(request, str(equipment.pk))
+    if hasattr(response, "render"):
+        response.render()
+    return response
+
+
+def _make_fighter_mods(count):
+    """A handful of fighter-affecting modifications of assorted types."""
+    ContentStat.objects.get_or_create(
+        field_name="movement",
+        defaults={"short_name": "M", "full_name": "Movement"},
+    )
+    mods = []
+    for i in range(count):
+        mods.append(
+            ContentModFighterStat.objects.create(
+                stat="movement", mode="improve", value=str(i + 1)
+            )
+        )
+        rule = ContentRule.objects.create(name=f"Rule {i}")
+        mods.append(ContentModFighterRule.objects.create(rule=rule, mode="add"))
+    return mods
+
+
+@pytest.mark.django_db
+def test_change_page_query_count_does_not_scale_with_rows(
+    admin_user, equipment, content_house, make_content_fighter
+):
+    """Regression: the page must not rebuild its option lists per inline row.
+
+    Fighter selects, and the modifications select on every upgrade row, used to
+    be assembled inside each row's form — one pass over every fighter (with an
+    N+1 on house) and every modification (with an N+1 on each modification's
+    related objects) for each row on the page.
+    """
+    fighters = [
+        make_content_fighter(
+            type=f"Fighter {i}",
+            category="GANGER",
+            house=content_house,
+            base_cost=50,
+        )
+        for i in range(30)
+    ]
+    mods = _make_fighter_mods(10)
+
+    # Several inline rows of each kind, all of which used to multiply the cost.
+    for i, fighter in enumerate(fighters[:5]):
+        ContentEquipmentFighterProfile.objects.create(
+            equipment=equipment, content_fighter=fighter
+        )
+    for i in range(8):
+        upgrade = ContentEquipmentUpgrade.objects.create(
+            equipment=equipment, name=f"Upgrade {i}", position=i, cost=5
+        )
+        upgrade.modifiers.set(mods[:4])
+    equipment.modifiers.set(mods[:3])
+
+    _, info = capture_queries(lambda: _render_change_page(admin_user, equipment))
+
+    # Before: ~30 fighters x 6 fighter-profile forms, plus ~20 modifications x
+    # 9 upgrade forms, each a query. A generous flat ceiling catches a
+    # regression without being brittle about the exact count.
+    assert info.count < 100, f"too many queries: {info.count}"
+
+
+@pytest.mark.django_db
+def test_change_page_renders_grouped_and_preselected_fighter(
+    admin_user, equipment, content_house, make_content_fighter
+):
+    """Sharing one option list across rows must not lose grouping or selection."""
+    fighter = make_content_fighter(
+        type="Profile Fighter",
+        category="GANGER",
+        house=content_house,
+        base_cost=50,
+    )
+    ContentEquipmentFighterProfile.objects.create(
+        equipment=equipment, content_fighter=fighter
+    )
+
+    response = _render_change_page(admin_user, equipment)
+    assert response.status_code == 200
+
+    html = response.content.decode()
+    assert f'<optgroup label="{content_house.name}">' in html
+    assert f'value="{fighter.pk}" selected' in html
+
+
+@pytest.mark.django_db
+def test_change_page_preselects_modifiers(admin_user, equipment):
+    """The modifications already on the equipment render as selected options."""
+    mods = _make_fighter_mods(2)
+    equipment.modifiers.set(mods)
+
+    html = _render_change_page(admin_user, equipment).content.decode()
+    for mod in mods:
+        assert f'value="{mod.pk}" selected' in html
+
+
+@pytest.mark.django_db
+def test_modifiers_field_offers_only_fighter_modifications(admin_user, equipment):
+    """Weapon-only modification types stay out of the equipment's list."""
+    fighter_mod = ContentModFighterStat.objects.create(
+        stat="movement", mode="improve", value="1"
+    )
+    weapon_mod = ContentModStat.objects.create(
+        stat="strength", mode="improve", value="1"
+    )
+
+    form = _equipment_form_class(admin_user, equipment)(instance=equipment)
+    offered = {str(pk) for pk, _label in form.fields["modifiers"].widget.choices}
+
+    assert str(fighter_mod.pk) in offered
+    assert str(weapon_mod.pk) not in offered
+    # The queryset backs validation, so it must agree with what is offered.
+    assert form.fields["modifiers"].queryset.filter(pk=weapon_mod.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_modifiers_can_still_be_saved(admin_user, equipment, equipment_category):
+    """Overriding the widget's choices must not break validation or saving."""
+    mods = _make_fighter_mods(2)
+
+    form = _equipment_form_class(admin_user, equipment)(
+        data={
+            "name": equipment.name,
+            "category": str(equipment_category.pk),
+            "cost": "10",
+            "rarity": "C",
+            "modifiers": [str(mod.pk) for mod in mods],
+            "upgrade_mode": ContentEquipment.UpgradeMode.SINGLE,
+        },
+        instance=equipment,
+    )
+
+    assert form.is_valid(), form.errors
+    form.save()
+    assert set(equipment.modifiers.all()) == set(mods)
+
+
+@pytest.mark.django_db
+def test_prime_stat_definitions_avoids_a_query_per_modification():
+    """Labelling many fighter stat modifications costs one stat query, not N."""
+    _make_fighter_mods(5)
+    mods = list(ContentModFighterStat.objects.all())
+
+    def label_all():
+        ContentModFighterStat.prime_stat_definitions(mods)
+        return [str(mod) for mod in mods]
+
+    labels, info = capture_queries(label_all)
+
+    assert len(labels) == 5
+    assert all("Movement" in label for label in labels)
+    assert info.count == 1, f"expected a single stat query, got {info.count}"


### PR DESCRIPTION
The ContentEquipment change page in the admin was issuing thousands of queries, because each inline row assembled its own copy of two very large dropdowns.

## What was happening

- The **fighter-profile inline** grouped its fighter dropdown by house inside each row's form `__init__`. That walks all 596 fighters and queries each one's house — once per row, plus once more for the hidden "add another" template row.
- The **upgrade inline** did the same with the modifications dropdown. Modifications are polymorphic, so a queryset can't `select_related` the related objects their labels read from; each one fetched its own. Equipment with 18 upgrades paid that ~190-query bill 19 times over.
- Two smaller versions of the same thing: the `auto_companion_for_fighter` dropdown listed every fighter without `select_related` on house, and `ContentModFighterStat`'s label looked its stat up one row at a time.

## What changed

Both dropdowns are now built once per page and shared across rows (`share_field_choices`). Modifications are loaded one concrete type at a time so `select_related` can cover their labels, and `ContentModFighterStat.prime_stat_definitions` resolves many stat lookups in a single query. Inline rows also prefetch the traits and modifiers they display.

The querysets that back validation are unchanged — only how the options are assembled. The house grouping of the fighter dropdowns, and the restriction to fighter-affecting modification types, behave as before.

Two deliberate display changes:

- The modifications dropdown is now sorted by label. `ContentMod` declares no default ordering, so previously it came out in whatever order the database returned — building the options per type made that order unstable, and sorting is more useful anyway.
- Fighter dropdowns are ordered by house then type. The old path grouped an unordered queryset, which could emit the same house as several separate `<optgroup>`s.

While in here, the equipment-category limit inline (which had a hand-rolled fix for this same bug) now uses the shared helper.

## Numbers

Measured locally against a copy of the content library:

| Page | Queries | Time |
|---|---|---|
| Unborn (18 upgrades) | 3421 → 59 | 3.3s → 0.7s |
| Shotgun (13 weapon profiles) | 4574 → 70 | 1.8s → 0.6s |

The win should be bigger in production, where each query is a round trip to Cloud SQL rather than a local socket.

## Review follow-ups

A review pass caught a latent bug in the first commit worth calling out: the modifications option list was driven by a hardcoded map of modification types. A type missing from that map would render no `<option>`, and an option that isn't rendered can't be submitted — so it would have been silently cleared from the field on the next save. All seven concrete subclasses were covered, so nothing was actually at risk, but an eighth would have turned equipment edits into quiet data loss. The list is now built from the content types actually present, with the map demoted to an optimisation.

Also from that pass: a guard so a `readonly_fields` entry can't 500 the page, and `select_related` on the parent equipment (and the fighter's house) that each inline row was re-fetching for its label.

## Tests

New `test_admin_equipment_change_page.py` covers the query ceiling (596 queries before the fix, well under 100 after), that grouping and pre-selected values survive the shared option lists, that weapon-only modification types stay out of the equipment list, and that saving still works. Full suite passes (3620).

## How to try it

Open any equipment in the admin — `/admin/content/contentequipment/<id>/change/`. The ones with many upgrades (Unborn, Natborn, Vatborn) or many weapon profiles (Shotgun, Grenade launcher) were the worst affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

