### PR TITLE
refactor: flex layout for classic card body, footer and portrait

### DIFF
--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -555,9 +555,9 @@
         overflow: hidden;
     }
 
-    // XP + Kills — pinned row of two equal columns. The gap between them is the
-    // shared --cc-detail-gap so the XP/Kills split lines up with the
-    // Skills+Rules / Gear columns above.
+    // XP + Kills — a row of two equal columns at the top of the footer. The gap
+    // between them is the shared --cc-detail-gap so the XP/Kills split lines up
+    // with the Skills+Rules / Gear columns above.
     .cc-kills {
         flex: 0 0 auto;
         height: var(--cc-kills-h);

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -27,30 +27,28 @@
     --cc-h: 110mm;
     --cc-pad: 3.2mm;
 
-    // Condition tabs across the top; the save value fills the leftover space.
+    // Top chrome is still individually pinned (see the .cc-region users below).
     --cc-tabs-top: 0;
     --cc-tabs-h: 6mm;
     --cc-name-top: 7mm;
     --cc-name-h: 11mm;
     --cc-stat-top: 18.5mm;
     --cc-stat-h: 11mm;
-    --cc-weap-top: 30mm;
-    --cc-weap-h: 30mm;
-    // detail block: 2-column grid (skills / rules / gear / other). Its height
-    // stops ~2mm short of the pinned XP/Kills row to leave a margin above it.
-    --cc-detail-top: 60mm;
-    --cc-detail-h: 21.5mm;
+    // Everything below the statline lives in one flex column (.cc-main) pinned
+    // from here to the bottom padding — no per-region top/height pins. Weapons +
+    // detail flow from the top (.cc-body); XP/Kills + Notes + Injuries attach at
+    // the bottom (.cc-foot); the slack flexes between them.
+    --cc-body-top: 30mm;
+    --cc-body-gap: 1.5mm; // between the weapons table and the detail block
     // Gap between the two detail columns — shared with the XP/Kills row so the
     // two splits line up. Change here and both stay aligned.
     --cc-detail-gap: 3mm;
-    // XP/Kills, notes, and injuries are pinned so they never clip.
-    --cc-kills-top: 83.5mm;
+    // Fixed heights for the bottom write-in fields so their boxes keep room to
+    // write in by hand (and the fit-to-box script has a bound to shrink into).
     --cc-kills-h: 3.5mm;
-    --cc-notes-top: 87.5mm;
     --cc-notes-h: 9.5mm;
-    // injuries sit under notes at the very bottom
-    --cc-injuries-top: 97.5mm;
     --cc-injuries-h: 10mm;
+    --cc-foot-gap: 0.5mm; // between the XP/Kills, Notes and Injuries rows
     // shared label-column width for the XP / Kills / Notes / Injuries rows so
     // their write-in boxes all start at the same x.
     --cc-fieldlabel-w: 13mm;
@@ -191,7 +189,7 @@
     // injuries are printed inside; the rest is space to fill in by hand.
     // =======================================================================
     .cc-injuries {
-        top: var(--cc-injuries-top);
+        flex: 0 0 auto;
         height: var(--cc-injuries-h);
         display: flex;
         flex-direction: row;
@@ -348,12 +346,44 @@
     }
 
     // =======================================================================
-    // Weapons
+    // Body + footer — the two flex columns that replace the old per-region
+    // absolute pins for everything below the statline.
+    //
+    //   .cc-main  absolutely pinned from --cc-body-top to the bottom padding.
+    //   .cc-body  weapons + detail, flowing from the top. Grows to fill so the
+    //             slack shows as whitespace below the detail, above the footer.
+    //   .cc-foot  XP/Kills + Notes + Injuries, content-sized, sitting flush at
+    //             the bottom and growing upward.
+    // =======================================================================
+    .cc-main {
+        top: var(--cc-body-top);
+        bottom: var(--cc-pad);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    .cc-body {
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--cc-body-gap);
+        overflow: hidden;
+    }
+
+    .cc-foot {
+        flex: 0 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: var(--cc-foot-gap);
+    }
+
+    // =======================================================================
+    // Weapons — sizes to its content at the top of the body column.
     // =======================================================================
     .cc-weapons {
-        top: var(--cc-weap-top);
-        height: var(--cc-weap-h);
-        overflow: hidden;
+        flex: 0 0 auto;
     }
 
     .cc-wtable {
@@ -427,12 +457,14 @@
     // they flow in reading order (Skills, Rules, Gear, then the "other" groups)
     // and the browser splits them to keep the columns even.
     .cc-detail {
-        top: var(--cc-detail-top);
-        height: var(--cc-detail-h);
+        // Fills the remaining body height below the weapons table; its content
+        // flows from the top. A definite flex height keeps .cc-detail__cols'
+        // `max-height: 100%` bound so the fit-to-box script can still shrink
+        // long content into the column box.
+        flex: 1 1 auto;
+        min-height: 0;
         display: flex;
         flex-direction: column;
-        justify-content: flex-end;
-        overflow: hidden;
     }
 
     .cc-detail__cols {
@@ -476,8 +508,14 @@
         margin-bottom: 1mm;
     }
 
+    // Long labels (e.g. "Legendary Names") wrap to their narrowest — one word
+    // per line — so the value keeps as much horizontal space as possible.
+    // Blank cards override this with a fixed label column (see the
+    // [data-kind="blank"] block below).
     .cc-detail .cc-label {
-        flex: 0 0 auto;
+        flex: 0 1 auto;
+        width: min-content;
+        overflow-wrap: break-word;
     }
 
     .cc-detail .cc-section__body {
@@ -502,7 +540,7 @@
     // shared --cc-detail-gap so the XP/Kills split lines up with the
     // Skills+Rules / Gear columns above.
     .cc-kills {
-        top: var(--cc-kills-top);
+        flex: 0 0 auto;
         height: var(--cc-kills-h);
         display: flex;
         align-items: stretch;
@@ -535,7 +573,7 @@
 
     // Notes — label + write-in box.
     .cc-notes {
-        top: var(--cc-notes-top);
+        flex: 0 0 auto;
         height: var(--cc-notes-h);
         display: flex;
         flex-direction: row;
@@ -565,24 +603,22 @@
         position: absolute;
         z-index: 3;
         right: var(--cc-pad);
-        bottom: var(--cc-pad);
+        bottom: calc(var(--cc-pad) - 1.5mm);
         width: auto;
         height: auto;
         max-width: var(--cc-portrait-w);
-        max-height: 26mm;
+        max-height: 24mm;
         border: 0.4mm solid var(--cc-ink);
         border-radius: 1mm;
         -webkit-print-color-adjust: exact;
         print-color-adjust: exact;
     }
 
-    // Keep the bottom write-in rows clear of the portrait footprint.
-    &.has-portrait {
-        .cc-kills,
-        .cc-notes,
-        .cc-injuries {
-            right: calc(var(--cc-pad) + var(--cc-portrait-w) + 2mm);
-        }
+    // Keep the footer's write-in rows clear of the portrait footprint. The rows
+    // are flex children now (not absolutely positioned), so shrink the footer's
+    // content width with padding rather than a `right` offset.
+    &.has-portrait .cc-foot {
+        padding-right: calc(var(--cc-portrait-w) + 2mm);
     }
 
     // =======================================================================

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -58,9 +58,11 @@
     --cc-fieldlabel-w: 13mm;
 
     --cc-cog-size: 12mm;
-    // fighter portrait footprint (bottom-right); ~20% of the card width. The
-    // bottom rows reserve this width so their text doesn't run under the image.
+    // Fighter portrait column at the right of the footer; ~20% of the card
+    // width. Its height comes from the write-in fields beside it, so the two
+    // stay aligned automatically when those row heights change.
     --cc-portrait-w: 20mm;
+    --cc-portrait-gap: 2mm; // between the write-in fields and the portrait
 
     position: relative;
     box-sizing: border-box;
@@ -377,8 +379,20 @@
         overflow: hidden;
     }
 
+    // Bottom row: write-in fields on the left, portrait column on the right.
+    // `align-items: stretch` makes the portrait exactly as tall as the stack of
+    // fields, so its edges line up with the write-in boxes.
     .cc-foot {
         flex: 0 0 auto;
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+        gap: var(--cc-portrait-gap);
+    }
+
+    .cc-foot__fields {
+        flex: 1 1 auto;
+        min-width: 0;
         display: flex;
         flex-direction: column;
         gap: var(--cc-foot-gap);
@@ -599,31 +613,36 @@
         color: rgba(29, 26, 22, 0.9);
     }
 
-    // Fighter portrait, pinned to the bottom-right corner with a thin border and
-    // slightly rounded corners. Never wider than the reserved footprint (a height
-    // cap keeps tall portraits from dominating); aspect ratio preserved. The
-    // bottom rows reserve this width (see &.has-portrait) so their write-in text
-    // stops at the image rather than running underneath it.
+    // Fighter portrait — a fixed-width right-hand column of the footer rather
+    // than an absolutely-positioned overlay, so the layout needs no knowledge of
+    // whether an image is present. It stretches to the height of the write-in
+    // fields beside it, which is what makes its top and bottom edges align with
+    // them exactly; `object-fit: cover` fills that frame (cropping rather than
+    // letterboxing, which would reintroduce a gap and break the alignment).
+    // The column itself carries the frame and holds no in-flow content, so its
+    // hypothetical height is zero: the write-in fields alone set the row height
+    // and the portrait can never make the footer block taller, whatever the
+    // source image's aspect ratio. `align-self: stretch` then sizes it to match
+    // the fields exactly, which is what aligns its edges with the boxes.
     .cc-portrait {
-        position: absolute;
-        z-index: 3;
-        right: var(--cc-pad);
-        bottom: calc(var(--cc-pad) - 1.5mm);
-        width: auto;
-        height: auto;
-        max-width: var(--cc-portrait-w);
-        max-height: 24mm;
+        position: relative;
+        flex: 0 0 var(--cc-portrait-w);
+        align-self: stretch;
+        overflow: hidden;
         border: 0.4mm solid var(--cc-ink);
         border-radius: 1mm;
-        -webkit-print-color-adjust: exact;
-        print-color-adjust: exact;
     }
 
-    // Keep the footer's write-in rows clear of the portrait footprint. The rows
-    // are flex children now (not absolutely positioned), so shrink the footer's
-    // content width with padding rather than a `right` offset.
-    &.has-portrait .cc-foot {
-        padding-right: calc(var(--cc-portrait-w) + 2mm);
+    // Fills the frame. `cover` crops rather than letterboxing — letterboxing
+    // would leave a gap inside the frame and break the alignment it exists for.
+    .cc-portrait__img {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
     }
 
     // =======================================================================

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -40,6 +40,10 @@
     // the bottom (.cc-foot); the slack flexes between them.
     --cc-body-top: 30mm;
     --cc-body-gap: 1.5mm; // between the weapons table and the detail block
+    // Breathing room between the flowing body and the bottom-attached footer.
+    // Blank cards spread their write-in boxes to fill the detail block, so
+    // without this the last box butts straight up against the XP/Kills row.
+    --cc-main-gap: 2mm;
     // Gap between the two detail columns — shared with the XP/Kills row so the
     // two splits line up. Change here and both stay aligned.
     --cc-detail-gap: 3mm;
@@ -360,6 +364,7 @@
         bottom: var(--cc-pad);
         display: flex;
         flex-direction: column;
+        gap: var(--cc-main-gap);
         overflow: hidden;
     }
 

--- a/gyrinx/core/templates/core/includes/classic_card.html
+++ b/gyrinx/core/templates/core/includes/classic_card.html
@@ -44,113 +44,127 @@ Params:
             </div>
         {% endfor %}
     </div>
-    {% comment %} Weapons — real rows, plus blank write-in rows on blank cards {% endcomment %}
-    <div class="cc-region cc-weapons">
-        <table class="cc-wtable">
-            <thead>
-                <tr>
-                    <th class="cc-w-name">Weapon</th>
-                    <th class="cc-w-group">S</th>
-                    <th>L</th>
-                    <th class="cc-w-group">S</th>
-                    <th>L</th>
-                    <th class="cc-w-group">Str</th>
-                    <th>Ap</th>
-                    <th>D</th>
-                    <th>Am</th>
-                    <th class="cc-w-group cc-w-traits">Traits</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for w in card.weapons %}
-                    <tr class="{% if w.is_secondary %}cc-w-sub{% endif %}">
-                        <td class="cc-w-name">{% if w.is_secondary %}<i class="bi-dash"></i> {% endif %}{{ w.name }}</td>
-                        <td class="cc-w-group">{{ w.rng_s|default:"-" }}</td>
-                        <td>{{ w.rng_l|default:"-" }}</td>
-                        <td class="cc-w-group">{{ w.acc_s|default:"-" }}</td>
-                        <td>{{ w.acc_l|default:"-" }}</td>
-                        <td class="cc-w-group">{{ w.strength|default:"-" }}</td>
-                        <td>{{ w.ap|default:"-" }}</td>
-                        <td>{{ w.damage|default:"-" }}</td>
-                        <td>{{ w.ammo|default:"-" }}</td>
-                        <td class="cc-w-group cc-w-traits">{{ w.traits }}</td>
-                    </tr>
-                {% endfor %}
-                {% if card.kind == "blank" %}
-                    {% for c in "1234567" %}
-                        <tr class="cc-w-blank">
-                            <td class="cc-w-name"></td>
-                            <td class="cc-w-group"></td>
-                            <td></td>
-                            <td class="cc-w-group"></td>
-                            <td></td>
-                            <td class="cc-w-group"></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td class="cc-w-group cc-w-traits"></td>
+    {% comment %}
+    Everything below the statline is one absolutely-pinned flex column. The body
+    (weapons + detail) flows from the top; the footer (XP/Kills + Notes +
+    Injuries) attaches to the bottom; the slack flexes between them. Only the top
+    chrome above and the portrait below keep their own absolute positioning.
+    {% endcomment %}
+    <div class="cc-region cc-main">
+        <div class="cc-body">
+            {% comment %} Weapons — real rows, plus blank write-in rows on blank cards {% endcomment %}
+            <div class="cc-weapons">
+                <table class="cc-wtable">
+                    <thead>
+                        <tr>
+                            <th class="cc-w-name">Weapon</th>
+                            <th class="cc-w-group">S</th>
+                            <th>L</th>
+                            <th class="cc-w-group">S</th>
+                            <th>L</th>
+                            <th class="cc-w-group">Str</th>
+                            <th>Ap</th>
+                            <th>D</th>
+                            <th>Am</th>
+                            <th class="cc-w-group cc-w-traits">Traits</th>
                         </tr>
-                    {% endfor %}
+                    </thead>
+                    <tbody>
+                        {% for w in card.weapons %}
+                            <tr class="{% if w.is_secondary %}cc-w-sub{% endif %}">
+                                <td class="cc-w-name">{% if w.is_secondary %}<i class="bi-dash"></i> {% endif %}{{ w.name }}</td>
+                                <td class="cc-w-group">{{ w.rng_s|default:"-" }}</td>
+                                <td>{{ w.rng_l|default:"-" }}</td>
+                                <td class="cc-w-group">{{ w.acc_s|default:"-" }}</td>
+                                <td>{{ w.acc_l|default:"-" }}</td>
+                                <td class="cc-w-group">{{ w.strength|default:"-" }}</td>
+                                <td>{{ w.ap|default:"-" }}</td>
+                                <td>{{ w.damage|default:"-" }}</td>
+                                <td>{{ w.ammo|default:"-" }}</td>
+                                <td class="cc-w-group cc-w-traits">{{ w.traits }}</td>
+                            </tr>
+                        {% endfor %}
+                        {% if card.kind == "blank" %}
+                            {% for c in "1234567" %}
+                                <tr class="cc-w-blank">
+                                    <td class="cc-w-name"></td>
+                                    <td class="cc-w-group"></td>
+                                    <td></td>
+                                    <td class="cc-w-group"></td>
+                                    <td></td>
+                                    <td class="cc-w-group"></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td class="cc-w-group cc-w-traits"></td>
+                                </tr>
+                            {% endfor %}
+                        {% endif %}
+                    </tbody>
+                </table>
+                {% if not card.weapons and card.kind != "blank" %}
+                    <div class="cc-weapons__empty">No weapons.</div>
                 {% endif %}
-            </tbody>
-        </table>
-        {% if not card.weapons and card.kind != "blank" %}
-            <div class="cc-weapons__empty">No weapons.</div>
-        {% endif %}
-    </div>
-    {% comment %} Lower detail block — bottom-aligned, balanced 2 columns: skills, rules, gear, then others {% endcomment %}
-    <div class="cc-region cc-detail">
-        <div class="cc-detail__cols">
-            <div class="cc-section cc-skills">
-                <div class="cc-label">Skills</div>
-                {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.skills|join:", " }}</div>{% endif %}
             </div>
-            <div class="cc-section cc-rules-q">
-                <div class="cc-label">Rules</div>
-                {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.rules|join:", " }}</div>{% endif %}
-            </div>
-            <div class="cc-section cc-wargear">
-                <div class="cc-label">Gear</div>
-                {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.wargear|join:", " }}</div>{% endif %}
-            </div>
-            {% if card.powers %}
-                <div class="cc-section cc-powers">
-                    <div class="cc-label">Wyrd Powers</div>
-                    <div class="cc-section__body">{{ card.powers|join:", " }}</div>
+            {% comment %} Lower detail block — balanced 2 columns: skills, rules, gear, then others {% endcomment %}
+            <div class="cc-detail">
+                <div class="cc-detail__cols">
+                    <div class="cc-section cc-skills">
+                        <div class="cc-label">Skills</div>
+                        {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.skills|join:", " }}</div>{% endif %}
+                    </div>
+                    <div class="cc-section cc-rules-q">
+                        <div class="cc-label">Rules</div>
+                        {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.rules|join:", " }}</div>{% endif %}
+                    </div>
+                    <div class="cc-section cc-wargear">
+                        <div class="cc-label">Gear</div>
+                        {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.wargear|join:", " }}</div>{% endif %}
+                    </div>
+                    {% if card.powers %}
+                        <div class="cc-section cc-powers">
+                            <div class="cc-label">Wyrd Powers</div>
+                            <div class="cc-section__body">{{ card.powers|join:", " }}</div>
+                        </div>
+                    {% endif %}
+                    {% for cat in card.gear_categories %}
+                        <div class="cc-section cc-gearcat">
+                            <div class="cc-label">{{ cat.0 }}</div>
+                            <div class="cc-section__body">{{ cat.1|join:", " }}</div>
+                        </div>
+                    {% endfor %}
                 </div>
-            {% endif %}
-            {% for cat in card.gear_categories %}
-                <div class="cc-section cc-gearcat">
-                    <div class="cc-label">{{ cat.0 }}</div>
-                    <div class="cc-section__body">{{ cat.1|join:", " }}</div>
+            </div>
+        </div>
+        <div class="cc-foot">
+            {% comment %}
+            XP (bold value + write-in box) + Kills (write-in box). Two equal
+            columns matching the detail block's columns above, so the XP/Kills
+            split lines up with the Skills+Rules / Gear split.
+            {% endcomment %}
+            <div class="cc-kills">
+                <div class="cc-kills__col">
+                    <span class="cc-kills__lbl"><span class="cc-label">XP</span> <span class="cc-kills__xp">{{ card.xp }}</span></span>
+                    <span class="cc-writein"></span>
                 </div>
-            {% endfor %}
+                <div class="cc-kills__col">
+                    <span class="cc-kills__lbl"><span class="cc-label">Kills</span></span>
+                    <span class="cc-writein"></span>
+                </div>
+            </div>
+            {% comment %} Notes — write-in box {% endcomment %}
+            <div class="cc-notes">
+                <div class="cc-label">Notes</div>
+                <div class="cc-writein cc-notes__box">
+                    {% for line in card.notes_lines %}<div>{{ line }}</div>{% endfor %}
+                </div>
+            </div>
+            {% comment %} Injuries — write-in box under notes {% endcomment %}
+            <div class="cc-injuries">
+                <div class="cc-label">Injuries</div>
+                <div class="cc-writein cc-injuries__box">{{ card.injuries|join:", " }}</div>
+            </div>
         </div>
-    </div>
-    {% comment %} XP (bold value + write-in box) + Kills (write-in box), pinned.
-    Two equal columns matching the detail block's columns above, so the XP/Kills
-    split lines up with the Skills+Rules / Gear split. {% endcomment %}
-    <div class="cc-region cc-kills">
-        <div class="cc-kills__col">
-            <span class="cc-kills__lbl"><span class="cc-label">XP</span> <span class="cc-kills__xp">{{ card.xp }}</span></span>
-            <span class="cc-writein"></span>
-        </div>
-        <div class="cc-kills__col">
-            <span class="cc-kills__lbl"><span class="cc-label">Kills</span></span>
-            <span class="cc-writein"></span>
-        </div>
-    </div>
-    {% comment %} Notes — write-in box {% endcomment %}
-    <div class="cc-region cc-notes">
-        <div class="cc-label">Notes</div>
-        <div class="cc-writein cc-notes__box">
-            {% for line in card.notes_lines %}<div>{{ line }}</div>{% endfor %}
-        </div>
-    </div>
-    {% comment %} Injuries — write-in box under notes {% endcomment %}
-    <div class="cc-region cc-injuries">
-        <div class="cc-label">Injuries</div>
-        <div class="cc-writein cc-injuries__box">{{ card.injuries|join:", " }}</div>
     </div>
     {% comment %} Fighter portrait, if set — pinned bottom-right, capped width {% endcomment %}
     {% if card.image_url %}

--- a/gyrinx/core/templates/core/includes/classic_card.html
+++ b/gyrinx/core/templates/core/includes/classic_card.html
@@ -6,7 +6,7 @@ Params:
   theme   -- background theme key (blank/odd/even/paper_odd/paper_even/dark)
   show_grid -- if truthy, overlay a mm alignment grid (lab tuning aid)
 {% endcomment %}
-<div class="classic-card theme-{{ theme|default:'blank' }}{% if card.dead %} is-dead{% endif %}{% if card.image_url %} has-portrait{% endif %}{% if show_grid %} show-grid{% endif %}"
+<div class="classic-card theme-{{ theme|default:'blank' }}{% if card.dead %} is-dead{% endif %}{% if show_grid %} show-grid{% endif %}"
      data-kind="{{ card.kind }}">
     <div class="cc-bg"></div>
     {% comment %} Condition tabs + save value in the leftover space {% endcomment %}
@@ -47,8 +47,8 @@ Params:
     {% comment %}
     Everything below the statline is one absolutely-pinned flex column. The body
     (weapons + detail) flows from the top; the footer (XP/Kills + Notes +
-    Injuries) attaches to the bottom; the slack flexes between them. Only the top
-    chrome above and the portrait below keep their own absolute positioning.
+    Injuries, plus the portrait) attaches to the bottom; the slack flexes between
+    them. Only the top chrome above keeps its own absolute positioning.
     {% endcomment %}
     <div class="cc-region cc-main">
         <div class="cc-body">

--- a/gyrinx/core/templates/core/includes/classic_card.html
+++ b/gyrinx/core/templates/core/includes/classic_card.html
@@ -136,38 +136,53 @@ Params:
                 </div>
             </div>
         </div>
+        {% comment %}
+        Bottom row: the write-in fields on the left, the portrait as a fixed
+        right-hand column. Both stretch to the same height, so the image's top
+        and bottom edges line up with the write-in boxes beside it.
+        {% endcomment %}
         <div class="cc-foot">
+            <div class="cc-foot__fields">
+                {% comment %}
+                XP (bold value + write-in box) + Kills (write-in box). Two equal
+                columns matching the detail block's columns above, so the XP/Kills
+                split lines up with the Skills+Rules / Gear split.
+                {% endcomment %}
+                <div class="cc-kills">
+                    <div class="cc-kills__col">
+                        <span class="cc-kills__lbl"><span class="cc-label">XP</span> <span class="cc-kills__xp">{{ card.xp }}</span></span>
+                        <span class="cc-writein"></span>
+                    </div>
+                    <div class="cc-kills__col">
+                        <span class="cc-kills__lbl"><span class="cc-label">Kills</span></span>
+                        <span class="cc-writein"></span>
+                    </div>
+                </div>
+                {% comment %} Notes — write-in box {% endcomment %}
+                <div class="cc-notes">
+                    <div class="cc-label">Notes</div>
+                    <div class="cc-writein cc-notes__box">
+                        {% for line in card.notes_lines %}<div>{{ line }}</div>{% endfor %}
+                    </div>
+                </div>
+                {% comment %} Injuries — write-in box under notes {% endcomment %}
+                <div class="cc-injuries">
+                    <div class="cc-label">Injuries</div>
+                    <div class="cc-writein cc-injuries__box">{{ card.injuries|join:", " }}</div>
+                </div>
+            </div>
             {% comment %}
-            XP (bold value + write-in box) + Kills (write-in box). Two equal
-            columns matching the detail block's columns above, so the XP/Kills
-            split lines up with the Skills+Rules / Gear split.
+            The image is wrapped rather than being the flex item itself: an
+            <img> contributes its own intrinsic height to the row, so a tall
+            portrait would stretch the whole footer. The wrapper has no
+            intrinsic height, so the fields decide the row height and the image
+            fills whatever that turns out to be.
             {% endcomment %}
-            <div class="cc-kills">
-                <div class="cc-kills__col">
-                    <span class="cc-kills__lbl"><span class="cc-label">XP</span> <span class="cc-kills__xp">{{ card.xp }}</span></span>
-                    <span class="cc-writein"></span>
+            {% if card.image_url %}
+                <div class="cc-portrait">
+                    <img class="cc-portrait__img" src="{{ card.image_url }}" alt="">
                 </div>
-                <div class="cc-kills__col">
-                    <span class="cc-kills__lbl"><span class="cc-label">Kills</span></span>
-                    <span class="cc-writein"></span>
-                </div>
-            </div>
-            {% comment %} Notes — write-in box {% endcomment %}
-            <div class="cc-notes">
-                <div class="cc-label">Notes</div>
-                <div class="cc-writein cc-notes__box">
-                    {% for line in card.notes_lines %}<div>{{ line }}</div>{% endfor %}
-                </div>
-            </div>
-            {% comment %} Injuries — write-in box under notes {% endcomment %}
-            <div class="cc-injuries">
-                <div class="cc-label">Injuries</div>
-                <div class="cc-writein cc-injuries__box">{{ card.injuries|join:", " }}</div>
-            </div>
+            {% endif %}
         </div>
     </div>
-    {% comment %} Fighter portrait, if set — pinned bottom-right, capped width {% endcomment %}
-    {% if card.image_url %}
-        <img class="cc-portrait" src="{{ card.image_url }}" alt="">
-    {% endif %}
 </div>

--- a/gyrinx/core/tests/test_print_config_classic.py
+++ b/gyrinx/core/tests/test_print_config_classic.py
@@ -214,7 +214,6 @@ def test_classic_renders_fighter_portrait(
     # separately rather than raw occurrences of the "cc-portrait" prefix.
     assert body.count('class="cc-portrait"') == 1
     assert body.count("cc-portrait__img") == 1
-    assert "has-portrait" in body
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_print_config_classic.py
+++ b/gyrinx/core/tests/test_print_config_classic.py
@@ -209,7 +209,11 @@ def test_classic_renders_fighter_portrait(
     client.force_login(user)
     body = client.get(_print_url(lst, cfg)).content.decode()
 
-    assert body.count("cc-portrait") == 1  # only the fighter with an image
+    # Exactly one portrait column, for the fighter with an image. The image
+    # lives in a wrapper (see classic_card.html), so count the two parts
+    # separately rather than raw occurrences of the "cc-portrait" prefix.
+    assert body.count('class="cc-portrait"') == 1
+    assert body.count("cc-portrait__img") == 1
     assert "has-portrait" in body
 
 


### PR DESCRIPTION
Layout work on the grimdark "classic mode" print card — the fixed 100 × 110 mm
fighter card in `gyrinx/core/templates/core/includes/classic_card.html`.

## Summary

- Lay out everything below the statline with flex instead of per-region absolute
  millimetre coordinates, so the card can be reasoned about as ordinary flow.
- Wrap long detail labels (e.g. "Legendary Names") so the value beside them keeps
  as much width as possible.
- Make the fighter portrait a real right-hand column of the bottom block, aligned
  with the write-in boxes instead of floating in the card's corner.

## The problem

Every region of the card was pinned with absolute mm coordinates driven by CSS
variables — `--cc-weap-top`, `--cc-detail-top`, `--cc-kills-top` and so on.
Because each row's position was stated in absolute terms rather than relative to
its neighbours, nudging any one row meant re-tuning the offsets of every row
below it. The weapons table also had a hard 30 mm height whatever it contained.

Two smaller issues came from the same rigidity: long section labels were forced
onto a single line and ate into the space for their value, and the fighter
portrait was positioned by hand-tuned corner offsets that never quite lined up
with the boxes beside it.

## What changed

Everything below the statline is now one absolutely-pinned flex column holding
two groups:

- **Body** — the weapons table and the detail block (skills, rules, gear and any
  extra categories), flowing down from the top. The weapons table sizes to its
  content rather than a fixed height.
- **Footer** — XP/Kills, Notes and Injuries, attached to the bottom.

Slack falls between the two groups. The footer rows keep their existing internal
layout and fixed heights, so nothing about how they read has changed. The top
chrome (condition tabs, nameplate, name, cost, statline) stays absolutely
positioned, which is genuinely what it wants.

Long detail labels now wrap to their narrowest width — one word per line — so
the value takes the maximum remaining horizontal space.

The portrait is a flex column of the footer, stretched to the same height as the
write-in fields, so its top and bottom edges align with them exactly. The layout
no longer needs to know whether an image is present.

The image sits inside a wrapper rather than being the flex item itself. An
`<img>` contributes its own intrinsic height to a flex row, so a tall portrait
stretched the whole bottom block — a 1:3 source pushed it from 24 mm to 58 mm.
The wrapper has no intrinsic height, so the write-in fields alone determine the
row height and the portrait cannot grow it, whatever the source aspect ratio.
The image fills that frame with `object-fit: cover`, which crops rather than
letterboxing (letterboxing would leave a gap inside the frame and defeat the
alignment).

## Bug fixed

On blank (fillable) cards the Gear write-in box overlapped the XP/Kills row.
Blank cards spread their Skills/Rules/Gear boxes to fill the detail block, and
once the body ran flush into the footer the last box had nowhere to go. The old
fixed-height detail block left about 2 mm of clearance above the XP row; that
separation is now explicit.

## Test plan

- [x] `pytest gyrinx/core/tests/test_print_lab.py gyrinx/core/tests/test_print_config_classic.py gyrinx/core/tests/test_print_config_stash.py gyrinx/core/tests/test_print_config_delete.py` — 55 passed
- [x] Print lab at `/_debug/print-lab/sheet/`: weapons and detail flow from the top, XP/Kills/Notes/Injuries sit at the bottom, across the fighter, vehicle, psyker and blank presets
- [x] Psyker preset: "Legendary Names", "Wyrd Powers" and "Status Items" wrap, with their values taking the remaining width
- [x] Blank card: Gear box clears the XP/Kills row
- [x] Portrait measured at 1:9, 9:1 and 1:1 source aspect ratios — bottom block height unchanged in all three, top and bottom edges pixel-aligned with the write-in boxes
- [ ] Worth a look on a real gang's print output with a fighter portrait uploaded, and a print-to-PDF to confirm pagination is unaffected

## Notes

- Retires the now-redundant `--cc-weap-top`, `--cc-weap-h`, `--cc-detail-top`,
  `--cc-detail-h`, `--cc-kills-top`, `--cc-notes-top` and `--cc-injuries-top`
  variables.
- `test_classic_renders_fighter_portrait` asserted on the raw count of
  `cc-portrait` in the response body. The portrait is two elements now (wrapper
  plus image), so the test counts them separately; the intent — exactly one
  portrait, for the fighter that has an image — is unchanged.

Refs #1726

🤖 Generated with [Claude Code](https://claude.com/claude-code)