### PR TITLE
refactor: build the cost-change signal pairs from one factory

### DIFF
--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -38,270 +38,147 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
-# Pre-save signal handlers
+# Cost-change signals
 #
-# These signals detect when cost fields change on content models and mark
-# affected core objects (assignments, fighters, lists) as dirty.
+# Every price-bearing content model needs the same pair of receivers: a
+# pre_save that spots a cost edit, flags the instance and marks affected core
+# rows dirty; and a post_save that enqueues propagation (audit actions and
+# cache deltas). Rather than hand-write that pair ten times, they are built by
+# one factory and registered per model below.
 # =============================================================================
 
 
-@receiver(
-    pre_save, sender=ContentEquipment, dispatch_uid="content_equipment_cost_change"
+# Django stores receivers as weakrefs, so a receiver needs a strong reference
+# somewhere or it is collected and the signal silently stops firing. The
+# module-level functions this factory replaced had one implicitly (their own
+# module global); closures built inside a factory do not, so we keep them here.
+#
+# This is easy to get wrong because it does not reproduce in development or in
+# the test suite: `Signal.connect` only calls `func_accepts_kwargs(receiver)`
+# when `settings.DEBUG` is true, and that check runs through an `lru_cache`
+# keyed on the function — which pins it. With DEBUG on, every receiver is held
+# alive incidentally; with DEBUG off (production) nothing holds it, and the
+# receiver is collected. Green locally, dead in prod, no error either way.
+_COST_CHANGE_RECEIVERS = []
+
+
+def register_cost_change(
+    model, *, change_uid, action_uid, field="cost", also_watch=None
+):
+    """Register the standard cost-change receiver pair for a content model.
+
+    Args:
+        model: the content model class whose price edits should propagate.
+        change_uid: ``dispatch_uid`` for the ``pre_save`` receiver.
+        action_uid: ``dispatch_uid`` for the ``post_save`` receiver. Both are
+            passed explicitly rather than derived from the model, because the
+            shipped strings predate any single scheme — ``ContentFighter`` is
+            ``content_fighter_base_cost_change`` but ``content_fighter_cost_action``
+            — and ``dispatch_uid`` is the identity Django dedupes registrations
+            on, so they must stay byte-identical.
+        field: the cost field to compare, through the int-coercing helpers.
+        also_watch: optional second field, compared by its *raw* stored value,
+            whose change also counts as a cost change. Two models need this,
+            for different reasons — see the call sites.
+    """
+
+    @receiver(pre_save, sender=model, dispatch_uid=change_uid)
+    @traced(f"signal_{change_uid}")
+    def on_cost_change(sender, instance, **kwargs):
+        old_cost = get_old_cost(sender, instance, field)
+        if old_cost is None:
+            return  # New instance, nothing existing to reprice
+
+        changed = old_cost != get_new_cost(instance, field)
+        if not changed and also_watch is not None:
+            old_raw = get_old_field(sender, instance, also_watch)
+            new_raw = getattr(instance, also_watch)
+            changed = old_raw is not MISSING and old_raw != new_raw
+
+        if changed:
+            instance._cost_changed = True  # Flag for post_save to create actions
+            # The pre-change value rides to the async task: amount-snapshot
+            # (DERIVED) receipts are maintained by delta, which needs it.
+            instance._old_cost_for_propagation = old_cost
+            instance.set_dirty()
+
+    @receiver(post_save, sender=model, dispatch_uid=action_uid)
+    @traced(f"signal_{action_uid}")
+    def on_cost_change_saved(sender, instance, created, **kwargs):
+        if created or not getattr(instance, "_cost_changed", False):
+            return
+        _enqueue_content_cost_propagation(instance)
+        instance._cost_changed = False  # Clear flag
+
+    _COST_CHANGE_RECEIVERS.extend((on_cost_change, on_cost_change_saved))
+
+
+register_cost_change(
+    ContentEquipment,
+    change_uid="content_equipment_cost_change",
+    action_uid="content_equipment_cost_action",
 )
-@traced("signal_content_equipment_cost_change")
-def handle_equipment_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentEquipment.cost changes.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save, sender=ContentFighter, dispatch_uid="content_fighter_base_cost_change"
+register_cost_change(
+    ContentFighter,
+    field="base_cost",
+    change_uid="content_fighter_base_cost_change",
+    action_uid="content_fighter_cost_action",
 )
-@traced("signal_content_fighter_base_cost_change")
-def handle_fighter_base_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected list fighters dirty when ContentFighter.base_cost changes.
-    """
-    old_cost = get_old_cost(sender, instance, "base_cost")
-    if old_cost is None:
-        return  # New instance, no existing list fighters
-
-    new_cost = get_new_cost(instance, "base_cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save, sender=ContentWeaponProfile, dispatch_uid="content_profile_cost_change"
+register_cost_change(
+    ContentWeaponProfile,
+    change_uid="content_profile_cost_change",
+    action_uid="content_profile_cost_action",
 )
-@traced("signal_content_profile_cost_change")
-def handle_profile_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentWeaponProfile.cost changes.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save,
-    sender=ContentWeaponAccessory,
-    dispatch_uid="content_accessory_cost_change",
+register_cost_change(
+    ContentWeaponAccessory,
+    change_uid="content_accessory_cost_change",
+    action_uid="content_accessory_cost_action",
+    # A cost_expression edit reprices every assignment carrying this accessory
+    # just as surely as a flat-cost edit, and the int compare cannot see it.
+    also_watch="cost_expression",
 )
-@traced("signal_content_accessory_cost_change")
-def handle_accessory_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentWeaponAccessory.cost or
-    cost_expression changes.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    changed = old_cost != new_cost
-    if not changed:
-        # A cost_expression edit reprices every assignment carrying this
-        # accessory just as surely as a flat-cost edit, but was previously
-        # unwatched: nothing went dirty and no audit action was recorded.
-        old_expression = get_old_field(sender, instance, "cost_expression")
-        changed = (
-            old_expression is not MISSING and old_expression != instance.cost_expression
-        )
-
-    if changed:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save, sender=ContentEquipmentUpgrade, dispatch_uid="content_upgrade_cost_change"
+register_cost_change(
+    ContentEquipmentUpgrade,
+    change_uid="content_upgrade_cost_change",
+    action_uid="content_upgrade_cost_action",
 )
-@traced("signal_content_upgrade_cost_change")
-def handle_upgrade_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentEquipmentUpgrade.cost changes.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save,
-    sender=ContentFighterEquipmentListItem,
-    dispatch_uid="content_equipment_list_item_cost_change",
+register_cost_change(
+    ContentFighterEquipmentListItem,
+    change_uid="content_equipment_list_item_cost_change",
+    action_uid="content_equipment_list_item_cost_action",
 )
-@traced("signal_content_equipment_list_item_cost_change")
-def handle_equipment_list_item_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentFighterEquipmentListItem.cost changes.
-
-    This model provides cost overrides for equipment on specific fighter types.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save,
-    sender=ContentFighterEquipmentListWeaponAccessory,
-    dispatch_uid="content_equipment_list_accessory_cost_change",
+register_cost_change(
+    ContentFighterEquipmentListWeaponAccessory,
+    change_uid="content_equipment_list_accessory_cost_change",
+    action_uid="content_equipment_list_accessory_cost_action",
 )
-@traced("signal_content_equipment_list_accessory_cost_change")
-def handle_equipment_list_accessory_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentFighterEquipmentListWeaponAccessory.cost changes.
-
-    This model provides cost overrides for weapon accessories on specific fighter types.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save,
-    sender=ContentFighterEquipmentListUpgrade,
-    dispatch_uid="content_equipment_list_upgrade_cost_change",
+register_cost_change(
+    ContentFighterEquipmentListUpgrade,
+    change_uid="content_equipment_list_upgrade_cost_change",
+    action_uid="content_equipment_list_upgrade_cost_action",
 )
-@traced("signal_content_equipment_list_upgrade_cost_change")
-def handle_equipment_list_upgrade_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentFighterEquipmentListUpgrade.cost changes.
-
-    This model provides cost overrides for equipment upgrades on specific fighter types.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save,
-    sender=ContentFighterHouseOverride,
-    dispatch_uid="content_fighter_house_override_cost_change",
+register_cost_change(
+    ContentFighterHouseOverride,
+    change_uid="content_fighter_house_override_cost_change",
+    action_uid="content_fighter_house_override_cost_action",
 )
-@traced("signal_content_fighter_house_override_cost_change")
-def handle_fighter_house_override_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected fighters dirty when ContentFighterHouseOverride.cost changes.
-
-    This model provides cost overrides for fighters in specific houses.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing fighters
-
-    new_cost = get_new_cost(instance, "cost")
-    if old_cost != new_cost:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
-
-
-@receiver(
-    pre_save,
-    sender=ContentEquipmentListExpansionItem,
-    dispatch_uid="content_expansion_item_cost_change",
+register_cost_change(
+    ContentEquipmentListExpansionItem,
+    change_uid="content_expansion_item_cost_change",
+    action_uid="content_expansion_item_cost_action",
+    # The int helpers coerce None to 0, but on expansion items None means "use
+    # the base price" and 0 means "free" — a 0 <-> None edit DOES reprice, and
+    # only the raw compare catches it.
+    also_watch="cost",
 )
-@traced("signal_content_expansion_item_cost_change")
-def handle_expansion_item_cost_change(sender, instance, **kwargs):
-    """
-    Mark affected assignments dirty when ContentEquipmentListExpansionItem.cost changes.
-
-    This model provides cost overrides for equipment in expansion lists.
-    """
-    old_cost = get_old_cost(sender, instance, "cost")
-    if old_cost is None:
-        return  # New instance, no existing assignments
-
-    new_cost = get_new_cost(instance, "cost")
-    changed = old_cost != new_cost
-    if not changed:
-        # The int helpers coerce None to 0, but on expansion items None means
-        # "use the base price" and 0 means "free" — a 0 <-> None edit DOES
-        # reprice and must sweep. Compare the raw values to catch it.
-        old_raw = get_old_field(sender, instance, "cost")
-        changed = old_raw is not MISSING and old_raw != instance.cost
-
-    if changed:
-        instance._cost_changed = True  # Flag for post_save to create actions
-        # The pre-change value rides to the async task: amount-snapshot
-        # (DERIVED) receipts are maintained by delta, which needs it.
-        instance._old_cost_for_propagation = old_cost
-        instance.set_dirty()
 
 
 # =============================================================================
-# Post-save signal handlers
+# Cost-change propagation: finding affected lists, recording, enqueueing
 #
-# These handlers run after content models are saved. If the pre_save handler
-# detected a cost change (via _cost_changed flag), they create ListAction
-# records for affected lists.
+# The machinery the post_save receivers above hand off to — resolve which
+# lists a content price change touches, record the CONTENT_COST_CHANGE
+# actions, and hand the work to the async task.
 # =============================================================================
 
 
@@ -776,28 +653,6 @@ def _enqueue_content_cost_propagation(instance):
 
 
 @receiver(
-    post_save, sender=ContentEquipment, dispatch_uid="content_equipment_cost_action"
-)
-@traced("signal_content_equipment_cost_action")
-def create_equipment_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after equipment cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False  # Clear flag
-
-
-@receiver(post_save, sender=ContentFighter, dispatch_uid="content_fighter_cost_action")
-@traced("signal_content_fighter_cost_action")
-def create_fighter_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after fighter base cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
     post_save,
     sender=ContentFighter,
     dispatch_uid="content_fighter_sync_auto_equipment_cost",
@@ -851,116 +706,6 @@ def sync_auto_equipment_cost(sender, instance, created, **kwargs):
         changed = True
     if changed:
         equipment.save()
-
-
-@receiver(
-    post_save, sender=ContentWeaponProfile, dispatch_uid="content_profile_cost_action"
-)
-@traced("signal_content_profile_cost_action")
-def create_profile_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after weapon profile cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
-    post_save,
-    sender=ContentWeaponAccessory,
-    dispatch_uid="content_accessory_cost_action",
-)
-@traced("signal_content_accessory_cost_action")
-def create_accessory_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after weapon accessory cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
-    post_save,
-    sender=ContentEquipmentUpgrade,
-    dispatch_uid="content_upgrade_cost_action",
-)
-@traced("signal_content_upgrade_cost_action")
-def create_upgrade_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after equipment upgrade cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
-    post_save,
-    sender=ContentFighterEquipmentListItem,
-    dispatch_uid="content_equipment_list_item_cost_action",
-)
-@traced("signal_content_equipment_list_item_cost_action")
-def create_equipment_list_item_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after equipment list item cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
-    post_save,
-    sender=ContentFighterEquipmentListWeaponAccessory,
-    dispatch_uid="content_equipment_list_accessory_cost_action",
-)
-@traced("signal_content_equipment_list_accessory_cost_action")
-def create_equipment_list_accessory_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after equipment list accessory cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
-    post_save,
-    sender=ContentFighterEquipmentListUpgrade,
-    dispatch_uid="content_equipment_list_upgrade_cost_action",
-)
-@traced("signal_content_equipment_list_upgrade_cost_action")
-def create_equipment_list_upgrade_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after equipment list upgrade cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
-    post_save,
-    sender=ContentFighterHouseOverride,
-    dispatch_uid="content_fighter_house_override_cost_action",
-)
-@traced("signal_content_fighter_house_override_cost_action")
-def create_fighter_house_override_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after fighter house override cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
-
-
-@receiver(
-    post_save,
-    sender=ContentEquipmentListExpansionItem,
-    dispatch_uid="content_expansion_item_cost_action",
-)
-@traced("signal_content_expansion_item_cost_action")
-def create_expansion_item_cost_action(sender, instance, created, **kwargs):
-    """Create CONTENT_COST_CHANGE actions after expansion item cost change."""
-    if created or not getattr(instance, "_cost_changed", False):
-        return
-    _enqueue_content_cost_propagation(instance)
-    instance._cost_changed = False
 
 
 # =============================================================================

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -2,9 +2,13 @@
 Signal handlers for content model cost changes.
 
 This module contains:
-- Pre-save handlers that detect cost changes and mark objects dirty
-- Post-save handlers that create CONTENT_COST_CHANGE actions
-- Helper function for creating cost change actions
+- ``register_cost_change``, the factory that builds the pre_save/post_save
+  receiver pair every price-bearing content model needs, plus the per-model
+  registrations
+- The propagation machinery those receivers hand off to: resolving affected
+  lists, recording CONTENT_COST_CHANGE actions, enqueueing the async task
+- ``sync_auto_equipment_cost``, the one genuinely different post_save
+- Delete-side handlers that orphan pins when a price source is deleted
 """
 
 import logging
@@ -48,20 +52,6 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-# Django stores receivers as weakrefs, so a receiver needs a strong reference
-# somewhere or it is collected and the signal silently stops firing. The
-# module-level functions this factory replaced had one implicitly (their own
-# module global); closures built inside a factory do not, so we keep them here.
-#
-# This is easy to get wrong because it does not reproduce in development or in
-# the test suite: `Signal.connect` only calls `func_accepts_kwargs(receiver)`
-# when `settings.DEBUG` is true, and that check runs through an `lru_cache`
-# keyed on the function — which pins it. With DEBUG on, every receiver is held
-# alive incidentally; with DEBUG off (production) nothing holds it, and the
-# receiver is collected. Green locally, dead in prod, no error either way.
-_COST_CHANGE_RECEIVERS = []
-
-
 def register_cost_change(
     model, *, change_uid, action_uid, field="cost", also_watch=None
 ):
@@ -80,9 +70,17 @@ def register_cost_change(
         also_watch: optional second field, compared by its *raw* stored value,
             whose change also counts as a cost change. Two models need this,
             for different reasons — see the call sites.
+
+    Both receivers connect with ``weak=False``. Django holds receivers weakly by
+    default, and a closure built in here — unlike the module-level functions it
+    replaced — has no other reference, so it would be collected and the signal
+    would silently stop firing. That does not reproduce locally: ``connect``
+    only calls ``func_accepts_kwargs`` when ``settings.DEBUG`` is on, and that
+    runs through an ``lru_cache`` keyed on the function, which incidentally pins
+    it. With DEBUG off (production) nothing does. Green in dev, dead in prod.
     """
 
-    @receiver(pre_save, sender=model, dispatch_uid=change_uid)
+    @receiver(pre_save, sender=model, dispatch_uid=change_uid, weak=False)
     @traced(f"signal_{change_uid}")
     def on_cost_change(sender, instance, **kwargs):
         old_cost = get_old_cost(sender, instance, field)
@@ -102,15 +100,13 @@ def register_cost_change(
             instance._old_cost_for_propagation = old_cost
             instance.set_dirty()
 
-    @receiver(post_save, sender=model, dispatch_uid=action_uid)
+    @receiver(post_save, sender=model, dispatch_uid=action_uid, weak=False)
     @traced(f"signal_{action_uid}")
     def on_cost_change_saved(sender, instance, created, **kwargs):
         if created or not getattr(instance, "_cost_changed", False):
             return
         _enqueue_content_cost_propagation(instance)
         instance._cost_changed = False  # Clear flag
-
-    _COST_CHANGE_RECEIVERS.extend((on_cost_change, on_cost_change_saved))
 
 
 register_cost_change(

--- a/gyrinx/content/models/signal_handlers.py
+++ b/gyrinx/content/models/signal_handlers.py
@@ -108,6 +108,15 @@ def register_cost_change(
         _enqueue_content_cost_propagation(instance)
         instance._cost_changed = False  # Clear flag
 
+    # Without this every generated receiver answers to the same two names, so
+    # anything introspecting them — logging, error reporting, a debugger
+    # listing a signal's receivers — cannot tell the ten models apart. (Raw
+    # traceback frames still show the shared code-object name; this fixes the
+    # `__name__`/`__qualname__` that tooling actually reports.)
+    for func, uid in ((on_cost_change, change_uid), (on_cost_change_saved, action_uid)):
+        func.__name__ = uid
+        func.__qualname__ = f"register_cost_change.<locals>.{uid}"
+
 
 register_cost_change(
     ContentEquipment,

--- a/gyrinx/content/tests/test_content_cost_signals.py
+++ b/gyrinx/content/tests/test_content_cost_signals.py
@@ -1446,7 +1446,9 @@ def test_every_cost_change_dispatch_uid_is_registered_and_live():
     registered_pre = {
         e[0][0]
         for e in pre_save.receivers
-        if isinstance(e[0][0], str) and e[0][0].endswith("_cost_change")
+        if isinstance(e[0][0], str)
+        and e[0][0].endswith("_cost_change")
+        and _live(pre_save, e[0][0])
     }
     expected_pre = {change for _n, change, _a in COST_CHANGE_PAIRS}
     assert registered_pre == expected_pre, (

--- a/gyrinx/content/tests/test_content_cost_signals.py
+++ b/gyrinx/content/tests/test_content_cost_signals.py
@@ -1440,10 +1440,13 @@ def test_every_cost_change_dispatch_uid_is_registered_and_live():
             f"{model_name}: post_save receiver not live"
         )
 
+    # Scoped to the cost-change detectors by their `_cost_change` suffix rather
+    # than a `content_` prefix, so an unrelated pre_save receiver on a content
+    # model can't fail this test.
     registered_pre = {
         e[0][0]
         for e in pre_save.receivers
-        if isinstance(e[0][0], str) and e[0][0].startswith("content_")
+        if isinstance(e[0][0], str) and e[0][0].endswith("_cost_change")
     }
     expected_pre = {change for _n, change, _a in COST_CHANGE_PAIRS}
     assert registered_pre == expected_pre, (

--- a/gyrinx/content/tests/test_content_cost_signals.py
+++ b/gyrinx/content/tests/test_content_cost_signals.py
@@ -1401,15 +1401,24 @@ COST_CHANGE_PAIRS = [
 ]
 
 
-def _receiver_entries(signal, uid):
-    """Registry entries for a dispatch_uid. Django's entry is
-    ``(lookup_key, receiver_or_weakref, sender_ref, is_async)``; indices 0 and 1
-    have been stable across versions, but this pokes at a private structure."""
-    return [e for e in signal.receivers if e[0][0] == uid]
+def _receiver_entries(signal, uid, sender=None):
+    """Registry entries for a dispatch_uid, optionally scoped to a sender.
+
+    Django's entry is ``(lookup_key, receiver_or_weakref, sender_ref,
+    is_async)`` and the lookup key is ``(dispatch_uid, sender_id)``; indices 0
+    and 1 have been stable across versions, but this pokes at a private
+    structure. Matching the sender matters: without it a uid wired to the wrong
+    model would still satisfy a per-model assertion.
+    """
+    entries = [e for e in signal.receivers if e[0][0] == uid]
+    if sender is not None:
+        entries = [e for e in entries if e[0][1] == id(sender)]
+    return entries
 
 
-def _live(signal, uid):
-    """True if a receiver for ``uid`` is registered AND still alive.
+def _live(signal, uid, sender=None):
+    """True if a receiver for ``uid`` (and ``sender``, when given) is registered
+    AND still alive.
 
     Handles both connection styles: a ``weak=True`` entry stores a weakref that
     must be dereferenced, while a ``weak=False`` entry stores the function
@@ -1417,7 +1426,7 @@ def _live(signal, uid):
     A dead weakref lingers in ``signal.receivers`` until Django sweeps it, so
     membership alone is not proof of life.
     """
-    for entry in _receiver_entries(signal, uid):
+    for entry in _receiver_entries(signal, uid, sender):
         target = entry[1]
         if isinstance(target, weakref.ReferenceType):
             if target() is not None:
@@ -1432,12 +1441,16 @@ def test_every_cost_change_dispatch_uid_is_registered_and_live():
     strings predate any single scheme, so they must stay byte-identical. Also
     asserts the set matches exactly, so registering an eleventh model without
     listing it here fails *here* rather than somewhere less obvious."""
+    from django.apps import apps
     from django.db.models.signals import post_save, pre_save
 
     for model_name, change_uid, action_uid in COST_CHANGE_PAIRS:
-        assert _live(pre_save, change_uid), f"{model_name}: pre_save receiver not live"
-        assert _live(post_save, action_uid), (
-            f"{model_name}: post_save receiver not live"
+        model = apps.get_model("content", model_name)
+        assert _live(pre_save, change_uid, model), (
+            f"{model_name}: pre_save receiver not live for this sender"
+        )
+        assert _live(post_save, action_uid, model), (
+            f"{model_name}: post_save receiver not live for this sender"
         )
 
     # Scoped to the cost-change detectors by their `_cost_change` suffix rather

--- a/gyrinx/content/tests/test_content_cost_signals.py
+++ b/gyrinx/content/tests/test_content_cost_signals.py
@@ -1455,6 +1455,20 @@ def test_every_cost_change_dispatch_uid_is_registered_and_live():
         "cost-change pre_save registrations drifted from COST_CHANGE_PAIRS"
     )
 
+    # Same check on the other half of each pair, so a hand-written or unlisted
+    # `_cost_action` receiver can't slip past a matching pre_save set.
+    registered_post = {
+        e[0][0]
+        for e in post_save.receivers
+        if isinstance(e[0][0], str)
+        and e[0][0].endswith("_cost_action")
+        and _live(post_save, e[0][0])
+    }
+    expected_post = {action for _n, _c, action in COST_CHANGE_PAIRS}
+    assert registered_post == expected_post, (
+        "cost-change post_save registrations drifted from COST_CHANGE_PAIRS"
+    )
+
 
 def test_factory_receivers_survive_gc_with_debug_off():
     """The factory's receivers must outlive garbage collection in production.

--- a/gyrinx/content/tests/test_content_cost_signals.py
+++ b/gyrinx/content/tests/test_content_cost_signals.py
@@ -5,6 +5,8 @@ When a Content model's cost field changes, affected core objects
 (assignments, fighters, lists) should be marked as dirty.
 """
 
+import weakref
+
 import pytest
 
 from gyrinx.content.models import (
@@ -1399,41 +1401,68 @@ COST_CHANGE_PAIRS = [
 ]
 
 
-def _registered_uids(signal):
-    return {entry[0][0] for entry in signal.receivers if isinstance(entry[0][0], str)}
+def _receiver_entries(signal, uid):
+    """Registry entries for a dispatch_uid. Django's entry is
+    ``(lookup_key, receiver_or_weakref, sender_ref, is_async)``; indices 0 and 1
+    have been stable across versions, but this pokes at a private structure."""
+    return [e for e in signal.receivers if e[0][0] == uid]
 
 
-def test_every_cost_change_dispatch_uid_is_registered():
+def _live(signal, uid):
+    """True if a receiver for ``uid`` is registered AND still alive.
+
+    Handles both connection styles: a ``weak=True`` entry stores a weakref that
+    must be dereferenced, while a ``weak=False`` entry stores the function
+    itself (calling that would *invoke the receiver*, so check the type first).
+    A dead weakref lingers in ``signal.receivers`` until Django sweeps it, so
+    membership alone is not proof of life.
+    """
+    for entry in _receiver_entries(signal, uid):
+        target = entry[1]
+        if isinstance(target, weakref.ReferenceType):
+            if target() is not None:
+                return True
+        else:
+            return True
+    return False
+
+
+def test_every_cost_change_dispatch_uid_is_registered_and_live():
     """dispatch_uid is the identity Django dedupes registrations on, and these
-    strings predate any single scheme, so they must stay byte-identical."""
+    strings predate any single scheme, so they must stay byte-identical. Also
+    asserts the set matches exactly, so registering an eleventh model without
+    listing it here fails *here* rather than somewhere less obvious."""
     from django.db.models.signals import post_save, pre_save
 
-    pre_uids = _registered_uids(pre_save)
-    post_uids = _registered_uids(post_save)
     for model_name, change_uid, action_uid in COST_CHANGE_PAIRS:
-        assert change_uid in pre_uids, f"{model_name}: pre_save {change_uid} missing"
-        assert action_uid in post_uids, f"{model_name}: post_save {action_uid} missing"
+        assert _live(pre_save, change_uid), f"{model_name}: pre_save receiver not live"
+        assert _live(post_save, action_uid), (
+            f"{model_name}: post_save receiver not live"
+        )
 
-
-def test_every_factory_receiver_has_a_strong_reference():
-    """One strong ref per registered receiver — see the next test for why."""
-    from gyrinx.content.models import signal_handlers
-
-    assert len(signal_handlers._COST_CHANGE_RECEIVERS) == 2 * len(COST_CHANGE_PAIRS)
+    registered_pre = {
+        e[0][0]
+        for e in pre_save.receivers
+        if isinstance(e[0][0], str) and e[0][0].startswith("content_")
+    }
+    expected_pre = {change for _n, change, _a in COST_CHANGE_PAIRS}
+    assert registered_pre == expected_pre, (
+        "cost-change pre_save registrations drifted from COST_CHANGE_PAIRS"
+    )
 
 
 def test_factory_receivers_survive_gc_with_debug_off():
     """The factory's receivers must outlive garbage collection in production.
 
-    Django stores receivers as weakrefs, so a closure built inside a factory
-    needs a strong reference somewhere or it is collected and the signal
-    silently stops firing. This does NOT reproduce under the test settings:
-    `Signal.connect` only calls `func_accepts_kwargs` when `settings.DEBUG` is
-    on, and that runs through an `lru_cache` keyed on the function, pinning it.
-    So the bug is invisible in dev/CI and live in production.
+    Django holds receivers weakly by default, so a closure built inside a
+    factory would be collected and the signal would silently stop firing. The
+    factory therefore connects with ``weak=False``.
 
-    This test therefore runs with DEBUG off, and first proves the mechanism is
-    real (an unheld closure does die) before asserting the guard defeats it.
+    This does NOT reproduce under the test settings: ``Signal.connect`` only
+    calls ``func_accepts_kwargs`` when ``settings.DEBUG`` is on, and that runs
+    through an ``lru_cache`` keyed on the function, which incidentally pins it.
+    So the bug is invisible in dev/CI and live in production — hence DEBUG off
+    here, and a control proving an ordinary weak receiver really does die.
     """
     import gc
 
@@ -1443,14 +1472,11 @@ def test_factory_receivers_survive_gc_with_debug_off():
 
     from gyrinx.content.models import signal_handlers
 
-    def alive(signal, uid):
-        return any(e[0][0] == uid and e[1]() is not None for e in signal.receivers)
-
-    kept_before = len(signal_handlers._COST_CHANGE_RECEIVERS)
     try:
         with override_settings(DEBUG=False):
-            # Control: without a strong reference the receiver is collected.
-            # If this ever stops holding, the assertions below prove nothing.
+            # Control: a weakly-connected closure with no other reference is
+            # collected. If this stops holding, the assertion below proves
+            # nothing.
             def register_unheld():
                 @receiver(
                     pre_save, sender=ContentEquipment, dispatch_uid="probe_unheld"
@@ -1460,22 +1486,21 @@ def test_factory_receivers_survive_gc_with_debug_off():
 
             register_unheld()
             gc.collect()
-            assert not alive(pre_save, "probe_unheld"), (
-                "control failed: an unreferenced receiver survived, so this test "
-                "cannot demonstrate that the strong-ref list does anything"
+            assert not _live(pre_save, "probe_unheld"), (
+                "control failed: an unreferenced weak receiver survived, so this "
+                "test cannot demonstrate that weak=False does anything"
             )
 
-            # The factory keeps its receivers, so they survive the same collection.
+            # The factory's pair survives the same collection.
             signal_handlers.register_cost_change(
                 ContentEquipment,
                 change_uid="probe_held_change",
                 action_uid="probe_held_action",
             )
             gc.collect()
-            assert alive(pre_save, "probe_held_change")
-            assert alive(post_save, "probe_held_action")
+            assert _live(pre_save, "probe_held_change")
+            assert _live(post_save, "probe_held_action")
     finally:
         pre_save.disconnect(sender=ContentEquipment, dispatch_uid="probe_unheld")
         pre_save.disconnect(sender=ContentEquipment, dispatch_uid="probe_held_change")
         post_save.disconnect(sender=ContentEquipment, dispatch_uid="probe_held_action")
-        del signal_handlers._COST_CHANGE_RECEIVERS[kept_before:]

--- a/gyrinx/content/tests/test_content_cost_signals.py
+++ b/gyrinx/content/tests/test_content_cost_signals.py
@@ -1336,3 +1336,146 @@ def test_no_action_when_equipment_cost_change_has_zero_delta(
 
     # Clean up
     override.delete()
+
+
+# --- Registration invariants (#1863) -------------------------------------------
+#
+# The ten cost-change receiver pairs are built by a factory
+# (signal_handlers.register_cost_change) rather than hand-written. Two things
+# about that are easy to break silently, so they are pinned here.
+
+
+COST_CHANGE_PAIRS = [
+    (
+        "ContentEquipment",
+        "content_equipment_cost_change",
+        "content_equipment_cost_action",
+    ),
+    (
+        "ContentFighter",
+        "content_fighter_base_cost_change",
+        "content_fighter_cost_action",
+    ),
+    (
+        "ContentWeaponProfile",
+        "content_profile_cost_change",
+        "content_profile_cost_action",
+    ),
+    (
+        "ContentWeaponAccessory",
+        "content_accessory_cost_change",
+        "content_accessory_cost_action",
+    ),
+    (
+        "ContentEquipmentUpgrade",
+        "content_upgrade_cost_change",
+        "content_upgrade_cost_action",
+    ),
+    (
+        "ContentFighterEquipmentListItem",
+        "content_equipment_list_item_cost_change",
+        "content_equipment_list_item_cost_action",
+    ),
+    (
+        "ContentFighterEquipmentListWeaponAccessory",
+        "content_equipment_list_accessory_cost_change",
+        "content_equipment_list_accessory_cost_action",
+    ),
+    (
+        "ContentFighterEquipmentListUpgrade",
+        "content_equipment_list_upgrade_cost_change",
+        "content_equipment_list_upgrade_cost_action",
+    ),
+    (
+        "ContentFighterHouseOverride",
+        "content_fighter_house_override_cost_change",
+        "content_fighter_house_override_cost_action",
+    ),
+    (
+        "ContentEquipmentListExpansionItem",
+        "content_expansion_item_cost_change",
+        "content_expansion_item_cost_action",
+    ),
+]
+
+
+def _registered_uids(signal):
+    return {entry[0][0] for entry in signal.receivers if isinstance(entry[0][0], str)}
+
+
+def test_every_cost_change_dispatch_uid_is_registered():
+    """dispatch_uid is the identity Django dedupes registrations on, and these
+    strings predate any single scheme, so they must stay byte-identical."""
+    from django.db.models.signals import post_save, pre_save
+
+    pre_uids = _registered_uids(pre_save)
+    post_uids = _registered_uids(post_save)
+    for model_name, change_uid, action_uid in COST_CHANGE_PAIRS:
+        assert change_uid in pre_uids, f"{model_name}: pre_save {change_uid} missing"
+        assert action_uid in post_uids, f"{model_name}: post_save {action_uid} missing"
+
+
+def test_every_factory_receiver_has_a_strong_reference():
+    """One strong ref per registered receiver — see the next test for why."""
+    from gyrinx.content.models import signal_handlers
+
+    assert len(signal_handlers._COST_CHANGE_RECEIVERS) == 2 * len(COST_CHANGE_PAIRS)
+
+
+def test_factory_receivers_survive_gc_with_debug_off():
+    """The factory's receivers must outlive garbage collection in production.
+
+    Django stores receivers as weakrefs, so a closure built inside a factory
+    needs a strong reference somewhere or it is collected and the signal
+    silently stops firing. This does NOT reproduce under the test settings:
+    `Signal.connect` only calls `func_accepts_kwargs` when `settings.DEBUG` is
+    on, and that runs through an `lru_cache` keyed on the function, pinning it.
+    So the bug is invisible in dev/CI and live in production.
+
+    This test therefore runs with DEBUG off, and first proves the mechanism is
+    real (an unheld closure does die) before asserting the guard defeats it.
+    """
+    import gc
+
+    from django.db.models.signals import post_save, pre_save
+    from django.dispatch import receiver
+    from django.test import override_settings
+
+    from gyrinx.content.models import signal_handlers
+
+    def alive(signal, uid):
+        return any(e[0][0] == uid and e[1]() is not None for e in signal.receivers)
+
+    kept_before = len(signal_handlers._COST_CHANGE_RECEIVERS)
+    try:
+        with override_settings(DEBUG=False):
+            # Control: without a strong reference the receiver is collected.
+            # If this ever stops holding, the assertions below prove nothing.
+            def register_unheld():
+                @receiver(
+                    pre_save, sender=ContentEquipment, dispatch_uid="probe_unheld"
+                )
+                def _handler(sender, instance, **kwargs):
+                    pass
+
+            register_unheld()
+            gc.collect()
+            assert not alive(pre_save, "probe_unheld"), (
+                "control failed: an unreferenced receiver survived, so this test "
+                "cannot demonstrate that the strong-ref list does anything"
+            )
+
+            # The factory keeps its receivers, so they survive the same collection.
+            signal_handlers.register_cost_change(
+                ContentEquipment,
+                change_uid="probe_held_change",
+                action_uid="probe_held_action",
+            )
+            gc.collect()
+            assert alive(pre_save, "probe_held_change")
+            assert alive(post_save, "probe_held_action")
+    finally:
+        pre_save.disconnect(sender=ContentEquipment, dispatch_uid="probe_unheld")
+        pre_save.disconnect(sender=ContentEquipment, dispatch_uid="probe_held_change")
+        post_save.disconnect(sender=ContentEquipment, dispatch_uid="probe_held_action")
+        del signal_handlers._COST_CHANGE_RECEIVERS[kept_before:]


### PR DESCRIPTION
Redo of #1909, which was ~5 weeks stale and unrebasable — `signal_handlers.py` had gained +419/−116 lines from nine other PRs underneath it. Same idea, written fresh against current main.

## What changed

Ten price-bearing content models each had a hand-written `pre_save` cost detector and a hand-written `post_save` fan-out — **twenty near-identical receivers**. They're now one `register_cost_change()` factory plus ten registrations. **No behaviour change**; `signal_handlers.py` loses ~260 lines.

Details worth knowing:

- **All 20 `dispatch_uid`s are passed explicitly and preserved byte-identical.** They predate any single scheme (`ContentFighter` is `content_fighter_base_cost_change` but `content_fighter_cost_action`), and `dispatch_uid` is the identity Django dedupes registrations on — so they can't be derived from the model. A test asserts every one is registered *and live*, and that the registered set matches the expected set.
- **The two "special" detectors turned out to be the same shape.** Both do a raw `get_old_field` compare on top of the int compare — the weapon accessory for `cost_expression`, the expansion item to catch a `0 <-> None` edit that the int coercion hides (None means "use base price", 0 means "free"). One optional `also_watch` parameter covers both, with each rationale kept at its call site.
- `sync_auto_equipment_cost` stays hand-written — it's a genuinely different `post_save` on `ContentFighter`, including its `raw=` fixture-loading guard from #1995.

## The part that isn't obvious: receiver lifetime

Django holds receivers **weakly** by default. The module-level functions this replaces each had an implicit strong reference (their own module global); a closure built inside a factory does not — so it gets collected and the signal **silently stops firing**, with no error.

The trap is that **this cannot reproduce in dev or CI**: `Signal.connect` only calls `func_accepts_kwargs(receiver)` when `settings.DEBUG` is true, and that check runs through an `@lru_cache` keyed on the function — which pins it. With DEBUG on every receiver is held alive incidentally; with DEBUG off (production) nothing holds it. Green locally, dead in prod.

Both receivers therefore connect with **`weak=False`**, which puts the guarantee at the connect site — the same idiom already used at `core/models/state_machine.py:135`. (An earlier revision kept a module-level strong-ref list instead; review rightly pointed out that a list is a step decoupled from the `@receiver` calls, so anyone adding a third receiver and forgetting to extend it would silently reintroduce the bug.)

The regression test runs with `DEBUG=False` and first asserts that an ordinary weakly-connected receiver really does die, so it can't pass vacuously.

## Test plan

- [x] Full suite: **3643 passed, 13 skipped**.
- [x] Cost-signal suites (`test_content_cost_signals`, `test_propagate_content_cost_change`, `test_cost_propagation`, `test_list_refresh_cost`).
- [x] Verified out of band, with DEBUG forced off *before* app loading: all 20 receivers live after a forced GC, all 20 dispatch_uids and all 20 `@traced` span names byte-identical to main, per-receiver closure captures correct, and `ContentFighter`'s post_save ordering unchanged (cost action still before `sync_auto_equipment_cost`).
- [x] Mutation-tested: dropping `weak=False` fails the regression test.
- [x] `ruff` clean; no migrations.

## Known pre-existing gap (not addressed here)

None of these ten receivers has a `raw` guard, so during `loaddata` / `loaddata_overwrite` every price row whose cost differs from the local row calls `set_dirty()` — bulk-writing to `ListFighterEquipmentAssignment` — and enqueues a propagation task on commit. The #1991/#1995 fixture-load sweep missed this pair. `main` has the identical gap, so fixing it here would break this PR's no-behaviour-change property — but the factory turns it from ten edits into one.

Refs #1863, #1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TRm5Myq3DXj5QNKC4FxCh
