### PR TITLE
feat: offer classic cards from the default print config's Print button

### DIFF
--- a/gyrinx/core/templates/core/print_config/index.html
+++ b/gyrinx/core/templates/core/print_config/index.html
@@ -38,11 +38,31 @@
                         </td>
                         <td class="text-secondary">All cards and active fighters</td>
                         <td class="text-end">
-                            <a href="{% url 'core:list-print' list.id %}"
-                               class="btn btn-primary btn-sm">
-                                <i class="bi-printer"></i>
-                                Print
-                            </a>
+                            <div class="btn-group" role="group">
+                                {% comment %}
+                                The surrounding .table-responsive scrolls on overflow,
+                                which clips an absolutely-positioned menu. Popper's fixed
+                                strategy positions against the viewport instead, so the
+                                menu escapes the wrapper.
+                                {% endcomment %}
+                                <button type="button"
+                                        class="btn btn-primary btn-sm dropdown-toggle"
+                                        data-bs-toggle="dropdown"
+                                        data-bs-popper-config='{"strategy": "fixed"}'
+                                        aria-expanded="false">
+                                    <i class="bi-printer"></i>
+                                    Print
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end">
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'core:list-print' list.id %}">Default cards</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item"
+                                           href="{% url 'core:list-print' list.id %}?style=classic">Classic cards</a>
+                                    </li>
+                                </ul>
+                            </div>
                         </td>
                     </tr>
                     <!-- User configurations -->

--- a/gyrinx/core/templates/core/print_config/index.html
+++ b/gyrinx/core/templates/core/print_config/index.html
@@ -38,7 +38,7 @@
                         </td>
                         <td class="text-secondary">All cards and active fighters</td>
                         <td class="text-end">
-                            <div class="btn-group" role="group">
+                            <div class="btn-group" role="group" aria-label="Print options">
                                 {% comment %}
                                 The surrounding .table-responsive scrolls on overflow,
                                 which clips an absolutely-positioned menu. Popper's fixed

--- a/gyrinx/core/tests/test_print_config_classic.py
+++ b/gyrinx/core/tests/test_print_config_classic.py
@@ -298,8 +298,10 @@ def test_print_config_index_default_row_offers_both_styles(client, user, make_li
 
     assert resp.status_code == 200
     content = resp.content.decode()
-    print_url = reverse("core:list-print", kwargs={"id": lst.id})
-    assert 'data-bs-toggle="dropdown"' in content
+    print_url = _print_url(lst)
+    # Not data-bs-toggle="dropdown" — base.html's theme switcher carries that on
+    # every page, so it would pass with this dropdown deleted.
+    assert "data-bs-popper-config" in content
     assert f'href="{print_url}"' in content
     assert f'href="{print_url}?style=classic"' in content
 

--- a/gyrinx/core/tests/test_print_config_classic.py
+++ b/gyrinx/core/tests/test_print_config_classic.py
@@ -289,6 +289,22 @@ def test_crew_print_dropdown_offers_both_styles(client, user, make_list, campaig
 
 
 @pytest.mark.django_db
+def test_print_config_index_default_row_offers_both_styles(client, user, make_list):
+    """The built-in Default row's Print control links both card styles."""
+    lst = make_list("Gang")
+    client.force_login(user)
+
+    resp = client.get(reverse("core:print-config-index", args=[lst.id]))
+
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    print_url = reverse("core:list-print", kwargs={"id": lst.id})
+    assert 'data-bs-toggle="dropdown"' in content
+    assert f'href="{print_url}"' in content
+    assert f'href="{print_url}?style=classic"' in content
+
+
+@pytest.mark.django_db
 def test_crew_classic_print_renders_crew_fighters(
     client, user, make_list, make_list_fighter, campaign
 ):


### PR DESCRIPTION
Printing a gang in the classic card style was only reachable from a crew page, or by hand-editing the URL. From a gang's own print-configs page, the built-in **Default** row offered a single Print button that always produced the standard web-style sheet.

That Print button is now a dropdown with **Default cards** / **Classic cards**, matching the control already on the crew page. No view or model changes — Classic cards links to the existing `?style=classic` URL that `ListPrintView` already handles.

One wrinkle worth noting: the row sits inside a `.table-responsive` wrapper, which scrolls on overflow and so clips an ordinary dropdown menu (the second option was invisible). The toggle passes Popper a fixed positioning strategy so the menu is positioned against the viewport and escapes the wrapper.

## Test plan

- [x] `pytest -n auto` — full suite green (3642 passed, 13 skipped)
- [x] New test asserts the Default row renders a dropdown linking both print URLs
- [x] Manually checked in the browser: menu opens fully (not clipped), both items link to `/list/<id>/print` and `/list/<id>/print?style=classic`, and both URLs render their expected templates

## How to try it

1. Open any gang, then its Print Configurations page (`/list/<id>/print-configs`)
2. Click **Print** on the Default row — pick either card style