### PR TITLE
ci: have the automerge app approve Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,6 +30,22 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Enabling auto-merge is not sufficient on its own: the default branch
+      # requires an approving review, so every Dependabot PR parks at
+      # REVIEW_REQUIRED until a human approves it. That is what let eight PRs
+      # pile up — auto-merge was armed on all of them and fired the moment they
+      # were approved. Approving here (as the App, never GITHUB_TOKEN) closes
+      # the loop. Gated to minor/patch, same as the merge below, so majors still
+      # get a human.
+      - name: Approve
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr review --approve "$PR_URL"
+
       - name: Enable auto-merge
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-minor' ||


### PR DESCRIPTION
Fixes the reason the Dependabot backlog built up in the first place.

Auto-merge was already armed on all eight stalled PRs — it just never fired, because the default branch requires an approving review and nothing ever supplied one. The PRs sat at `REVIEW_REQUIRED` indefinitely. When I approved them by hand yesterday they merged on their own, in a cascade, with no other intervention. Without this change the same pile-up starts again next week.

The `gyrinx-automerge` App is already listed as an always-bypass actor on the reviews ruleset, so in principle it shouldn't need to approve — but that bypass demonstrably does not take effect for auto-merge, since the PRs still reported `REVIEW_REQUIRED` with auto-merge enabled by the App. An explicit approval is what actually unblocks them.

Approving is gated to `semver-minor` / `semver-patch`, exactly matching the existing merge gate, so major bumps still stop for a human. The review is submitted with the App token rather than `GITHUB_TOKEN`, for the same reason the merge is.

## Caveat worth knowing

The reviews ruleset also sets `require_code_owner_review: true`, and `CODEOWNERS` is `* @tgvashworth`. A GitHub App cannot be a code owner, so the App's approval satisfies `required_approving_review_count: 1` but may not satisfy the code-owner requirement. If Dependabot PRs still park at `REVIEW_REQUIRED` after this merges, the remaining fix is to relax `require_code_owner_review` — which is a policy call, not something I'd change unilaterally.

We'll find out on the next Dependabot PR. I couldn't test it here because there are none open.