### PR TITLE
ci: converge on uv, and stop uv.lock and pre-commit from rotting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,22 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # .pre-commit-config.yaml pins its own djlint/ruff, independent of
+  # requirements.txt. While the two agree the drift is invisible; when they
+  # diverge the commit hook reverts the exact reformat CI demands and no commit
+  # can satisfy both (see #2038). Keep them moving together.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+
+  # The Dockerfile pins the uv release it copies its binary from.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -27,13 +27,11 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Cache Python dependencies
-        uses: actions/cache@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          enable-cache: true
+          cache-dependency-glob: "requirements.txt"
 
       - name: Cache npm dependencies
         uses: actions/cache@v6
@@ -45,9 +43,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m venv .venv && \
-          . .venv/bin/activate && \
-          pip install --editable .
+          uv venv .venv && \
+          uv pip install --editable .
+
+      # uv.lock is not installed from — the image and CI resolve from
+      # requirements.txt — so nothing exercised it and it silently rotted, at
+      # one point holding a Twisted version a full major release behind and
+      # generating a high-severity alert on its own (see #2038). --refresh is
+      # required: dependencies are dynamic (read from requirements.txt), and
+      # without it uv compares against cached project metadata and reports a
+      # stale lock as current.
+      - name: Check uv.lock is up to date
+        run: uv lock --check --refresh
 
       - name: Write to .env file
         run: |

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: "24"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "requirements.txt"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,20 +40,16 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Cache pip
-        id: cache-pip
-        uses: actions/cache@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          enable-cache: true
+          cache-dependency-glob: "requirements.txt"
 
       - name: Install dependencies
         run: |
-          python -m venv .venv && \
-          . .venv/bin/activate && \
-          pip install --editable .
+          uv venv .venv && \
+          uv pip install --editable .
 
       - name: Write to .env file
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "requirements.txt"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,16 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100
 
+# Pinned so the image resolves with the same uv as CI and scripts/dev.sh.
+# Dependabot's docker ecosystem keeps this tag current.
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /usr/local/bin/uv
+
 WORKDIR /app
-RUN python -m venv /opt/venv
-# Enable venv
-ENV PATH="/opt/venv/bin:$PATH"
+RUN uv venv /opt/venv
+# Enable venv. VIRTUAL_ENV is what uv reads to pick an install target; PATH
+# alone is not enough.
+ENV VIRTUAL_ENV="/opt/venv" \
+    PATH="/opt/venv/bin:$PATH"
 
 # Set application settings
 ENV DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-gyrinx.settings}
@@ -24,7 +30,7 @@ COPY gyrinx/ /app/gyrinx/
 COPY content/ /app/content/
 # Set a version for setuptools-scm when .git is not available
 ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_GYRINX=1.0.0
-RUN pip install --editable .
+RUN uv pip install --editable .
 
 # Install system dependencies for Node.js
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,13 @@ requires-python = ">=3.12"
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 
+[tool.uv]
+# uv.lock's format is versioned. An older uv silently rewrites the lock to its
+# own older format, which then fails the `uv lock --check` guard in CI with no
+# obvious cause. Refusing to run is clearer: uv prints "Update `uv` by running
+# `uv self update`". Raise this floor when the lock is next regenerated.
+required-version = ">=0.11"
+
 [project.scripts]
 manage = "scripts.manage:main"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",


### PR DESCRIPTION
Follow-ups #2 and #3 from the dependency sweep, in one PR as requested, taking the uv direction rather than deleting the lock.

## The actual bug being fixed

`uv.lock` rotted because nothing used it. The image and CI both resolve from `requirements.txt`, so the lock was never exercised and drifted until Twisted was a full major version behind — generating a high-severity DoS alert entirely on its own, from a file nothing installs from.

`uv lock --check` in format-check makes that impossible to repeat. Two details there are load-bearing and worth not "simplifying" later:

- **`--refresh` is required.** Dependencies are dynamic (read from `requirements.txt`), so without it uv compares against cached project metadata and reports a stale lock as current. I verified this: I edited a pinned version, and plain `uv lock --check` passed anyway. With `--refresh` it correctly exits 2.
- **The lock records no project version**, so the check doesn't fail spuriously on every commit from setuptools-scm. I checked before relying on it.

## uv everywhere

CI and the Dockerfile move off pip onto uv, matching what `scripts/dev.sh` and `setup_web.sh` already do. `astral-sh/setup-uv` replaces the manual pip caching; in Docker the binary is copied from a pinned `ghcr.io/astral-sh/uv` tag.

Note this makes uv the *installer* everywhere, but `requirements.txt` is still the resolution source. Making `uv.lock` the thing prod installs from (`uv sync --locked`) is the natural next step, but it changes what actually ships and deserves its own PR rather than riding along with a config change.

## Dependabot coverage

Adds the `pre-commit` ecosystem — the gap that caused the whole mess. `.pre-commit-config.yaml` pins its own djlint/ruff independently of `requirements.txt`, and nothing kept them in step. While the versions agreed the drift was invisible; when they diverged, the commit hook reverted the exact reformat CI demanded and no commit could satisfy both, which is why a routine djlint bump sat unmergeable for a week. Also adds the `docker` ecosystem so the pinned uv tag doesn't become the next thing to quietly age. I verified both ecosystem names against GitHub's supported-ecosystems table before committing, since an invalid `dependabot.yml` silently disables *all* updates.

## Production image verified identical

Since this changes how the production image is built, I built both Dockerfiles and compared the installed package sets after normalising names (uv emits PEP 503 form, pip preserves original casing — a raw `diff` looks alarming and is entirely cosmetic):

**138 packages each. No additions, no removals, no version mismatches.** The image also runs: `/opt/venv/bin/python`, Django 6.0.7, `manage` entry point present, `google.cloud.logging` imports.

One real behaviour change: `uv venv` does not seed pip, so there is no `pip` binary in the image. Nothing needs it — the entrypoint only calls `manage` and `daphne`, and nothing in the codebase shells out to pip — and `uv` itself is in the image, so `uv pip install` still works if you shell into a container to debug. It also makes the image slightly smaller. Flagging it because it is a change, not because I think it bites.

## One thing to know before merging

**You will need `uv self update`.** `[tool.uv] required-version = ">=0.11"` is deliberate: uv.lock's format is versioned, this regenerates it at revision 3, and an older uv silently rewrites the lock back to its own format — which then fails CI for no visible reason. Refusing to run is clearer; uv prints the exact fix. But your local uv is 0.7.19, so `dev.sh` will refuse to provision a worktree until you update.

## Testing

`uv lock --check --refresh` passes on a clean tree and exits 2 on a deliberately stale one, and the step is confirmed running in CI (not silently skipped). Docker image builds and smoke-tests clean, with a package set identical to the pip build. format-check now runs in 48s, down from 1m32s; the full test suite passes. All pre-commit hooks pass.