### PR TITLE
fix: stop the Lore page stretching fighter photos into squares

### DIFF
--- a/gyrinx/core/templates/core/includes/list_about.html
+++ b/gyrinx/core/templates/core/includes/list_about.html
@@ -58,7 +58,7 @@
                         <div class="mb-2">
                             <img src="{{ fighter.image.url }}"
                                  alt="{{ fighter.name }}"
-                                 class="img-fluid rounded size-em-5">
+                                 class="img-fluid rounded size-em-5 object-fit-cover">
                         </div>
                     {% endif %}
                     {{ fighter.narrative|safe_rich_text|safe }}
@@ -73,7 +73,7 @@
                         <div class="mb-2">
                             <img src="{{ fighter.image.url }}"
                                  alt="{{ fighter.name }}"
-                                 class="img-fluid rounded size-em-5">
+                                 class="img-fluid rounded size-em-5 object-fit-cover">
                         </div>
                     {% endif %}
                     <p class="text-secondary">No lore added yet.</p>

--- a/gyrinx/core/templates/core/list_fighter_narrative_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_narrative_edit.html
@@ -20,7 +20,7 @@
                         <div class="mb-2 me-2 flex-shrink-0">
                             <img src="{{ fighter.image.url }}"
                                  alt="{{ fighter.name }}"
-                                 class="size-em-4 size-em-md-5 img-thumbnail">
+                                 class="size-em-4 size-em-md-5 img-thumbnail object-fit-cover">
                         </div>
                     {% endif %}
                     <div class="flex-grow-1">


### PR DESCRIPTION
Fighter photos on a gang's Lore page were being stretched out of shape — a wide or tall photo got squeezed into a square, distorting the miniature.

The images carry a `size-em-5` class that sets **both** width and height to 16em. That overrides `img-fluid`'s `height: auto`, leaving the browser at its default `object-fit: fill` — it stretches the image to fill the square rather than cropping it.

## Summary

- Add Bootstrap's `object-fit-cover` utility to the fighter photos in `gyrinx/core/templates/core/includes/list_about.html` (both the with-lore and no-lore branches), so the photo keeps its aspect ratio and centre-crops to fill the square frame.
- Apply the same fix to the thumbnail on `gyrinx/core/templates/core/list_fighter_narrative_edit.html`, which had the identical defect.
- No new CSS: `object-fit-cover` ships with Bootstrap 5.3 and is already in the compiled stylesheet. This matches the existing approach for the classic card portrait in `gyrinx/core/static/core/scss/_classic_card.scss`, which uses `cover` for the same reason.

## Test plan

- [x] Attached a deliberately wide 900×300 test image (containing circles, so distortion is obvious) to a fighter and loaded the Lore page. Before: the image was crushed into a 224×224 box and the circles rendered as tall ellipses. After: the circles stay round — aspect ratio preserved, centre crop.
- [x] `./scripts/fmt.sh` — djlint reports 0 errors.
- [x] `pytest gyrinx/core/tests/test_notes_page.py gyrinx/core/tests/test_xss_protection.py` — 46 passed (both exercise the Lore page).

## How to try it

Open any gang's Lore page (`/list/<id>/about`) for a gang whose fighters have photos that aren't square. The photos should now fill their frame without distortion.