### PR TITLE
fix: stop Safari splitting classic card detail groups across columns

### DIFF
--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -518,7 +518,22 @@
 
     // Each group is inline (label left, value wraps to its right) and stays
     // whole within a column; baseline-align the label with the body's text.
+    //
+    // `inline-flex` (not `flex`) is load-bearing: WebKit ignores `break-inside:
+    // avoid` on a block-level flex container inside a multicol, and its attempt
+    // to fragment one produces garbage — on iOS Safari a long Rules group was
+    // sliced mid-list with the second half painted overlapping the next group,
+    // and when the column box had a constrained height the trailing group (Gear)
+    // was dropped from the card altogether. An atomic inline-level box is
+    // *monolithic* per CSS Fragmentation, so no engine may split it; `width:
+    // 100%` keeps each group on its own line so the block still reads as a
+    // stack. Verified against iOS 26 Safari — the prefixed
+    // `-webkit-column-break-inside: avoid` does NOT fix this, inline-flex does.
+    // Blank cards re-blockify these back to flex items (the [data-kind="blank"]
+    // override swaps the column box to a flex column), so they are unaffected.
     .cc-detail .cc-section {
+        display: inline-flex;
+        width: 100%;
         flex-direction: row;
         align-items: baseline;
         gap: 1.5mm;


### PR DESCRIPTION
On mobile Safari, the Skills / Rules / Gear block at the bottom of a classic print card renders differently from every other browser: a long Rules list gets cut in half across the two columns, with the leftover half drawn on top of the next group. Worse — and this is the part that isn't just cosmetic — on a real card the **Gear section can disappear from the card altogether**. Reported against a Spyrer leader; reproduces on the print lab's "Cawdor Leader" preset, where Gear is simply absent on iOS.

## Cause

That block is a two-column CSS multicol. Each group (label + body) is a flex row marked `break-inside: avoid` so it stays whole within one column. WebKit doesn't honour `break-inside: avoid` on a block-level flex container inside a multicol, and its attempt to fragment one is broken — it either paints the two halves overlapping, or, when the column box has a constrained height (the normal case on a real card, since the block is sized to the space left above the XP/Notes footer), drops the trailing group.

## Fix

Make each group an atomic inline-level box (`display: inline-flex; width: 100%`). Per CSS Fragmentation an atomic inline is *monolithic*, so no engine is permitted to split it — the guarantee no longer depends on a break hint being respected. `width: 100%` keeps one group per line, so the block still reads as a stack and nothing else about the layout changes.

Things that were tried and did **not** work, recorded in the code comment so nobody re-treads them: the prefixed `-webkit-column-break-inside: avoid`, and a float-based label layout. Both still split on iOS.

Blank (fillable) cards are unaffected — their `[data-kind="blank"]` override turns the column box into a flex column, which re-blockifies these back to plain flex items.

## Verification

Reproduced and verified on **real iOS 26 Safari** (iPhone 17 Pro simulator), against desktop Chrome as the reference:

| Preset | Before (iOS) | After (iOS) |
|---|---|---|
| Cawdor Leader | Gear section missing entirely | Skills + Rules in col 1, Gear in col 2 — matches Chrome |
| Overflow (stress test) | split/overlap | line-for-line identical to Chrome |
| Psyker | — | line-for-line identical to Chrome |
| Blank (fillable) | — | unchanged, write-in boxes correct |

`pytest -k print` — 62 passed.

## How to try it

With the dev server running, open the print lab sheet on a phone (or the iOS simulator) and compare against desktop:

- `/_debug/print-lab/sheet/?source=preset&preset=leader`
- `/_debug/print-lab/sheet/?source=preset&preset=overflow`

Gear should be present on both, and the Rules list should never be cut in half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)