### PR TITLE
fix(deps): stop base-image bumps from auto-merging to production

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,3 +79,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # The base image *is* the production Python runtime, but its tag is read
+      # as plain semver: 3.12.7-slim -> 3.14.6-slim looks like a minor bump, so
+      # dependabot-auto-merge.yml approves it and arms auto-merge. That would
+      # ship a new Python to production unattended — it opened exactly that PR
+      # (#2048) within minutes of the docker ecosystem being added. Patch bumps
+      # (3.12.7 -> 3.12.8) still flow; runtime upgrades stay deliberate.
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Fixes a consequence of adding the docker ecosystem in #2043 that I did not anticipate, and that I would rather fix in the same session that caused it.

## What happened

Within minutes of #2043 merging, Dependabot opened **#2048**, bumping the base image from `python:3.12.7-slim` to `python:3.14.6-slim`. `dependabot-auto-merge.yml` approved it and armed auto-merge.

The image tag is read as plain semver, so `3.12.7 → 3.14.6` registers as a **minor** bump and sails through the minor/patch gate — despite swapping the production Python runtime two feature releases forward. The only thing that stopped it merging unattended was the code-owner review requirement, which is luck rather than design, and is precisely the requirement we're discussing relaxing so Dependabot PRs stop stalling. Relaxing it without this fix would have made a Python 3.14 deploy an unattended event.

I've disabled auto-merge on #2048 in the meantime; it stays open for a deliberate decision.

## The fix

Ignore major and minor updates for the `python` image only. Patch-level base image updates (`3.12.7 → 3.12.8`, which carry the security fixes you actually want flowing automatically) are unaffected. Runtime upgrades become a deliberate, tested change.

The rest of the docker ecosystem still does its job — keeping the pinned `ghcr.io/astral-sh/uv` tag current, which is why it was added.

## Note

This is a general hazard with Dependabot's docker ecosystem, not something specific to this repo: any base image whose tag encodes a runtime version will be misread as semver. Worth remembering if another image is ever pinned here.