### PR TITLE
fix: classic card print — restore detail columns in print, lighter background, larger text

### DIFF
--- a/gyrinx/core/print_cards.py
+++ b/gyrinx/core/print_cards.py
@@ -50,6 +50,10 @@ THEMES = [
 ]
 DEFAULT_THEME = "blank"
 
+# Roughly how many characters of value text fit on one line of one detail
+# column. Feeds the column-balancing estimate only (see DetailGroup.height).
+DETAIL_CHARS_PER_LINE = 28
+
 
 # ---------------------------------------------------------------------------
 # Normalised card data
@@ -65,6 +69,31 @@ class StatCell:
     highlight: bool = False
     first_of_group: bool = False
     modded: bool = False
+
+
+@dataclass
+class DetailGroup:
+    """One labelled row in the lower detail block (Skills / Rules / Gear / ...)."""
+
+    label: str
+    items: list[str] = field(default_factory=list)
+    css_class: str = ""
+
+    @property
+    def text(self) -> str:
+        return ", ".join(self.items)
+
+    @property
+    def height(self) -> int:
+        """Rough rendered line count, used to balance the two detail columns.
+
+        Only ever compared against other groups' estimates to pick a split
+        point, so it needs to rank groups correctly rather than predict the
+        real layout. A long label ("Legendary Names") wraps to one word per
+        line (see the .cc-label rule), which can outgrow a short value.
+        """
+        body_lines = -(-len(self.text) // DETAIL_CHARS_PER_LINE)  # ceil
+        return max(1, body_lines, len(self.label.split()))
 
 
 @dataclass
@@ -113,6 +142,61 @@ class ClassicCard:
     captured: bool = False
     dead: bool = False
     fighter_id: str = ""
+
+    @property
+    def detail_groups(self) -> list[DetailGroup]:
+        """The lower detail block's rows, in reading order."""
+        groups = [
+            DetailGroup("Skills", self.skills, "cc-skills"),
+            DetailGroup("Rules", self.rules, "cc-rules-q"),
+            DetailGroup("Gear", self.wargear, "cc-wargear"),
+        ]
+        if self.powers:
+            groups.append(DetailGroup("Wyrd Powers", self.powers, "cc-powers"))
+        groups += [
+            DetailGroup(label, list(items), "cc-gearcat")
+            for label, items in self.gear_categories
+        ]
+        return groups
+
+    @property
+    def detail_columns(self) -> list[list[DetailGroup]]:
+        """``detail_groups`` split into the card's two detail columns.
+
+        This split is done here rather than by CSS multi-column layout because
+        WebKit does not support a multi-column container nested inside another
+        fragmentation context: when printing (where the page *is* a fragmenta-
+        tion context) iOS Safari collapses the block to a single full-width
+        column, so cards printed from an iPhone lost the two-column detail
+        layout entirely. Splitting server-side renders identically on screen
+        and on paper, in every engine.
+
+        Groups keep their reading order and are cut at one point, exactly as
+        column-major flow would: column one takes the first N, column two the
+        rest. The cut is the one that minimises the taller column, which is
+        what multicol's balancing was doing for us.
+
+        Blank (fillable) cards keep every group in one full-width column so
+        their write-in boxes are as wide as possible. An empty column is never
+        returned — each column is a flex item, so an empty one would still
+        claim half the width.
+        """
+        groups = self.detail_groups
+        if self.kind == "blank" or not groups:
+            return [groups] if groups else []
+
+        heights = [g.height for g in groups]
+        total = sum(heights)
+        best_split, best_tallest = len(groups), total
+        run = 0
+        # Prefer the largest qualifying left column on a tie, matching how
+        # column-major flow fills column one before spilling into column two.
+        for split in range(1, len(groups) + 1):
+            run += heights[split - 1]
+            tallest = max(run, total - run)
+            if tallest <= best_tallest:
+                best_split, best_tallest = split, tallest
+        return [c for c in (groups[:best_split], groups[best_split:]) if c]
 
 
 def _get(obj, name, default=""):

--- a/gyrinx/core/print_cards.py
+++ b/gyrinx/core/print_cards.py
@@ -182,8 +182,8 @@ class ClassicCard:
         claim half the width.
         """
         groups = self.detail_groups
-        if self.kind == "blank" or not groups:
-            return [groups] if groups else []
+        if self.kind == "blank":
+            return [groups]
 
         heights = [g.height for g in groups]
         total = sum(heights)

--- a/gyrinx/core/print_cards.py
+++ b/gyrinx/core/print_cards.py
@@ -165,11 +165,11 @@ class ClassicCard:
 
         This split is done here rather than by CSS multi-column layout because
         WebKit does not support a multi-column container nested inside another
-        fragmentation context: when printing (where the page *is* a fragmenta-
-        tion context) iOS Safari collapses the block to a single full-width
-        column, so cards printed from an iPhone lost the two-column detail
-        layout entirely. Splitting server-side renders identically on screen
-        and on paper, in every engine.
+        fragmentation context: when printing (where the page *is* a
+        fragmentation context) iOS Safari collapses the block to a single
+        full-width column, so cards printed from an iPhone lost the two-column
+        detail layout entirely. Splitting server-side renders identically on
+        screen and on paper, in every engine.
 
         Groups keep their reading order and are cut at one point, exactly as
         column-major flow would: column one takes the first N, column two the

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -500,7 +500,12 @@
     .cc-detail__cols {
         display: flex;
         flex-direction: row;
-        align-items: flex-start;
+        // Columns stretch (the flex default) rather than sizing to their
+        // content: blank cards spread their write-in boxes down the column with
+        // `justify-content: space-between`, which does nothing unless the
+        // column is as tall as the block. Groups stack from the top either way,
+        // so this is invisible on a normal card.
+        align-items: stretch;
         gap: var(--cc-detail-gap);
         max-height: 100%;
         overflow: hidden;

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -510,7 +510,7 @@
         max-height: 100%;
         overflow: hidden;
         // em anchor: labels + bodies below are em-relative so the fit-to-box
-        // script (print_lab_sheet.html) can shrink the whole block as one unit.
+        // script (includes/classic_sheet.html) can shrink the block as one unit.
         font-size: 2.5mm;
     }
 

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -491,14 +491,29 @@
         flex-direction: column;
     }
 
+    // Two side-by-side columns. Which groups land in which column is decided in
+    // Python (ClassicCard.detail_columns), NOT by CSS multi-column layout:
+    // WebKit doesn't support a multicol container nested inside another
+    // fragmentation context, so when printing (the page being a fragmentation
+    // context) iOS Safari collapsed the whole block to one full-width column.
+    // Two plain flex columns fragment fine and render identically everywhere.
     .cc-detail__cols {
-        column-count: 2;
-        column-gap: var(--cc-detail-gap);
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        gap: var(--cc-detail-gap);
         max-height: 100%;
         overflow: hidden;
         // em anchor: labels + bodies below are em-relative so the fit-to-box
         // script (print_lab_sheet.html) can shrink the whole block as one unit.
         font-size: 2.5mm;
+    }
+
+    .cc-detail__col {
+        flex: 1 1 0;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
     }
 
     .cc-section {
@@ -521,29 +536,17 @@
         font-size: 1em;
     }
 
-    // Each group is inline (label left, value wraps to its right) and stays
-    // whole within a column; baseline-align the label with the body's text.
-    //
-    // `inline-flex` (not `flex`) is load-bearing: WebKit ignores `break-inside:
-    // avoid` on a block-level flex container inside a multicol, and its attempt
-    // to fragment one produces garbage — on iOS Safari a long Rules group was
-    // sliced mid-list with the second half painted overlapping the next group,
-    // and when the column box had a constrained height the trailing group (Gear)
-    // was dropped from the card altogether. An atomic inline-level box is
-    // *monolithic* per CSS Fragmentation, so no engine may split it; `width:
-    // 100%` keeps each group on its own line so the block still reads as a
-    // stack. Verified against iOS 26 Safari — the prefixed
-    // `-webkit-column-break-inside: avoid` does NOT fix this, inline-flex does.
-    // Blank cards re-blockify these back to flex items (the [data-kind="blank"]
-    // override swaps the column box to a flex column), so they are unaffected.
+    // Each group is a row (label left, value wraps to its right), baseline-
+    // aligned with the body's first line. These used to need `inline-flex` to
+    // stop WebKit slicing a group across a column break — with the columns now
+    // built in Python there is no fragmentation to guard against, so they are
+    // ordinary flex rows again.
     .cc-detail .cc-section {
-        display: inline-flex;
-        width: 100%;
+        display: flex;
         flex-direction: row;
         align-items: baseline;
         gap: 1.5mm;
         min-width: 0;
-        break-inside: avoid;
         margin-bottom: 1mm;
     }
 
@@ -691,13 +694,14 @@
         }
 
         // Skills / Rules / Gear full-width, each a label beside a write-in box
-        // (like the XP / Notes rows), spread to fill the detail area.
+        // (like the XP / Notes rows), spread to fill the detail area. Every
+        // group is in the first column (see ClassicCard.detail_columns), so the
+        // column itself carries the spread and the empty second one is dropped.
         .cc-detail__cols {
-            column-count: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
             height: 100%;
+        }
+        .cc-detail__col {
+            justify-content: space-between;
         }
         .cc-detail .cc-section {
             flex-direction: row;

--- a/gyrinx/core/static/core/scss/_classic_card.scss
+++ b/gyrinx/core/static/core/scss/_classic_card.scss
@@ -20,7 +20,7 @@
     --cc-line-soft: rgba(29, 26, 22, 0.35);
     --cc-hl: rgba(122, 45, 41, 0.16); // mental-stat / highlighted band tint
     --cc-paper: #fff; // base the texture fades onto
-    --cc-fade: 0.5; // white wash over the texture (0 = full-strength texture)
+    --cc-fade: 0.6; // white wash over the texture (0 = full-strength texture)
 
     // --- geometry (mm) — tune the whole card from here ---------------------
     --cc-w: 100mm;
@@ -414,7 +414,7 @@
         width: 100%;
         border-collapse: collapse;
         table-layout: fixed;
-        font-size: 2.3mm;
+        font-size: 2.5mm;
 
         th,
         td {
@@ -430,7 +430,7 @@
             text-transform: uppercase;
             letter-spacing: 0.02em;
             border-bottom: 0.3mm solid var(--cc-line);
-            font-size: 2mm;
+            font-size: 2.15mm;
         }
 
         .cc-w-name {
@@ -447,7 +447,7 @@
         .cc-w-traits {
             width: 22%;
             text-align: left;
-            font-size: 2mm;
+            font-size: 2.15mm;
             color: rgba(29, 26, 22, 0.85);
         }
 
@@ -463,7 +463,7 @@
     }
 
     .cc-weapons__empty {
-        font-size: 2.3mm;
+        font-size: 2.5mm;
         color: rgba(29, 26, 22, 0.5);
         font-style: italic;
         padding-top: 1mm;
@@ -498,7 +498,7 @@
         overflow: hidden;
         // em anchor: labels + bodies below are em-relative so the fit-to-box
         // script (print_lab_sheet.html) can shrink the whole block as one unit.
-        font-size: 2.3mm;
+        font-size: 2.5mm;
     }
 
     .cc-section {

--- a/gyrinx/core/templates/core/includes/classic_card.html
+++ b/gyrinx/core/templates/core/includes/classic_card.html
@@ -106,31 +106,22 @@ Params:
                     <div class="cc-weapons__empty">No weapons.</div>
                 {% endif %}
             </div>
-            {% comment %} Lower detail block — balanced 2 columns: skills, rules, gear, then others {% endcomment %}
+            {% comment %}
+            Lower detail block — two balanced columns (skills, rules, gear, then
+            others). The split is computed in Python (ClassicCard.detail_columns)
+            rather than by CSS multicol, which WebKit collapses to one column
+            when printing. Blank cards put everything in the first column.
+            {% endcomment %}
             <div class="cc-detail">
                 <div class="cc-detail__cols">
-                    <div class="cc-section cc-skills">
-                        <div class="cc-label">Skills</div>
-                        {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.skills|join:", " }}</div>{% endif %}
-                    </div>
-                    <div class="cc-section cc-rules-q">
-                        <div class="cc-label">Rules</div>
-                        {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.rules|join:", " }}</div>{% endif %}
-                    </div>
-                    <div class="cc-section cc-wargear">
-                        <div class="cc-label">Gear</div>
-                        {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ card.wargear|join:", " }}</div>{% endif %}
-                    </div>
-                    {% if card.powers %}
-                        <div class="cc-section cc-powers">
-                            <div class="cc-label">Wyrd Powers</div>
-                            <div class="cc-section__body">{{ card.powers|join:", " }}</div>
-                        </div>
-                    {% endif %}
-                    {% for cat in card.gear_categories %}
-                        <div class="cc-section cc-gearcat">
-                            <div class="cc-label">{{ cat.0 }}</div>
-                            <div class="cc-section__body">{{ cat.1|join:", " }}</div>
+                    {% for column in card.detail_columns %}
+                        <div class="cc-detail__col">
+                            {% for group in column %}
+                                <div class="cc-section {{ group.css_class }}">
+                                    <div class="cc-label">{{ group.label }}</div>
+                                    {% if card.kind == "blank" %}<div class="cc-writein cc-section__box"></div>{% else %}<div class="cc-section__body">{{ group.text }}</div>{% endif %}
+                                </div>
+                            {% endfor %}
                         </div>
                     {% endfor %}
                 </div>

--- a/gyrinx/core/tests/test_print_lab.py
+++ b/gyrinx/core/tests/test_print_lab.py
@@ -4,6 +4,7 @@ import pytest
 from django.test import override_settings
 from django.urls import reverse
 
+from gyrinx.core.print_cards import DetailGroup
 from gyrinx.core.views.print_lab import (
     PRESET_LABELS,
     ClassicCard,
@@ -324,3 +325,68 @@ def test_all_presets_render_without_error(client):
     for key in PRESET_LABELS:
         url = reverse("debug_print_lab_sheet") + f"?source=preset&preset={key}"
         assert client.get(url).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Detail block columns
+#
+# The two columns are split in Python rather than by CSS multi-column layout,
+# because WebKit collapses a multicol nested inside a fragmentation context —
+# printing from iOS Safari lost the two-column layout entirely.
+# ---------------------------------------------------------------------------
+
+
+def test_detail_groups_cover_every_labelled_row():
+    card = synthetic_presets()["psyker"]
+    labels = [g.label for g in card.detail_groups]
+    assert labels[:3] == ["Skills", "Rules", "Gear"]
+    assert "Wyrd Powers" in labels
+    for category_label, _ in card.gear_categories:
+        assert category_label in labels
+
+
+def test_detail_group_text_joins_items():
+    group = DetailGroup("Skills", ["Nerves of Steel", "Spring Up"])
+    assert group.text == "Nerves of Steel, Spring Up"
+
+
+def test_detail_columns_split_into_two_without_losing_groups():
+    card = synthetic_presets()["overflow"]
+    columns = card.detail_columns
+    assert len(columns) == 2
+    flattened = [g.label for col in columns for g in col]
+    assert flattened == [g.label for g in card.detail_groups]  # order preserved
+
+
+def test_detail_columns_balance_the_taller_column():
+    """The split point is chosen to keep the taller column as short as it can
+    be — a naive fixed split would pile everything into column one."""
+    card = ClassicCard(
+        skills=["A very long list of skills " * 4],
+        rules=["Short"],
+        wargear=["Also short"],
+    )
+    left, right = card.detail_columns
+    assert [g.label for g in left] == ["Skills"]
+    assert [g.label for g in right] == ["Rules", "Gear"]
+
+
+def test_detail_columns_never_returns_an_empty_column():
+    """An empty column is still a flex item, so it would claim half the width."""
+    for key in PRESET_LABELS:
+        for column in synthetic_presets()[key].detail_columns:
+            assert column
+
+
+def test_blank_card_keeps_one_full_width_detail_column():
+    card = synthetic_presets()["blank"]
+    assert len(card.detail_columns) == 1
+    assert [g.label for g in card.detail_columns[0]] == ["Skills", "Rules", "Gear"]
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_sheet_renders_two_detail_columns(client):
+    url = reverse("debug_print_lab_sheet") + "?source=preset&preset=psyker"
+    body = client.get(url).content.decode()
+    assert body.count('class="cc-detail__col"') == 2


### PR DESCRIPTION
Two commits: the print tweaks that were asked for, and a print bug they surfaced.

## Restore the detail columns when printing (`7f6a0a45`)

Printing a gang from an iPhone lost the two-column detail block — Skills, Rules and Gear came out stacked full-width in one column, even though the same page on screen had two.

The block used CSS multi-column layout. WebKit doesn't support a multicol container nested inside another fragmentation context, and when printing the page itself is one, so iOS Safari collapses it to a single column. Chrome's print output was affected too, more quietly: it could drop the trailing group off the card entirely — a "Status Items" row was going missing from the densest preset card.

The split is now computed in Python (`ClassicCard.detail_columns`) and rendered as two plain flex columns. Groups keep their reading order and are cut at one point, exactly as column-major flow would; the cut chosen is the one that minimises the taller column, which is what multicol's balancing was doing for us. Blank cards keep everything in one full-width column so their write-in boxes stay wide.

This also retires the `inline-flex` + `break-inside: avoid` workarounds on `.cc-section`. They existed only to stop WebKit slicing a group across a column break — with no fragmentation context left, they're dead weight.

Verified two columns in the iOS Safari print preview, a Chrome print PDF, and desktop WebKit under print media.

## Print tweaks (`16080f95`)

- **Lighter background.** The white wash over the plate texture goes 0.5 → 0.6. The dark theme is untouched — it deliberately pins the wash to 0.
- **Bigger weapons table.** Body text 2.3mm → 2.5mm, headers and the traits column 2mm → 2.15mm so they stay in proportion.
- **Bigger detail block.** The em anchor goes 2.3mm → 2.5mm, scaling its labels and bodies together.

Every print-lab preset was measured for overflow, including the deliberately over-stuffed one. No region overflows or clips; only the densest card trips the fit-to-box shrink, and it settles well above its floor.

## Checks

`pytest -n auto`: 3903 passed, 13 skipped (7 new tests covering the column split). `stylelint` reports no new problems.

## How to try it

With the dev server running, open `/_debug/print-lab/` and print-preview the sheet — or print a real gang from an iPhone, which is where this showed up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)