### PR TITLE
fix(deps): patch brace-expansion without downgrading npm-run-all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -871,11 +871,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.1",
@@ -923,14 +926,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1166,13 +1171,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/console-clear": {
       "version": "1.1.1",
@@ -3775,29 +3773,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "js-yaml": "^4.3.0",
     "markdownlint-cli2": {
       "js-yaml": "5.2.2"
-    }
+    },
+    "brace-expansion": "^5.0.8"
   },
   "devDependencies": {
     "@github/markdownlint-github": "^0.8.3",


### PR DESCRIPTION
Clears the last outstanding npm advisory. `npm audit` goes from 3 high to 0.

## The problem

New advisory **GHSA-mh99-v99m-4gvg** (high — DoS via unbounded expansion causing OOM) covers `brace-expansion <=5.0.7`. Two chains reach it:

- `nodemon → minimatch@10.2.4 → brace-expansion@5.0.8` — already clear.
- `npm-run-all@4.1.5 → minimatch@3.1.5 → brace-expansion@1.1.16` — vulnerable, and **1.1.16 is the last 1.x release**, so there is no patch on that line.

`npm audit fix --force` "resolves" it by installing `npm-run-all@1.1.3` — a three-major-version downgrade of the tool that runs every `css` script. That is worse than the advisory.

## The fix

Override `brace-expansion` to `^5.0.8`, which lets `npm-run-all` stay where it is. This matches the existing override pattern in `package.json` (`fast-uri`, `js-yaml`).

## Verified, not assumed

That override hands brace-expansion **5.x to a consumer expecting 1.x** — a four-major jump — so a clean `npm audit` alone proves nothing. What I actually checked:

- `npm run css` succeeds end to end (exit 0).
- Glob matching still works: `npm-run-all "css-p*"` correctly resolves and runs `css-prefix`.
- **Brace expansion itself still works through minimatch 3.1.5**: `npm-run-all "css-{compile,prefix}"` expands to *both* scripts. This is the code path the advisory is about, so it is the one that matters.
- `npm audit`: 0 vulnerabilities. Prettier clean.

## Underlying issue, not fixed here

`npm-run-all` has been unmaintained since 2018, which is why it is still pinning minimatch 3.x. `npm-run-all2` is the maintained fork and the real fix, but swapping the build-script runner deserves its own PR rather than riding along with a security patch.