### PR TITLE
refactor: classify stats from ContentStat only, not a hardcoded fallback

### DIFF
--- a/docs/logging-and-tracing-reference.md
+++ b/docs/logging-and-tracing-reference.md
@@ -326,7 +326,7 @@ def track(
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `event` | `str` | Event name (e.g., `stat_config_fallback_used`) |
+| `event` | `str` | Event name (e.g., `list_action_apply_succeeded`) |
 | `n` | `int` | Count increment. Default: `1` |
 | `value` | `Optional[float]` | Numeric value for distributions |
 | `**labels` | `Any` | Arbitrary key-value metadata |
@@ -344,11 +344,11 @@ def track(
 
 ```json
 {
-    "event": "stat_config_fallback_used",
+    "event": "list_action_apply_succeeded",
     "n": 1,
     "labels": {
-        "stat_name": "ammo",
-        "model_type": "ContentModStatApply"
+        "action_type": "advancement",
+        "list_id": "0f9c1e2a-..."
     }
 }
 ```
@@ -614,7 +614,7 @@ Query events in Cloud Logging:
 
 ```
 resource.type="cloud_run_revision"
-jsonPayload.event="stat_config_fallback_used"
+jsonPayload.event="list_action_apply_succeeded"
 ```
 
 Filter by labels:

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -46,8 +46,8 @@ track("error_occurred", error_type="ValidationError", endpoint="/lists/create", 
 # Track when a feature is used
 track("feature_used", feature="equipment_upgrade", list_id=str(list.id))
 
-# Track backward compatibility code
-track("stat_config_fallback_used", stat_name="ammo", model_class="ContentModStatApply")
+# Track an action being applied
+track("list_action_apply_succeeded", action_type="advancement", list_id=str(list.id))
 ```
 
 #### Performance Metrics
@@ -101,7 +101,7 @@ When running in production, events can be queried using Cloud Logging queries:
 
 ```
 resource.type="cloud_run_revision"
-jsonPayload.event="stat_config_fallback_used"
+jsonPayload.event="list_action_apply_succeeded"
 ```
 
 You can filter by labels:

--- a/gyrinx/conftest.py
+++ b/gyrinx/conftest.py
@@ -1,10 +1,12 @@
 from typing import Callable
 
 import pytest
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
+from django.db.models.signals import post_migrate
 
 from gyrinx.content.models import (
     ContentBook,
@@ -84,13 +86,16 @@ def warm_contenttype_cache(django_db_setup, django_db_blocker):
 
 
 # Stats that every real environment is guaranteed to have, because data
-# migration content.0148 creates them. Tests run with --nomigrations, so data
-# migrations never execute and the test database would otherwise have no
-# ContentStat rows at all — mod formatting would then be driven by absent
-# configuration rather than by the definitions production actually holds.
+# migrations create them: content.0148 seeds the stats that modifications
+# classify, and content.0156 seeds the standard fighter statline. Tests run
+# with --nomigrations, so data migrations never execute and the test database
+# would otherwise have no ContentStat rows at all — mod formatting would then
+# be driven by absent configuration rather than by the definitions production
+# actually holds.
 #
 # field_name -> (short_name, full_name, inverted, inches, modifier, target)
 CANONICAL_CONTENT_STATS = {
+    # From content.0148 — the stats a modification classifies
     "accuracy_long": ("L", "Long Accuracy", False, False, True, False),
     "accuracy_short": ("S", "Short Accuracy", False, False, True, False),
     "ammo": ("Am", "Ammo", True, False, False, True),
@@ -107,40 +112,62 @@ CANONICAL_CONTENT_STATS = {
     "save": ("Sv", "Save", True, False, False, True),
     "weapon_skill": ("WS", "Weapon Skill", True, False, False, True),
     "willpower": ("Wil", "Willpower", True, False, False, True),
+    # Also from content.0156 — carry no classification flags
+    "attacks": ("A", "Attacks", False, False, False, False),
+    "strength": ("S", "Strength", False, False, False, False),
+    "toughness": ("T", "Toughness", False, False, False, False),
+    "wounds": ("W", "Wounds", False, False, False, False),
 }
+
+
+def _seed_content_stats(**kwargs):
+    """Create or correct every canonical ContentStat row."""
+    from gyrinx.content.models.statline import ContentStat
+
+    for field_name, (
+        short_name,
+        full_name,
+        is_inverted,
+        is_inches,
+        is_modifier,
+        is_target,
+    ) in CANONICAL_CONTENT_STATS.items():
+        ContentStat.objects.update_or_create(
+            field_name=field_name,
+            defaults={
+                "short_name": short_name,
+                "full_name": full_name,
+                "is_inverted": is_inverted,
+                "is_inches": is_inches,
+                "is_modifier": is_modifier,
+                "is_target": is_target,
+            },
+        )
 
 
 @pytest.fixture(scope="session", autouse=True)
 def content_stat_definitions(django_db_setup, django_db_blocker):
-    """Seed the ContentStat rows that migration content.0148 guarantees.
+    """Seed the ContentStat rows the data migrations guarantee.
 
     Stat classification (inverted / inches / modifier / target) is read from
     ContentStat when a modification is applied. Without these rows every stat
     would look unconfigured, so tests would exercise a code path that no real
     environment reaches. Tests needing stats beyond this set create their own.
+
+    Seeding once per session is not enough: a transactional test truncates
+    every table on teardown, which would leave the rest of that worker's
+    transactional tests running against an empty table. Django re-emits
+    post_migrate after that flush — the same hook that restores content types
+    and permissions — so re-seed from there too.
     """
     with django_db_blocker.unblock():
-        from gyrinx.content.models.statline import ContentStat
+        _seed_content_stats()
 
-        for field_name, (
-            short_name,
-            full_name,
-            is_inverted,
-            is_inches,
-            is_modifier,
-            is_target,
-        ) in CANONICAL_CONTENT_STATS.items():
-            ContentStat.objects.get_or_create(
-                field_name=field_name,
-                defaults={
-                    "short_name": short_name,
-                    "full_name": full_name,
-                    "is_inverted": is_inverted,
-                    "is_inches": is_inches,
-                    "is_modifier": is_modifier,
-                    "is_target": is_target,
-                },
-            )
+    post_migrate.connect(
+        _seed_content_stats,
+        sender=apps.get_app_config("content"),
+        dispatch_uid="tests.seed_content_stats",
+    )
 
 
 @pytest.fixture(scope="session")

--- a/gyrinx/conftest.py
+++ b/gyrinx/conftest.py
@@ -83,6 +83,66 @@ def warm_contenttype_cache(django_db_setup, django_db_blocker):
         ContentType.objects.get_for_model(ContentModFighterStat)
 
 
+# Stats that every real environment is guaranteed to have, because data
+# migration content.0148 creates them. Tests run with --nomigrations, so data
+# migrations never execute and the test database would otherwise have no
+# ContentStat rows at all — mod formatting would then be driven by absent
+# configuration rather than by the definitions production actually holds.
+#
+# field_name -> (short_name, full_name, inverted, inches, modifier, target)
+CANONICAL_CONTENT_STATS = {
+    "accuracy_long": ("L", "Long Accuracy", False, False, True, False),
+    "accuracy_short": ("S", "Short Accuracy", False, False, True, False),
+    "ammo": ("Am", "Ammo", True, False, False, True),
+    "armour_piercing": ("AP", "Armour Piercing", True, False, True, False),
+    "ballistic_skill": ("BS", "Ballistic Skill", True, False, False, True),
+    "cool": ("Cl", "Cool", True, False, False, True),
+    "handling": ("Hnd", "Handling", True, False, False, True),
+    "initiative": ("I", "Initiative", True, False, False, True),
+    "intelligence": ("Int", "Intelligence", True, False, False, True),
+    "leadership": ("Ld", "Leadership", True, False, False, True),
+    "movement": ("M", "Movement", False, True, False, False),
+    "range_long": ("L", "Long Range", False, True, False, False),
+    "range_short": ("S", "Short Range", False, True, False, False),
+    "save": ("Sv", "Save", True, False, False, True),
+    "weapon_skill": ("WS", "Weapon Skill", True, False, False, True),
+    "willpower": ("Wil", "Willpower", True, False, False, True),
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def content_stat_definitions(django_db_setup, django_db_blocker):
+    """Seed the ContentStat rows that migration content.0148 guarantees.
+
+    Stat classification (inverted / inches / modifier / target) is read from
+    ContentStat when a modification is applied. Without these rows every stat
+    would look unconfigured, so tests would exercise a code path that no real
+    environment reaches. Tests needing stats beyond this set create their own.
+    """
+    with django_db_blocker.unblock():
+        from gyrinx.content.models.statline import ContentStat
+
+        for field_name, (
+            short_name,
+            full_name,
+            is_inverted,
+            is_inches,
+            is_modifier,
+            is_target,
+        ) in CANONICAL_CONTENT_STATS.items():
+            ContentStat.objects.get_or_create(
+                field_name=field_name,
+                defaults={
+                    "short_name": short_name,
+                    "full_name": full_name,
+                    "is_inverted": is_inverted,
+                    "is_inches": is_inches,
+                    "is_modifier": is_modifier,
+                    "is_target": is_target,
+                },
+            )
+
+
 @pytest.fixture(scope="session")
 def content_books(django_db_setup, django_db_blocker):
     """Create ContentBook objects needed for tests."""

--- a/gyrinx/content/models/modifier.py
+++ b/gyrinx/content/models/modifier.py
@@ -31,6 +31,10 @@ from .base import Content
 
 logger = logging.getLogger(__name__)
 
+# Stat names already reported as having no ContentStat, so each is only
+# warned about once per process. See _get_stat_configuration.
+_undefined_stats_warned: set[str] = set()
+
 
 class ContentMod(PolymorphicModel, Content):
     """
@@ -68,10 +72,10 @@ class ContentModStatApplyMixin:
             content_stat = all_stats.get(self.stat)
             if content_stat is not None:
                 return (
-                    content_stat["is_inverted"],
-                    content_stat["is_inches"],
-                    content_stat["is_modifier"],
-                    content_stat["is_target"],
+                    content_stat.get("is_inverted", False),
+                    content_stat.get("is_inches", False),
+                    content_stat.get("is_modifier", False),
+                    content_stat.get("is_target", False),
                 )
         else:
             content_stat = ContentStat.objects.filter(field_name=self.stat).first()
@@ -83,12 +87,17 @@ class ContentModStatApplyMixin:
                     content_stat.is_target,
                 )
 
-        logger.warning(
-            "No ContentStat defined for stat %r on %s — "
-            "applying the modification without stat-specific formatting",
-            self.stat,
-            self.__class__.__name__,
-        )
+        # Once per stat per process: a modification is applied for every stat
+        # of every fighter on a page, so warning each time would turn one bad
+        # stat name into hundreds of identical lines per request.
+        if self.stat not in _undefined_stats_warned:
+            _undefined_stats_warned.add(self.stat)
+            logger.warning(
+                "No ContentStat defined for stat %r on %s — "
+                "applying the modification without stat-specific formatting",
+                self.stat,
+                self.__class__.__name__,
+            )
         return (False, False, False, False)
 
     def apply(self, input_value: str, mod_ctx: Optional[ModContext] = None) -> str:

--- a/gyrinx/content/models/modifier.py
+++ b/gyrinx/content/models/modifier.py
@@ -14,6 +14,7 @@ This module contains:
 - ContentModApplication: Pack-scoped house-rule application of a ContentMod to a target
 """
 
+import logging
 from typing import Optional
 
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -25,9 +26,10 @@ from polymorphic.models import PolymorphicModel
 from simple_history.models import HistoricalRecords
 
 from gyrinx.core.models.util import ModContext
-from gyrinx.tracker import track
 
 from .base import Content
+
+logger = logging.getLogger(__name__)
 
 
 class ContentMod(PolymorphicModel, Content):
@@ -47,80 +49,47 @@ class ContentMod(PolymorphicModel, Content):
 
 
 class ContentModStatApplyMixin:
-    inverted_stats = [
-        "ammo",
-        "armour_piercing",
-        "weapon_skill",
-        "ballistic_skill",
-        "intelligence",
-        "leadership",
-        "cool",
-        "willpower",
-        "initiative",
-        "handling",
-        "save",
-    ]
-
-    inch_stats = ["range_short", "range_long", "movement"]
-
-    modifier_stats = ["accuracy_short", "accuracy_long", "armour_piercing"]
-
-    target_roll_stats = [
-        "ammo",
-        "weapon_skill",
-        "ballistic_skill",
-        "intelligence",
-        "leadership",
-        "cool",
-        "willpower",
-        "initiative",
-        "handling",
-        "save",
-    ]
-
     def _get_stat_configuration(self, all_stats: Optional[dict[str, dict]] = None):
         """
-        Get stat configuration from ContentStat or fallback to hardcoded values.
+        Read this modification's stat classification from its ContentStat.
         Returns a tuple of (is_inverted, is_inches, is_modifier, is_target).
+
+        A stat with no ContentStat row is treated as unclassified — the value
+        is modified but not reformatted. Every stat referenced by a
+        modification has a definition, so this is a data problem when it
+        happens rather than a supported configuration; it is logged rather
+        than raised so one bad stat name cannot take out a fighter's card.
         """
         from .statline import ContentStat
 
         # all_stats is an optimisation to reduce the N+1 query problem from
         # fetching ContentStat objects individually
-        if all_stats:
-            content_stat = all_stats.get(self.stat, {})
-            return (
-                content_stat.get("is_inverted", False),
-                content_stat.get("is_inches", False),
-                content_stat.get("is_modifier", False),
-                content_stat.get("is_target", False),
-            )
-        # Check if we have a ContentStat object with the new fields
-        try:
-            content_stat = ContentStat.objects.get(field_name=self.stat)
-            if content_stat:
-                # Use ContentStat fields if available
+        if all_stats is not None:
+            content_stat = all_stats.get(self.stat)
+            if content_stat is not None:
+                return (
+                    content_stat["is_inverted"],
+                    content_stat["is_inches"],
+                    content_stat["is_modifier"],
+                    content_stat["is_target"],
+                )
+        else:
+            content_stat = ContentStat.objects.filter(field_name=self.stat).first()
+            if content_stat is not None:
                 return (
                     content_stat.is_inverted,
                     content_stat.is_inches,
                     content_stat.is_modifier,
                     content_stat.is_target,
                 )
-        except ContentStat.DoesNotExist:
-            # Track that we're using fallback values
-            track(
-                "stat_config_fallback_used",
-                stat_name=self.stat,
-                model_class=self.__class__.__name__,
-            )
 
-        # Fallback to hardcoded values for backwards compatibility
-        return (
-            self.stat in self.inverted_stats,
-            self.stat in self.inch_stats,
-            self.stat in self.modifier_stats,
-            self.stat in self.target_roll_stats,
+        logger.warning(
+            "No ContentStat defined for stat %r on %s — "
+            "applying the modification without stat-specific formatting",
+            self.stat,
+            self.__class__.__name__,
         )
+        return (False, False, False, False)
 
     def apply(self, input_value: str, mod_ctx: Optional[ModContext] = None) -> str:
         """

--- a/gyrinx/content/tests/test_mods.py
+++ b/gyrinx/content/tests/test_mods.py
@@ -150,12 +150,10 @@ def test_content_stat_modifier():
 
 
 @pytest.mark.django_db
-def test_content_stat_backward_compatibility():
-    """Test that stats work correctly when ContentStat doesn't exist."""
-    # Test with a stat that doesn't have a ContentStat object
-    # Should fall back to hardcoded values
+def test_standard_stats_are_classified_from_their_definitions():
+    """The stats every environment defines behave according to those definitions."""
 
-    # Test inverted stat (weapon_skill is in inverted_stats)
+    # Inverted: improving a target roll lowers the number
     mod = ContentModStat.objects.create(
         stat="weapon_skill",
         mode="improve",
@@ -163,7 +161,7 @@ def test_content_stat_backward_compatibility():
     )
     assert mod.apply("4+") == "3+"
 
-    # Test inches stat (movement is in inch_stats)
+    # Inches: keeps its quote mark
     mod = ContentModStat.objects.create(
         stat="movement",
         mode="improve",
@@ -171,7 +169,7 @@ def test_content_stat_backward_compatibility():
     )
     assert mod.apply('4"') == '5"'
 
-    # Test modifier stat (accuracy_short is in modifier_stats)
+    # Modifier: keeps its plus prefix
     mod = ContentModStat.objects.create(
         stat="accuracy_short",
         mode="improve",
@@ -179,14 +177,62 @@ def test_content_stat_backward_compatibility():
     )
     assert mod.apply("+2") == "+3"
 
-    # Test target roll stat (ammo is in target_roll_stats)
+    # Target roll: ammo is both inverted and a target, so improving decreases it
     mod = ContentModStat.objects.create(
         stat="ammo",
         mode="improve",
         value="1",
     )
-    # ammo is both inverted and target, so improving should decrease the number
     assert mod.apply("5+") == "4+"
+
+
+@pytest.mark.django_db
+def test_stat_definition_drives_classification():
+    """Classification follows the ContentStat row, not the stat's name.
+
+    Weapon Skill is conventionally an inverted target roll. Redefining it
+    proves the behaviour is data-driven rather than baked into the code.
+    """
+    ContentStat.objects.update_or_create(
+        field_name="weapon_skill",
+        defaults={
+            "short_name": "WS",
+            "full_name": "Weapon Skill",
+            "is_inverted": False,
+            "is_inches": False,
+            "is_modifier": False,
+            "is_target": False,
+        },
+    )
+
+    mod = ContentModStat.objects.create(
+        stat="weapon_skill",
+        mode="improve",
+        value="1",
+    )
+
+    # No longer inverted, and no longer formatted as a target roll
+    assert mod.apply("4") == "5"
+
+
+@pytest.mark.django_db
+def test_undefined_stat_is_modified_without_reformatting():
+    """A stat with no definition still applies, it just gains no formatting.
+
+    Every stat a modification can name has a definition, so this is a data
+    problem rather than a supported configuration — but it must not take a
+    page down when it happens.
+    """
+    mod = ContentModStat.objects.create(
+        stat="undefined_stat",
+        mode="improve",
+        value="1",
+    )
+
+    assert mod.apply("3") == "4"
+
+    mod.mode = "worsen"
+    assert mod.apply("3") == "2"
 
 
 @pytest.mark.django_db

--- a/gyrinx/content/tests/test_mods.py
+++ b/gyrinx/content/tests/test_mods.py
@@ -1,6 +1,9 @@
+import logging
+
 import pytest
 
 from gyrinx.content.models import ContentModFighterStat, ContentModStat, ContentStat
+from gyrinx.content.models import modifier
 
 
 @pytest.mark.django_db
@@ -216,23 +219,48 @@ def test_stat_definition_drives_classification():
 
 
 @pytest.mark.django_db
-def test_undefined_stat_is_modified_without_reformatting():
+def test_undefined_stat_is_modified_without_reformatting(caplog):
     """A stat with no definition still applies, it just gains no formatting.
 
     Every stat a modification can name has a definition, so this is a data
     problem rather than a supported configuration — but it must not take a
     page down when it happens.
     """
+    # Warnings are emitted once per stat per process, so make sure this one
+    # has not already been reported by an earlier test in the same worker.
+    modifier._undefined_stats_warned.discard("undefined_stat")
+
     mod = ContentModStat.objects.create(
         stat="undefined_stat",
         mode="improve",
         value="1",
     )
 
-    assert mod.apply("3") == "4"
+    with caplog.at_level(logging.WARNING, logger=modifier.__name__):
+        assert mod.apply("3") == "4"
+
+    assert "undefined_stat" in caplog.text
 
     mod.mode = "worsen"
     assert mod.apply("3") == "2"
+
+
+@pytest.mark.django_db
+def test_undefined_stat_is_only_warned_about_once(caplog):
+    """One bad stat name must not flood the logs on every render."""
+    modifier._undefined_stats_warned.discard("noisy_stat")
+
+    mod = ContentModStat.objects.create(
+        stat="noisy_stat",
+        mode="improve",
+        value="1",
+    )
+
+    with caplog.at_level(logging.WARNING, logger=modifier.__name__):
+        for _ in range(5):
+            mod.apply("3")
+
+    assert len([r for r in caplog.records if "noisy_stat" in r.getMessage()]) == 1
 
 
 @pytest.mark.django_db

--- a/gyrinx/tests/test_tracker.py
+++ b/gyrinx/tests/test_tracker.py
@@ -92,20 +92,20 @@ def test_track_event_with_all_parameters(caplog_json):
     }
 
 
-def test_track_stat_config_fallback_use_case(caplog_json):
-    """Test the specific use case from ContentModStatApplyMixin."""
+def test_track_model_context_labels(caplog_json):
+    """Test an event carrying labels that identify a model and one of its fields."""
     tracker.track(
-        "stat_config_fallback_used",
+        "content_stat_missing",
         stat_name="ammo",
-        model_class="ContentModStatApply",
+        model_class="ContentModStat",
     )
 
     logs = caplog_json.get_json_logs()
     assert len(logs) == 1
     assert logs[0] == {
-        "event": "stat_config_fallback_used",
+        "event": "content_stat_missing",
         "n": 1,
-        "labels": {"stat_name": "ammo", "model_class": "ContentModStatApply"},
+        "labels": {"stat_name": "ammo", "model_class": "ContentModStat"},
     }
 
 

--- a/gyrinx/tests/test_tracker.py
+++ b/gyrinx/tests/test_tracker.py
@@ -95,7 +95,7 @@ def test_track_event_with_all_parameters(caplog_json):
 def test_track_model_context_labels(caplog_json):
     """Test an event carrying labels that identify a model and one of its fields."""
     tracker.track(
-        "content_stat_missing",
+        "example_event",
         stat_name="ammo",
         model_class="ContentModStat",
     )
@@ -103,7 +103,7 @@ def test_track_model_context_labels(caplog_json):
     logs = caplog_json.get_json_logs()
     assert len(logs) == 1
     assert logs[0] == {
-        "event": "content_stat_missing",
+        "event": "example_event",
         "n": 1,
         "labels": {"stat_name": "ammo", "model_class": "ContentModStat"},
     }

--- a/gyrinx/tracker.py
+++ b/gyrinx/tracker.py
@@ -14,13 +14,13 @@ def track(event: str, n: int = 1, value: Optional[float] = None, **labels: Any) 
     In development, logs as JSON string to console.
 
     Args:
-        event: Event name (e.g. 'stat_config_fallback_used')
+        event: Event name (e.g. 'list_action_apply_succeeded')
         n: Count increment (default=1)
         value: Optional numeric value (e.g. for distributions)
         **labels: Arbitrary key=value metadata
 
     Example:
-        track("stat_config_fallback_used", stat_name="ammo", model_type="ContentModStatApply")
+        track("list_action_apply_succeeded", action_type="advancement", list_id=str(pk))
     """
     payload = {
         "event": event,


### PR DESCRIPTION
When a modification changes a fighter or weapon stat, the app needs to know what
kind of stat it is: does *improving* it mean a bigger number or a smaller one
(Cool 4+ improves to 3+), and how should the result be written (`4\"`, `3+`,
`+2`)? That's four flags — inverted, inches, modifier, target.

Those flags lived in two places. The real source is a `ContentStat` row per stat,
editable in admin. But `ContentModStatApplyMixin` also carried four hardcoded
lists of stat names, used whenever a stat had no row — a leftover from before the
`ContentStat` rows existed.

The fallback has been dead for a while. Migration `content.0148` (January) creates
a row for every stat named in those lists, so no migrated database can reach it.
Production bears that out: every stat referenced by an actual weapon or fighter
modification has a `ContentStat` row, and every row's flags agree exactly with
what the lists claim. The `stat_config_fallback_used` telemetry that was watching
this seam has never fired.

## Summary

- Delete the four hardcoded lists; classification now comes from `ContentStat` alone.
- A stat with no definition is still modified, just not reformatted, and logs a
  warning. This is what the prefetched-stats path already did, so the two lookup
  paths can no longer disagree — previously the same modification could format one
  way on a fighter card and another way on a weapon profile. It also means a bad
  stat name typed into admin degrades formatting instead of breaking a gang page.
- Seed the canonical `ContentStat` rows in tests. This turned out to be the
  substance of the change: tests run with `--nomigrations`, so `0148` never ran and
  the test database had **no** `ContentStat` rows at all. Every mod-formatting test
  had been validating the fallback rather than the path every real environment
  takes. Removing the fallback without seeding would have silently changed what the
  suite was testing.
- Drop the now-unused `stat_config_fallback_used` telemetry and its stale references.

No schema change, and nothing to deploy in a particular order.

## Test plan

- [x] `pytest -n auto` — 3898 passed, 13 skipped
- [x] **Equivalence on real data:** dumped every fighter's rendered statline before
      and after the change against a database forked from the content template —
      all 275 fighters, including 50 modified stats, byte-identical. Covers inches,
      target rolls, plain values and `-`.
- [x] Production check: no stat referenced by any modification is missing a
      `ContentStat` row, and no row's flags disagree with the deleted lists.
- [x] Page render: a public gang page returns 200 with statlines formatted
      correctly (`4+`, `8\"`, `-`) and zero missing-definition warnings logged.
- [x] `./scripts/fmt.sh`, `./scripts/check_migrations.sh`

## Next steps

This is Track A of three. Track B (retire the legacy advancement-application path,
~2,650 rows to backfill) and Track C (retire the 12 legacy statline override
columns, ~3,000 fighters to migrate) remain, and both need data migrations.

Refs #1861
Refs #1855