### PR TITLE
fix: make the bg-body-tertiary utility match the section header surface

### DIFF
--- a/gyrinx/core/static/core/scss/_tokens.scss
+++ b/gyrinx/core/static/core/scss/_tokens.scss
@@ -25,12 +25,11 @@ $gy-action-confirm: $success;
 $gy-text-muted: var(--bs-secondary-color); // replaces deprecated text-muted
 
 // Surfaces
-// Section header bars use bg-body-tertiary (matches card-header lightness).
-// Bootstrap's light-mode default (#f8f9fa) is only 3% off white and the bars
-// read as barely-there against the page; this is one step darker so a section
-// header actually separates its content from what precedes it. Dark mode keeps
-// Bootstrap's value, where the contrast was already right.
-$gy-surface-header-light: #f1f3f5;
+// There is no $gy- token for the section-header / card-header surface: it is
+// Bootstrap's own `$body-tertiary-bg`, set in styles.scss before Bootstrap is
+// imported so that `--bs-tertiary-bg`, its `-rgb` twin and the
+// `.bg-body-tertiary` utility cannot drift apart. Read it as `$body-tertiary-bg`
+// from SCSS, or `var(--bs-tertiary-bg)` from a declaration.
 
 // Section header bar height. Derived from Bootstrap's own btn-sm metrics plus
 // the bar's vertical padding, so a bar whose action is a btn-sm and a bar whose

--- a/gyrinx/core/static/core/scss/styles.scss
+++ b/gyrinx/core/static/core/scss/styles.scss
@@ -35,6 +35,22 @@ $cyan: #10bdd3;
 // Card header background — match section header bars (bg-body-tertiary)
 $card-cap-bg: var(--bs-tertiary-bg);
 
+// The section-header / card-header surface. Bootstrap's light-mode default
+// ($gray-100, #f8f9fa) is 3% off white, so those bars read as barely-there
+// against the page; one step darker makes a section header actually separate its
+// content from what precedes it. Dark mode is a different variable
+// ($body-tertiary-bg-dark) and keeps Bootstrap's value, where contrast was
+// already right.
+//
+// Set HERE, before bootstrap/scss/variables — not as a `--bs-tertiary-bg`
+// override in :root afterwards. Bootstrap derives *two* custom properties from
+// this one variable, `--bs-tertiary-bg` and `--bs-tertiary-bg-rgb`, and the
+// `.bg-body-tertiary` utility reads the rgb one. Overriding only the first left
+// the utility on the old colour, so a bar written `bg-body-tertiary rounded …`
+// and a bar written `.section-header` rendered two different greys. Setting the
+// source keeps them in step and needs no specificity games with [data-bs-theme].
+$body-tertiary-bg: #f1f3f5;
+
 // Required
 @import "bootstrap/scss/variables";
 @import "bootstrap/scss/variables-dark";
@@ -144,21 +160,19 @@ button[aria-busy="true"] {
 // theme is an attribute on that same html element, and `[data-bs-theme="dark"]`
 // has exactly the same specificity as `:root` — so a `:root` declaration that
 // appears after Bootstrap's (this file is imported last) wins in BOTH themes.
-// That is how the darker tertiary-bg below leaked into dark mode and turned
-// every section header bar and card header near-white.
+// A darker tertiary-bg was declared here once and leaked into dark mode that
+// way, turning every section header bar and card header near-white; it now
+// comes from `$body-tertiary-bg` above, before Bootstrap, where per-theme values
+// are separate variables and this trap does not exist.
 //
-// `--bs-secondary-color` had the same latent bug and only got away with it
-// because the dark block immediately below re-declares it. The `:not()` makes
-// both correct by construction instead of by coincidence. Safe because dark mode
-// here is attribute-driven (core/js/index.js sets data-bs-theme), never a bare
+// `--bs-secondary-color` has the same latent bug and only gets away with it
+// because the dark block immediately below re-declares it. The `:not()` makes it
+// correct by construction instead of by coincidence. Safe because dark mode here
+// is attribute-driven (core/js/index.js sets data-bs-theme), never a bare
 // prefers-color-scheme media query.
 :root:not([data-bs-theme="dark"]),
 [data-bs-theme="light"] {
     --bs-secondary-color: #{lighten($secondary, 15%)};
-
-    // One step darker than Bootstrap's #f8f9fa so section header bars and card
-    // headers actually read as a surface. See $gy-surface-header-light.
-    --bs-tertiary-bg: #{$gy-surface-header-light};
 }
 
 [data-bs-theme="dark"] {

--- a/gyrinx/core/templates/core/debug/design_system.html
+++ b/gyrinx/core/templates/core/debug/design_system.html
@@ -743,7 +743,7 @@
             </div>
             <h3 class="h6 caps-label mb-2">Section header bar (several actions)</h3>
             <div class="mb-4">
-                <div class="bg-body-tertiary rounded px-2 py-2 d-flex justify-content-between align-items-center mb-2">
+                <div class="section-header mb-2">
                     <h2 class="h5 mb-0">Gangs</h2>
                     <div class="hstack gap-2 flex-wrap justify-content-end section-actions">
                         <span>
@@ -758,11 +758,13 @@
                     </div>
                 </div>
                 <div class="px-2">
-                    <p class="text-secondary fs-7 mb-0">
-                        Actions sit in a <code>hstack gap-2 section-actions</code> row, each wrapped in a
-                        <code>span</code> so <code>.section-actions</code> can put a <code>·</code> between them —
-                        the separators stay right when items are conditionally rendered. A link to a management
-                        page is <code>bi-pencil</code> plus the noun, not "Manage X →".
+                    <p class="text-secondary mb-0">
+                        Same <code>.section-header</code> as above — the bar does not change when a section grows
+                        from one action to several. Actions sit in a <code>hstack gap-2 section-actions</code> row,
+                        each wrapped in a <code>span</code> so <code>.section-actions</code> can put a
+                        <code>·</code> between them; the separators stay right when items are conditionally
+                        rendered. A link to a management page is <code>bi-pencil</code> plus the noun, not
+                        "Manage X →".
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
The darker light-mode grey we gave section header bars only reached half the places that use it, so the design system's new "Section header bar (several actions)" example rendered the old near-white grey while the two examples either side of it rendered the new one.

## Why

Bootstrap builds *two* custom properties out of one SCSS variable: `--bs-tertiary-bg` and `--bs-tertiary-bg-rgb`. The `.bg-body-tertiary` utility reads the **rgb** one. Our override set only `--bs-tertiary-bg`, in a `:root` block after Bootstrap — so `.section-header` and `.card-header` moved to `#f1f3f5` and everything styled with the utility stayed on Bootstrap's `#f8f9fa`.

## The fix

Set `$body-tertiary-bg` *before* importing `bootstrap/scss/variables` instead of overriding a custom property afterwards. Bootstrap then emits both properties from the one value, so they can't diverge, and the `:root` override goes away — along with the `:not([data-bs-theme="dark"])` guard it needed to stop leaking into dark mode.

`$gy-surface-header-light` had no consumers left once the override went, so it's a comment pointing at `$body-tertiary-bg` rather than a second name for one colour.

## What changes visually

In light mode only, these move from `#f8f9fa` to the same `#f1f3f5` the section headers already use: the site footer, the account overview stat tiles, content-pack description boxes, and the campaign property / sub-asset schema editors.

Dark mode is untouched — it comes from a separate variable. Verified `rgb(43, 48, 53)` before and after, with `.section-header`, `.bg-body-tertiary` and `.card-header` computing identically in both themes.

The campaign page needed no changes: its five section bars already used `.section-header`. The design-system page was the last template hand-writing the seven-utility bar that class replaced.

## How to try it

- `/_debug/design-system/` → **Containers and cards**. The three "Section header bar" examples should be the same grey and the same height; toggle the theme and they should stay in step.
- `/accounts/` for the stat tiles, and any page footer.