### PR TITLE
fix: campaign start page spacing and gang credit alignment

### DIFF
--- a/gyrinx/core/templates/core/campaign/campaign_start.html
+++ b/gyrinx/core/templates/core/campaign/campaign_start.html
@@ -5,43 +5,56 @@
 {% endblock head_title %}
 {% block content %}
     {% url 'core:campaign' campaign.id as campaign_url %}
-    {% include "core/includes/back.html" with url=campaign_url text=campaign.name %}
+    <c-back url="{{ campaign_url }}" text="{{ campaign.name }}" />
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <h1 class="h3">Start Campaign: {{ campaign.name }}</h1>
-        <form action="{% url 'core:campaign-start' campaign.id %}" method="post">
+        <form action="{% url 'core:campaign-start' campaign.id %}"
+              method="post"
+              class="vstack gap-3">
             {% csrf_token %}
-            <p>Are you sure you want to start this campaign?</p>
-            <div class="alert alert-warning alert-icon mb-0" role="alert">
-                <i class="bi-exclamation-triangle"></i>
-                <div>
-                    This action cannot be undone. Once started, the campaign will move from <strong>Pre-Campaign</strong> to <strong>In Progress</strong> status.
-                </div>
+            <p class="mb-0">Are you sure you want to start this campaign?</p>
+            <c-callout variant="warning" class="mb-0">
+                This action cannot be undone. Once started, the campaign will move from <strong>Pre-Campaign</strong> to <strong>In Progress</strong> status.
+            </c-callout>
+            <div>
+                <h2 class="h5 mb-2">Gang credit allocation</h2>
+                <table class="table table-sm table-borderless mb-0">
+                    <thead>
+                        <tr>
+                            <th scope="col">Gang</th>
+                            <th scope="col">Owner</th>
+                            {% if campaign.budget > 0 %}<th scope="col" class="text-end">Credits</th>{% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for list in lists %}
+                            <tr>
+                                <td>{{ list.name }}</td>
+                                <td class="text-secondary">{{ list.owner.username }}</td>
+                                {% if campaign.budget > 0 %}
+                                    <td class="text-end">
+                                        {% with credits_to_add=campaign.budget|subtract:list.wealth_current %}
+                                            <c-badge>
+                                                {{ credits_to_add|max:0 }}¢
+                                            </c-badge>
+                                        {% endwith %}
+                                    </td>
+                                {% endif %}
+                            </tr>
+                        {% empty %}
+                            <tr>
+                                <td colspan="{% if campaign.budget > 0 %}3{% else %}2{% endif %}"
+                                    class="text-secondary fst-italic">No gangs added yet</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
-            <h3 class="h5">Gang credit allocation</h3>
-            <div class="vstack gap-2">
-                {% for list in lists %}
-                    <div class="d-flex justify-content-between align-items-center">
-                        <h4 class="fs-6 mb-0">{{ list.name }}</h4>
-                        <div>
-                            <i class="bi-person"></i> {{ list.owner.username }}
-                        </div>
-                        {% if campaign.budget > 0 %}
-                            <div class="badge text-bg-secondary">
-                                {% with credits_to_add=campaign.budget|subtract:list.wealth_current %}
-                                    {{ credits_to_add|max:0 }}¢
-                                {% endwith %}
-                            </div>
-                        {% endif %}
-                    </div>
-                {% empty %}
-                    <div>
-                        <em>No gangs added yet</em>
-                    </div>
-                {% endfor %}
-            </div>
-            <div class="mt-3">
-                <button type="submit" class="btn btn-success">Start Campaign</button>
-                <a href="{% url 'core:campaign' campaign.id %}" class="btn btn-link">Cancel</a>
+            <div>
+                <c-btn variant="success" type="submit">
+                    Start Campaign
+                </c-btn>
+                <c-cancel url="{{ campaign_url }}" />
             </div>
         </form>
     </div>

--- a/scripts/raw_markup_baseline.json
+++ b/scripts/raw_markup_baseline.json
@@ -1,9 +1,9 @@
 {
-  "alert": 73,
-  "badge": 83,
+  "alert": 72,
+  "badge": 82,
   "border-rounded": 75,
-  "btn": 423,
-  "include-back": 85,
+  "btn": 421,
+  "include-back": 84,
   "include-cancel": 19,
   "include-form_field": 24,
   "invalid-feedback": 27


### PR DESCRIPTION
The "Start Campaign" confirmation screen had no vertical spacing between its sections, and the gang credit list had columns that didn't line up.

Two independent causes:

1. **No spacing.** The `vstack gap-3` sat on the `<div>` wrapping the `<form>`. A vstack only puts gaps *between its own direct children*, and the form was the only one — so the intro copy, warning callout, section heading, gang list and button row were all flush against each other. The vstack now sits on the form.

2. **Misaligned columns.** Each gang row was a `d-flex justify-content-between`, which distributes free space *within that row*. With gang names of different lengths, the owner name and credit badge landed at a different x position on every row. Replaced with a real table with Gang / Owner / Credits headers, so the columns share widths. The campaign-level `budget > 0` check moved out of the row loop and onto the column.

While in the file: converted the remaining hand-written Bootstrap to the cotton components (`c-back`, `c-callout`, `c-badge`, `c-btn`, `c-cancel`) — this drops 4 raw-markup sites from the baseline — and fixed a heading level skip (`h3` directly under `h1`).

## How to try it

Visit the start screen of any pre-campaign campaign that has gangs added:

`/campaign/<id>/start`

Gang names, owners and credit badges should sit in aligned columns under headers, with even spacing between each block on the page.

## Testing

- 511 campaign tests pass; the 242 cotton call-site gate tests pass.
- Rendered the page and measured it in the browser: every row's cells now share identical x offsets, and the form reports a 16px row gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)