### PR TITLE
fix: stop copied fighters double-counting stat advancements

### DIFF
--- a/gyrinx/core/migrations/0196_convert_legacy_stat_advancements.py
+++ b/gyrinx/core/migrations/0196_convert_legacy_stat_advancements.py
@@ -130,7 +130,7 @@ def convert(apps, schema_editor):
             stat["field_name"]: stat["value"]
             for stat in fighter.content_fighter_statline
         }
-        dirty = False
+        cleared = {}
 
         for stat in STAT_FIELDS:
             counts = grouped.get((fighter.id, stat))
@@ -161,13 +161,11 @@ def convert(apps, schema_editor):
                 if override != expected:
                     left_alone.append((fighter.id, stat, override, "mismatch"))
                     continue
-                setattr(fighter, f"{stat}_override", None)
-                dirty = True
+                cleared[f"{stat}_override"] = None
                 converted_keys.append((fighter.id, stat))
             elif mod_count and override not in (None, ""):
                 if override == after_advancements(stat, base, mod_count):
-                    setattr(fighter, f"{stat}_override", None)
-                    dirty = True
+                    cleared[f"{stat}_override"] = None
                     repaired.append((fighter.id, stat, override, base))
                 else:
                     # Still worth reporting: an override sitting alongside
@@ -178,8 +176,13 @@ def convert(apps, schema_editor):
                         (fighter.id, stat, override, "override-over-mod-advancements")
                     )
 
-        if dirty:
-            fighter.save()
+        if cleared:
+            # Written with an UPDATE rather than save(): saving a fighter fires
+            # post_save receivers that materialise child fighters and bump the
+            # parent list's modified timestamp. Neither belongs in a migration
+            # that is only clearing a stat field, and the timestamp churn would
+            # reorder every affected gang for its owner.
+            ListFighter.objects.filter(pk=fighter.pk).update(**cleared)
 
     # Flip only the advancements whose override was successfully cleared.
     for fighter_id, stat in converted_keys:
@@ -227,6 +230,10 @@ def unconvert(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ("core", "0195_crew_credits_owed"),
+        # Stat classification is read from ContentStat rows, which this content
+        # migration guarantees. Without the dependency the ordering is only
+        # incidental, and running first would leave every stat unclassified.
+        ("content", "0148_ensure_contentstat_entries_exist"),
     ]
 
     operations = [

--- a/gyrinx/core/migrations/0196_convert_legacy_stat_advancements.py
+++ b/gyrinx/core/migrations/0196_convert_legacy_stat_advancements.py
@@ -1,0 +1,212 @@
+"""Move stat advancements off the legacy override fields onto the mod system.
+
+Two disjoint passes, both keyed on (fighter, stat):
+
+1. **Convert** — where legacy advancements exist, the override field holds the
+   value they wrote. Clearing it and flipping the rows to the mod system leaves
+   the displayed statline unchanged, because the mods then recompute exactly
+   what the override held.
+
+2. **Repair** — where *no* legacy advancement exists but the override still
+   matches what one would have written, the override and the mod-system
+   advancements both apply and the improvement is counted twice. Clearing the
+   override drops the duplicate. This state is produced by
+   ``ListFighter.copy_attributes_to()``, which carried the override across
+   while letting the copied advancement default onto the mod system.
+
+Rows whose override cannot be explained by their advancements are left alone
+and reported — they are manual stat edits, not advancement output.
+"""
+
+from django.db import migrations
+
+STAT_FIELDS = [
+    "movement",
+    "weapon_skill",
+    "ballistic_skill",
+    "strength",
+    "toughness",
+    "wounds",
+    "initiative",
+    "attacks",
+    "leadership",
+    "cool",
+    "willpower",
+    "intelligence",
+]
+
+
+def improved(base_value, count):
+    """The value the legacy path would have written after ``count`` improvements.
+
+    Mirrors the arithmetic in the (now removed) legacy branch of
+    ``ListFighterAdvancement.apply_advancement``. Returns None when the base
+    cannot be parsed, which means the override cannot be attributed and the
+    row must be left alone.
+    """
+    if not base_value or count < 1:
+        return None
+
+    # Target rolls improve downwards: "4+" -> "3+"
+    if "+" in base_value:
+        try:
+            return f"{int(base_value.replace('+', '')) - count}+"
+        except ValueError:
+            return None
+
+    try:
+        value = str(int(base_value.replace('"', "")) + count)
+    except ValueError:
+        return None
+
+    # Distances keep their quote mark: '4"' -> '5"'
+    if '"' in base_value:
+        return f'{value}"'
+    return value
+
+
+def _shadowed_by_stat_override(apps):
+    """(fighter_id, stat) pairs whose legacy override field is not being read.
+
+    A fighter on a custom statline reads its per-stat overrides from
+    ``ListFighterStatOverride`` instead of the legacy ``*_override`` field.
+    Where such a row exists the legacy override is inert, and so is the
+    advancement that wrote it — converting it to a modifier would start
+    applying an improvement that currently does nothing, moving the fighter's
+    displayed stat. These carry an override in both stores and need
+    reconciling by hand.
+    """
+    StatOverride = apps.get_model("core", "ListFighterStatOverride")
+    return {
+        (fighter_id, field_name)
+        for fighter_id, field_name in StatOverride.objects.values_list(
+            "list_fighter_id", "content_stat__stat__field_name"
+        )
+    }
+
+
+def _advancements_by_fighter_stat(Advancement):
+    """Live stat advancements grouped as {(fighter_id, stat): [legacy, mod]}."""
+    grouped = {}
+    rows = Advancement.objects.filter(
+        advancement_type="stat", archived=False
+    ).values_list("fighter_id", "stat_increased", "uses_mod_system")
+    for fighter_id, stat, uses_mod_system in rows:
+        if not stat:
+            continue
+        counts = grouped.setdefault((fighter_id, stat), [0, 0])
+        counts[1 if uses_mod_system else 0] += 1
+    return grouped
+
+
+def convert(apps, schema_editor):
+    Advancement = apps.get_model("core", "ListFighterAdvancement")
+    ListFighter = apps.get_model("core", "ListFighter")
+
+    grouped = _advancements_by_fighter_stat(Advancement)
+    shadowed = _shadowed_by_stat_override(apps)
+    fighter_ids = {fighter_id for fighter_id, _ in grouped}
+
+    converted_keys = []
+    repaired = []
+    unattributed = []
+
+    fighters = ListFighter.objects.filter(id__in=fighter_ids).select_related(
+        "content_fighter"
+    )
+    for fighter in fighters.iterator():
+        dirty = False
+        for stat in STAT_FIELDS:
+            counts = grouped.get((fighter.id, stat))
+            if counts is None:
+                continue
+            legacy_count, mod_count = counts
+
+            if (fighter.id, stat) in shadowed:
+                unattributed.append(
+                    (fighter.id, stat, None, None, "shadowed-by-stat-override")
+                )
+                continue
+
+            override = getattr(fighter, f"{stat}_override", None)
+            base = getattr(fighter.content_fighter, stat, None)
+
+            if legacy_count:
+                # Pass 1: the override is this fighter's legacy advancement
+                # output. Only clear it if the arithmetic agrees — otherwise
+                # something else wrote the value and converting would move the
+                # displayed stat.
+                if override in (None, ""):
+                    unattributed.append(
+                        (fighter.id, stat, override, base, "no-override")
+                    )
+                    continue
+                if override != improved(base, legacy_count):
+                    unattributed.append((fighter.id, stat, override, base, "mismatch"))
+                    continue
+                setattr(fighter, f"{stat}_override", None)
+                dirty = True
+                converted_keys.append((fighter.id, stat))
+            elif mod_count and override not in (None, ""):
+                # Pass 2: no legacy advancement, yet the override looks exactly
+                # like advancement output — the improvement is being applied
+                # twice. Anything else is a manual edit and stays.
+                if override == improved(base, mod_count):
+                    setattr(fighter, f"{stat}_override", None)
+                    dirty = True
+                    repaired.append((fighter.id, stat, override, base, mod_count))
+
+        if dirty:
+            fighter.save()
+
+    # Flip only the advancements whose override was successfully cleared.
+    for fighter_id, stat in converted_keys:
+        Advancement.objects.filter(
+            fighter_id=fighter_id,
+            stat_increased=stat,
+            advancement_type="stat",
+            archived=False,
+            uses_mod_system=False,
+        ).update(uses_mod_system=True)
+
+    # Archived legacy rows never reach the statline, so they carry no override
+    # implication and can move across wholesale.
+    archived_flipped = Advancement.objects.filter(
+        uses_mod_system=False, archived=True
+    ).update(uses_mod_system=True)
+
+    print(
+        f"\n  converted {len(converted_keys)} fighter/stat pairs to the mod system"
+        f"\n  repaired {len(repaired)} double-counted stats"
+        f"\n  flipped {archived_flipped} archived legacy advancements"
+        f"\n  left {len(unattributed)} unattributed overrides untouched"
+    )
+    for row in repaired:
+        print(
+            f"  repaired: fighter={row[0]} stat={row[1]} was={row[2]!r} base={row[3]!r}"
+        )
+    for row in unattributed:
+        print(
+            f"  unattributed: fighter={row[0]} stat={row[1]} override={row[2]!r} base={row[3]!r} ({row[4]})"
+        )
+
+
+def unconvert(apps, schema_editor):
+    """Deliberately does nothing.
+
+    Nothing records which advancements this migration flipped, so a reverse
+    pass cannot tell them apart from the majority that were already on the mod
+    system. Flipping every stat advancement back to the legacy system would
+    corrupt those, which is far worse than being unable to reverse. Restore
+    from a backup if this genuinely needs undoing.
+    """
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0195_crew_credits_owed"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert, unconvert),
+    ]

--- a/gyrinx/core/migrations/0196_convert_legacy_stat_advancements.py
+++ b/gyrinx/core/migrations/0196_convert_legacy_stat_advancements.py
@@ -4,18 +4,27 @@ Two disjoint passes, both keyed on (fighter, stat):
 
 1. **Convert** — where legacy advancements exist, the override field holds the
    value they wrote. Clearing it and flipping the rows to the mod system leaves
-   the displayed statline unchanged, because the mods then recompute exactly
+   the displayed statline unchanged, provided the modifiers recompute exactly
    what the override held.
 
-2. **Repair** — where *no* legacy advancement exists but the override still
-   matches what one would have written, the override and the mod-system
-   advancements both apply and the improvement is counted twice. Clearing the
-   override drops the duplicate. This state is produced by
-   ``ListFighter.copy_attributes_to()``, which carried the override across
-   while letting the copied advancement default onto the mod system.
+2. **Repair** — where *no* legacy advancement exists but the override matches
+   what the modifiers produce anyway, the override and the advancements both
+   apply and the improvement is counted twice. Clearing the override drops the
+   duplicate. This state is produced by ``ListFighter.copy_attributes_to()``,
+   which carried the override across while letting the copied advancement
+   default onto the mod system.
 
-Rows whose override cannot be explained by their advancements are left alone
-and reported — they are manual stat edits, not advancement output.
+Anything else is left alone and reported.
+
+Both passes gate on what the mod system will actually compute — never on a
+re-derivation of what the legacy code would have written. The two disagree.
+The legacy path read the base from the fighter's stat columns and decided
+direction and formatting from the *shape* of that string, so a Ballistic Skill
+stored as "4" was "improved" to "5". The mod system reads the base from the
+fighter's statline, which for a custom statline is a different value entirely
+("4+"), and classifies the stat from its ``ContentStat`` row, giving "3+".
+Gating on the legacy formula therefore passed fighters whose displayed stat
+would move — the exact thing these passes exist to prevent.
 """
 
 from django.db import migrations
@@ -36,47 +45,15 @@ STAT_FIELDS = [
 ]
 
 
-def improved(base_value, count):
-    """The value the legacy path would have written after ``count`` improvements.
-
-    Mirrors the arithmetic in the (now removed) legacy branch of
-    ``ListFighterAdvancement.apply_advancement``. Returns None when the base
-    cannot be parsed, which means the override cannot be attributed and the
-    row must be left alone.
-    """
-    if not base_value or count < 1:
-        return None
-
-    # Target rolls improve downwards: "4+" -> "3+"
-    if "+" in base_value:
-        try:
-            return f"{int(base_value.replace('+', '')) - count}+"
-        except ValueError:
-            return None
-
-    try:
-        value = str(int(base_value.replace('"', "")) + count)
-    except ValueError:
-        return None
-
-    # Distances keep their quote mark: '4"' -> '5"'
-    if '"' in base_value:
-        return f'{value}"'
-    return value
-
-
-def _shadowed_by_stat_override(apps):
+def _shadowed_by_stat_override(StatOverride):
     """(fighter_id, stat) pairs whose legacy override field is not being read.
 
     A fighter on a custom statline reads its per-stat overrides from
     ``ListFighterStatOverride`` instead of the legacy ``*_override`` field.
     Where such a row exists the legacy override is inert, and so is the
-    advancement that wrote it — converting it to a modifier would start
-    applying an improvement that currently does nothing, moving the fighter's
-    displayed stat. These carry an override in both stores and need
-    reconciling by hand.
+    advancement that wrote it — converting would start applying an improvement
+    that currently does nothing, moving the fighter's displayed stat.
     """
-    StatOverride = apps.get_model("core", "ListFighterStatOverride")
     return {
         (fighter_id, field_name)
         for fighter_id, field_name in StatOverride.objects.values_list(
@@ -100,22 +77,61 @@ def _advancements_by_fighter_stat(Advancement):
 
 
 def convert(apps, schema_editor):
-    Advancement = apps.get_model("core", "ListFighterAdvancement")
-    ListFighter = apps.get_model("core", "ListFighter")
+    # Deliberately uses the live models rather than the historical ones this
+    # migration is handed. The question being asked — "will this fighter's card
+    # still show the same value afterwards?" — is answered by how the app
+    # computes a statline today: which base it reads, and how it classifies the
+    # stat. Re-deriving that here is precisely what an earlier revision of this
+    # migration got wrong.
+    from gyrinx.content.models.statline import ContentStat
+    from gyrinx.core.models.list import ListFighter, ListFighterStatOverride
+    from gyrinx.core.models.list.advancement import (
+        AdvancementStatMod,
+        ListFighterAdvancement,
+    )
+    from gyrinx.core.models.util import ModContext
 
-    grouped = _advancements_by_fighter_stat(Advancement)
-    shadowed = _shadowed_by_stat_override(apps)
+    grouped = _advancements_by_fighter_stat(ListFighterAdvancement)
+    shadowed = _shadowed_by_stat_override(ListFighterStatOverride)
     fighter_ids = {fighter_id for fighter_id, _ in grouped}
+
+    mod_ctx = ModContext(
+        all_stats={
+            stat["field_name"]: stat for stat in ContentStat.objects.all().values()
+        }
+    )
+
+    def after_advancements(stat, base_value, count):
+        """What the mod system shows for ``count`` advancements on ``base_value``.
+
+        Returns None if the value cannot be modified. Stats are free text and
+        production holds malformed ones (a stray underscore, say), which makes
+        applying a modifier raise. That must not abort the deploy — an
+        unusable value simply means this pair cannot be verified.
+        """
+        mod = AdvancementStatMod(stat)
+        value = base_value
+        try:
+            for _ in range(count):
+                value = mod.apply(value, mod_ctx)
+        except (ValueError, TypeError):
+            return None
+        return value
 
     converted_keys = []
     repaired = []
-    unattributed = []
+    left_alone = []
 
     fighters = ListFighter.objects.filter(id__in=fighter_ids).select_related(
         "content_fighter"
     )
     for fighter in fighters.iterator():
+        statline_base = {
+            stat["field_name"]: stat["value"]
+            for stat in fighter.content_fighter_statline
+        }
         dirty = False
+
         for stat in STAT_FIELDS:
             counts = grouped.get((fighter.id, stat))
             if counts is None:
@@ -123,45 +139,51 @@ def convert(apps, schema_editor):
             legacy_count, mod_count = counts
 
             if (fighter.id, stat) in shadowed:
-                unattributed.append(
-                    (fighter.id, stat, None, None, "shadowed-by-stat-override")
-                )
+                left_alone.append((fighter.id, stat, None, "shadowed-by-stat-override"))
                 continue
 
             override = getattr(fighter, f"{stat}_override", None)
-            base = getattr(fighter.content_fighter, stat, None)
+            base = statline_base.get(stat)
+            if base is None:
+                left_alone.append((fighter.id, stat, override, "stat-not-in-statline"))
+                continue
 
             if legacy_count:
-                # Pass 1: the override is this fighter's legacy advancement
-                # output. Only clear it if the arithmetic agrees — otherwise
-                # something else wrote the value and converting would move the
-                # displayed stat.
                 if override in (None, ""):
-                    unattributed.append(
-                        (fighter.id, stat, override, base, "no-override")
+                    left_alone.append((fighter.id, stat, override, "no-override"))
+                    continue
+                expected = after_advancements(stat, base, legacy_count)
+                if expected is None:
+                    left_alone.append(
+                        (fighter.id, stat, override, "unmodifiable-value")
                     )
                     continue
-                if override != improved(base, legacy_count):
-                    unattributed.append((fighter.id, stat, override, base, "mismatch"))
+                if override != expected:
+                    left_alone.append((fighter.id, stat, override, "mismatch"))
                     continue
                 setattr(fighter, f"{stat}_override", None)
                 dirty = True
                 converted_keys.append((fighter.id, stat))
             elif mod_count and override not in (None, ""):
-                # Pass 2: no legacy advancement, yet the override looks exactly
-                # like advancement output — the improvement is being applied
-                # twice. Anything else is a manual edit and stays.
-                if override == improved(base, mod_count):
+                if override == after_advancements(stat, base, mod_count):
                     setattr(fighter, f"{stat}_override", None)
                     dirty = True
-                    repaired.append((fighter.id, stat, override, base, mod_count))
+                    repaired.append((fighter.id, stat, override, base))
+                else:
+                    # Still worth reporting: an override sitting alongside
+                    # mod-system advancements is being applied on top of them,
+                    # so the stat may be inflated even though we cannot prove
+                    # by how much.
+                    left_alone.append(
+                        (fighter.id, stat, override, "override-over-mod-advancements")
+                    )
 
         if dirty:
             fighter.save()
 
     # Flip only the advancements whose override was successfully cleared.
     for fighter_id, stat in converted_keys:
-        Advancement.objects.filter(
+        ListFighterAdvancement.objects.filter(
             fighter_id=fighter_id,
             stat_increased=stat,
             advancement_type="stat",
@@ -171,7 +193,7 @@ def convert(apps, schema_editor):
 
     # Archived legacy rows never reach the statline, so they carry no override
     # implication and can move across wholesale.
-    archived_flipped = Advancement.objects.filter(
+    archived_flipped = ListFighterAdvancement.objects.filter(
         uses_mod_system=False, archived=True
     ).update(uses_mod_system=True)
 
@@ -179,15 +201,15 @@ def convert(apps, schema_editor):
         f"\n  converted {len(converted_keys)} fighter/stat pairs to the mod system"
         f"\n  repaired {len(repaired)} double-counted stats"
         f"\n  flipped {archived_flipped} archived legacy advancements"
-        f"\n  left {len(unattributed)} unattributed overrides untouched"
+        f"\n  left {len(left_alone)} pairs alone"
     )
-    for row in repaired:
+    for fighter_id, stat, override, base in repaired:
         print(
-            f"  repaired: fighter={row[0]} stat={row[1]} was={row[2]!r} base={row[3]!r}"
+            f"  repaired: fighter={fighter_id} stat={stat} was={override!r} base={base!r}"
         )
-    for row in unattributed:
+    for fighter_id, stat, override, reason in left_alone:
         print(
-            f"  unattributed: fighter={row[0]} stat={row[1]} override={row[2]!r} base={row[3]!r} ({row[4]})"
+            f"  left alone: fighter={fighter_id} stat={stat} override={override!r} ({reason})"
         )
 
 

--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -2697,6 +2697,10 @@ class ListFighter(AppBase):
                 description=advancement.description,
                 xp_cost=advancement.xp_cost,
                 cost_increase=advancement.cost_increase,
+                # Must travel too: the stat overrides copied above already hold
+                # what a legacy advancement wrote, so letting the copy default
+                # onto the mod system would apply the same improvement twice.
+                uses_mod_system=advancement.uses_mod_system,
                 owner=target_fighter.owner,
             )
 

--- a/gyrinx/core/tests/test_migration_convert_legacy_advancements.py
+++ b/gyrinx/core/tests/test_migration_convert_legacy_advancements.py
@@ -4,10 +4,11 @@ import pytest
 from django.apps import apps
 
 from gyrinx.core.models import ListFighter, ListFighterAdvancement
+from gyrinx.models import FighterCategoryChoices
 
 migration = __import__(
     "gyrinx.core.migrations.0196_convert_legacy_stat_advancements",
-    fromlist=["convert", "improved"],
+    fromlist=["convert"],
 )
 
 
@@ -32,18 +33,54 @@ def make_advancement(fighter, user, stat, *, uses_mod_system):
     )
 
 
-def test_improved_replicates_legacy_arithmetic():
-    # Target rolls improve downwards
-    assert migration.improved("4+", 1) == "3+"
-    assert migration.improved("4+", 2) == "2+"
-    # Distances keep their quote mark
-    assert migration.improved('4"', 1) == '5"'
-    # Plain values just count up
-    assert migration.improved("3", 2) == "5"
-    # Anything unparseable cannot be attributed
-    assert migration.improved("-", 1) is None
-    assert migration.improved("", 1) is None
-    assert migration.improved("4+", 0) is None
+@pytest.mark.django_db
+def test_legacy_value_written_from_a_differently_shaped_base_is_left_alone(
+    user, make_list, make_list_fighter, make_content_fighter, content_house
+):
+    """The legacy arithmetic and the mod system do not always agree.
+
+    Where a target roll is stored without its "+", the legacy code read the
+    string shape and counted upwards, writing a worse value. The mod system
+    classifies the stat from its definition and counts downwards. Converting
+    such a fighter would move its displayed stat, so it must be skipped.
+    """
+    # Ballistic Skill stored as "4" rather than "4+"
+    cf = make_content_fighter(
+        type="Odd Statline Fighter",
+        category=FighterCategoryChoices.GANGER,
+        house=content_house,
+        base_cost=50,
+        movement='4"',
+        weapon_skill="4+",
+        ballistic_skill="4",
+        strength="3",
+        toughness="3",
+        wounds="1",
+        initiative="4+",
+        attacks="1",
+        leadership="7",
+        cool="7",
+        willpower="7",
+        intelligence="7",
+    )
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Odd Fighter", content_fighter=cf)
+
+    # The legacy path saw no "+", so it counted up: 4 -> 5
+    make_advancement(fighter, user, "ballistic_skill", uses_mod_system=False)
+    fighter.ballistic_skill_override = "5"
+    fighter.save()
+
+    before = stat_value(fighter, "ballistic_skill")
+
+    migration.convert(apps, None)
+
+    fighter.refresh_from_db()
+    assert fighter.ballistic_skill_override == "5"
+    assert ListFighterAdvancement.objects.filter(
+        fighter=fighter, uses_mod_system=False
+    ).exists()
+    assert stat_value(fighter, "ballistic_skill") == before
 
 
 @pytest.mark.django_db
@@ -182,6 +219,49 @@ def test_advancements_shadowed_by_a_stat_override_are_left_alone(
         fighter=fighter, uses_mod_system=False
     ).exists()
     assert stat_value(fighter, "weapon_skill") == before
+
+
+@pytest.mark.django_db
+def test_a_malformed_stat_value_is_survived(
+    user, make_list, make_list_fighter, make_content_fighter, content_house
+):
+    """Stats are free text, and production holds values that cannot be modified.
+
+    Applying a modifier to one raises, which must not abort the migration —
+    the pair simply cannot be verified, so it is left alone.
+    """
+    cf = make_content_fighter(
+        type="Malformed Fighter",
+        category=FighterCategoryChoices.GANGER,
+        house=content_house,
+        base_cost=50,
+        movement='4"',
+        weapon_skill="4+",
+        ballistic_skill="4+",
+        strength="3",
+        toughness="3",
+        wounds="1",
+        initiative="4+",
+        attacks="1",
+        leadership="7_",  # a real shape seen in production
+        cool="7",
+        willpower="7",
+        intelligence="7",
+    )
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Malformed Fighter", content_fighter=cf)
+
+    make_advancement(fighter, user, "leadership", uses_mod_system=False)
+    fighter.leadership_override = "8"
+    fighter.save()
+
+    migration.convert(apps, None)
+
+    fighter.refresh_from_db()
+    assert fighter.leadership_override == "8"
+    assert ListFighterAdvancement.objects.filter(
+        fighter=fighter, uses_mod_system=False
+    ).exists()
 
 
 @pytest.mark.django_db

--- a/gyrinx/core/tests/test_migration_convert_legacy_advancements.py
+++ b/gyrinx/core/tests/test_migration_convert_legacy_advancements.py
@@ -1,0 +1,207 @@
+"""Tests for the 0196 migration that moves stat advancements onto the mod system."""
+
+import pytest
+from django.apps import apps
+
+from gyrinx.core.models import ListFighter, ListFighterAdvancement
+
+migration = __import__(
+    "gyrinx.core.migrations.0196_convert_legacy_stat_advancements",
+    fromlist=["convert", "improved"],
+)
+
+
+def stat_value(fighter, field_name):
+    """The value shown for a stat on the fighter's statline."""
+    fresh = ListFighter.objects.get(pk=fighter.pk)
+    for stat in fresh.statline:
+        if stat.field_name == field_name:
+            return stat.value
+    raise AssertionError(f"{field_name} not in statline")
+
+
+def make_advancement(fighter, user, stat, *, uses_mod_system):
+    return ListFighterAdvancement.objects.create(
+        fighter=fighter,
+        advancement_type=ListFighterAdvancement.ADVANCEMENT_STAT,
+        stat_increased=stat,
+        uses_mod_system=uses_mod_system,
+        xp_cost=5,
+        cost_increase=5,
+        owner=user,
+    )
+
+
+def test_improved_replicates_legacy_arithmetic():
+    # Target rolls improve downwards
+    assert migration.improved("4+", 1) == "3+"
+    assert migration.improved("4+", 2) == "2+"
+    # Distances keep their quote mark
+    assert migration.improved('4"', 1) == '5"'
+    # Plain values just count up
+    assert migration.improved("3", 2) == "5"
+    # Anything unparseable cannot be attributed
+    assert migration.improved("-", 1) is None
+    assert migration.improved("", 1) is None
+    assert migration.improved("4+", 0) is None
+
+
+@pytest.mark.django_db
+def test_convert_leaves_the_displayed_statline_untouched(
+    user, make_list, make_list_fighter
+):
+    """Converting legacy advancements must not move the fighter's stats."""
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Legacy Fighter")
+
+    # Base weapon skill is 5+; two legacy advancements wrote 3+ into the override.
+    make_advancement(fighter, user, "weapon_skill", uses_mod_system=False)
+    make_advancement(fighter, user, "weapon_skill", uses_mod_system=False)
+    fighter.weapon_skill_override = "3+"
+    fighter.save()
+
+    assert stat_value(fighter, "weapon_skill") == "3+"
+
+    migration.convert(apps, None)
+
+    fighter.refresh_from_db()
+    assert fighter.weapon_skill_override is None
+    assert not ListFighterAdvancement.objects.filter(
+        fighter=fighter, uses_mod_system=False
+    ).exists()
+    # Same value, now computed from the advancements rather than stored
+    assert stat_value(fighter, "weapon_skill") == "3+"
+
+
+@pytest.mark.django_db
+def test_repair_drops_a_double_counted_improvement(user, make_list, make_list_fighter):
+    """An override duplicating a mod-system advancement is applied twice."""
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Copied Fighter")
+
+    # What copy_attributes_to used to produce: the override a legacy
+    # advancement wrote, alongside an advancement on the mod system.
+    make_advancement(fighter, user, "ballistic_skill", uses_mod_system=True)
+    fighter.ballistic_skill_override = "4+"
+    fighter.save()
+
+    # Base is 5+ and one advancement was taken, so 4+ is correct — but the
+    # override and the mod both apply, so the fighter shows 3+.
+    assert stat_value(fighter, "ballistic_skill") == "3+"
+
+    migration.convert(apps, None)
+
+    fighter.refresh_from_db()
+    assert fighter.ballistic_skill_override is None
+    assert stat_value(fighter, "ballistic_skill") == "4+"
+
+
+@pytest.mark.django_db
+def test_manual_stat_edits_are_left_alone(user, make_list, make_list_fighter):
+    """An override that no advancement could have written is a manual edit."""
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Hand Edited Fighter")
+
+    # One legacy advancement on a 5+ base would have written 4+, not 2+.
+    make_advancement(fighter, user, "weapon_skill", uses_mod_system=False)
+    fighter.weapon_skill_override = "2+"
+    fighter.save()
+
+    migration.convert(apps, None)
+
+    fighter.refresh_from_db()
+    assert fighter.weapon_skill_override == "2+"
+    # The advancement stays legacy, so the value is not applied twice
+    assert ListFighterAdvancement.objects.filter(
+        fighter=fighter, uses_mod_system=False
+    ).exists()
+    assert stat_value(fighter, "weapon_skill") == "2+"
+
+
+@pytest.mark.django_db
+def test_repair_ignores_an_unrelated_override(user, make_list, make_list_fighter):
+    """A manual edit alongside a mod-system advancement is legitimate."""
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Mixed Fighter")
+
+    make_advancement(fighter, user, "toughness", uses_mod_system=True)
+    # Base toughness is 3, one advancement would give 4 — 6 is a manual edit.
+    fighter.toughness_override = "6"
+    fighter.save()
+
+    migration.convert(apps, None)
+
+    fighter.refresh_from_db()
+    assert fighter.toughness_override == "6"
+
+
+@pytest.mark.django_db
+def test_advancements_shadowed_by_a_stat_override_are_left_alone(
+    user, make_list, make_list_fighter, content_fighter
+):
+    """A fighter reading its stats from the newer override store is skipped.
+
+    Its legacy override — and so the advancement that wrote it — is inert.
+    Converting would start applying an improvement that currently does
+    nothing, moving the displayed stat.
+    """
+    from gyrinx.content.models.statline import (
+        ContentStat,
+        ContentStatline,
+        ContentStatlineType,
+        ContentStatlineTypeStat,
+    )
+    from gyrinx.core.models.list import ListFighterStatOverride
+
+    statline_type = ContentStatlineType.objects.create(name="Custom Type")
+    stat = ContentStat.objects.get(field_name="weapon_skill")
+    type_stat = ContentStatlineTypeStat.objects.create(
+        statline_type=statline_type, stat=stat, position=1
+    )
+    statline = ContentStatline.objects.create(
+        content_fighter=content_fighter, statline_type=statline_type
+    )
+    statline.stats.create(statline_type_stat=type_stat, value="5+")
+
+    lst = make_list("Test List")
+    fighter = make_list_fighter(lst, "Custom Statline Fighter")
+
+    make_advancement(fighter, user, "weapon_skill", uses_mod_system=False)
+    fighter.weapon_skill_override = "4+"
+    fighter.save()
+    ListFighterStatOverride.objects.create(
+        list_fighter=fighter, content_stat=type_stat, value="3+", owner=user
+    )
+
+    before = stat_value(fighter, "weapon_skill")
+
+    migration.convert(apps, None)
+
+    fighter.refresh_from_db()
+    assert ListFighterAdvancement.objects.filter(
+        fighter=fighter, uses_mod_system=False
+    ).exists()
+    assert stat_value(fighter, "weapon_skill") == before
+
+
+@pytest.mark.django_db
+def test_copy_attributes_to_keeps_advancements_on_the_same_system(
+    user, make_list, make_list_fighter
+):
+    """Copying must not flip a legacy advancement onto the mod system.
+
+    The copy carries the override across, so a flipped advancement would apply
+    the same improvement twice on the copy.
+    """
+    lst = make_list("Test List")
+    source = make_list_fighter(lst, "Source Fighter")
+    make_advancement(source, user, "weapon_skill", uses_mod_system=False)
+    source.weapon_skill_override = "4+"
+    source.save()
+
+    target = make_list_fighter(lst, "Target Fighter")
+    source.copy_attributes_to(target)
+
+    copied = ListFighterAdvancement.objects.get(fighter=target)
+    assert copied.uses_mod_system is False
+    assert stat_value(target, "weapon_skill") == stat_value(source, "weapon_skill")


### PR DESCRIPTION
When a fighter takes a "characteristic increase" advancement, the improvement can
be recorded two ways. The old way wrote the new value into a text field on the
fighter (`ballistic_skill_override = "4+"`). The new way stores nothing and
recomputes the improvement at display time. A per-row flag says which.

**The bug:** copying a fighter carried those override fields across, but recreated
the advancement without the flag — so the copy defaulted onto the new system. The
override already held what that advancement had written, so both applied. A copied
fighter with one Ballistic Skill advancement showed `3+` where it should show `4+`.

That copy path was also the only remaining route by which advancements on the old
system were still being created — 13 new ones last month, long after new
advancements started defaulting to the new system.

## Summary

- `copy_attributes_to()` now carries the flag across, matching what `clone()`
  already did. This stops both the double-counting and the trickle of new
  old-system rows.
- Migration `core.0196` moves existing stat advancements onto the new system and
  repairs the fighters already double-counting. Two disjoint passes keyed on
  (fighter, stat): **convert** where old-system advancements wrote the override
  (clearing it and flipping the rows leaves the displayed stat identical, because
  the recomputed value equals what the override held), and **repair** where an
  override duplicates a new-system advancement (clearing it drops the duplicate).
- Overrides that can't be attributed to advancements are **left alone and
  reported**, not guessed at. Three kinds: manual stat edits, advancements with no
  override, and fighters whose custom statline reads the newer per-stat override
  store — there the old override, and the advancement that wrote it, are inert, so
  converting would start applying an improvement that currently does nothing.
- The reverse is deliberately a no-op. Nothing records which rows were flipped, so
  a reverse pass couldn't distinguish them from the ~5,500 already on the new
  system, and flipping those back would corrupt them. Being unable to reverse is
  much safer than reversing wrongly.

## What this does to production

Dry-run against production, read-only:

| Outcome | Fighter/stat pairs |
|---|---|
| Convert — no visible change | 2,306 |
| Repair a double-counted stat | 23 |
| Left alone — override doesn't match its advancements | 63 |
| Left alone — override sitting on top of mod-system advancements | 43 |
| Left alone — no override to attribute | 35 |
| Left alone — shadowed by the newer override store | 12 |
| Left alone — stat not in the fighter's statline | 2 |

The 23 repairs are the only visible change: each drops one improvement that was
being applied twice. The 155 left alone keep their advancements on the old system,
so retiring that code path (the next piece of work) needs them resolved first. All
of them are named in the migration's output, including the 43 that an earlier
revision skipped silently.

## Test plan

- [x] `pytest -n auto` — 3977 passed, 13 skipped
- [x] New tests cover both passes, all three left-alone cases, and the copy fix.
      The repair test reproduces the production bug (asserts the fighter shows
      `3+`) and confirms the migration corrects it to `4+`.
- [x] **Verified against real data:** ran the migration on a database forked from
      the content template and diffed every fighter's rendered statline before and
      after — 16 conversions, **zero displayed stats moved**. An earlier revision
      did move two stats; that is what surfaced the shadowed-override case now
      handled explicitly.
- [x] Full CI stack locally: ruff, djlint, prettier, migration conflict check,
      `makemigrations --check`, bandit (exit 0)

Refs #1861

## On deploy — the migration log is the only record

The migration prints one line per repair and per skip. Once it has run, the 23 repaired
fighter/stat pairs cannot be identified again, because the evidence is the override it
cleared. Recording them durably was considered and deliberately not done, so the deploy
log is worth keeping if you want to see what moved.

The 108 pairs this migration leaves alone, and notifying players about stat changes, are
tracked in #2070.

