### PR TITLE
feat: route admin login through allauth and require 2FA

### DIFF
--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -65,6 +65,25 @@ Bandit is configured in `pyproject.toml`:
 - reCAPTCHA verification for registration (when enabled)
 - Password validation using Django validators
 
+### Django admin access
+
+The admin has no login form of its own. `/admin/login/` redirects into the allauth
+login flow, so an admin session is created by the same code path — and the same
+second-factor challenge — as an ordinary app session. See `gyrinx/admin_site.py`.
+
+Reaching the admin also requires a second factor, unless `ADMIN_REQUIRE_MFA` is set
+to `False` (the default in local development, where seeded users have no
+authenticator). Staff who do not meet the requirement are redirected into allauth to
+set up TOTP or to enter a code — they are never locked out. The requirement covers
+`/admin/doc/` as well as the admin proper.
+
+Two consequences worth knowing:
+
+- Enabling this in an environment where staff sign in with a password only will send
+  them through TOTP setup on their next visit to the admin.
+- `MFA_SUPPORTED_TYPES` is TOTP-only, so there are no recovery codes. Losing the
+  authenticator means an admin has to reset it from the database.
+
 ### Pre-commit Hooks
 
 Security checks run automatically on commit via pre-commit:

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -71,11 +71,16 @@ The admin has no login form of its own. `/admin/login/` redirects into the allau
 login flow, so an admin session is created by the same code path — and the same
 second-factor challenge — as an ordinary app session. See `gyrinx/admin_site.py`.
 
-Reaching the admin also requires a second factor, unless `ADMIN_REQUIRE_MFA` is set
-to `False` (the default in local development, where seeded users have no
-authenticator). Staff who do not meet the requirement are redirected into allauth to
-set up TOTP or to enter a code — they are never locked out. The requirement covers
-`/admin/doc/` as well as the admin proper.
+Reaching the admin also requires a second factor. Left unset, `ADMIN_REQUIRE_MFA`
+follows `DEBUG`: on in production, off locally, where each worktree has its own
+database and requiring TOTP would mean enrolling a separate authenticator per
+worktree. Set `ADMIN_REQUIRE_MFA=True` to exercise the production gate locally, or
+`False` to switch it off. Only the second factor is relaxed — admin login goes
+through allauth in every environment.
+
+Staff who do not meet the requirement are redirected into allauth to set up TOTP or
+to enter a code — they are never locked out. The requirement covers `/admin/doc/` as
+well as the admin proper.
 
 Two consequences worth knowing:
 

--- a/gyrinx/admin_site.py
+++ b/gyrinx/admin_site.py
@@ -91,6 +91,42 @@ def _mfa_gate_url(request):
     return None
 
 
+def admin_second_factor_required(user) -> bool:
+    """Whether this user must prove a second factor to reach the admin."""
+    from allauth.mfa.utils import is_mfa_enabled
+
+    return (
+        admin_requires_mfa()
+        and user.is_authenticated
+        and user.is_active
+        and user.is_staff
+        and is_mfa_enabled(user)
+    )
+
+
+def is_admin_bound_request(request) -> bool:
+    """Whether this request is a step on the way into the admin.
+
+    Reads the ``next`` target, so it holds for allauth's own pages while they
+    are standing between the visitor and an admin URL.
+    """
+    if request is None:
+        return False
+
+    next_url = request.GET.get(REDIRECT_FIELD_NAME)
+    if not next_url and request.method == "POST":
+        next_url = request.POST.get(REDIRECT_FIELD_NAME)
+    if not next_url:
+        return False
+    if not url_has_allowed_host_and_scheme(
+        next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return False
+    return next_url.startswith(reverse("admin:index"))
+
+
 def admin_gated_patterns(url_patterns):
     """Put ``url_patterns`` behind the same gate as the admin's own views.
 

--- a/gyrinx/admin_site.py
+++ b/gyrinx/admin_site.py
@@ -1,0 +1,208 @@
+"""Admin site that hands authentication to django-allauth.
+
+Django's own admin login view authenticates against a username and password and
+nothing else. It knows nothing about allauth's login stages, so a staff account
+with TOTP configured could sign in at ``/admin/login/`` without ever being asked
+for a second factor — the app's front door is protected, the admin's is not.
+
+``GyrinxAdminSite`` closes that door. The admin login view never renders a form:
+it only redirects into the allauth flow, so every admin session is created by the
+same code path (and the same second-factor challenge) as every app session.
+
+On top of that, when ``ADMIN_REQUIRE_MFA`` is on, reaching the admin requires
+that the staff user actually *has* a second factor configured, and that the
+current session was authenticated with it. Users who fall short are sent to
+allauth to set up TOTP or to enter a code, rather than being locked out.
+"""
+
+from functools import wraps
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.admin.apps import AdminConfig
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
+
+#: Message shown when a staff user has no second factor configured at all.
+MFA_SETUP_MESSAGE = (
+    "Two-factor authentication is required to use the Gyrinx admin. "
+    "Set up an authenticator app to continue."
+)
+
+#: Message shown when a staff user has a second factor, but this session was
+#: signed in without using it (e.g. a session that predates the setup).
+MFA_CHALLENGE_MESSAGE = (
+    "Enter your two-factor authentication code to continue to the Gyrinx admin."
+)
+
+
+_UNSET = object()
+
+
+def admin_requires_mfa() -> bool:
+    """Whether the admin is gated on a completed second-factor challenge."""
+    return getattr(settings, "ADMIN_REQUIRE_MFA", True)
+
+
+def session_authenticated_with_mfa(request) -> bool:
+    """Whether this session completed an allauth MFA challenge.
+
+    allauth logs every authentication step it performs into the session, so this
+    is a statement about *this* session rather than about the user's settings —
+    a session created before the user enabled TOTP does not count.
+    """
+    from allauth.account.authentication import get_authentication_records
+
+    return any(
+        record.get("method") == "mfa" for record in get_authentication_records(request)
+    )
+
+
+def mfa_gate_url(request):
+    """The allauth URL this staff user must visit to satisfy 2FA, or ``None``.
+
+    ``None`` means the request already satisfies the requirement (or the
+    requirement is switched off).
+
+    Cached on the request: ``has_permission`` is consulted several times while
+    rendering an admin page, and the authenticator lookup is a query.
+    """
+    cached = getattr(request, "_admin_mfa_gate_url", _UNSET)
+    if cached is not _UNSET:
+        return cached
+
+    request._admin_mfa_gate_url = _mfa_gate_url(request)
+    return request._admin_mfa_gate_url
+
+
+def _mfa_gate_url(request):
+    from allauth.mfa.utils import is_mfa_enabled
+
+    if not admin_requires_mfa():
+        return None
+    if not is_mfa_enabled(request.user):
+        return reverse("mfa_activate_totp")
+    if not session_authenticated_with_mfa(request):
+        return reverse("mfa_reauthenticate")
+    return None
+
+
+def admin_gated_patterns(url_patterns):
+    """Put ``url_patterns`` behind the same gate as the admin's own views.
+
+    ``AdminSite.admin_view`` protects everything routed through the site itself,
+    but admin-adjacent URLconfs (admindocs) are decorated with Django's
+    ``staff_member_required``, which only knows about ``is_staff``. Wrapping
+    their callbacks sends visitors through the admin login view instead, so
+    there is one place that decides who gets in.
+    """
+    from django.urls import URLPattern
+
+    return [
+        URLPattern(
+            pattern.pattern,
+            _admin_access_required(pattern.callback),
+            pattern.default_args,
+            pattern.name,
+        )
+        for pattern in url_patterns
+    ]
+
+
+def _admin_access_required(view):
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        from django.contrib import admin
+        from django.contrib.auth.views import redirect_to_login
+
+        if not admin.site.has_permission(request):
+            return redirect_to_login(
+                request.get_full_path(),
+                reverse("admin:login", current_app=admin.site.name),
+                REDIRECT_FIELD_NAME,
+            )
+        return view(request, *args, **kwargs)
+
+    return wrapper
+
+
+class GyrinxAdminSite(AdminSite):
+    def has_permission(self, request):
+        """Staff-and-active, plus the second-factor requirement."""
+        if not super().has_permission(request):
+            return False
+        return mfa_gate_url(request) is None
+
+    def login(self, request, extra_context=None):
+        """Redirect into allauth instead of rendering the admin's login form.
+
+        Every admin view routes here when :meth:`has_permission` says no, so this
+        is the single place that decides where an under-authenticated visitor
+        goes: the allauth login page, TOTP setup, or a TOTP challenge.
+        """
+        next_url = self._admin_next_url(request)
+
+        if not request.user.is_authenticated:
+            return self._redirect_with_next(settings.LOGIN_URL, next_url)
+
+        if not (request.user.is_active and request.user.is_staff):
+            raise PermissionDenied
+
+        gate_url = mfa_gate_url(request)
+        if gate_url:
+            from allauth.mfa.utils import is_mfa_enabled
+
+            messages.warning(
+                request,
+                MFA_CHALLENGE_MESSAGE
+                if is_mfa_enabled(request.user)
+                else MFA_SETUP_MESSAGE,
+            )
+            return self._redirect_with_next(gate_url, next_url)
+
+        # Fully authorised — they only landed here via a stale bookmark or a
+        # redirect chain that has since been satisfied.
+        return HttpResponseRedirect(next_url)
+
+    def _admin_next_url(self, request):
+        """Where to send the visitor once they are authenticated.
+
+        Falls back to the admin index, and never points back at the login view
+        itself (which would bounce the visitor around in a loop).
+        """
+        index_url = reverse("admin:index", current_app=self.name)
+        login_url = reverse("admin:login", current_app=self.name)
+
+        next_url = request.GET.get(REDIRECT_FIELD_NAME) or request.POST.get(
+            REDIRECT_FIELD_NAME
+        )
+        if not next_url:
+            return index_url
+        if not url_has_allowed_host_and_scheme(
+            next_url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return index_url
+        if next_url.split("?")[0] == login_url:
+            return index_url
+        return next_url
+
+    @staticmethod
+    def _redirect_with_next(url, next_url):
+        # Imported here, not at module scope: this module is loaded while
+        # INSTALLED_APPS is still being resolved, before the app registry (and
+        # so the models django.contrib.auth.views imports) is ready.
+        from django.contrib.auth.views import redirect_to_login
+
+        return redirect_to_login(next_url, url, REDIRECT_FIELD_NAME)
+
+
+class GyrinxAdminConfig(AdminConfig):
+    """Installed in place of ``django.contrib.admin`` to swap in the site above."""
+
+    default_site = "gyrinx.admin_site.GyrinxAdminSite"

--- a/gyrinx/admin_site.py
+++ b/gyrinx/admin_site.py
@@ -44,8 +44,18 @@ _UNSET = object()
 
 
 def admin_requires_mfa() -> bool:
-    """Whether the admin is gated on a completed second-factor challenge."""
-    return getattr(settings, "ADMIN_REQUIRE_MFA", True)
+    """Whether the admin is gated on a completed second-factor challenge.
+
+    An explicit ``ADMIN_REQUIRE_MFA`` wins. Left unset, the gate follows
+    ``DEBUG``: on in production, off in local development, where each worktree
+    has its own database and requiring TOTP would mean a separate authenticator
+    per worktree. Note that this only relaxes the *second factor* — admin login
+    still goes through allauth everywhere.
+    """
+    configured = getattr(settings, "ADMIN_REQUIRE_MFA", None)
+    if configured is not None:
+        return bool(configured)
+    return not settings.DEBUG
 
 
 def session_authenticated_with_mfa(request) -> bool:

--- a/gyrinx/analytics/admin.py
+++ b/gyrinx/analytics/admin.py
@@ -17,8 +17,15 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 
-class AnalyticsAdminSite(admin.AdminSite):
-    """Custom admin site with analytics dashboard"""
+class AnalyticsAdminSite(admin.site.__class__):
+    """Custom admin site with analytics dashboard.
+
+    Extends whatever class ``admin.site`` is currently using rather than
+    ``admin.AdminSite`` directly, so it composes with the site installed by
+    ``gyrinx.admin_site`` (which routes admin login through allauth) instead of
+    replacing it. ``gyrinx.maintenance`` then stacks on top of this — see
+    ``gyrinx/maintenance/admin.py``.
+    """
 
     def get_urls(self):
         urls = super().get_urls()

--- a/gyrinx/core/adapter.py
+++ b/gyrinx/core/adapter.py
@@ -17,6 +17,35 @@ class CustomAccountAdapter(DefaultAccountAdapter):
         # Override with setting, otherwise default to super.
         return getattr(settings, "ACCOUNT_ALLOW_SIGNUPS", allow_signups)
 
+    def get_reauthentication_methods(self, user):
+        """Drop "use your password" when the destination is the Django admin.
+
+        allauth's reauthentication normally accepts a password as proof of
+        identity, which is the right trade-off for ordinary account changes. It
+        is the wrong one here: the admin asks for reauthentication precisely
+        because the session has not passed a second-factor challenge, so a
+        password gets the user nowhere — allauth would record the wrong method
+        and the admin would bounce them straight back to this page.
+
+        See gyrinx/admin_site.py for the gate itself.
+        """
+        from allauth.core import context
+
+        from gyrinx.admin_site import (
+            admin_second_factor_required,
+            is_admin_bound_request,
+        )
+
+        methods = super().get_reauthentication_methods(user)
+        if not is_admin_bound_request(getattr(context, "request", None)):
+            return methods
+        if not admin_second_factor_required(user):
+            return methods
+
+        # Never return an empty list: that would deny reauthentication outright
+        # rather than steer it.
+        return [m for m in methods if m.get("id") != "reauthenticate"] or methods
+
     def send_mail(self, template_prefix, email, context):
         """
         Override send_mail to add custom headers from EMAIL_EXTRA_HEADERS setting.

--- a/gyrinx/core/tests/test_admin_login_security.py
+++ b/gyrinx/core/tests/test_admin_login_security.py
@@ -5,6 +5,8 @@ password and nothing else, which would let a staff account with TOTP configured
 into the admin without ever being challenged.
 """
 
+from urllib.parse import unquote
+
 import pytest
 from allauth.account.models import EmailAddress
 from allauth.mfa.totp.internal import auth as totp_auth
@@ -17,6 +19,7 @@ ALLAUTH_LOGIN = "/accounts/login/"
 MFA_ACTIVATE = "/accounts/2fa/totp/activate/"
 MFA_AUTHENTICATE = "/accounts/2fa/authenticate/"
 MFA_REAUTHENTICATE = "/accounts/2fa/reauthenticate/"
+ACCOUNT_REAUTHENTICATE = "/accounts/reauthenticate/"
 
 
 @pytest.fixture
@@ -260,3 +263,66 @@ def test_admindocs_is_reachable_when_the_gate_is_satisfied(staff_user):
 @pytest.mark.django_db
 def test_admindocs_url_names_are_unchanged():
     assert reverse("django-admindocs-docroot") == "/admin/doc/"
+
+
+# ------------------------------------------------------- password is not a second factor
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_password_reauthentication_does_not_open_the_admin(staff_user):
+    """A password is what the session already has — it proves nothing new."""
+    enable_totp(staff_user)
+    client = Client()
+    client.force_login(staff_user)
+
+    response = client.post(
+        f"{ACCOUNT_REAUTHENTICATE}?next={ADMIN_INDEX}", {"password": "password"}
+    )
+    assert response.status_code == 302
+
+    response = client.get(ADMIN_INDEX, follow=True)
+    assert response.redirect_chain[-1][0] == f"{MFA_REAUTHENTICATE}?next={ADMIN_INDEX}"
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_the_challenge_page_does_not_offer_a_password_alternative(staff_user):
+    enable_totp(staff_user)
+    client = Client()
+    client.force_login(staff_user)
+
+    response = client.get(f"{MFA_REAUTHENTICATE}?next={ADMIN_INDEX}")
+
+    alternatives = response.context["reauthentication_alternatives"]
+    assert [alt["id"] for alt in alternatives] == []
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_going_to_password_reauthentication_by_hand_is_steered_to_the_code(staff_user):
+    enable_totp(staff_user)
+    client = Client()
+    client.force_login(staff_user)
+
+    response = client.get(f"{ACCOUNT_REAUTHENTICATE}?next={ADMIN_INDEX}")
+
+    assert response.status_code == 302
+    assert response.url.startswith(MFA_REAUTHENTICATE)
+    assert ADMIN_INDEX in unquote(response.url)
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_password_reauthentication_still_works_away_from_the_admin(user):
+    """Ordinary account flows keep the password option."""
+    EmailAddress.objects.create(
+        user=user, email="testuser@example.com", verified=True, primary=True
+    )
+    enable_totp(user)
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(f"{ACCOUNT_REAUTHENTICATE}?next=/account/")
+
+    assert response.status_code == 200

--- a/gyrinx/core/tests/test_admin_login_security.py
+++ b/gyrinx/core/tests/test_admin_login_security.py
@@ -326,3 +326,44 @@ def test_password_reauthentication_still_works_away_from_the_admin(user):
     response = client.get(f"{ACCOUNT_REAUTHENTICATE}?next=/account/")
 
     assert response.status_code == 200
+
+
+# ------------------------------------------------------- the DEBUG default
+
+
+@override_settings(ADMIN_REQUIRE_MFA=None, DEBUG=True)
+@pytest.mark.django_db
+def test_the_gate_is_off_in_debug_by_default(staff_user):
+    """Local worktrees each have their own database — one TOTP each is a faff."""
+    client = Client()
+    client.force_login(staff_user)
+
+    assert client.get(ADMIN_INDEX).status_code == 200
+
+
+@override_settings(ADMIN_REQUIRE_MFA=None, DEBUG=False)
+@pytest.mark.django_db
+def test_the_gate_is_on_outside_debug_by_default(staff_user):
+    client = Client()
+    client.force_login(staff_user)
+
+    assert client.get(ADMIN_INDEX).status_code == 302
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True, DEBUG=True)
+@pytest.mark.django_db
+def test_the_gate_can_still_be_forced_on_in_debug(staff_user):
+    """So the production behaviour can be exercised locally."""
+    client = Client()
+    client.force_login(staff_user)
+
+    assert client.get(ADMIN_INDEX).status_code == 302
+
+
+@override_settings(ADMIN_REQUIRE_MFA=None, DEBUG=True)
+@pytest.mark.django_db
+def test_admin_login_still_goes_through_allauth_in_debug():
+    """DEBUG relaxes the second factor, never the login path."""
+    response = Client().get(ADMIN_LOGIN)
+
+    assert response.url == f"{ALLAUTH_LOGIN}?next={ADMIN_INDEX}"

--- a/gyrinx/core/tests/test_admin_login_security.py
+++ b/gyrinx/core/tests/test_admin_login_security.py
@@ -1,0 +1,262 @@
+"""The Django admin must authenticate through allauth, second factor included.
+
+See gyrinx/admin_site.py — Django's own admin login form takes a username and
+password and nothing else, which would let a staff account with TOTP configured
+into the admin without ever being challenged.
+"""
+
+import pytest
+from allauth.account.models import EmailAddress
+from allauth.mfa.totp.internal import auth as totp_auth
+from django.test import Client, override_settings
+from django.urls import reverse
+
+ADMIN_INDEX = "/admin/"
+ADMIN_LOGIN = "/admin/login/"
+ALLAUTH_LOGIN = "/accounts/login/"
+MFA_ACTIVATE = "/accounts/2fa/totp/activate/"
+MFA_AUTHENTICATE = "/accounts/2fa/authenticate/"
+MFA_REAUTHENTICATE = "/accounts/2fa/reauthenticate/"
+
+
+@pytest.fixture
+def staff_user(make_user):
+    user = make_user("staffer", "password")
+    user.is_staff = True
+    user.is_superuser = True
+    user.email = "staffer@example.com"
+    user.save()
+    EmailAddress.objects.create(
+        user=user, email=user.email, verified=True, primary=True
+    )
+    return user
+
+
+def enable_totp(user):
+    """Give ``user`` a TOTP authenticator and return its secret."""
+    secret = totp_auth.generate_totp_secret()
+    totp_auth.TOTP.activate(user, secret)
+    return secret
+
+
+def totp_code(secret):
+    counter = next(totp_auth.yield_hotp_counters_from_time())
+    return totp_auth.format_hotp_value(totp_auth.hotp_value(secret, counter))
+
+
+@pytest.fixture
+def pass_captcha(monkeypatch):
+    """The project's allauth login form carries a reCAPTCHA field."""
+    monkeypatch.setattr(
+        "django_recaptcha.fields.ReCaptchaField.validate", lambda self, value: True
+    )
+
+
+# ------------------------------------------------------- the form is gone
+
+
+@pytest.mark.django_db
+def test_admin_login_redirects_anonymous_users_to_allauth():
+    response = Client().get(ADMIN_LOGIN)
+
+    assert response.status_code == 302
+    assert response.url == f"{ALLAUTH_LOGIN}?next={ADMIN_INDEX}"
+
+
+@pytest.mark.django_db
+def test_admin_login_does_not_render_a_login_form():
+    response = Client().get(ADMIN_LOGIN, follow=True)
+
+    # We land on allauth's login page, not the admin's.
+    assert response.redirect_chain[-1][0].startswith(ALLAUTH_LOGIN)
+    assert b"id_username" not in response.content
+
+
+@pytest.mark.django_db
+def test_admin_login_form_cannot_be_used_to_authenticate(staff_user):
+    """Posting credentials at the admin login URL must not create a session."""
+    client = Client()
+
+    response = client.post(ADMIN_LOGIN, {"username": "staffer", "password": "password"})
+
+    assert response.status_code == 302
+    assert response.url.startswith(ALLAUTH_LOGIN)
+    assert "_auth_user_id" not in client.session
+    assert client.get(ADMIN_INDEX).status_code == 302
+
+
+@pytest.mark.django_db
+def test_admin_preserves_the_requested_page_as_next(staff_user):
+    response = Client().get("/admin/auth/user/")
+
+    # admin_view bounces to the admin login, which bounces on to allauth.
+    assert response.status_code == 302
+    assert response.url == f"{ADMIN_LOGIN}?next=/admin/auth/user/"
+
+    response = Client().get(response.url)
+    assert response.url == f"{ALLAUTH_LOGIN}?next=/admin/auth/user/"
+
+
+@pytest.mark.django_db
+def test_next_pointing_back_at_the_admin_login_falls_back_to_the_index():
+    response = Client().get(f"{ADMIN_LOGIN}?next={ADMIN_LOGIN}")
+
+    assert response.url == f"{ALLAUTH_LOGIN}?next={ADMIN_INDEX}"
+
+
+@pytest.mark.django_db
+def test_offsite_next_is_rejected():
+    response = Client().get(f"{ADMIN_LOGIN}?next=https://evil.example.com/")
+
+    assert response.url == f"{ALLAUTH_LOGIN}?next={ADMIN_INDEX}"
+
+
+@pytest.mark.django_db
+def test_logged_in_non_staff_user_is_forbidden(user):
+    client = Client()
+    client.force_login(user)
+
+    assert client.get(ADMIN_LOGIN).status_code == 403
+
+
+# ------------------------------------------------------- the 2FA gate
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_staff_without_a_second_factor_is_sent_to_totp_setup(staff_user):
+    client = Client()
+    client.force_login(staff_user)
+
+    response = client.get(ADMIN_INDEX)
+    assert response.status_code == 302
+    assert response.url == f"{ADMIN_LOGIN}?next={ADMIN_INDEX}"
+
+    response = client.get(response.url)
+    assert response.url == f"{MFA_ACTIVATE}?next={ADMIN_INDEX}"
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_session_that_never_passed_a_challenge_is_sent_to_reauthenticate(staff_user):
+    """A session predating the TOTP setup has not actually shown a code."""
+    enable_totp(staff_user)
+    client = Client()
+    client.force_login(staff_user)
+
+    response = client.get(ADMIN_LOGIN)
+
+    assert response.url == f"{MFA_REAUTHENTICATE}?next={ADMIN_INDEX}"
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_passing_the_challenge_opens_the_admin(staff_user):
+    secret = enable_totp(staff_user)
+    client = Client()
+    client.force_login(staff_user)
+
+    assert client.get(ADMIN_INDEX).status_code == 302
+
+    response = client.post(
+        f"{MFA_REAUTHENTICATE}?next={ADMIN_INDEX}",
+        {"code": totp_code(secret)},
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert response.redirect_chain[-1][0] == ADMIN_INDEX
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_a_wrong_code_does_not_open_the_admin(staff_user):
+    enable_totp(staff_user)
+    client = Client()
+    client.force_login(staff_user)
+
+    client.post(f"{MFA_REAUTHENTICATE}?next={ADMIN_INDEX}", {"code": "000000"})
+
+    assert client.get(ADMIN_INDEX).status_code == 302
+
+
+@override_settings(ADMIN_REQUIRE_MFA=False)
+@pytest.mark.django_db
+def test_gate_can_be_switched_off_for_local_development(staff_user):
+    client = Client()
+    client.force_login(staff_user)
+
+    assert client.get(ADMIN_INDEX).status_code == 200
+
+
+# ------------------------------------------------------- end to end
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_signing_in_for_the_admin_goes_through_the_full_allauth_flow(
+    staff_user, pass_captcha
+):
+    secret = enable_totp(staff_user)
+    client = Client()
+
+    # Start at the admin, get pushed out to allauth.
+    response = client.get(ADMIN_INDEX, follow=True)
+    assert response.redirect_chain[-1][0] == f"{ALLAUTH_LOGIN}?next={ADMIN_INDEX}"
+
+    # A correct username and password is not enough on its own.
+    response = client.post(
+        f"{ALLAUTH_LOGIN}?next={ADMIN_INDEX}",
+        {"login": "staffer", "password": "password", "captcha": "dummy"},
+    )
+    assert response.status_code == 302
+    assert response.url.startswith(MFA_AUTHENTICATE)
+    assert client.get(ADMIN_INDEX).status_code == 302
+
+    # The second factor completes the login and lands us in the admin.
+    response = client.post(response.url, {"code": totp_code(secret)}, follow=True)
+    assert response.status_code == 200
+    assert response.redirect_chain[-1][0] == ADMIN_INDEX
+
+
+@pytest.mark.django_db
+def test_admin_index_is_reachable_once_authenticated(staff_user):
+    """Sanity check that the replacement site still serves the admin itself."""
+    client = Client()
+    client.force_login(staff_user)
+
+    with override_settings(ADMIN_REQUIRE_MFA=False):
+        response = client.get(ADMIN_INDEX)
+
+    assert response.status_code == 200
+    assert reverse("admin:index") == ADMIN_INDEX
+
+
+# ------------------------------------------------------- admindocs
+
+
+@override_settings(ADMIN_REQUIRE_MFA=True)
+@pytest.mark.django_db
+def test_admindocs_is_behind_the_same_gate(staff_user):
+    """admindocs' own staff_member_required knows nothing about the 2FA gate."""
+    client = Client()
+    client.force_login(staff_user)
+
+    response = client.get("/admin/doc/")
+
+    assert response.status_code == 302
+    assert response.url == f"{ADMIN_LOGIN}?next=/admin/doc/"
+
+
+@override_settings(ADMIN_REQUIRE_MFA=False)
+@pytest.mark.django_db
+def test_admindocs_is_reachable_when_the_gate_is_satisfied(staff_user):
+    client = Client()
+    client.force_login(staff_user)
+
+    assert client.get("/admin/doc/").status_code == 200
+
+
+@pytest.mark.django_db
+def test_admindocs_url_names_are_unchanged():
+    assert reverse("django-admindocs-docroot") == "/admin/doc/"

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -113,7 +113,11 @@ INSTALLED_APPS = [
     "daphne",
     # Added so we can override templates
     "django.forms",
-    "django.contrib.admin",
+    # Replaces "django.contrib.admin": swaps in an AdminSite whose login view
+    # redirects into allauth (so admin sessions get the same 2FA challenge as
+    # app sessions) instead of rendering Django's own username/password form.
+    # See gyrinx/admin_site.py.
+    "gyrinx.admin_site.GyrinxAdminConfig",
     "django.contrib.auth",
     "polymorphic",
     "django.contrib.contenttypes",
@@ -273,6 +277,9 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 LOGIN_REDIRECT_URL = "/"
+# Everything that needs a login — including the Django admin — goes through
+# allauth, which applies the MFA stage.
+LOGIN_URL = "account_login"
 
 # Allauth settings
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
@@ -299,6 +306,12 @@ USERSESSIONS_TRACK_ACTIVITY = True
 # https://docs.allauth.org/en/latest/mfa/introduction.html
 MFA_TOTP_ISSUER = "Gyrinx"  # This will appear in the authenticator app
 MFA_SUPPORTED_TYPES = ["totp"]  # Only support TOTP, not SMS or recovery codes initially
+
+# Require staff to hold a second factor, and to have used it in the current
+# session, before the Django admin will let them in. Staff who fall short are
+# redirected into allauth's TOTP setup or challenge — never locked out.
+# See gyrinx/admin_site.py.
+ADMIN_REQUIRE_MFA = os.getenv("ADMIN_REQUIRE_MFA", "True") == "True"
 
 
 # Password validation

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -311,7 +311,14 @@ MFA_SUPPORTED_TYPES = ["totp"]  # Only support TOTP, not SMS or recovery codes i
 # session, before the Django admin will let them in. Staff who fall short are
 # redirected into allauth's TOTP setup or challenge — never locked out.
 # See gyrinx/admin_site.py.
-ADMIN_REQUIRE_MFA = os.getenv("ADMIN_REQUIRE_MFA", "True") == "True"
+#
+# Unset (the default) means "follow DEBUG": required in production, off in local
+# development. Each worktree has its own database, so requiring TOTP locally
+# would mean enrolling a separate authenticator per worktree. The environment
+# variable forces either answer — set it to True to exercise the production gate
+# locally.
+_admin_require_mfa = os.getenv("ADMIN_REQUIRE_MFA")
+ADMIN_REQUIRE_MFA = None if _admin_require_mfa is None else _admin_require_mfa == "True"
 
 
 # Password validation

--- a/gyrinx/settings_dev.py
+++ b/gyrinx/settings_dev.py
@@ -49,11 +49,12 @@ if "runserver" in sys.argv and not _UNDER_PYTEST:
 # Disable secure cookies for local development
 CSRF_COOKIE_SECURE = False
 
-# Local admin access doesn't demand a second factor by default — seeded dev users
-# have no authenticator. The redirect of /admin/login/ into allauth still applies.
-# Set ADMIN_REQUIRE_MFA=True to exercise the production gate locally; tests that
-# cover it use override_settings.
-ADMIN_REQUIRE_MFA = os.getenv("ADMIN_REQUIRE_MFA", "False") == "True"
+# The admin's 2FA gate follows DEBUG when ADMIN_REQUIRE_MFA is unset, which
+# leaves it off for the dev server. pytest-django forces DEBUG = False, though,
+# so without this the whole suite would run with the gate on. Tests that cover it
+# use override_settings.
+if _UNDER_PYTEST and os.getenv("ADMIN_REQUIRE_MFA") is None:
+    ADMIN_REQUIRE_MFA = False
 
 # Allow local hosts for development
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "testserver"]

--- a/gyrinx/settings_dev.py
+++ b/gyrinx/settings_dev.py
@@ -49,6 +49,12 @@ if "runserver" in sys.argv and not _UNDER_PYTEST:
 # Disable secure cookies for local development
 CSRF_COOKIE_SECURE = False
 
+# Local admin access doesn't demand a second factor by default — seeded dev users
+# have no authenticator. The redirect of /admin/login/ into allauth still applies.
+# Set ADMIN_REQUIRE_MFA=True to exercise the production gate locally; tests that
+# cover it use override_settings.
+ADMIN_REQUIRE_MFA = os.getenv("ADMIN_REQUIRE_MFA", "False") == "True"
+
 # Allow local hosts for development
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "testserver"]
 

--- a/gyrinx/urls.py
+++ b/gyrinx/urls.py
@@ -19,8 +19,10 @@ from debug_toolbar.toolbar import debug_toolbar_urls
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.admindocs import urls as admindocs_urls
 from django.urls import include, path, re_path
 
+from gyrinx.admin_site import admin_gated_patterns
 from gyrinx.core.views import debug as debug_views
 from gyrinx.core.views import print_lab as print_lab_views
 from gyrinx.pages import views
@@ -75,7 +77,11 @@ urlpatterns = (
         path("api/", include("gyrinx.api.urls")),
         path("tasks/", include("gyrinx.tasks.urls")),
         path("accounts/", include("allauth.urls")),
-        path("admin/doc/", include("django.contrib.admindocs.urls")),
+        # admindocs decorates its views with staff_member_required, which knows
+        # nothing about the admin's 2FA gate — route it through the same check.
+        # A bare list keeps admindocs' URL names unnamespaced, as base_site.html
+        # expects.
+        path("admin/doc/", include(admin_gated_patterns(admindocs_urls.urlpatterns))),
         path("400/", views.error_400, name="error_400"),
         path("403/", views.error_403, name="error_403"),
         path("404/", views.error_404, name="error_404"),


### PR DESCRIPTION
## What

The Django admin had its own login form, which checks a username and password and nothing else. It knows nothing about allauth's login stages, so a staff account with two-factor set up could sign in at `/admin/login/` without ever being asked for a code — the app's front door was protected, the admin's was not.

This removes that door. `/admin/login/` no longer renders a form; it only redirects into the allauth flow, so an admin session is created by exactly the same path (and the same second-factor challenge) as an app session. That part applies in every environment.

On top of that, reaching the admin requires that a staff user actually holds a second factor, and that the current session was authenticated with it. The session-level check matters: a session created before the user set up TOTP has not really shown a code, so it doesn't count.

Nobody gets locked out. Staff who fall short are redirected into allauth's TOTP setup or challenge with a message explaining why, and can complete it there and carry on to the page they wanted.

## Local development

`ADMIN_REQUIRE_MFA` is unset by default, which means "follow `DEBUG`": the second-factor requirement is on in production and off for the local dev server. Each worktree has its own database, so requiring TOTP locally would mean enrolling a separate authenticator per worktree.

Set `ADMIN_REQUIRE_MFA=True` to exercise the production gate locally, or `False` to force it off. Only the second factor is relaxed — admin login still goes through allauth locally.

## A password is not a second factor

allauth's "Confirm Access" page normally offers "Use your password" next to the authenticator code — sensible for ordinary account changes, wrong here. A password could never actually open the admin (the gate requires an `mfa` authentication record, and password reauthentication records `password`), but taking the offer sent you straight back to the same page with no explanation. That reads like a hole in the control even though it isn't one.

The account adapter now drops the password method when the pending `next` points into the admin and the user is staff with a second factor. allauth uses that same list to decide whether a reauthentication view is available at all, so visiting the password page by hand with `next=/admin/` redirects to the code challenge instead of dead-ending. Ordinary account flows are untouched.

## Also in here

- `/admin/doc/` is decorated with Django's `staff_member_required`, which only knows about `is_staff` and would have sat outside the new gate. Its URL patterns now route through the admin login view too.
- `AnalyticsAdminSite` extended `admin.AdminSite` directly, which silently replaced any base site class rather than composing with it (this is what defeated the first version of this change). It now extends `admin.site.__class__`, matching the pattern `MaintenanceAdminSite` already documents. The chain is now `MaintenanceAdminSite → AnalyticsAdminSite → GyrinxAdminSite → AdminSite`.

## Two things to know before deploying

- Staff who currently sign in with a password only will be sent through TOTP setup the next time they open the admin.
- `MFA_SUPPORTED_TYPES` is TOTP-only, so there are no recovery codes. Losing an authenticator means resetting it from the database. Worth considering enabling recovery codes separately.

## Tests

25 tests in `gyrinx/core/tests/test_admin_login_security.py`, including an end-to-end one that signs in through allauth with a real TOTP code and shows a correct username and password alone leaves you outside the admin. Full suite: 4034 passed, 13 skipped.

## How to try it

Plain `./scripts/dev.sh` gives you the local behaviour: `/admin/login/` redirects into allauth, no TOTP needed. To see the production gate:

```bash
ADMIN_REQUIRE_MFA=True ./scripts/dev.sh
```

Then, on the port printed in the banner:

- `/admin/login/` logged out → `/accounts/login/?next=/admin/`
- Logged in as staff with no authenticator → `/accounts/2fa/totp/activate/?next=/admin/`
- Logged in as staff with TOTP, session not yet challenged → `/accounts/2fa/reauthenticate/?next=/admin/`, with no password alternative offered; entering a code lands you in the admin
- `/accounts/reauthenticate/?next=/account/` still offers the password, as before

Verified against a running server in each of those states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)