### PR TITLE
fix: stop advancements stacking on a stat that gear sets

### DIFF
--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -1347,10 +1347,18 @@ class ListFighter(AppBase):
         # packs are subscribed.
         pack_mods = list(self.list.pack_mods_for(self.content_fighter))
 
+        # Advancements come first so that a "set" from equipment still wins.
+        # A set discards whatever it is applied to, so ordering is only visible
+        # when one is present: with advancements last, a fighter whose gear
+        # fixes a stat ("your movement is 8\"") had their advancement stack on
+        # top of it. Before advancements moved onto the mod system they were
+        # held in the override field, which a set discarded — so this ordering
+        # is what restores that behaviour. Improve/worsen mods are additive, so
+        # their order relative to each other does not matter.
         return (
-            equipment_mods
+            advancement_mods
+            + equipment_mods
             + injury_mods
-            + advancement_mods
             + roll_result_mods
             + pack_mods
         )

--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -1350,7 +1350,7 @@ class ListFighter(AppBase):
         # Advancements come first so that a "set" from equipment still wins.
         # A set discards whatever it is applied to, so ordering is only visible
         # when one is present: with advancements last, a fighter whose gear
-        # fixes a stat ("your movement is 8\"") had their advancement stack on
+        # fixes a stat ('your movement is 8 inches') had their advancement stack on
         # top of it. Before advancements moved onto the mod system they were
         # held in the override field, which a set discarded — so this ordering
         # is what restores that behaviour. Improve/worsen mods are additive, so

--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -1347,19 +1347,27 @@ class ListFighter(AppBase):
         # packs are subscribed.
         pack_mods = list(self.list.pack_mods_for(self.content_fighter))
 
-        # Advancements come first so that a "set" from equipment still wins.
-        # A set discards whatever it is applied to, so ordering is only visible
-        # when one is present: with advancements last, a fighter whose gear
-        # fixes a stat ('your movement is 8 inches') had their advancement stack on
-        # top of it. Before advancements moved onto the mod system they were
-        # held in the override field, which a set discarded — so this ordering
-        # is what restores that behaviour. Improve/worsen mods are additive, so
-        # their order relative to each other does not matter.
+        # The fighter's own permanent improvements — advancements and roll
+        # results — come first, so that a "set" from equipment still wins. A
+        # set discards whatever it is applied to, so with these applied last a
+        # fighter whose gear fixes a stat ('your movement is 8 inches') had the
+        # improvement stack on top of it instead of being overridden by it.
+        # Before advancements moved onto the mod system they were held in the
+        # override field, which a set discarded, so this restores that.
+        #
+        # Injuries and house rules stay after equipment, so they still modify
+        # whatever the gear set.
+        #
+        # Ordering between improve/worsen mods is almost always irrelevant, but
+        # not quite: apply() misreads a negative intermediate value as a
+        # stat-linked one, so a plain stat driven below zero mid-chain can come
+        # out formatted as "+1" rather than "1" depending on order. That is a
+        # parser bug rather than something this ordering should work around.
         return (
             advancement_mods
+            + roll_result_mods
             + equipment_mods
             + injury_mods
-            + roll_result_mods
             + pack_mods
         )
 

--- a/gyrinx/core/tests/test_mod_ordering.py
+++ b/gyrinx/core/tests/test_mod_ordering.py
@@ -27,7 +27,9 @@ def shown(fighter, stat):
 @pytest.fixture
 def wheels():
     """Equipment that fixes a fighter's movement, rather than adjusting it."""
-    category, _ = ContentEquipmentCategory.objects.get_or_create(name="Set Gear")
+    category, _ = ContentEquipmentCategory.objects.get_or_create(
+        name="Set Gear", defaults={"group": "Vehicle & Mount"}
+    )
     gear = ContentEquipment.objects.create(
         name="Ash Wheels", category=category, cost="0"
     )

--- a/gyrinx/core/tests/test_mod_ordering.py
+++ b/gyrinx/core/tests/test_mod_ordering.py
@@ -33,9 +33,10 @@ def wheels():
     gear = ContentEquipment.objects.create(
         name="Ash Wheels", category=category, cost="0"
     )
-    gear.modifiers.add(
-        ContentModFighterStat.objects.create(stat="movement", mode="set", value='8"')
+    mod, _ = ContentModFighterStat.objects.get_or_create(
+        stat="movement", mode="set", value='8"'
     )
+    gear.modifiers.add(mod)
     return gear
 
 
@@ -94,7 +95,92 @@ def test_an_advancement_still_applies_without_a_set(user, make_list, make_list_f
     """The reordering must not stop ordinary advancements working."""
     lst = make_list("Gang")
     fighter = make_list_fighter(lst, "Plain Fighter")
-    base = shown(fighter, "movement")
+    assert shown(fighter, "movement") == '5"'
+
     advance(fighter, user, "movement")
 
-    assert shown(fighter, "movement") != base
+    assert shown(fighter, "movement") == '6"'
+
+
+@pytest.mark.django_db
+def test_an_injury_still_worsens_a_stat_the_gear_set(
+    user, make_list, make_list_fighter, wheels
+):
+    """Injuries apply after equipment, so a set is not the last word."""
+    from gyrinx.content.models import ContentInjury, ContentInjuryDefaultOutcome
+    from gyrinx.core.models.list import ListFighterInjury
+
+    injury = ContentInjury.objects.create(
+        name="Buckled Wheel",
+        phase=ContentInjuryDefaultOutcome.NO_CHANGE,
+    )
+    injury.modifiers.add(
+        ContentModFighterStat.objects.get_or_create(
+            stat="movement", mode="worsen", value="1"
+        )[0]
+    )
+
+    lst = make_list("Gang", status="campaign_mode")
+    fighter = make_list_fighter(lst, "Injured Rider")
+    give(fighter, wheels)
+    ListFighterInjury.objects.create(fighter=fighter, injury=injury, owner=user)
+
+    # The gear sets 8"; the injury still takes one off it
+    assert shown(fighter, "movement") == '7"'
+
+
+@pytest.mark.django_db
+def test_advancement_set_and_injury_together(
+    user, make_list, make_list_fighter, wheels
+):
+    """All three at once: the advancement is swallowed, the injury is not."""
+    from gyrinx.content.models import ContentInjury, ContentInjuryDefaultOutcome
+    from gyrinx.core.models.list import ListFighterInjury
+
+    injury = ContentInjury.objects.create(
+        name="Cracked Axle",
+        phase=ContentInjuryDefaultOutcome.NO_CHANGE,
+    )
+    injury.modifiers.add(
+        ContentModFighterStat.objects.get_or_create(
+            stat="movement", mode="worsen", value="1"
+        )[0]
+    )
+
+    lst = make_list("Gang", status="campaign_mode")
+    fighter = make_list_fighter(lst, "Injured Ashwheel")
+    give(fighter, wheels)
+    advance(fighter, user, "movement")
+    ListFighterInjury.objects.create(fighter=fighter, injury=injury, owner=user)
+
+    assert shown(fighter, "movement") == '7"'
+
+
+@pytest.mark.django_db
+def test_a_roll_result_does_not_stack_on_a_set_either(
+    user, make_list, make_list_fighter, wheels
+):
+    """Power Boosts are permanent improvements, same as advancements.
+
+    Both roll-result stat mods in content improve movement or initiative, and
+    every set-mode mod targets movement — so this is the same collision.
+    """
+    from gyrinx.content.models.roll_table import ContentRollTable, ContentRollTableRow
+    from gyrinx.core.models.list import ListFighterRollResult
+
+    table = ContentRollTable.objects.create(name="Power Boost")
+    row = ContentRollTableRow.objects.create(
+        table=table, roll_value="1", name="Speed Boost"
+    )
+    row.modifiers.add(
+        ContentModFighterStat.objects.get_or_create(
+            stat="movement", mode="improve", value="1"
+        )[0]
+    )
+
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Boosted Rider")
+    give(fighter, wheels)
+    ListFighterRollResult.objects.create(fighter=fighter, row=row, owner=user)
+
+    assert shown(fighter, "movement") == '8"'

--- a/gyrinx/core/tests/test_mod_ordering.py
+++ b/gyrinx/core/tests/test_mod_ordering.py
@@ -1,0 +1,98 @@
+"""Ordering of the modifications that build a fighter's statline.
+
+Order is only observable when a "set" modification is involved, because
+improve/worsen are additive. A set discards whatever it is applied to, so
+whether it wins depends entirely on what comes after it.
+"""
+
+import pytest
+
+from gyrinx.content.models import (
+    ContentEquipment,
+    ContentEquipmentCategory,
+    ContentModFighterStat,
+)
+from gyrinx.core.models import ListFighter, ListFighterAdvancement
+from gyrinx.core.models.list import ListFighterEquipmentAssignment
+
+
+def shown(fighter, stat):
+    fresh = ListFighter.objects.get(pk=fighter.pk)
+    for entry in fresh.statline:
+        if entry.field_name == stat:
+            return entry.value
+    raise AssertionError(f"{stat} missing from statline")
+
+
+@pytest.fixture
+def wheels():
+    """Equipment that fixes a fighter's movement, rather than adjusting it."""
+    category, _ = ContentEquipmentCategory.objects.get_or_create(name="Set Gear")
+    gear = ContentEquipment.objects.create(
+        name="Ash Wheels", category=category, cost="0"
+    )
+    gear.modifiers.add(
+        ContentModFighterStat.objects.create(stat="movement", mode="set", value='8"')
+    )
+    return gear
+
+
+def give(fighter, gear):
+    ListFighterEquipmentAssignment.objects.create(
+        list_fighter=fighter, content_equipment=gear
+    )
+
+
+def advance(fighter, user, stat):
+    return ListFighterAdvancement.objects.create(
+        fighter=fighter,
+        advancement_type=ListFighterAdvancement.ADVANCEMENT_STAT,
+        stat_increased=stat,
+        uses_mod_system=True,
+        xp_cost=5,
+        cost_increase=5,
+        owner=user,
+    )
+
+
+@pytest.mark.django_db
+def test_gear_that_sets_a_stat_wins_over_an_advancement(
+    user, make_list, make_list_fighter, wheels
+):
+    """An advancement must not stack on top of a stat the gear fixes.
+
+    Advancements used to live in the fighter's override field, which a set
+    discarded. Moving them onto the mod system and applying them after the
+    set made them add to it instead, inflating movement on real fighters.
+    """
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Ashwheel Drax")
+    give(fighter, wheels)
+    advance(fighter, user, "movement")
+
+    assert shown(fighter, "movement") == '8"'
+
+
+@pytest.mark.django_db
+def test_several_advancements_still_do_not_stack_on_a_set(
+    user, make_list, make_list_fighter, wheels
+):
+    """The worst real case ran to four advancements over a set value."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Four Advancements")
+    give(fighter, wheels)
+    for _ in range(4):
+        advance(fighter, user, "movement")
+
+    assert shown(fighter, "movement") == '8"'
+
+
+@pytest.mark.django_db
+def test_an_advancement_still_applies_without_a_set(user, make_list, make_list_fighter):
+    """The reordering must not stop ordinary advancements working."""
+    lst = make_list("Gang")
+    fighter = make_list_fighter(lst, "Plain Fighter")
+    base = shown(fighter, "movement")
+    advance(fighter, user, "movement")
+
+    assert shown(fighter, "movement") != base


### PR DESCRIPTION
Some equipment fixes a stat outright — "your movement is 8 inches" — rather than
adjusting it. Those modifications discard whatever they are applied to, so whether
they win depends entirely on what runs after them.

Advancements were being applied last, so instead of being overridden by the fixed
value they added to it. **Eleven production fighters currently show an inflated
movement.** The worst, with four movement advancements over a 9" set, reads 13".

| Fighter | Gang | Shows | Should show |
|---|---|---|---|
| Korra "Ashwheel" Drax | Wild maidens | 13" | 9" |
| Lillex the Needle Threader | The Vapor Waves | 11" | 9" |
| Hekate | Night Witches | 10" | 9" |
| Electra ×2 | ByteRiot Bytchs | 10" | 9" |
| Chosen, Rakho the Dusty | Forsaken of the Second Light | 9" | 8" |
| Sugar | Sixkiller Co. | 9" | 8" |
| Deinopis subrufa | The Sump Web | 9" | 8" |
| Mordran Zigrin, Mackie | Zigrin's Nautical Scavengers | 9" | 8" |

## The fix

Apply the fighter's own permanent improvements — advancements **and roll results** —
before equipment, so a set still wins. Injuries and house rules stay after equipment,
so they continue to modify whatever the gear set.

Before advancements moved onto the mod system they were held in the fighter's
override field, which a set discarded — so this restores the behaviour these
fighters used to have. Improve/worsen modifications are additive, so their order
relative to each other is unchanged, and the ordering is only observable at all
when a set is present.

## How this surfaced

Four of the eleven were tipped over by migration `core.0196` (#2069), which moved
advancements off the override field onto the mod system. Once an advancement was a
modifier rather than a stored value, the set stopped discarding it. The other seven
were already inflated — they were on the mod system before that migration ran.

Roll results (Spyrer Power Boosts) had the same collision one line down — the only
roll-result stat mods in content improve movement and initiative, and every set-mode
mod targets movement. No production fighter has that combination today, so moving
them is preventative; leaving them would have been the same bug waiting.

The migration's verification compared every fighter's rendered statline before and
after against real data and found nothing. The content template it runs against does
hold two set-mode modifications — but **no fighter in it has that gear assigned**, so
the combination never arose. A clean result on data that cannot express the failure
is not evidence, and the missing thing was the combination rather than the mod.

## Test plan

- [x] `pytest` — 4,012 passed, 13 skipped
- [x] Six tests: a set beats one advancement and still beats four; an ordinary
      advancement without a set is unaffected; an injury still worsens a stat the gear
      set; all three together; and a roll result over a set
- [x] **Verified against production, read-only:** with this change all eleven render
      the value their gear sets — Korra returns to 9"
- [x] **No collateral:** every fighter's rendered statline in a template-forked
      database is byte-identical, and the query-count snapshot is unchanged
- [x] ruff, migration checks, bandit clean

Refs #2070
