### PR TITLE
fix: name the source of a stat change; rework the injuries editor

### DIFF
--- a/gyrinx/content/models/base.py
+++ b/gyrinx/content/models/base.py
@@ -143,3 +143,7 @@ class StatlineDisplay:
     classes: str = ""
     modded: bool = False
     highlight: bool = False
+    # What changed this stat, for the tooltip — "Eye Injury", "Bionic eye
+    # (mundane), Eye Injury". Empty when nothing did, or when the value moved
+    # through an override rather than a modification.
+    modded_by: str = ""

--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -1425,10 +1425,14 @@ class ListFighter(AppBase):
         Deliberately NOT a second ``cached_property``. Callers invalidate the
         mod cache with ``del fighter._mods`` — the idiom used throughout the
         test suite — and a separate cache would survive that and go stale.
-        Sources are stashed by ``_mods`` itself, so the two can never diverge.
+        The pairs are stashed by ``_mods`` itself, so the two can never diverge.
+
+        Returns the stored list rather than zipping on demand: ``statline``
+        asks for the sources of every stat in turn, so a rebuild here would run
+        a dozen times per fighter on the gang page.
         """
-        mods = self._mods  # populates _mod_sources as a side effect
-        return list(zip(mods, self._mod_sources))
+        self._mods  # populates _mod_pairs as a side effect
+        return self._mod_pairs
 
     @cached_property
     @traced("listfighter_mods")
@@ -1436,7 +1440,7 @@ class ListFighter(AppBase):
         """Every modification applying to this fighter, in application order.
 
         Alongside the mods it records what applied each one, in
-        ``self._mod_sources`` — read through ``_mods_with_sources``. The source
+        ``self._mod_pairs`` — read through ``_mods_with_sources``. The source
         is carried beside the modification rather than set on it: ``ContentMod``
         rows are shared library content and the same instance can be reached
         from several fighters through the prefetch cache, so writing to one
@@ -1531,7 +1535,7 @@ class ListFighter(AppBase):
             + injury_mods
             + pack_mods
         )
-        self._mod_sources = [source for _, source in pairs]
+        self._mod_pairs = pairs
         return [mod for mod, _ in pairs]
 
     @traced("listfighter_apply_mods")

--- a/gyrinx/core/models/list/fighter.py
+++ b/gyrinx/core/models/list/fighter.py
@@ -1418,15 +1418,44 @@ class ListFighter(AppBase):
 
     # Stats & rules
 
+    @property
+    def _mods_with_sources(self) -> pylist[tuple]:
+        """``(mod, source)`` pairs, where source names what applied the mod.
+
+        Deliberately NOT a second ``cached_property``. Callers invalidate the
+        mod cache with ``del fighter._mods`` — the idiom used throughout the
+        test suite — and a separate cache would survive that and go stale.
+        Sources are stashed by ``_mods`` itself, so the two can never diverge.
+        """
+        mods = self._mods  # populates _mod_sources as a side effect
+        return list(zip(mods, self._mod_sources))
+
     @cached_property
     @traced("listfighter_mods")
-    def _mods(self):
+    def _mods(self) -> pylist:
+        """Every modification applying to this fighter, in application order.
+
+        Alongside the mods it records what applied each one, in
+        ``self._mod_sources`` — read through ``_mods_with_sources``. The source
+        is carried beside the modification rather than set on it: ``ContentMod``
+        rows are shared library content and the same instance can be reached
+        from several fighters through the prefetch cache, so writing to one
+        would leak a label across gangs.
+
+        Sources are what the statline tooltip shows ("Modified by Eye Injury"),
+        so they name the thing a player would recognise — the item, the injury —
+        rather than the internal model.
+        """
         from gyrinx.core.models.list.advancement import AdvancementStatMod
 
-        # Remember: virtual and needs flattening!
-        equipment_mods = [
-            mod for assign in self.assignments_cached for mod in assign.mods
-        ]
+        # Remember: virtual and needs flattening! One label per assignment
+        # rather than per mod, so gear with several modifications is resolved
+        # once.
+        equipment_mods = []
+        for assign in self.assignments_cached:
+            equipment = assign.equipment
+            label = str(equipment.name) if equipment is not None else "Equipment"
+            equipment_mods.extend((mod, label) for mod in assign.mods)
 
         # Add injury mods if in campaign mode
         injury_mods = []
@@ -1443,14 +1472,15 @@ class ListFighter(AppBase):
                 # cancels them. Only a suppressing treatment drops them.
                 if injury.injury_id in suppressed:
                     continue
-                injury_mods.extend(injury.injury.modifiers.all())
+                name = str(injury.injury.name)
+                injury_mods.extend((mod, name) for mod in injury.injury.modifiers.all())
 
         # Add advancement mods for stat advancements using the mod system
         # (not legacy override fields)
         # Note: Use .all() with Python filtering to leverage prefetched data.
         # Using .filter() would bypass the prefetch cache and cause N+1 queries.
         advancement_mods = [
-            AdvancementStatMod(adv.stat_increased)
+            (AdvancementStatMod(adv.stat_increased), "Advancement")
             for adv in self.advancements.all()
             if (
                 not adv.archived
@@ -1466,12 +1496,17 @@ class ListFighter(AppBase):
         roll_result_mods = []
         for result in self.roll_results.all():
             if not result.archived:
-                roll_result_mods.extend(result.row.modifiers.all())
+                label = str(getattr(result.row, "name", "") or "Roll result")
+                roll_result_mods.extend(
+                    (mod, label) for mod in result.row.modifiers.all()
+                )
 
         # Pack-scoped house-rule mods targeting this fighter's content_fighter
         # (e.g. "fighter X gets +1 toughness as a house rule"). Empty when no
         # packs are subscribed.
-        pack_mods = list(self.list.pack_mods_for(self.content_fighter))
+        pack_mods = [
+            (mod, "House rule") for mod in self.list.pack_mods_for(self.content_fighter)
+        ]
 
         # The fighter's own permanent improvements — advancements and roll
         # results — come first, so that a "set" from equipment still wins. A
@@ -1489,13 +1524,15 @@ class ListFighter(AppBase):
         # stat-linked one, so a plain stat driven below zero mid-chain can come
         # out formatted as "+1" rather than "1" depending on order. That is a
         # parser bug rather than something this ordering should work around.
-        return (
+        pairs = (
             advancement_mods
             + roll_result_mods
             + equipment_mods
             + injury_mods
             + pack_mods
         )
+        self._mod_sources = [source for _, source in pairs]
+        return [mod for mod, _ in pairs]
 
     @traced("listfighter_apply_mods")
     def _apply_mods(
@@ -1632,11 +1669,15 @@ class ListFighter(AppBase):
         Includes both ContentModFighterStat (from equipment/injuries) and
         AdvancementStatMod (from stat advancements using the mod system).
         """
+        return [mod for mod, _ in self._statmods_with_sources(stat)]
+
+    def _statmods_with_sources(self, stat: str) -> pylist[tuple]:
+        """``_statmods`` with each mod paired with what applied it."""
         from gyrinx.core.models.list.advancement import AdvancementStatMod
 
         return [
-            mod
-            for mod in self._mods
+            (mod, source)
+            for mod, source in self._mods_with_sources
             if isinstance(mod, (ContentModFighterStat, AdvancementStatMod))
             and mod.stat == stat
         ]
@@ -1718,15 +1759,22 @@ class ListFighter(AppBase):
                     input_value = value_override
 
             # Apply the mods
-            statmods = self._statmods(stat["field_name"])
+            statmods_with_sources = self._statmods_with_sources(stat["field_name"])
             value = self._apply_mods(
                 stat["field_name"],
                 input_value,
-                statmods,
+                [mod for mod, _ in statmods_with_sources],
                 mod_ctx,
             )
 
             modded = value != stat["value"]
+            # De-duplicated in application order: two mods from the same item
+            # name it once.
+            sources = []
+            for _, source in statmods_with_sources:
+                if source and source not in sources:
+                    sources.append(source)
+
             sd = StatlineDisplay(
                 name=stat["name"],
                 field_name=stat["field_name"],
@@ -1734,6 +1782,7 @@ class ListFighter(AppBase):
                 highlight=stat["highlight"],
                 value=value,
                 modded=modded,
+                modded_by=", ".join(sources),
             )
             stats.append(sd)
 

--- a/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
+++ b/gyrinx/core/templates/core/includes/fighter_card_content_inner.html
@@ -269,7 +269,10 @@
                     {% for entry in fighter.injuries_display %}
                         {% if not forloop.first %},{% endif %}
                         {% if entry.is_treated %}
-                            <span class="text-secondary" title="Treated by {{ entry.treated_by }}">{{ entry.injury.injury.name }}
+                            <span bs-tooltip
+                                  data-bs-toggle="tooltip"
+                                  class="tooltipped"
+                                  title="Treated by {{ entry.treated_by }}">{{ entry.injury.injury.name }}
                                 <c-icon name="wrench-adjustable" />
                                 <span class="visually-hidden">— treated by {{ entry.treated_by }}</span></span>
                         {% else %}

--- a/gyrinx/core/templates/core/includes/list_fighter_statline.html
+++ b/gyrinx/core/templates/core/includes/list_fighter_statline.html
@@ -4,7 +4,7 @@
             <span bs-tooltip
                   data-bs-toggle="tooltip"
                   class="tooltipped"
-                  title="Modified by equipment, accessories, upgrades, a pack house rule, or manually">{{ stat.value }}</span>
+                  title="{% if stat.modded_by %}Modified by {{ stat.modded_by }}{% else %}Modified manually{% endif %}">{{ stat.value }}</span>
         {% else %}
             {{ stat.value }}
         {% endif %}

--- a/gyrinx/core/templates/core/list_fighter_injuries_edit.html
+++ b/gyrinx/core/templates/core/list_fighter_injuries_edit.html
@@ -4,38 +4,45 @@
     Edit Injuries - {{ fighter.name }} - {{ list.name }}
 {% endblock head_title %}
 {% block content %}
-    {% include "core/includes/list_common_header.html" with list=list link_list="true" %}
+    {% include "core/includes/list_common_header.html" with list=list link_list="true" fighter=fighter fighter_url_name="core:list-fighter-injuries-edit" %}
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <h1 class="h3">Edit {{ fighter.term_injury_plural }}: {{ fighter.name }}</h1>
-        <div class="card">
-            <div class="card-body">
-                <div class="d-flex align-items-center justify-content-between">
-                    <div>
-                        <strong>{{ fighter.term_singular }} State:</strong>
-                        <span class="badge {% if fighter.is_injured %}text-bg-warning{% elif fighter.is_dead %}text-bg-danger{% else %}text-bg-success{% endif %} ms-2">
-                            {{ fighter.get_injury_state_display }}
-                        </span>
-                    </div>
-                    <a href="{% url 'core:list-fighter-state-edit' list.id fighter.id %}"
-                       class="btn btn-secondary btn-sm">
-                        <i class="bi-pencil"></i>
-                        Update {{ fighter.term_singular }} State
-                    </a>
+        <div class="d-flex flex-wrap gap-3 border-bottom pb-3 mb-2">
+            <div class="flex-grow-1 col-md-3 flex-md-grow-0">
+                <div class="caps-label">{{ fighter.term_singular }} state</div>
+                <div>
+                    <c-badge state="{{ fighter.injury_state }}">
+                        {{ fighter.get_injury_state_display }}
+                    </c-badge>
                 </div>
+                <a href="{% url 'core:list-fighter-state-edit' list.id fighter.id %}"
+                   class="fs-7 linked">Update state</a>
+            </div>
+            <div class="flex-grow-1 col-md-3 flex-md-grow-0">
+                <div class="caps-label">{{ fighter.term_injury_plural }}</div>
+                <div>{{ fighter.injuries_display|length }}</div>
             </div>
         </div>
-        {% if fighter.injuries_display %}
-            <div class="card">
-                <div class="card-header">
-                    <h5 class="mb-0">Current {{ fighter.term_injury_plural }}</h5>
+        <section>
+            <div class="section-header mb-2">
+                <h2 class="h5 mb-0">{{ fighter.term_injury_plural }}</h2>
+                <div class="hstack gap-2 section-actions">
+                    <span>
+                        <a href="{% url 'core:list-fighter-injury-add' list.id fighter.id %}"
+                           class="icon-link linked fs-7">
+                            <i class="bi-plus-lg"></i> Add {{ fighter.term_injury_singular }}
+                        </a>
+                    </span>
                 </div>
-                <div class="card-body mb-last-0">
-                    <table class="table table-sm table-borderless">
+            </div>
+            <div class="px-2">
+                {% if fighter.injuries_display %}
+                    <table class="table table-sm table-borderless mb-0 fs-7">
                         <thead>
                             <tr>
                                 <th>{{ fighter.term_injury_singular }}</th>
                                 <th>Received</th>
-                                <th>
+                                <th class="text-end">
                                     <span class="visually-hidden">Actions</span>
                                 </th>
                             </tr>
@@ -45,14 +52,16 @@
                                 <tr>
                                     <td rowspan="{{ entry.row_span }}">{{ entry.injury.injury.name }}</td>
                                     <td>{{ entry.injury.date_received|date:"M j, Y" }}</td>
-                                    <td>
+                                    <td class="text-end">
                                         <a href="{% url 'core:list-fighter-injury-remove' list.id fighter.id entry.injury.id %}"
-                                           class="link-danger">Remove</a>
+                                           class="link-danger icon-link">
+                                            <i class="bi-trash"></i> Remove
+                                        </a>
                                     </td>
                                 </tr>
                                 {% if entry.is_treated %}
                                     <tr>
-                                        <td colspan="2" class="ps-4 fs-7 text-secondary">
+                                        <td colspan="2" class="text-secondary">
                                             <c-icon name="wrench-adjustable" />
                                             Treated by {{ entry.treated_by }}
                                         </td>
@@ -60,7 +69,7 @@
                                 {% endif %}
                                 {% if entry.injury.notes %}
                                     <tr>
-                                        <td colspan="2" class="ps-4 fs-7 text-secondary">
+                                        <td colspan="2" class="ps-4 text-secondary">
                                             <em>{{ entry.injury.notes }}</em>
                                         </td>
                                     </tr>
@@ -68,21 +77,12 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                </div>
+                {% else %}
+                    <p class="text-secondary mb-0">{{ fighter.proximal_demonstrative }} has no {{ fighter.term_injury_plural|lower }}.</p>
+                {% endif %}
             </div>
-        {% else %}
-            <div class="alert alert-info alert-icon mb-0" role="alert">
-                <i class="bi-info-circle"></i>
-                <div>{{ fighter.proximal_demonstrative }} has no {{ fighter.term_injury_plural|lower }}.</div>
-            </div>
-        {% endif %}
-        <div>
-            <a href="{% url 'core:list-fighter-injury-add' list.id fighter.id %}"
-               class="btn btn-primary">
-                <i class="bi-plus-lg"></i> Add {{ fighter.term_injury_singular }}
-            </a>
-            <a href="{% url 'core:list' list.id %}#{{ fighter.id }}"
-               class="btn btn-link">Cancel</a>
-        </div>
+        </section>
+        <c-back url="{% url 'core:list' list.id %}#{{ fighter.id }}"
+                text="{{ list.name }}" />
     </div>
 {% endblock content %}

--- a/gyrinx/core/tests/test_equipment_injury_links.py
+++ b/gyrinx/core/tests/test_equipment_injury_links.py
@@ -359,3 +359,66 @@ def test_classic_print_card_leaves_an_untreated_injury_bare(injured_fighter):
     from gyrinx.core.print_cards import card_from_fighter
 
     assert card_from_fighter(injured_fighter).injuries == ["Eye Injury"]
+
+
+def _stat_display(fighter, field_name):
+    return next(s for s in fighter.statline if s.field_name == field_name)
+
+
+@pytest.mark.django_db
+def test_statline_names_the_injury_that_changed_a_stat(injured_fighter):
+    """The tooltip should say what moved the stat, not just that something did."""
+    bs = _stat_display(injured_fighter, "ballistic_skill")
+
+    assert bs.modded
+    assert bs.modded_by == "Eye Injury"
+
+
+@pytest.mark.django_db
+def test_statline_names_every_source_in_application_order(
+    injured_fighter, bionic_eye, eye_injury
+):
+    """An offset stat is touched twice — both sources are named."""
+    ContentEquipmentInjuryLink.objects.create(equipment=bionic_eye, injury=eye_injury)
+    fighter = _assign(injured_fighter, bionic_eye)
+
+    bs = _stat_display(fighter, "ballistic_skill")
+
+    # Equipment applies before injuries, so it is named first.
+    assert bs.modded_by == "Bionic eye (mundane), Eye Injury"
+
+
+@pytest.mark.django_db
+def test_suppressed_injury_is_not_named_as_a_source(
+    injured_fighter, make_equipment, eye_injury
+):
+    """A suppressed injury no longer modifies the stat, so it isn't credited."""
+    cyberteknika = make_equipment(
+        "Ocular Cyberteknika", category="Status Items", cost=50
+    )
+    ContentEquipmentInjuryLink.objects.create(
+        equipment=cyberteknika,
+        injury=eye_injury,
+        mode=ContentEquipmentInjuryLink.Mode.SUPPRESS,
+    )
+    fighter = _assign(injured_fighter, cyberteknika)
+
+    assert "Eye Injury" not in _stat_display(fighter, "ballistic_skill").modded_by
+
+
+@pytest.mark.django_db
+def test_unmodified_stat_has_no_source(injured_fighter):
+    assert _stat_display(injured_fighter, "strength").modded_by == ""
+
+
+@pytest.mark.django_db
+def test_statline_tooltip_renders_the_source(client, injured_fighter, user):
+    """The gang page shows the specific source rather than the catch-all."""
+    client.force_login(user)
+
+    content = client.get(
+        reverse("core:list", args=(injured_fighter.list.id,))
+    ).content.decode()
+
+    assert 'title="Modified by Eye Injury"' in content
+    assert "Modified by equipment, accessories" not in content

--- a/scripts/raw_markup_baseline.json
+++ b/scripts/raw_markup_baseline.json
@@ -1,8 +1,8 @@
 {
-  "alert": 72,
-  "badge": 82,
+  "alert": 71,
+  "badge": 81,
   "border-rounded": 72,
-  "btn": 416,
+  "btn": 413,
   "include-back": 82,
   "include-cancel": 18,
   "include-form_field": 24,


### PR DESCRIPTION
Follow-up polish on the equipment-injury links from #2076.

## Statline tooltips name what changed the stat

A modified stat on a fighter card carried a catch-all tooltip: "Modified by equipment, accessories, upgrades, a pack house rule, or manually". It told you *that* something had changed, never *what*. With injuries now interacting with gear, that's the question people actually have.

Each modification is now carried with a label naming what applied it, so the tooltip reads "Modified by Eye Injury", or "Modified by Bionic eye (mundane), Eye Injury" when two things touched the same stat. Labels name the thing a player recognises — the item, the injury, "Advancement", "House rule" — not the internal model.

Two implementation notes worth flagging:

- The label sits *beside* the modification, never on it. `ContentMod` rows are shared library content and the same instance is reachable from several fighters through the prefetch cache, so writing a label onto one would leak it across gangs.
- Sources are stashed by `_mods` itself rather than living in their own `cached_property`. Callers invalidate with `del fighter._mods` — the idiom used throughout the test suite — and a second cache would quietly survive that and go stale. I hit exactly that: an early version broke seven unrelated skill-tree and psyker tests.

## Treated-injury markers use the real tooltip convention

They were using a bare `title` attribute. Now `bs-tooltip` + `.tooltipped`, matching the counters and weapon-profile markers.

## Injuries editor reworked onto standard page furniture

The page was a stack of Bootstrap cards with the add button stranded at the bottom. It now uses:

- a section header with "Add injury" as an action inside it
- the fighter switcher, so you can move between fighters without going back to the gang
- info columns for fighter state, replacing the boxed state panel
- `bi-trash` for the destructive action, and a right-aligned action column
- no stray indent before the treated marker

This drops three raw `btn` sites, one `alert` and one `badge` from the raw-markup ratchet; baseline updated to match.

## Test plan

- [x] `pytest -n auto` — 4078 passed, 13 skipped
- [x] New tests: the injury is named as a source, both sources are named in application order, a suppressed injury is *not* credited, an unmodified stat has no source, and the tooltip renders on the gang page
- [x] Verified against real seeded data on a dev server — bionics and Cyberteknika linked as the docs runbook prescribes

Refs #1027