### PR TITLE
fix: replace leaky persistent DB connections with a psycopg connection pool

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -91,6 +91,9 @@ steps:
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID
       - "--region=$_DEPLOY_REGION"
+      # The DB connection pool in gyrinx/settings_prod.py is sized against
+      # this instance cap — revisit both together.
+      - "--max-instances=3"
       - "--quiet"
     id: Deploy
     entrypoint: gcloud

--- a/docs/how-to-guides/task-framework.md
+++ b/docs/how-to-guides/task-framework.md
@@ -342,6 +342,6 @@ my_task("arg1", "arg2")
 ```
 
 1. **Common failure causes**:
-   - `429`: Database connection pool exhausted (check `CONN_MAX_AGE`, connection limits)
+   - `429`: Database at capacity — the psycopg connection pool timed out waiting for a connection, or Postgres is out of connection slots (check the pool sizing in `gyrinx/settings_prod.py` and Cloud SQL connection limits)
    - `500`: Unhandled exception (check task code)
    - `400`: Message format issues (check enqueue arguments)

--- a/gyrinx/core/tests/test_performance_view_queries.py
+++ b/gyrinx/core/tests/test_performance_view_queries.py
@@ -46,6 +46,15 @@ User = get_user_model()
 def normalize_sql_uuids(sql):
     """Replace UUIDs in SQL with numbered placeholders for consistent comparison."""
 
+    # psycopg 3 renders UUID params as dashless quoted literals with a cast
+    # ('0123...cdef'::uuid); rewrite them to the dashed form first so both
+    # renderings share one placeholder map.
+    def dash_uuid(match):
+        h = match.group(1)
+        return f"'{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:]}'::uuid"
+
+    sql = re.sub(r"'([0-9a-f]{32})'::uuid", dash_uuid, sql, flags=re.IGNORECASE)
+
     # Pattern to match UUIDs (8-4-4-4-12 format)
     uuid_pattern = r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"
 

--- a/gyrinx/core/tests/test_performance_view_queries.py
+++ b/gyrinx/core/tests/test_performance_view_queries.py
@@ -72,6 +72,19 @@ def normalize_sql_uuids(sql):
     return re.sub(uuid_pattern, replace_uuid, sql, flags=re.IGNORECASE)
 
 
+def test_normalize_sql_uuids_unifies_driver_renderings():
+    # psycopg2 renders UUID params dashed; psycopg 3 renders them dashless.
+    # Both must normalize to the same placeholder or the snapshot churns on
+    # every run.
+    dashed = "SELECT 1 WHERE id = '06ac5c9e-3fd4-4fcf-ad8f-3aa872139930'::uuid"
+    dashless = "SELECT 1 WHERE id = '06ac5c9e3fd44fcfad8f3aa872139930'::uuid"
+    assert (
+        normalize_sql_uuids(dashed)
+        == normalize_sql_uuids(dashless)
+        == "SELECT 1 WHERE id = 'UUID-1'::uuid"
+    )
+
+
 def strip_sql_comments(sql):
     """Strip SQL comments from the end of queries.
 

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -52,19 +52,38 @@ SECURE_HSTS_PRELOAD = False
 
 BASE_URL = "https://gyrinx.app"
 
-# Persistent database connections.
+# Database connection pooling (psycopg_pool via Django's `pool` option).
 #
-# Django's default (CONN_MAX_AGE=0) opens a brand-new Postgres connection on
-# every request. On Cloud SQL each connect pays TLS + auth latency (tens of ms)
-# and adds connection-churn load on the instance. Reuse connections for up to
-# 60s, with a health check at the start of each request so a connection dropped
-# by the server (or the Cloud SQL proxy) is transparently re-established rather
-# than surfacing as an error.
+# Persistent connections (CONN_MAX_AGE > 0) must stay OFF here: they are
+# per-thread, and under an ASGI server (daphne) sync ORM work runs on a
+# rotating set of executor threads, so expired connections stranded on
+# dormant threads are never reaped. In production this leaked idle
+# connections until Cloud SQL's max_connections (50 on db-g1-small) was
+# exhausted.
 #
-# Dev/tests intentionally keep the Django default (0) — short-lived processes
-# and pytest don't benefit, and persistent connections complicate test teardown.
-DATABASES["default"]["CONN_MAX_AGE"] = 60  # noqa: F405
-DATABASES["default"]["CONN_HEALTH_CHECKS"] = True  # noqa: F405
+# The pool gives the same reuse benefit (no per-request TLS + auth
+# handshake) with a hard per-process cap and is safe under ASGI:
+# connections return to the pool at the end of every request regardless
+# of which thread ran it. CONN_HEALTH_CHECKS is unnecessary — the pool
+# checks connections on checkout.
+#
+# Sizing: Cloud Run runs at most 3 instances (one daphne process each),
+# so max_size 12 caps the app at 36 connections, leaving headroom under
+# the 50-connection limit for cloudsqladmin, prodshell, migrations at
+# deploy time, and background-task delivery. Requests beyond the cap
+# queue for a connection for up to `timeout` seconds rather than failing
+# the database.
+#
+# Dev/tests intentionally keep the Django default (no pool) — short-lived
+# processes and pytest don't benefit, and the pool complicates teardown.
+DATABASES["default"]["OPTIONS"] = {  # noqa: F405
+    **DATABASES["default"].get("OPTIONS", {}),  # noqa: F405
+    "pool": {
+        "min_size": 2,
+        "max_size": 12,
+        "timeout": 10,
+    },
+}
 
 STORAGES = {
     **STORAGES,

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -72,8 +72,9 @@ BASE_URL = "https://gyrinx.app"
 # connection dropped by the server or the Cloud SQL proxy is verified
 # (and replaced) on checkout instead of failing the request.
 #
-# Sizing: the live service runs at most 3 instances (one daphne process
-# each), so max_size 8 caps steady state at 24 connections — and at most
+# Sizing: Cloud Run runs at most 3 instances (--max-instances in
+# cloudbuild.yaml, one daphne process each), so max_size 8 caps steady
+# state at 24 connections — and at most
 # 48 in the worst case during a rolling deploy, when old and new
 # revisions briefly overlap and both serve traffic. That stays under the
 # 50-connection limit with room for cloudsqladmin, prodshell, and
@@ -88,7 +89,9 @@ DATABASES["default"]["OPTIONS"] = {  # noqa: F405
     "pool": {
         "min_size": 1,
         "max_size": 8,
-        "timeout": 10,
+        # Fail reasonably fast when the DB is down or the pool is
+        # saturated, so requests shed instead of piling up.
+        "timeout": 5,
     },
 }
 

--- a/gyrinx/settings_prod.py
+++ b/gyrinx/settings_prod.py
@@ -55,32 +55,39 @@ BASE_URL = "https://gyrinx.app"
 # Database connection pooling (psycopg_pool via Django's `pool` option).
 #
 # Persistent connections (CONN_MAX_AGE > 0) must stay OFF here: they are
-# per-thread, and under an ASGI server (daphne) sync ORM work runs on a
-# rotating set of executor threads, so expired connections stranded on
-# dormant threads are never reaped. In production this leaked idle
+# per-thread, and under an ASGI server (daphne) Django runs each request's
+# sync ORM work on a fresh single-use thread (ThreadSensitiveContext →
+# one ThreadPoolExecutor(max_workers=1) per request). The thread dies with
+# its connection still open — close_old_connections declines to close a
+# connection younger than the max age — so nothing is ever reused and the
+# socket lingers until cyclic GC. In production this leaked idle
 # connections until Cloud SQL's max_connections (50 on db-g1-small) was
-# exhausted.
+# exhausted, while delivering zero of the reuse it was meant to buy.
 #
-# The pool gives the same reuse benefit (no per-request TLS + auth
+# The pool gives the reuse benefit for real (no per-request TLS + auth
 # handshake) with a hard per-process cap and is safe under ASGI:
 # connections return to the pool at the end of every request regardless
-# of which thread ran it. CONN_HEALTH_CHECKS is unnecessary — the pool
-# checks connections on checkout.
+# of which thread ran it. CONN_HEALTH_CHECKS must stay True — it is what
+# makes Django pass check=ConnectionPool.check_connection, so a
+# connection dropped by the server or the Cloud SQL proxy is verified
+# (and replaced) on checkout instead of failing the request.
 #
-# Sizing: Cloud Run runs at most 3 instances (one daphne process each),
-# so max_size 12 caps the app at 36 connections, leaving headroom under
-# the 50-connection limit for cloudsqladmin, prodshell, migrations at
-# deploy time, and background-task delivery. Requests beyond the cap
-# queue for a connection for up to `timeout` seconds rather than failing
-# the database.
+# Sizing: the live service runs at most 3 instances (one daphne process
+# each), so max_size 8 caps steady state at 24 connections — and at most
+# 48 in the worst case during a rolling deploy, when old and new
+# revisions briefly overlap and both serve traffic. That stays under the
+# 50-connection limit with room for cloudsqladmin, prodshell, and
+# deploy-time migrations. Requests beyond the cap queue for a connection
+# for up to `timeout` seconds rather than failing the database.
 #
 # Dev/tests intentionally keep the Django default (no pool) — short-lived
 # processes and pytest don't benefit, and the pool complicates teardown.
+DATABASES["default"]["CONN_HEALTH_CHECKS"] = True  # noqa: F405
 DATABASES["default"]["OPTIONS"] = {  # noqa: F405
     **DATABASES["default"].get("OPTIONS", {}),  # noqa: F405
     "pool": {
-        "min_size": 2,
-        "max_size": 12,
+        "min_size": 1,
+        "max_size": 8,
         "timeout": 10,
     },
 }

--- a/gyrinx/tasks/tests/test_views.py
+++ b/gyrinx/tasks/tests/test_views.py
@@ -84,6 +84,34 @@ def test_pubsub_handler_rejects_missing_data(client, bypass_oidc):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "FATAL: remaining connection slots are reserved",
+        "FATAL: too many connections for role",
+        "couldn't get a connection after 5.00 sec",
+    ],
+)
+def test_pubsub_handler_returns_429_when_db_at_capacity(
+    client, bypass_oidc, error_message
+):
+    """Postgres exhaustion and psycopg_pool checkout timeouts both nack with 429."""
+    from django.db import OperationalError
+
+    url = reverse("tasks:pubsub")
+    with patch(
+        "gyrinx.tasks.views.connection.ensure_connection",
+        side_effect=OperationalError(error_message),
+    ):
+        response = client.post(
+            url,
+            data=json.dumps(make_pubsub_message("any_task")),
+            content_type="application/json",
+        )
+    assert response.status_code == 429
+
+
+@pytest.mark.django_db
 def test_pubsub_handler_rejects_unknown_task(client, bypass_oidc):
     """Unknown task name should return 400."""
     url = reverse("tasks:pubsub")

--- a/gyrinx/tasks/views.py
+++ b/gyrinx/tasks/views.py
@@ -132,7 +132,15 @@ def pubsub_push_handler(request):
     try:
         connection.ensure_connection()
     except OperationalError as e:
-        if "connection slots" in str(e) or "too many connections" in str(e).lower():
+        # "connection slots" / "too many connections": Postgres itself is
+        # full. "couldn't get a connection": psycopg_pool exhausted its
+        # max_size and timed out waiting for a checkout.
+        msg = str(e).lower()
+        if (
+            "connection slots" in msg
+            or "too many connections" in msg
+            or "couldn't get a connection" in msg
+        ):
             logger.warning(
                 "Database connection pool exhausted, returning 429 for retry",
                 extra={"error": str(e)},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "Pillow==12.3.0",
     "playwright==1.61.0",
     "pre-commit==4.6.0",
-    "psycopg2-binary==2.9.12",
+    "psycopg[binary,pool]==3.3.4",
     "pyasn1==0.6.4",
     "pydantic==2.13.4",
     "pydot==4.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1056,7 +1056,7 @@ dependencies = [
     { name = "pillow" },
     { name = "playwright" },
     { name = "pre-commit" },
-    { name = "psycopg2-binary" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pyasn1" },
     { name = "pydantic" },
     { name = "pydot" },
@@ -1126,7 +1126,7 @@ requires-dist = [
     { name = "pillow", specifier = "==12.3.0" },
     { name = "playwright", specifier = "==1.61.0" },
     { name = "pre-commit", specifier = "==4.6.0" },
-    { name = "psycopg2-binary", specifier = "==2.9.12" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = "==3.3.4" },
     { name = "pyasn1", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydot", specifier = "==4.0.1" },
@@ -1787,41 +1787,72 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2-binary"
-version = "2.9.12"
+name = "psycopg"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
-    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
-    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
-    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
-    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
-    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
-    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Production has been running out of database connections: Cloud SQL (db-g1-small) allows 50, and a live check found 44 open with 35 idle — the oldest idle for ~25 minutes.
- Root cause: `CONN_MAX_AGE=60` (added in #1871) doesn't work under daphne. Under ASGI, Django runs each request's sync ORM work on a **fresh single-use thread** (one `ThreadSensitiveContext` → one `ThreadPoolExecutor(max_workers=1)` per request); persistent connections are per-thread, `close_old_connections` declines to close a connection younger than the max age, and the thread then dies with the connection open — reclaimed only by cyclic GC. An adversarial A/B repro through the real `ASGIHandler` confirmed it: 100 requests → **40 leaked connections** with `CONN_MAX_AGE=60`, **0** with the default — and zero connection reuse in either arm, so the setting was pure cost.
- Fix: drop `CONN_MAX_AGE` and use Django's native connection pool instead, which returns connections to the pool at the end of every request regardless of which thread ran it, and puts a hard cap on connections per process. Verified under real daphne: three waves of 20 concurrent requests settle at exactly `max_size` idle backends.

## Changes

- `pyproject.toml` / `uv.lock`: swap `psycopg2-binary` for `psycopg[binary,pool]==3.3.4` — Django's `pool` option requires psycopg 3. Nothing in the codebase imports psycopg2 directly, and the sqlcommenter middleware uses Django's driver-agnostic `execute_wrapper`, so this is a clean swap.
- `gyrinx/settings_prod.py`: pool sized `min_size=1, max_size=8, timeout=5`. With at most 3 instances, steady state caps at 24 connections and the worst case during a rolling deploy — when old and new revisions overlap — at 48, under the 50 limit with room for cloudsqladmin, prodshell, and deploy-time migrations. Requests beyond the cap queue up to 5s for a connection instead of failing the database.
- `CONN_HEALTH_CHECKS=True` is **kept**: it is what makes Django pass `check=ConnectionPool.check_connection` to psycopg_pool (`django/db/backends/postgresql/base.py`), so connections dropped by the server or the Cloud SQL Auth Proxy are verified and replaced on checkout.
- `gyrinx/tasks/views.py`: the Pub/Sub handler's 429 backpressure path only matched Postgres's own exhaustion messages; pool saturation raises `OperationalError: couldn't get a connection after N sec`, which would have fallen through to a 500 and a Pub/Sub retry storm. Now caught, with handler tests for all three message forms.
- `cloudbuild.yaml`: deploy now pins `--max-instances=3`, so the pool-sizing premise lives in the repo instead of console state.
- `gyrinx/core/tests/test_performance_view_queries.py`: psycopg 3 renders UUID params as dashless `'hex'::uuid` literals, which slipped past the snapshot normalizer; it now canonicalises them to the dashed form first (with a direct test that both drivers' renderings normalise identically). The checked-in snapshot is unchanged.
- `docs/how-to-guides/task-framework.md`: 429 troubleshooting no longer points at `CONN_MAX_AGE`.

## Test plan

- [x] Full suite under psycopg 3: failure set is byte-for-byte identical to the psycopg2 baseline on the same tree (31 pre-existing failures from the admin-2FA change #2074, unrelated to this PR — see note below)
- [x] Leak A/B repro through the real `ASGIHandler` (psycopg2 + `CONN_MAX_AGE=60`): 40 stranded connections, cleared only by forced GC; 0 with the default
- [x] Pool behaviour under real daphne: 3 × 20 concurrent requests → all 200s, pg_stat_activity settles at exactly `max_size` idle backends
- [x] Prod settings import with the pool config present, `CONN_HEALTH_CHECKS=True`, and `CONN_MAX_AGE` unset
- [x] Handler 429 tests cover Postgres exhaustion and pool checkout timeout
- [ ] After deploy: watch Cloud SQL connection count — expect steady state well under 30 with idle connections held by the pool, not stranded

## Notes for reviewers

- **Known accepted trade-off:** under sustained load beyond 8 concurrent DB-bound queries per instance, requests queue in `pool.getconn()` for up to 5s then error — bounded degradation instead of exhausting the database. The task endpoint returns 429 (Pub/Sub backoff) in that state.
- The service runs with default CPU throttling (no `--no-cpu-throttling`); pool growth happens on a background thread, but growth is only ever triggered while requests are in flight (CPU allocated), so this is acceptable.
- 31 admin tests currently fail on `main` itself (they 302 to the admin login) — introduced by #2074 (admin login via allauth + 2FA), reproduced with both drivers on an unmodified tree. Not addressed here; needs its own fix.

Refs #1871