### PR TITLE
fix: detect pytest via sys.modules so the admin MFA gate stays off under tests

### DIFF
--- a/gyrinx/core/tests/test_admin_login_security.py
+++ b/gyrinx/core/tests/test_admin_login_security.py
@@ -5,11 +5,13 @@ password and nothing else, which would let a staff account with TOTP configured
 into the admin without ever being challenged.
 """
 
+import os
 from urllib.parse import unquote
 
 import pytest
 from allauth.account.models import EmailAddress
 from allauth.mfa.totp.internal import auth as totp_auth
+from django.conf import settings
 from django.test import Client, override_settings
 from django.urls import reverse
 
@@ -53,6 +55,23 @@ def pass_captcha(monkeypatch):
     monkeypatch.setattr(
         "django_recaptcha.fields.ReCaptchaField.validate", lambda self, value: True
     )
+
+
+# ------------------------------------- pytest keeps the gate off by default
+
+
+def test_pytest_detection_keeps_the_mfa_gate_off():
+    """Regression guard for settings_dev's pytest detection.
+
+    Unset, ADMIN_REQUIRE_MFA follows DEBUG — and pytest-django forces
+    DEBUG = False, so the gate would be ON for the whole suite. settings_dev
+    turns it off when it detects pytest. If that detection breaks, dozens of
+    admin tests fail with 302s to the login page; this test names the cause
+    directly.
+    """
+    if os.getenv("ADMIN_REQUIRE_MFA") is not None:
+        pytest.skip("ADMIN_REQUIRE_MFA is forced in the environment")
+    assert settings.ADMIN_REQUIRE_MFA is False
 
 
 # ------------------------------------------------------- the form is gone

--- a/gyrinx/settings_dev.py
+++ b/gyrinx/settings_dev.py
@@ -21,7 +21,15 @@ WHITENOISE_AUTOREFRESH = True
 # every component guard in exactly the place they are supposed to catch things.
 COTTON_STRICT_COMPONENTS = True
 
-_UNDER_PYTEST = bool(os.getenv("PYTEST_CURRENT_TEST")) or "pytest" in os.getenv("_", "")
+# pytest is always imported before Django settings load when any pytest launcher
+# is driving the process (plain pytest, pytest-xdist workers, ptw, IDE runners,
+# CI shells), and never under runserver/management commands. The previous
+# environment-based detection (PYTEST_CURRENT_TEST, or "pytest" in $_) silently
+# missed under launchers that don't set $_ to the pytest binary —
+# PYTEST_CURRENT_TEST isn't set yet at settings-import time — which flipped
+# pytest-only settings (like the admin MFA gate below) to their production
+# values for the whole suite.
+_UNDER_PYTEST = "pytest" in sys.modules
 
 # Disable debug toolbar in tests - prevents 'djdt' namespace errors when tests
 # use @override_settings(DEBUG=True). pytest-xdist workers set RUN_MAIN env var.


### PR DESCRIPTION
## Summary

- Since #2074, the admin requires a completed 2FA challenge unless `ADMIN_REQUIRE_MFA` is off. `gyrinx/settings_dev.py` turns it off under pytest — but detected pytest from `PYTEST_CURRENT_TEST` (which isn't set yet when settings import) or `"pytest" in $_` (which only some shells set to the pytest binary's path).
- Under launchers that set neither (`ptw`, IDE test runners, some CI shells), the whole suite silently ran with the production MFA gate enabled, and ~30 admin tests failed with a 302 to the login page instead of rendering the admin.
- Replace the detection with `"pytest" in sys.modules`: pytest is always imported before Django settings load under any pytest launcher (including xdist workers), and never under `runserver` or management commands. This also hardens the other `_UNDER_PYTEST` consumers (debug-toolbar config, tasks backend selection).

The admin 2FA behaviour itself is unchanged — the security tests in `gyrinx/core/tests/test_admin_login_security.py` set `ADMIN_REQUIRE_MFA` explicitly and still cover the gate.

Refs #2074 (the PR that introduced the gate; the change there is kept as-is).

## Test plan

- [x] `pytest -q` — 4078 passed, 13 skipped
- [x] `env -u PYTEST_CURRENT_TEST _=/usr/bin/make pytest -q` (reproduces the broken environment; previously 30 failures) — 4078 passed, 13 skipped
- [x] Non-pytest settings load (`django.setup()` from plain python) leaves `ADMIN_REQUIRE_MFA` unset, so the dev server and production behaviour are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)