### PR TITLE
fix: actually record what notification was asked for

### DIFF
--- a/gyrinx/core/maintenance/stat_advancements.py
+++ b/gyrinx/core/maintenance/stat_advancements.py
@@ -778,9 +778,19 @@ def run(*, notify=True, triggered_by=None):
             # identity — Change is mutable and compared by value.
             stale = {(c.fighter_id, c.stat) for c in skipped}
             delivered = [c for c in plan.visible if (c.fighter_id, c.stat) not in stale]
-            transaction.on_commit(
-                lambda: _deliver(record, build_messages_for(delivered))
-            )
+            outgoing = build_messages_for(delivered)
+
+            # Recorded before the send so that "0 sent" can be read afterwards.
+            # Without it a delivery that crashed looks exactly like having had
+            # nothing to send, and a re-run cannot tell the difference either:
+            # these pairs are already recorded as handled, so it finds nothing
+            # visible and sends nothing.
+            result.notify_requested = True
+            result.messages_expected = len(outgoing)
+            record.summary = result.as_dict()
+            record.save(update_fields=["summary", "modified"])
+
+            transaction.on_commit(lambda: _deliver(record, outgoing))
 
     record.refresh_from_db()
     result.messages_sent = (record.summary or {}).get("messages_sent", 0)

--- a/gyrinx/core/tests/test_maintenance_stat_advancements.py
+++ b/gyrinx/core/tests/test_maintenance_stat_advancements.py
@@ -607,3 +607,34 @@ def test_a_summary_distinguishes_nothing_to_send_from_not_sent(
     assert summary["messages_expected"] == 0
     # There was a visible change — it just was not going to be announced
     assert summary["visible"] == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_summary_records_what_notification_was_asked_for():
+    """The requested count is what makes "0 sent" readable after the fact.
+
+    Testing only the notify=False case would pass against code that never
+    sets these at all, since False and 0 are their defaults.
+    """
+    from django.contrib.auth import get_user_model
+
+    from gyrinx.content.models import ContentHouse
+    from gyrinx.core.models.list import List
+
+    User = get_user_model()
+    owner = User.objects.create_user(username="intentrec", password="pw")
+    house = ContentHouse.objects.create(name="Intent House")
+    cf = make_simple_content_fighter(house)
+    lst = List.objects.create(name="Gang", owner=owner, content_house=house)
+    fighter = ListFighter.objects.create(
+        list=lst, name="Feuer", content_fighter=cf, owner=owner
+    )
+    advancement(fighter, owner, "toughness", uses_mod_system=False)
+
+    result = run(notify=True)
+    result.backfill.refresh_from_db()
+    summary = result.backfill.summary
+
+    assert summary["notify_requested"] is True
+    assert summary["messages_expected"] == 1
+    assert summary["messages_sent"] == 1


### PR DESCRIPTION
The stat-advancement cleanup run recorded a summary that contradicts itself:
`messages_sent: 28` alongside `notify_requested: False` and `messages_expected: 0`.
Twenty-eight messages genuinely went out, so notification plainly was requested.

The two fields shipped, but nothing ever set them. Worse than merely missing: a
summary reading "0 expected, 0 sent" is exactly what a **failed** delivery would
have produced, so the one thing those fields exist to distinguish is the thing
they now obscure.

## The change

Set them where the messages are built, before the send is registered, so the
recorded intent is durable whatever happens to the delivery afterwards.

## Why it was not caught

The edit that should have added these lines was applied with a string
replacement that stopped matching once the formatter reflowed the surrounding
code, and it reported success anyway. The accompanying test only exercised the
`notify=False` path — where `False` and `0` are the correct answers — so it
passed against code that did nothing at all.

The new test covers `notify=True` and fails against the shipped behaviour.

## Effect on the run that already happened

None on the data. That run is verified correct: 104 pairs changed, 46 stats
visibly corrected, 0 skipped, and spot checks confirm the intended values
(Feuer strength 6, Gallow movement 5", Jaxx toughness 6). Legacy rows fell from
134 to 19, which is the population deliberately left alone.

Its `Backfill` record keeps the misleading pair of fields. It cannot be
reconstructed after the fact, and `messages_sent: 28` is the trustworthy figure
in it.

## Test plan

- [x] `pytest` — 4,109 passed, 13 skipped
- [x] New test asserts `notify_requested`, `messages_expected` and
      `messages_sent` agree; verified to fail against the previous code
- [x] ruff, migration checks, bandit clean

Refs #2070