### PR TITLE
fix: serve a real robots.txt and stop counting crawlers as engagement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY pyproject.toml uv.lock /app/
 COPY scripts/ /app/scripts/
 COPY gyrinx/ /app/gyrinx/
 COPY content/ /app/content/
+# Root-level static assets (favicon.ico) served by WhiteNoise via
+# WHITENOISE_ROOT — without this the container warns "No directory at:
+# /app/static/" and /favicon.ico falls through to the page router.
+COPY static/ /app/static/
 # Set a version for setuptools-scm when .git is not available
 ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_GYRINX=1.0.0
 # --locked installs exactly what uv.lock pins and fails if the lock is stale, so

--- a/gyrinx/core/models/events.py
+++ b/gyrinx/core/models/events.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from enum import Enum
 
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -257,6 +258,23 @@ def get_client_ip(request):
     return request.META.get("REMOTE_ADDR")
 
 
+# Matches the crawlers seen in practice (Amazonbot, Googlebot, bingbot,
+# Bytespider, Google-Read-Aloud, ...) plus the generic self-identifying
+# patterns. Deliberately broad: "bot" also matches e.g. Cubot phone UAs, but
+# losing a stray device is cheaper than counting crawlers as engagement —
+# 2026-07-28 showed crawler traffic outnumbering humans on fighter pages.
+BOT_USER_AGENT_RE = re.compile(
+    r"bot|crawler|spider|slurp|read-aloud|bingpreview|facebookexternalhit",
+    re.IGNORECASE,
+)
+
+
+def is_bot_request(request):
+    """True if the request's User-Agent identifies a crawler."""
+    user_agent = request.META.get("HTTP_USER_AGENT", "")
+    return bool(BOT_USER_AGENT_RE.search(user_agent))
+
+
 def log_event(
     user, noun, verb, object=None, request=None, ip_address=None, field=None, **context
 ):
@@ -288,6 +306,10 @@ def log_event(
         )
     """
     try:
+        # Crawlers are traffic, not engagement — don't record them as events.
+        if request is not None and is_bot_request(request):
+            return None
+
         # Extract session ID from request if available
         session_id = None
         if (

--- a/gyrinx/core/tests/test_events.py
+++ b/gyrinx/core/tests/test_events.py
@@ -403,3 +403,50 @@ def test_log_event_with_x_forwarded_for():
     )
 
     assert event.ip_address == "192.168.1.100"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_agent",
+    [
+        "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot) Chrome/119.0.6045.214 Safari/537.36",
+        "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+        "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)",
+        "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
+    ],
+)
+def test_log_event_skips_crawler_user_agents(user_agent):
+    """Crawler requests must not be recorded as engagement events."""
+    from django.test import RequestFactory
+
+    request = RequestFactory().get("/", HTTP_USER_AGENT=user_agent)
+    result = log_event(
+        user=None, noun=EventNoun.LIST_FIGHTER, verb=EventVerb.VIEW, request=request
+    )
+    assert result is None
+    assert Event.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_log_event_records_normal_user_agents():
+    """An ordinary browser UA still produces an event."""
+    from django.test import RequestFactory
+
+    request = RequestFactory().get(
+        "/",
+        HTTP_USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15",
+    )
+    user = User.objects.create_user(username="humanuser")
+    result = log_event(
+        user=user, noun=EventNoun.LIST_FIGHTER, verb=EventVerb.VIEW, request=request
+    )
+    assert result is not None
+    assert Event.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_log_event_without_request_still_records():
+    """Internal calls that pass no request are unaffected by the bot filter."""
+    user = User.objects.create_user(username="internaluser")
+    result = log_event(user=user, noun=EventNoun.LIST, verb=EventVerb.CREATE)
+    assert result is not None

--- a/gyrinx/pages/tests/test_robots.py
+++ b/gyrinx/pages/tests/test_robots.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_robots_txt_served_as_plain_text(client):
+    response = client.get("/robots.txt")
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/plain")
+
+
+@pytest.mark.django_db
+def test_robots_txt_policy(client):
+    """Amazonbot and Bytespider are excluded entirely; fighter detail pages,
+    accounts, and admin are disallowed for every agent."""
+    body = client.get("/robots.txt").content.decode()
+    sections = body.split("\n\n")
+    assert "User-agent: Amazonbot\nDisallow: /" in sections
+    assert "User-agent: Bytespider\nDisallow: /" in sections
+    general = [s for s in sections if s.startswith("User-agent: *")][0]
+    assert "Disallow: /list/*/fighter/" in general
+    assert "Disallow: /accounts/" in general
+    assert "Disallow: /admin/" in general

--- a/gyrinx/pages/views.py
+++ b/gyrinx/pages/views.py
@@ -4,11 +4,35 @@ from django.contrib.flatpages.models import FlatPage
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import (
     Http404,
+    HttpResponse,
     HttpResponsePermanentRedirect,
 )
 from django.shortcuts import get_object_or_404, render
 
 from gyrinx.pages.models import FlatPageVisibility
+
+# Crawl policy. Amazonbot alone was ~70% of page traffic (2026-07-28) crawling
+# every fighter page of every public list; it feeds Amazon product answers and
+# brings no users, so it is excluded entirely. Bytespider (ByteDance) likewise.
+# For everyone else (Googlebot, bingbot, ...) the list overview pages carry the
+# search value — the per-fighter detail pages are crawl noise, so they are
+# disallowed for all agents.
+ROBOTS_TXT = """\
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: *
+Disallow: /list/*/fighter/
+Disallow: /accounts/
+Disallow: /admin/
+"""
+
+
+def robots_txt(request):
+    return HttpResponse(ROBOTS_TXT, content_type="text/plain")
 
 
 def flatpage(request, url):

--- a/gyrinx/templates/robots.txt
+++ b/gyrinx/templates/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /admin/

--- a/gyrinx/urls.py
+++ b/gyrinx/urls.py
@@ -73,6 +73,7 @@ _debug_urls = [
 urlpatterns = (
     debug_toolbar_urls()
     + [
+        path("robots.txt", views.robots_txt, name="robots_txt"),
         path("", include("gyrinx.core.urls")),
         path("api/", include("gyrinx.api.urls")),
         path("tasks/", include("gyrinx.tasks.urls")),

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /admin/


### PR DESCRIPTION
## Summary

- Investigation of today's suspiciously flat ~2 req/s traffic found crawlers enumerating the site: **Amazonbot alone was ~70% of fighter-page requests**, with Googlebot, Bytespider, and bingbot behind it. Today's event tracking recorded 2,911 anonymous fighter-view events across 2,092 distinct fighters — all robots, no humans.
- Root cause of the free-for-all: **prod has never served a robots.txt.** The repo's `static/robots.txt` was never `COPY`ed into the Docker image, so `/robots.txt` 301'd via APPEND_SLASH to the homepage — which crawlers interpret as "no policy, crawl everything".

## Changes

- `gyrinx/pages/views.py` + `gyrinx/urls.py`: `/robots.txt` is now a Django view (single source of truth; the stale `static/robots.txt` and orphaned `gyrinx/templates/robots.txt` are deleted). Policy: Amazonbot and Bytespider disallowed entirely (they feed Amazon/ByteDance products and bring no users); `/list/*/fighter/`, `/accounts/`, `/admin/` disallowed for all agents. List overview pages remain crawlable for search.
- `gyrinx/core/models/events.py`: `log_event` drops requests whose User-Agent identifies a crawler (bot/crawler/spider/slurp/…), so the events feed counts humans. Internal calls without a request are unaffected. The match is deliberately broad — losing the odd Cubot phone beats counting Amazonbot as engagement.
- `Dockerfile`: `COPY static/ /app/static/` — fixes `/favicon.ico` (which also fell through to the page router) and the "No directory at: /app/static/" warning on every boot.

## Test plan

- [x] New tests: robots.txt served as text/plain with the exact policy; `log_event` skips four real crawler UAs, records a normal browser UA, and ignores the filter for requestless internal calls
- [x] Full suite: 4,118 passed
- [x] Real container image: `/robots.txt` 200 with policy, `/favicon.ico` 200, boot warning gone
- [ ] Post-deploy: Amazonbot request volume should fall away over ~24-48h as it re-reads robots.txt; `event_view_list_fighter` counts should drop to human levels immediately

## Notes

- Bytespider is known to sometimes ignore robots.txt; if it persists, a Cloud Armor UA-based rule is the escalation path (mind the `targetRuleIds` gotcha).
- Crawl volume was never a cost problem (~124k req/day is trivial) — this is about honest analytics and not feeding scrapers every fighter page.