### PR TITLE
feat: clone campaign assets, sub-assets and all

### DIFF
--- a/gyrinx/core/forms/campaign.py
+++ b/gyrinx/core/forms/campaign.py
@@ -562,6 +562,22 @@ class CampaignAssetForm(forms.ModelForm):
         return instance
 
 
+class CampaignAssetCloneForm(forms.Form):
+    """Form for cloning a campaign asset.
+
+    Only the name is editable — the clone always copies the source asset's
+    description, properties and sub-assets. Duplicate names are allowed: some
+    campaigns hand every gang an identical asset (#2075).
+    """
+
+    name = forms.CharField(
+        max_length=200,
+        label="Name",
+        help_text="The name for the copy. This can be the same as the original.",
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
+
+
 class AssetTransferForm(forms.Form):
     """Form for transferring an asset to a new holder"""
 

--- a/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
@@ -17,7 +17,7 @@
                 <p class="mb-0">
                     This makes a copy of the {{ asset.asset_type.name_singular|lower }} <strong>{{ asset.name }}</strong>, including its
                     description and properties{% if sub_asset_count %} and its {{ sub_asset_count }} sub-asset{{ sub_asset_count|pluralize }}{% endif %}.
-                    The copy starts unowned, whoever holds the original.
+                    The copy starts unowned, even if the original is held by a gang.
                 </p>
             </c-callout>
             <c-form.field :field="form.name" />

--- a/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
@@ -16,7 +16,7 @@
             <c-callout variant="info" class="mb-0">
                 <p class="mb-0">
                     This makes a copy of the {{ asset.asset_type.name_singular|lower }} <strong>{{ asset.name }}</strong>, including its
-                    description and properties{% if sub_asset_count %} and its {{ sub_asset_count }} sub-asset{{ sub_asset_count|pluralize }}{% endif %}.
+                    description and properties{% if sub_asset_count %}, plus its {{ sub_asset_count }} sub-asset{{ sub_asset_count|pluralize }}{% endif %}.
                     The copy starts unowned, even if the original is held by a gang.
                 </p>
             </c-callout>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
@@ -4,8 +4,7 @@
     Clone {{ asset.name }} - {{ campaign.name }}
 {% endblock head_title %}
 {% block content %}
-    {% url 'core:campaign-assets' campaign.id as campaign_assets_url %}
-    <c-back url="{{ campaign_assets_url }}" text="Back to Assets" />
+    <c-back url="{{ return_url }}" text="Back" />
     <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
         <h1 class="h3">Clone {{ asset.name }}</h1>
         <h2 class="h5 text-secondary">{{ campaign.name }}</h2>
@@ -13,6 +12,7 @@
               method="post"
               class="vstack gap-3">
             {% csrf_token %}
+            {% return_url_field %}
             <c-callout variant="info" class="mb-0">
                 <p class="mb-0">
                     This makes a copy of the {{ asset.asset_type.name_singular|lower }} <strong>{{ asset.name }}</strong>, including its
@@ -23,9 +23,9 @@
             <c-form.field :field="form.name" />
             <div class="mt-3">
                 <c-btn variant="success" type="submit">
-                    <i class="bi-copy"></i> Clone {{ asset.asset_type.name_singular }}
+                    <i class="bi-copy" aria-hidden="true"></i> Clone {{ asset.asset_type.name_singular }}
                 </c-btn>
-                <c-cancel url="{{ campaign_assets_url }}" />
+                <c-cancel url="{{ return_url }}" />
             </div>
         </form>
     </div>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
@@ -1,0 +1,32 @@
+{% extends "core/layouts/base.html" %}
+{% load custom_tags %}
+{% block head_title %}
+    Clone {{ asset.name }} - {{ campaign.name }}
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:campaign-assets' campaign.id as campaign_assets_url %}
+    <c-back url="{{ campaign_assets_url }}" text="Back to Assets" />
+    <div class="col-12 col-md-8 col-lg-6 px-0 vstack gap-3">
+        <h1 class="h3">Clone {{ asset.name }}</h1>
+        <h2 class="h5 text-secondary">{{ campaign.name }}</h2>
+        <form action="{% url 'core:campaign-asset-clone' campaign.id asset.id %}"
+              method="post"
+              class="vstack gap-3">
+            {% csrf_token %}
+            <c-callout variant="info" class="mb-0">
+                <p class="mb-0">
+                    This makes a copy of the {{ asset.asset_type.name_singular|lower }} <strong>{{ asset.name }}</strong>, including its
+                    description and properties{% if sub_asset_count %} and its {{ sub_asset_count }} sub-asset{{ sub_asset_count|pluralize }}{% endif %}.
+                    The copy starts unowned, whoever holds the original.
+                </p>
+            </c-callout>
+            <c-form.field :field="form.name" />
+            <div class="mt-3">
+                <c-btn variant="success" type="submit">
+                    <i class="bi-copy"></i> Clone {{ asset.asset_type.name_singular }}
+                </c-btn>
+                <c-cancel url="{{ campaign_assets_url }}" />
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_clone.html
@@ -15,7 +15,7 @@
             {% return_url_field %}
             <c-callout variant="info" class="mb-0">
                 <p class="mb-0">
-                    This makes a copy of the {{ asset.asset_type.name_singular|lower }} <strong>{{ asset.name }}</strong>, including its
+                    This makes a copy of the {{ asset.asset_type.name_singular }} <strong>{{ asset.name }}</strong>, including its
                     description and properties{% if sub_asset_count %}, plus its {{ sub_asset_count }} sub-asset{{ sub_asset_count|pluralize }}{% endif %}.
                     The copy starts unowned, even if the original is held by a gang.
                 </p>
@@ -23,7 +23,8 @@
             <c-form.field :field="form.name" />
             <div class="mt-3">
                 <c-btn variant="success" type="submit">
-                    <i class="bi-copy" aria-hidden="true"></i> Clone {{ asset.asset_type.name_singular }}
+                    <c-icon name="clone" />
+                    Clone {{ asset.asset_type.name_singular }}
                 </c-btn>
                 <c-cancel url="{{ return_url }}" />
             </div>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
@@ -25,6 +25,8 @@
                        class="icon-link linked"><i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer</a>
                     <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
                        class="icon-link linked"><i class="bi-pencil" aria-hidden="true"></i> Edit</a>
+                    <a href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}"
+                       class="icon-link linked"><i class="bi-copy" aria-hidden="true"></i> Clone</a>
                 </span>
             {% endif %}
         </div>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
@@ -26,7 +26,7 @@
                     <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
                        class="icon-link linked"><i class="bi-pencil" aria-hidden="true"></i> Edit</a>
                     <a href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
-                       class="icon-link linked"><i class="bi-copy" aria-hidden="true"></i> Clone</a>
+                       class="icon-link linked"><c-icon name="clone" /> Clone</a>
                 </span>
             {% endif %}
         </div>

--- a/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
+++ b/gyrinx/core/templates/core/campaign/campaign_asset_detail.html
@@ -25,7 +25,7 @@
                        class="icon-link linked"><i class="bi-arrow-left-right" aria-hidden="true"></i> Transfer</a>
                     <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
                        class="icon-link linked"><i class="bi-pencil" aria-hidden="true"></i> Edit</a>
-                    <a href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}"
+                    <a href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
                        class="icon-link linked"><i class="bi-copy" aria-hidden="true"></i> Clone</a>
                 </span>
             {% endif %}

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -142,6 +142,9 @@
                                                     <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
                                                        class="linked-secondary fs-7">Edit</a>
                                                     ·
+                                                    <a href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}"
+                                                       class="linked-secondary fs-7">Clone</a>
+                                                    ·
                                                     <a href="{% url 'core:campaign-asset-remove' campaign.id asset.id %}"
                                                        class="link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7">Remove</a>
                                                 </span>
@@ -167,6 +170,12 @@
                                                             <a class="dropdown-item"
                                                                href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}">
                                                                 <i class="bi-pencil"></i> Edit
+                                                            </a>
+                                                        </li>
+                                                        <li>
+                                                            <a class="dropdown-item"
+                                                               href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}">
+                                                                <i class="bi-copy"></i> Clone
                                                             </a>
                                                         </li>
                                                         <li>

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -41,11 +41,13 @@
                             <!-- Expanded links for sm and up -->
                             <a href="{% url 'core:campaign-asset-type-edit' campaign.id asset_type.id %}"
                                class="icon-link linked-secondary fs-7 d-none d-sm-inline">
-                                <i class="bi-pencil"></i> Edit Type
+                                <c-icon name="edit" />
+                                Edit Type
                             </a>
                             <a href="{% url 'core:campaign-asset-type-remove' campaign.id asset_type.id %}"
                                class="icon-link link-danger link-underline-opacity-50 link-underline-opacity-100-hover fs-7 d-none d-sm-inline">
-                                <i class="bi-trash"></i> Remove Type
+                                <c-icon name="delete" />
+                                Remove Type
                             </a>
                             <!-- Dropdown for mobile -->
                             <div class="dropdown d-sm-none">
@@ -62,13 +64,15 @@
                                     <li>
                                         <a class="dropdown-item"
                                            href="{% url 'core:campaign-asset-type-edit' campaign.id asset_type.id %}">
-                                            <i class="bi-pencil"></i> Edit Type
+                                            <c-icon name="edit" />
+                                            Edit Type
                                         </a>
                                     </li>
                                     <li>
                                         <a class="dropdown-item text-danger"
                                            href="{% url 'core:campaign-asset-type-remove' campaign.id asset_type.id %}">
-                                            <i class="bi-trash"></i> Remove Type
+                                            <c-icon name="delete" />
+                                            Remove Type
                                         </a>
                                     </li>
                                 </ul>
@@ -163,25 +167,29 @@
                                                         <li>
                                                             <a class="dropdown-item"
                                                                href="{% url 'core:campaign-asset-transfer' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}">
-                                                                <i class="bi-arrow-left-right"></i> Transfer
+                                                                <c-icon name="arrow-left-right" />
+                                                                Transfer
                                                             </a>
                                                         </li>
                                                         <li>
                                                             <a class="dropdown-item"
                                                                href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}">
-                                                                <i class="bi-pencil"></i> Edit
+                                                                <c-icon name="edit" />
+                                                                Edit
                                                             </a>
                                                         </li>
                                                         <li>
                                                             <a class="dropdown-item"
                                                                href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}">
-                                                                <i class="bi-copy" aria-hidden="true"></i> Clone
+                                                                <c-icon name="clone" />
+                                                                Clone
                                                             </a>
                                                         </li>
                                                         <li>
                                                             <a class="dropdown-item text-danger"
                                                                href="{% url 'core:campaign-asset-remove' campaign.id asset.id %}">
-                                                                <i class="bi-trash"></i> Remove
+                                                                <c-icon name="delete" />
+                                                                Remove
                                                             </a>
                                                         </li>
                                                     </ul>

--- a/gyrinx/core/templates/core/campaign/campaign_assets.html
+++ b/gyrinx/core/templates/core/campaign/campaign_assets.html
@@ -142,7 +142,7 @@
                                                     <a href="{% url 'core:campaign-asset-edit' campaign.id asset.id %}"
                                                        class="linked-secondary fs-7">Edit</a>
                                                     ·
-                                                    <a href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}"
+                                                    <a href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}"
                                                        class="linked-secondary fs-7">Clone</a>
                                                     ·
                                                     <a href="{% url 'core:campaign-asset-remove' campaign.id asset.id %}"
@@ -174,8 +174,8 @@
                                                         </li>
                                                         <li>
                                                             <a class="dropdown-item"
-                                                               href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}">
-                                                                <i class="bi-copy"></i> Clone
+                                                               href="{% url 'core:campaign-asset-clone' campaign.id asset.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                                <i class="bi-copy" aria-hidden="true"></i> Clone
                                                             </a>
                                                         </li>
                                                         <li>

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -1068,3 +1068,94 @@ def test_campaign_assets_page_offers_clone(client, user, campaign, cloneable_ass
         reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id])
         in response.content.decode()
     )
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_returns_to_detail_page(
+    client, user, campaign, cloneable_asset
+):
+    """Cloning from an asset's detail page returns there, not to the list."""
+    client.force_login(user)
+    detail_url = reverse(
+        "core:campaign-asset-detail", args=[campaign.id, cloneable_asset.id]
+    )
+
+    response = client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement", "return_url": detail_url},
+    )
+    assert response.status_code == 302
+    assert response.url == detail_url
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_no_action_outside_in_progress(
+    client, user, cloneable_asset
+):
+    """Pre-campaign gangs get the copy without an entry in the action log."""
+    campaign = cloneable_asset.asset_type.campaign
+    campaign.status = Campaign.PRE_CAMPAIGN
+    campaign.save()
+    client.force_login(user)
+
+    client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement"},
+    )
+
+    assert CampaignAsset.objects.count() == 2
+    assert not CampaignAction.objects.filter(campaign=campaign).exists()
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_rejects_empty_name(
+    client, user, campaign, cloneable_asset
+):
+    """An empty name re-renders the form and creates nothing."""
+    client.force_login(user)
+
+    response = client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": ""},
+    )
+    assert response.status_code == 200
+    assert CampaignAsset.objects.count() == 1
+    assert CampaignSubAsset.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_scoped_to_its_campaign(
+    client, user, make_campaign, cloneable_asset
+):
+    """An asset cannot be cloned through another campaign's URL."""
+    other_campaign = make_campaign("Other Campaign", status=Campaign.IN_PROGRESS)
+    client.force_login(user)
+
+    response = client.post(
+        reverse(
+            "core:campaign-asset-clone", args=[other_campaign.id, cloneable_asset.id]
+        ),
+        {"name": "Settlement"},
+    )
+    assert response.status_code == 404
+    assert CampaignAsset.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_does_not_share_property_dicts(
+    client, user, campaign, cloneable_asset
+):
+    """The copy owns its properties rather than aliasing the source's dict."""
+    client.force_login(user)
+
+    client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement"},
+    )
+
+    clone = CampaignAsset.objects.exclude(pk=cloneable_asset.pk).get()
+    clone.properties["boon"] = "changed"
+    clone.save()
+
+    cloneable_asset.refresh_from_db()
+    assert cloneable_asset.properties == {"boon": "+D6 income"}

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -878,3 +878,193 @@ def test_campaign_asset_detail_breadcrumb_includes_type():
     content = response.content.decode()
     # Appears in the caps-label heading and, now, the breadcrumb crumb.
     assert content.count("Zone") >= 2
+
+
+@pytest.fixture
+def cloneable_asset(user, campaign):
+    """An asset with a description, properties and two sub-assets."""
+    asset_type = CampaignAssetType.objects.create(
+        campaign=campaign,
+        name_singular="Territory",
+        name_plural="Territories",
+        property_schema=[{"key": "boon", "label": "Boon"}],
+        sub_asset_schema={
+            "structure": {
+                "label": "Structure",
+                "label_plural": "Structures",
+                "property_schema": [{"key": "benefit", "label": "Benefit"}],
+            }
+        },
+        owner=user,
+    )
+    asset = CampaignAsset.objects.create(
+        asset_type=asset_type,
+        name="Settlement",
+        description="<p>A shanty town.</p>",
+        properties={"boon": "+D6 income"},
+        owner=user,
+    )
+    CampaignSubAsset.objects.create(
+        parent_asset=asset,
+        sub_asset_type="structure",
+        name="Generator Hall",
+        properties={"benefit": "Free power"},
+        owner=user,
+    )
+    CampaignSubAsset.objects.create(
+        parent_asset=asset,
+        sub_asset_type="structure",
+        name="Water Still",
+        properties={"benefit": "Clean water"},
+        owner=user,
+    )
+    return asset
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_copies_content_and_sub_assets(
+    client, user, campaign, cloneable_asset
+):
+    """Cloning under the same name leaves two identical assets side by side."""
+    client.force_login(user)
+
+    response = client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement"},
+    )
+    assert response.status_code == 302
+
+    assets = CampaignAsset.objects.filter(
+        asset_type=cloneable_asset.asset_type, name="Settlement"
+    )
+    assert assets.count() == 2
+
+    clone = assets.exclude(pk=cloneable_asset.pk).get()
+    assert clone.description == cloneable_asset.description
+    assert clone.properties == {"boon": "+D6 income"}
+    assert clone.owner == user
+
+    # Sub-assets are copied onto the clone, not shared with the original.
+    assert cloneable_asset.sub_assets.count() == 2
+    clone_subs = clone.sub_assets.order_by("name")
+    assert [s.name for s in clone_subs] == ["Generator Hall", "Water Still"]
+    assert [s.sub_asset_type for s in clone_subs] == ["structure", "structure"]
+    assert clone_subs[0].properties == {"benefit": "Free power"}
+    assert set(clone_subs.values_list("pk", flat=True)).isdisjoint(
+        cloneable_asset.sub_assets.values_list("pk", flat=True)
+    )
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_can_be_renamed(client, user, campaign, cloneable_asset):
+    """The name is editable at clone time."""
+    client.force_login(user)
+
+    client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement (North)"},
+    )
+
+    clone = CampaignAsset.objects.get(name="Settlement (North)")
+    assert clone.asset_type == cloneable_asset.asset_type
+    assert clone.sub_assets.count() == 2
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_does_not_copy_holder(
+    client, user, campaign, cloneable_asset, list_with_campaign
+):
+    """A clone starts unowned even when the original is held."""
+    cloneable_asset.holder = list_with_campaign
+    cloneable_asset.save()
+
+    client.force_login(user)
+    client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement"},
+    )
+
+    clone = CampaignAsset.objects.exclude(pk=cloneable_asset.pk).get()
+    assert clone.holder is None
+    cloneable_asset.refresh_from_db()
+    assert cloneable_asset.holder == list_with_campaign
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_get_prefills_name(
+    client, user, campaign, cloneable_asset
+):
+    """The confirmation page pre-fills the source name and mentions the sub-assets."""
+    client.force_login(user)
+
+    response = client.get(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id])
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert 'value="Settlement"' in content
+    assert "2 sub-assets" in content
+    # Nothing is created by merely viewing the page.
+    assert CampaignAsset.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_records_campaign_action(
+    client, user, campaign, cloneable_asset
+):
+    """Cloning in an in-progress campaign is recorded in the action log."""
+    client.force_login(user)
+
+    client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement"},
+    )
+
+    action = CampaignAction.objects.get(campaign=campaign)
+    assert "Settlement" in action.description
+    assert action.user == user
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_requires_admin(
+    client, make_user, campaign, cloneable_asset
+):
+    """A user who does not administer the campaign cannot clone its assets."""
+    other = make_user("intruder", "pw")
+    client.force_login(other)
+
+    response = client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement"},
+    )
+    assert response.status_code == 404
+    assert CampaignAsset.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_refused_for_archived_campaign(
+    client, user, campaign, cloneable_asset
+):
+    """Archived campaigns are read-only."""
+    campaign.archive()
+    client.force_login(user)
+
+    response = client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement"},
+        follow=True,
+    )
+    assert response.status_code == 200
+    assert CampaignAsset.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_campaign_assets_page_offers_clone(client, user, campaign, cloneable_asset):
+    """The assets page links to the clone action for admins."""
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaign-assets", args=[campaign.id]))
+    assert (
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id])
+        in response.content.decode()
+    )

--- a/gyrinx/core/tests/test_campaign_assets.py
+++ b/gyrinx/core/tests/test_campaign_assets.py
@@ -1142,10 +1142,16 @@ def test_campaign_asset_clone_scoped_to_its_campaign(
 
 
 @pytest.mark.django_db
-def test_campaign_asset_clone_does_not_share_property_dicts(
+def test_campaign_asset_clone_properties_are_stored_independently(
     client, user, campaign, cloneable_asset
 ):
-    """The copy owns its properties rather than aliasing the source's dict."""
+    """Editing the copy's properties leaves the original's untouched, and vice
+    versa — for the asset and its sub-assets.
+
+    This pins the stored rows, not the in-process dicts: once a request is over
+    both sides are deserialised separately, so aliasing is unobservable from
+    here. The deepcopy in the view guards the in-request case.
+    """
     client.force_login(user)
 
     client.post(
@@ -1157,5 +1163,41 @@ def test_campaign_asset_clone_does_not_share_property_dicts(
     clone.properties["boon"] = "changed"
     clone.save()
 
+    clone_sub = clone.sub_assets.get(name="Generator Hall")
+    clone_sub.properties["benefit"] = "rewired"
+    clone_sub.save()
+
     cloneable_asset.refresh_from_db()
     assert cloneable_asset.properties == {"boon": "+D6 income"}
+    assert cloneable_asset.sub_assets.get(name="Generator Hall").properties == {
+        "benefit": "Free power"
+    }
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_rejects_offsite_return_url(
+    client, user, campaign, cloneable_asset
+):
+    """An attacker-supplied return_url falls back to the assets list."""
+    client.force_login(user)
+
+    response = client.post(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id]),
+        {"name": "Settlement", "return_url": "https://evil.example/steal"},
+    )
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaign-assets", args=[campaign.id])
+
+
+@pytest.mark.django_db
+def test_campaign_asset_clone_page_requires_admin(
+    client, make_user, campaign, cloneable_asset
+):
+    """Non-admins cannot even open the clone confirmation page."""
+    other = make_user("onlooker", "pw")
+    client.force_login(other)
+
+    response = client.get(
+        reverse("core:campaign-asset-clone", args=[campaign.id, cloneable_asset.id])
+    )
+    assert response.status_code == 404

--- a/gyrinx/core/urls/campaign.py
+++ b/gyrinx/core/urls/campaign.py
@@ -145,6 +145,11 @@ patterns = [
         name="campaign-asset-edit",
     ),
     path(
+        "campaign/<id>/assets/<asset_id>/clone",
+        campaign_assets.campaign_asset_clone,
+        name="campaign-asset-clone",
+    ),
+    path(
         "campaign/<id>/assets/<asset_id>/transfer",
         campaign_assets.campaign_asset_transfer,
         name="campaign-asset-transfer",

--- a/gyrinx/core/views/campaign/assets.py
+++ b/gyrinx/core/views/campaign/assets.py
@@ -531,12 +531,14 @@ def campaign_asset_clone(request, id, asset_id):
 
     default_url = reverse("core:campaign-assets", args=(campaign.id,))
     return_url = get_return_url(request, default_url)
-    sub_assets = list(asset.sub_assets.all())
 
     if request.method == "POST":
         form = CampaignAssetCloneForm(request.POST)
         if form.is_valid():
             with transaction.atomic():
+                # Read inside the transaction so a concurrent sub-asset change
+                # can't be missed between counting and copying.
+                sub_assets = list(asset.sub_assets.all())
                 clone = CampaignAsset.objects.create(
                     asset_type=asset.asset_type,
                     owner=request.user,
@@ -602,7 +604,7 @@ def campaign_asset_clone(request, id, asset_id):
             "campaign": campaign,
             "asset": asset,
             "form": form,
-            "sub_asset_count": len(sub_assets),
+            "sub_asset_count": asset.sub_assets.count(),
             "return_url": return_url,
         },
     )

--- a/gyrinx/core/views/campaign/assets.py
+++ b/gyrinx/core/views/campaign/assets.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from gyrinx import messages
 from gyrinx.core.forms.campaign import (
     AssetTransferForm,
+    CampaignAssetCloneForm,
     CampaignAssetForm,
     CampaignAssetTypeForm,
 )
@@ -17,6 +18,7 @@ from gyrinx.core.models.campaign import (
     CampaignAction,
     CampaignAsset,
     CampaignAssetType,
+    CampaignSubAsset,
 )
 from gyrinx.core.models.events import EventNoun, EventVerb, log_event
 from gyrinx.core.utils import get_return_url, safe_redirect
@@ -490,6 +492,114 @@ def campaign_asset_edit(request, id, asset_id):
         request,
         "core/campaign/campaign_asset_edit.html",
         {"form": form, "campaign": campaign, "asset": asset},
+    )
+
+
+@login_required
+def campaign_asset_clone(request, id, asset_id):
+    """
+    Clone an existing asset, including its sub-assets.
+
+    The clone copies the source asset's description, properties and sub-assets,
+    but never its holder — a fresh copy starts unowned and is then transferred.
+    Duplicate names are allowed (#2075).
+
+    **Context**
+
+    ``campaign``
+        The :model:`core.Campaign` the asset belongs to.
+    ``asset``
+        The :model:`core.CampaignAsset` being cloned.
+    ``form``
+        A CampaignAssetCloneForm for naming the copy.
+
+    **Template**
+
+    :template:`core/campaign/campaign_asset_clone.html`
+    """
+    campaign = get_campaign_admin_or_404(request, id)
+    asset = get_object_or_404(CampaignAsset, id=asset_id, asset_type__campaign=campaign)
+
+    # Prevent cloning within archived campaigns
+    if campaign.archived:
+        messages.error(request, "Cannot clone assets in archived campaigns.")
+        return HttpResponseRedirect(
+            reverse("core:campaign-assets", args=(campaign.id,))
+        )
+
+    if request.method == "POST":
+        form = CampaignAssetCloneForm(request.POST)
+        if form.is_valid():
+            with transaction.atomic():
+                clone = CampaignAsset.objects.create(
+                    asset_type=asset.asset_type,
+                    owner=request.user,
+                    name=form.cleaned_data["name"],
+                    description=asset.description,
+                    holder=None,
+                    properties=asset.properties,
+                )
+
+                sub_asset_count = 0
+                for sub_asset in asset.sub_assets.all():
+                    CampaignSubAsset.objects.create(
+                        parent_asset=clone,
+                        owner=request.user,
+                        sub_asset_type=sub_asset.sub_asset_type,
+                        name=sub_asset.name,
+                        properties=sub_asset.properties,
+                    )
+                    sub_asset_count += 1
+
+                if campaign.is_in_progress:
+                    CampaignAction.objects.create(
+                        campaign=campaign,
+                        user=request.user,
+                        owner=request.user,
+                        description=(
+                            f"Asset Cloned: {clone.name} "
+                            f"({asset.asset_type.name_singular}) was copied from {asset.name}"
+                        ),
+                    )
+
+            log_event(
+                user=request.user,
+                noun=EventNoun.CAMPAIGN_ASSET,
+                verb=EventVerb.CLONE,
+                object=clone,
+                request=request,
+                campaign_id=str(campaign.id),
+                campaign_name=campaign.name,
+                asset_name=clone.name,
+                asset_type=asset.asset_type.name_singular,
+                source_asset_id=str(asset.id),
+                sub_assets_cloned=sub_asset_count,
+            )
+
+            track(
+                "campaign_asset_cloned",
+                campaign_id=str(campaign.id),
+                asset_type=asset.asset_type.name_singular,
+                sub_assets_cloned=sub_asset_count,
+            )
+
+            messages.success(request, f"Asset '{clone.name}' created as a copy.")
+
+            return HttpResponseRedirect(
+                reverse("core:campaign-assets", args=(campaign.id,))
+            )
+    else:
+        form = CampaignAssetCloneForm(initial={"name": asset.name})
+
+    return render(
+        request,
+        "core/campaign/campaign_asset_clone.html",
+        {
+            "campaign": campaign,
+            "asset": asset,
+            "form": form,
+            "sub_asset_count": asset.sub_assets.count(),
+        },
     )
 
 

--- a/gyrinx/core/views/campaign/assets.py
+++ b/gyrinx/core/views/campaign/assets.py
@@ -1,5 +1,7 @@
 """Campaign asset management views."""
 
+from copy import deepcopy
+
 from django.contrib.auth.decorators import login_required
 from django.db import models, transaction
 from django.http import HttpResponseRedirect
@@ -527,6 +529,10 @@ def campaign_asset_clone(request, id, asset_id):
             reverse("core:campaign-assets", args=(campaign.id,))
         )
 
+    default_url = reverse("core:campaign-assets", args=(campaign.id,))
+    return_url = get_return_url(request, default_url)
+    sub_assets = list(asset.sub_assets.all())
+
     if request.method == "POST":
         form = CampaignAssetCloneForm(request.POST)
         if form.is_valid():
@@ -537,19 +543,19 @@ def campaign_asset_clone(request, id, asset_id):
                     name=form.cleaned_data["name"],
                     description=asset.description,
                     holder=None,
-                    properties=asset.properties,
+                    # Deep-copied so the clone never shares the source's dict.
+                    properties=deepcopy(asset.properties),
                 )
 
-                sub_asset_count = 0
-                for sub_asset in asset.sub_assets.all():
+                for sub_asset in sub_assets:
                     CampaignSubAsset.objects.create(
                         parent_asset=clone,
                         owner=request.user,
                         sub_asset_type=sub_asset.sub_asset_type,
                         name=sub_asset.name,
-                        properties=sub_asset.properties,
+                        properties=deepcopy(sub_asset.properties),
                     )
-                    sub_asset_count += 1
+                sub_asset_count = len(sub_assets)
 
                 if campaign.is_in_progress:
                     CampaignAction.objects.create(
@@ -585,9 +591,7 @@ def campaign_asset_clone(request, id, asset_id):
 
             messages.success(request, f"Asset '{clone.name}' created as a copy.")
 
-            return HttpResponseRedirect(
-                reverse("core:campaign-assets", args=(campaign.id,))
-            )
+            return safe_redirect(request, return_url, fallback_url=default_url)
     else:
         form = CampaignAssetCloneForm(initial={"name": asset.name})
 
@@ -598,7 +602,8 @@ def campaign_asset_clone(request, id, asset_id):
             "campaign": campaign,
             "asset": asset,
             "form": form,
-            "sub_asset_count": asset.sub_assets.count(),
+            "sub_asset_count": len(sub_assets),
+            "return_url": return_url,
         },
     )
 


### PR DESCRIPTION
Campaign admins can copy an existing asset instead of building an identical one by hand.

Some campaigns hand out the same thing repeatedly — a starting territory every gang receives, or a settlement that appears several times on the map. Until now each copy had to be recreated from scratch, re-entering the description, every custom property and every sub-asset underneath it.

## Summary

- Adds a Clone action for campaign assets, reachable from the assets list, the mobile action menu on that list, and the asset detail page. It opens a confirmation page with the name pre-filled, so the copy can be renamed or kept identical.
- The copy carries across the description, the asset's properties and all of its sub-assets (with their own properties). It always starts unowned, regardless of who holds the original — holders are set afterwards via the existing Transfer action.
- Two assets of the same type may share a name. This already worked in the data model; the clone flow makes it usable, which is the point for campaigns where every gang gets the same asset.

No model or migration changes were needed. The work is a view (`gyrinx/core/views/campaign/assets.py`), a single-field form (`gyrinx/core/forms/campaign.py`), a URL, and one new template.

## Test plan

- [x] Cloning under the same name leaves two identical assets side by side
- [x] Description, properties and all sub-assets are copied; sub-assets belong to the copy rather than being shared with the original
- [x] The copy starts unowned even when the original is held, and the original keeps its holder
- [x] The name can be changed at clone time
- [x] The confirmation page pre-fills the source name and creates nothing on its own
- [x] Cloning is recorded in the campaign action log for in-progress campaigns
- [x] Non-admins get a 404; archived campaigns refuse the action
- [x] Verified end to end against real local data (an asset with three sub-assets): links render, the clone succeeds, and both copies list correctly
- [x] Full suite green (4127 passed, 13 skipped)

Closes #2075