### PR TITLE
docs: point instructions and docs at the n23 paths

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,11 +21,11 @@ for the specifics.
 
 **Security.** Never apply `|safe` to user-supplied content — the project ships a
 `safe_rich_text` filter for sanitising. Always validate redirect targets from user
-input with `safe_redirect` / `get_return_url` (`gyrinx/core/utils.py`).
+input with `safe_redirect` / `get_return_url` (`n23/core/utils.py`).
 
 **The fighter list is the hot query path.** Adding a FK or M2M to `ListFighter`
 means updating `ListFighterQuerySet.with_related_data()` and the query-count
-snapshot at `gyrinx/core/tests/fixtures/performance_view_queries.json`. Missing a
+snapshot at `n23/core/tests/fixtures/performance_view_queries.json`. Missing a
 prefetch degrades silently in dev and only shows up under load.
 
 **Content packs: archive is a soft-delete for the *owner*, not a retraction.** Once
@@ -40,7 +40,7 @@ history); content models inherit `Content`. Never call `self.full_clean()` from
 no `TestCase` — and should use the fixtures in `gyrinx/conftest.py` rather than
 building users, houses, fighters or lists inline.
 
-**Don't commit generated CSS.** `gyrinx/core/static/core/css/` is built from SCSS.
+**Don't commit generated CSS.** `n23/core/static/core/css/` is built from SCSS.
 
 ## Long-term projects
 

--- a/.github/workflows/claude-docs-update.yml
+++ b/.github/workflows/claude-docs-update.yml
@@ -147,11 +147,11 @@ jobs:
 
             Analyse each PR to determine if it introduced changes that affect the content library
             documentation. Look for:
-            - New or modified content models (gyrinx/content/models/*.py)
+            - New or modified content models (n23/content/models/*.py)
             - New fields added to existing content models
-            - Changed admin configuration (gyrinx/content/admin.py)
+            - Changed admin configuration (n23/content/admin.py)
             - New views, URL patterns, or templates related to content
-            - Changes to pack functionality (gyrinx/core/models/pack.py, gyrinx/core/views/pack.py)
+            - Changes to pack functionality (n23/core/models/pack.py, n23/core/views/pack.py)
             - Any other changes that affect how content is structured, administered, or used
 
             ## Step 2: Identify documentation gaps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,7 @@ Docker layer to go through.
 ptw .
 
 # Run specific test
-pytest gyrinx/core/tests/test_models_core.py::test_basic_list
+pytest n23/core/tests/test_models_core.py::test_basic_list
 
 # Run tests with pytest directly
 pytest
@@ -347,10 +347,10 @@ echo 'print(List.objects.filter(archived=False).count())' | manage prodshell
 - **One-off production data repairs run as a Backfill, not a management command.** The app runs on
   Cloud Run, so `manage` can't be pointed at production and `prodshell` is read-only — a repair
   written as a command has no way to be run. Put the logic in a module, add a `Backfill.Operation`
-  choice (`gyrinx/core/models/backfill.py`), and trigger it from the maintenance admin
+  choice (`n23/core/models/backfill.py`), and trigger it from the maintenance admin
   (`gyrinx/maintenance/admin.py`): GET previews a dry run, POST applies and records a `Backfill`
   row holding the outcome. Small repairs apply synchronously (see `persistent_stash_view`); long
-  ones run as the self-re-enqueueing task chain in `gyrinx/core/tasks.py`, reporting progress into
+  ones run as the self-re-enqueueing task chain in `n23/core/tasks.py`, reporting progress into
   the same record.
 
 ## Key Models Reference
@@ -431,7 +431,7 @@ pack-aware content.
   `CustomContentPack` or `CustomContentPackItem`. This applies to both directions: the M2M lookup that finds *which*
   packs a list/campaign is subscribed to (e.g. `CustomContentPack.objects.filter(subscribed_lists__id=...)`), and the
   pack-item lookup that resolves content within those packs. The canonical join is `ContentQuerySet.with_packs(packs,
-  include_archived_items=True)` in `gyrinx/content/models/base.py` — subscriber paths **must** pass
+  include_archived_items=True)` in `n23/content/models/base.py` — subscriber paths **must** pass
   `include_archived_items=True`; the default excludes archived items so owner-side callers don't surface them.
 - **Pack-owner library views, gallery / featured listings, list-creation pack pickers, and campaign pack-add UIs** —
   these are pack-discovery / write paths. Filtering `archived=False` is correct here so archived packs don't appear
@@ -564,25 +564,25 @@ and override the `owner` kwarg on the factory fixtures.
 
 **Models:**
 
-- `gyrinx/content/models.py` - Game content models
-- `gyrinx/core/models/list.py` - User list/fighter models
-- `gyrinx/core/models/campaign.py` - Campaign models
+- `n23/content/models/` - Game content models
+- `n23/core/models/list/` - User list/fighter models
+- `n23/core/models/campaign.py` - Campaign models
 
 **Views:**
 
-- `gyrinx/core/views/list.py` - List/fighter views
-- `gyrinx/core/views/campaign.py` - Campaign views
-- `gyrinx/core/views/vehicle.py` - Vehicle flow
+- `n23/core/views/list/` - List/fighter views
+- `n23/core/views/campaign/` - Campaign views
+- `n23/core/views/vehicle.py` - Vehicle flow
 
 **Templates:**
 
-- `gyrinx/core/templates/core/` - Main templates
-- `gyrinx/core/templates/core/includes/` - Reusable components
+- `n23/core/templates/core/` - Main templates
+- `n23/core/templates/core/includes/` - Reusable components
 
 **Tests:**
 
-- `gyrinx/core/tests/` - Core app tests
-- `gyrinx/content/tests/` - Content app tests
+- `n23/core/tests/` - Core app tests
+- `n23/content/tests/` - Content app tests
 
 ## important-instruction-reminders
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ rebuilds the test DB from current model definitions on every run:
 
 ```bash
 pytest                            # full suite, parallel
-pytest gyrinx/core/tests/         # one directory
+pytest n23/core/tests/         # one directory
 pytest -k campaign                # by name
 ```
 

--- a/docs/developing-gyrinx/admin-customizations.md
+++ b/docs/developing-gyrinx/admin-customizations.md
@@ -4,7 +4,7 @@ This document describes the most important Django admin customizations in Gyrinx
 
 ## Overview
 
-The content admin module (`gyrinx/content/admin.py`) contains extensive customizations to provide a better user experience for managing game content. These customizations handle complex relationships between fighters, equipment, and various game mechanics.
+The content admin module (`n23/content/admin.py`) contains extensive customizations to provide a better user experience for managing game content. These customizations handle complex relationships between fighters, equipment, and various game mechanics.
 
 ## Key Admin Customizations
 

--- a/docs/developing-gyrinx/frontend-development.md
+++ b/docs/developing-gyrinx/frontend-development.md
@@ -152,7 +152,7 @@ All designs start with mobile layout and scale up:
 ### File Structure
 
 ```
-gyrinx/core/static/core/scss/
+n23/core/static/core/scss/
 ├── styles.scss           # Main entry point
 ├── _variables.scss       # Custom Bootstrap variables
 ├── _components.scss      # Custom component styles
@@ -294,7 +294,7 @@ DEBUG=True  # in settings_dev.py
 ### File Organization
 
 ```
-gyrinx/core/static/core/
+n23/core/static/core/
 ├── css/
 │   └── styles.css        # Compiled from SCSS
 ├── js/

--- a/docs/developing-gyrinx/models-and-database.md
+++ b/docs/developing-gyrinx/models-and-database.md
@@ -9,7 +9,7 @@ Gyrinx uses Django's ORM with PostgreSQL as the database. The application is str
 All application models inherit from `AppBase`, which provides:
 
 ```python
-# gyrinx/core/models/base.py
+# n23/core/models/base.py
 class AppBase(HistoryMixin, Base, Owned, Archived):
     objects = HistoryAwareManager()
 ```

--- a/docs/developing-gyrinx/testing.md
+++ b/docs/developing-gyrinx/testing.md
@@ -11,14 +11,14 @@ Gyrinx uses pytest for testing with Django integration. Tests are organized by a
 pytest
 
 # Run tests for specific app
-pytest gyrinx/core/tests/
-pytest gyrinx/content/tests/
+pytest n23/core/tests/
+pytest n23/content/tests/
 
 # Run specific test file
-pytest gyrinx/core/tests/test_models_core.py
+pytest n23/core/tests/test_models_core.py
 
 # Run specific test function
-pytest gyrinx/core/tests/test_models_core.py::test_list_creation
+pytest n23/core/tests/test_models_core.py::test_list_creation
 
 # Run with verbose output
 pytest -v

--- a/docs/fighter-cost-system-reference.md
+++ b/docs/fighter-cost-system-reference.md
@@ -25,7 +25,7 @@ The total cost of a list is calculated by:
 Total List Cost = Sum of all fighter costs + Current credits
 ```
 
-Implementation: `List.cost_int()` in `n23/core/models/list.py:137`
+Implementation: `List.cost_int()` in `n23/core/models/list/list.py`
 
 ### 2. Fighter Cost
 
@@ -35,7 +35,7 @@ Each fighter's cost is calculated as:
 Fighter Cost = Base Cost + Advancement Cost + Sum of Equipment Assignment Costs
 ```
 
-Implementation: `ListFighter.cost_int()` in `n23/core/models/list.py:543`
+Implementation: `ListFighter.cost_int()` in `n23/core/models/list/fighter.py`
 
 ### 3. Base Fighter Cost
 
@@ -46,7 +46,7 @@ The base cost follows this priority hierarchy:
 3. House override: `ContentFighterHouseOverride.cost` (if exists)
 4. Content fighter: `ContentFighter.base_cost`
 
-Implementation: `ListFighter._base_cost_int` property in `n23/core/models/list.py:567`
+Implementation: `ListFighter._base_cost_int` property in `n23/core/models/list/fighter.py`
 
 ### 4. Equipment Assignment Cost
 
@@ -62,7 +62,7 @@ Or if total cost override is set:
 Assignment Cost = total_cost_override
 ```
 
-Implementation: `ListFighterEquipmentAssignment.cost_int()` in `n23/core/models/list.py:1333`
+Implementation: `ListFighterEquipmentAssignment.cost_int()` in `n23/core/models/list/assignment.py`
 
 ### 5. Equipment Base Cost
 
@@ -73,7 +73,7 @@ Equipment base cost priority:
 3. Fighter equipment list: `ContentFighterEquipmentListItem.cost`
 4. Base equipment: `ContentEquipment.cost`
 
-Implementation: `ListFighterEquipmentAssignment._equipment_cost_with_override()` in `n23/core/models/list.py:1354`
+Implementation: `ListFighterEquipmentAssignment._equipment_cost_with_override()` in `n23/core/models/list/assignment.py`
 
 ### 6. Weapon Profile Cost
 
@@ -83,7 +83,7 @@ Profile costs follow this priority:
 2. Fighter equipment list: `ContentFighterEquipmentListItem.cost` (with weapon_profile)
 3. Base profile: `ContentWeaponProfile.cost`
 
-Implementation: `ListFighterEquipmentAssignment._profile_cost_with_override_for_profile()` in `n23/core/models/list.py:1404`
+Implementation: `ListFighterEquipmentAssignment._profile_cost_with_override_for_profile()` in `n23/core/models/list/assignment.py`
 
 ### 7. Weapon Accessory Cost
 
@@ -93,7 +93,7 @@ Accessory costs follow this priority:
 2. Fighter equipment list: `ContentFighterEquipmentListWeaponAccessory.cost`
 3. Base accessory: `ContentWeaponAccessory.cost`
 
-Implementation: `ListFighterEquipmentAssignment._accessory_cost_with_override()` in `n23/core/models/list.py:1469`
+Implementation: `ListFighterEquipmentAssignment._accessory_cost_with_override()` in `n23/core/models/list/assignment.py`
 
 ### 8. Equipment Upgrade Cost
 
@@ -102,7 +102,7 @@ Upgrade costs depend on the equipment's upgrade mode:
 - Multi mode: Individual upgrade cost
 - Single mode: Cumulative cost (sum of all upgrades up to selected position)
 
-Implementation: `ContentEquipmentUpgrade.cost_int()` in `n23/content/models.py:1528`
+Implementation: `ContentEquipmentUpgrade.cost_int()` in `n23/content/models/equipment.py`
 
 ### 9. Campaign Advancement Cost
 

--- a/docs/fighter-cost-system-reference.md
+++ b/docs/fighter-cost-system-reference.md
@@ -25,7 +25,7 @@ The total cost of a list is calculated by:
 Total List Cost = Sum of all fighter costs + Current credits
 ```
 
-Implementation: `List.cost_int()` in `gyrinx/core/models/list.py:137`
+Implementation: `List.cost_int()` in `n23/core/models/list.py:137`
 
 ### 2. Fighter Cost
 
@@ -35,7 +35,7 @@ Each fighter's cost is calculated as:
 Fighter Cost = Base Cost + Advancement Cost + Sum of Equipment Assignment Costs
 ```
 
-Implementation: `ListFighter.cost_int()` in `gyrinx/core/models/list.py:543`
+Implementation: `ListFighter.cost_int()` in `n23/core/models/list.py:543`
 
 ### 3. Base Fighter Cost
 
@@ -46,7 +46,7 @@ The base cost follows this priority hierarchy:
 3. House override: `ContentFighterHouseOverride.cost` (if exists)
 4. Content fighter: `ContentFighter.base_cost`
 
-Implementation: `ListFighter._base_cost_int` property in `gyrinx/core/models/list.py:567`
+Implementation: `ListFighter._base_cost_int` property in `n23/core/models/list.py:567`
 
 ### 4. Equipment Assignment Cost
 
@@ -62,7 +62,7 @@ Or if total cost override is set:
 Assignment Cost = total_cost_override
 ```
 
-Implementation: `ListFighterEquipmentAssignment.cost_int()` in `gyrinx/core/models/list.py:1333`
+Implementation: `ListFighterEquipmentAssignment.cost_int()` in `n23/core/models/list.py:1333`
 
 ### 5. Equipment Base Cost
 
@@ -73,7 +73,7 @@ Equipment base cost priority:
 3. Fighter equipment list: `ContentFighterEquipmentListItem.cost`
 4. Base equipment: `ContentEquipment.cost`
 
-Implementation: `ListFighterEquipmentAssignment._equipment_cost_with_override()` in `gyrinx/core/models/list.py:1354`
+Implementation: `ListFighterEquipmentAssignment._equipment_cost_with_override()` in `n23/core/models/list.py:1354`
 
 ### 6. Weapon Profile Cost
 
@@ -83,7 +83,7 @@ Profile costs follow this priority:
 2. Fighter equipment list: `ContentFighterEquipmentListItem.cost` (with weapon_profile)
 3. Base profile: `ContentWeaponProfile.cost`
 
-Implementation: `ListFighterEquipmentAssignment._profile_cost_with_override_for_profile()` in `gyrinx/core/models/list.py:1404`
+Implementation: `ListFighterEquipmentAssignment._profile_cost_with_override_for_profile()` in `n23/core/models/list.py:1404`
 
 ### 7. Weapon Accessory Cost
 
@@ -93,7 +93,7 @@ Accessory costs follow this priority:
 2. Fighter equipment list: `ContentFighterEquipmentListWeaponAccessory.cost`
 3. Base accessory: `ContentWeaponAccessory.cost`
 
-Implementation: `ListFighterEquipmentAssignment._accessory_cost_with_override()` in `gyrinx/core/models/list.py:1469`
+Implementation: `ListFighterEquipmentAssignment._accessory_cost_with_override()` in `n23/core/models/list.py:1469`
 
 ### 8. Equipment Upgrade Cost
 
@@ -102,7 +102,7 @@ Upgrade costs depend on the equipment's upgrade mode:
 - Multi mode: Individual upgrade cost
 - Single mode: Cumulative cost (sum of all upgrades up to selected position)
 
-Implementation: `ContentEquipmentUpgrade.cost_int()` in `gyrinx/content/models.py:1528`
+Implementation: `ContentEquipmentUpgrade.cost_int()` in `n23/content/models.py:1528`
 
 ### 9. Campaign Advancement Cost
 
@@ -187,7 +187,7 @@ The facts system provides fast O(1) reads of cached cost values. Each cost-beari
 
 ### Facts Dataclasses
 
-Cached values are returned as immutable dataclasses (defined in `gyrinx/core/models/facts.py`):
+Cached values are returned as immutable dataclasses (defined in `n23/core/models/facts.py`):
 
 ```python
 @dataclass(frozen=True)
@@ -514,7 +514,7 @@ ContentEquipmentUpgrade:
 
 Key test files for the cost system:
 
-- `gyrinx/core/tests/test_cost_display.py` - Cost formatting tests
-- `gyrinx/core/tests/test_models_core.py` - Core cost calculation tests
-- `gyrinx/core/tests/test_assignments.py` - Equipment assignment cost tests
-- `gyrinx/content/tests/test_cost_methods.py` - Comprehensive tests for all cost mixins
+- `n23/core/tests/test_cost_display.py` - Cost formatting tests
+- `n23/core/tests/test_models_core.py` - Core cost calculation tests
+- `n23/core/tests/test_assignments.py` - Equipment assignment cost tests
+- `n23/content/tests/test_cost_methods.py` - Comprehensive tests for all cost mixins

--- a/docs/how-to-guides/handler-development.md
+++ b/docs/how-to-guides/handler-development.md
@@ -17,10 +17,10 @@ Handlers are functions that:
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| `Delta` | `gyrinx/core/cost/propagation.py` | Represents a cost change to propagate |
-| `propagate_from_assignment()` | `gyrinx/core/cost/propagation.py` | Updates assignment and fighter cache |
-| `propagate_from_fighter()` | `gyrinx/core/cost/propagation.py` | Updates fighter cache |
-| `create_action()` | `gyrinx/core/models/list.py` | Creates ListAction and updates list cache |
+| `Delta` | `n23/core/cost/propagation.py` | Represents a cost change to propagate |
+| `propagate_from_assignment()` | `n23/core/cost/propagation.py` | Updates assignment and fighter cache |
+| `propagate_from_fighter()` | `n23/core/cost/propagation.py` | Updates fighter cache |
+| `create_action()` | `n23/core/models/list.py` | Creates ListAction and updates list cache |
 
 ---
 

--- a/docs/how-to-guides/handler-development.md
+++ b/docs/how-to-guides/handler-development.md
@@ -20,7 +20,7 @@ Handlers are functions that:
 | `Delta` | `n23/core/cost/propagation.py` | Represents a cost change to propagate |
 | `propagate_from_assignment()` | `n23/core/cost/propagation.py` | Updates assignment and fighter cache |
 | `propagate_from_fighter()` | `n23/core/cost/propagation.py` | Updates fighter cache |
-| `create_action()` | `n23/core/models/list.py` | Creates ListAction and updates list cache |
+| `create_action()` | `n23/core/models/list/list.py` | Creates ListAction and updates list cache |
 
 ---
 

--- a/docs/how-to-guides/task-framework.md
+++ b/docs/how-to-guides/task-framework.md
@@ -11,7 +11,7 @@ Practical recipes for common task operations.
 
 ### Steps
 
-1. **Define the task function** in `gyrinx/core/tasks.py`:
+1. **Define the task function** in `n23/core/tasks.py`:
 
 ```python
 from django.tasks import task

--- a/docs/integration_testing.md
+++ b/docs/integration_testing.md
@@ -157,19 +157,19 @@ def test_search_functionality(client):
 Run all integration tests:
 
 ```bash
-pytest gyrinx/core/tests/test_integration_*.py
+pytest n23/core/tests/test_integration_*.py
 ```
 
 Run a specific test:
 
 ```bash
-pytest gyrinx/core/tests/test_integration_core_functionality.py::test_create_list_and_add_fighter
+pytest n23/core/tests/test_integration_core_functionality.py::test_create_list_and_add_fighter
 ```
 
 Run with verbose output:
 
 ```bash
-pytest -v gyrinx/core/tests/test_integration_*.py
+pytest -v n23/core/tests/test_integration_*.py
 ```
 
 ## Debugging Tips

--- a/docs/logging-and-tracing-reference.md
+++ b/docs/logging-and-tracing-reference.md
@@ -357,7 +357,7 @@ def track(
 
 ## Event System
 
-Module: `gyrinx/core/models/events.py`
+Module: `n23/core/models/events.py`
 
 Database-persisted event logging with structured event types.
 
@@ -637,7 +637,7 @@ jsonPayload.labels.endpoint="..."
 | `gyrinx/tracker.py` | Structured event tracking module |
 | `gyrinx/tracing.py` | OpenTelemetry tracing module |
 | `gyrinx/query.py` | SQL query capture utilities |
-| `gyrinx/core/models/events.py` | Event model and log_event function |
+| `n23/core/models/events.py` | Event model and log_event function |
 | `gyrinx/wsgi.py` | Tracing initialization for WSGI |
 | `gyrinx/asgi.py` | Tracing initialization for ASGI |
 

--- a/docs/operations/content-data-management.md
+++ b/docs/operations/content-data-management.md
@@ -115,7 +115,7 @@ Re-download from the bucket. The export job creates valid JSON, so corruption us
 
 ## Technical Details
 
-The command lives at `gyrinx/core/management/commands/loaddata_overwrite.py`.
+The command lives at `n23/core/management/commands/loaddata_overwrite.py`.
 
 The command uses PostgreSQL's `TRUNCATE CASCADE` for fast deletion, but falls back to regular `DELETE` if that fails. Foreign key checks are disabled with `SET session_replication_role = 'replica'` during import.
 

--- a/docs/technical-design/cost-propagation-architecture.md
+++ b/docs/technical-design/cost-propagation-architecture.md
@@ -600,7 +600,7 @@ def handle_equipment_purchase(*, user, lst, fighter, assignment):
 When a Content model's cost field changes, mark the affected tree dirty:
 
 ```python
-# n23/core/signals/content_cost.py
+# n23/content/signals.py
 
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
@@ -768,7 +768,7 @@ def campaign_detail_view(request, campaign_id):
 
 ### Phase 6: Content Signals
 
-1. Create `n23/core/signals/content_cost.py`
+1. Implemented in `n23/content/signals.py`
 2. Implement dirty marking for content changes
 3. Register signals in `apps.py`
 
@@ -844,7 +844,7 @@ facts_from_db without also propagating.
 |-----------|------|
 | Facts dataclasses | `n23/core/models/facts.py` |
 | Propagation functions | `n23/core/cost/propagation.py` |
-| List facts methods | `n23/core/models/list.py` |
+| List facts methods | `n23/core/models/list/list.py` |
 | Content signals | `n23/content/signals.py` |
 | Equipment handlers | `n23/core/handlers/equipment/` |
 | Fighter handlers | `n23/core/handlers/fighter/` |

--- a/docs/technical-design/cost-propagation-architecture.md
+++ b/docs/technical-design/cost-propagation-architecture.md
@@ -78,7 +78,7 @@ Note that this design is not in implementation order. See Implementation Phases 
 ### 1. Facts Dataclasses
 
 ```python
-# gyrinx/core/models/facts.py
+# n23/core/models/facts.py
 
 from dataclasses import dataclass
 from typing import Optional
@@ -310,7 +310,7 @@ class List(...):
 ### 3. Write-Time Propagation
 
 ```python
-# gyrinx/core/cost/propagation.py
+# n23/core/cost/propagation.py
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -600,7 +600,7 @@ def handle_equipment_purchase(*, user, lst, fighter, assignment):
 When a Content model's cost field changes, mark the affected tree dirty:
 
 ```python
-# gyrinx/core/signals/content_cost.py
+# n23/core/signals/content_cost.py
 
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
@@ -749,14 +749,14 @@ def campaign_detail_view(request, campaign_id):
 
 ### Phase 3: Facts Interface
 
-1. Create `gyrinx/core/models/facts.py` with dataclasses
+1. Create `n23/core/models/facts.py` with dataclasses
 2. Add `facts()` and `facts_from_db()` to all three models
 3. Add `_calculate_rating()` methods (reuse existing `cost_int()` if possible)
 4. Test facts interface in isolation
 
 ### Phase 4: Propagation
 
-1. Create `gyrinx/core/cost/propagation.py`
+1. Create `n23/core/cost/propagation.py`
 2. Implement `propagate_from_assignment()` and `propagate_from_fighter()`
 3. ~~Implement `is_stash_linked()` or reuse existing logic~~ (not implemented — bucketing follows `fighter.is_stash`, matching `facts_from_db`; a routing helper existed briefly and was removed when its child-fighter branch diverged from the recompute)
 4. Test propagation logic in isolation
@@ -768,7 +768,7 @@ def campaign_detail_view(request, campaign_id):
 
 ### Phase 6: Content Signals
 
-1. Create `gyrinx/core/signals/content_cost.py`
+1. Create `n23/core/signals/content_cost.py`
 2. Implement dirty marking for content changes
 3. Register signals in `apps.py`
 
@@ -793,9 +793,9 @@ The following describes what was actually implemented, noting changes from the o
 | Phase 1: Handler Migration | **Complete** | All handlers use propagation pattern |
 | Phase 2: Data Model | **Complete** | Migration `0120_add_cached_rating_and_dirty_fields` |
 | Phase 3: Facts Interface | **Complete** | Simplified facts dataclasses |
-| Phase 4: Propagation | **Complete** | In `gyrinx/core/cost/propagation.py` |
+| Phase 4: Propagation | **Complete** | In `n23/core/cost/propagation.py` |
 | Phase 5: Handler Updates | **Complete** | All handlers call `propagate_from_*` |
-| Phase 6: Content Signals | **Complete** | In `gyrinx/content/signals.py` |
+| Phase 6: Content Signals | **Complete** | In `n23/content/signals.py` |
 | Phase 7: Batch Recalculation | **Deferred** | Using lazy evaluation instead |
 
 ### Key Changes from Original Design
@@ -842,12 +842,12 @@ facts_from_db without also propagating.
 
 | Component | File |
 |-----------|------|
-| Facts dataclasses | `gyrinx/core/models/facts.py` |
-| Propagation functions | `gyrinx/core/cost/propagation.py` |
-| List facts methods | `gyrinx/core/models/list.py` |
-| Content signals | `gyrinx/content/signals.py` |
-| Equipment handlers | `gyrinx/core/handlers/equipment/` |
-| Fighter handlers | `gyrinx/core/handlers/fighter/` |
+| Facts dataclasses | `n23/core/models/facts.py` |
+| Propagation functions | `n23/core/cost/propagation.py` |
+| List facts methods | `n23/core/models/list.py` |
+| Content signals | `n23/content/signals.py` |
+| Equipment handlers | `n23/core/handlers/equipment/` |
+| Fighter handlers | `n23/core/handlers/fighter/` |
 
 ### Debugging
 

--- a/docs/test-performance-improvements.md
+++ b/docs/test-performance-improvements.md
@@ -75,7 +75,7 @@ For maximum performance:
 pytest -n auto --reuse-db
 
 # Run specific app tests in parallel
-pytest -n auto gyrinx/core/tests/
+pytest -n auto n23/core/tests/
 ```
 
 ## CI/CD Configuration

--- a/docs/useful-scripts.md
+++ b/docs/useful-scripts.md
@@ -40,7 +40,7 @@ DB from current model definitions on every run.
 ```bash
 ./scripts/test.sh                  # full suite, parallel
 ./scripts/test.sh -n 0             # serial
-./scripts/test.sh gyrinx/core/     # a directory
+./scripts/test.sh n23/core/     # a directory
 ./scripts/test.sh -k campaign      # by name
 ```
 

--- a/n23/core/CLAUDE.md
+++ b/n23/core/CLAUDE.md
@@ -36,7 +36,7 @@ into N+1 territory silently in dev and shows up only under load.
   a helper: `get_list_and_fighter()` in [views/fighter/permissions.py](views/fighter/permissions.py).
   Prefer it for new code. Older modules (`state.py`, `xp.py`) still inline the `Q()` and may
   be migrated when touched.
-- Validate redirect targets with `safe_redirect` from [gyrinx/core/utils.py](utils.py) whenever
+- Validate redirect targets with `safe_redirect` from [n23/core/utils.py](utils.py) whenever
   a `next=` or similar comes from user input.
 
 ## Tests


### PR DESCRIPTION
## What

The rename in #2096 moved the code and left the prose pointing at the old locations. This is the narrative catching up: 17 markdown files plus the docs-update workflow, all file-path references.

No dotted module paths change here — those moved with the code, because a stale `from gyrinx.core.models import …` in a docs code sample would simply be wrong. What was left behind was file *locations* in prose, which needed reading rather than sed.

**In scope:** `CLAUDE.md`, `README.md`, `n23/core/CLAUDE.md`, `.github/copilot-instructions.md`, `.github/workflows/claude-docs-update.yml`, and `docs/`.

**Deliberately untouched:**

- `.claude/notes/` and `playbooks/*/output/` — dated records of past work, not live guidance. Rewriting them would falsify what was true when they were written.
- Two comments in `gyrinx/tasks/` that read "moved `gyrinx.core` to `n23.core`". Still accurate, and they're the reason `gyrinx.` stays in `FIRST_PARTY_PREFIXES`.

## One thing beyond a path swap

`CLAUDE.md`'s file-location list named four `.py` files that have been packages for a while — `content/models`, `core/models/list`, `core/views/list`, `core/views/campaign`. Wrong before the rename too, but that list exists precisely to send people to the right place, and I was editing the lines anyway.

## Test plan

Docs and one workflow file only — no Python, templates, SCSS or JS touched.

- [x] Every `n23/` path the diff introduces resolves on disk (40 references checked), with two knowingly-stale exceptions below
- [x] Repo-wide relative-link check: 9 unresolved, byte-identical to `main` — all pre-existing placeholders (`{path to before screenshot}` and the like)
- [x] `./scripts/fmt.sh` clean; markdownlint passes

Two references left stale on purpose:

- `docs/fighter-cost-system-reference.md` carries `list.py:<line>` implementation pointers that predate that module becoming a package. They were equally wrong before this change; fixing them means relocating eight methods, and the file moves in the docs reorganisation anyway.
- `docs/technical-design/cost-propagation-architecture.md` describes a planned `core/signals/content_cost.py` that was never built at that path. It's a historical design document.

## Next

The last piece of #2093 is moving the edition documentation under `docs/n23/` — 28 files and 25 GitBook redirects.

Refs #2093
