### PR TITLE
fix: lock the row before validating a state transition

### DIFF
--- a/docs/technical-reference/state-machine.md
+++ b/docs/technical-reference/state-machine.md
@@ -140,7 +140,18 @@ transition_to(
 | `metadata` | `dict` | `None` | Optional metadata to store with transition |
 | `save` | `bool` | `True` | Whether to save the model after transitioning |
 
-When `save=False`, the status is updated in memory but not persisted to the model. However, **the transition record is still created in the database**. This is useful when you need to update multiple fields atomically, but you must wrap the entire operation in `transaction.atomic()` to ensure consistency (see Patterns section below).
+When `save=False`, the status is updated in memory but not persisted to the model. However, **the transition record is still created in the database**. This is useful when you need to update multiple fields atomically, and you **must** wrap the entire operation in `transaction.atomic()` (see Patterns section below) — `transition_to` raises `RuntimeError` if you don't, since the transition record would otherwise commit while the parent row kept its old status.
+
+### Concurrency
+
+`transition_to()` takes a `SELECT … FOR UPDATE` lock on the parent row and validates against the status it reads back from that locked row, not against the status on the instance in memory — which may be stale. Concurrent transitions on one row therefore serialise: the second sees the first's committed status and is rejected with `InvalidStateTransition`, rather than both validating against the same starting status and both applying.
+
+Two consequences worth knowing:
+
+- **A stale instance is judged on the row, not on itself.** An instance loaded before someone else transitioned the row cannot transition as though nothing had changed, even single-threaded.
+- **`e.from_status` reports the committed status.** In a rejection it is the status the row actually held, which may differ from the one the caller believed it was transitioning from.
+
+Callers that pre-check the status themselves and then act on it need their own lock. The state machine can only serialise the transition; it cannot see a check-then-act sequence wrapped around it, and every individual step such a sequence takes may be a legal transition. `gyrinx/tasks/signals.py` is the worked example.
 
 ### Transition Model Fields
 
@@ -167,7 +178,7 @@ from gyrinx.state_machine import InvalidStateTransition
 try:
     order.states.transition_to("DELIVERED")  # Invalid from PENDING
 except InvalidStateTransition as e:
-    print(e.from_status)  # "PENDING"
+    print(e.from_status)  # "PENDING" — the row's committed status, not the instance's
     print(e.to_status)    # "DELIVERED"
     print(e.allowed)      # ["CONFIRMED", "CANCELLED"]
 ```
@@ -197,7 +208,19 @@ StateMachine(
     initial="A",
     transitions={"A": ["INVALID"]},  # ValueError: Transition target 'INVALID' not in states
 )
+
+# A state too long for the status column raises ValueError
+StateMachine(
+    states=[("A", "A"), ("X" * 51, "Too long")],  # ValueError: State 'XXX...' is 51 characters
+    initial="A",
+    transitions={},
+)
 ```
+
+State values must fit `STATUS_MAX_LENGTH` (50) — the width of the `status`
+column and of the transition table's `from_status` / `to_status`. Checking it
+here means an over-long state fails at declaration rather than at the first
+write, far from the mistake that caused it.
 
 ## Patterns
 

--- a/gyrinx/state_machine.py
+++ b/gyrinx/state_machine.py
@@ -32,7 +32,12 @@ from gyrinx.tracing import span
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["StateMachine", "InvalidStateTransition"]
+__all__ = ["StateMachine", "InvalidStateTransition", "STATUS_MAX_LENGTH"]
+
+# Width of the status column and of the transition table's from_status /
+# to_status. _validate_config rejects longer state values so an over-long state
+# fails at declaration time rather than at the first write.
+STATUS_MAX_LENGTH = 50
 
 
 class InvalidStateTransition(Exception):
@@ -84,6 +89,16 @@ class StateMachine:
         """Validate state machine configuration at creation time."""
         valid_states = [s[0] for s in self.states]
 
+        # Validate state values fit the status column. Checked here because the
+        # database only objects at write time, long after the declaration that
+        # caused it.
+        for state in valid_states:
+            if len(state) > STATUS_MAX_LENGTH:
+                raise ValueError(
+                    f"State '{state}' is {len(state)} characters, exceeding the "
+                    f"{STATUS_MAX_LENGTH}-character limit of the status field"
+                )
+
         # Validate initial state exists
         if self.initial not in valid_states:
             raise ValueError(
@@ -124,7 +139,7 @@ class StateMachine:
 
         # Add the status field to the model
         status_field = models.CharField(
-            max_length=50,
+            max_length=STATUS_MAX_LENGTH,
             db_index=True,
             default=self.initial,
             choices=self.states,
@@ -190,8 +205,10 @@ class StateMachine:
                 on_delete=models.CASCADE,
                 related_name="_state_transitions",
             ),
-            "from_status": models.CharField(max_length=50, blank=True, db_index=True),
-            "to_status": models.CharField(max_length=50, db_index=True),
+            "from_status": models.CharField(
+                max_length=STATUS_MAX_LENGTH, blank=True, db_index=True
+            ),
+            "to_status": models.CharField(max_length=STATUS_MAX_LENGTH, db_index=True),
             "transitioned_at": models.DateTimeField(
                 default=timezone.now, db_index=True
             ),
@@ -287,6 +304,20 @@ class StateMachineAccessor:
         """Get list of valid statuses to transition to from current status."""
         return self.sm.transitions.get(self.current, [])
 
+    def _locked_status(self) -> str:
+        """Lock the parent row and return its committed status.
+
+        The lock is held until the surrounding transaction ends, which is what
+        serialises concurrent transitions. Reads through ``_base_manager`` so a
+        model whose default manager filters rows (archived ones, say) can still
+        transition.
+        """
+        return (
+            self.instance.__class__._base_manager.select_for_update()
+            .values_list("status", flat=True)
+            .get(pk=self.instance.pk)
+        )
+
     def transition_to(
         self,
         new_status: str,
@@ -295,6 +326,19 @@ class StateMachineAccessor:
     ):
         """
         Transition to a new status with validation and history tracking.
+
+        Validation reads the status from the *locked* parent row rather than
+        from this instance, which may be stale. Two concurrent transitions
+        therefore serialise: the second one sees the first's committed status
+        and is rejected, instead of both validating against the same starting
+        status and both applying.
+
+        Note this only reads the status column — fields set on the instance but
+        not yet saved are left alone, which is what makes ``save=False`` usable
+        by callers that batch the status write in with other fields.
+
+        With ``save=False`` the caller must be inside a transaction, or the
+        lock is released before it writes the status.
 
         Args:
             new_status: The status to transition to
@@ -307,21 +351,25 @@ class StateMachineAccessor:
         Raises:
             InvalidStateTransition: If the transition is not allowed
         """
-        if not self.can_transition_to(new_status):
-            allowed = self.get_valid_transitions()
-            raise InvalidStateTransition(self.current, new_status, allowed)
-
-        old_status = self.current
         model_name = self.instance.__class__.__name__
 
         with span(
             "state_transition",
             model=model_name,
             instance_id=str(self.instance.pk),
-            from_status=old_status,
             to_status=new_status,
-        ):
+        ) as current_span:
             with transaction.atomic():
+                # Inside the transaction: taking the lock is part of the work
+                # this span measures, and a contended transition waits here.
+                old_status = self._locked_status()
+                if current_span is not None:
+                    current_span.set_attribute("from_status", old_status)
+
+                allowed = self.sm.transitions.get(old_status, [])
+                if new_status not in allowed:
+                    raise InvalidStateTransition(old_status, new_status, allowed)
+
                 self.instance.status = new_status
 
                 if save:

--- a/gyrinx/state_machine.py
+++ b/gyrinx/state_machine.py
@@ -337,8 +337,9 @@ class StateMachineAccessor:
         not yet saved are left alone, which is what makes ``save=False`` usable
         by callers that batch the status write in with other fields.
 
-        With ``save=False`` the caller must be inside a transaction, or the
-        lock is released before it writes the status.
+        ``save=False`` requires the caller to already be inside a transaction,
+        and raises if it is not: the transition record would otherwise commit
+        while the parent row still held its old status.
 
         Args:
             new_status: The status to transition to
@@ -350,26 +351,38 @@ class StateMachineAccessor:
 
         Raises:
             InvalidStateTransition: If the transition is not allowed
+            RuntimeError: If save=False outside a transaction
         """
         model_name = self.instance.__class__.__name__
 
-        with span(
-            "state_transition",
-            model=model_name,
-            instance_id=str(self.instance.pk),
-            to_status=new_status,
-        ) as current_span:
-            with transaction.atomic():
-                # Inside the transaction: taking the lock is part of the work
-                # this span measures, and a contended transition waits here.
-                old_status = self._locked_status()
-                if current_span is not None:
-                    current_span.set_attribute("from_status", old_status)
+        if (
+            not save
+            and not transaction.get_connection(self.instance._state.db).in_atomic_block
+        ):
+            raise RuntimeError(
+                f"{model_name}.transition_to(save=False) must be called inside a "
+                "transaction. Without one the transition record commits while the "
+                "parent row keeps its old status."
+            )
 
-                allowed = self.sm.transitions.get(old_status, [])
-                if new_status not in allowed:
-                    raise InvalidStateTransition(old_status, new_status, allowed)
+        with transaction.atomic():
+            old_status = self._locked_status()
+            allowed = self.sm.transitions.get(old_status, [])
+            if new_status not in allowed:
+                # Raised before the span opens, deliberately. A rejection is a
+                # routine outcome — a double-clicked button, the loser of a race,
+                # both of which the views turn into a flash message — and span()
+                # records exceptions, so raising inside would file every one of
+                # them as an error in the traces.
+                raise InvalidStateTransition(old_status, new_status, allowed)
 
+            with span(
+                "state_transition",
+                model=model_name,
+                instance_id=str(self.instance.pk),
+                from_status=old_status,
+                to_status=new_status,
+            ):
                 self.instance.status = new_status
 
                 if save:

--- a/gyrinx/tasks/CLAUDE.md
+++ b/gyrinx/tasks/CLAUDE.md
@@ -50,10 +50,12 @@ lapse). Two invariants live here:
 1. **`TaskExecution` state** ([`signals.py`](signals.py)). `SUCCESSFUL` is the only
    sticky terminal state: a redelivery of a SUCCESSFUL task re-runs the function but
    leaves the record SUCCESSFUL. A redelivery of a FAILED task is a *retry* — the
-   record is reset so the fresh attempt records its own outcome. **Never** let
-   `handle_task_started` mark an already-terminal execution RUNNING — that is an
-   illegal state transition that raises, and via the prod push handler becomes a
-   500 → Pub/Sub redelivery storm. Both handlers are `@transaction.atomic` and
+   record is reset to READY *before* it starts, so the fresh attempt records its
+   own outcome. So the two terminal states part company here: SUCCESSFUL must
+   never go straight to RUNNING, while FAILED may — but only by way of that
+   reset. **Never** let `handle_task_started` mark a terminal execution RUNNING
+   directly; that is an illegal state transition that raises, and via the prod
+   push handler becomes a 500 → Pub/Sub redelivery storm. Both handlers are `@transaction.atomic` and
    take a `select_for_update` lock on the execution row, because these guards are
    check-then-act: each step they take is a legal transition on its own, so the
    state machine's own row lock cannot catch two deliveries interleaving here.

--- a/gyrinx/tasks/CLAUDE.md
+++ b/gyrinx/tasks/CLAUDE.md
@@ -53,7 +53,10 @@ lapse). Two invariants live here:
    record is reset so the fresh attempt records its own outcome. **Never** let
    `handle_task_started` mark an already-terminal execution RUNNING — that is an
    illegal state transition that raises, and via the prod push handler becomes a
-   500 → Pub/Sub redelivery storm.
+   500 → Pub/Sub redelivery storm. Both handlers are `@transaction.atomic` and
+   take a `select_for_update` lock on the execution row, because these guards are
+   check-then-act: each step they take is a legal transition on its own, so the
+   state machine's own row lock cannot catch two deliveries interleaving here.
 2. **Business-logic idempotency is the task's job.** The propagation tasks take a
    `select_for_update` lock on the `List` row so two concurrent duplicate deliveries
    don't double-apply. Regression coverage:

--- a/gyrinx/tasks/signals.py
+++ b/gyrinx/tasks/signals.py
@@ -8,6 +8,7 @@ work with any backend (ImmediateBackend, PubSubBackend, etc.).
 
 import logging
 
+from django.db import transaction
 from django.dispatch import receiver
 from django.tasks.base import TaskResultStatus
 from django.tasks.signals import task_enqueued, task_finished, task_started
@@ -55,16 +56,26 @@ def handle_task_enqueued(sender, task_result, **kwargs):
 
 @receiver(task_started)
 @traced("signal_task_started")
+@transaction.atomic
 def handle_task_started(sender, task_result, **kwargs):
     """
     Update TaskExecution to RUNNING when task starts.
+
+    Atomic, and the execution row is locked below, because everything here is
+    check-then-act: the branches read the status and then transition on the
+    strength of it. Each step they take is a legal transition on its own, so the
+    state machine's own locking cannot catch two deliveries interleaving here —
+    without the lock, two concurrent redeliveries of a FAILED execution can both
+    reset it to READY and both mark it RUNNING.
 
     Args:
         sender: The backend class executing the task
         task_result: TaskResult instance with task metadata
     """
     try:
-        execution = TaskExecution.objects.get(task_id=task_result.id)
+        execution = TaskExecution.objects.select_for_update().get(
+            task_id=task_result.id
+        )
 
         # At-least-once delivery can re-fire task_started for the same task_id.
         # Re-marking a terminal execution RUNNING is an illegal state transition
@@ -115,16 +126,25 @@ def handle_task_started(sender, task_result, **kwargs):
 
 @receiver(task_finished)
 @traced("signal_task_finished")
+@transaction.atomic
 def handle_task_finished(sender, task_result, **kwargs):
     """
     Update TaskExecution to SUCCESSFUL or FAILED when task finishes.
+
+    Locked for the same reason as task_started: the terminal-state guard below
+    is check-then-act. Two concurrent finishes that both passed it would have
+    the second raise InvalidStateTransition, now that transition_to() validates
+    against the committed row — and via the Pub/Sub push handler that raise is a
+    500, which is the redelivery storm the guard exists to prevent.
 
     Args:
         sender: The backend class that executed the task
         task_result: TaskResult instance with task metadata and results
     """
     try:
-        execution = TaskExecution.objects.get(task_id=task_result.id)
+        execution = TaskExecution.objects.select_for_update().get(
+            task_id=task_result.id
+        )
 
         # Skip if already completed (idempotency)
         if execution.status in ("SUCCESSFUL", "FAILED"):

--- a/gyrinx/tasks/tests/test_signal_concurrency.py
+++ b/gyrinx/tasks/tests/test_signal_concurrency.py
@@ -17,19 +17,30 @@ import threading
 
 import pytest
 from django.db import connection
+from django.tasks.base import TaskResultStatus
 from django.utils import timezone
 
 from gyrinx.tasks.models import TaskExecution
-from gyrinx.tasks.signals import handle_task_started
+from gyrinx.tasks.signals import handle_task_finished, handle_task_started
 
 TRANSITIONS = TaskExecution.states.transition_model
 
 
 class _Delivery:
-    """The only thing the lifecycle handlers read off a TaskResult."""
+    """The fields the lifecycle handlers read off a TaskResult."""
 
-    def __init__(self, task_id):
+    def __init__(self, task_id, status=None, return_value=None, errors=()):
         self.id = task_id
+        self.status = status
+        self._return_value = return_value
+        self.errors = list(errors)
+
+
+class _Error:
+    """Stands in for a TaskError; the handler reads the traceback off it."""
+
+    def __init__(self, traceback):
+        self.traceback = traceback
 
 
 def _run_concurrently(target, *, n=2, timeout=15):
@@ -114,6 +125,61 @@ def test_concurrent_first_deliveries_start_once():
     execution.refresh_from_db()
     assert execution.status == "RUNNING"
     assert TRANSITIONS.objects.filter(instance=execution).count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_finishes_record_one_success():
+    """Two simultaneous SUCCESSFUL finishes settle the execution once.
+
+    This is the case the finish handler's lock exists for: both deliveries pass
+    the terminal-state guard while the record is still RUNNING, and unlocked the
+    second would raise InvalidStateTransition — which through the Pub/Sub push
+    handler is a 500 and the redelivery storm the guard is there to prevent.
+    """
+    execution = _make_execution(task_id="finish-ok")
+    execution.mark_running()
+    before = TRANSITIONS.objects.filter(instance=execution).count()
+
+    delivery = _Delivery(
+        "finish-ok",
+        status=TaskResultStatus.SUCCESSFUL,
+        return_value={"ok": True},
+    )
+    errors = _run_concurrently(
+        lambda: handle_task_finished(sender=None, task_result=delivery)
+    )
+
+    assert not errors, f"delivery thread(s) raised: {errors!r}"
+    execution.refresh_from_db()
+    assert execution.status == "SUCCESSFUL"
+    assert execution.return_value == {"ok": True}
+    assert execution.finished_at is not None
+    settled = TRANSITIONS.objects.filter(instance=execution).count() - before
+    assert settled == 1, "the second finish should have seen the first and skipped"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_finishes_record_one_failure():
+    """The same guarantee for a failing task, including its error fields."""
+    execution = _make_execution(task_id="finish-bad")
+    execution.mark_running()
+    before = TRANSITIONS.objects.filter(instance=execution).count()
+
+    delivery = _Delivery(
+        "finish-bad",
+        status=TaskResultStatus.FAILED,
+        errors=[_Error('  File "t.py", line 1\nValueError: boom')],
+    )
+    errors = _run_concurrently(
+        lambda: handle_task_finished(sender=None, task_result=delivery)
+    )
+
+    assert not errors, f"delivery thread(s) raised: {errors!r}"
+    execution.refresh_from_db()
+    assert execution.status == "FAILED"
+    assert execution.error_message == "boom"
+    settled = TRANSITIONS.objects.filter(instance=execution).count() - before
+    assert settled == 1
 
 
 @pytest.mark.django_db

--- a/gyrinx/tasks/tests/test_signal_concurrency.py
+++ b/gyrinx/tasks/tests/test_signal_concurrency.py
@@ -33,11 +33,20 @@ class _Delivery:
 
 
 def _run_concurrently(target, *, n=2, timeout=15):
-    """Run ``target`` on ``n`` threads and return whatever they raised."""
+    """Run ``target`` on ``n`` threads simultaneously; return whatever they raised.
+
+    The barrier matters. Without it the threads are free to serialise, and a
+    handler that runs entirely after the other has committed re-reads the new
+    status and skips correctly whether or not it holds a lock — so the test
+    would pass on unlocked code. Releasing both threads immediately before the
+    call puts them in the handler together, which is the case being tested.
+    """
     errors = []
+    start = threading.Barrier(n, timeout=timeout)
 
     def wrapped():
         try:
+            start.wait()
             target()
         except Exception as e:  # noqa: BLE001 - surface, don't swallow
             errors.append(e)
@@ -75,9 +84,7 @@ def test_concurrent_retries_of_a_failed_execution_start_once():
     execution.mark_running()
     execution.mark_failed(error_message="transient boom")
     assert execution.status == "FAILED"
-
-    # Clear the setup's transitions so the count below is only the race.
-    TRANSITIONS.objects.all().delete()
+    before = TRANSITIONS.objects.filter(instance=execution).count()
 
     errors = _run_concurrently(
         lambda: handle_task_started(sender=None, task_result=_Delivery("dup"))
@@ -86,7 +93,8 @@ def test_concurrent_retries_of_a_failed_execution_start_once():
     assert not errors, f"delivery thread(s) raised: {errors!r}"
     execution.refresh_from_db()
     assert execution.status == "RUNNING"
-    assert TRANSITIONS.objects.count() == 1, (
+    started = TRANSITIONS.objects.filter(instance=execution).count() - before
+    assert started == 1, (
         "the second retry should have seen the first's RUNNING and skipped"
     )
 
@@ -105,10 +113,10 @@ def test_concurrent_first_deliveries_start_once():
     assert not errors, f"delivery thread(s) raised: {errors!r}"
     execution.refresh_from_db()
     assert execution.status == "RUNNING"
-    assert TRANSITIONS.objects.count() == 1
+    assert TRANSITIONS.objects.filter(instance=execution).count() == 1
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_missing_execution_is_logged_not_raised():
     """An unknown task_id stays a warning even with the handler now atomic —
     a raise here 500s the prod push handler into a redelivery storm."""

--- a/gyrinx/tasks/tests/test_signal_concurrency.py
+++ b/gyrinx/tasks/tests/test_signal_concurrency.py
@@ -1,0 +1,117 @@
+"""Concurrency: two simultaneous deliveries hitting the lifecycle signals.
+
+The signal handlers are check-then-act — they read the execution's status and
+then transition on the strength of it. Every step they take is a legal
+transition on its own, so the state machine's row lock cannot catch two
+deliveries interleaving *here*; the handlers need their own lock.
+
+The FAILED case is the one that bites. A redelivery of a FAILED execution is a
+retry, so the handler resets the record to READY before marking it RUNNING. Two
+concurrent retries could both read FAILED, both reset, and both mark RUNNING,
+leaving two RUNNING transitions for one attempt. These tests run the handlers on
+separate threads against a real (committed) database, as a concurrent Pub/Sub
+redelivery would.
+"""
+
+import threading
+
+import pytest
+from django.db import connection
+from django.utils import timezone
+
+from gyrinx.tasks.models import TaskExecution
+from gyrinx.tasks.signals import handle_task_started
+
+TRANSITIONS = TaskExecution.states.transition_model
+
+
+class _Delivery:
+    """The only thing the lifecycle handlers read off a TaskResult."""
+
+    def __init__(self, task_id):
+        self.id = task_id
+
+
+def _run_concurrently(target, *, n=2, timeout=15):
+    """Run ``target`` on ``n`` threads and return whatever they raised."""
+    errors = []
+
+    def wrapped():
+        try:
+            target()
+        except Exception as e:  # noqa: BLE001 - surface, don't swallow
+            errors.append(e)
+        finally:
+            # Each thread has its own connection; leaving it open strands it.
+            connection.close()
+
+    threads = [threading.Thread(target=wrapped) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=timeout)
+
+    stuck = [t for t in threads if t.is_alive()]
+    assert not stuck, (
+        f"{len(stuck)} delivery thread(s) did not finish within {timeout}s (deadlock?)"
+    )
+    return errors
+
+
+def _make_execution(task_id="dup"):
+    return TaskExecution.objects.create(
+        task_id=task_id,
+        task_name="_concurrency_probe",
+        args=[],
+        kwargs={},
+        enqueued_at=timezone.now(),
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_retries_of_a_failed_execution_start_once():
+    """Two simultaneous retries of a FAILED execution produce one RUNNING."""
+    execution = _make_execution()
+    execution.mark_running()
+    execution.mark_failed(error_message="transient boom")
+    assert execution.status == "FAILED"
+
+    # Clear the setup's transitions so the count below is only the race.
+    TRANSITIONS.objects.all().delete()
+
+    errors = _run_concurrently(
+        lambda: handle_task_started(sender=None, task_result=_Delivery("dup"))
+    )
+
+    assert not errors, f"delivery thread(s) raised: {errors!r}"
+    execution.refresh_from_db()
+    assert execution.status == "RUNNING"
+    assert TRANSITIONS.objects.count() == 1, (
+        "the second retry should have seen the first's RUNNING and skipped"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_first_deliveries_start_once():
+    """The same guarantee from READY: a duplicate delivery of a fresh execution
+    marks it RUNNING once rather than twice."""
+    execution = _make_execution(task_id="fresh")
+    assert execution.status == "READY"
+
+    errors = _run_concurrently(
+        lambda: handle_task_started(sender=None, task_result=_Delivery("fresh"))
+    )
+
+    assert not errors, f"delivery thread(s) raised: {errors!r}"
+    execution.refresh_from_db()
+    assert execution.status == "RUNNING"
+    assert TRANSITIONS.objects.count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_missing_execution_is_logged_not_raised():
+    """An unknown task_id stays a warning even with the handler now atomic —
+    a raise here 500s the prod push handler into a redelivery storm."""
+    handle_task_started(sender=None, task_result=_Delivery("never-enqueued"))
+
+    assert not TaskExecution.objects.filter(task_id="never-enqueued").exists()

--- a/gyrinx/tests/test_state_machine.py
+++ b/gyrinx/tests/test_state_machine.py
@@ -498,6 +498,22 @@ def test_concurrent_transitions_from_the_same_status_apply_once():
     assert obj.states.history.count() == 1, "only the winning transition is recorded"
 
 
+@pytest.mark.django_db(transaction=True)
+def test_save_false_outside_a_transaction_raises():
+    """save=False hands the status write to the caller, who must be in a
+    transaction — otherwise the transition record commits while the parent row
+    still holds its old status. Make that loud rather than silent."""
+    obj = StateMachineTestModel.objects.create()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        obj.states.transition_to("RUNNING", save=False)
+
+    assert "must be called inside a transaction" in str(exc_info.value)
+    obj.refresh_from_db()
+    assert obj.status == "PENDING"
+    assert obj.states.history.count() == 0
+
+
 @pytest.mark.django_db
 def test_transition_validates_against_the_database_not_the_instance():
     """A stale instance is judged on the row's committed status, not its own.

--- a/gyrinx/tests/test_state_machine.py
+++ b/gyrinx/tests/test_state_machine.py
@@ -2,10 +2,13 @@
 Tests for the StateMachine descriptor and per-model transition tables.
 """
 
+import threading
+
 import pytest
 from django.db import connection, models
 
 from gyrinx.state_machine import (
+    STATUS_MAX_LENGTH,
     InvalidStateTransition,
     StateMachine,
 )
@@ -415,3 +418,102 @@ def test_invalid_transition_target_raises():
             transitions={"READY": ["INVALID"]},
         )
     assert "Transition target 'INVALID' not in states" in str(exc_info.value)
+
+
+def test_state_longer_than_the_status_column_raises():
+    """A state too long for the status column should be rejected at declaration.
+
+    Without this the column only objects at write time, far from the
+    declaration that caused it.
+    """
+    too_long = "X" * (STATUS_MAX_LENGTH + 1)
+    with pytest.raises(ValueError) as exc_info:
+        StateMachine(
+            states=[("READY", "Ready"), (too_long, "Too long")],
+            initial="READY",
+            transitions={"READY": [too_long]},
+        )
+    assert f"is {STATUS_MAX_LENGTH + 1} characters" in str(exc_info.value)
+
+
+def test_state_exactly_at_the_limit_is_allowed():
+    """The limit is inclusive — a state that exactly fills the column is fine."""
+    exactly = "X" * STATUS_MAX_LENGTH
+    sm = StateMachine(
+        states=[("READY", "Ready"), (exactly, "At the limit")],
+        initial="READY",
+        transitions={"READY": [exactly]},
+    )
+    assert sm.initial == "READY"
+
+
+# =============================================================================
+# Concurrency
+# =============================================================================
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_transitions_from_the_same_status_apply_once():
+    """Two simultaneous transitions from the same starting status: one wins.
+
+    Both threads hold an instance read before either transitions, which is the
+    stale-read the row lock exists to catch. Before the lock, both validated
+    against their own in-memory PENDING, both passed, and both applied — leaving
+    a last-writer-wins status and two transition records describing incompatible
+    histories. Now the second reads the first's committed status under the lock
+    and is rejected.
+    """
+    obj = StateMachineTestModel.objects.create()
+    stale_instances = [
+        StateMachineTestModel.objects.get(pk=obj.pk),
+        StateMachineTestModel.objects.get(pk=obj.pk),
+    ]
+
+    rejected = []
+
+    def transition(instance):
+        def run():
+            try:
+                instance.states.transition_to("RUNNING")
+            except InvalidStateTransition as e:
+                rejected.append(e)
+            finally:
+                # Each thread has its own connection; leaving it open strands it.
+                connection.close()
+
+        return run
+
+    threads = [threading.Thread(target=transition(i)) for i in stale_instances]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    stuck = [t for t in threads if t.is_alive()]
+    assert not stuck, f"{len(stuck)} thread(s) did not finish within 15s (deadlock?)"
+
+    obj.refresh_from_db()
+    assert obj.status == "RUNNING"
+    assert len(rejected) == 1, "exactly one transition should have been rejected"
+    assert obj.states.history.count() == 1, "only the winning transition is recorded"
+
+
+@pytest.mark.django_db
+def test_transition_validates_against_the_database_not_the_instance():
+    """A stale instance is judged on the row's committed status, not its own.
+
+    The sequential half of the concurrency guarantee, and the cheaper test: an
+    instance holding a status the database has since moved past must not be
+    allowed to transition as though nothing had changed.
+    """
+    obj = StateMachineTestModel.objects.create()
+    stale = StateMachineTestModel.objects.get(pk=obj.pk)
+
+    obj.states.transition_to("RUNNING")
+
+    assert stale.status == "PENDING"  # stale in memory
+    with pytest.raises(InvalidStateTransition) as exc_info:
+        stale.states.transition_to("RUNNING")
+
+    # Reports the committed status, not the stale one it was asked from.
+    assert exc_info.value.from_status == "RUNNING"


### PR DESCRIPTION
Anything in the app with a status that moves through fixed steps — a battle going pre-battle → in-progress → post-battle, a background job going ready → running → succeeded/failed — shares one small state-machine helper. This fixes two weaknesses in it. Neither is new, and neither is known to have caused damage in production yet.

## Two concurrent transitions could both succeed

`transition_to()` checked whether a move was allowed *before* opening its transaction, and checked against the copy of the record held in memory. Two things happening at once could both ask "may I?", both be told yes, and both go ahead. The result was a last-writer-wins status plus two history rows describing incompatible versions of what happened, with nothing to detect it.

It now locks the row first and reads the status back from the locked row, so the second caller sees what the first actually committed and is turned away. The lock only reads the status column and leaves unsaved fields on the instance alone — that matters because `TaskExecution` sets `started_at`, `return_value` and `error_message` in memory before transitioning and saves them together afterwards, and re-reading the whole record would have silently thrown those away.

The battle views already catch the rejection and show a friendly message, so the losing request gets "this battle cannot be started" rather than an error page. The rejection is raised before the trace span opens, so these routine outcomes don't get filed as errors in Cloud Trace.

## The background-task handlers needed their own lock

This is the part that isn't obvious. Closing the race turns silent corruption into a raised exception, so any caller that checks the status without a lock and then acts on it starts throwing where it previously got away with it.

Both task lifecycle handlers in `gyrinx/tasks/signals.py` are exactly that shape. Every individual step they take is a legal transition, so the state machine's own lock can't catch two deliveries interleaving inside them — they need locking in their own right. Duplicate delivery is by design in the task system (Pub/Sub is at-least-once), so this is the more likely of the two races in practice. Left unlocked, a duplicate finish would now raise, and through the production push handler that is a 500 and a redelivery storm — the exact failure the guard exists to prevent. Verified: with the state-machine fix in place but the handler locks removed, both new signal tests fail with `InvalidStateTransition`.

## State values that don't fit the column

The status column holds 50 characters, but configuration validation only checked that state names were known to each other, never their length. An over-long state was accepted at declaration and only failed later at write time, far from the mistake that caused it. It is now rejected up front. `STATUS_MAX_LENGTH` replaces the 50 that was hard-coded in three places, so the check and the columns can't drift apart. No migration — the width is unchanged.

## Also here

- `transition_to(save=False)` now raises if called outside a transaction rather than only documenting the requirement. That mode hands the status write to the caller, so without a surrounding transaction the history row commits while the record keeps its old status. All three existing callers already comply.
- `docs/technical-reference/state-machine.md` gains the fourth validation rule, a section on the concurrency guarantee, and a note that `from_status` on a rejection reports the row's committed status rather than the caller's in-memory one.

## Test plan

- [x] Full suite: 4164 passed, 13 skipped
- [x] Every new test verified to fail without its fix, not just pass with it — the state-machine tests reproduce two `PENDING → RUNNING` rows for one record; the signal tests raise `InvalidStateTransition`
- [x] The signal concurrency tests sync their threads on a barrier. Without it they could serialise and pass on unlocked code (measured: 1 pass in 20); with it, 10 of 10 runs fail when the lock is removed
- [x] Two threads transitioning one row against real Postgres: one wins, one is rejected, one history row written
- [x] Same check against the dev database on a real battle, through the real settings and connection pool: no transaction or deadlock errors, database restored afterwards
- [x] Existing battle start/end view tests (which POST through the real views and charge crew credits) still pass
- [x] `./scripts/fmt.sh` clean; pre-commit's missing-migration check passes

No UI changed, so there was nothing to click through in the browser.

Closes #2095
Refs #2094