### PR TITLE
refactor: split game vocabulary out of the platform's shared models

### DIFF
--- a/bandit/bandit-baseline.json
+++ b/bandit/bandit-baseline.json
@@ -1,6 +1,6 @@
 {
   "errors": [],
-  "generated_at": "2026-08-04T22:02:32Z",
+  "generated_at": "2026-08-04T22:06:39Z",
   "metrics": {
     "./analytics/streamlit/app.py": {
       "CONFIDENCE.HIGH": 0,
@@ -557,7 +557,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 225,
+      "loc": 85,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -1103,7 +1103,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 1391,
+      "loc": 1388,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -1987,7 +1987,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 921,
+      "loc": 922,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2832,7 +2832,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 81,
+      "loc": 79,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2845,7 +2845,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 364,
+      "loc": 362,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2858,7 +2858,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 940,
+      "loc": 937,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2871,7 +2871,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 256,
+      "loc": 253,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2910,7 +2910,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 2501,
+      "loc": 2498,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2923,7 +2923,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 1152,
+      "loc": 1149,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2936,7 +2936,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 79,
+      "loc": 76,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -2975,7 +2975,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 502,
+      "loc": 500,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -4002,7 +4002,7 @@
       "SEVERITY.LOW": 0,
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 5369,
+      "loc": 5370,
       "nosec": 0,
       "skipped_tests": 3
     },
@@ -4081,6 +4081,19 @@
       "SEVERITY.MEDIUM": 0,
       "SEVERITY.UNDEFINED": 0,
       "loc": 46,
+      "nosec": 0,
+      "skipped_tests": 0
+    },
+    "./n23/models.py": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 154,
       "nosec": 0,
       "skipped_tests": 0
     },
@@ -4210,7 +4223,7 @@
       "SEVERITY.LOW": 15,
       "SEVERITY.MEDIUM": 9,
       "SEVERITY.UNDEFINED": 0,
-      "loc": 71196,
+      "loc": 71188,
       "nosec": 4,
       "skipped_tests": 56
     }

--- a/bandit/bandit-baseline.txt
+++ b/bandit/bandit-baseline.txt
@@ -1,4 +1,4 @@
-Run started:2026-08-04 22:02:35.735525+00:00
+Run started:2026-08-04 22:06:42.593548+00:00
 
 Test results:
 >> Issue: [B703:django_mark_safe] Potential XSS on mark_safe function.
@@ -340,7 +340,7 @@ Test results:
 --------------------------------------------------
 
 Code scanned:
-	Total lines of code: 71196
+	Total lines of code: 71188
 	Total lines skipped (#nosec): 4
 	Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 56
 

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ from n23.core.models.action import ListAction, ListActionType
 from n23.core.models.campaign import Campaign
 from n23.core.models.list import List, ListFighter
 from n23.core.models.pack import CustomContentPack, CustomContentPackItem
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 # Re-export the local task-queue driver fixture so tests can request `task_queue`
 # to drive the durable queue in manual mode (inject duplicates/failures/drops).

--- a/gyrinx/models.py
+++ b/gyrinx/models.py
@@ -1,3 +1,10 @@
+"""Platform base models and generic helpers.
+
+Abstract bases shared by every app — platform and edition alike. Game concepts
+that used to live here (fighter categories, the cost mixins, credit formatting)
+moved to ``n23.models``: they are edition vocabulary, not infrastructure.
+"""
+
 import logging
 import uuid
 from typing import List, TypeVar, Union
@@ -25,51 +32,6 @@ def is_int(value):
         return True
     except (ValueError, TypeError):
         return False
-
-
-def format_cost_display(cost_value, show_sign=False):
-    """
-    Format a cost value for display with proper sign handling.
-
-    Parameters
-    ----------
-    cost_value : int or str
-        The cost value to format
-    show_sign : bool
-        Whether to show '+' for positive values (default: False)
-
-    Returns
-    -------
-    str
-        Formatted cost string with '¢' suffix
-
-    Examples
-    --------
-    >>> format_cost_display(5)
-    '5¢'
-    >>> format_cost_display(5, show_sign=True)
-    '+5¢'
-    >>> format_cost_display(-5)
-    '-5¢'
-    >>> format_cost_display(-5, show_sign=True)
-    '-5¢'
-    >>> format_cost_display(0)
-    '0¢'
-    >>> format_cost_display(0, show_sign=True)
-    '+0¢'
-    """
-    # Convert to int if it's a string
-    if isinstance(cost_value, str):
-        if not is_int(cost_value):
-            return cost_value  # Return as-is if not a number
-        cost_value = int(cost_value)
-
-    # Format with sign if requested and positive or zero
-    if show_sign and cost_value >= 0:
-        return f"+{cost_value}¢"
-
-    # Otherwise just return with currency symbol
-    return f"{cost_value}¢"
 
 
 def is_valid_uuid(uuid_to_test, version=4):
@@ -148,155 +110,5 @@ class Base(models.Model):
         abstract = True
 
 
-class FighterCategoryChoices(models.TextChoices):
-    LEADER = "LEADER", "Leader"
-    CHAMPION = "CHAMPION", "Champion"
-    GANGER = "GANGER", "Ganger"
-    JUVE = "JUVE", "Juve"
-    CREW = "CREW", "Crew"
-    EXOTIC_BEAST = "EXOTIC_BEAST", "Exotic Beast"
-    HANGER_ON = "HANGER_ON", "Hanger-on"
-    BRUTE = "BRUTE", "Brute"
-    HIRED_GUN = "HIRED_GUN", "Hired Gun"
-    BOUNTY_HUNTER = "BOUNTY_HUNTER", "Bounty Hunter"
-    HOUSE_AGENT = "HOUSE_AGENT", "House Agent"
-    HIVE_SCUM = "HIVE_SCUM", "Hive Scum"
-    DRAMATIS_PERSONAE = "DRAMATIS_PERSONAE", "Dramatis Personae"
-    PROSPECT = "PROSPECT", "Prospect"
-    SPECIALIST = "SPECIALIST", "Specialist"
-    STASH = "STASH", "Stash"
-    VEHICLE = "VEHICLE", "Vehicle"
-    ALLY = "ALLY", "Ally"
-    GANG_TERRAIN = "GANG_TERRAIN", "Gang Terrain"
-
-
-equipment_category_groups = [
-    "Gear",
-    "Vehicle & Mount",
-    "Weapons & Ammo",
-    "Other",
-]
-equipment_category_group_choices = [(x, x) for x in equipment_category_groups]
-
-
 T = TypeVar("T")
 QuerySetOf = Union[QuerySet, List[T]]
-
-
-class CostMixin(models.Model):
-    """
-    Mixin for models that have cost calculation logic.
-
-    This mixin provides common cost methods (cost_int, cost_display) that can be
-    used by models with cost fields. It handles both integer and string cost fields.
-
-    For models with special cost calculation logic, override the cost_int() method.
-
-    Attributes
-    ----------
-    cost_field_name : str
-        The name of the field that stores the cost. Defaults to 'cost'.
-        Can be overridden in subclasses if the field has a different name.
-    """
-
-    cost_field_name = "cost"
-
-    class Meta:
-        abstract = True
-
-    def cost_int(self):
-        """
-        Returns the integer cost of this item.
-
-        This method handles both integer and string cost fields:
-        - If the cost field is an integer, returns it directly
-        - If the cost field is a string that can be converted to int, converts and returns it
-        - If the cost field is empty or non-numeric, returns 0
-
-        Override this method in subclasses for custom cost calculation logic.
-
-        Returns
-        -------
-        int
-            The cost as an integer
-        """
-        cost_value = getattr(self, self.cost_field_name, None)
-
-        # Handle None or empty values
-        if cost_value is None or cost_value == "":
-            return 0
-
-        # If it's already an integer, return it
-        if isinstance(cost_value, int):
-            return cost_value
-
-        # If it's a string, try to convert
-        if isinstance(cost_value, str):
-            if is_int(cost_value):
-                return int(cost_value)
-            return 0
-
-        # Default case
-        return 0
-
-    def cost_display(self, show_sign=False):
-        """
-        Returns a readable cost string with currency symbol.
-
-        Parameters
-        ----------
-        show_sign : bool
-            Whether to show '+' for positive values (default: False)
-
-        Returns
-        -------
-        str
-            Formatted cost string with '¢' suffix
-        """
-        cost_value = getattr(self, self.cost_field_name, None)
-
-        # Special handling for string costs that aren't numeric
-        if isinstance(cost_value, str) and not is_int(cost_value):
-            return cost_value
-
-        # For empty string costs, return empty
-        if cost_value == "" or cost_value is None:
-            return ""
-
-        return format_cost_display(self.cost_int(), show_sign=show_sign)
-
-
-class FighterCostMixin(CostMixin):
-    """
-    Extended cost mixin for models that have fighter-specific cost overrides.
-
-    This mixin adds the cost_for_fighter_int() method that checks for the
-    presence of an annotated 'cost_for_fighter' attribute.
-    """
-
-    class Meta:
-        abstract = True
-
-    def cost_for_fighter_int(self):
-        """
-        Returns the fighter-specific cost if available.
-
-        This method expects the model to be annotated with a 'cost_for_fighter'
-        attribute using the model's with_cost_for_fighter() queryset method.
-
-        Returns
-        -------
-        int
-            The fighter-specific cost
-
-        Raises
-        ------
-        AttributeError
-            If the model hasn't been annotated with cost_for_fighter
-        """
-        if hasattr(self, "cost_for_fighter"):
-            return self.cost_for_fighter
-
-        raise AttributeError(
-            "cost_for_fighter not available. Use with_cost_for_fighter()"
-        )

--- a/gyrinx/tests/test_forms.py
+++ b/gyrinx/tests/test_forms.py
@@ -5,7 +5,7 @@ from django import forms
 
 from n23.core.forms.terms import fighter_group_key
 from gyrinx.forms import group_select, group_sorter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 from n23.content.models import ContentFighter, ContentHouse
 from gyrinx.widgets import BsCheckboxSelectMultipleCompact
 

--- a/n23/content/admin.py
+++ b/n23/content/admin.py
@@ -20,11 +20,8 @@ from polymorphic.admin import (
 from n23.content.actions import copy_selected_to_fighter, copy_selected_to_house
 from n23.content.models.availability_preset import ContentAvailabilityPreset
 from gyrinx.forms import group_select
-from gyrinx.models import (
-    SMART_QUOTES,
-    FighterCategoryChoices,
-    equipment_category_groups,
-)
+from gyrinx.models import SMART_QUOTES
+from n23.models import FighterCategoryChoices, equipment_category_groups
 
 from .models import (
     ContentAdvancementAssignment,

--- a/n23/content/models/__init__.py
+++ b/n23/content/models/__init__.py
@@ -133,8 +133,8 @@ from .availability_preset import ContentAvailabilityPreset
 from . import signal_handlers  # noqa: F401
 
 # Re-export FighterCategoryChoices for backward compatibility
-# (some code imports it from content.models instead of gyrinx.models)
-from gyrinx.models import FighterCategoryChoices  # noqa: F401
+# (some code imports it from content.models instead of n23.models)
+from n23.models import FighterCategoryChoices  # noqa: F401
 
 __all__ = [
     # Base

--- a/n23/content/models/availability_preset.py
+++ b/n23/content/models/availability_preset.py
@@ -10,7 +10,7 @@ from django.db.models import Case, IntegerField, Q, Value, When
 from multiselectfield import MultiSelectField
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 from .base import Content
 

--- a/n23/content/models/default_assignment.py
+++ b/n23/content/models/default_assignment.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import CostMixin
+from n23.models import CostMixin
 
 from .base import Content
 from .weapon import VirtualWeaponProfile

--- a/n23/content/models/equipment.py
+++ b/n23/content/models/equipment.py
@@ -22,11 +22,11 @@ from django.db.models.functions import Cast, Coalesce
 from django.utils.functional import cached_property
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import (
+from gyrinx.models import QuerySetOf
+from n23.models import (
     CostMixin,
     FighterCategoryChoices,
     FighterCostMixin,
-    QuerySetOf,
     equipment_category_group_choices,
     format_cost_display,
 )

--- a/n23/content/models/equipment_list.py
+++ b/n23/content/models/equipment_list.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import CostMixin
+from n23.models import CostMixin
 
 from .base import Content
 

--- a/n23/content/models/expansion.py
+++ b/n23/content/models/expansion.py
@@ -22,7 +22,7 @@ from multiselectfield import MultiSelectField
 from polymorphic.models import PolymorphicModel
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import FighterCategoryChoices, format_cost_display
+from n23.models import FighterCategoryChoices, format_cost_display
 
 from .base import Content
 

--- a/n23/content/models/fighter.py
+++ b/n23/content/models/fighter.py
@@ -15,7 +15,7 @@ from django.utils.functional import cached_property
 from multiselectfield import MultiSelectField
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 from .base import Content, ContentManager, ContentQuerySet
 

--- a/n23/content/models/gang_skills.py
+++ b/n23/content/models/gang_skills.py
@@ -15,7 +15,7 @@ from django.core.validators import MinValueValidator
 from django.db import models
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 from .base import Content
 

--- a/n23/content/models/injury.py
+++ b/n23/content/models/injury.py
@@ -12,7 +12,7 @@ from django.db import models
 from multiselectfield import MultiSelectField
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 from .base import Content
 

--- a/n23/content/models/promotion.py
+++ b/n23/content/models/promotion.py
@@ -22,7 +22,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 from .base import Content
 

--- a/n23/content/models/signal_handlers.py
+++ b/n23/content/models/signal_handlers.py
@@ -19,7 +19,7 @@ from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
 
 from n23.content.signals import MISSING, get_new_cost, get_old_cost, get_old_field
-from gyrinx.models import format_cost_display
+from n23.models import format_cost_display
 from gyrinx.tracing import traced
 
 from .equipment import (

--- a/n23/content/models/statline.py
+++ b/n23/content/models/statline.py
@@ -14,7 +14,7 @@ from django.db import models
 from multiselectfield import MultiSelectField
 from simple_history.models import HistoricalRecords
 
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 from .base import Content
 

--- a/n23/content/models/weapon.py
+++ b/n23/content/models/weapon.py
@@ -23,7 +23,7 @@ from django.utils.functional import cached_property
 from simple_history.models import HistoricalRecords
 from simpleeval import simple_eval
 
-from gyrinx.models import FighterCostMixin, format_cost_display
+from n23.models import FighterCostMixin, format_cost_display
 
 from .base import Content, ContentManager, ContentQuerySet, StatlineDisplay
 

--- a/n23/content/tests/test_admin_actions.py
+++ b/n23/content/tests/test_admin_actions.py
@@ -614,7 +614,7 @@ def test_fighter_display_tolerates_dangling_house(make_content_fighter, content_
     import uuid
 
     from n23.content.admin import fighter_house_name
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     fighter = make_content_fighter(
         type="Drifter",

--- a/n23/content/tests/test_availability_preset.py
+++ b/n23/content/tests/test_availability_preset.py
@@ -12,7 +12,7 @@ from n23.content.models import (
     ContentHouse,
 )
 from n23.core.models.list import List, ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/content/tests/test_content.py
+++ b/n23/content/tests/test_content.py
@@ -11,7 +11,7 @@ from n23.content.models import (
     ContentRule,
     ContentWeaponProfile,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/content/tests/test_content_cost_signals.py
+++ b/n23/content/tests/test_content_cost_signals.py
@@ -25,7 +25,7 @@ from n23.core.models.list import (
     ListFighter,
     ListFighterEquipmentAssignment,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.fixture

--- a/n23/content/tests/test_cost_methods.py
+++ b/n23/content/tests/test_cost_methods.py
@@ -20,7 +20,7 @@ from n23.content.models import (
     ContentWeaponAccessory,
     ContentWeaponProfile,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 # ContentEquipment cost methods tests

--- a/n23/content/tests/test_default_assignment.py
+++ b/n23/content/tests/test_default_assignment.py
@@ -7,7 +7,7 @@ from n23.content.models import (
     ContentFighterDefaultAssignment,
     ContentHouse,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/content/tests/test_equipment_list.py
+++ b/n23/content/tests/test_equipment_list.py
@@ -11,7 +11,7 @@ from n23.content.models import (
     ContentWeaponAccessory,
     ContentWeaponProfile,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/content/tests/test_equipment_upgrade_overrides.py
+++ b/n23/content/tests/test_equipment_upgrade_overrides.py
@@ -14,7 +14,7 @@ from n23.core.models import (
     ListFighterEquipmentAssignment,
     VirtualListFighterEquipmentAssignment,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/content/tests/test_expansion_weapon_profiles.py
+++ b/n23/content/tests/test_expansion_weapon_profiles.py
@@ -12,7 +12,7 @@ from n23.content.models import (
     ContentHouse,
     ContentWeaponProfile,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 from n23.content.models import (
     ContentEquipmentListExpansion,
     ContentEquipmentListExpansionItem,

--- a/n23/content/tests/test_fighter_category_restrictions.py
+++ b/n23/content/tests/test_fighter_category_restrictions.py
@@ -8,7 +8,7 @@ from n23.content.models import (
     ContentFighter,
 )
 from n23.core.models import List, ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/content/tests/test_fighter_equipment_category_limit.py
+++ b/n23/content/tests/test_fighter_equipment_category_limit.py
@@ -11,7 +11,7 @@ from n23.content.models import (
 )
 from n23.content.admin import ContentFighterEquipmentCategoryLimitForm
 from n23.core.models import List, ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/content/tests/test_models_advancement_equipment.py
+++ b/n23/content/tests/test_models_advancement_equipment.py
@@ -6,7 +6,7 @@ from n23.content.models import (
     ContentAdvancementEquipment,
 )
 from n23.core.models import ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/content/tests/test_policy.py
+++ b/n23/content/tests/test_policy.py
@@ -12,7 +12,7 @@ from n23.content.models import (
     ContentFighter,
     ContentPolicy,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @dataclass

--- a/n23/content/tests/test_promotion.py
+++ b/n23/content/tests/test_promotion.py
@@ -18,7 +18,7 @@ from n23.content.models.promotion import (
     PROMOTION_TARGET_CATEGORIES,
     seed_default_promotions,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def _make_path(**kwargs):

--- a/n23/core/cost/reconcile.py
+++ b/n23/core/cost/reconcile.py
@@ -28,7 +28,7 @@ from n23.core.models.list import (
     List,
     ListFighterEquipmentAssignment,
 )
-from gyrinx.models import format_cost_display
+from n23.models import format_cost_display
 
 
 @dataclass(frozen=True)

--- a/n23/core/cost/reconcile_notify.py
+++ b/n23/core/cost/reconcile_notify.py
@@ -29,7 +29,7 @@ from django.utils.html import format_html, format_html_join
 
 from n23.core.models.list import List
 from n23.core.models.notification import Notification, NotificationType
-from gyrinx.models import format_cost_display
+from n23.models import format_cost_display
 
 logger = logging.getLogger(__name__)
 

--- a/n23/core/forms/list.py
+++ b/n23/core/forms/list.py
@@ -24,7 +24,8 @@ from gyrinx.forms import (
     group_select,
     group_sorter,
 )
-from gyrinx.models import SMART_QUOTES, FighterCategoryChoices
+from gyrinx.models import SMART_QUOTES
+from n23.models import FighterCategoryChoices
 from gyrinx.widgets import TINYMCE_EXTRA_ATTRS, TinyMCEWithUpload
 
 

--- a/n23/core/forms/pack.py
+++ b/n23/core/forms/pack.py
@@ -24,7 +24,7 @@ from n23.core.models.pack import (
     CustomContentPackAttachment,
 )
 from gyrinx.forms import group_select
-from gyrinx.models import FighterCategoryChoices, equipment_category_groups
+from n23.models import FighterCategoryChoices, equipment_category_groups
 from gyrinx.widgets import TINYMCE_EXTRA_ATTRS, TinyMCEWithUpload
 
 

--- a/n23/core/forms/post_battle.py
+++ b/n23/core/forms/post_battle.py
@@ -15,7 +15,7 @@ from n23.core.models.battle import Battle
 from n23.core.models.campaign import CampaignAsset
 from n23.core.models.list import List, ListFighter
 from gyrinx.forms import group_select
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 class RepeatedSelect(forms.SelectMultiple):

--- a/n23/core/forms/vehicle.py
+++ b/n23/core/forms/vehicle.py
@@ -14,7 +14,7 @@ from n23.core.forms.list import ContentFighterChoiceField, group_select
 from n23.core.models.list import List
 from n23.core.forms.terms import fighter_group_key
 from gyrinx.forms import group_sorter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 class VehicleEquipmentChoiceField(forms.ModelChoiceField):

--- a/n23/core/handlers/crew.py
+++ b/n23/core/handlers/crew.py
@@ -36,7 +36,7 @@ from n23.core.models.crew import (
     roll_selection_spec,
 )
 from n23.core.models.list import ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 from gyrinx.tracing import traced
 
 logger = logging.getLogger(__name__)

--- a/n23/core/handlers/fighter/hire_clone.py
+++ b/n23/core/handlers/fighter/hire_clone.py
@@ -10,7 +10,7 @@ from n23.core.cost.propagation import Delta, propagate_from_fighter
 from n23.core.models.action import ListAction, ListActionType
 from n23.core.models.campaign import CampaignAction
 from n23.core.models.list import List, ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 from gyrinx.tracing import traced
 
 

--- a/n23/core/models/list/_common.py
+++ b/n23/core/models/list/_common.py
@@ -2,9 +2,7 @@ import logging
 
 from django.core.exceptions import ValidationError
 
-from gyrinx.models import (
-    FighterCategoryChoices,
-)
+from n23.models import FighterCategoryChoices
 
 logger = logging.getLogger(__name__)
 pylist = list

--- a/n23/core/models/list/advancement.py
+++ b/n23/core/models/list/advancement.py
@@ -15,9 +15,7 @@ from n23.content.models import (
 from n23.core.models.base import AppBase
 from n23.core.models.list.assignment import ListFighterEquipmentAssignment
 from n23.core.models.list.fighter import ListFighter
-from gyrinx.models import (
-    FighterCategoryChoices,
-)
+from n23.models import FighterCategoryChoices
 
 logger = logging.getLogger(__name__)
 pylist = list

--- a/n23/core/models/list/assignment.py
+++ b/n23/core/models/list/assignment.py
@@ -24,11 +24,8 @@ from n23.content.models import (
 from n23.core.models.facts import AssignmentFacts
 from n23.core.models.history_mixin import HistoryMixin
 from n23.core.models.list._common import preferred_equipment_list_override
-from gyrinx.models import (
-    Archived,
-    Base,
-    format_cost_display,
-)
+from gyrinx.models import Archived, Base
+from n23.models import format_cost_display
 from n23.core.models.list.fighter import ListFighter
 from gyrinx.tracing import traced
 

--- a/n23/core/models/list/campaign_state.py
+++ b/n23/core/models/list/campaign_state.py
@@ -16,10 +16,7 @@ from n23.content.models import (
 from n23.core.models.base import AppBase
 from n23.core.models.list.fighter import ListFighter
 from n23.core.models.list.list import List
-from gyrinx.models import (
-    Archived,
-    Base,
-)
+from gyrinx.models import Archived, Base
 
 logger = logging.getLogger(__name__)
 pylist = list

--- a/n23/core/models/list/fighter.py
+++ b/n23/core/models/list/fighter.py
@@ -56,11 +56,8 @@ from n23.core.models.list._common import (
 )
 from n23.core.models.list.list import List
 from n23.core.models.util import ModContext
-from gyrinx.models import (
-    FighterCategoryChoices,
-    QuerySetOf,
-    format_cost_display,
-)
+from gyrinx.models import QuerySetOf
+from n23.models import FighterCategoryChoices, format_cost_display
 from gyrinx.tracing import traced
 
 if TYPE_CHECKING:

--- a/n23/core/models/list/list.py
+++ b/n23/core/models/list/list.py
@@ -31,11 +31,8 @@ from n23.core.models.history_aware_manager import HistoryAwareManager
 from n23.core.tasks import (
     refresh_list_facts,
 )
-from gyrinx.models import (
-    FighterCategoryChoices,
-    QuerySetOf,
-    format_cost_display,
-)
+from gyrinx.models import QuerySetOf
+from n23.models import FighterCategoryChoices, format_cost_display
 from gyrinx.tracing import span, traced
 from gyrinx.tracker import track
 

--- a/n23/core/models/list/psyker.py
+++ b/n23/core/models/list/psyker.py
@@ -8,10 +8,7 @@ from n23.content.models import (
     ContentPsykerPower,
 )
 from n23.core.models.list.fighter import ListFighter
-from gyrinx.models import (
-    Archived,
-    Base,
-)
+from gyrinx.models import Archived, Base
 
 logger = logging.getLogger(__name__)
 pylist = list

--- a/n23/core/models/list/virtual.py
+++ b/n23/core/models/list/virtual.py
@@ -16,10 +16,8 @@ from n23.content.models import (
 )
 from n23.core.models.list.assignment import ListFighterEquipmentAssignment
 from n23.core.models.list.fighter import ListFighter
-from gyrinx.models import (
-    QuerySetOf,
-    format_cost_display,
-)
+from gyrinx.models import QuerySetOf
+from n23.models import format_cost_display
 
 if TYPE_CHECKING:
     from n23.core.models.list.psyker import ListFighterPsykerPowerAssignment

--- a/n23/core/templatetags/custom_tags.py
+++ b/n23/core/templatetags/custom_tags.py
@@ -19,7 +19,7 @@ from django.utils.safestring import SafeData, mark_safe
 
 from n23.content.models import ContentPageRef
 from n23.core import url
-from gyrinx.models import format_cost_display
+from n23.models import format_cost_display
 
 register = template.Library()
 

--- a/n23/core/tests/test_advancement_confirm_equipment_exclusion.py
+++ b/n23/core/tests/test_advancement_confirm_equipment_exclusion.py
@@ -10,7 +10,7 @@ from n23.content.models import (
     ContentEquipmentUpgrade,
 )
 from n23.core.models import ListFighterAdvancement, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_campaign_credit_spending.py
+++ b/n23/core/tests/test_campaign_credit_spending.py
@@ -234,7 +234,7 @@ def test_add_vehicle_creates_campaign_action(
 ):
     """Test that adding a vehicle in campaign mode creates a campaign action."""
     from n23.core.models.campaign import CampaignAction
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     client.login(username="testuser", password="password")
 

--- a/n23/core/tests/test_can_buy_any_equipment.py
+++ b/n23/core/tests/test_can_buy_any_equipment.py
@@ -12,7 +12,7 @@ from n23.content.models import (
     ContentWeaponProfile,
 )
 from n23.core.models.list import List, ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/core/tests/test_can_hire_any_fighters.py
+++ b/n23/core/tests/test_can_hire_any_fighters.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from n23.content.models import ContentFighter, ContentHouse
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/core/tests/test_clone.py
+++ b/n23/core/tests/test_clone.py
@@ -565,7 +565,7 @@ def test_list_clone_preserves_expansion_equipment_cost(
         ContentEquipmentListExpansionRuleByAttribute,
     )
     from n23.core.models import ListAttributeAssignment
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     # Create a house
     house = make_content_house("Test House")

--- a/n23/core/tests/test_clone_fighter_stat_overrides.py
+++ b/n23/core/tests/test_clone_fighter_stat_overrides.py
@@ -10,7 +10,7 @@ from n23.content.models import (
     ContentStatlineTypeStat,
 )
 from n23.core.models.list import ListFighterStatOverride
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_clone_linked_equipment.py
+++ b/n23/core/tests/test_clone_linked_equipment.py
@@ -6,7 +6,7 @@ from n23.content.models import (
     ContentEquipmentFighterProfile,
 )
 from n23.core.models.list import ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_clone_linked_fighter_complete.py
+++ b/n23/core/tests/test_clone_linked_fighter_complete.py
@@ -19,7 +19,7 @@ from n23.core.models.list import (
     ListFighterEquipmentAssignment,
     ListFighterStatOverride,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_clone_linked_fighter_equipment.py
+++ b/n23/core/tests/test_clone_linked_fighter_equipment.py
@@ -5,7 +5,7 @@ from n23.content.models import (
     ContentEquipmentFighterProfile,
 )
 from n23.core.models.list import ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_combined_equipment_lists.py
+++ b/n23/core/tests/test_combined_equipment_lists.py
@@ -8,7 +8,7 @@ from n23.content.models import (
     ContentFighterEquipmentListItem,
 )
 from n23.core.models import List, ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/core/tests/test_cost_display.py
+++ b/n23/core/tests/test_cost_display.py
@@ -12,7 +12,7 @@ from n23.content.models import (
     ContentWeaponAccessory,
 )
 from n23.core.models.list import List, ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices, format_cost_display
+from n23.models import FighterCategoryChoices, format_cost_display
 
 
 class TestFormatCostDisplay:

--- a/n23/core/tests/test_crew.py
+++ b/n23/core/tests/test_crew.py
@@ -71,7 +71,7 @@ from n23.core.models.list import (
     ListFighterEquipmentAssignment,
     ListFighterEquipmentSet,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 # --- Selection-spec parser --------------------------------------------------

--- a/n23/core/tests/test_dead_fighter_cost.py
+++ b/n23/core/tests/test_dead_fighter_cost.py
@@ -13,7 +13,7 @@ from n23.core.models.list import (
     ListFighter,
     ListFighterAdvancement,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def clear_fighter_cached_properties(fighter):

--- a/n23/core/tests/test_equipment_assignment_form_no_options_display.py
+++ b/n23/core/tests/test_equipment_assignment_form_no_options_display.py
@@ -10,7 +10,7 @@ from n23.content.models import (
 )
 from n23.core.forms.advancement import EquipmentAssignmentSelectionForm
 from n23.core.models import ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_equipment_cost_filter.py
+++ b/n23/core/tests/test_equipment_cost_filter.py
@@ -13,7 +13,7 @@ from n23.content.models import (
     ContentWeaponProfile,
 )
 from n23.core.models import List, ListFighter, User
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.fixture

--- a/n23/core/tests/test_equipment_link.py
+++ b/n23/core/tests/test_equipment_link.py
@@ -7,7 +7,7 @@ from n23.content.models import (
     ContentEquipmentFighterProfile,
 )
 from n23.core.models.list import List, ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_equipment_list_expansion.py
+++ b/n23/core/tests/test_equipment_list_expansion.py
@@ -22,7 +22,7 @@ from n23.content.models import (
 )
 from n23.core.models import List, ListAttributeAssignment
 from n23.core.models.list import ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_fighter_advancement_cost.py
+++ b/n23/core/tests/test_fighter_advancement_cost.py
@@ -6,7 +6,7 @@ from n23.core.models.list import (
     ListFighter,
     ListFighterAdvancement,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_fighter_advancements.py
+++ b/n23/core/tests/test_fighter_advancements.py
@@ -2,7 +2,7 @@ from urllib.parse import urlencode
 from django.urls import reverse
 import pytest
 
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_fighter_category_terms.py
+++ b/n23/core/tests/test_fighter_category_terms.py
@@ -6,7 +6,7 @@ from n23.content.models import (
     ContentHouse,
 )
 from n23.core.models.list import List, ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_fighter_injuries.py
+++ b/n23/core/tests/test_fighter_injuries.py
@@ -11,7 +11,7 @@ from n23.content.models import (
 )
 from n23.core.models.campaign import Campaign
 from n23.core.models.list import List, ListFighter, ListFighterInjury
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def create_test_data():

--- a/n23/core/tests/test_fighter_ordering.py
+++ b/n23/core/tests/test_fighter_ordering.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from n23.content.models import ContentFighter, ContentHouse
 from n23.core.forms.list import ListFighterForm
 from n23.core.models import List, ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_forms_advancement_equipment.py
+++ b/n23/core/tests/test_forms_advancement_equipment.py
@@ -2,7 +2,7 @@ import pytest
 
 from n23.content.models import ContentAdvancementEquipment
 from n23.core.forms.advancement import AdvancementTypeForm
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_gang_wide_skills.py
+++ b/n23/core/tests/test_gang_wide_skills.py
@@ -13,7 +13,7 @@ from n23.content.models import (
 from n23.core.forms.skill_tree import ListSkillTreeForm
 from n23.core.models.list import List, ListFighter, ListSkillTreeAssignment
 from n23.core.models.pack import CustomContentPack, CustomContentPackItem
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def _add_to_pack(pack, obj):

--- a/n23/core/tests/test_handlers_equipment_cost_override.py
+++ b/n23/core/tests/test_handlers_equipment_cost_override.py
@@ -15,7 +15,7 @@ from n23.content.models import ContentEquipmentFighterProfile
 from n23.core.handlers.equipment import handle_equipment_cost_override
 from n23.core.models.action import ListActionType
 from n23.core.models.list import ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_handlers_equipment_purchases.py
+++ b/n23/core/tests/test_handlers_equipment_purchases.py
@@ -18,7 +18,7 @@ from n23.core.handlers.equipment import (
 from n23.core.models.action import ListAction, ListActionType
 from n23.core.models.campaign import CampaignAction
 from n23.core.models.list import ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_handlers_equipment_removal.py
+++ b/n23/core/tests/test_handlers_equipment_removal.py
@@ -14,7 +14,7 @@ from n23.content.models import (
 from n23.core.handlers.equipment import handle_equipment_removal
 from n23.core.models.action import ListActionType
 from n23.core.models.list import ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_handlers_fighter_advancement.py
+++ b/n23/core/tests/test_handlers_fighter_advancement.py
@@ -26,7 +26,7 @@ from n23.core.models.list import (
     ListFighterAdvancement,
     ListFighterEquipmentAssignment,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 # --- Fixtures ---

--- a/n23/core/tests/test_handlers_fighter_capture.py
+++ b/n23/core/tests/test_handlers_fighter_capture.py
@@ -23,7 +23,7 @@ from n23.core.models.list import (
     ListFighter,
     ListFighterEquipmentAssignment,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/core/tests/test_handlers_fighter_edit.py
+++ b/n23/core/tests/test_handlers_fighter_edit.py
@@ -15,7 +15,7 @@ from n23.content.models import ContentEquipmentFighterProfile
 from n23.core.handlers.fighter import handle_fighter_edit
 from n23.core.models.action import ListActionType
 from n23.core.models.list import ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_handlers_fighter_lifecycle.py
+++ b/n23/core/tests/test_handlers_fighter_lifecycle.py
@@ -109,7 +109,7 @@ def test_handle_fighter_kill_with_equipment(
     lst.save()
 
     # Create stash fighter
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     # We need the make_content_fighter fixture, but we'll create a simple stash manually
     stash_type = content_fighter.__class__.objects.create(
@@ -175,7 +175,7 @@ def test_handle_fighter_kill_linked_equipment_not_duplicated(
         ContentEquipmentCategory,
         ContentEquipmentEquipmentProfile,
     )
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     lst = list_with_campaign
     stash_type = content_fighter.__class__.objects.create(
@@ -239,7 +239,7 @@ def test_handle_fighter_kill_child_fighter_not_duplicated(
         ContentEquipmentCategory,
         ContentEquipmentFighterProfile,
     )
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     lst = list_with_campaign
     stash_type = content_fighter.__class__.objects.create(
@@ -426,7 +426,7 @@ def test_handle_fighter_resurrect_validates_not_stash(
     """Test resurrection rejects stash fighters."""
     lst = list_with_campaign
 
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     stash_type = make_content_fighter(
         type="Stash",
@@ -573,7 +573,7 @@ def test_handle_fighter_resurrect_appends_reason_to_campaign_action(
 
 def _make_stash_fighter(*, user, lst, content_fighter):
     """Create a stash fighter on ``lst`` reusing the existing ContentFighter house."""
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     stash_type = content_fighter.__class__.objects.create(
         house=content_fighter.house,

--- a/n23/core/tests/test_handlers_fighter_operations.py
+++ b/n23/core/tests/test_handlers_fighter_operations.py
@@ -17,7 +17,7 @@ from n23.core.handlers.fighter import (
 from n23.core.models.action import ListAction, ListActionType
 from n23.core.models.campaign import CampaignAction
 from n23.core.models.list import ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_handlers_fighter_removal.py
+++ b/n23/core/tests/test_handlers_fighter_removal.py
@@ -192,7 +192,7 @@ def test_handle_equipment_removal_stash_fighter(
     make_equipment,
 ):
     """Test removing equipment from stash fighter affects stash, not rating."""
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     lst = list_with_campaign
     lst.credits_current = 500
@@ -818,7 +818,7 @@ def test_handle_fighter_deletion_stash_fighter(
     make_content_fighter,
 ):
     """Test deleting a stash fighter affects stash, not rating."""
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     lst = list_with_campaign
     lst.credits_current = 500

--- a/n23/core/tests/test_handlers_fighter_vehicle.py
+++ b/n23/core/tests/test_handlers_fighter_vehicle.py
@@ -31,7 +31,7 @@ def test_handle_vehicle_purchase_initializes_crew_rating_current(
     vehicle_equipment.creates_child_fighter = False  # Simple vehicle
     vehicle_equipment.save()
 
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     vehicle_fighter = make_content_fighter(
         type="Vehicle",
@@ -85,7 +85,7 @@ def test_handle_vehicle_purchase_propagates_assignment_rating_current(
     vehicle_equipment.creates_child_fighter = False
     vehicle_equipment.save()
 
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     vehicle_fighter = make_content_fighter(
         type="Vehicle",
@@ -144,7 +144,7 @@ def test_handle_vehicle_purchase_to_stash(
     vehicle_equipment.creates_child_fighter = False
     vehicle_equipment.save()
 
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     vehicle_fighter = make_content_fighter(
         type="Vehicle",
@@ -191,7 +191,7 @@ def test_handle_vehicle_purchase_child_fighter_rating_current(
     lst.save()
 
     from n23.content.models import ContentEquipmentFighterProfile
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     # Create vehicle fighter that will be auto-created as a child
     vehicle_fighter = make_content_fighter(

--- a/n23/core/tests/test_handlers_vehicle_purchases.py
+++ b/n23/core/tests/test_handlers_vehicle_purchases.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from n23.core.handlers.fighter import handle_vehicle_purchase
 from n23.core.models.action import ListAction, ListActionType
 from n23.core.models.list import ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_house_restricted_categories.py
+++ b/n23/core/tests/test_house_restricted_categories.py
@@ -18,7 +18,7 @@ from n23.content.models import (
     ContentWeaponProfile,
 )
 from n23.core.models.list import ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.fixture

--- a/n23/core/tests/test_injury_campaign_actions.py
+++ b/n23/core/tests/test_injury_campaign_actions.py
@@ -11,7 +11,7 @@ from n23.content.models import (
 )
 from n23.core.models.campaign import Campaign, CampaignAction
 from n23.core.models.list import List, ListFighter, ListFighterInjury
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def create_test_campaign_data():

--- a/n23/core/tests/test_injury_modifications.py
+++ b/n23/core/tests/test_injury_modifications.py
@@ -16,7 +16,7 @@ from n23.content.models import (
 )
 from n23.core.models.campaign import Campaign
 from n23.core.models.list import List, ListFighter, ListFighterInjury
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def create_base_test_data():

--- a/n23/core/tests/test_injury_modifiers.py
+++ b/n23/core/tests/test_injury_modifiers.py
@@ -10,7 +10,7 @@ from n23.content.models import (
 )
 from n23.core.models.campaign import Campaign
 from n23.core.models.list import List, ListFighter, ListFighterInjury
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_injury_views.py
+++ b/n23/core/tests/test_injury_views.py
@@ -11,7 +11,7 @@ from n23.content.models import (
 )
 from n23.core.models.campaign import Campaign, CampaignAction
 from n23.core.models.list import List, ListFighter, ListFighterInjury
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def create_test_data(client):

--- a/n23/core/tests/test_integration_core_functionality.py
+++ b/n23/core/tests/test_integration_core_functionality.py
@@ -18,7 +18,7 @@ from n23.content.models import (
     ContentWeaponProfile,
 )
 from n23.core.models.list import List, ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/core/tests/test_list_fighter_group_keys.py
+++ b/n23/core/tests/test_list_fighter_group_keys.py
@@ -8,7 +8,7 @@ from n23.content.models import (
     ContentHouse,
 )
 from n23.core.models.list import List, ListFighter, ListFighterEquipmentAssignment
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/core/tests/test_list_packs.py
+++ b/n23/core/tests/test_list_packs.py
@@ -10,7 +10,7 @@ from n23.content.models import ContentFighter, ContentHouse, ContentRule
 from n23.content.models.weapon import ContentWeaponTrait
 from n23.core.models.list import List
 from n23.core.models.pack import CustomContentPack, CustomContentPackItem
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_maintenance_stat_advancements.py
+++ b/n23/core/tests/test_maintenance_stat_advancements.py
@@ -11,7 +11,7 @@ from n23.core.maintenance.stat_advancements import (
     build_plan,
     send_messages,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def make_simple_content_fighter(house):
@@ -21,7 +21,7 @@ def make_simple_content_fighter(house):
     their own.
     """
     from n23.content.models import ContentFighter
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     return ContentFighter.objects.create(
         type="Commit Order Fighter",

--- a/n23/core/tests/test_maintenance_statlines.py
+++ b/n23/core/tests/test_maintenance_statlines.py
@@ -19,7 +19,7 @@ from n23.core.maintenance.statlines import (
 )
 from n23.core.models import Backfill
 from n23.core.models.list import ListFighter
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 # Mirrors content.0156: position order, Ld..Int highlighted, Ld first of group.
 _TYPE_META = {

--- a/n23/core/tests/test_migration_convert_legacy_advancements.py
+++ b/n23/core/tests/test_migration_convert_legacy_advancements.py
@@ -4,7 +4,7 @@ import pytest
 from django.apps import apps
 
 from n23.core.models import ListFighter, ListFighterAdvancement
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 migration = __import__(
     "n23.core.migrations.0196_convert_legacy_stat_advancements",

--- a/n23/core/tests/test_migration_fix_movement_advances.py
+++ b/n23/core/tests/test_migration_fix_movement_advances.py
@@ -4,7 +4,7 @@ from django.apps import apps
 
 from n23.content.models import ContentFighter, ContentHouse
 from n23.core.models import List, ListFighter, ListFighterAdvancement
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_mod_ctx_optimization.py
+++ b/n23/core/tests/test_mod_ctx_optimization.py
@@ -9,7 +9,7 @@ from n23.content.models import (
 )
 from n23.core.models import List, ListFighter, ListFighterEquipmentAssignment
 from n23.core.models.util import ModContext
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 from gyrinx.query import capture_queries
 
 

--- a/n23/core/tests/test_models_core.py
+++ b/n23/core/tests/test_models_core.py
@@ -20,7 +20,7 @@ from n23.core.models.list import (
     ListFighterEquipmentAssignment,
     VirtualListFighterEquipmentAssignment,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.fixture

--- a/n23/core/tests/test_models_list_fighter_advancement_equipment.py
+++ b/n23/core/tests/test_models_list_fighter_advancement_equipment.py
@@ -11,7 +11,7 @@ from n23.core.models import (
     ListFighterAdvancement,
     ListFighterEquipmentAssignment,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.mark.django_db

--- a/n23/core/tests/test_models_pack.py
+++ b/n23/core/tests/test_models_pack.py
@@ -13,7 +13,7 @@ from n23.content.models import (
     ContentWeaponProfile,
 )
 from n23.core.models import CustomContentPack, CustomContentPackItem
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.fixture

--- a/n23/core/tests/test_performance_view_queries.py
+++ b/n23/core/tests/test_performance_view_queries.py
@@ -36,7 +36,7 @@ from n23.core.models.list import (
     ListFighter,
     ListFighterEquipmentAssignment,
 )
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 from gyrinx.util import print_word_diff
 
 User = get_user_model()

--- a/n23/core/tests/test_pinning.py
+++ b/n23/core/tests/test_pinning.py
@@ -426,7 +426,7 @@ def test_vehicle_purchase_pins(
     ctx, user, make_content_fighter, content_house, make_equipment
 ):
     from n23.core.handlers.fighter.vehicle import handle_vehicle_purchase
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     vehicle_equipment = make_equipment("Ridgehauler", cost=100)
     vehicle_fighter = make_content_fighter(

--- a/n23/core/tests/test_post_battle_updates.py
+++ b/n23/core/tests/test_post_battle_updates.py
@@ -409,7 +409,7 @@ def test_post_battle_vehicle_state_choices(
     make_content_fighter,
     make_list_fighter,
 ):
-    from gyrinx.models import FighterCategoryChoices
+    from n23.models import FighterCategoryChoices
 
     client.force_login(user)
     vehicle_cf = make_content_fighter(

--- a/n23/core/tests/test_promotion_paths.py
+++ b/n23/core/tests/test_promotion_paths.py
@@ -16,7 +16,7 @@ from n23.core.handlers.fighter.advancement import (
 )
 from n23.core.models.campaign import CampaignAction
 from n23.core.models.list import ListFighter, ListFighterAdvancement
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.fixture

--- a/n23/core/tests/test_ruleline_skilline_queries.py
+++ b/n23/core/tests/test_ruleline_skilline_queries.py
@@ -21,7 +21,7 @@ from n23.content.models import (
 )
 from n23.core.models.list import List, ListFighter
 from n23.core.models.pack import CustomContentPack, CustomContentPackItem
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 User = get_user_model()
 

--- a/n23/core/tests/test_weapon_availability_filtering.py
+++ b/n23/core/tests/test_weapon_availability_filtering.py
@@ -11,7 +11,7 @@ from n23.content.models import (
     ContentWeaponProfile,
 )
 from n23.core.models import List, ListFighter, User
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 @pytest.fixture

--- a/n23/core/views/fighter/advancements.py
+++ b/n23/core/views/fighter/advancements.py
@@ -37,7 +37,7 @@ from n23.core.models.list import (
     ListFighterEquipmentAssignment,
 )
 from n23.core.views.list.common import get_clean_list_or_404
-from gyrinx.models import FighterCategoryChoices
+from n23.models import FighterCategoryChoices
 
 
 def can_fighter_roll_dice_for_advancement(fighter):

--- a/n23/core/views/pack.py
+++ b/n23/core/views/pack.py
@@ -85,7 +85,8 @@ from n23.core.models.pack import (
     CustomContentPackPermission,
 )
 from n23.core.utils import safe_redirect, search_queryset
-from gyrinx.models import FighterCategoryChoices, is_valid_uuid
+from gyrinx.models import is_valid_uuid
+from n23.models import FighterCategoryChoices
 
 
 class ContentTypeEntry(NamedTuple):
@@ -1937,7 +1938,7 @@ def add_pack_fighter_stats(request, id):
     statline_type_override = None
     if params.statline_type_id:
         from n23.core.forms.pack import _EXCLUDED_FIGHTER_CATEGORIES
-        from gyrinx.models import FighterCategoryChoices as FCC
+        from n23.models import FighterCategoryChoices as FCC
 
         allowed_categories = {
             v for v, _ in FCC.choices if v not in _EXCLUDED_FIGHTER_CATEGORIES
@@ -5252,7 +5253,6 @@ def house_rule_picker(request, id):
         q = picker_data["search_query"]
     else:  # fighter
         target_label = "fighters & vehicles"
-        from gyrinx.models import FighterCategoryChoices
 
         fighters_qs = (
             ContentFighter.objects.with_packs([pack])

--- a/n23/models.py
+++ b/n23/models.py
@@ -1,0 +1,209 @@
+"""Edition vocabulary shared across n23.core and n23.content.
+
+These are game concepts, not infrastructure: fighter categories, equipment
+category groupings, the cost mixins and credit formatting. They sit beside the
+platform's ``gyrinx.models`` rather than inside it so the platform carries no
+game semantics.
+
+All classes here are abstract — nothing in this module creates a table.
+"""
+
+from django.db import models
+
+from gyrinx.models import is_int
+from gyrinx.models import QuerySetOf  # noqa: F401  (re-exported for callers)
+
+
+def format_cost_display(cost_value, show_sign=False):
+    """
+    Format a cost value for display with proper sign handling.
+
+    Parameters
+    ----------
+    cost_value : int or str
+        The cost value to format
+    show_sign : bool
+        Whether to show '+' for positive values (default: False)
+
+    Returns
+    -------
+    str
+        Formatted cost string with '¢' suffix
+
+    Examples
+    --------
+    >>> format_cost_display(5)
+    '5¢'
+    >>> format_cost_display(5, show_sign=True)
+    '+5¢'
+    >>> format_cost_display(-5)
+    '-5¢'
+    >>> format_cost_display(-5, show_sign=True)
+    '-5¢'
+    >>> format_cost_display(0)
+    '0¢'
+    >>> format_cost_display(0, show_sign=True)
+    '+0¢'
+    """
+    # Convert to int if it's a string
+    if isinstance(cost_value, str):
+        if not is_int(cost_value):
+            return cost_value  # Return as-is if not a number
+        cost_value = int(cost_value)
+
+    # Format with sign if requested and positive or zero
+    if show_sign and cost_value >= 0:
+        return f"+{cost_value}¢"
+
+    # Otherwise just return with currency symbol
+    return f"{cost_value}¢"
+
+
+class FighterCategoryChoices(models.TextChoices):
+    LEADER = "LEADER", "Leader"
+    CHAMPION = "CHAMPION", "Champion"
+    GANGER = "GANGER", "Ganger"
+    JUVE = "JUVE", "Juve"
+    CREW = "CREW", "Crew"
+    EXOTIC_BEAST = "EXOTIC_BEAST", "Exotic Beast"
+    HANGER_ON = "HANGER_ON", "Hanger-on"
+    BRUTE = "BRUTE", "Brute"
+    HIRED_GUN = "HIRED_GUN", "Hired Gun"
+    BOUNTY_HUNTER = "BOUNTY_HUNTER", "Bounty Hunter"
+    HOUSE_AGENT = "HOUSE_AGENT", "House Agent"
+    HIVE_SCUM = "HIVE_SCUM", "Hive Scum"
+    DRAMATIS_PERSONAE = "DRAMATIS_PERSONAE", "Dramatis Personae"
+    PROSPECT = "PROSPECT", "Prospect"
+    SPECIALIST = "SPECIALIST", "Specialist"
+    STASH = "STASH", "Stash"
+    VEHICLE = "VEHICLE", "Vehicle"
+    ALLY = "ALLY", "Ally"
+    GANG_TERRAIN = "GANG_TERRAIN", "Gang Terrain"
+
+
+equipment_category_groups = [
+    "Gear",
+    "Vehicle & Mount",
+    "Weapons & Ammo",
+    "Other",
+]
+equipment_category_group_choices = [(x, x) for x in equipment_category_groups]
+
+
+class CostMixin(models.Model):
+    """
+    Mixin for models that have cost calculation logic.
+
+    This mixin provides common cost methods (cost_int, cost_display) that can be
+    used by models with cost fields. It handles both integer and string cost fields.
+
+    For models with special cost calculation logic, override the cost_int() method.
+
+    Attributes
+    ----------
+    cost_field_name : str
+        The name of the field that stores the cost. Defaults to 'cost'.
+        Can be overridden in subclasses if the field has a different name.
+    """
+
+    cost_field_name = "cost"
+
+    class Meta:
+        abstract = True
+
+    def cost_int(self):
+        """
+        Returns the integer cost of this item.
+
+        This method handles both integer and string cost fields:
+        - If the cost field is an integer, returns it directly
+        - If the cost field is a string that can be converted to int, converts and returns it
+        - If the cost field is empty or non-numeric, returns 0
+
+        Override this method in subclasses for custom cost calculation logic.
+
+        Returns
+        -------
+        int
+            The cost as an integer
+        """
+        cost_value = getattr(self, self.cost_field_name, None)
+
+        # Handle None or empty values
+        if cost_value is None or cost_value == "":
+            return 0
+
+        # If it's already an integer, return it
+        if isinstance(cost_value, int):
+            return cost_value
+
+        # If it's a string, try to convert
+        if isinstance(cost_value, str):
+            if is_int(cost_value):
+                return int(cost_value)
+            return 0
+
+        # Default case
+        return 0
+
+    def cost_display(self, show_sign=False):
+        """
+        Returns a readable cost string with currency symbol.
+
+        Parameters
+        ----------
+        show_sign : bool
+            Whether to show '+' for positive values (default: False)
+
+        Returns
+        -------
+        str
+            Formatted cost string with '¢' suffix
+        """
+        cost_value = getattr(self, self.cost_field_name, None)
+
+        # Special handling for string costs that aren't numeric
+        if isinstance(cost_value, str) and not is_int(cost_value):
+            return cost_value
+
+        # For empty string costs, return empty
+        if cost_value == "" or cost_value is None:
+            return ""
+
+        return format_cost_display(self.cost_int(), show_sign=show_sign)
+
+
+class FighterCostMixin(CostMixin):
+    """
+    Extended cost mixin for models that have fighter-specific cost overrides.
+
+    This mixin adds the cost_for_fighter_int() method that checks for the
+    presence of an annotated 'cost_for_fighter' attribute.
+    """
+
+    class Meta:
+        abstract = True
+
+    def cost_for_fighter_int(self):
+        """
+        Returns the fighter-specific cost if available.
+
+        This method expects the model to be annotated with a 'cost_for_fighter'
+        attribute using the model's with_cost_for_fighter() queryset method.
+
+        Returns
+        -------
+        int
+            The fighter-specific cost
+
+        Raises
+        ------
+        AttributeError
+            If the model hasn't been annotated with cost_for_fighter
+        """
+        if hasattr(self, "cost_for_fighter"):
+            return self.cost_for_fighter
+
+        raise AttributeError(
+            "cost_for_fighter not available. Use with_cost_for_fighter()"
+        )


### PR DESCRIPTION
gyrinx/models.py was mixed: abstract infrastructure alongside game
concepts. Everything in it is abstract, so this is a pure Python move
with no table, no migration and no schema change.

Stays in gyrinx/models.py — genuine infrastructure, and load-bearing for
the platform's own models (gyrinx.api, gyrinx.pages and gyrinx.tasks all
inherit Base):
  Base, Owned, Archived, QuerySetOf, SMART_QUOTES, is_int, is_valid_uuid

Moves to n23/models.py — edition vocabulary, used only by n23:
  FighterCategoryChoices (96 call sites), CostMixin, FighterCostMixin,
  format_cost_display, equipment_category_groups

This is the mirror image of the coupling the rest of the stack removes:
rather than the platform depending on the edition, the platform was
*defining* game concepts. Moving them wholesale was not an option — Base
is inherited by three platform models, so the file had to be split.

4166 tests pass; makemigrations --check reports no changes, confirming
nothing here was concrete.

Refs #2093

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>