### PR TITLE
chore: run ci-checks on PRs targeting any branch, not just main

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,8 +1,10 @@
 name: CI Checks
 
 on:
+  # No base-branch filter: stacked PRs target another feature branch, and a
+  # `branches: [main]` filter would skip them — but ci-checks is a required
+  # status check once the PR retargets to main, so it must run on every PR.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
   merge_group:


### PR DESCRIPTION
## Summary

- `ci-checks` only triggered on PRs whose base branch is `main` (`pull_request: branches: [main]`), so stacked PRs — like #2105, which targets `n23-split-1-platform-modules` — never got a run.
- Since `ci-checks` is a required status check on `main` (ruleset), a stacked PR could never merge after retargeting to `main`: no run ever existed for its head commit.
- This removes the base-branch filter so `ci-checks` runs on every PR, matching how the Tests and CodeQL workflows already trigger. The `push: main` and `merge_group` triggers are unchanged.

Note: existing stacked PRs won't pick this up until their branches contain this change — update the stack (rebase or merge main in) after this lands.

## Test plan

- [ ] `ci-checks` appears and runs on this PR (base = main, unchanged behaviour)
- [ ] After merging + rebasing the stack, `ci-checks` runs on #2105 (base = feature branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)