### PR TITLE
test: stop crew query-count tests depending on cache warmth

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.db.models.signals import post_migrate
 
 from n23.content.models import (
@@ -65,6 +65,28 @@ def django_test_settings():
     settings.PASSWORD_HASHERS = [
         "django.contrib.auth.hashers.MD5PasswordHasher",
     ]
+
+
+@pytest.fixture(autouse=True)
+def clear_content_page_ref_cache():
+    """Empty the per-title page-ref cache before every test.
+
+    ``ContentPageRef.find_similar`` caches one entry per title in a process-local
+    ``LocMemCache``, and it sits in the fighter-card render path. Nothing else
+    clears it — every other autouse fixture here is session-scoped — so its
+    contents at test start depend on which tests ran earlier *in the same xdist
+    worker*, and it keeps filling while a test runs.
+
+    That makes query counts depend on worker history and on how many renders have
+    already happened, which is what made the relative query-count tests in
+    test_crew.py flaky on CI but not locally (#2114).
+
+    Only this cache is cleared. The ``default`` cache deliberately holds
+    ``BANNER_CACHE_KEY`` from ``django_test_settings`` so the banner query stays
+    out of every test's count; clearing that here would put the query back.
+    """
+    caches["content_page_ref_cache"].clear()
+    yield
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/n23/core/tests/test_crew.py
+++ b/n23/core/tests/test_crew.py
@@ -3052,7 +3052,9 @@ def test_selection_form_issues_no_per_fighter_set_query(
         ListFighterEquipmentSet.objects.create(
             list_fighter=fighter, name=f"Kit {i}", owner=fighter.owner
         )
-    assert _stable_query_count(render_query_count) == one_fighter_with_sets
+    # <= not ==: an N+1 makes this grow, which still fails. A *smaller* count
+    # is warmed caches, which is never the regression this guards against.
+    assert _stable_query_count(render_query_count) <= one_fighter_with_sets
 
 
 @pytest.mark.django_db
@@ -3730,7 +3732,9 @@ def test_crew_page_forecast_costs_no_per_fighter_query(
         ListFighterEquipmentSet.objects.create(
             list_fighter=extra, name=f"Kit {i}", owner=extra.owner
         )
-    assert _stable_query_count(render_query_count) == baseline
+    # <= not ==: an N+1 makes this grow, which still fails. A *smaller* count
+    # is warmed caches, which is never the regression this guards against.
+    assert _stable_query_count(render_query_count) <= baseline
 
 
 @pytest.mark.django_db
@@ -4508,7 +4512,9 @@ def test_battle_spread_third_gang_with_crew_adds_no_queries(
     crew_setup["battle"].set_participants([riot, iron, third])
     _pending_crew(crew_setup, third)
 
-    assert _stable_query_count(render_query_count) == two_gangs
+    # <= not ==: an N+1 makes this grow, which still fails. A *smaller* count
+    # is warmed caches, which is never the regression this guards against.
+    assert _stable_query_count(render_query_count) <= two_gangs
 
 
 # --- Crew-page rating-gap note ----------------------------------------------
@@ -4621,7 +4627,9 @@ def test_crew_page_opponent_fighter_count_does_not_raise_query_count(
     # Grow the opponent's crew; the batched opponent load must stay flat.
     add_chosen(iron_crew, iron_fighters[2:8])
 
-    assert _stable_query_count(render_query_count) == few
+    # <= not ==: an N+1 makes this grow, which still fails. A *smaller* count
+    # is warmed caches, which is never the regression this guards against.
+    assert _stable_query_count(render_query_count) <= few
 
 
 # --- Stash items -------------------------------------------------------------


### PR DESCRIPTION
Fixes the CI flakiness in the crew query-count tests reported in #2114.

## What was actually going wrong

The failures all had the same impossible shape: *fewer* queries measured with *more* data (`assert 153 == 155`). A per-row N+1 — the thing these tests exist to catch — can only push the count up. So the problem was never the render being measured; it was the baseline moving between the two halves of the comparison.

The cause is a process-local cache that nothing ever cleared. `ContentPageRef.find_similar` (`n23/content/models/metadata.py`) caches one entry per title in a `LocMemCache`, and it sits in the fighter-card render path. Every other autouse fixture in `conftest.py` is session-scoped, so that cache's contents at the start of a test depended on which tests had already run **in the same xdist worker** — and it kept filling *while* the test ran. The baseline render and the with-more-data render measured different cache states, and the second could quite legitimately come out lower.

That is why it reproduced on CI and not locally: it is a function of worker assignment and test ordering, not of the code under test.

## The original theory was not the cause

#2114 proposed that `_stable_query_count` was silently returning an **unstabilised** sample via its final `return prev`. That is not what happened in the observed failures. In those, the helper *did* stabilise — twice, at two different values. Two stable-but-different counts is not a failure to settle; it is the measurement floor shifting underneath a helper that was working exactly as documented.

Making non-stabilisation loud would therefore not have caught these failures, which is why this PR does not do it.

The issue does, though, describe a real and separate risk: if the count genuinely never settles, `return prev` hands back an arbitrary sample, and should it happen to coincide with the other side of the comparison the assertion passes having measured nothing. That is a false-*pass* hazard rather than the false-*failure* seen on CI. **This PR does not address it** — worth keeping #2114 open, or opening a follow-up, if you want the helper to fail loudly when it runs out of attempts.

## Changes

**`conftest.py`** — a new function-scoped autouse fixture empties `content_page_ref_cache` before every test, so both halves of each comparison start from the same cache state.

Only that cache is cleared. The `default` cache deliberately holds `BANNER_CACHE_KEY`, set by `django_test_settings` to keep the banner query out of every test's count; clearing it here would put that query back into thousands of tests.

**`n23/core/tests/test_crew.py`** — the four strict `== baseline` assertions become `<=`, each with a comment saying why. These tests guard against per-row N+1s, which make the count grow, and a count that grows still fails. A count that shrinks is warm caches — never the regression being guarded against. A fifth call site already used `<= many + 2`, so this makes the file consistent with itself.

The two changes are belt and braces: the fixture removes the drift, the `<=` means residual one-shot warming can't fail the build in a direction that is not a regression.

## Testing

- Full suite: **4147 passed, 13 skipped** — unchanged from main's baseline.
- `pytest n23/core/tests/test_crew.py -q -n 0` run three times consecutively: 293 passed each time.

Refs #2114
