### PR TITLE
refactor: discover task routes from apps instead of naming them in the platform

### DIFF
--- a/.claude/notes/task-registry-footgun.md
+++ b/.claude/notes/task-registry-footgun.md
@@ -1,5 +1,25 @@
 # Background task registry: the silent dev/prod split, and a better abstraction
 
+## Status
+
+Both recommendations have landed.
+
+- **(A) System check** — shipped as `gyrinx/tasks/checks.py` (`gyrinx.tasks.E001`
+  / `E002`).
+- **(B) Declaration-owned registration** — shipped, but as a declarative list
+  rather than the `@gyrinx_task` decorator sketched below. Each app declares a
+  module-level `task_routes = [TaskRoute(fn, ...)]` in its own `<app>/tasks.py`,
+  and `gyrinx/tasks/discovery.py` collects those across installed apps. Same
+  outcome — config lives beside the function, the platform names no edition task
+  (#2093) — with a smaller blast radius than rewriting every `@task` decorator.
+  The decorator remains open as a later refinement: it is the only version that
+  makes omission *structurally* impossible, which is why (A) stays the tripwire.
+
+Note that this is **not** option D. Discovery collects per-app *declarations*,
+which still carry ack deadlines and schedules explicitly; it does not scan for
+`@task` functions and provision topics for whatever it finds.
+
+
 ## The incident
 
 The Phase 8 cost-pinning PR (#1946) shipped a new background task, `backfill_pins`

--- a/docs/how-to-guides/task-framework.md
+++ b/docs/how-to-guides/task-framework.md
@@ -25,25 +25,22 @@ def send_notification(user_id: str, message: str):
     # ... send notification logic
 ```
 
-1. **Register the task** in `gyrinx/tasks/registry.py`:
+1. **Declare a route for it** in the same file's `task_routes` list:
 
 ```python
-from n23.core.tasks import send_notification
+# n23/core/tasks.py
+from gyrinx.tasks import TaskRoute
 
-def _get_tasks() -> list[TaskRoute]:
-    global _tasks
-    if _tasks is None:
-        from n23.core.tasks import (
-            # ... existing imports
-            send_notification,
-        )
-
-        _tasks = [
-            # ... existing tasks
-            TaskRoute(send_notification),
-        ]
-    return _tasks
+task_routes = [
+    # ... existing routes
+    TaskRoute(send_notification),
+]
 ```
+
+The platform picks this up automatically — no platform file to edit. If the app
+has no `tasks.py` yet, create one and add the list; discovery finds any
+`<app>/tasks.py`. Forget this step and the `gyrinx.tasks.E001` system check
+fails on `manage check`, `runserver` and CI.
 
 1. **Enqueue the task** from your application code:
 
@@ -311,7 +308,7 @@ Set `TASKS_FAULT_SEED` to make the injected chaos reproducible, and `TASKS_WORKE
 
 ### Steps
 
-1. **Remove the task** from `gyrinx/tasks/registry.py`
+1. **Remove the task** from the `task_routes` list in its app's `tasks.py`
 
 2. **Deploy** - The orphan cleanup will automatically delete the Cloud Scheduler job
 

--- a/docs/technical-reference/task-framework.md
+++ b/docs/technical-reference/task-framework.md
@@ -4,13 +4,19 @@ This reference documents the complete configuration options, environment variabl
 
 ## TaskRoute Configuration
 
-Register tasks in `gyrinx/tasks/registry.py` using `TaskRoute`:
+Declare tasks in the `task_routes` list of the app's own `tasks.py`, using
+`TaskRoute`. The platform discovers these lists across all installed apps:
 
 ```python
-from gyrinx.tasks import TaskRoute
-from n23.core.tasks import my_task
+# n23/core/tasks.py
+from django.tasks import task
 
-tasks = [
+from gyrinx.tasks import TaskRoute
+
+@task
+def my_task(): ...
+
+task_routes = [
     TaskRoute(my_task),
 ]
 ```

--- a/gyrinx/api/tasks.py
+++ b/gyrinx/api/tasks.py
@@ -12,6 +12,8 @@ import requests
 from django.conf import settings
 from django.tasks import task
 
+from gyrinx.tasks import TaskRoute
+
 logger = logging.getLogger(__name__)
 
 
@@ -127,3 +129,9 @@ def _update_discord_message(application_id: str, interaction_token: str, content
         )
     except Exception as e:
         logger.error(f"Failed to update Discord message: {e}")
+
+
+# Declared for the platform to discover (see gyrinx/tasks/discovery.py).
+task_routes = [
+    TaskRoute(trigger_discord_issue_action),
+]

--- a/gyrinx/tasks/CLAUDE.md
+++ b/gyrinx/tasks/CLAUDE.md
@@ -28,8 +28,10 @@ Design notes for the local backend: `.claude/notes/local-async-tasks-research.md
 - [`models.py`](models.py) — `TaskExecution` (observability + state machine) and
   `QueuedTask` (the durable queue row).
 - [`signals.py`](signals.py) — lifecycle handlers that maintain `TaskExecution`.
-- [`registry.py`](registry.py) / [`route.py`](route.py) — task registration and
-  per-task config.
+- [`registry.py`](registry.py) / [`route.py`](route.py) /
+  [`discovery.py`](discovery.py) — task registration and per-task config. Apps
+  declare their own routes in a `task_routes` list in their `<app>/tasks.py`;
+  the registry collects them, so the platform names no edition task (#2093).
 - [`provisioning.py`](provisioning.py) / [`apps.py`](apps.py) — Pub/Sub + Scheduler
   provisioning (Cloud Run only; skipped locally, in migrations, and in tests).
 

--- a/gyrinx/tasks/__init__.py
+++ b/gyrinx/tasks/__init__.py
@@ -5,24 +5,25 @@ This module provides background task processing using Django 6.0's native
 task framework with Google Cloud Pub/Sub as the production backend.
 
 Usage:
-    1. Define tasks using Django's @task decorator in your app
-    2. Register them explicitly in gyrinx/tasks/registry.py
+    1. Define tasks using Django's @task decorator in your app's tasks.py
+    2. Declare a TaskRoute for each in that module's `task_routes` list
     3. Enqueue with task.enqueue(...)
 
+The platform discovers `task_routes` from every installed app, so registering a
+task never means editing platform code (see gyrinx/tasks/discovery.py).
+
 Example:
-    # In n23/core/tasks.py
+    # In n23/core/tasks.py — declaration and route in one file
     from django.tasks import task
+
+    from gyrinx.tasks import TaskRoute
 
     @task
     def send_welcome_email(user_id: int):
         user = User.objects.get(id=user_id)
         send_mail(...)
 
-    # In gyrinx/tasks/registry.py
-    from gyrinx.tasks import TaskRoute
-    from n23.core.tasks import send_welcome_email
-
-    tasks = [
+    task_routes = [
         TaskRoute(send_welcome_email),
     ]
 

--- a/gyrinx/tasks/backend.py
+++ b/gyrinx/tasks/backend.py
@@ -91,7 +91,7 @@ class PubSubBackend(BaseTaskBackend):
             TaskResult with the task ID (status is READY, though publish may still be in flight)
 
         Raises:
-            ValueError: If task is not registered in registry.py
+            ValueError: If the task isn't declared in its app's task_routes
         """
         task_id = str(uuid.uuid4())
         task_name = task.func.__name__
@@ -100,7 +100,9 @@ class PubSubBackend(BaseTaskBackend):
         route = get_task(task_name)
         if not route:
             raise ValueError(
-                f"Task '{task_name}' not registered. Add it to gyrinx/tasks/registry.py"
+                f"Task '{task_name}' not registered. Add "
+                f"TaskRoute({task_name}) to the task_routes list in the "
+                f"tasks.py module that declares it."
             )
 
         topic_path = self.publisher.topic_path(self.project_id, route.topic_name)

--- a/gyrinx/tasks/checks.py
+++ b/gyrinx/tasks/checks.py
@@ -1,43 +1,31 @@
 """System check: every ``@task`` in a known module must be registered (#1947).
 
-Declaring a background task is a two-step ritual split across two files with
-nothing coupling them: ``@task`` in the task module, plus a ``TaskRoute`` entry
-in ``gyrinx/tasks/registry.py``. Only the **production** Pub/Sub backend enforces
-the second step (enqueue lookup + topic provisioning) — dev's ImmediateBackend
-never consults the registry and tests call ``.func`` directly. Miss step two and
-everything is green locally while the task is dead on arrival in prod.
+Declaring a background task takes two steps in the same file: ``@task`` on the
+function, plus a ``TaskRoute`` entry in that module's ``task_routes`` list.
+Only the **production** Pub/Sub backend enforces the second step (enqueue lookup
++ topic provisioning) — dev's ImmediateBackend never consults the registry and
+tests call ``.func`` directly. Miss step two and everything is green locally
+while the task is dead on arrival in prod.
 
 This check turns that omission into a red error at check time — ``runserver``,
 ``migrate``, ``check --deploy``, CI — seconds after the mistake is made, in the
-author's own terminal. It also flags registry entries that aren't actually
+author's own terminal. It also flags entries that aren't actually
 ``@task``-decorated functions.
 """
 
 import importlib
-import importlib.util
 
-from django.apps import apps as django_apps
 from django.core.checks import Error, register
 from django.tasks import Task
 
+from gyrinx.tasks.discovery import ROUTES_ATTR, first_party_task_modules
 from gyrinx.tasks.registry import get_all_tasks
 
 # Escape hatch for a task module NOT named ``<app>.tasks`` (an unconventional
-# location auto-discovery in ``_task_module_paths`` wouldn't find). Empty by
-# default: every first-party ``<app>/tasks.py`` is auto-discovered, as is any
-# module that already owns a registered task, so listing those here would only
-# duplicate the scan.
+# location discovery wouldn't find). Empty by default: every first-party
+# ``<app>/tasks.py`` is discovered, as is any module that already owns a
+# registered task, so listing those here would only duplicate the scan.
 TASK_MODULES = ()
-
-# Import prefixes we consider first-party. Auto-discovery is restricted to these
-# so a third-party app's task module can't spuriously demand entries in *our*
-# registry. ``n23.``/``n26.`` are the per-edition namespaces (#2093): the current
-# edition moved out of ``gyrinx.core``/``gyrinx.content`` to ``n23.*``, and n26
-# will land alongside it. ``gyrinx.`` stays because the platform packages
-# (tasks, api, pages, analytics, maintenance) still live there. Losing any of
-# these silently narrows the scan rather than erroring — a brand-new edition
-# app's first task would go unregistered, which only surfaces in production.
-FIRST_PARTY_PREFIXES = ("gyrinx.", "n23.", "n26.")
 
 
 def _task_module_paths(routes):
@@ -47,23 +35,18 @@ def _task_module_paths(routes):
     - every module that already owns a registered task (so a second task added
       beside a registered one is caught);
     - each first-party app's conventional ``<app>.tasks`` module, when it exists
-      — this closes the "brand-new app's first task, never registered" gap
-      without waiting for declaration-owned registration (#1947 rec 2). See
-      ``FIRST_PARTY_PREFIXES`` for what counts as first-party.
+      — this closes the "brand-new app's first task, never registered" gap.
+
+    That third source is ``discovery.first_party_task_modules()``, the very list
+    the registry collects routes from. Sharing it is the point: scanning a
+    different set than discovery reads would leave the difference unpoliced.
+    Deduplicated in first-seen order rather than through a set, so the errors
+    this check emits come out in a stable order.
     """
-    paths = set(TASK_MODULES)
-    paths |= {route.path.rsplit(".", 1)[0] for route in routes}
-    for app_config in django_apps.get_app_configs():
-        if not app_config.name.startswith(FIRST_PARTY_PREFIXES):
-            continue
-        candidate = f"{app_config.name}.tasks"
-        try:
-            spec = importlib.util.find_spec(candidate)
-        except (ImportError, AttributeError, ValueError):
-            spec = None  # parent not importable / not a package — nothing to scan
-        if spec is not None:
-            paths.add(candidate)
-    return paths
+    paths = list(TASK_MODULES)
+    paths += [route.path.rsplit(".", 1)[0] for route in routes]
+    paths += first_party_task_modules()
+    return list(dict.fromkeys(paths))
 
 
 def _declared_tasks(module_paths):
@@ -105,26 +88,27 @@ def check_tasks_registered(app_configs, **kwargs):
                     f"Background task '{name}' ({mod_path}) is declared with @task "
                     f"but not registered.",
                     hint=(
-                        f"In gyrinx/tasks/registry.py, import it "
-                        f"(`from {mod_path} import {name}`) and add "
-                        f"`TaskRoute({name})` to the list. Unregistered tasks pass "
-                        f"locally (dev's ImmediateBackend and .func test calls skip "
-                        f"the registry) but fail on enqueue in production."
+                        f"Add `TaskRoute({name})` to the `{ROUTES_ATTR}` list in "
+                        f"{mod_path.replace('.', '/')}.py (create the list if the "
+                        f"module hasn't got one). Unregistered tasks pass locally "
+                        f"(dev's ImmediateBackend and .func test calls skip the "
+                        f"registry) but fail on enqueue in production."
                     ),
                     id="gyrinx.tasks.E001",
                 )
             )
 
     # Reverse: a registry entry must wrap a real @task. A deleted function fails
-    # at import of registry.py already; this catches registering a plain function.
+    # at import of the declaring module already; this catches registering a
+    # plain function.
     for route in routes:
         if not isinstance(route.func, Task):
             errors.append(
                 Error(
                     f"Registry entry '{route.name}' is not a @task-decorated function.",
                     hint=(
-                        "Every TaskRoute in gyrinx/tasks/registry.py must wrap a "
-                        "function decorated with django.tasks @task."
+                        f"Every TaskRoute in a `{ROUTES_ATTR}` list must wrap a "
+                        f"function decorated with django.tasks @task."
                     ),
                     id="gyrinx.tasks.E002",
                 )

--- a/gyrinx/tasks/discovery.py
+++ b/gyrinx/tasks/discovery.py
@@ -1,0 +1,125 @@
+"""Autodiscovery of per-app task routes.
+
+Modelled on ``django.contrib.admin.autodiscover()``: the platform walks the
+installed apps, imports each one's conventional module, and lets the app itself
+say what it wants registered. Here the module is ``<app>/tasks.py`` — where the
+task functions already live — and the declaration is a module-level
+``task_routes`` list, the same shape as a URLconf's ``urlpatterns``:
+
+    from django.tasks import task
+    from gyrinx.tasks import TaskRoute
+
+    @task
+    def send_welcome_email(user_id: int): ...
+
+    task_routes = [
+        TaskRoute(send_welcome_email),
+    ]
+
+**Declarations are discovered, not tasks.** We deliberately do not scan for
+``@task``-decorated functions and register everything we find. A route carries
+per-task configuration (ack deadline, retry backoff, cron schedule) and is the
+surface that provisions a Pub/Sub topic — infrastructure with a cost and an IAM
+footprint. Creating one as an implicit side effect of "somebody imported a
+module" is the wrong trade; the app states its intent explicitly, and the
+platform only collects it. (``.claude/notes/task-registry-footgun.md``, option
+D.) ``gyrinx.tasks.checks`` polices the gap this leaves — a ``@task`` declared
+and then left out of ``task_routes``.
+
+Why this exists: ``gyrinx/tasks/registry.py`` used to import eight tasks from
+``n23.core.tasks`` by name, so the platform depended on the edition it is meant
+to be independent of (#2093). Inverting it means a new edition — or any new app
+— registers its own tasks without the platform being edited at all.
+"""
+
+import importlib
+import importlib.util
+
+from django.apps import apps as django_apps
+from django.core.exceptions import ImproperlyConfigured
+
+from gyrinx.tasks.route import TaskRoute
+
+# The conventional per-app module that declares background tasks.
+TASK_MODULE_NAME = "tasks"
+
+# The module-level name that module uses to declare its routes.
+ROUTES_ATTR = "task_routes"
+
+# Import prefixes we consider first-party. Discovery is restricted to these so a
+# third-party app's ``tasks`` module is never imported on our behalf, and so
+# nothing outside the project can put a route into our registry. ``n23.``/``n26.``
+# are the per-edition namespaces (#2093): the current edition moved out of
+# ``gyrinx.core``/``gyrinx.content`` to ``n23.*``, and n26 will land alongside
+# it. ``gyrinx.`` stays because the platform packages (tasks, api, pages,
+# analytics, maintenance) still live there.
+#
+# This is also the single definition of "first-party" shared with
+# ``gyrinx.tasks.checks``. That matters: the check's job is "every declared
+# @task is registered", so if it scanned a different set of modules than
+# discovery collected from, the difference would be an unpoliced hole. Losing a
+# prefix here silently narrows both at once rather than erroring — a brand-new
+# edition app's first task would go unregistered, which only surfaces in
+# production.
+FIRST_PARTY_PREFIXES = ("gyrinx.", "n23.", "n26.")
+
+
+def first_party_task_modules() -> list[str]:
+    """Every first-party ``<app>.tasks`` module that actually exists.
+
+    Ordered by ``INSTALLED_APPS`` (which ``get_app_configs()`` preserves) and
+    returned as a list rather than a set: this ordering reaches topic
+    provisioning and the tests, and set iteration order would make both flaky.
+    """
+    modules = []
+    for app_config in django_apps.get_app_configs():
+        if not app_config.name.startswith(FIRST_PARTY_PREFIXES):
+            continue
+        candidate = f"{app_config.name}.{TASK_MODULE_NAME}"
+        try:
+            spec = importlib.util.find_spec(candidate)
+        except (ImportError, AttributeError, ValueError):
+            spec = None  # parent not importable / not a package — nothing there
+        if spec is not None:
+            modules.append(candidate)
+    return modules
+
+
+def discover_task_routes() -> list[TaskRoute]:
+    """Import every first-party task module and collect its declared routes.
+
+    Ordering is deterministic: apps in ``INSTALLED_APPS`` order, and within an
+    app the order the module lists them in.
+
+    Raises:
+        ImproperlyConfigured: if a ``task_routes`` entry isn't a ``TaskRoute``,
+            or if two apps declare the same task name.
+    """
+    routes: list[TaskRoute] = []
+    seen: dict[str, str] = {}  # task name -> the module that declared it
+
+    for mod_path in first_party_task_modules():
+        module = importlib.import_module(mod_path)
+        declared = getattr(module, ROUTES_ATTR, None)
+        if declared is None:
+            continue
+
+        for route in declared:
+            if not isinstance(route, TaskRoute):
+                raise ImproperlyConfigured(
+                    f"{mod_path}.{ROUTES_ATTR} contains {route!r}, which is not a "
+                    f"TaskRoute. Wrap the task: TaskRoute(my_task)."
+                )
+            # Names must be unique: enqueue and the push handler both resolve a
+            # task by bare function name, so a collision would silently route
+            # one app's task to the other app's topic.
+            if route.name in seen:
+                raise ImproperlyConfigured(
+                    f"Duplicate task name '{route.name}' declared in both "
+                    f"{seen[route.name]}.{ROUTES_ATTR} and {mod_path}.{ROUTES_ATTR}. "
+                    f"Task names must be unique across the project."
+                )
+            seen[route.name] = mod_path
+            routes.append(route)
+
+    return routes

--- a/gyrinx/tasks/registry.py
+++ b/gyrinx/tasks/registry.py
@@ -1,63 +1,54 @@
 """
-Task Registry - Explicit task registration.
+Task Registry - the collected view of every app's task routes.
 
-Add your tasks here, similar to Django's urlpatterns.
+Apps declare their own routes in their own ``<app>/tasks.py``, as a module-level
+``task_routes`` list:
 
-Usage:
+    from django.tasks import task
     from gyrinx.tasks import TaskRoute
-    from n23.core.tasks import send_welcome_email, generate_report
 
-    tasks = [
+    @task
+    def send_welcome_email(user_id: int): ...
+
+    task_routes = [
         TaskRoute(send_welcome_email),
         TaskRoute(generate_report, ack_deadline=600),
     ]
 
-Note: Task imports are done lazily in _get_tasks() to avoid circular imports
-during Django startup. The backend imports this module before Django's task
-framework is fully initialized.
+This module collects them (see ``gyrinx.tasks.discovery``) and offers the lookup
+helpers the backends and provisioning use. It names no tasks itself: the
+platform should not have to know what an edition calls its work (#2093).
 """
 
-from gyrinx.tasks import TaskRoute
+from gyrinx.tasks.discovery import discover_task_routes
+from gyrinx.tasks.route import TaskRoute
 
-# Cache for lazily-loaded tasks
+# Cache for the lazily-discovered routes.
 _tasks: list[TaskRoute] | None = None
 
 
 def _get_tasks() -> list[TaskRoute]:
     """
-    Lazily load and cache the task list.
+    Discover the routes on first use, then cache them.
 
-    This avoids circular imports that occur when importing task functions
-    at module level (n23.core.tasks uses @task decorator from django.tasks,
-    which triggers backend loading, which imports this registry).
+    Discovery must not run at this module's import time, for two independent
+    reasons:
+
+    1. **Circular import.** Importing an app's ``tasks`` module runs Django's
+       ``@task`` decorator, which loads the configured task backend, which does
+       ``from gyrinx.tasks.registry import get_task`` at module scope. Pulling
+       the app modules in from here at import time would re-enter this module
+       while it is still half-built.
+    2. **The app registry.** Discovery walks ``django.apps``, which is only
+       populated once Django has loaded every app — later than this module is
+       first imported.
+
+    Deferring to first call sidesteps both: by the time anything asks for a
+    route, the apps are loaded and the backend is fully imported.
     """
     global _tasks
     if _tasks is None:
-        from gyrinx.api.tasks import trigger_discord_issue_action
-        from n23.core.tasks import (
-            backfill_pins,
-            complete_campaign_list_clone,
-            reconcile_all_lists,
-            hello_world,
-            propagate_content_cost_change,
-            propagate_default_child_fighter_assignment,
-            refresh_list_facts,
-        )
-
-        _tasks = [
-            TaskRoute(hello_world),
-            TaskRoute(propagate_content_cost_change),
-            TaskRoute(propagate_default_child_fighter_assignment),
-            TaskRoute(refresh_list_facts),
-            TaskRoute(trigger_discord_issue_action),
-            # A 250-row batch through pin_assignment is many queries; give
-            # the worker room before Pub/Sub redelivers.
-            TaskRoute(backfill_pins, ack_deadline=600),
-            TaskRoute(reconcile_all_lists, ack_deadline=600),
-            # Cloning a full gang (fighters, equipment, stash, facts recompute) is
-            # many queries; give the worker room before Pub/Sub redelivers.
-            TaskRoute(complete_campaign_list_clone, ack_deadline=600),
-        ]
+        _tasks = discover_task_routes()
     return _tasks
 
 

--- a/gyrinx/tasks/tests/test_checks.py
+++ b/gyrinx/tasks/tests/test_checks.py
@@ -29,7 +29,7 @@ def test_current_registry_passes_the_check():
 
 def test_unregistered_declared_task_is_flagged(monkeypatch):
     """Drop one real task from the registry view and the check reports E001 for
-    it — the exact mistake #1947 is about (declared, forgotten in registry.py)."""
+    it — the exact mistake #1947 is about (declared, left out of task_routes)."""
     routes = [r for r in get_all_tasks() if r.name != "hello_world"]
     monkeypatch.setattr(checks, "get_all_tasks", lambda: routes)
 
@@ -38,7 +38,10 @@ def test_unregistered_declared_task_is_flagged(monkeypatch):
     e001 = [e for e in errors if e.id == "gyrinx.tasks.E001"]
     assert len(e001) == 1
     assert "hello_world" in e001[0].msg
-    assert "registry.py" in e001[0].hint
+    # The hint must point at the module that declares the task, not at the
+    # platform registry — that redirection is the whole point of #2093.
+    assert "task_routes" in e001[0].hint
+    assert "n23/core/tasks.py" in e001[0].hint
 
 
 def test_module_owning_a_registered_task_is_scanned(monkeypatch):
@@ -65,36 +68,9 @@ def test_app_discovery_reaches_conventional_task_modules(monkeypatch):
     assert "n23.core.tasks" in paths
 
 
-def test_app_discovery_covers_edition_namespaces(monkeypatch):
-    """The per-edition namespaces are first-party too. The n23 rename (#2093)
-    moved ``gyrinx.core`` to ``n23.core``; if the prefix filter still only
-    accepted ``gyrinx.``, this scan would silently stop discovering the
-    edition's task module and the #1947 guard would weaken to nothing —
-    a gap that only shows up in production."""
-
-    class _StubAppConfig:
-        def __init__(self, name):
-            self.name = name
-
-    monkeypatch.setattr(checks, "TASK_MODULES", ())
-    monkeypatch.setattr(
-        checks.django_apps,
-        "get_app_configs",
-        lambda: [
-            _StubAppConfig("n23.core"),
-            _StubAppConfig("n26.content"),
-            _StubAppConfig("thirdparty.app"),
-        ],
-    )
-    # Pretend every candidate resolves, so this exercises the prefix filter
-    # rather than module resolution.
-    monkeypatch.setattr(checks.importlib.util, "find_spec", lambda name: object())
-
-    paths = checks._task_module_paths([])
-
-    assert "n23.core.tasks" in paths
-    assert "n26.content.tasks" in paths
-    assert "thirdparty.app.tasks" not in paths
+# The prefix filter itself now lives in gyrinx.tasks.discovery and is covered
+# by test_discovery.py — the check consumes that same list rather than
+# repeating the scan.
 
 
 def test_registry_entry_that_isnt_a_task_is_flagged(monkeypatch):

--- a/gyrinx/tasks/tests/test_discovery.py
+++ b/gyrinx/tasks/tests/test_discovery.py
@@ -1,0 +1,149 @@
+"""Autodiscovery of per-app ``task_routes`` (#2093).
+
+The platform no longer names the edition's tasks; it collects what each app
+declares. These pin the properties that makes that safe: the right modules are
+scanned, ordering is stable, per-task config survives, and the two ways this can
+be got wrong are loud rather than silent.
+"""
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.tasks import task
+
+from gyrinx.tasks import discovery
+from gyrinx.tasks.registry import get_all_tasks
+from gyrinx.tasks.route import TaskRoute
+
+
+class _StubAppConfig:
+    def __init__(self, name):
+        self.name = name
+
+
+@task
+def _discovery_sample_task():
+    pass
+
+
+def test_first_party_task_modules_covers_edition_namespaces(monkeypatch):
+    """The per-edition namespaces are first-party too. The n23 rename (#2093)
+    moved ``gyrinx.core`` to ``n23.core``; if the prefix filter still only
+    accepted ``gyrinx.``, discovery would silently stop collecting the edition's
+    routes and every one of its tasks would be unroutable in production."""
+    monkeypatch.setattr(
+        discovery.django_apps,
+        "get_app_configs",
+        lambda: [
+            _StubAppConfig("n23.core"),
+            _StubAppConfig("n26.content"),
+            _StubAppConfig("thirdparty.app"),
+        ],
+    )
+    # Pretend every candidate resolves, so this exercises the prefix filter
+    # rather than module resolution.
+    monkeypatch.setattr(discovery.importlib.util, "find_spec", lambda name: object())
+
+    modules = discovery.first_party_task_modules()
+
+    assert "n23.core.tasks" in modules
+    assert "n26.content.tasks" in modules
+    assert "thirdparty.app.tasks" not in modules
+
+
+def test_first_party_task_modules_skips_apps_without_one():
+    """Only modules that actually exist are returned — most apps have no tasks.py."""
+    modules = discovery.first_party_task_modules()
+
+    assert "n23.core.tasks" in modules
+    assert "gyrinx.api.tasks" in modules
+    assert "n23.content.tasks" not in modules
+
+
+def test_first_party_task_modules_is_ordered_and_stable():
+    """Ordering reaches topic provisioning, so it must not come from a set."""
+    first = discovery.first_party_task_modules()
+
+    assert isinstance(first, list)
+    assert first == discovery.first_party_task_modules()
+
+
+def test_discovery_finds_the_real_declarations():
+    """Every app's declared routes end up in the registry, from both the edition
+    and the platform's own api app."""
+    names = {route.name for route in get_all_tasks()}
+
+    assert "hello_world" in names  # n23.core.tasks
+    assert "trigger_discord_issue_action" in names  # gyrinx.api.tasks
+
+
+def test_discovery_preserves_per_task_config():
+    """ack_deadline=600 is load-bearing for the long-running maintenance tasks;
+    autodiscovery must carry each route's own config, not flatten to defaults."""
+    routes = {route.name: route for route in get_all_tasks()}
+
+    assert routes["backfill_pins"].ack_deadline == 600
+    assert routes["reconcile_all_lists"].ack_deadline == 600
+    assert routes["complete_campaign_list_clone"].ack_deadline == 600
+    assert routes["hello_world"].ack_deadline == 300
+
+
+def test_discovery_is_deterministically_ordered():
+    """Topic provisioning iterates this list; set-ordered discovery would make
+    provisioning and these tests flaky."""
+    assert [r.path for r in discovery.discover_task_routes()] == [
+        r.path for r in discovery.discover_task_routes()
+    ]
+
+
+def test_topic_names_derive_from_the_declaring_module():
+    """A task's Pub/Sub topic is its module path. Discovery moved the *route*
+    declarations, never the functions — so the topics are unchanged. Renaming a
+    topic orphans the old one and needs a redeploy to recreate it."""
+    routes = {route.name: route for route in get_all_tasks()}
+
+    assert routes["hello_world"].path == "n23.core.tasks.hello_world"
+    assert (
+        routes["trigger_discord_issue_action"].path
+        == "gyrinx.api.tasks.trigger_discord_issue_action"
+    )
+    assert routes["hello_world"].topic_name.endswith(
+        "gyrinx.tasks--n23.core.tasks.hello_world"
+    )
+
+
+def test_non_taskroute_entry_is_rejected(monkeypatch):
+    """A bare function in task_routes fails loudly at discovery rather than
+    blowing up later inside the backend."""
+    module = type("_M", (), {discovery.ROUTES_ATTR: [_discovery_sample_task]})
+
+    monkeypatch.setattr(discovery, "first_party_task_modules", lambda: ["fake.tasks"])
+    monkeypatch.setattr(discovery.importlib, "import_module", lambda path: module)
+
+    with pytest.raises(ImproperlyConfigured, match="not a\\s+TaskRoute"):
+        discovery.discover_task_routes()
+
+
+def test_duplicate_task_name_across_apps_is_rejected(monkeypatch):
+    """Two apps declaring the same task name would silently route one app's task
+    to the other's topic — enqueue resolves by bare function name."""
+    module = type(
+        "_M", (), {discovery.ROUTES_ATTR: [TaskRoute(_discovery_sample_task)]}
+    )
+
+    monkeypatch.setattr(
+        discovery, "first_party_task_modules", lambda: ["a.tasks", "b.tasks"]
+    )
+    monkeypatch.setattr(discovery.importlib, "import_module", lambda path: module)
+
+    with pytest.raises(ImproperlyConfigured, match="Duplicate task name"):
+        discovery.discover_task_routes()
+
+
+def test_module_without_declarations_is_skipped(monkeypatch):
+    """A tasks.py with no task_routes contributes nothing — no crash."""
+    module = type("_M", (), {})
+
+    monkeypatch.setattr(discovery, "first_party_task_modules", lambda: ["fake.tasks"])
+    monkeypatch.setattr(discovery.importlib, "import_module", lambda path: module)
+
+    assert discovery.discover_task_routes() == []

--- a/n23/__init__.py
+++ b/n23/__init__.py
@@ -8,8 +8,9 @@ table, migration record or content type.
 
 Editions never import each other. They do depend on the platform (``gyrinx.*``)
 — but note the reverse is also still true in a handful of places: ``gyrinx.urls``
-mounts ``n23.core.urls``, ``gyrinx.tasks.registry`` imports the edition's tasks,
-and ``gyrinx.forms``/``api``/``maintenance``/``analytics`` reach into edition
-models. Those are the concrete blockers to standing up a second edition, and are
-tracked on #2093 rather than fixed here.
+mounts ``n23.core.urls``, and ``gyrinx.forms``/``api``/``maintenance``/``analytics``
+reach into edition models. Those are the concrete blockers to standing up a
+second edition, and are tracked on #2093 rather than fixed here. Background
+tasks are no longer among them: this package declares its own routes in
+``n23/core/tasks.py`` and the platform discovers them.
 """

--- a/n23/core/tasks.py
+++ b/n23/core/tasks.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 
 from django.tasks import task
 
+from gyrinx.tasks import TaskRoute
+
 logger = logging.getLogger(__name__)
 
 
@@ -756,3 +758,27 @@ def backfill_pins(
         from n23.core.models import Backfill
 
         _update_backfill(backfill_id, progress, status=Backfill.Status.DONE)
+
+
+# =============================================================================
+# Task routes
+#
+# This edition's background tasks, declared for the platform to discover (see
+# gyrinx/tasks/discovery.py). A @task that isn't listed here can't be enqueued
+# in production; the gyrinx.tasks.E001 system check fails the build if one is
+# missed.
+# =============================================================================
+
+task_routes = [
+    TaskRoute(hello_world),
+    TaskRoute(propagate_content_cost_change),
+    TaskRoute(propagate_default_child_fighter_assignment),
+    TaskRoute(refresh_list_facts),
+    # A 250-row batch through pin_assignment is many queries; give
+    # the worker room before Pub/Sub redelivers.
+    TaskRoute(backfill_pins, ack_deadline=600),
+    TaskRoute(reconcile_all_lists, ack_deadline=600),
+    # Cloning a full gang (fighters, equipment, stash, facts recompute) is
+    # many queries; give the worker room before Pub/Sub redelivers.
+    TaskRoute(complete_campaign_list_clone, ack_deadline=600),
+]


### PR DESCRIPTION
## What this changes

`gyrinx/tasks/registry.py` is platform code, but its `_get_tasks()` imported
eight task functions from `n23.core.tasks` by name. The platform therefore had
to know what the edition calls its work — one of the concrete blockers to
standing up a second edition (#2093).

This inverts it. Each app declares its own routes in a module-level
`task_routes` list in its own `<app>/tasks.py`:

```python
# n23/core/tasks.py
@task
def backfill_pins(...): ...

task_routes = [
    TaskRoute(backfill_pins, ack_deadline=600),
]
```

A new `gyrinx/tasks/discovery.py` walks the installed apps and collects those
lists, modelled on `django.contrib.admin.autodiscover()`. This is the first
autodiscovery in the codebase, so it also sets the pattern. Registering a task
in a new app now needs no platform edit at all.

## Topic names are unchanged

**This is the important one, and it is verified rather than asserted.**
`TaskRoute.path` is derived from `func.__module__`, so a task's Pub/Sub topic
follows the module its function lives in. **No task function moved module** —
only the route declarations did.

Every route's `path`, `topic_name`, `ack_deadline`, retry delays and schedule
were dumped before and after the change and compared. The two are byte-identical:

```
$ diff before.canon after.canon
$ echo $?
0
```

All eight, unchanged:

| task | topic |
|---|---|
| `trigger_discord_issue_action` | `{env}--gyrinx.tasks--gyrinx.api.tasks.trigger_discord_issue_action` |
| `backfill_pins` | `{env}--gyrinx.tasks--n23.core.tasks.backfill_pins` |
| `complete_campaign_list_clone` | `{env}--gyrinx.tasks--n23.core.tasks.complete_campaign_list_clone` |
| `hello_world` | `{env}--gyrinx.tasks--n23.core.tasks.hello_world` |
| `propagate_content_cost_change` | `{env}--gyrinx.tasks--n23.core.tasks.propagate_content_cost_change` |
| `propagate_default_child_fighter_assignment` | `{env}--gyrinx.tasks--n23.core.tasks.propagate_default_child_fighter_assignment` |
| `reconcile_all_lists` | `{env}--gyrinx.tasks--n23.core.tasks.reconcile_all_lists` |
| `refresh_list_facts` | `{env}--gyrinx.tasks--n23.core.tasks.refresh_list_facts` |

No topic is renamed, so nothing is orphaned and provisioning has nothing new to
create on deploy. `test_topic_names_derive_from_the_declaring_module` pins this
going forward.

## Design notes

- **Declarations are discovered, not tasks.** We deliberately don't scan for
  `@task` functions and register whatever turns up. A route carries per-task
  config and provisions a Pub/Sub topic — infrastructure with a cost and an IAM
  footprint — so it stays an explicit statement of intent. That's the option-D
  rejection recorded in `.claude/notes/task-registry-footgun.md`; this change is
  that note's option B, landed as a declarative list rather than the
  `@gyrinx_task` decorator it sketched. The decorator is still open as a later
  refinement (it's the only version that makes omission *structurally*
  impossible), which is why the #1947 system check stays the tripwire.
- **Per-task config survives.** The three `ack_deadline=600` routes keep their
  deadline and their explanatory comments, now sitting beside the functions they
  describe. Asserted by `test_discovery_preserves_per_task_config`.
- **Discovery stays lazy**, for two independent reasons now written on
  `_get_tasks()`: (1) importing an app's tasks module runs Django's `@task`,
  which loads the configured backend, which does
  `from gyrinx.tasks.registry import get_task` at module scope — doing discovery
  at registry-import time would re-enter the module half-built; (2) discovery
  walks `django.apps`, which isn't populated until every app has loaded, later
  than the registry is first imported. Deferring to first call sidesteps both.
- **Ordering is deterministic**: INSTALLED_APPS order, then declaration order,
  with no set iteration anywhere (`first_party_task_modules()` returns a list,
  and `checks._task_module_paths` now dedupes in first-seen order instead of
  building a set). Confirmed stable across three runs. The only change is that
  `trigger_discord_issue_action` now groups with its own app instead of sitting
  mid-list; topic provisioning is order-insensitive.
- **`FIRST_PARTY_PREFIXES` is still needed**, but now has a single home in
  `discovery.py`, shared with `checks.py`. It's what stops a third-party app's
  `tasks.py` being imported on our behalf. Sharing it matters: the check's job is
  "every declared `@task` is registered", so if it scanned a different module set
  than discovery collected from, the difference would be an unpoliced hole.
  `checks.py` no longer repeats the app scan.
- **Error messages now point at the right file.** The `gyrinx.tasks.E001` hint
  and `PubSubBackend.enqueue`'s "not registered" error used to send authors to
  `gyrinx/tasks/registry.py`; they now name the app's own `task_routes`.

## Testing

- Full suite: **4160 passed, 13 skipped**. Net +9 tests: 10 new in
  `test_discovery.py`, and `test_app_discovery_covers_edition_namespaces` moved
  out of `test_checks.py` into it (the prefix filter it exercises now lives in
  `discovery.py`). That implies a pre-change baseline of 4151 on this tree — one
  more than the 4150 I was given; `HEAD` is exactly `origin/main` (9b1d67c5) and
  nothing failed, so the difference is in the baseline figure, not a regression.
- The chaos/redelivery coverage still exercises real routes through the registry:
  `test_task_chaos_concurrency.py` and `test_maintenance_pin_ops.py` — 26 passed.
  They import the real `n23.core.tasks` functions and resolve them via
  `get_task()` in manual-queue mode, so they'd fail if discovery missed a route.
- `manage check` — clean, 0 issues (this is what runs the #1947 check).
- `./scripts/dev.sh` starts and serves `HTTP 200`; provisioning correctly skipped
  outside Cloud Run.
- `./scripts/fmt.sh` clean; `ruff check` clean; all pre-commit hooks pass.

## Docs

Updated the how-to, technical reference, `gyrinx/tasks/CLAUDE.md`, the package
docstring and `n23/__init__.py` (background tasks are no longer on its list of
reverse-dependency blockers). The design note records what actually shipped.
