### PR TITLE
refactor: let the edition register its analytics and broadcast contributions

### DIFF
--- a/gyrinx/analytics/admin.py
+++ b/gyrinx/analytics/admin.py
@@ -11,9 +11,8 @@ from django.shortcuts import render
 from django.urls import path
 from django.utils import timezone
 
-from n23.core.models import Campaign, List, ListFighter
-
 from gyrinx.analytics.models import Event
+from gyrinx.analytics.registry import growth_series
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
@@ -189,84 +188,38 @@ class AnalyticsAdminSite(admin.site.__class__):
         }
 
     def get_cumulative_creation_data(self, start_date):
-        """Get cumulative creation data for fighters, lists, and campaigns"""
-        # Get daily counts for fighters in list-building lists
-        daily_fighters = (
-            ListFighter.objects.filter(
-                created__gte=start_date, list__status=List.LIST_BUILDING
-            )
-            .annotate(date=TruncDate("created"))
-            .values("date")
-            .annotate(count=Count("id"))
-            .order_by("date")
-        )
+        """Cumulative creation counts, one line per registered growth series.
 
-        # Get daily counts for list-building lists
-        daily_lists = (
-            List.objects.filter(created__gte=start_date, status=List.LIST_BUILDING)
-            .annotate(date=TruncDate("created"))
-            .values("date")
-            .annotate(count=Count("id"))
-            .order_by("date")
-        )
+        What gets counted is the edition's business — the platform only knows
+        how to accumulate. See ``gyrinx.analytics.registry``; with nothing
+        registered the chart renders empty rather than failing.
+        """
+        series = growth_series()
+        counts_by_series = [s.daily_counts(start_date) for s in series]
 
-        # Get daily counts for campaigns
-        daily_campaigns = (
-            Campaign.objects.filter(created__gte=start_date)
-            .annotate(date=TruncDate("created"))
-            .values("date")
-            .annotate(count=Count("id"))
-            .order_by("date")
-        )
-
-        # Create dictionaries for quick lookup
-        fighter_counts = {entry["date"]: entry["count"] for entry in daily_fighters}
-        list_counts = {entry["date"]: entry["count"] for entry in daily_lists}
-        campaign_counts = {entry["date"]: entry["count"] for entry in daily_campaigns}
+        datasets = [
+            {
+                "label": s.label,
+                "data": [],
+                "borderColor": s.border_color,
+                "backgroundColor": s.background_color,
+                "tension": 0.1,
+            }
+            for s in series
+        ]
 
         # Generate all dates in the range
         current_date = start_date.date()
         end_date = timezone.now().date()
 
         labels = []
-        datasets = [
-            {
-                "label": "Fighters (Cumulative)",
-                "data": [],
-                "borderColor": "rgb(75, 192, 192)",
-                "backgroundColor": "rgba(75, 192, 192, 0.2)",
-                "tension": 0.1,
-            },
-            {
-                "label": "Lists (Cumulative)",
-                "data": [],
-                "borderColor": "rgb(54, 162, 235)",
-                "backgroundColor": "rgba(54, 162, 235, 0.2)",
-                "tension": 0.1,
-            },
-            {
-                "label": "Campaigns (Cumulative)",
-                "data": [],
-                "borderColor": "rgb(255, 99, 132)",
-                "backgroundColor": "rgba(255, 99, 132, 0.2)",
-                "tension": 0.1,
-            },
-        ]
-
-        cumulative_fighters = 0
-        cumulative_lists = 0
-        cumulative_campaigns = 0
+        running_totals = [0] * len(series)
 
         while current_date <= end_date:
-            # Add daily counts to cumulative totals
-            cumulative_fighters += fighter_counts.get(current_date, 0)
-            cumulative_lists += list_counts.get(current_date, 0)
-            cumulative_campaigns += campaign_counts.get(current_date, 0)
-
             labels.append(current_date.strftime("%Y-%m-%d"))
-            datasets[0]["data"].append(cumulative_fighters)
-            datasets[1]["data"].append(cumulative_lists)
-            datasets[2]["data"].append(cumulative_campaigns)
+            for i, counts in enumerate(counts_by_series):
+                running_totals[i] += counts.get(current_date, 0)
+                datasets[i]["data"].append(running_totals[i])
 
             current_date += timedelta(days=1)
 

--- a/gyrinx/analytics/registry.py
+++ b/gyrinx/analytics/registry.py
@@ -1,0 +1,79 @@
+"""Extension point: the lines plotted on the dashboard's growth chart.
+
+The platform owns the analytics dashboard, but it has no idea what a gang or a
+fighter is — only an edition does. So the dashboard asks: each edition
+registers one :class:`GrowthSeries` per line it wants on the cumulative-growth
+chart, carrying a callable that answers "how many of these were created on each
+day since <date>?". The platform does the cumulating and the Chart.js shaping.
+
+Editions register from their admin package, which Django imports during
+``admin.autodiscover()`` — see ``n23/core/admin/analytics.py``. Registration is
+therefore complete long before any dashboard request is served.
+
+An empty registry is not an error: the chart simply has no lines.
+"""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+
+from django.db.models import Count, QuerySet
+from django.db.models.functions import TruncDate
+
+__all__ = [
+    "GrowthSeries",
+    "daily_counts_by_date",
+    "growth_series",
+    "register_growth_series",
+]
+
+
+@dataclass(frozen=True)
+class GrowthSeries:
+    """One line on the cumulative-growth chart.
+
+    ``daily_counts`` is called with the window's start datetime and returns a
+    mapping of day to "how many were created that day". Days with none may be
+    omitted — the platform accumulates the values and fills the gaps.
+    """
+
+    key: str
+    label: str
+    border_color: str
+    background_color: str
+    daily_counts: Callable[[datetime], Mapping[date, int]]
+
+
+_series: dict[str, GrowthSeries] = {}
+
+
+def register_growth_series(series: GrowthSeries) -> None:
+    """Add a line to the growth chart, replacing any earlier one with its key.
+
+    Re-registering a key keeps the original chart position, so a series can be
+    overridden without reshuffling the chart.
+    """
+    _series[series.key] = series
+
+
+def growth_series() -> tuple[GrowthSeries, ...]:
+    """Every registered series, in registration order."""
+    return tuple(_series.values())
+
+
+def daily_counts_by_date(
+    queryset: QuerySet, start_date: datetime, field: str = "created"
+) -> dict[date, int]:
+    """Count rows per calendar day since ``start_date`` — the usual series body.
+
+    Offered here so editions don't each re-derive the ``TruncDate``/``Count``
+    incantation, and so every series groups days the same way.
+    """
+    rows = (
+        queryset.filter(**{f"{field}__gte": start_date})
+        .annotate(_day=TruncDate(field))
+        .values("_day")
+        .annotate(_count=Count("id"))
+        .order_by("_day")
+    )
+    return {row["_day"]: row["_count"] for row in rows}

--- a/gyrinx/site/admin.py
+++ b/gyrinx/site/admin.py
@@ -1,9 +1,12 @@
 """Admin for notifications, including a broadcast (create-to-many) view.
 
 Banner and ImpersonationLog are still registered from ``n23.core.admin``; only
-the notification admin has been brought over so far. The "participants of a
-campaign" broadcast audience reaches into the edition for ``Campaign`` — the
-same edition-facing dependency ``gyrinx.analytics.admin`` already has.
+the notification admin has been brought over so far.
+
+Who a broadcast can be addressed to is not decided here: audiences come from
+``gyrinx.site.registry``, which the platform seeds with "all active users" and
+each edition extends with its own (see ``n23/core/admin/broadcast.py``). That
+is what keeps this module free of edition imports.
 """
 
 from django import forms
@@ -19,8 +22,8 @@ from gyrinx.site.models import (
     NotificationType,
     notify_many,
 )
+from gyrinx.site.registry import broadcast_audiences, get_broadcast_audience
 from gyrinx.widgets import TinyMCEWithUpload
-from n23.core.models.campaign import Campaign
 
 User = get_user_model()
 
@@ -35,26 +38,19 @@ class NotificationAdminForm(forms.ModelForm):
 
 
 class BroadcastForm(forms.Form):
-    AUDIENCE_ALL = "all_active"
-    AUDIENCE_WITH_LIST = "with_list"
-    AUDIENCE_CAMPAIGN = "campaign"
-    AUDIENCE_CHOICES = [
-        (AUDIENCE_ALL, "All active users"),
-        (AUDIENCE_WITH_LIST, "Users with a list"),
-        (AUDIENCE_CAMPAIGN, "Participants of a campaign"),
-    ]
+    """The broadcast composer. Its audience options come from the registry.
+
+    Audience choices and any fields those audiences need are built per instance
+    rather than declared on the class, because an edition may not have finished
+    registering when this module is first imported.
+    """
 
     subject = forms.CharField(max_length=255)
     content = forms.CharField(widget=TinyMCEWithUpload, required=False)
     notification_type = forms.ChoiceField(
         choices=NotificationType.choices, initial=NotificationType.GENERAL
     )
-    audience = forms.ChoiceField(choices=AUDIENCE_CHOICES)
-    campaign = forms.ModelChoiceField(
-        queryset=Campaign.objects.all(),
-        required=False,
-        help_text="Required when audience is 'Participants of a campaign'.",
-    )
+    audience = forms.ChoiceField(choices=())
     send_as_system = forms.BooleanField(
         required=False,
         initial=True,
@@ -62,27 +58,36 @@ class BroadcastForm(forms.Form):
         help_text="Show a Gyrinx badge instead of your username. Uncheck to attribute it to yourself.",
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        audiences = broadcast_audiences()
+        self.fields["audience"].choices = [(a.key, a.label) for a in audiences]
+        # Qualifier fields are optional at field level and enforced in clean()
+        # only for the audience that owns them — otherwise picking "all active
+        # users" would demand a campaign.
+        qualifiers = []
+        for audience in audiences:
+            if audience.field_name and audience.field:
+                field = audience.field()
+                field.required = False
+                self.fields[audience.field_name] = field
+                qualifiers.append(audience.field_name)
+        # Keep each qualifier next to the dropdown that governs it, rather than
+        # trailing after the send-as-system checkbox.
+        self.order_fields(
+            ["subject", "content", "notification_type", "audience", *qualifiers]
+        )
+
     def clean(self):
         cleaned = super().clean()
-        if cleaned.get("audience") == self.AUDIENCE_CAMPAIGN and not cleaned.get(
-            "campaign"
-        ):
-            self.add_error("campaign", "Choose a campaign for this audience.")
+        audience = get_broadcast_audience(cleaned.get("audience"))
+        if audience and audience.field_name and not cleaned.get(audience.field_name):
+            self.add_error(audience.field_name, audience.field_required_error)
         return cleaned
 
     def get_recipients(self):
-        audience = self.cleaned_data["audience"]
-        if audience == self.AUDIENCE_ALL:
-            return User.objects.filter(is_active=True)
-        if audience == self.AUDIENCE_WITH_LIST:
-            return User.objects.filter(list__isnull=False).distinct()
-        # Campaign participants: list owners in the campaign + the arbitrator.
-        campaign = self.cleaned_data["campaign"]
-        ids = set(campaign.lists.values_list("owner_id", flat=True))
-        if campaign.owner_id:
-            ids.add(campaign.owner_id)
-        ids.discard(None)
-        return User.objects.filter(pk__in=ids)
+        audience = get_broadcast_audience(self.cleaned_data["audience"])
+        return audience.recipients(self.cleaned_data)
 
 
 @admin.register(Notification)

--- a/gyrinx/site/registry.py
+++ b/gyrinx/site/registry.py
@@ -1,0 +1,80 @@
+"""Extension point: who a notification broadcast can be addressed to.
+
+The broadcast page is platform furniture, but most useful audiences are
+edition-shaped ("everyone in this campaign"). Rather than have the platform
+import edition models to offer them, each audience is registered here: a label
+for the dropdown, an optional extra form field to qualify it, and a callable
+that turns the submitted form data into a queryset of users.
+
+The platform contributes "All active users" at the bottom of this module, so it
+is always first in the dropdown no matter when editions register theirs — they
+have to import this module to register, which runs that line first. Editions
+register from their admin package (see ``n23/core/admin/broadcast.py``).
+"""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from django import forms
+from django.contrib.auth import get_user_model
+from django.db.models import QuerySet
+
+__all__ = [
+    "BroadcastAudience",
+    "broadcast_audiences",
+    "get_broadcast_audience",
+    "register_broadcast_audience",
+]
+
+User = get_user_model()
+
+
+@dataclass(frozen=True)
+class BroadcastAudience:
+    """One option in the broadcast form's "audience" dropdown.
+
+    ``recipients`` receives the form's ``cleaned_data`` and returns the users to
+    notify. An audience that needs qualifying — which campaign? — declares
+    ``field_name`` plus a ``field`` factory; the form adds that field, and
+    requires it only when this audience is the one selected.
+    """
+
+    key: str
+    label: str
+    recipients: Callable[[Mapping], QuerySet]
+    field_name: str | None = None
+    #: Called per form instance — form fields are stateful, so never share one.
+    field: Callable[[], forms.Field] | None = None
+    field_required_error: str = "This is required for the selected audience."
+
+
+_audiences: dict[str, BroadcastAudience] = {}
+
+
+def register_broadcast_audience(audience: BroadcastAudience) -> None:
+    """Offer ``audience`` on the broadcast page, replacing any with its key."""
+    _audiences[audience.key] = audience
+
+
+def broadcast_audiences() -> tuple[BroadcastAudience, ...]:
+    """Every registered audience, in registration order (= dropdown order)."""
+    return tuple(_audiences.values())
+
+
+def get_broadcast_audience(key: str) -> BroadcastAudience | None:
+    return _audiences.get(key)
+
+
+def _all_active_users(cleaned_data):
+    return User.objects.filter(is_active=True)
+
+
+# The platform's own audience. Registered at import time so it leads the
+# dropdown regardless of the order editions are autodiscovered in.
+register_broadcast_audience(
+    BroadcastAudience(
+        key="all_active",
+        label="All active users",
+        recipients=_all_active_users,
+    )
+)

--- a/gyrinx/tests/test_admin_registration.py
+++ b/gyrinx/tests/test_admin_registration.py
@@ -1,9 +1,15 @@
-"""Guard: models that moved to platform apps must still reach the admin.
+"""Guard: things the admin only has because a module got imported.
 
 Admin registration happens as a side effect of importing the module holding the
 ``@admin.register`` call. Moving a model between apps can quietly orphan that
 import — the model keeps working everywhere except the admin, and no other test
 notices. That happened to Event during the platform split (#2093).
+
+The platform registries have the same shape of failure. The edition pushes
+growth-chart lines and broadcast audiences into ``gyrinx.analytics.registry``
+and ``gyrinx.site.registry`` from side-effect-only modules under
+``n23/core/admin/``. Nothing raises if those imports go missing; the chart just
+loses its lines and the dropdown its options. So assert they arrived.
 """
 
 import pytest
@@ -11,7 +17,9 @@ from django.contrib import admin
 
 from gyrinx.accounts.models import UserProfile
 from gyrinx.analytics.models import Event
+from gyrinx.analytics.registry import growth_series
 from gyrinx.site.models import Banner, ImpersonationLog, Notification
+from gyrinx.site.registry import broadcast_audiences
 
 
 @pytest.mark.parametrize(
@@ -22,4 +30,22 @@ def test_moved_model_is_still_registered_in_admin(model):
         f"{model.__name__} has no ModelAdmin. The module holding its "
         f"@admin.register is probably no longer imported — check the admin "
         f"package __init__ for the app that owns it."
+    )
+
+
+@pytest.mark.parametrize("key", ["n23_fighters", "n23_lists", "n23_campaigns"])
+def test_edition_growth_series_reaches_the_dashboard(key):
+    assert key in {s.key for s in growth_series()}, (
+        f"Growth series {key!r} is not registered, so the analytics "
+        f"dashboard's growth chart will be missing a line. Check that "
+        f"n23/core/admin/__init__.py still imports .analytics."
+    )
+
+
+@pytest.mark.parametrize("key", ["all_active", "with_list", "campaign"])
+def test_broadcast_audience_is_offered(key):
+    assert key in {a.key for a in broadcast_audiences()}, (
+        f"Broadcast audience {key!r} is not registered, so it will be missing "
+        f"from the notification broadcast dropdown. Edition audiences come "
+        f"from n23/core/admin/broadcast.py."
     )

--- a/gyrinx/tests/test_analytics_dashboard.py
+++ b/gyrinx/tests/test_analytics_dashboard.py
@@ -1,0 +1,130 @@
+"""The admin analytics dashboard, and the growth chart it builds from the registry.
+
+The chart's lines are contributed by the edition (``n23/core/admin/analytics.py``)
+through ``gyrinx.analytics.registry``. Registration failures are silent — the
+page still renders, just with an empty chart — so these tests assert the data
+actually plots, not merely that the page returns 200.
+"""
+
+import json
+
+import pytest
+from django.urls import reverse
+
+from gyrinx.analytics.registry import (
+    GrowthSeries,
+    daily_counts_by_date,
+    growth_series,
+    register_growth_series,
+)
+
+
+@pytest.fixture
+def dashboard_admin(make_user):
+    u = make_user("dashboard-admin", "password")
+    u.is_staff = True
+    u.is_superuser = True
+    u.save()
+    return u
+
+
+def _cumulative(response):
+    return json.loads(response.context["cumulative_data"])
+
+
+@pytest.mark.django_db
+def test_dashboard_renders_for_staff(client, dashboard_admin):
+    client.force_login(dashboard_admin)
+    resp = client.get(reverse("admin:analytics_dashboard"))
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_growth_chart_has_a_line_per_registered_series(client, dashboard_admin):
+    client.force_login(dashboard_admin)
+    resp = client.get(reverse("admin:analytics_dashboard"))
+
+    data = _cumulative(resp)
+    assert [d["label"] for d in data["datasets"]] == [s.label for s in growth_series()]
+    # Every line is plotted over the same x-axis as the chart's labels.
+    for dataset in data["datasets"]:
+        assert len(dataset["data"]) == len(data["labels"])
+
+
+@pytest.mark.django_db
+def test_growth_chart_counts_the_editions_objects(
+    client, dashboard_admin, make_list, make_list_fighter, make_campaign
+):
+    lst = make_list("Growth Gang")
+    make_list_fighter(lst, "Growth Fighter")
+    make_campaign("Growth Campaign")
+
+    client.force_login(dashboard_admin)
+    resp = client.get(reverse("admin:analytics_dashboard"))
+
+    totals = {d["label"]: d["data"][-1] for d in _cumulative(resp)["datasets"]}
+    assert totals["Fighters (Cumulative)"] >= 1
+    assert totals["Lists (Cumulative)"] >= 1
+    assert totals["Campaigns (Cumulative)"] >= 1
+
+
+@pytest.mark.django_db
+def test_series_values_accumulate_and_never_fall(client, dashboard_admin, make_list):
+    make_list("Cumulative Gang")
+
+    client.force_login(dashboard_admin)
+    resp = client.get(reverse("admin:analytics_dashboard"))
+
+    for dataset in _cumulative(resp)["datasets"]:
+        values = dataset["data"]
+        assert values == sorted(values), f"{dataset['label']} is not cumulative"
+
+
+@pytest.mark.django_db
+def test_daily_counts_by_date_groups_by_creation_day(make_campaign):
+    """The helper editions build their series from."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from n23.core.models import Campaign
+
+    make_campaign("Counted One")
+    make_campaign("Counted Two")
+
+    counts = daily_counts_by_date(
+        Campaign.objects.all(), timezone.now() - timedelta(days=1)
+    )
+    assert sum(counts.values()) == 2
+    assert set(counts) == {timezone.now().date()}
+
+
+@pytest.mark.django_db
+def test_registering_a_key_twice_replaces_rather_than_duplicates():
+    """Re-registration overrides in place — a series can't be double-plotted."""
+    before = len(growth_series())
+    series = GrowthSeries(
+        key="test_dupe",
+        label="First",
+        border_color="rgb(0, 0, 0)",
+        background_color="rgba(0, 0, 0, 0.2)",
+        daily_counts=lambda start: {},
+    )
+    register_growth_series(series)
+    try:
+        register_growth_series(
+            GrowthSeries(
+                key="test_dupe",
+                label="Second",
+                border_color="rgb(1, 1, 1)",
+                background_color="rgba(1, 1, 1, 0.2)",
+                daily_counts=lambda start: {},
+            )
+        )
+        registered = growth_series()
+        assert len(registered) == before + 1
+        assert registered[-1].label == "Second"
+    finally:
+        from gyrinx.analytics import registry
+
+        registry._series.pop("test_dupe", None)

--- a/n23/core/admin/__init__.py
+++ b/n23/core/admin/__init__.py
@@ -1,5 +1,17 @@
+"""The edition's admin surface.
+
+Importing a module here is what registers it — both the ``@admin.register``
+classes and the side-effect-only modules (``analytics``, ``broadcast``) that
+push edition features into platform registries. Those two export nothing, so
+they look removable and are not: drop one and the feature quietly vanishes from
+the admin. ``gyrinx/tests/test_admin_registration.py`` guards against exactly
+that.
+"""
+
 from .action import *  # noqa: F403
+from .analytics import *  # noqa: F403
 from .backfill import *  # noqa: F403
+from .broadcast import *  # noqa: F403
 from .campaign import *  # noqa: F403
 from .events import *  # noqa: F403
 from .impersonation import *  # noqa: F403

--- a/n23/core/admin/analytics.py
+++ b/n23/core/admin/analytics.py
@@ -1,0 +1,68 @@
+"""What this edition contributes to the platform's analytics dashboard.
+
+The dashboard's growth chart used to query ``List``/``ListFighter``/``Campaign``
+directly from ``gyrinx/analytics/admin.py``, which made the platform import the
+edition. The lines are declared here instead and pushed into the platform's
+registry; the platform accumulates them without knowing what they count.
+
+Imported by ``n23.core.admin`` — which Django imports during
+``admin.autodiscover()`` — so the series are registered before any request is
+served. Keep the import in ``n23/core/admin/__init__.py``: dropping it does not
+break anything loudly, it just empties the chart.
+"""
+
+from gyrinx.analytics.registry import (
+    GrowthSeries,
+    daily_counts_by_date,
+    register_growth_series,
+)
+from n23.core.models import Campaign, List, ListFighter
+
+__all__ = []
+
+
+def _fighters_in_list_building(start_date):
+    return daily_counts_by_date(
+        ListFighter.objects.filter(list__status=List.LIST_BUILDING), start_date
+    )
+
+
+def _list_building_lists(start_date):
+    return daily_counts_by_date(
+        List.objects.filter(status=List.LIST_BUILDING), start_date
+    )
+
+
+def _campaigns(start_date):
+    return daily_counts_by_date(Campaign.objects.all(), start_date)
+
+
+# Registration order is chart order; the colours are the ones the chart has
+# always used for these three lines.
+register_growth_series(
+    GrowthSeries(
+        key="n23_fighters",
+        label="Fighters (Cumulative)",
+        border_color="rgb(75, 192, 192)",
+        background_color="rgba(75, 192, 192, 0.2)",
+        daily_counts=_fighters_in_list_building,
+    )
+)
+register_growth_series(
+    GrowthSeries(
+        key="n23_lists",
+        label="Lists (Cumulative)",
+        border_color="rgb(54, 162, 235)",
+        background_color="rgba(54, 162, 235, 0.2)",
+        daily_counts=_list_building_lists,
+    )
+)
+register_growth_series(
+    GrowthSeries(
+        key="n23_campaigns",
+        label="Campaigns (Cumulative)",
+        border_color="rgb(255, 99, 132)",
+        background_color="rgba(255, 99, 132, 0.2)",
+        daily_counts=_campaigns,
+    )
+)

--- a/n23/core/admin/broadcast.py
+++ b/n23/core/admin/broadcast.py
@@ -1,0 +1,62 @@
+"""Audiences this edition adds to the platform's notification broadcast page.
+
+"Users with a list" and "Participants of a campaign" are both statements about
+edition data, so they are declared here and registered into
+``gyrinx.site.registry`` rather than hard-coded into the platform's form.
+
+Imported by ``n23.core.admin`` — Django imports that during
+``admin.autodiscover()``, so both audiences are in the dropdown before any
+request is served. Drop the import from ``n23/core/admin/__init__.py`` and the
+options silently disappear from the page.
+"""
+
+from django import forms
+from django.contrib.auth import get_user_model
+
+from gyrinx.site.registry import BroadcastAudience, register_broadcast_audience
+from n23.core.models.campaign import Campaign
+
+__all__ = []
+
+User = get_user_model()
+
+
+def _users_with_a_list(cleaned_data):
+    return User.objects.filter(list__isnull=False).distinct()
+
+
+def _campaign_participants(cleaned_data):
+    """List owners in the campaign, plus the arbitrator."""
+    campaign = cleaned_data["campaign"]
+    ids = set(campaign.lists.values_list("owner_id", flat=True))
+    if campaign.owner_id:
+        ids.add(campaign.owner_id)
+    ids.discard(None)
+    return User.objects.filter(pk__in=ids)
+
+
+def _campaign_field():
+    return forms.ModelChoiceField(
+        queryset=Campaign.objects.all(),
+        required=False,
+        help_text="Required when audience is 'Participants of a campaign'.",
+    )
+
+
+register_broadcast_audience(
+    BroadcastAudience(
+        key="with_list",
+        label="Users with a list",
+        recipients=_users_with_a_list,
+    )
+)
+register_broadcast_audience(
+    BroadcastAudience(
+        key="campaign",
+        label="Participants of a campaign",
+        recipients=_campaign_participants,
+        field_name="campaign",
+        field=_campaign_field,
+        field_required_error="Choose a campaign for this audience.",
+    )
+)


### PR DESCRIPTION
Part 1 of 2 removing the last platform→edition Python imports (#2093). Part 2 (the maintenance console) is stacked on this one.

## What changed

Two of the three remaining platform→edition imports existed so the platform could ask a question only an edition can answer.

- `gyrinx/analytics/admin.py` imported `List`, `ListFighter` and `Campaign` purely to count rows per day for the dashboard's cumulative growth chart.
- `gyrinx/site/admin.py` imported `Campaign` for the "participants of a campaign" broadcast audience. The neighbouring "users with a list" audience reached into the edition too, via the `list__isnull` reverse accessor — a string, so it never showed up as an import.

Both are inverted the same way: the platform declares an extension point and does the generic work, the edition registers what it wants counted or offered.

**`gyrinx/analytics/registry.py`** takes a `GrowthSeries` per chart line, each carrying a callable that answers "how many were created each day since `<date>`?". The dashboard accumulates and shapes for Chart.js without knowing what it is plotting. It also offers `daily_counts_by_date()` so editions don't each rewrite the `TruncDate`/`Count` grouping.

**`gyrinx/site/registry.py`** takes a `BroadcastAudience` per dropdown option: a label, a `recipients` callable fed the form's `cleaned_data`, and optionally a qualifier field plus the error to raise when that audience is chosen without it. `BroadcastForm` builds its choices and qualifier fields per instance and orders qualifiers next to the dropdown that governs them, so the rendered page is unchanged. The platform keeps "all active users" and registers it at registry-import time, which guarantees it leads the dropdown whatever order editions are autodiscovered in.

The edition registers from `n23/core/admin/analytics.py` and `n23/core/admin/broadcast.py`, imported by `n23.core.admin` during `admin.autodiscover()` — well before any request is served.

## Testing

Both registries fail silently by design (an empty chart, a short dropdown) — the same trap that quietly unregistered the `Event` admin during the platform split. So `test_admin_registration.py` now also asserts the three growth series and three audiences are present, and the analytics dashboard gets its first tests: it had none, and the growth chart is the part this rewrites.

- Full suite: **4163 passed, 13 skipped** (base at `9b1d67c5` measures 4151; +12 from this PR).
- The admin registry and the full list of admin URL names are **byte-identical** before and after.
- The growth chart was diffed against the old hard-coded implementation over a 1-year window on a populated dev database: same labels, same numbers, all three lines non-zero (Fighters 136, Lists 50, Campaigns 29).
- Browser-checked at `/admin/`, `/admin/analytics/dashboard/` (all three lines plot) and the broadcast page (3 audiences, campaign dropdown populated with 29 campaigns, field order unchanged).

## How to try it

```
./scripts/dev.sh
```

Then, as a superuser: `/admin/analytics/dashboard/?time_scale=1y` — the "Cumulative Creations" chart should plot Fighters, Lists and Campaigns as before. And `/admin/gyrinxsite/notification/broadcast/` — the audience dropdown should offer all three options, with the Campaign picker directly beneath it.
