### PR TITLE
fix: repoint robots.txt at the /n23/ URLs and stop the page-ref cache thrashing

### DIFF
--- a/gyrinx/pages/tests/test_robots.py
+++ b/gyrinx/pages/tests/test_robots.py
@@ -1,4 +1,8 @@
+import re
+import uuid
+
 import pytest
+from django.urls import Resolver404, resolve
 
 
 @pytest.mark.django_db
@@ -11,12 +15,54 @@ def test_robots_txt_served_as_plain_text(client):
 @pytest.mark.django_db
 def test_robots_txt_policy(client):
     """Amazonbot and Bytespider are excluded entirely; fighter detail pages,
-    accounts, and admin are disallowed for every agent."""
+    print views, accounts, and admin are disallowed for every agent."""
     body = client.get("/robots.txt").content.decode()
     sections = body.split("\n\n")
     assert "User-agent: Amazonbot\nDisallow: /" in sections
     assert "User-agent: Bytespider\nDisallow: /" in sections
     general = [s for s in sections if s.startswith("User-agent: *")][0]
-    assert "Disallow: /list/*/fighter/" in general
+    assert "Disallow: /n23/list/*/fighter/" in general
+    assert "Disallow: /n23/list/*/print" in general
     assert "Disallow: /accounts/" in general
     assert "Disallow: /admin/" in general
+
+
+@pytest.mark.django_db
+def test_every_disallowed_edition_path_resolves_to_a_real_view(client):
+    """Each edition Disallow must name a path this site actually serves.
+
+    The previous version of this test asserted the literal string
+    ``Disallow: /list/*/fighter/`` was present. When the edition moved under
+    ``/n23/`` (#2110) that rule stopped matching any real URL, but the string was
+    still in the file, so the test kept passing — and every fighter and print
+    page silently became crawlable. Asserting the text says nothing about whether
+    the rule does anything.
+
+    So substitute a real id for each wildcard and require the path to resolve. A
+    Disallow that resolves nowhere is protecting nothing.
+    """
+    body = client.get("/robots.txt").content.decode()
+    general = [s for s in body.split("\n\n") if s.startswith("User-agent: *")][0]
+
+    paths = re.findall(r"^Disallow: (\S+)$", general, re.M)
+    assert paths, "expected Disallow rules for the catch-all agent"
+
+    # /accounts/ and /admin/ are third-party URLconfs mounted at a prefix; the
+    # bare prefix is not itself a route, so they are checked by the policy test
+    # above rather than resolved here.
+    edition_paths = [p for p in paths if p.startswith("/n23/")]
+    assert edition_paths, "expected the edition paths to be covered"
+
+    unresolved = []
+    for path in edition_paths:
+        probe = path.replace("*", str(uuid.uuid4()))
+        try:
+            resolve(probe if probe.endswith("/") else probe + "/")
+        except Resolver404:
+            unresolved.append(path)
+
+    assert not unresolved, (
+        f"robots.txt Disallow rules matching no route: {unresolved}. "
+        "A rule that resolves nowhere protects nothing — check these against "
+        "n23/core/urls/__init__.py."
+    )

--- a/gyrinx/pages/views.py
+++ b/gyrinx/pages/views.py
@@ -16,7 +16,14 @@ from gyrinx.pages.models import FlatPageVisibility
 # brings no users, so it is excluded entirely. Bytespider (ByteDance) likewise.
 # For everyone else (Googlebot, bingbot, ...) the list overview pages carry the
 # search value — the per-fighter detail pages are crawl noise, so they are
-# disallowed for all agents.
+# disallowed for all agents. The print views are the most expensive pages on
+# the site and have no business being indexed.
+#
+# These paths carry the /n23/ edition prefix. They MUST be kept in step with
+# n23/core/urls/__init__.py: when the edition moved under /n23/ in #2110 these
+# rules silently stopped matching, every fighter and print page became
+# crawlable, and the resulting crawl took the site down. The test below asserts
+# each pattern resolves to a real view rather than just checking the text.
 ROBOTS_TXT = """\
 User-agent: Amazonbot
 Disallow: /
@@ -25,7 +32,9 @@ User-agent: Bytespider
 Disallow: /
 
 User-agent: *
-Disallow: /list/*/fighter/
+Disallow: /n23/list/*/fighter/
+Disallow: /n23/list/*/print
+Disallow: /n23/list/*/print/
 Disallow: /accounts/
 Disallow: /admin/
 """

--- a/gyrinx/settings.py
+++ b/gyrinx/settings.py
@@ -266,14 +266,24 @@ DATABASES = {
 # Caching
 # https://docs.djangoproject.com/en/6.0/topics/cache/
 
+# Both caches are per-process LocMemCache, so every container starts cold and
+# each gunicorn worker keeps its own copy. That is tolerable only if the cache is
+# big enough to hold the whole working set — the default MAX_ENTRIES of 300 is
+# not. Production has 420 rules + 120 skills resolving against 570 page refs, so
+# at the default the cache culled a third of itself continuously and the hit rate
+# collapsed under crawl load, putting an unindexable LIKE query on the database
+# for every rule on every fighter card. Sized well above the working set so it
+# behaves as a cache rather than a rotating buffer.
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "unique-snowflake",
+        "OPTIONS": {"MAX_ENTRIES": 5000, "CULL_FREQUENCY": 10},
     },
     "content_page_ref_cache": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "content-page-ref-cache",
+        "OPTIONS": {"MAX_ENTRIES": 5000, "CULL_FREQUENCY": 10},
     },
 }
 

--- a/n23/content/models/metadata.py
+++ b/n23/content/models/metadata.py
@@ -151,6 +151,10 @@ class ContentPolicy(Content):
         verbose_name_plural = "Policies"
 
 
+# Distinguishes "cached, and the answer is nothing" from "not cached".
+_MISSING = object()
+
+
 class ContentPageRef(Content):
     """
     Represents a reference to a page (or pages) in a rulebook (:model:`content.ContentBook`). Provides a parent
@@ -217,15 +221,29 @@ class ContentPageRef(Content):
         Uses caching to avoid repeated lookups. Returns a QuerySet.
         """
         cache = caches["content_page_ref_cache"]
-        key = f"content_page_ref_cache:{title}"
-        cached = cache.get(key)
-        if cached:
+        # Include the kwargs in the key: the same title looked up with and without
+        # a category is two different questions with two different answers.
+        key = f"content_page_ref_cache:{title}:{sorted(kwargs.items())}"
+        # Sentinel rather than a truthiness test. An empty result is falsy, so
+        # `if cached:` treated "we looked and there is nothing" as a cache miss —
+        # meaning any title without a page ref re-ran an unindexable LIKE query on
+        # every single call and could never be cached.
+        cached = cache.get(key, _MISSING)
+        if cached is not _MISSING:
             return cached
 
-        refs = ContentPageRef.objects.filter(**kwargs).filter(
-            Q(title__icontains=title) | Q(title=title)
+        # Evaluated to a list before caching. A QuerySet is lazy, and caching one
+        # stores a re-runnable query rather than the answer.
+        refs = list(
+            ContentPageRef.objects.filter(**kwargs).filter(
+                Q(title__icontains=title) | Q(title=title)
+            )
         )
-        cache.set(key, refs)
+        # An hour, not forever: with MAX_ENTRIES well above the working set
+        # nothing is evicted, so a permanent entry would hide admin edits to page
+        # refs until the container restarted. An hour costs at most one requery
+        # per title per process and self-heals.
+        cache.set(key, refs, 3600)
         return refs
 
     # TODO: Move this to a custom Manager


### PR DESCRIPTION
fix: repoint robots.txt at the /n23/ URLs and stop the page-ref cache thrashing

Production incident. Traffic climbing since roughly midnight, database
connection-pool timeouts across gang pages, and downtime alerts.

**Cause.** `robots.txt` disallowed `/list/*/fighter/`. When the edition moved
under `/n23/` in #2110 that rule stopped matching any real URL, so every fighter
page and every print view became crawlable. Crawlers then enumerated the most
expensive pages on the site — gang detail, print, lore-notes — at roughly 5
requests a second. Each container accepts 40 concurrent requests but holds 8
database connections, so those threads queued past the 5s pool timeout and
returned 500s.

The existing test asserted the literal string `"Disallow: /list/*/fighter/"` was
present. It checked the text existed, not that it matched a route, so it passed
straight through the URL move. `test_every_disallowed_edition_path_resolves_to_a_real_view`
now substitutes an id for each wildcard and requires the path to resolve — a
Disallow that resolves nowhere protects nothing. Verified it fails against the
old paths.

Print views are now disallowed too. They are the heaviest pages here and have no
reason to be indexed.

**The amplifier.** Both caches are `LocMemCache` with no `MAX_ENTRIES`, so they
default to 300 entries. Production resolves 420 rules and 120 skills against 570
page refs — roughly double that — so the cache culled a third of itself
continuously and the hit rate collapsed exactly when load was highest. Every miss
runs `title__icontains`, a `LIKE '%…%'` no index can serve, holding one of the
eight connections.

Worse, `ContentPageRef.find_similar` tested the cached value for truthiness:

```python
cached = cache.get(key)
if cached:      # an empty result is falsy, so it reads as a miss
```

Any title with no page ref re-queried on every call and could never cache. Now a
sentinel distinguishes "cached, and the answer is nothing" from "not cached".
Measured before and after: an empty lookup went from one query *every* call to
one query then zero.

Also: the cache key now includes the kwargs, since the same title asked with and
without a category is two different questions; the result is evaluated to a list
before caching rather than storing a lazy queryset; and entries expire after an
hour so admin edits to page refs appear without a restart.

`MAX_ENTRIES` raised to 5000 on both caches, comfortably above the working set.

**Scope.** This is mitigation plus cause. It does not address the underlying
capacity: 8 pool connections against 40 container concurrency on a `db-g1-small`
with `max_connections=50` will not survive much more than current traffic, and
robots.txt only takes effect when crawlers next read it.

Verified: robots tests pass and fail correctly against the old paths; the cache
behaviour measured directly; `{% ref %}` renders correctly for both a hit
(tooltip with page refs) and a miss (plain text) — the path affected by
`find_similar` now returning a list; content and pages suites pass (336 passed).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ToFTcKVBQptbR7eTWkWuWH
