### PR TITLE
docs: add an incident reports folder, starting with the 6 August crawler overload

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -83,6 +83,8 @@ Documentation for Necromunda 2023, the edition Gyrinx currently implements. Ever
 - [Content Data Management](operations/content-data-management.md)
 - [Deployment](deployment.md)
 - [Runbook](runbook.md)
+- [Incident Reports](operations/incidents/README.md)
+  - [Crawler Overload (6 Aug 2026)](operations/incidents/2026-08-06-crawler-overload.md)
 
 ## Links
 

--- a/docs/operations/incidents/2026-08-06-crawler-overload.md
+++ b/docs/operations/incidents/2026-08-06-crawler-overload.md
@@ -1,0 +1,142 @@
+# Crawler overload — 6 August 2026
+
+Search and AI crawlers began walking pages that had been excluded from crawling,
+and the load took the site down intermittently for several hours.
+
+Operational specifics — thresholds, current rule configuration, capacity figures
+— are deliberately absent; see the private runbook. What follows is the
+mechanism and the reasoning.
+
+## Symptoms
+
+- Request volume climbing from around midnight.
+- Intermittent 500s, concentrated on the most query-heavy pages: gang detail and
+  its print variants, and the paginated gang index.
+- `OperationalError: couldn't get a connection` raised from the database
+  connection pool.
+- `CacheKeyWarning` for the page-reference cache filling the logs — which turned
+  out to be a symptom rather than a fault, since that warning fires on every
+  cache operation and its volume tracked the miss rate.
+
+## Cause
+
+`robots.txt` disallowed a set of paths. When the edition moved under a `/n23/`
+URL prefix, **those paths stopped matching any real URL**, and the pages they had
+been protecting became crawlable. Nothing errored; the file was still valid and
+still served.
+
+The test covering it asserted that the expected `Disallow` line was *present in
+the response*. It verified the text existed, not that it corresponded to a route
+the site actually serves, so it passed unchanged through the URL restructure.
+
+A second instance of the same class sat next to it: a rule naming one crawler by
+a token that crawler does not use. It had never matched anything, and nothing
+had ever indicated that.
+
+**The lesson.** A `robots.txt` rule is a claim about your URL structure, and it
+rots silently when that structure changes. Assert that each rule *resolves to a
+real route*, not that the file contains the right words. The fixed test
+substitutes an id for each wildcard and requires resolution.
+
+## Why crawling was enough to cause an outage
+
+Three multipliers, none introduced by the crawl. It only found them.
+
+**Connection pool versus container concurrency.** Each container accepts
+considerably more concurrent requests than it holds database connections. Pages
+issuing many queries occupy a connection for a long time, so under load the
+excess threads queue, exceed the pool timeout and return 500.
+
+Worth knowing for diagnosis: this is *client-side pool exhaustion*, and it looks
+much like the database refusing connections while requiring a different response.
+The database was nowhere near its limit. Searching the logs for
+`FATAL: too many clients` distinguishes the two in seconds.
+
+**A cache smaller than its working set.** The page-reference caches used the
+framework default for maximum entries, which was well below the number of
+distinct lookups the content generates. Past that ceiling the cache evicts a
+fraction of itself on every insert, so under a broad crawl — which touches many
+distinct keys in quick succession — the hit rate collapses toward zero and each
+miss runs a query no index can serve.
+
+**Empty results were never cached.** The lookup tested the cached value for
+truthiness:
+
+```python
+cached = cache.get(key)
+if cached:      # an empty result is falsy, so it reads as a cache miss
+```
+
+Anything with no match re-queried on every single call and could never be cached.
+Fixed with a sentinel, so "cached, and the answer is nothing" is distinct from
+"not cached".
+
+**Compounding all three:** the caches are per-process, so every new container and
+worker starts cold. Autoscaling under load therefore makes the miss rate worse at
+exactly the moment it can least afford to.
+
+## Response
+
+**Corrected the cause.** `robots.txt` repointed at the current URL structure,
+with the print views excluded too — they are the most expensive pages and have no
+reason to be indexed. The test rewritten to assert resolution.
+
+**Sized the caches to the working set** and fixed the empty-result hole.
+
+**Blocked declared crawlers at the edge** with a Cloud Armor deny rule. Search
+engines and link-preview fetchers are exempt: blocking the former costs search
+visibility, and the latter is a different agent from the AI crawler that shares
+its vendor, so blocking it would break link previews.
+
+**Capped anonymous throughput** on the affected paths once it became clear the
+remaining load came from a client presenting as an ordinary browser and spread
+thinly across many addresses — a shape that defeats both agent-based blocking and
+per-address rate limiting. Signed-in users are unaffected.
+
+## Judgements worth recording
+
+**Roll out edge rules in preview first.** Cloud Armor's preview mode evaluates a
+rule and logs what it would have done without acting. It took a few minutes and
+confirmed the rule matched only what was intended before it was enforced. This is
+cheap insurance on a policy that has produced false positives before.
+
+**A rule left in preview is worse than no rule.** The policy already contained a
+per-address rate limit that had been in preview indefinitely — logging, never
+acting. It appeared on the dashboard as protection that did not exist.
+
+**Its own preview logs decided its fate.** Rather than reasoning about whether to
+enforce it, we read what it *would* have done. It would have blocked a major
+search engine's crawler, and because that rule bans an address outright rather
+than rejecting a single request, the damage would have been ongoing and
+attributed to nothing. It was deleted rather than enforced or left misleading.
+
+**Identity-based controls only work on clients that are honest about their
+identity.** Well-behaved crawlers identify themselves and were stopped. A client
+that presents as a browser is a different problem needing a different control.
+
+## Cloud Armor notes
+
+Two syntax details that cost time:
+
+- Capture groups are rejected in rule expressions. Use non-capturing `(?:...)`.
+- For case-insensitive matching, use the inline `(?i)` flag rather than a
+  `.lower()` call on the header.
+
+Rule changes take a minute or two to propagate. Test with an actual request
+rather than assuming an update has taken effect — and note that Cloud Armor has
+no enable/disable switch, so preview mode is how a rule is turned off without
+losing it.
+
+## Diagnostic checklist
+
+1. **Is it real traffic?** Group requests by user agent and source address over
+   the last half hour. Many addresses making one or two requests each means
+   per-address limiting will not help.
+2. **Which paths are failing?** Concentration on expensive pages suggests
+   crawling rather than a user-facing regression.
+3. **Pool or database?** Look for `FATAL: too many clients`. Its absence means
+   the application's connection pool is the constraint.
+4. **Did something deploy just before it started?** Compare the running revision
+   and build history against the time errors began.
+5. **Is `robots.txt` still accurate?** Any URL restructure can invalidate it
+   silently, and nothing will tell you.

--- a/docs/operations/incidents/README.md
+++ b/docs/operations/incidents/README.md
@@ -1,0 +1,35 @@
+# Incident Reports
+
+Write-ups of production incidents: what broke, why, and what changed as a result.
+They exist so the next person to meet a similar failure starts with what we
+learned rather than from scratch.
+
+## What belongs here
+
+- The failure mechanism, in enough detail to recognise it again.
+- Reasoning behind the fixes, especially where an obvious-looking option was
+  rejected.
+- Diagnostic steps that turned out to matter, including the misleading ones.
+
+## What does not
+
+**This repository is public.** A good incident report describes how a system
+failed; it must not double as instructions for making it fail again. So these
+write-ups deliberately leave out:
+
+- Specific thresholds, limits and capacity figures.
+- The exact composition of allow and deny lists.
+- Any description of how a control could be circumvented.
+- Current weaknesses and where cover is thin.
+
+That detail is real and worth recording — it lives in the private runbook and in
+the cloud console, not here. When a report needs to refer to it, it says so and
+stops.
+
+If you are writing one of these, the test is: *could a reader use this to hurt
+us more efficiently than they could without it?* If yes, generalise until the
+answer is no. The mechanism is the lesson; the numbers are not.
+
+## Reports
+
+- [Crawler overload — 6 August 2026](2026-08-06-crawler-overload.md)


### PR DESCRIPTION
docs: add an incident reports folder, starting with the 6 August crawler overload

`docs/operations/incidents/` with an index and the first report, so these
accumulate somewhere obvious rather than as loose files under Operations.

## The public-repo filter

This repository is public, and the first draft of this write-up was, on reading
it back, a serviceable guide to knocking the site over: exact rate thresholds,
the composition of the allow and deny lists, capacity figures down to pool sizes
and connection limits, which pages are most expensive to render, a "still
exposed" section enumerating where cover is thin — and an explicit description of
how the anonymous throttle could be bypassed.

All of that is real and worth recording. None of it belongs in a public
repository. It has been removed; it lives in the private runbook and the cloud
console, and the report says so where a reader would otherwise wonder.

What is kept is the part that helps a future responder and cannot be turned
against us:

- `robots.txt` rules are claims about URL structure and rot silently when that
  structure changes. Assert that each rule *resolves to a real route*, not that
  the file contains the right text — the old test checked the string was present
  and passed straight through the URL move that broke it.
- A cache whose maximum-entries setting is below its working set evicts on every
  insert and collapses to a near-zero hit rate under a broad crawl.
- Testing a cached value for truthiness means an empty result can never be
  cached, so it re-queries forever.
- Per-process caches start cold on every new container, so autoscaling worsens
  the miss rate exactly when load peaks.
- Client-side connection-pool exhaustion resembles a database refusing
  connections but needs a different response; one log search separates them.
- A security rule left in preview indefinitely is worse than no rule — it looks
  like protection on the dashboard and provides none.
- Preview logs can decide whether to enforce a rule, rather than reasoning about
  it in the abstract.

The index states the standard for future reports and gives the test to apply:
could a reader use this to hurt us more efficiently than they could without it?
If so, generalise until they cannot. The mechanism is the lesson; the numbers are
not.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ToFTcKVBQptbR7eTWkWuWH
