### PR TITLE
fix: make the model-move migrations survive a rollback

### DIFF
--- a/n23/core/migrations/0203_move_userprofile_to_accounts.py
+++ b/n23/core/migrations/0203_move_userprofile_to_accounts.py
@@ -1,5 +1,37 @@
 from django.db import migrations
 
+_MOVED = ["userprofile", "historicaluserprofile"]
+
+
+def _move_content_types(apps, from_label, to_label, models):
+    """Carry ContentType rows between app labels, in place and idempotently.
+
+    In place so the id survives: every permission grant and generic reference
+    points at that id, and minting a new row would orphan them.
+
+    The stray-clearing step is what makes a rollback survivable. Unapplying this
+    migration leaves the model in the migration state, so post_migrate mints a
+    fresh row under the label we are moving *to*; without clearing it first, the
+    update below collides on the (app_label, model) unique constraint the next
+    time this runs. Its permissions are auto-created and referenced by nothing —
+    the real grants hang off the original row — so they go with it.
+    """
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
+
+    for model in models:
+        original = ContentType.objects.filter(app_label=from_label, model=model).first()
+        if original is None:
+            continue  # already moved, or never existed — nothing to carry
+
+        stray = ContentType.objects.filter(app_label=to_label, model=model).exclude(
+            pk=original.pk
+        )
+        Permission.objects.filter(content_type__in=stray).delete()
+        stray.delete()
+
+        ContentType.objects.filter(pk=original.pk).update(app_label=to_label)
+
 
 def content_types_to_accounts(apps, schema_editor):
     """Repoint the existing ContentType rows at the new app label.
@@ -9,17 +41,11 @@ def content_types_to_accounts(apps, schema_editor):
     automatically and any GenericForeignKey pointing at a profile stays valid.
     (Checked against production: zero Event rows currently point at one.)
     """
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(
-        app_label="core", model__in=["userprofile", "historicaluserprofile"]
-    ).update(app_label="accounts")
+    _move_content_types(apps, "core", "accounts", _MOVED)
 
 
 def content_types_to_core(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(
-        app_label="accounts", model__in=["userprofile", "historicaluserprofile"]
-    ).update(app_label="core")
+    _move_content_types(apps, "accounts", "core", _MOVED)
 
 
 class Migration(migrations.Migration):
@@ -33,6 +59,7 @@ class Migration(migrations.Migration):
         ("core", "0202_migrate_stat_overrides_operation"),
         ("accounts", "0001_move_userprofile_to_accounts"),
         ("contenttypes", "0002_remove_content_type_name"),
+        ("auth", "0001_initial"),
     ]
 
     operations = [

--- a/n23/core/migrations/0204_move_site_models_to_platform.py
+++ b/n23/core/migrations/0204_move_site_models_to_platform.py
@@ -5,20 +5,44 @@ from django.db import migrations
 MOVED = ["banner", "historicalbanner", "impersonationlog"]
 
 
+def _move_content_types(apps, from_label, to_label, models):
+    """Carry ContentType rows between app labels, in place and idempotently.
+
+    In place so the id survives: every permission grant and generic reference
+    points at that id, and minting a new row would orphan them.
+
+    The stray-clearing step is what makes a rollback survivable. Unapplying this
+    migration leaves the model in the migration state, so post_migrate mints a
+    fresh row under the label we are moving *to*; without clearing it first, the
+    update below collides on the (app_label, model) unique constraint the next
+    time this runs. Its permissions are auto-created and referenced by nothing —
+    the real grants hang off the original row — so they go with it.
+    """
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
+
+    for model in models:
+        original = ContentType.objects.filter(app_label=from_label, model=model).first()
+        if original is None:
+            continue  # already moved, or never existed — nothing to carry
+
+        stray = ContentType.objects.filter(app_label=to_label, model=model).exclude(
+            pk=original.pk
+        )
+        Permission.objects.filter(content_type__in=stray).delete()
+        stray.delete()
+
+        ContentType.objects.filter(pk=original.pk).update(app_label=to_label)
+
+
 def content_types_to_platform(apps, schema_editor):
     """Carry the ContentType rows over rather than letting post_migrate make new
     ones — same ids means attached permissions follow automatically."""
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(app_label="core", model__in=MOVED).update(
-        app_label="gyrinxsite"
-    )
+    _move_content_types(apps, "core", "gyrinxsite", MOVED)
 
 
 def content_types_to_core(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(app_label="gyrinxsite", model__in=MOVED).update(
-        app_label="core"
-    )
+    _move_content_types(apps, "gyrinxsite", "core", MOVED)
 
 
 class Migration(migrations.Migration):
@@ -28,6 +52,7 @@ class Migration(migrations.Migration):
         ("core", "0203_move_userprofile_to_accounts"),
         ("gyrinxsite", "0001_move_site_models_to_platform"),
         ("contenttypes", "0002_remove_content_type_name"),
+        ("auth", "0001_initial"),
     ]
 
     operations = [

--- a/n23/core/migrations/0205_move_event_to_analytics.py
+++ b/n23/core/migrations/0205_move_event_to_analytics.py
@@ -3,20 +3,44 @@
 from django.db import migrations
 
 
+def _move_content_types(apps, from_label, to_label, models):
+    """Carry ContentType rows between app labels, in place and idempotently.
+
+    In place so the id survives: every permission grant and generic reference
+    points at that id, and minting a new row would orphan them.
+
+    The stray-clearing step is what makes a rollback survivable. Unapplying this
+    migration leaves the model in the migration state, so post_migrate mints a
+    fresh row under the label we are moving *to*; without clearing it first, the
+    update below collides on the (app_label, model) unique constraint the next
+    time this runs. Its permissions are auto-created and referenced by nothing —
+    the real grants hang off the original row — so they go with it.
+    """
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
+
+    for model in models:
+        original = ContentType.objects.filter(app_label=from_label, model=model).first()
+        if original is None:
+            continue  # already moved, or never existed — nothing to carry
+
+        stray = ContentType.objects.filter(app_label=to_label, model=model).exclude(
+            pk=original.pk
+        )
+        Permission.objects.filter(content_type__in=stray).delete()
+        stray.delete()
+
+        ContentType.objects.filter(pk=original.pk).update(app_label=to_label)
+
+
 def content_type_to_analytics(apps, schema_editor):
     """Carry the ContentType row over in place, keeping its id so attached
     permissions and any GenericForeignKey referencing it stay valid."""
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(app_label="core", model="event").update(
-        app_label="analytics"
-    )
+    _move_content_types(apps, "core", "analytics", ["event"])
 
 
 def content_type_to_core(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(app_label="analytics", model="event").update(
-        app_label="core"
-    )
+    _move_content_types(apps, "analytics", "core", ["event"])
 
 
 class Migration(migrations.Migration):
@@ -26,6 +50,7 @@ class Migration(migrations.Migration):
         ("core", "0204_move_site_models_to_platform"),
         ("analytics", "0001_move_event_to_analytics"),
         ("contenttypes", "0002_remove_content_type_name"),
+        ("auth", "0001_initial"),
     ]
 
     operations = [

--- a/n23/core/migrations/0212_move_notification_to_platform.py
+++ b/n23/core/migrations/0212_move_notification_to_platform.py
@@ -3,20 +3,44 @@
 from django.db import migrations
 
 
+def _move_content_types(apps, from_label, to_label, models):
+    """Carry ContentType rows between app labels, in place and idempotently.
+
+    In place so the id survives: every permission grant and generic reference
+    points at that id, and minting a new row would orphan them.
+
+    The stray-clearing step is what makes a rollback survivable. Unapplying this
+    migration leaves the model in the migration state, so post_migrate mints a
+    fresh row under the label we are moving *to*; without clearing it first, the
+    update below collides on the (app_label, model) unique constraint the next
+    time this runs. Its permissions are auto-created and referenced by nothing —
+    the real grants hang off the original row — so they go with it.
+    """
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
+
+    for model in models:
+        original = ContentType.objects.filter(app_label=from_label, model=model).first()
+        if original is None:
+            continue  # already moved, or never existed — nothing to carry
+
+        stray = ContentType.objects.filter(app_label=to_label, model=model).exclude(
+            pk=original.pk
+        )
+        Permission.objects.filter(content_type__in=stray).delete()
+        stray.delete()
+
+        ContentType.objects.filter(pk=original.pk).update(app_label=to_label)
+
+
 def content_type_to_platform(apps, schema_editor):
     """Carry the ContentType row over in place, keeping its id so attached
     permissions and any GenericForeignKey referencing it stay valid."""
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(app_label="core", model="notification").update(
-        app_label="gyrinxsite"
-    )
+    _move_content_types(apps, "core", "gyrinxsite", ["notification"])
 
 
 def content_type_to_core(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    ContentType.objects.filter(app_label="gyrinxsite", model="notification").update(
-        app_label="core"
-    )
+    _move_content_types(apps, "gyrinxsite", "core", ["notification"])
 
 
 class Migration(migrations.Migration):
@@ -30,6 +54,7 @@ class Migration(migrations.Migration):
         ("core", "0211_drop_notification_related_columns"),
         ("gyrinxsite", "0002_move_notification_to_platform"),
         ("contenttypes", "0002_remove_content_type_name"),
+        ("auth", "0001_initial"),
     ]
 
     operations = [

--- a/n23/core/migrations/0215_remove_stray_notification_content_type.py
+++ b/n23/core/migrations/0215_remove_stray_notification_content_type.py
@@ -1,0 +1,67 @@
+"""Delete the stray `core | notification` ContentType row left in production.
+
+`Notification` moved from `core` to `gyrinxsite` in 0212. Production ended up
+with *both* rows: 224 (gyrinxsite, the real one, id preserved along with its
+permissions) and 248 (core, a duplicate minted by post_migrate's
+create_contenttypes while the migration state still said `core`). 0212 has since
+been taught to clear strays in both directions, but that only protects future
+runs — the row already exists and no migration will remove it on its own.
+
+Checked against production before writing this, across every column in the
+schema that references django_content_type:
+
+    auth_permission                                             4
+    django_admin_log                                            0
+    content_contentequipmentlistexpansionrule.polymorphic_ctype 0
+    content_contentmod.polymorphic_ctype                        0
+    content_contentmodapplication.target_content_type           0
+    core_customcontentpackitem.content_type                     0
+    core_event.object_type                                      0
+    core_notification.scope_content_type                        0
+    core_notification.target_content_type                       0
+
+The four permissions are the auto-created add/change/delete/view set, and no
+user and no group holds any of them — the grants people actually have hang off
+224. So nothing references this row and deleting it changes no behaviour; it
+only stops the admin's permission picker listing "notification" twice.
+
+Written as a migration rather than a Backfill because it repairs migration
+bookkeeping, is a single idempotent delete, and needs no preview or progress
+reporting. Matched on (app_label, model), never on the id.
+"""
+
+from django.db import migrations
+
+STRAY = {"app_label": "core", "model": "notification"}
+REAL = {"app_label": "gyrinxsite", "model": "notification"}
+
+
+def remove_stray(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
+
+    # Only ever delete the duplicate, and only while the real row exists — so a
+    # database where the move never happened, or was rolled back, is left alone.
+    if not ContentType.objects.filter(**REAL).exists():
+        return
+    stray = ContentType.objects.filter(**STRAY)
+    Permission.objects.filter(content_type__in=stray).delete()
+    stray.delete()
+
+
+def noop(apps, schema_editor):
+    """Deliberately not reversed.
+
+    Re-creating the duplicate would only restore the collision 0212 now guards
+    against, and post_migrate mints one by itself if the state ever calls for it.
+    """
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0214_move_backfill_to_maintenance"),
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("auth", "0001_initial"),
+    ]
+
+    operations = [migrations.RunPython(remove_stray, noop)]


### PR DESCRIPTION
fix: make the model-move migrations survive a rollback

Four of the five app-moving migrations from the platform/edition split cannot be
rolled back and re-applied. Found while reviewing #2132, which got it right;
0203, 0204, 0205 and 0212 predate that and do a bare `update()` on the
ContentType row.

## The failure

Unapplying one of these leaves the model in the migration state, so
post_migrate's `create_contenttypes` mints a fresh row under the label the model
is moving *to*. Rolling forward again then collides:

    django.db.utils.IntegrityError: duplicate key value violates unique
    constraint "django_content_type_app_label_model_76bd3d3b_uniq"
    DETAIL: Key (app_label, model)=(gyrinxsite, notification) already exists.

That is not inferred — it was reproduced against a populated database by
unapplying 0212, observing the duplicate appear, and re-applying. Rollback and
retry is exactly what a failed deploy does.

Each direction now clears any stray before renaming, and no-ops if the move has
already happened, matching 0214. Verified by repeating the same cycle with the
guard in place: the duplicate still appears while rolled back, the re-apply
succeeds, and the row count returns to one with the original id (224) intact.

Editing applied migrations is safe here — only the RunPython bodies change, no
state or database operation is touched, so the graph, the recorded history and
`makemigrations --check` are all unaffected. The new bodies are idempotent.

## The row already in production

0215 removes it. Production holds both 224 (gyrinxsite, the real row, with the
permissions) and 248 (core, the duplicate). The guard above only protects future
runs; nothing removes a row that already exists.

Checked before writing it, across every column in the schema that references
django_content_type — all nine — plus the permission grants:

    auth_permission                    4   (auto-created add/change/delete/view)
    django_admin_log                   0
    polymorphic_ctype (×2 tables)      0
    target_content_type (contentmod)   0
    customcontentpackitem.content_type 0
    event.object_type                  0
    notification.scope_content_type    0
    notification.target_content_type   0

No user and no group holds any of those four permissions; the grants people
actually have hang off 224. So nothing references the row, and deleting it
changes no behaviour — it only stops the admin permission picker listing
"notification" twice.

It is guarded both ways: it matches on (app_label, model) rather than the id,
and it does nothing unless the real gyrinxsite row exists, so a database where
the move never happened is left alone. Not reversible by design — re-creating
the duplicate would only restore the collision.

Written as a migration rather than a Backfill because it repairs migration
bookkeeping, is one idempotent delete, and needs no preview or progress
reporting.

## Scope

Only `notification` actually has a duplicate in production. The other four moved
models (userprofile, banner, impersonationlog, event) were each checked and have
exactly one row. The guards on their migrations are preventive.

Full CI stack locally: ruff, format, djlint, prettier, migration conflicts,
bandit, and `pytest` at 4194 passed / 13 skipped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ToFTcKVBQptbR7eTWkWuWH
