### PR TITLE
fix: copy the n26 edition into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,17 @@ ENV DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-gyrinx.settings}
 COPY pyproject.toml uv.lock /app/
 COPY scripts/ /app/scripts/
 COPY gyrinx/ /app/gyrinx/
-# The n23 edition apps (n23.core / n23.content). Copied separately because the
-# image is built from an explicit file list, not the whole tree — omit this and
-# the container starts without the edition installed, which no test catches.
+# The edition apps (n23.core / n23.content, n26.core / n26.library /
+# n26.designsystem). Copied separately because the image is built from an
+# explicit file list, not the whole tree — omit one and the container starts
+# without that edition installed.
+#
+# These must be copied *before* `uv sync` below. The editable install writes a
+# static `__editable___gyrinx_..._finder.py` whose module mapping is computed
+# from whatever top-level packages exist at install time, so a directory that
+# arrives after the sync is not importable however present its files are.
 COPY n23/ /app/n23/
+COPY n26/ /app/n26/
 # Game data files, unrelated to the n23 Python package above.
 COPY content/ /app/content/
 # Root-level static assets (favicon.ico) served by WhiteNoise via


### PR DESCRIPTION
Fixes the failed n26 deploy. The container died at startup:

```
ModuleNotFoundError: No module named 'n26'
```

The image is built from an explicit list of directories rather than the whole
tree. n26 was never added to that list, so the container had the edition in
`INSTALLED_APPS` and not on disk, and never got past `django.setup()`.

Nothing local could have caught it. Tests, migrations and the dev server all run
against the working tree, where n26 plainly exists. The Dockerfile is the only
place the file list is written down, and only a built image exercises it.

## The bit that isn't obvious

The `COPY` has to go **above** `uv sync`, not at the end of the file where it
would look more natural.

The editable install writes a finder module whose package mapping is computed
once, from the top-level directories present at install time. A directory copied
after the sync is absent from that mapping and stays unimportable however
present its files are — so the obvious-looking placement reproduces the same
error, with the files sitting right there in the image.

## Verified

Built the image and ran `manage check` inside it — the same `django.setup()`
path that failed in production.

## Not an outage

Cloud Run held traffic on the last healthy revision (`gyrinx-01466-2g7`), so the
site stayed up throughout. `gyrinx-01467-28d` never became ready. This unblocks
the deploy rather than repairing a live fault.
