### PR TITLE
fix: a site banner no longer takes the n26 edition down, and stores a meaning instead of a class

### DIFF
--- a/gyrinx/site/icons.py
+++ b/gyrinx/site/icons.py
@@ -1,0 +1,87 @@
+"""The site banner's icons, named once and drawn by each edition.
+
+The banner is platform-owned and shown by every edition, but the editions do
+not share an icon set: n23 draws Bootstrap Icons from a webfont, n26 draws the
+hand-kept SVG registry in ``n26/core/icons.py``. So the banner cannot store a
+drawing — it stores a *meaning*, and each edition resolves that meaning in its
+own set.
+
+Before this it stored a Bootstrap Icons class directly, in a free-text field.
+That was fine for as long as Bootstrap was the only consumer, and stopped being
+fine the moment n26 rendered the same row: a live banner set to
+``bi-blockquote-left`` reached n26's registry, which raises on a name it does
+not have, and took every page of the edition down. A key that both sides are
+guaranteed to understand removes the failure rather than translating around it.
+
+One table with both columns, rather than a key list here and a mapping in each
+edition, so that adding an icon is a single edit and cannot be half-done. The
+n26 column is *strings*, not imports — this module must never import from an
+edition package (see ``gyrinx/site/templatetags/platform_tags.py`` for the same
+rule and why). ``n26/tests/test_platform_integration.py`` checks the column
+against the real registry, so the two cannot drift in silence.
+
+Keys are meanings, not pictures: a banner author picks "News", not "a bell". If
+the drawing for news should change, it changes here and both editions follow.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BannerIcon:
+    """One meaning, and the drawing each edition uses for it."""
+
+    key: str
+    #: What the banner author sees in the select box.
+    label: str
+    #: A Bootstrap Icons class, for n23 and the platform's own templates.
+    bootstrap: str
+    #: A name in n26/core/icons.py.
+    n26: str
+
+
+#: Every icon a site banner may carry.
+#:
+#: Deliberately short, and semantic rather than decorative. A banner says one
+#: thing to everyone who loads the site; the useful distinctions are what kind
+#: of thing it is saying, and there are not many of those. A longer list would
+#: mostly be inviting authors to pick a picture, which is how a warning ends up
+#: wearing a star.
+BANNER_ICONS: tuple[BannerIcon, ...] = (
+    BannerIcon("info", "Information", "bi-info-circle", "information-circle"),
+    BannerIcon("success", "Success", "bi-check-circle", "check-circle"),
+    BannerIcon("warning", "Warning", "bi-exclamation-triangle", "exclamation-triangle"),
+    BannerIcon("news", "News", "bi-bell", "bell"),
+    BannerIcon("highlight", "Highlight", "bi-star", "star"),
+    BannerIcon("thanks", "Thanks", "bi-heart", "heart"),
+    BannerIcon("maintenance", "Maintenance", "bi-gear", "cog-6-tooth"),
+)
+
+_BY_KEY: dict[str, BannerIcon] = {icon.key: icon for icon in BANNER_ICONS}
+
+#: For the model field, which makes the admin render a select box. No blank row
+#: here — the field is blank=True, so Django adds the empty choice itself.
+CHOICES: list[tuple[str, str]] = [(icon.key, icon.label) for icon in BANNER_ICONS]
+
+
+def bootstrap_class(key: str) -> str:
+    """The Bootstrap Icons class for a key, or "" if there is none.
+
+    Total, like its n26 counterpart, and for the same reason: the value comes
+    out of a database column. A select box makes an unknown key unlikely, not
+    impossible — a row written before the choices existed, a key retired from
+    the table, a banner restored from history. None of those is worth a 500.
+    """
+    icon = _BY_KEY.get(key or "")
+    return icon.bootstrap if icon else ""
+
+
+def n26_name(key: str) -> str:
+    """The n26 registry name for a key, or "" if there is none.
+
+    Empty is a real answer, not a failure: it leaves the n26 announcement to
+    draw the icon its tone implies, which is the component's own decision and
+    a better one than anything this module could guess.
+    """
+    icon = _BY_KEY.get(key or "")
+    return icon.n26 if icon else ""

--- a/gyrinx/site/migrations/0004_banner_icon_keys.py
+++ b/gyrinx/site/migrations/0004_banner_icon_keys.py
@@ -1,0 +1,126 @@
+"""Banner.icon stops being a Bootstrap Icons class and becomes a meaning.
+
+The column used to hold free text that only Bootstrap could read, which is why
+a live banner set to ``bi-blockquote-left`` could take a whole edition down.
+It now holds one of the keys in ``gyrinx/site/icons.py``, and each edition
+resolves that key in its own icon set.
+
+The maps below are frozen copies rather than imports from that module. A
+migration has to keep meaning what it meant on the day it ran, and the table it
+was written against will keep changing after this.
+
+Historical rows are converted too. The field's vocabulary changed wholesale, so
+leaving history in the old one would show values in the history admin that mean
+nothing — and restoring a banner from history would write a key that is not a
+valid choice. This rewrites how a value is spelled, not what any banner said.
+"""
+
+from django.db import migrations, models
+
+import gyrinx.site.icons
+
+#: What each old Bootstrap class meant. Anything not listed — and the column was
+#: free text, so anything at all could be in there — becomes no icon, which is
+#: the one answer that is never wrong-looking.
+#:
+#: bi-blockquote-left is the value prod was actually running: a "we have news"
+#: banner about N26, wearing a quotation mark because the field offered no
+#: better option. It becomes news, which is what it was for.
+LEGACY_KEYS = {
+    "bi-info-circle": "info",
+    "bi-info-circle-fill": "info",
+    "bi-info-square": "info",
+    "bi-check-circle": "success",
+    "bi-check-circle-fill": "success",
+    "bi-check": "success",
+    "bi-check-lg": "success",
+    "bi-exclamation-triangle": "warning",
+    "bi-exclamation-triangle-fill": "warning",
+    "bi-exclamation-circle": "warning",
+    "bi-exclamation-octagon": "warning",
+    "bi-bell": "news",
+    "bi-bell-fill": "news",
+    "bi-megaphone": "news",
+    "bi-megaphone-fill": "news",
+    "bi-blockquote-left": "news",
+    "bi-newspaper": "news",
+    "bi-star": "highlight",
+    "bi-star-fill": "highlight",
+    "bi-stars": "highlight",
+    "bi-heart": "thanks",
+    "bi-heart-fill": "thanks",
+    "bi-gear": "maintenance",
+    "bi-gear-fill": "maintenance",
+    "bi-tools": "maintenance",
+    "bi-wrench": "maintenance",
+}
+
+#: For the way back, so this migration is reversible. Not the exact inverse:
+#: several old classes collapsed onto one key, and un-collapsing picks the
+#: representative the new table already names.
+BOOTSTRAP_BY_KEY = {
+    "info": "bi-info-circle",
+    "success": "bi-check-circle",
+    "warning": "bi-exclamation-triangle",
+    "news": "bi-bell",
+    "highlight": "bi-star",
+    "thanks": "bi-heart",
+    "maintenance": "bi-gear",
+}
+
+#: Both tables the field lives on: the banner and its simple-history mirror.
+TABLES = ("Banner", "HistoricalBanner")
+
+
+def _remap(apps, mapping, already_correct):
+    for name in TABLES:
+        model = apps.get_model("gyrinxsite", name)
+        for row in model.objects.exclude(icon="").iterator():
+            if row.icon in already_correct:
+                continue
+            row.icon = mapping.get(row.icon, "")
+            row.save(update_fields=["icon"])
+
+
+def to_keys(apps, schema_editor):
+    """Bootstrap classes become keys. Rows already holding a key are left be,
+    so a re-run cannot blank them."""
+    _remap(apps, LEGACY_KEYS, already_correct=set(BOOTSTRAP_BY_KEY))
+
+
+def to_bootstrap_classes(apps, schema_editor):
+    _remap(apps, BOOTSTRAP_BY_KEY, already_correct=set(LEGACY_KEYS))
+
+
+class Migration(migrations.Migration):
+    dependencies = [("gyrinxsite", "0003_changelog_entry")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="banner",
+            name="icon",
+            field=models.CharField(
+                blank=True,
+                choices=gyrinx.site.icons.CHOICES,
+                help_text=(
+                    "What kind of thing the banner is saying. Each edition "
+                    "draws it from its own icon set — see gyrinx/site/icons.py."
+                ),
+                max_length=50,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="historicalbanner",
+            name="icon",
+            field=models.CharField(
+                blank=True,
+                choices=gyrinx.site.icons.CHOICES,
+                help_text=(
+                    "What kind of thing the banner is saying. Each edition "
+                    "draws it from its own icon set — see gyrinx/site/icons.py."
+                ),
+                max_length=50,
+            ),
+        ),
+        migrations.RunPython(to_keys, to_bootstrap_classes),
+    ]

--- a/gyrinx/site/models.py
+++ b/gyrinx/site/models.py
@@ -16,6 +16,7 @@ from simple_history.models import HistoricalRecords
 
 from gyrinx.base_models import AppBase
 from gyrinx.history_aware_manager import HistoryAwareManager
+from gyrinx.site import icons as banner_icons
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,11 @@ class Banner(AppBase):
     icon = models.CharField(
         max_length=50,
         blank=True,
-        help_text="Bootstrap icon class (e.g., 'bi-info-circle')",
+        choices=banner_icons.CHOICES,
+        help_text=(
+            "What kind of thing the banner is saying. Each edition draws it "
+            "from its own icon set — see gyrinx/site/icons.py."
+        ),
     )
     colour = models.CharField(
         max_length=20,
@@ -72,6 +77,18 @@ class Banner(AppBase):
     def __str__(self):
         status = "LIVE" if self.is_live else "Draft"
         return f"[{status}] {self.text[:50]}..."
+
+    @property
+    def bootstrap_icon(self) -> str:
+        """The Bootstrap Icons class for this banner, or "" for no icon.
+
+        A property rather than a template filter because Bootstrap is the
+        platform's own stack, not an edition's: platform templates can ask the
+        model directly. n26 does not get an equivalent — it resolves the same
+        key through its own filter, so that this model never has to know an
+        edition's icon names.
+        """
+        return banner_icons.bootstrap_class(self.icon)
 
     def save(self, *args, **kwargs):
         # If this banner is being set to live, turn off all other live banners

--- a/gyrinx/templates/platform/includes/site_banner.html
+++ b/gyrinx/templates/platform/includes/site_banner.html
@@ -4,7 +4,12 @@
         <div class="container">
             <div class="alert alert-{{ banner.colour }} hstack gap-2 border-0 mb-0 py-2 px-0 alert-dismissible fade show align-middle align-items-center"
                  role="alert">
-                {% if banner.icon %}<i class="{{ banner.icon }}"></i>{% endif %}
+                {% comment %}
+                banner.icon is a meaning ("news"), not a class — bootstrap_icon
+                resolves it. Guard on the resolved class, not on banner.icon: a
+                key with no drawing must render nothing, not an empty <i>.
+                {% endcomment %}
+                {% if banner.bootstrap_icon %}<i class="{{ banner.bootstrap_icon }}"></i>{% endif %}
                 <div class="flex-grow-1 hstack gap-2 flex-wrap">
                     {{ banner.text }}
                     {% if banner.cta_url and banner.cta_text %}

--- a/gyrinx/tests/test_banner_icons.py
+++ b/gyrinx/tests/test_banner_icons.py
@@ -1,0 +1,116 @@
+"""The site banner's icon keys, and the way out of the old free-text field.
+
+Banner.icon used to hold a Bootstrap Icons class typed into a text box. That
+worked while Bootstrap was the only thing reading it and broke the moment a
+second edition rendered the same row — n26's icon registry raises on a name it
+does not have, so a banner set to bi-blockquote-left 500'd every page of that
+edition. The column now holds a meaning, and each edition draws it.
+
+The n26 half of the table is checked in n26/tests/test_platform_integration.py,
+which may import an edition package; this module may not.
+"""
+
+from importlib import import_module
+
+import pytest
+
+from gyrinx.site import icons as banner_icons
+from gyrinx.site.models import Banner
+
+MIGRATION = import_module("gyrinx.site.migrations.0004_banner_icon_keys")
+
+
+class TestTheTable:
+    def test_keys_are_unique(self):
+        keys = [entry.key for entry in banner_icons.BANNER_ICONS]
+        assert len(keys) == len(set(keys))
+
+    def test_every_key_names_a_bootstrap_class(self):
+        """The platform's own templates interpolate this straight into a
+        class attribute, so it has to look like one."""
+        wrong = [
+            entry.key
+            for entry in banner_icons.BANNER_ICONS
+            if not entry.bootstrap.startswith("bi-")
+        ]
+        assert not wrong
+
+    def test_choices_offer_every_key_and_nothing_else(self):
+        assert banner_icons.CHOICES == [
+            (entry.key, entry.label) for entry in banner_icons.BANNER_ICONS
+        ]
+
+    def test_there_is_no_blank_choice(self):
+        """The field is blank=True, so Django supplies the empty option
+        itself; a second one would show two ways to say no icon."""
+        assert "" not in dict(banner_icons.CHOICES)
+
+    @pytest.mark.parametrize("key", ["nonsense", "", None, "bi-info-circle"])
+    def test_the_lookups_are_total(self, key):
+        """Including a leftover Bootstrap class, which is exactly what a
+        row written before this change holds."""
+        assert banner_icons.bootstrap_class(key) == ""
+        assert banner_icons.n26_name(key) == ""
+
+    def test_a_known_key_resolves_in_both_sets(self):
+        assert banner_icons.bootstrap_class("warning") == "bi-exclamation-triangle"
+        assert banner_icons.n26_name("warning") == "exclamation-triangle"
+
+
+@pytest.mark.django_db
+class TestTheModel:
+    def test_the_property_resolves_the_key(self):
+        banner = Banner.objects.create(
+            text="Scheduled maintenance.", icon="maintenance"
+        )
+        assert banner.bootstrap_icon == "bi-gear"
+
+    def test_a_banner_with_no_icon_has_no_class(self):
+        """The platform template guards on this, so "" has to mean "draw
+        nothing" rather than "draw an empty <i>"."""
+        banner = Banner.objects.create(text="Quietly.", icon="")
+        assert banner.bootstrap_icon == ""
+
+    def test_the_admin_gets_a_select_box(self):
+        """The whole point of the change: choices on the field is what
+        makes the default widget a select rather than a text input."""
+        field = Banner._meta.get_field("icon")
+        assert field.choices
+        assert field.formfield().widget.__class__.__name__ == "Select"
+
+
+class TestTheLegacyMigration:
+    """The data migration's maps, tested directly. Tests run
+    --nomigrations, so the migration itself never executes here."""
+
+    def test_the_value_prod_was_running_becomes_news(self):
+        """bi-blockquote-left: a "we have news" banner wearing a
+        quotation mark, because the free-text field offered nothing
+        better. This is the row that took n26 down."""
+        assert MIGRATION.LEGACY_KEYS["bi-blockquote-left"] == "news"
+
+    def test_every_legacy_value_maps_to_a_real_key(self):
+        keys = {entry.key for entry in banner_icons.BANNER_ICONS}
+        unknown = {
+            source: target
+            for source, target in MIGRATION.LEGACY_KEYS.items()
+            if target not in keys
+        }
+        assert not unknown
+
+    def test_the_reverse_map_covers_every_key(self):
+        """Otherwise reversing the migration silently blanks whichever
+        key it forgot."""
+        keys = {entry.key for entry in banner_icons.BANNER_ICONS}
+        assert set(MIGRATION.BOOTSTRAP_BY_KEY) == keys
+
+    def test_the_reverse_map_agrees_with_the_table(self):
+        for entry in banner_icons.BANNER_ICONS:
+            assert MIGRATION.BOOTSTRAP_BY_KEY[entry.key] == entry.bootstrap
+
+    def test_going_back_and_forward_returns_the_same_key(self):
+        """Not every old class survives the round trip — several
+        collapsed onto one key — but every *key* must."""
+        for entry in banner_icons.BANNER_ICONS:
+            back = MIGRATION.BOOTSTRAP_BY_KEY[entry.key]
+            assert MIGRATION.LEGACY_KEYS[back] == entry.key

--- a/n26/core/icons.py
+++ b/n26/core/icons.py
@@ -171,64 +171,6 @@ LOCAL = frozenset({"pencil", "arrow-up-tray", "printer", "star"})
 # stroke_width means nothing on a solid icon and is ignored.
 SOLID = frozenset({"github", "discord"})
 
-# Bootstrap Icons names that mean the same thing as one of ours.
-#
-# The platform stores icon names as Bootstrap Icons classes — Banner.icon is
-# documented as one, and the n23 templates render it as `<i class="{{ icon }}">`
-# against a font this edition does not load. n26 draws from ICONS above, so a
-# name arriving from that vocabulary has to be translated or dropped; what it
-# must never do is reach paths() and raise, which is what took every n26 page
-# down when a live banner was set to bi-blockquote-left.
-#
-# Deliberately short. It covers what a site banner actually reaches for, and
-# everything else resolves to "" so the caller falls back to something sensible
-# of its own. Growing it to chase Bootstrap's ~2,000 icons would be pretending
-# to a correspondence that mostly does not exist.
-BOOTSTRAP_ALIASES: dict[str, str] = {
-    "bi-info-circle": "information-circle",
-    "bi-info-circle-fill": "information-circle",
-    "bi-exclamation-triangle": "exclamation-triangle",
-    "bi-exclamation-triangle-fill": "exclamation-triangle",
-    "bi-check-circle": "check-circle",
-    "bi-check-circle-fill": "check-circle",
-    "bi-check": "check",
-    "bi-bell": "bell",
-    "bi-bell-fill": "bell",
-    "bi-star": "star",
-    "bi-star-fill": "star",
-    "bi-heart": "heart",
-    "bi-heart-fill": "heart",
-    "bi-truck": "truck",
-    "bi-gear": "cog-6-tooth",
-    "bi-gear-fill": "cog-6-tooth",
-    "bi-search": "magnifying-glass",
-    "bi-pencil": "pencil",
-    "bi-printer": "printer",
-    "bi-github": "github",
-    "bi-discord": "discord",
-    "bi-arrow-right": "arrow-right",
-    "bi-plus": "plus",
-    "bi-dash": "minus",
-    "bi-x": "x-mark",
-    "bi-x-lg": "x-mark",
-}
-
-
-def from_bootstrap(name: str) -> str:
-    """Our name for a Bootstrap Icons name, or "" if we have no equivalent.
-
-    Never raises. This is the seam where data typed into the admin — rather
-    than a name written by whoever wrote the template — becomes an icon, and
-    a banner someone set to an icon we happen not to have should be a banner
-    without an icon, not a 500 on every page of the edition.
-
-    A name already in our own vocabulary passes through, so a caller need not
-    know which of the two it is holding.
-    """
-    if name in ICONS:
-        return name
-    return BOOTSTRAP_ALIASES.get(name, "")
-
 
 def paths(name: str) -> list[str]:
     """The subpaths for `name`, or a loud error naming what is available.

--- a/n26/core/icons.py
+++ b/n26/core/icons.py
@@ -171,6 +171,64 @@ LOCAL = frozenset({"pencil", "arrow-up-tray", "printer", "star"})
 # stroke_width means nothing on a solid icon and is ignored.
 SOLID = frozenset({"github", "discord"})
 
+# Bootstrap Icons names that mean the same thing as one of ours.
+#
+# The platform stores icon names as Bootstrap Icons classes — Banner.icon is
+# documented as one, and the n23 templates render it as `<i class="{{ icon }}">`
+# against a font this edition does not load. n26 draws from ICONS above, so a
+# name arriving from that vocabulary has to be translated or dropped; what it
+# must never do is reach paths() and raise, which is what took every n26 page
+# down when a live banner was set to bi-blockquote-left.
+#
+# Deliberately short. It covers what a site banner actually reaches for, and
+# everything else resolves to "" so the caller falls back to something sensible
+# of its own. Growing it to chase Bootstrap's ~2,000 icons would be pretending
+# to a correspondence that mostly does not exist.
+BOOTSTRAP_ALIASES: dict[str, str] = {
+    "bi-info-circle": "information-circle",
+    "bi-info-circle-fill": "information-circle",
+    "bi-exclamation-triangle": "exclamation-triangle",
+    "bi-exclamation-triangle-fill": "exclamation-triangle",
+    "bi-check-circle": "check-circle",
+    "bi-check-circle-fill": "check-circle",
+    "bi-check": "check",
+    "bi-bell": "bell",
+    "bi-bell-fill": "bell",
+    "bi-star": "star",
+    "bi-star-fill": "star",
+    "bi-heart": "heart",
+    "bi-heart-fill": "heart",
+    "bi-truck": "truck",
+    "bi-gear": "cog-6-tooth",
+    "bi-gear-fill": "cog-6-tooth",
+    "bi-search": "magnifying-glass",
+    "bi-pencil": "pencil",
+    "bi-printer": "printer",
+    "bi-github": "github",
+    "bi-discord": "discord",
+    "bi-arrow-right": "arrow-right",
+    "bi-plus": "plus",
+    "bi-dash": "minus",
+    "bi-x": "x-mark",
+    "bi-x-lg": "x-mark",
+}
+
+
+def from_bootstrap(name: str) -> str:
+    """Our name for a Bootstrap Icons name, or "" if we have no equivalent.
+
+    Never raises. This is the seam where data typed into the admin — rather
+    than a name written by whoever wrote the template — becomes an icon, and
+    a banner someone set to an icon we happen not to have should be a banner
+    without an icon, not a 500 on every page of the edition.
+
+    A name already in our own vocabulary passes through, so a caller need not
+    know which of the two it is holding.
+    """
+    if name in ICONS:
+        return name
+    return BOOTSTRAP_ALIASES.get(name, "")
+
 
 def paths(name: str) -> list[str]:
     """The subpaths for `name`, or a loud error naming what is available.

--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load banner %}
 {% comment %}
 The n26 page shell. Block names and order match the platform base template
 (head_title, stylesheet, body, content, extra_body, extra_script) so templates
@@ -95,9 +96,17 @@ banner, is_impersonating / impersonator, gtm_container_id, messages, user.
            class="sr-only focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-50 focus:rounded-control focus:bg-accent focus:px-3 focus:py-2 focus:text-accent-foreground">
             Skip to main content
         </a>
+        {% comment %}
+        Both attributes go through a filter because Banner is platform-owned and
+        speaks Bootstrap: its icon is a Bootstrap Icons class and its colour a
+        Bootstrap contextual colour, neither of which this edition has. See
+        core/templatetags/banner.py — passing banner.icon straight to the icon
+        component 500s the whole edition the moment someone sets a banner to an
+        icon n26 does not draw.
+        {% endcomment %}
         {% if banner %}
-            <c-n26.site.announcement tone="{{ banner.colour|default:'info' }}"
-                                     icon="{{ banner.icon }}"
+            <c-n26.site.announcement tone="{{ banner.colour|banner_tone }}"
+                                     icon="{{ banner.icon|banner_icon }}"
                                      cta_text="{{ banner.cta_text }}"
                                      cta_url="{{ banner.cta_url }}"
                                      id="site-banner-{{ banner.id }}">

--- a/n26/core/templatetags/banner.py
+++ b/n26/core/templatetags/banner.py
@@ -1,24 +1,25 @@
-"""The site banner, translated from the platform's vocabulary into ours.
+"""The site banner, resolved into this edition's terms.
 
-`Banner` is platform-owned and older than this edition: it stores its icon as
-a Bootstrap Icons class and its colour as a Bootstrap contextual colour, both
-of which the n23 templates hand straight to Bootstrap. n26 has neither — its
-icons are the hand-kept set in core/icons.py and its announcement takes one of
-five tones — so the two attributes have to be translated on the way in.
+`Banner` is platform-owned and shown by every edition, so it stores neither a
+drawing nor a colour but a pair of keys: an icon meaning ("news") and a
+Bootstrap contextual colour. The first is edition-neutral by design and each
+edition looks it up in its own set; the second is Bootstrap's vocabulary, which
+n26 does not share, so it is mapped onto the announcement's five tones.
 
-Doing it here rather than in the template keeps the mapping somewhere it can be
-read and tested, and keeps the shell to one filter per attribute.
+Doing both here rather than in the template keeps the mappings somewhere they
+can be read and tested, and keeps the shell to one filter per attribute.
 
-Both filters are total: any value at all, including the ones nobody has typed
-yet, resolves to something the components accept. That is the point of them. A
-live banner set to an icon this edition does not have took every n26 page down
-with a KeyError, because the icon component raises on an unknown name — which
-is right for a name a template author wrote, and wrong for one an admin typed.
+Both filters are total. Any value at all — including a key written before the
+choices existed, or one retired from the table since — resolves to something
+the components accept. That matters because <c-n26.icon> raises on a name it
+does not have, which is right for a name a template author wrote and fatal for
+one that arrived from a database column: it once took every page of the
+edition down at once.
 """
 
 from django import template
 
-from n26.core import icons
+from gyrinx.site import icons as banner_icons
 
 register = template.Library()
 
@@ -48,11 +49,12 @@ def banner_tone(colour):
 
 
 @register.filter
-def banner_icon(name):
-    """The icon name for a banner's Bootstrap icon class.
+def banner_icon(key):
+    """This edition's icon name for a banner's icon key.
 
-    Empty when there is no equivalent, which leaves <c-n26.site.announcement>
-    to draw the icon its tone implies — a better answer than no icon at all,
-    since the bar's colour and its icon are meant to say the same thing.
+    Empty when the key has no drawing here, which leaves
+    <c-n26.site.announcement> to draw the icon its tone implies — a better
+    answer than no icon at all, since the bar's colour and its icon are meant
+    to say the same thing.
     """
-    return icons.from_bootstrap(name or "")
+    return banner_icons.n26_name(key or "")

--- a/n26/core/templatetags/banner.py
+++ b/n26/core/templatetags/banner.py
@@ -1,0 +1,58 @@
+"""The site banner, translated from the platform's vocabulary into ours.
+
+`Banner` is platform-owned and older than this edition: it stores its icon as
+a Bootstrap Icons class and its colour as a Bootstrap contextual colour, both
+of which the n23 templates hand straight to Bootstrap. n26 has neither — its
+icons are the hand-kept set in core/icons.py and its announcement takes one of
+five tones — so the two attributes have to be translated on the way in.
+
+Doing it here rather than in the template keeps the mapping somewhere it can be
+read and tested, and keeps the shell to one filter per attribute.
+
+Both filters are total: any value at all, including the ones nobody has typed
+yet, resolves to something the components accept. That is the point of them. A
+live banner set to an icon this edition does not have took every n26 page down
+with a KeyError, because the icon component raises on an unknown name — which
+is right for a name a template author wrote, and wrong for one an admin typed.
+"""
+
+from django import template
+
+from n26.core import icons
+
+register = template.Library()
+
+#: Bootstrap's contextual colours against the announcement's five tones.
+#:
+#: The four that carry the same meaning in both map across; the rest are
+#: degrees of "no particular meaning" and become the tone that says so.
+#: primary is the exception — it is Bootstrap's "this is the important one"
+#: rather than a sentiment, and a site banner using it wants the informational
+#: blue, which is what info already is.
+TONES: dict[str, str] = {
+    "primary": "info",
+    "secondary": "neutral",
+    "success": "success",
+    "danger": "danger",
+    "warning": "warning",
+    "info": "info",
+    "light": "neutral",
+    "dark": "neutral",
+}
+
+
+@register.filter
+def banner_tone(colour):
+    """The announcement tone for a banner's Bootstrap colour."""
+    return TONES.get(colour or "", "info")
+
+
+@register.filter
+def banner_icon(name):
+    """The icon name for a banner's Bootstrap icon class.
+
+    Empty when there is no equivalent, which leaves <c-n26.site.announcement>
+    to draw the icon its tone implies — a better answer than no icon at all,
+    since the bar's colour and its icon are meant to say the same thing.
+    """
+    return icons.from_bootstrap(name or "")

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -122,11 +122,11 @@ class TestTheDashboard:
 class TestTheSiteBanner:
     """The platform's banner, drawn in this edition's terms.
 
-    Banner is older than n26 and stores Bootstrap: a Bootstrap Icons
-    class and a Bootstrap contextual colour. n26 has neither vocabulary,
-    so the shell translates both — and the translation has to be total,
-    because the values come from a text field in the admin rather than
-    from anything a template author wrote.
+    Banner is platform-owned and shown by every edition, so it stores an
+    icon *meaning* rather than a drawing, and each edition resolves that
+    meaning in its own set. The colour is still Bootstrap's vocabulary,
+    which n26 does not share, so the shell maps it onto the
+    announcement's five tones.
     """
 
     @pytest.fixture
@@ -140,14 +140,33 @@ class TestTheSiteBanner:
 
         return make
 
-    def test_an_icon_this_edition_does_not_have_is_dropped_not_fatal(
+    def test_a_key_is_drawn_from_this_editions_own_set(
         self, tester, client, default_pack, live_banner
     ):
-        """The regression: a live banner set to bi-blockquote-left took
-        down every page under /n26/ with a KeyError out of the icon
-        registry, because the icon component raises on an unknown name.
-        Raising is right for a name in a template and wrong for one an
-        admin typed, so the shell now resolves it before it gets there.
+        """info's default icon is information-circle, so asking for
+        success against an info bar proves the key was resolved rather
+        than the tone's fallback being used."""
+        from n26.core import icons
+
+        live_banner(icon="success", colour="info")
+
+        body = client.get("/n26/").content.decode()
+        assert icons.ICONS["check-circle"][0] in body
+        assert icons.ICONS["information-circle"][0] not in body
+
+    def test_a_key_with_no_drawing_here_is_not_fatal(
+        self, tester, client, default_pack, live_banner
+    ):
+        """The regression that started this. A live banner set to
+        bi-blockquote-left took every page under /n26/ down with a
+        KeyError out of the icon registry, which raises on a name it
+        does not have — right for a name a template author wrote, fatal
+        for one that arrived from a database column.
+
+        The select box makes such a value unlikely rather than
+        impossible: a row written before the choices existed, a key
+        retired from the table, a banner restored from history. None of
+        those is worth a 500, so the lookup stays total.
         """
         live_banner(icon="bi-blockquote-left", colour="primary")
 
@@ -155,7 +174,7 @@ class TestTheSiteBanner:
         assert response.status_code == 200
         assert "N26 support is coming." in response.content.decode()
 
-    def test_a_dropped_icon_leaves_the_one_the_tone_implies(
+    def test_an_unresolved_key_leaves_the_icon_the_tone_implies(
         self, tester, client, default_pack, live_banner
     ):
         """Not "no icon": the bar's colour and its icon say the same
@@ -163,24 +182,10 @@ class TestTheSiteBanner:
         """
         from n26.core import icons
 
-        live_banner(icon="bi-blockquote-left", colour="danger")
+        live_banner(icon="nonsense", colour="danger")
 
         body = client.get("/n26/").content.decode()
         assert icons.ICONS["exclamation-triangle"][0] in body
-
-    def test_an_icon_with_an_equivalent_is_translated(
-        self, tester, client, default_pack, live_banner
-    ):
-        """Where the two sets do agree, the author's choice survives —
-        info's default is information-circle, so a check proves the
-        alias ran rather than the fallback."""
-        from n26.core import icons
-
-        live_banner(icon="bi-check-circle", colour="info")
-
-        body = client.get("/n26/").content.decode()
-        assert icons.ICONS["check-circle"][0] in body
-        assert icons.ICONS["information-circle"][0] not in body
 
     def test_a_bootstrap_colour_becomes_an_announcement_tone(
         self, tester, client, default_pack, live_banner
@@ -204,32 +209,28 @@ class TestTheSiteBanner:
         assert 'data-tone="info"' in body
 
 
-class TestTheBootstrapIconAliases:
-    def test_every_alias_points_at_an_icon_that_exists(self):
-        """The table is only useful while its targets are real, and a
-        rename in the registry would otherwise turn one into a 500 on
-        whichever page uses it."""
+class TestTheSharedIconKeys:
+    """gyrinx/site/icons.py names an n26 icon for every key, as a string,
+    because the platform may not import an edition package. Nothing but
+    this test keeps that column honest."""
+
+    def test_every_key_names_an_icon_this_edition_actually_has(self):
+        from gyrinx.site import icons as banner_icons
         from n26.core import icons
 
         missing = {
-            source: target
-            for source, target in icons.BOOTSTRAP_ALIASES.items()
-            if target not in icons.ICONS
+            entry.key: entry.n26
+            for entry in banner_icons.BANNER_ICONS
+            if entry.n26 not in icons.ICONS
         }
         assert not missing
 
-    def test_an_unknown_name_resolves_to_nothing_rather_than_raising(self):
-        from n26.core import icons
+    def test_the_lookup_is_total(self):
+        from gyrinx.site import icons as banner_icons
 
-        assert icons.from_bootstrap("bi-blockquote-left") == ""
-        assert icons.from_bootstrap("") == ""
-        assert icons.from_bootstrap("not an icon at all") == ""
-
-    def test_our_own_names_pass_straight_through(self):
-        """So a caller need not know which vocabulary it is holding."""
-        from n26.core import icons
-
-        assert icons.from_bootstrap("check-circle") == "check-circle"
+        assert banner_icons.n26_name("nonsense") == ""
+        assert banner_icons.n26_name("") == ""
+        assert banner_icons.n26_name(None) == ""
 
 
 class TestFoundingAGang:

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -119,6 +119,119 @@ class TestTheDashboard:
         assert "fine" in body
 
 
+class TestTheSiteBanner:
+    """The platform's banner, drawn in this edition's terms.
+
+    Banner is older than n26 and stores Bootstrap: a Bootstrap Icons
+    class and a Bootstrap contextual colour. n26 has neither vocabulary,
+    so the shell translates both — and the translation has to be total,
+    because the values come from a text field in the admin rather than
+    from anything a template author wrote.
+    """
+
+    @pytest.fixture
+    def live_banner(self):
+        from gyrinx.site.models import Banner
+
+        def make(**kwargs):
+            return Banner.objects.create(
+                text="N26 support is coming.", is_live=True, **kwargs
+            )
+
+        return make
+
+    def test_an_icon_this_edition_does_not_have_is_dropped_not_fatal(
+        self, tester, client, default_pack, live_banner
+    ):
+        """The regression: a live banner set to bi-blockquote-left took
+        down every page under /n26/ with a KeyError out of the icon
+        registry, because the icon component raises on an unknown name.
+        Raising is right for a name in a template and wrong for one an
+        admin typed, so the shell now resolves it before it gets there.
+        """
+        live_banner(icon="bi-blockquote-left", colour="primary")
+
+        response = client.get("/n26/")
+        assert response.status_code == 200
+        assert "N26 support is coming." in response.content.decode()
+
+    def test_a_dropped_icon_leaves_the_one_the_tone_implies(
+        self, tester, client, default_pack, live_banner
+    ):
+        """Not "no icon": the bar's colour and its icon say the same
+        thing, and a coloured bar with nothing in it reads as a mistake.
+        """
+        from n26.core import icons
+
+        live_banner(icon="bi-blockquote-left", colour="danger")
+
+        body = client.get("/n26/").content.decode()
+        assert icons.ICONS["exclamation-triangle"][0] in body
+
+    def test_an_icon_with_an_equivalent_is_translated(
+        self, tester, client, default_pack, live_banner
+    ):
+        """Where the two sets do agree, the author's choice survives —
+        info's default is information-circle, so a check proves the
+        alias ran rather than the fallback."""
+        from n26.core import icons
+
+        live_banner(icon="bi-check-circle", colour="info")
+
+        body = client.get("/n26/").content.decode()
+        assert icons.ICONS["check-circle"][0] in body
+        assert icons.ICONS["information-circle"][0] not in body
+
+    def test_a_bootstrap_colour_becomes_an_announcement_tone(
+        self, tester, client, default_pack, live_banner
+    ):
+        """primary is not one of the five tones. Left untranslated it
+        rendered data-tone="primary", which no rule matches, so the bar
+        silently kept the default blue — right by luck, and wrong the
+        moment the colour was secondary or dark."""
+        live_banner(colour="primary")
+
+        body = client.get("/n26/").content.decode()
+        assert 'data-tone="info"' in body
+        assert 'data-tone="primary"' not in body
+
+    def test_a_colourless_banner_still_gets_a_tone(
+        self, tester, client, default_pack, live_banner
+    ):
+        live_banner(colour="")
+
+        body = client.get("/n26/").content.decode()
+        assert 'data-tone="info"' in body
+
+
+class TestTheBootstrapIconAliases:
+    def test_every_alias_points_at_an_icon_that_exists(self):
+        """The table is only useful while its targets are real, and a
+        rename in the registry would otherwise turn one into a 500 on
+        whichever page uses it."""
+        from n26.core import icons
+
+        missing = {
+            source: target
+            for source, target in icons.BOOTSTRAP_ALIASES.items()
+            if target not in icons.ICONS
+        }
+        assert not missing
+
+    def test_an_unknown_name_resolves_to_nothing_rather_than_raising(self):
+        from n26.core import icons
+
+        assert icons.from_bootstrap("bi-blockquote-left") == ""
+        assert icons.from_bootstrap("") == ""
+        assert icons.from_bootstrap("not an icon at all") == ""
+
+    def test_our_own_names_pass_straight_through(self):
+        """So a caller need not know which vocabulary it is holding."""
+        from n26.core import icons
+
+        assert icons.from_bootstrap("check-circle") == "check-circle"
+
+
 class TestFoundingAGang:
     def test_the_form_page_renders_from_the_design_system(
         self, tester, client, default_pack, gang_type


### PR DESCRIPTION
## What's wrong

Every page under `/n26/` is currently a 500 in production.

The site banner is platform-owned and predates n26. It stored its icon as a Bootstrap Icons class in a free-text field (`Banner.icon`, help text: *"Bootstrap icon class (e.g. 'bi-info-circle')"*). That was fine while Bootstrap was the only thing reading it, and stopped being fine the moment a second edition rendered the same row.

`<c-n26.icon>` deliberately raises `KeyError` on a name it doesn't have — the right call for a name a template author wrote, the wrong one for a name an admin typed into a text box. The live production banner is set to `bi-blockquote-left`, so the n26 shell took the whole edition down:

```
KeyError: "no icon 'bi-blockquote-left'; available: arrow-right, arrow-top-right-on-square, …"
```

The colour had the same shape of bug, quieter. `primary` is not one of the n26 announcement's five tones, so it rendered `data-tone="primary"`, matched no CSS rule, and kept the default blue by luck. `secondary`, `light` and `dark` would have been visibly wrong.

Nothing to do with the recent CSS/Tailwind work — the stylesheet builds fine.

## The fix

Two commits. The first stops the bleeding by translating Bootstrap names at the n26 shell. The second removes the premise that caused it: **the banner now stores what it means, not which icon to draw.**

`Banner.icon` is a key, and each edition resolves it in its own set:

| Key | Label | n23 (Bootstrap) | n26 (SVG registry) |
|---|---|---|---|
| `info` | Information | `bi-info-circle` | `information-circle` |
| `success` | Success | `bi-check-circle` | `check-circle` |
| `warning` | Warning | `bi-exclamation-triangle` | `exclamation-triangle` |
| `news` | News | `bi-bell` | `bell` |
| `highlight` | Highlight | `bi-star` | `star` |
| `thanks` | Thanks | `bi-heart` | `heart` |
| `maintenance` | Maintenance | `bi-gear` | `cog-6-tooth` |

`choices` on the field makes the admin a select box, so an author picks a meaning and can no longer type a class only one edition can read.

One table (`gyrinx/site/icons.py`) holds both columns, rather than a key list in the platform and a mapping in each edition — adding an icon is a single edit that can't be half-done. The platform may not import an edition package (see `platform_tags.py`), so the n26 column is strings; a test in the n26 suite checks it against the real registry, which is the only thing stopping the two drifting.

Keys are meanings rather than pictures. A longer list would mostly invite authors to pick a drawing, which is how a warning ends up wearing a star.

`<c-n26.icon>` keeps raising, and both lookups stay total. A select makes an unknown key unlikely, not impossible — a row written before the choices existed, a key retired later, a banner restored from history — and none of those is worth a 500.

## Migration

`gyrinxsite.0004` converts the old classes, historical rows included: the vocabulary changed wholesale, so leaving history in the old one would show values that mean nothing and let a restore write an invalid choice. Prod's `bi-blockquote-left` becomes `news`, which is what that banner was for.

The maps are frozen copies rather than imports — a migration has to keep meaning what it meant on the day it ran. It's reversible, and I ran it forwards, backwards and forwards again against a local copy of the production row.

## Testing

Full suite green: 5439 passed, 12 skipped. Reverting just the first commit's template change makes four of the banner tests fail with the exact production `KeyError`.

Verified in the browser end to end: the admin now shows a select, the migrated row reads "News", and setting it to "Highlight" draws a star in **both** editions from the same key — n23 via the Bootstrap webfont, n26 via its SVG registry.

## One thing to decide

A blank icon means "no icon" in n23 (the template guards on the resolved class) but "the icon the tone implies" in n26, because the announcement component treats colour and icon as one decision. Defensible either way, and it's your call about your own design system — say the word and I'll make blank mean no icon everywhere.

Also noticed but not fixed: the platform routes banner CTA clicks through `core:track-banner-click`, while the n26 shell links `cta_url` directly, so clicks from n26 pages aren't counted. Happy to file it.