### PR TITLE
feat: the n26 gang screen, hooked up — sheet, hire, equip

### DIFF
--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -51,3 +51,21 @@ class CreateGangForm(forms.Form):
         """``(value, label)`` pairs for the view component's select —
         the same rows the field validates against, said once."""
         return [(str(row.pk), str(row)) for row in self.fields["gang_type"].queryset]
+
+
+class HireFighterForm(forms.Form):
+    """The one real field on the hire screen.
+
+    Which profile — and which of its options — is not a field here: every
+    Hire button in the picker is the form's submit, carrying the profile,
+    and the option inputs are scoped per-row by the picker itself. The
+    view reads those directly, because their names are composed from the
+    rows on the page rather than declared anywhere a Form could know.
+    """
+
+    name = forms.CharField(
+        max_length=200,
+        required=False,
+        label="Name",
+        help_text="Optional — you can name them later.",
+    )

--- a/n26/core/hire.py
+++ b/n26/core/hire.py
@@ -183,6 +183,47 @@ def build_hire_list(gang_type):
     return [build_hire_entry(profile, index=index) for profile in profiles]
 
 
+def shelve_hire_list(entries):
+    """The hire list in sections of categories — the picker's shape.
+
+    Groups by each profile's home category (``Section`` heading, then
+    ``Category`` inside it), taxonomy order — the same derivation
+    ``browse._sectioned`` does for collections. Profiles without a home
+    gather at the end under empty headings: a content gap to show, not
+    an error to hide.
+    """
+
+    def order(entry):
+        category = entry.profile.category
+        # Section, then category, then the entry — each level fully keyed,
+        # so a category's entries stay contiguous and the grouping below
+        # can work on runs.
+        if category is None:
+            return (1, 0, "", 0, "", entry.base_price, entry.name)
+        return (
+            0,
+            category.section.position,
+            category.section.name.lower(),
+            category.position,
+            category.name.lower(),
+            entry.base_price,
+            entry.name,
+        )
+
+    section_rows = []
+    for entry in sorted(entries, key=order):
+        category = entry.profile.category
+        section_name = category.section.name if category else ""
+        category_name = category.name if category else ""
+        if not section_rows or section_rows[-1]["name"] != section_name:
+            section_rows.append({"name": section_name, "categories": []})
+        categories = section_rows[-1]["categories"]
+        if not categories or categories[-1]["name"] != category_name:
+            categories.append({"name": category_name, "entries": []})
+        categories[-1]["entries"].append(entry)
+    return section_rows
+
+
 def hireable_profiles(gang_type):
     """The profiles of a gang type, with everything a preview card needs."""
     from n26.library.models import Profile
@@ -197,7 +238,9 @@ def hireable_profiles(gang_type):
     )
     return (
         Profile.objects.filter(gang_type=gang_type)
-        .select_related("profile_type", "built_ins")
+        # category__section rides along for the shelving — without it,
+        # grouping a listing costs two queries per profile.
+        .select_related("profile_type", "built_ins", "category__section")
         .prefetch_related(
             "statline__stats__statline_type_stat__stat",
             *(f"built_ins__{path}" for path in members),

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -204,6 +204,12 @@ class ModelCard:
     name: str
     rating: int
     statline: Statline
+    #: The miniature's pk, as a string, when this card draws a *stored*
+    #: model — what a renderer builds links from (Equip, Delete). Empty on
+    #: a hire preview or a gallery sample, which depict nobody: a card is
+    #: the same structure either way, and "" is how it says "nowhere to
+    #: link to".
+    id: str = ""
     #: The library entry it was hired from — "Escher Gang Queen". Shared
     #: content: many models across many gangs point at this one row.
     #: Blank when there is no profile to name, which a header draws as
@@ -385,6 +391,7 @@ def build_model_card(miniature, card=None, computed=None, assignment_set=None):
         card,
         computed=computed,
         name=miniature.name,
+        id=str(miniature.pk),
         owned_by=(miniature.owned_by.name if miniature.owned_by else None),
         xp=miniature.xp,
         xp_target=miniature.xp_target,
@@ -392,7 +399,7 @@ def build_model_card(miniature, card=None, computed=None, assignment_set=None):
 
 
 def card_to_model_card(
-    card, computed=None, *, name, owned_by=None, xp=0, xp_target=None
+    card, computed=None, *, name, id="", owned_by=None, xp=0, xp_target=None
 ):
     """Turn a card into the structure a renderer draws.
 
@@ -573,6 +580,7 @@ def card_to_model_card(
 
     return ModelCard(
         name=name,
+        id=id,
         rating=card.full_rating,
         # ``str`` rather than ``.name``: every other line on a card
         # reads a thing this way, so an annotation shows here as it

--- a/n26/core/templates/cotton/n26/view/gang_sheet.html
+++ b/n26/core/templates/cotton/n26/view/gang_sheet.html
@@ -138,8 +138,12 @@ row, which is what makes an eleven-fighter gang read as a wall.
     a phone. A row of actions that scrolls sideways hides the destructive one behind
     an edge, which is the wrong thing to hide behind an edge — better it wraps and
     the page gets a line taller.
+
+    Right-aligned, matching where the page keeps its other figures: the wealth
+    strip sits at the header's far end, and the buttons line up under it rather
+    than hanging off the title's edge with the width of the page between them.
     {% endcomment %}
-    <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+    <div class="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
         <div class="flex flex-wrap items-center gap-2">
             {{ actions }}
         </div>

--- a/n26/core/templates/n26/dashboard.html
+++ b/n26/core/templates/n26/dashboard.html
@@ -31,7 +31,7 @@ you type, which is all a list this size needs.
                     <c-n26.gang-table.row name="{{ gang.name }}"
                                           type="{{ gang.gang_type }}"
                                           :sheet="gang"
-                                          href="#" />
+                                          href="{% url 'n26-gang' gang.pk %}" />
                 {% endfor %}
             </c-n26.gang-table>
         </c-slot>

--- a/n26/core/templates/n26/equip.html
+++ b/n26/core/templates/n26/equip.html
@@ -65,7 +65,7 @@ TP-priced or exclusive lines to filter.
                                       :nested="True"
                                       model="query"
                                       placeholder="Search {{ chosen }}" />
-                    {% if category_options or cost_ceiling > cost_floor or has_trade_points %}
+                    {% if category_options or cost_ceiling > cost_floor or has_trade_points or has_exclusive %}
                         <div class="flex flex-wrap items-center gap-2">
                             {% if category_options %}
                                 <c-n26.filter-menu label="Category" name="category" :options="category_options" />
@@ -89,6 +89,15 @@ TP-priced or exclusive lines to filter.
                                                   prefix="≤ "
                                                   at_min_label="Freely available"
                                                   at_max_label="Any" />
+                            {% endif %}
+                            {% comment %}
+                            Gated on its own flag, not on has_trade_points: an
+                            exclusive line has trade_points=None ("E" answers
+                            no numeric question), so an exclusive-only list
+                            has TP nothing to slide — and this toggle is the
+                            only way to filter what it does have.
+                            {% endcomment %}
+                            {% if has_exclusive %}
                                 <c-n26.toggle label="Exclusive"
                                               :checked="True"
                                               @change="includeExclusive = $event.target.checked" />

--- a/n26/core/templates/n26/equip.html
+++ b/n26/core/templates/n26/equip.html
@@ -1,0 +1,129 @@
+{% extends "n26/layouts/base.html" %}
+{% comment %}
+Buying equipment for one fighter — the design system's collection picker over a
+real browse. The gallery's shell twin is designsystem/shell/shop.html; edit
+them together.
+
+Which list is being browsed is URL state (?list=<pk>), so a particular list is
+linkable and the back button walks the choices. The Buy buttons submit the
+line's identity and nothing else; every price is the server's own derivation.
+
+Trade Points are drawn where a line has them, but nothing charges them yet —
+that needs a TP budget, which is a session concept the edition has not built.
+The Exclusive toggle and TP slider only appear when the list actually has
+TP-priced or exclusive lines to filter.
+{% endcomment %}
+{% block head_title %}Equip {{ miniature.name }}{% endblock head_title %}
+{% block nav_heading %}Equip {{ miniature.name }}{% endblock nav_heading %}
+{% block nav_items %}
+    {% include 'n26/_nav.html' %}
+{% endblock %}
+{% block content %}
+    <c-n26.page-header title="Equip {{ miniature.name }}"
+                       lead="Buying for {{ gang.name }} — what you buy lands on this fighter's card.">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item>
+                    <c-n26.flair-link text="{{ gang.owner.username }}"
+                                      tone="current"
+                                      href="{% url 'n26-dashboard' %}" />
+                </c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{% url 'n26-gang' gang.pk %}">{{ gang.name }}</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    Equip
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    {% comment %}
+    Which list. Links, not client state: a list is a place you can be, so it
+    goes in the URL — linkable, back-button-friendly, and the server renders
+    the one you are on. One list draws no chooser; there is nothing to choose.
+    {% endcomment %}
+    {% if collections|length > 1 %}
+        <div class="mt-6 flex flex-wrap items-center gap-2">
+            {% for collection in collections %}
+                <c-ui.button size="sm"
+                             variant="{% if collection.pk == chosen.pk %}primary{% else %}default{% endif %}"
+                             href="?list={{ collection.pk }}">{{ collection }}</c-ui.button>
+            {% endfor %}
+        </div>
+    {% endif %}
+    {% if chosen %}
+        <form method="post"
+              action="{% url 'n26-equip' miniature.pk %}?list={{ chosen.pk }}">
+            {% csrf_token %}
+            <c-n26.collection-picker class="mt-6"
+                                     :categories="categories"
+                                     :sections="sections"
+                                     cost_floor="{{ cost_floor }}"
+                                     cost_ceiling="{{ cost_ceiling }}"
+                                     tp_ceiling="{{ tp_ceiling }}"
+                                     noun="items">
+                <c-slot name="filters">
+                    <c-n26.search-bar :live="True"
+                                      :nested="True"
+                                      model="query"
+                                      placeholder="Search {{ chosen }}" />
+                    {% if category_options or cost_ceiling > cost_floor or has_trade_points %}
+                        <div class="flex flex-wrap items-center gap-2">
+                            {% if category_options %}
+                                <c-n26.filter-menu label="Category" name="category" :options="category_options" />
+                            {% endif %}
+                            {% if cost_ceiling > cost_floor %}
+                                <c-n26.range-menu label="Price"
+                                                  model_min="minCost"
+                                                  model_max="maxCost"
+                                                  min="{{ cost_floor }}"
+                                                  max="{{ cost_ceiling }}"
+                                                  step="5"
+                                                  suffix="¢"
+                                                  at_max_label="Any" />
+                            {% endif %}
+                            {% if has_trade_points %}
+                                <c-n26.range-menu label="Trade points"
+                                                  model="maxTradePoints"
+                                                  min="0"
+                                                  max="{{ tp_ceiling }}"
+                                                  step="1"
+                                                  prefix="≤ "
+                                                  at_min_label="Freely available"
+                                                  at_max_label="Any" />
+                                <c-n26.toggle label="Exclusive"
+                                              :checked="True"
+                                              @change="includeExclusive = $event.target.checked" />
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                </c-slot>
+                {% for section_row in section_rows %}
+                    <c-n26.collection-picker.section name="{{ section_row.name }}" :open="section_row.first">
+                        {% for category in section_row.categories %}
+                            {% if category.name %}
+                                <c-n26.collection-picker.category name="{{ category.name }}">
+                                    {% for row in category.lines %}
+                                        {% include "n26/includes/equip_line.html" %}
+                                    {% endfor %}
+                                </c-n26.collection-picker.category>
+                            {% else %}
+                                {% comment %}
+                                Unnamed home: rows sit straight inside the
+                                section, the same convention as the hire page.
+                                {% endcomment %}
+                                {% for row in category.lines %}
+                                    {% include "n26/includes/equip_line.html" %}
+                                {% endfor %}
+                            {% endif %}
+                        {% endfor %}
+                    </c-n26.collection-picker.section>
+                {% endfor %}
+            </c-n26.collection-picker>
+        </form>
+    {% else %}
+        <p class="mt-6 text-muted">
+            No equipment lists yet — this fighter has nothing to browse. Lists
+            arrive with the gang's own content, or from the library's Trading
+            Post once it is sown.
+        </p>
+    {% endif %}
+{% endblock content %}

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -1,0 +1,131 @@
+{% extends "n26/layouts/base.html" %}
+{% comment %}
+A gang, whole — the design system's sheet over real rows.
+
+The gallery's shell version (designsystem/shell/gang.html) is this page with
+sample data, the same relationship shell/home.html has to n26/dashboard.html.
+What was judged there is what ships here, so the two should be edited together.
+
+  --- what is not wired yet ---
+
+Hire, Equip, Print, Cards and Delete have no routes. They are drawn anyway, at
+"#", so the screen keeps the shape the library settled on and the gaps are
+visible rather than quietly designed around. Each becomes a url tag as its
+feature lands.
+
+The gang's choices and counters are shown as settled facts. The library's row
+can open a picker that writes, and that picker does not exist — a Save button
+that saves nothing is worse than a value with no affordance at all.
+{% endcomment %}
+{% block head_title %}{{ sheet.name }}{% endblock head_title %}
+{% block nav_items %}
+    {% include 'n26/_nav.html' %}
+{% endblock %}
+{% block content %}
+    <c-n26.view.gang-sheet :sheet="sheet"
+                           owner="{{ gang.owner.username }}"
+                           owner_href="{% url 'n26-dashboard' %}"
+                           owner_flair_label="{% if gang.owner.is_staff %}Gyrinx staff{% endif %}"
+                           gangs_href="{% url 'n26-dashboard' %}">
+        {% comment %}
+        The staff badge is a fact about the owner, so it is drawn from the owner
+        rather than always. No type_flair: the only house artwork in the set is
+        Goliath's, and hanging it on an Escher gang would be a badge that lies.
+        The type still reads as text — flair-link draws the name with no badge.
+        {% endcomment %}
+        {% if gang.owner.is_staff %}
+            <c-slot name="owner_flair">
+                <c-n26.flair.staff />
+            </c-slot>
+        {% endif %}
+        {% comment %}
+        Only when there is something to list. An empty detail-list is still a
+        <dl>, and the sheet stacks its sections with gap-4 — so a gang with no
+        choices and no counters would pay a line of space for an element with
+        nothing in it. The component draws the slot only if it is filled.
+        {% endcomment %}
+        {% if sheet.choices or sheet.counters %}
+            <c-slot name="details">
+                <c-n26.detail-list>
+                    {% for choice in sheet.choices %}
+                        <c-n26.detail-list.row label="{{ choice.kind_label }}"
+                                               value="{% if choice.chosen %}{{ choice.chosen }}{% else %}—{% endif %}"
+                                               :editable="False" />
+                    {% endfor %}
+                    {% for counter in sheet.counters %}
+                        <c-n26.detail-list.row label="{{ counter.name }}"
+                                               value="{{ counter.value }}"
+                                               :editable="False" />
+                    {% endfor %}
+                </c-n26.detail-list>
+            </c-slot>
+        {% endif %}
+        {% comment %}
+        Hiring is a gang-level act: it adds a fighter to the roster. Buying is
+        not — equipment is bought for a particular model and lives on that
+        model's card — so the way to the trading post is the Equip on each card
+        below.
+        {% endcomment %}
+        <c-slot name="actions">
+            <c-ui.button size="sm" variant="primary" href="#">
+                Hire fighter
+            </c-ui.button>
+        </c-slot>
+        <c-slot name="secondary_actions">
+            <c-n26.button-group>
+                <c-ui.button size="sm" variant="default" href="#">
+                    Print
+                </c-ui.button>
+                <c-ui.dropdown>
+                    <c-slot name="trigger">
+                        <c-ui.button size="sm" variant="default" aria-label="More actions">
+                            <span class="n26-icon-only gap-0.5">
+                                <c-n26.icon name="ellipsis-vertical" class="size-4" />
+                                <c-n26.icon name="chevron-down" class="size-3" stroke_width="2.5" />
+                            </span>
+                        </c-ui.button>
+                    </c-slot>
+                    <c-ui.dropdown.item variant="danger" href="#">
+                        Delete gang
+                    </c-ui.dropdown.item>
+                </c-ui.dropdown>
+            </c-n26.button-group>
+        </c-slot>
+        <c-slot name="stash_empty">
+            Nothing in the stash yet.
+        </c-slot>
+        <c-slot name="members">
+            {% for member in sheet.models %}
+                <c-n26.model-card :card="member">
+                    <c-slot name="actions">
+                        {% comment %}
+                        Equip is the one you came for and the only per-model act
+                        that is not destructive, so it is the primary and it is on
+                        its own. Cards and Delete share the dropdown because
+                        neither is frequent and one is irreversible.
+                        {% endcomment %}
+                        <c-ui.button size="xs" variant="primary" href="#">
+                            Equip
+                        </c-ui.button>
+                        <c-ui.dropdown>
+                            <c-slot name="trigger">
+                                <c-ui.button size="xs" variant="default" aria-label="More actions">
+                                    <span class="n26-icon-only gap-0.5">
+                                        <c-n26.icon name="ellipsis-vertical" class="size-3.5" />
+                                        <c-n26.icon name="chevron-down" class="size-3" stroke_width="2.5" />
+                                    </span>
+                                </c-ui.button>
+                            </c-slot>
+                            <c-ui.dropdown.item href="#">
+                                Cards
+                            </c-ui.dropdown.item>
+                            <c-ui.dropdown.item variant="danger" href="#">
+                                Delete
+                            </c-ui.dropdown.item>
+                        </c-ui.dropdown>
+                    </c-slot>
+                </c-n26.model-card>
+            {% endfor %}
+        </c-slot>
+    </c-n26.view.gang-sheet>
+{% endblock content %}

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -67,7 +67,9 @@ that saves nothing is worse than a value with no affordance at all.
         below.
         {% endcomment %}
         <c-slot name="actions">
-            <c-ui.button size="sm" variant="primary" href="#">
+            <c-ui.button size="sm"
+                         variant="primary"
+                         href="{% url 'n26-hire-fighter' gang.pk %}">
                 Hire fighter
             </c-ui.button>
         </c-slot>

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -8,10 +8,10 @@ What was judged there is what ships here, so the two should be edited together.
 
   --- what is not wired yet ---
 
-Hire, Equip, Print, Cards and Delete have no routes. They are drawn anyway, at
-"#", so the screen keeps the shape the library settled on and the gaps are
-visible rather than quietly designed around. Each becomes a url tag as its
-feature lands.
+Print, Cards and Delete have no routes. They are drawn anyway, at "#", so the
+screen keeps the shape the library settled on and the gaps are visible rather
+than quietly designed around. Each becomes a url tag as its feature lands —
+Hire and Equip already have.
 
 The gang's choices and counters are shown as settled facts. The library's row
 can open a picker that writes, and that picker does not exist — a Save button
@@ -106,7 +106,7 @@ that saves nothing is worse than a value with no affordance at all.
                         its own. Cards and Delete share the dropdown because
                         neither is frequent and one is irreversible.
                         {% endcomment %}
-                        <c-ui.button size="xs" variant="primary" href="#">
+                        <c-ui.button size="xs" variant="primary" href="{% url 'n26-equip' member.id %}">
                             Equip
                         </c-ui.button>
                         <c-ui.dropdown>

--- a/n26/core/templates/n26/hire_fighter.html
+++ b/n26/core/templates/n26/hire_fighter.html
@@ -1,0 +1,95 @@
+{% extends "n26/layouts/base.html" %}
+{% comment %}
+Hiring a fighter — the design system's picker over the real gang list.
+
+The gallery's shell version (designsystem/shell/hire.html) is this page with
+sample rows, the same relationship the dashboard and the gang sheet have to
+their shell twins. Edit them together.
+
+Every Hire button in the list is this form's submit, carrying which profile was
+pressed; the option inputs are scoped per-row by the picker. The view maps them
+back through the same derivation that drew them.
+
+The demo's per-row "limited" marker is not here: it flags the rulebook's
+Champion/Brute/Hanger-on cap, which is not yet a fact the library records —
+drawing it from a hardcoded list would be a marker that lies.
+{% endcomment %}
+{% block head_title %}Hire a fighter{% endblock head_title %}
+{% block nav_heading %}Hire a fighter{% endblock nav_heading %}
+{% block nav_items %}
+    {% include 'n26/_nav.html' %}
+{% endblock %}
+{% block content %}
+    <c-n26.view.fighter-hire action="{% url 'n26-hire-fighter' gang.pk %}"
+                             gang="{{ gang.name }}"
+                             :form="form">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item>
+                    <c-n26.flair-link text="{{ gang.owner.username }}"
+                                      tone="current"
+                                      href="{% url 'n26-dashboard' %}" />
+                </c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{% url 'n26-gang' gang.pk %}">{{ gang.name }}</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    Hire
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+        {% csrf_token %}
+        <c-n26.profile-picker :categories="categories"
+                              :sections="sections"
+                              cost_floor="{{ price_floor }}"
+                              cost_ceiling="{{ price_ceiling }}">
+            <c-slot name="filters">
+                <c-n26.search-bar :live="True"
+                                  :nested="True"
+                                  model="query"
+                                  placeholder="Search the gang list" />
+                {% if category_options or price_ceiling > price_floor %}
+                    <div class="flex flex-wrap items-center gap-2">
+                        {% if category_options %}
+                            <c-n26.filter-menu label="Category" name="category" :options="category_options" />
+                        {% endif %}
+                        {% if price_ceiling > price_floor %}
+                            <c-n26.range-menu label="Price"
+                                              model_min="minCost"
+                                              model_max="maxCost"
+                                              min="{{ price_floor }}"
+                                              max="{{ price_ceiling }}"
+                                              step="5"
+                                              suffix="¢"
+                                              at_max_label="Any" />
+                        {% endif %}
+                    </div>
+                {% endif %}
+            </c-slot>
+            {% comment %}
+            Profiles without a home category arrive in a section and category
+            with empty names — a content gap the library will fill, shown
+            rather than papered over. The rows still need a section around
+            them (an item registers against its section's name), but an
+            unnamed *category* is skipped: the section component documents
+            that items may sit straight inside one, and a blank category
+            header would be a heading saying nothing.
+            {% endcomment %}
+            {% for section_row in section_rows %}
+                <c-n26.collection-picker.section name="{{ section_row.section.name }}" :open="section_row.first">
+                    {% for category in section_row.section.categories %}
+                        {% if category.name %}
+                            <c-n26.collection-picker.category name="{{ category.name }}">
+                                {% for entry in category.entries %}
+                                    <c-n26.profile-picker.row :entry="entry" value="{{ entry.profile.pk }}" />
+                                {% endfor %}
+                            </c-n26.collection-picker.category>
+                        {% else %}
+                            {% for entry in category.entries %}
+                                <c-n26.profile-picker.row :entry="entry" value="{{ entry.profile.pk }}" />
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                </c-n26.collection-picker.section>
+            {% endfor %}
+        </c-n26.profile-picker>
+    </c-n26.view.fighter-hire>
+{% endblock content %}

--- a/n26/core/templates/n26/includes/equip_line.html
+++ b/n26/core/templates/n26/includes/equip_line.html
@@ -1,0 +1,27 @@
+{% comment %}
+One buyable line: the picker's item with a Buy that submits the line's
+identity. Expects `row` — {"line": PricedLine, "key": "<label>:<pk>"} — from
+the equip view. An include rather than repeated inline, because the equip page
+draws it from two places (categorised and uncategorised rows) and a drifted
+copy would be a different till.
+
+Green Buy for the same reason Hire is green: it is the committing action and
+this form's only kind of submit. The type="submit"-through-attrs trick is the
+one profile-picker.row documents — the kit button renders {{ attrs }} before
+its own type="button", and HTML keeps the first of a duplicate pair.
+{% endcomment %}
+<c-n26.collection-picker.item name="{{ row.line.name }}"
+                              :cost="row.line.credits"
+                              :trade_points="row.line.trade_points"
+                              :exclusive="row.line.is_exclusive"
+                              :notes="row.line.notes">
+    <c-slot name="actions">
+        <c-ui.button size="sm"
+                     variant="success"
+                     type="submit"
+                     name="thing"
+                     value="{{ row.key }}">
+            Buy
+        </c-ui.button>
+    </c-slot>
+</c-n26.collection-picker.item>

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -188,6 +188,23 @@ def test_every_registration_name_is_a_known_category(
     assert registration_names <= set(response.context["categories"])
 
 
+def test_mixed_sections_fall_back_to_untabbed(client, tester, fighter, house_list):
+    """Same rule as the hire page: tabs only when every section is named,
+    or the homeless shelf is served but unreachable."""
+    from n26.library.models import Category, Section, Wargear
+
+    section = Section.objects.create(name="Armoury", position=0)
+    category = Category.objects.create(section=section, name="Blades", position=0)
+    sword = Wargear.objects.get(name="Sword")
+    sword.category = category
+    sword.save()
+    # The knife stays homeless.
+
+    client.force_login(tester)
+    response = client.get(equip_url(fighter, house_list))
+    assert response.context["sections"] == []
+
+
 def test_someone_elses_fighter_is_not_found(client, fighter):
     stranger = User.objects.create_user("stranger", is_staff=True)
     client.force_login(stranger)

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1,0 +1,188 @@
+"""Equipping a fighter: the till's contract, server side.
+
+``browse`` and ``Operation.buy`` have their own tests — these are about
+the wiring: the list draws from a list the fighter can actually browse,
+a Buy pays the server's price and never the form's, and refusals refuse
+cleanly.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.models import Assignment, Gang
+from n26.core.operations import operation
+from n26.library.authoring import create_collection, create_wargear
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def tester(db):
+    return User.objects.create_user("player", is_staff=True)
+
+
+@pytest.fixture
+def gang(gang_type, tester):
+    return Gang.objects.create(
+        name="The Ashen Choir",
+        owner=tester,
+        gang_type=gang_type,
+        starting_credits=100,
+        credits=100,
+    )
+
+
+@pytest.fixture
+def fighter(gang, make_profile, make_statline, tester):
+    profile = make_profile("Ganger", price=0)
+    make_statline(profile, movement=5, weapon_skill=4, toughness=3)
+    with operation(gang, actor=tester) as op:
+        return op.hire(profile, "Vex")
+
+
+@pytest.fixture
+def house_list(gang, tester):
+    """An equipment list the gang holds: a knife at reference, a sword
+    the list prices its own way."""
+    knife = create_wargear("Knife", price=10)
+    sword = create_wargear("Sword", price=20)
+    collection = create_collection(
+        "House List", entries=[knife, (sword, {"price_override": 35})]
+    )
+    with operation(gang, actor=tester) as op:
+        op.assign(collection, gang=gang)
+    return collection
+
+
+def equip_url(fighter, collection=None):
+    url = reverse("n26-equip", args=[fighter.pk])
+    return f"{url}?list={collection.pk}" if collection else url
+
+
+def key_of(thing):
+    return f"{thing._meta.label_lower}:{thing.pk}"
+
+
+def test_the_list_draws(client, tester, fighter, house_list):
+    client.force_login(tester)
+    body = client.get(equip_url(fighter)).content.decode()
+    assert "Knife" in body
+    assert "Sword" in body
+    # The entry's own price, not the item's reference price.
+    assert "35" in body
+
+
+def test_a_buy_lands_on_the_fighter_at_the_servers_price(
+    client, tester, gang, fighter, house_list
+):
+    from n26.library.models import Wargear
+
+    sword = Wargear.objects.get(name="Sword")
+    client.force_login(tester)
+    response = client.post(equip_url(fighter, house_list), {"thing": key_of(sword)})
+    assert response.status_code == 302
+
+    bought = Assignment.objects.get(wargear=sword)
+    assert bought.miniature == fighter
+    gang.refresh_from_db()
+    # The list's override, not the wargear's 20 — the pricing seam.
+    assert gang.credits == 65
+
+
+def test_a_buy_stays_on_the_shop(client, tester, fighter, house_list):
+    from n26.library.models import Wargear
+
+    knife = Wargear.objects.get(name="Knife")
+    client.force_login(tester)
+    response = client.post(equip_url(fighter, house_list), {"thing": key_of(knife)})
+    assert response.url == equip_url(fighter, house_list)
+
+
+def test_a_thing_not_on_the_list_is_refused(client, tester, gang, fighter, house_list):
+    """The till only accepts lines the browse produced. An off-list
+    thing — here a wargear that exists but sits on no list the fighter
+    holds — buys nothing, whatever the form says."""
+    stray = create_wargear("Contraband", price=5)
+
+    client.force_login(tester)
+    response = client.post(equip_url(fighter, house_list), {"thing": key_of(stray)})
+    assert response.status_code == 302
+    assert not Assignment.objects.filter(wargear=stray).exists()
+    gang.refresh_from_db()
+    assert gang.credits == 100
+
+
+def test_an_overspend_refuses_and_writes_nothing(
+    client, tester, gang, fighter, house_list
+):
+    from n26.library.models import Wargear
+
+    dear = create_wargear("Archeotech", price=500)
+    house_list.entries.create(wargear=dear)
+
+    client.force_login(tester)
+    response = client.post(equip_url(fighter, house_list), {"thing": key_of(dear)})
+    assert response.status_code == 302
+    assert not Assignment.objects.filter(wargear=dear).exists()
+    gang.refresh_from_db()
+    assert gang.credits == 100
+    assert Wargear.objects.filter(name="Archeotech").exists()  # refused, not deleted
+
+
+def test_the_standard_trading_post_is_offered(client, tester, fighter):
+    """With no lists of their own, a fighter still gets the library's
+    Trading Post when it exists — swept, not curated."""
+    from n26.library.authoring import create_trading_post
+
+    create_wargear("Lho Sticks", price=5, trade_point_price=1)
+    create_trading_post()
+
+    client.force_login(tester)
+    body = client.get(equip_url(fighter)).content.decode()
+    assert "Lho Sticks" in body
+
+
+def test_the_chosen_list_is_url_state(client, tester, fighter, house_list):
+    """?list= picks which collection is browsed."""
+    from n26.library.authoring import create_trading_post
+
+    create_wargear("Lho Sticks", price=5, trade_point_price=1)
+    create_trading_post()
+
+    client.force_login(tester)
+    on_house = client.get(equip_url(fighter, house_list)).content.decode()
+    assert "Knife" in on_house
+    assert "Lho Sticks" not in on_house
+
+
+def test_every_registration_name_is_a_known_category(
+    client, tester, fighter, house_list
+):
+    """Same client-side trap as the hire page: a row in an unnamed
+    category registers under its section's name, possibly ""."""
+    client.force_login(tester)
+    response = client.get(equip_url(fighter))
+    registration_names = {
+        category["name"] or section["name"]
+        for section in response.context["section_rows"]
+        for category in section["categories"]
+    }
+    assert registration_names <= set(response.context["categories"])
+
+
+def test_someone_elses_fighter_is_not_found(client, fighter):
+    stranger = User.objects.create_user("stranger", is_staff=True)
+    client.force_login(stranger)
+    assert client.get(equip_url(fighter)).status_code == 404
+
+
+def test_a_pk_that_is_not_a_ulid_is_not_found(client, tester):
+    client.force_login(tester)
+    assert client.get("/n26/fighters/nonsense/equip/").status_code == 404
+
+
+def test_the_sheet_links_each_card_to_equip(client, tester, gang, fighter):
+    client.force_login(tester)
+    body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+    assert reverse("n26-equip", args=[fighter.pk]) in body

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -143,6 +143,23 @@ def test_the_standard_trading_post_is_offered(client, tester, fighter):
     assert "Lho Sticks" in body
 
 
+def test_a_homebrew_trading_post_is_not_the_standard_one(
+    client, tester, fighter, homebrew
+):
+    """Collection names are only unique per pack. A pack that names its
+    own collection "Trading Post" must not be offered as the standard
+    fallback — it reaches a fighter the way any pack list does, by
+    being assigned or granted."""
+    from n26.library.authoring import create_trading_post
+
+    create_wargear("Bootleg Stimms", price=5, trade_point_price=1, pack=homebrew)
+    create_trading_post(pack=homebrew)
+
+    client.force_login(tester)
+    body = client.get(equip_url(fighter)).content.decode()
+    assert "Bootleg Stimms" not in body
+
+
 def test_the_chosen_list_is_url_state(client, tester, fighter, house_list):
     """?list= picks which collection is browsed."""
     from n26.library.authoring import create_trading_post

--- a/n26/core/test_views_gang_sheet.py
+++ b/n26/core/test_views_gang_sheet.py
@@ -1,0 +1,130 @@
+"""The gang sheet: the design system's view over real rows.
+
+Everything the page draws comes from ``render_gang``, which has its own
+tests — these are about the wiring: who may see a gang, what a bad URL
+does, and that the dashboard's rows actually reach it.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.models import Gang
+from n26.core.operations import operation
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def tester(db):
+    """Staff, because /n26/ is fenced to staff and testers.
+
+    Not a group member: staff is the shorter of the two ways through the
+    gate, and which one a viewer used is not what these tests are about.
+    """
+    return User.objects.create_user("player", is_staff=True)
+
+
+@pytest.fixture
+def gang(gang_type, tester):
+    return Gang.objects.create(
+        name="The Ashen Choir",
+        owner=tester,
+        gang_type=gang_type,
+        starting_credits=1000,
+        credits=340,
+    )
+
+
+def test_draws_the_gang(client, tester, gang):
+    client.force_login(tester)
+    response = client.get(reverse("n26-gang", args=[gang.pk]))
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert gang.name in body
+    assert str(gang.gang_type) in body
+
+
+def test_draws_each_member(client, tester, gang, make_profile, make_statline):
+    """A hired fighter reaches the page as a card of its own."""
+    profile = make_profile("Ganger", price=55)
+    make_statline(profile, movement=5, weapon_skill=4, toughness=3)
+    with operation(gang, actor=tester) as op:
+        op.hire(profile, "Vex")
+        op.hire(profile, "Sull")
+
+    client.force_login(tester)
+    body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+    assert "Vex" in body
+    assert "Sull" in body
+
+
+def test_draws_the_gangs_standing_facts(client, tester, gang):
+    """A counter the gang keeps reaches the details list, name and value."""
+    from n26.library.authoring import create_counter
+    from n26.tests.sandbox.actions import assign, tally
+
+    tally(assign(create_counter("Meat"), gang=gang, actor=tester), +3)
+
+    client.force_login(tester)
+    body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+    assert "Meat" in body
+
+
+def test_no_empty_details_list_when_there_is_nothing_to_list(client, tester, gang):
+    """The sheet spaces its sections, so an empty <dl> costs a visible gap.
+
+    Pinned because the fix is a conditional slot, and a slot that turns
+    out always to be filled would look identical in every other test.
+    """
+    client.force_login(tester)
+    before = (
+        client.get(reverse("n26-gang", args=[gang.pk])).content.decode().count("<dl")
+    )
+
+    from n26.library.authoring import create_counter
+    from n26.tests.sandbox.actions import assign, tally
+
+    tally(assign(create_counter("Meat"), gang=gang, actor=tester), +3)
+    after = (
+        client.get(reverse("n26-gang", args=[gang.pk])).content.decode().count("<dl")
+    )
+
+    assert after == before + 1
+
+
+def test_someone_elses_gang_is_not_found(client, gang):
+    """404 rather than 403 — which gangs exist is not there to be probed."""
+    stranger = User.objects.create_user("stranger", is_staff=True)
+    client.force_login(stranger)
+    assert client.get(reverse("n26-gang", args=[gang.pk])).status_code == 404
+
+
+def test_an_archived_gang_is_not_found(client, tester, gang):
+    gang.archived = True
+    gang.save()
+    client.force_login(tester)
+    assert client.get(reverse("n26-gang", args=[gang.pk])).status_code == 404
+
+
+def test_a_pk_that_is_not_a_ulid_is_not_found(client, tester):
+    """The id reaches ULIDField, which raises rather than missing.
+
+    Without the view catching that, a mistyped URL is a 500 and an
+    error report, for what is only ever somebody's bad link.
+    """
+    client.force_login(tester)
+    assert client.get("/n26/gangs/nonsense/").status_code == 404
+
+
+def test_founding_still_wins_over_the_id_route(client, tester):
+    """`gangs/new/` must not resolve "new" as a gang id."""
+    client.force_login(tester)
+    assert client.get(reverse("n26-create-gang")).status_code == 200
+
+
+def test_the_dashboard_links_to_the_sheet(client, tester, gang):
+    """The row's href is the whole point of the screen being reachable."""
+    client.force_login(tester)
+    body = client.get(reverse("n26-dashboard")).content.decode()
+    assert reverse("n26-gang", args=[gang.pk]) in body

--- a/n26/core/test_views_hire.py
+++ b/n26/core/test_views_hire.py
@@ -102,10 +102,16 @@ def test_an_option_maps_back_to_its_set(client, tester, gang, ganger):
     ganger.options.create(profile=ganger, group=group, default_set=fancy, position=1)
 
     client.force_login(tester)
-    # Group 0 is the synthesised "As standard"; the named group is 1.
+    # Group 0 is the synthesised "As standard"; the named group is 1. The
+    # key is slugified — lowercased — because that is what the template
+    # actually renders (`value|slugify` scopes the row's inputs). Posting
+    # the raw uppercase pk here would pass against a parser that no real
+    # browser can reach.
+    from django.utils.text import slugify
+
     response = client.post(
         hire_url(gang),
-        {"profile": str(ganger.pk), "name": "Vex", f"{ganger.pk}:1": "1"},
+        {"profile": str(ganger.pk), "name": "Vex", f"{slugify(str(ganger.pk))}:1": "1"},
     )
     assert response.status_code == 302
 
@@ -114,6 +120,72 @@ def test_an_option_maps_back_to_its_set(client, tester, gang, ganger):
     assert [row.default_set for row in chosen] == [fancy]
     gang.refresh_from_db()
     assert gang.credits == 120  # 200 - (55 + 25)
+
+
+def test_the_option_keys_match_what_the_template_renders(client, tester, gang, ganger):
+    """The rendered input names and the parser must agree on case.
+
+    The row template scopes inputs with `value|slugify`, which lowercases
+    the ULID; a parser reading the raw pk finds no keys, and every option
+    ticked in a real browser is silently dropped — the fighter hires as
+    default at base price, no error anywhere. So the page's HTML is the
+    fixture here: the name this asserts on is the name the parser reads.
+    """
+    from django.utils.text import slugify
+
+    group = OptionGroup.objects.create(profile=ganger, name="Armament", choose="one")
+    plain = DefaultAssignmentSet.objects.create(name="Knife", price=0)
+    ganger.options.create(profile=ganger, group=group, default_set=plain, position=0)
+
+    client.force_login(tester)
+    body = client.get(hire_url(gang)).content.decode()
+    assert f'name="{slugify(str(ganger.pk))}:1"' in body
+
+
+def test_a_double_pick_in_a_choose_one_group_is_refused(client, tester, gang, ganger):
+    """Radios stop this in a browser; a tampered POST naming two options
+    of a choose-one group must 404 like any other broken submission,
+    not 500 out of resolve_selection."""
+    from django.utils.text import slugify
+
+    group = OptionGroup.objects.create(profile=ganger, name="Armament", choose="one")
+    plain = DefaultAssignmentSet.objects.create(name="Knife", price=0)
+    fancy = DefaultAssignmentSet.objects.create(name="Chainsword", price=25)
+    ganger.options.create(profile=ganger, group=group, default_set=plain, position=0)
+    ganger.options.create(profile=ganger, group=group, default_set=fancy, position=1)
+
+    client.force_login(tester)
+    response = client.post(
+        hire_url(gang),
+        {
+            "profile": str(ganger.pk),
+            "name": "Vex",
+            f"{slugify(str(ganger.pk))}:1": ["0", "1"],
+        },
+    )
+    assert response.status_code == 404
+    assert not Miniature.objects.filter(membership__gang=gang).exists()
+
+
+def test_mixed_sections_fall_back_to_untabbed(
+    client, tester, gang, ganger, make_profile
+):
+    """Tabs are the picker's whole navigation once on, and only named
+    sections can be tabs — so content where some profiles have a home
+    and some do not must not tab, or the homeless shelf is served in
+    the HTML and unreachable in the UI."""
+    from n26.library.models import Category, Section
+
+    section = Section.objects.create(name="Gang List", position=0)
+    category = Category.objects.create(section=section, name="Champions", position=0)
+    homed = make_profile("Champion", price=95)
+    homed.category = category
+    homed.save()
+    # `ganger` stays homeless.
+
+    client.force_login(tester)
+    response = client.get(hire_url(gang))
+    assert response.context["sections"] == []
 
 
 def test_an_overspend_refuses_and_writes_nothing(client, tester, gang, make_profile):

--- a/n26/core/test_views_hire.py
+++ b/n26/core/test_views_hire.py
@@ -1,0 +1,167 @@
+"""Hiring a fighter: the picker's form contract, server side.
+
+``build_hire_list`` and ``Operation.hire`` have their own tests — these
+are about the wiring: the list draws, a press hires the right thing at
+the right price, options map back to the sets they were drawn from, and
+an overspend refuses cleanly.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.models import ChosenProfileOption, Gang, Miniature
+from n26.library.models import DefaultAssignmentSet, OptionGroup
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def tester(db):
+    return User.objects.create_user("player", is_staff=True)
+
+
+@pytest.fixture
+def gang(gang_type, tester):
+    return Gang.objects.create(
+        name="The Ashen Choir",
+        owner=tester,
+        gang_type=gang_type,
+        starting_credits=200,
+        credits=200,
+    )
+
+
+@pytest.fixture
+def ganger(make_profile, make_statline):
+    profile = make_profile("Ganger", price=55)
+    make_statline(profile, movement=5, weapon_skill=4, toughness=3)
+    return profile
+
+
+def hire_url(gang):
+    return reverse("n26-hire-fighter", args=[gang.pk])
+
+
+def test_the_list_draws_with_prices(client, tester, gang, ganger):
+    client.force_login(tester)
+    body = client.get(hire_url(gang)).content.decode()
+    assert "Ganger" in body
+    assert "55" in body
+
+
+def test_every_registration_name_is_a_known_category(client, tester, gang, ganger):
+    """The picker filters rows by ``categoryOn(name)`` client-side, and a
+    row in an unnamed category registers under its *section's* name —
+    possibly "". A categories list that omits a registration name hides
+    every such row silently: the page serves the rows, Alpine never shows
+    them, and no HTML assertion notices. So the context is pinned
+    instead: every name a row will register under must be in the list.
+    """
+    client.force_login(tester)
+    response = client.get(hire_url(gang))
+    registration_names = {
+        category["name"] or row["section"]["name"]
+        for row in response.context["section_rows"]
+        for category in row["section"]["categories"]
+    }
+    assert registration_names <= set(response.context["categories"])
+
+
+def test_a_press_hires_and_lands_on_the_sheet(client, tester, gang, ganger):
+    client.force_login(tester)
+    response = client.post(hire_url(gang), {"profile": str(ganger.pk), "name": "Vex"})
+    assert response.status_code == 302
+    assert response.url == reverse("n26-gang", args=[gang.pk])
+
+    fighter = Miniature.objects.get(membership__gang=gang)
+    assert fighter.name == "Vex"
+    gang.refresh_from_db()
+    assert gang.credits == 145  # 200 - 55
+    assert gang.rating == 55
+
+
+def test_an_unnamed_hire_takes_the_profiles_name(client, tester, gang, ganger):
+    client.force_login(tester)
+    client.post(hire_url(gang), {"profile": str(ganger.pk), "name": ""})
+    assert Miniature.objects.get(membership__gang=gang).name == "Ganger"
+
+
+def test_an_option_maps_back_to_its_set(client, tester, gang, ganger):
+    """The picker submits option *indices*; the server must resolve them
+    against the same ordering the rows were drawn from.
+
+    The profile here has only a named group, which is exactly the case
+    where ``build_hire_entry`` synthesises a default group in front —
+    so a parser reading raw ``grouped_options()`` would be off by one.
+    """
+    group = OptionGroup.objects.create(profile=ganger, name="Armament", choose="one")
+    plain = DefaultAssignmentSet.objects.create(name="Knife", price=0)
+    fancy = DefaultAssignmentSet.objects.create(name="Chainsword", price=25)
+    ganger.options.create(profile=ganger, group=group, default_set=plain, position=0)
+    ganger.options.create(profile=ganger, group=group, default_set=fancy, position=1)
+
+    client.force_login(tester)
+    # Group 0 is the synthesised "As standard"; the named group is 1.
+    response = client.post(
+        hire_url(gang),
+        {"profile": str(ganger.pk), "name": "Vex", f"{ganger.pk}:1": "1"},
+    )
+    assert response.status_code == 302
+
+    fighter = Miniature.objects.get(membership__gang=gang)
+    chosen = ChosenProfileOption.objects.filter(assignment=fighter.membership)
+    assert [row.default_set for row in chosen] == [fancy]
+    gang.refresh_from_db()
+    assert gang.credits == 120  # 200 - (55 + 25)
+
+
+def test_an_overspend_refuses_and_writes_nothing(client, tester, gang, make_profile):
+    expensive = make_profile("Gang Queen", price=500)
+
+    client.force_login(tester)
+    response = client.post(
+        hire_url(gang), {"profile": str(expensive.pk), "name": "Vesna"}
+    )
+    # Back to the hire page with a message, and no half-written rows.
+    assert response.status_code == 302
+    assert response.url == hire_url(gang)
+    assert Miniature.objects.filter(membership__gang=gang).count() == 0
+    gang.refresh_from_db()
+    assert gang.credits == 200
+
+
+def test_a_profile_of_another_gang_type_is_refused(
+    client, tester, gang, make_profile, person_type
+):
+    """The list is the gang type's; a tampered POST naming someone
+    else's profile must not hire it."""
+    from n26.library.models import GangType
+
+    other = GangType.objects.create(name="Goliath")
+    outsider = make_profile("Forge Tyrant", gang_type=other, price=10)
+
+    client.force_login(tester)
+    response = client.post(
+        hire_url(gang), {"profile": str(outsider.pk), "name": "Wrong"}
+    )
+    assert response.status_code == 200  # redisplays the list
+    assert Miniature.objects.filter(membership__gang=gang).count() == 0
+
+
+def test_someone_elses_gang_is_not_found(client, gang, ganger):
+    stranger = User.objects.create_user("stranger", is_staff=True)
+    client.force_login(stranger)
+    assert client.get(hire_url(gang)).status_code == 404
+    assert client.post(hire_url(gang), {"profile": str(ganger.pk)}).status_code == 404
+
+
+def test_a_pk_that_is_not_a_ulid_is_not_found(client, tester):
+    client.force_login(tester)
+    assert client.get("/n26/gangs/nonsense/hire/").status_code == 404
+
+
+def test_the_sheet_links_to_the_hire_page(client, tester, gang):
+    client.force_login(tester)
+    body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+    assert hire_url(gang) in body

--- a/n26/core/views.py
+++ b/n26/core/views.py
@@ -81,14 +81,27 @@ def gang_sheet(request, pk):
     rather than a 403: which gangs exist is not something a stranger
     should be able to probe for.
     """
-    from n26.core.models import Gang
     from n26.core.render import render_gang
 
-    # A pk that is not a ULID reaches to_python and raises ValidationError,
-    # which is a 500 for what is only ever a bad URL. Well-formed-but-absent
-    # already 404s on its own.
+    gang = _own_gang_or_404(request, pk)
+    return render(
+        request,
+        "n26/gang_sheet.html",
+        {"gang": gang, "sheet": render_gang(gang)},
+    )
+
+
+def _own_gang_or_404(request, pk):
+    """The gang, if it is the viewer's to act on.
+
+    A pk that is not a ULID reaches ``to_python`` and raises
+    ``ValidationError`` — a 500 for what is only ever a bad URL, so it is
+    caught here. Well-formed-but-absent already 404s on its own.
+    """
+    from n26.core.models import Gang
+
     try:
-        gang = get_object_or_404(
+        return get_object_or_404(
             Gang.objects.select_related("gang_type", "owner", "stash"),
             pk=pk,
             owner=request.user,
@@ -97,10 +110,112 @@ def gang_sheet(request, pk):
     except ValidationError:
         raise Http404("No such gang") from None
 
+
+@login_required
+def hire_fighter(request, pk):
+    """Hire a fighter: the design system's picker over the real gang list.
+
+    GET is ``build_hire_list`` shelved by each profile's home category.
+    POST is the picker's own contract: every Hire button submits the form
+    carrying ``profile``, and each option group's inputs are scoped
+    ``{profile_pk}:{group_index}`` with option indices as values. The
+    indices are mapped back through ``build_hire_entry`` — the same
+    derivation the rows were drawn from — because the entry *synthesises*
+    a default group when the profile has only named ones, so raw
+    ``grouped_options()`` would be off by one exactly there.
+
+    An overspend is refused by the operation itself (``NotEnoughCredits``
+    unwinds the transaction), and lands back here as a message: nothing
+    half-written, nothing lost but a click.
+    """
+    from n26.core.forms import HireFighterForm
+    from n26.core.hire import build_hire_entry, build_hire_list, shelve_hire_list
+    from n26.core.operations import NotEnoughCredits, operation
+    from n26.library.models import Profile
+
+    gang = _own_gang_or_404(request, pk)
+
+    if request.method == "POST":
+        form = HireFighterForm(request.POST)
+        try:
+            profile = Profile.objects.filter(
+                pk=request.POST.get("profile"), gang_type=gang.gang_type
+            ).first()
+        except ValidationError:
+            # A tampered pk, not a ULID at all. The genuine buttons never
+            # send one, so redisplaying the list is all it deserves.
+            profile = None
+        if profile is not None and form.is_valid():
+            entry = build_hire_entry(profile)
+            chosen = []
+            for group_index, group in enumerate(entry.groups):
+                picked = request.POST.getlist(f"{profile.pk}:{group_index}")
+                for value in picked:
+                    try:
+                        option = group.options[int(value)]
+                    except ValueError, IndexError:
+                        raise Http404("No such option") from None
+                    if option.default_set is not None:
+                        chosen.append(option.default_set)
+            try:
+                with operation(gang, actor=request.user) as op:
+                    miniature = op.hire(
+                        profile,
+                        form.cleaned_data["name"] or profile.name,
+                        option=chosen,
+                    )
+            except NotEnoughCredits as refusal:
+                messages.error(request, str(refusal))
+                return redirect("n26-hire-fighter", pk=gang.pk)
+            messages.success(request, f"Hired {miniature.name}.")
+            return redirect("n26-gang", pk=gang.pk)
+    else:
+        form = HireFighterForm()
+
+    section_rows = shelve_hire_list(build_hire_list(gang.gang_type))
+    entries = [
+        entry
+        for section_row in section_rows
+        for category in section_row["categories"]
+        for entry in category["entries"]
+    ]
+    prices = [entry.base_price for entry in entries]
     return render(
         request,
-        "n26/gang_sheet.html",
-        {"gang": gang, "sheet": render_gang(gang)},
+        "n26/hire_fighter.html",
+        {
+            "gang": gang,
+            "form": form,
+            "section_rows": [
+                {"section": section_row, "first": index == 0}
+                for index, section_row in enumerate(section_rows)
+            ],
+            # Tabs only when the content has real section headings — a
+            # single unnamed shelf would draw one blank tab.
+            "sections": [row["name"] for row in section_rows if row["name"]],
+            # The picker's all-on category state. These are *registration*
+            # names — an item in an unnamed category registers under its
+            # section's name (possibly ""), and a list that omits that name
+            # silently hides every such row: categoryOn("") is the filter.
+            "categories": list(
+                dict.fromkeys(
+                    category["name"] or section_row["name"]
+                    for section_row in section_rows
+                    for category in section_row["categories"]
+                )
+            ),
+            "category_options": [
+                {"value": name, "label": name}
+                for name in dict.fromkeys(
+                    category["name"]
+                    for section_row in section_rows
+                    for category in section_row["categories"]
+                    if category["name"]
+                )
+            ],
+            "price_floor": min(prices, default=0),
+            "price_ceiling": max(prices, default=0),
+        },
     )
 
 

--- a/n26/core/views.py
+++ b/n26/core/views.py
@@ -165,14 +165,20 @@ def equip(request, pk):
     from n26.core.card import build_card, build_modifier_index
     from n26.core.effects import compute
     from n26.core.operations import NotEnoughCredits, operation
-    from n26.library.models import Collection
+    from n26.library.models import Collection, get_default_pack
     from n26.library.standard_content import TRADING_POST_COLLECTION
 
     miniature = _own_miniature_or_404(request, pk)
     gang = miniature.gang
 
     collections = [access.collection for access in collections_for(miniature)]
-    post = Collection.objects.filter(name=TRADING_POST_COLLECTION).first()
+    # Pinned to the default pack: collection names are only unique per
+    # pack, so a homebrew pack's own "Trading Post" must not shadow the
+    # standard one here. A pack's post reaches a fighter the way any list
+    # does — by being assigned or granted, which collections_for found.
+    post = Collection.objects.filter(
+        name=TRADING_POST_COLLECTION, pack=get_default_pack()
+    ).first()
     if post is not None and post.pk not in {c.pk for c in collections}:
         collections.append(post)
 

--- a/n26/core/views.py
+++ b/n26/core/views.py
@@ -11,8 +11,9 @@ import json
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.http import JsonResponse
-from django.shortcuts import redirect, render
+from django.core.exceptions import ValidationError
+from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
 
 from n26.core.preview import PreviewError, preview
@@ -62,6 +63,44 @@ def dashboard(request):
             ],
             "changelog": ChangelogEntry.objects.filter(archived=False)[:5],
         },
+    )
+
+
+@login_required
+def gang_sheet(request, pk):
+    """One gang, whole: what it is worth, what it owns, who is in it.
+
+    The design system's gang sheet over real rows. ``render_gang``
+    already does the derivation — the gang's own lines, its choices and
+    counters, the stash, a card per member — in a fixed number of
+    queries however big the roster, so this view is the lookup and
+    nothing else, and the page draws the same component the gallery's
+    shell does.
+
+    Scoped to the owner, and a gang belonging to someone else is a 404
+    rather than a 403: which gangs exist is not something a stranger
+    should be able to probe for.
+    """
+    from n26.core.models import Gang
+    from n26.core.render import render_gang
+
+    # A pk that is not a ULID reaches to_python and raises ValidationError,
+    # which is a 500 for what is only ever a bad URL. Well-formed-but-absent
+    # already 404s on its own.
+    try:
+        gang = get_object_or_404(
+            Gang.objects.select_related("gang_type", "owner", "stash"),
+            pk=pk,
+            owner=request.user,
+            archived=False,
+        )
+    except ValidationError:
+        raise Http404("No such gang") from None
+
+    return render(
+        request,
+        "n26/gang_sheet.html",
+        {"gang": gang, "sheet": render_gang(gang)},
     )
 
 

--- a/n26/core/views.py
+++ b/n26/core/views.py
@@ -111,6 +111,166 @@ def _own_gang_or_404(request, pk):
         raise Http404("No such gang") from None
 
 
+def _own_miniature_or_404(request, pk):
+    """The fighter, if theirs to act on — the miniature-shaped twin of
+    ``_own_gang_or_404``, with the same bad-ULID guard. Archived
+    memberships and archived gangs are out: a dead fighter's Equip link
+    should go the way the fighter did."""
+    from n26.core.models import Miniature
+
+    try:
+        return get_object_or_404(
+            Miniature.objects.select_related(
+                "membership__gang__gang_type",
+                "membership__gang__owner",
+                "membership__gang__stash",
+            ),
+            pk=pk,
+            membership__gang__owner=request.user,
+            membership__gang__archived=False,
+            membership__archived=False,
+        )
+    except ValidationError:
+        raise Http404("No such fighter") from None
+
+
+def _thing_key(thing):
+    """One string naming a browsed line's item — what the Buy buttons
+    submit. Model label plus pk, the same pair ``browse`` dedupes on,
+    because a pk alone is ambiguous across the assignable tables."""
+    return f"{thing._meta.label_lower}:{thing.pk}"
+
+
+@login_required
+def equip(request, pk):
+    """Buy equipment for one fighter, from a list they can actually browse.
+
+    Which list is URL state (``?list=<pk>``), picked from
+    ``collections_for`` — the fighter's own lists, their gang's, computed
+    grants — plus the standard Trading Post when the library has one.
+
+    The Buy buttons submit the *identity* of a line, never its price:
+    the server re-browses the chosen collection and hands the found line
+    whole to ``Operation.buy``, so what is paid is always the server's
+    derivation and a tampered form can name nothing that is not on the
+    list. Browsed on equipment-list terms for now — Trade Points are
+    shown, not charged, because a TP budget is a session concept that
+    does not exist yet.
+
+    A purchase stays on the page: kitting out a fighter is a run of
+    purchases, and the breadcrumb is the way back.
+    """
+    from n26.core.access import collections_for
+    from n26.core.browse import browse, usability_for, with_use_notes
+    from n26.core.card import build_card, build_modifier_index
+    from n26.core.effects import compute
+    from n26.core.operations import NotEnoughCredits, operation
+    from n26.library.models import Collection
+    from n26.library.standard_content import TRADING_POST_COLLECTION
+
+    miniature = _own_miniature_or_404(request, pk)
+    gang = miniature.gang
+
+    collections = [access.collection for access in collections_for(miniature)]
+    post = Collection.objects.filter(name=TRADING_POST_COLLECTION).first()
+    if post is not None and post.pk not in {c.pk for c in collections}:
+        collections.append(post)
+
+    chosen = None
+    wanted = request.GET.get("list")
+    for collection in collections:
+        if str(collection.pk) == wanted:
+            chosen = collection
+            break
+    if chosen is None and collections:
+        chosen = collections[0]
+
+    view = None
+    if chosen is not None:
+        card = build_card(miniature)
+        index = build_modifier_index([node.assignable for node in card.all_nodes()])
+        view = with_use_notes(browse(chosen), usability_for(compute(card, index)))
+
+    if request.method == "POST" and view is not None:
+        key = request.POST.get("thing", "")
+        line = next(
+            (row for row in view.all_lines() if _thing_key(row.thing) == key), None
+        )
+        back = f"{request.path}?list={chosen.pk}"
+        if line is None:
+            # Not on this list — a stale page or a tampered form. The
+            # list itself is the answer either way.
+            messages.error(request, "That item is not on this list.")
+            return redirect(back)
+        try:
+            with operation(gang, actor=request.user) as op:
+                op.buy(miniature, line=line)
+        except NotEnoughCredits as refusal:
+            messages.error(request, str(refusal))
+            return redirect(back)
+        messages.success(request, f"Bought {line.name} for {miniature.name}.")
+        return redirect(back)
+
+    lines = list(view.all_lines()) if view is not None else []
+    trade_points = [
+        line.trade_points for line in lines if line.trade_points is not None
+    ]
+    sections = view.sections if view is not None else []
+    return render(
+        request,
+        "n26/equip.html",
+        {
+            "miniature": miniature,
+            "gang": gang,
+            "collections": collections,
+            "chosen": chosen,
+            # Each line paired with the key its Buy button submits, so the
+            # template never composes an identity of its own.
+            "section_rows": [
+                {
+                    "name": section.name,
+                    "first": index == 0,
+                    "categories": [
+                        {
+                            "name": category.name,
+                            "lines": [
+                                {"line": line, "key": _thing_key(line.thing)}
+                                for line in category.lines
+                            ],
+                        }
+                        for category in section.categories
+                    ],
+                }
+                for index, section in enumerate(sections)
+            ],
+            # Registration names, "" included — see the hire view: a row
+            # in an unnamed category registers under its section's name,
+            # and a list that omits one hides those rows client-side.
+            "categories": list(
+                dict.fromkeys(
+                    category.name or section.name
+                    for section in sections
+                    for category in section.categories
+                )
+            ),
+            "category_options": [
+                {"value": name, "label": name}
+                for name in dict.fromkeys(
+                    category.name
+                    for section in sections
+                    for category in section.categories
+                    if category.name
+                )
+            ],
+            "sections": [section.name for section in sections if section.name],
+            "cost_floor": min((line.credits for line in lines), default=0),
+            "cost_ceiling": max((line.credits for line in lines), default=0),
+            "tp_ceiling": max(trade_points, default=0),
+            "has_trade_points": bool(trade_points),
+        },
+    )
+
+
 @login_required
 def hire_fighter(request, pk):
     """Hire a fighter: the design system's picker over the real gang list.

--- a/n26/core/views.py
+++ b/n26/core/views.py
@@ -14,6 +14,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.text import slugify
 from django.views.decorators.http import require_POST
 
 from n26.core.preview import PreviewError, preview
@@ -268,11 +269,23 @@ def equip(request, pk):
                     if category.name
                 )
             ],
-            "sections": [section.name for section in sections if section.name],
+            # All-or-nothing, as on the hire page: tabs are the whole
+            # navigation once on, and an unnamed section can never be the
+            # active tab — mixed content would hide it.
+            "sections": (
+                [section.name for section in sections]
+                if sections and all(section.name for section in sections)
+                else []
+            ),
             "cost_floor": min((line.credits for line in lines), default=0),
             "cost_ceiling": max((line.credits for line in lines), default=0),
             "tp_ceiling": max(trade_points, default=0),
             "has_trade_points": bool(trade_points),
+            # Distinct from has_trade_points: an exclusive line has
+            # trade_points=None ("E" is not a number), so a list of
+            # exclusive-only items would otherwise never draw the toggle
+            # that is the only way to filter them.
+            "has_exclusive": any(line.is_exclusive for line in lines),
         },
     )
 
@@ -314,8 +327,15 @@ def hire_fighter(request, pk):
         if profile is not None and form.is_valid():
             entry = build_hire_entry(profile)
             chosen = []
+            # The row template scopes its option inputs with
+            # `value|slugify`, which lowercases the pk — so the keys must
+            # be read back through the same filter, or every option ticked
+            # in a real browser is silently ignored and the fighter buys
+            # as default. (A test posting the raw pk would pass anyway,
+            # which is exactly how that bug shipped the first time.)
+            scope = slugify(str(profile.pk))
             for group_index, group in enumerate(entry.groups):
-                picked = request.POST.getlist(f"{profile.pk}:{group_index}")
+                picked = request.POST.getlist(f"{scope}:{group_index}")
                 for value in picked:
                     try:
                         option = group.options[int(value)]
@@ -333,6 +353,12 @@ def hire_fighter(request, pk):
             except NotEnoughCredits as refusal:
                 messages.error(request, str(refusal))
                 return redirect("n26-hire-fighter", pk=gang.pk)
+            except ValueError:
+                # Two picks in a choose-one group, or a set the profile
+                # does not offer — resolve_selection refuses tampering
+                # the option indices cannot express. Same answer as a
+                # bad index: this is a broken link, not a rule to explain.
+                raise Http404("No such option") from None
             messages.success(request, f"Hired {miniature.name}.")
             return redirect("n26-gang", pk=gang.pk)
     else:
@@ -356,9 +382,17 @@ def hire_fighter(request, pk):
                 {"section": section_row, "first": index == 0}
                 for index, section_row in enumerate(section_rows)
             ],
-            # Tabs only when the content has real section headings — a
-            # single unnamed shelf would draw one blank tab.
-            "sections": [row["name"] for row in section_rows if row["name"]],
+            # Tabs only when *every* section is named. The tab strip is
+            # the picker's whole navigation once it is on: a section
+            # whose name is not in this list can never be the active tab,
+            # so mixed content — some profiles homed, some not — would
+            # serve the unnamed shelf in the HTML and make it unreachable.
+            # All-or-nothing keeps every row reachable either way.
+            "sections": (
+                [row["name"] for row in section_rows]
+                if section_rows and all(row["name"] for row in section_rows)
+                else []
+            ),
             # The picker's all-on category state. These are *registration*
             # names — an item in an unnamed category registers under its
             # section's name (possibly ""), and a list that omits that name

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("gangs/new/", views.create_gang, name="n26-create-gang"),
     # After gangs/new/, which would otherwise resolve "new" as an id.
     path("gangs/<str:pk>/", views.gang_sheet, name="n26-gang"),
+    path("gangs/<str:pk>/hire/", views.hire_fighter, name="n26-hire-fighter"),
     path("design/", include("n26.designsystem.urls")),
     path("authoring/", authoring_views.index, name="authoring-index"),
     path(

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     # After gangs/new/, which would otherwise resolve "new" as an id.
     path("gangs/<str:pk>/", views.gang_sheet, name="n26-gang"),
     path("gangs/<str:pk>/hire/", views.hire_fighter, name="n26-hire-fighter"),
+    path("fighters/<str:pk>/equip/", views.equip, name="n26-equip"),
     path("design/", include("n26.designsystem.urls")),
     path("authoring/", authoring_views.index, name="authoring-index"),
     path(

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -13,6 +13,8 @@ from n26.library import views as authoring_views
 urlpatterns = [
     path("", views.dashboard, name="n26-dashboard"),
     path("gangs/new/", views.create_gang, name="n26-create-gang"),
+    # After gangs/new/, which would otherwise resolve "new" as an id.
+    path("gangs/<str:pk>/", views.gang_sheet, name="n26-gang"),
     path("design/", include("n26.designsystem.urls")),
     path("authoring/", authoring_views.index, name="authoring-index"),
     path(


### PR DESCRIPTION
Makes the n26 gang screen real. Until now the edition's dashboard listed gangs
whose rows went nowhere (`href="#"`); the sheet, hiring and equipping existed
only as design-system pages over sample data. This wires all three to real
rows, so the core loop — found a gang, hire fighters, equip them — works end
to end. Everything is under `n26/`.

- **Gang sheet** — `/n26/gangs/<pk>/`: the design system's sheet over
  `render_gang`. Dashboard rows and the breadcrumb link through. Choices and
  counters draw as settled facts; Print/Cards/Delete stay at `#` until built.
- **Hire** — `/n26/gangs/<pk>/hire/`: the profile picker over
  `build_hire_list`. Every Hire button is the form's submit; option indices
  are resolved through the same derivation that drew the rows (the entry
  synthesises a default group, so raw `grouped_options()` is off by one —
  there is a test shaped exactly like that trap).
- **Equip** — `/n26/fighters/<pk>/equip/`: the collection picker over
  `browse`, per fighter. Which list is URL state (`?list=<pk>`), from
  `collections_for` plus the standard Trading Post. The Buy buttons submit a
  line's identity, never a price — the server re-browses and hands the found
  line whole to `Operation.buy`, so entry overrides and reference prices are
  always the server's own derivation.

Supporting changes: `ModelCard` gains an `id` (empty on previews, filled for
stored models — what Equip links are built from); `shelve_hire_list` groups
profiles by their home category with `category__section` joined so it costs no
queries; shared `_own_gang_or_404` / `_own_miniature_or_404` guards (owner
scope, archived excluded, and non-ULID pks 404 instead of 500ing in
`ULIDField.to_python`); the sheet's action runs right-align under the wealth
strip.

Refusals are uniform: someone else's gang or fighter is a 404 (nothing to
probe), an overspend unwinds whole via `NotEnoughCredits` and comes back as a
message, off-list or cross-gang-type things buy nothing.

One client-side trap worth knowing about: the pickers filter rows by
`categoryOn(name)`, and a row in an unnamed category registers under its
section's name — possibly `""`. A context that lists only named categories
hides every such row while the served HTML still contains them, so no HTML
assertion notices. Both list pages pin the context instead: every name a row
registers under must be in the categories list.

## Test plan

- [x] 30 new view tests across the three screens (ownership, refusals,
  pricing, option mapping, the registration-name pins; two with negative
  controls)
- [x] Full suite: 5445 passed / 12 skipped
- [x] Browser, on seeded data: dashboard row → sheet → Hire (named fighter,
  option totals) → success banner → Equip → house list showing an entry's
  price override, Trading Post sweeping at reference → bought a lasgun → card
  grew a Weapons row, wealth strip arithmetic correct throughout
- [x] Dark mode and the ⋮ dropdowns checked on the sheet

## Next steps

Delete (gang and fighter), Print/Cards, option groups at the till, buying into
the stash, and charging Trade Points once a TP budget concept exists.
