### PR TITLE
docs: give the n26 tree its CLAUDE.md files

### DIFF
--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -13,7 +13,7 @@ other signed-in users get a 404 — the beta is invisible, not locked.
 | `n26/core/` | Player data (gangs, models, assignments, the money ledger) and the pure-Python layers that turn rows into cards, sheets, and shop listings. |
 | `n26/designsystem/` | The living component gallery at `/n26/design/`. Documents the components; owns none of them. |
 | `n26/tests/` | Shared fixtures and the sandbox suites — whole slices of real rulebook content built and exercised end to end. |
-| `n26/design/` | The specification. These markdown files are where design decisions are recorded and argued. **Git-ignored — they exist only in the maintainer's checkout.** When present, read the relevant one before a non-trivial change (`glossary.md` defines the shared vocabulary); when absent, module docstrings are the next-best source. Code cites them as `design/foo.md`. |
+| `n26/design/` | The specification. These markdown files are where design decisions are recorded and argued. **Not committed — they exist only in the maintainer's checkout.** When present, read the relevant one before a non-trivial change (`glossary.md` defines the shared vocabulary); when absent, module docstrings are the next-best source. Code cites them as `design/foo.md`. |
 
 Each package has its own CLAUDE.md with the detailed rules. This file holds
 what is true everywhere.

--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -1,0 +1,124 @@
+# CLAUDE.md — the n26 edition
+
+n26 is a new edition of Gyrinx, built alongside the existing app rather than
+on top of it. It is mounted at `/n26/` and fenced behind the "N26 Testers"
+group (staff always pass; everyone else gets a 404 — the beta is invisible,
+not locked).
+
+## The map
+
+| package | what it holds |
+|---|---|
+| `n26/library/` | Game content and the tools for writing it: models, authoring verbs, specs, generated forms, spreadsheet ingest, the staff authoring pages. |
+| `n26/core/` | Player data (gangs, models, assignments, the money ledger) and the pure-Python layers that turn rows into cards, sheets, and shop listings. |
+| `n26/designsystem/` | The living component gallery at `/n26/design/`. Documents the components; owns none of them. |
+| `n26/tests/` | Shared fixtures and the sandbox suites — whole slices of real rulebook content built and exercised end to end. |
+| `n26/design/` | The specification. These markdown files are where design decisions are recorded and argued. Read the relevant one before a non-trivial change; `glossary.md` defines the vocabulary the code, the admin, and the docs all share. |
+
+Each package has its own CLAUDE.md with the detailed rules. This file holds
+what is true everywhere.
+
+## Boundaries — what may import what
+
+The dependency direction is: `library` holds content, `core` reads it.
+Concretely:
+
+- **Nothing in `n26/` imports `n23.*` or `gyrinx.*`.** n26 is a parallel
+  edition, not a layer on the old one. (One deliberate exception exists:
+  the dashboard reads `gyrinx.site.models.ChangelogEntry`, deferred inside
+  the view. Do not add a second.)
+- **`n26/core/models/` never imports `n26.library`.** It names library
+  models by label string (`"library.Profile"`). This keeps the model graph
+  one-way: core rows point at library rows, never the reverse.
+- **Library code imports core logic (`select`, `browse`) only inside
+  functions**, never at module level. Only the primitives —
+  `n26.core.models` base classes, `n26.core.constraints`,
+  `n26.core.fields` — are imported at the top of a file. Break either
+  discipline and the app stops booting; nothing enforces it mechanically,
+  so it is enforced here.
+- **`n26.core` never imports `n26.designsystem`.** The gallery documents
+  core; core must not know it exists.
+- The platform reaches n26 by string only (settings, one URL include,
+  pinned app labels: `n26`, `library`, `designsystem`). App labels are
+  what migrations key on — never change them.
+
+## Vocabulary rules
+
+- **The word "cost" is banned**, in field names, dataclass names, and
+  properties. It blurs two numbers that part company at the first
+  discount: a **price** (what a surface asks right now) and a **rating**
+  (what a purchase added to the gang's worth, pinned forever). A test
+  discovers and rejects offenders (`n26/tests/sandbox/test_money_words.py`).
+- The Python class is `Miniature` (to avoid Django's `Model`); every
+  user-facing word is "model".
+- "Profile" on its own means a hireable fighter entry. A weapon's firing
+  line is a `WeaponProfile`.
+- Use the words in `n26/design/glossary.md`. If you need a term that is
+  not there, that is a design conversation, not a naming choice.
+- British spelling throughout (`colour`, `Specialisation`).
+
+## Design stances that hold everywhere
+
+- **Inform, never police.** The app says things (as `Note`s on lines and
+  cards) and shortens lists; it almost never refuses. Owners may do
+  anything. The one hard no is spending past the founding budget.
+- **No rules text, ever.** The book's wording is copyrighted. We store
+  names, numbers, and behaviour; the player reads the rule in the book.
+- **Recompute, never nudge.** Pinned totals (ratings, credits) are
+  rewritten by recomputing from the ledger, never adjusted by deltas.
+  `n26.core.reconcile` proves the caches honest.
+- **Structures before renderers.** Every surface is built as a plain
+  dataclass first (a card, a sheet, a shop view, a spec); rendering it is
+  a separate, dumber step. Tests assert on the structure.
+- **UI state lives in the URL, with one sanctioned exception.** The
+  platform rule applies here too: anything that picks a form variant,
+  changes what the server renders, or should survive a reload belongs in
+  the URL. The exception: Alpine may narrow or reorder content already
+  on the page (filtering a table, a sidebar search) — presentation only,
+  nothing the server would render differently.
+- Python 3.14 is required, not just supported — some files use syntax
+  that will not parse on older versions.
+
+## Comments
+
+The house style: a comment states a constraint, an invariant, or a
+consequence the code cannot show — in plain words, for a reader who does
+not know the game. Two good examples of the register:
+
+> The stash is excluded: rating is what the models are worth; stashed
+> gear counts in wealth instead.
+
+> Stored effects write rows at assign time — running one here would
+> breed pets on every render.
+
+**The rule: a comment must make sense to a reader who has never seen any
+earlier version of this code.** That one test rejects everything we do
+not want:
+
+- No people ("agreed with Tom", "per review").
+- No tickets or PRs ("see #1234", "fixed in PR …").
+- No changelog narration ("used to be", "no longer", "exactly as
+  before", "ported from v1", dates).
+- No disguised TODOs ("for now", "note for later"). If work remains,
+  track it outside the code.
+
+Keep comments short. A constraint usually fits in one or two sentences;
+if the *reasoning* genuinely needs a paragraph, it belongs in the module
+docstring or a `n26/design/` doc, referenced by filename. Citing a
+design doc is fine; citing a person, a date, or an issue number is not.
+
+Design docs under `n26/design/` may record who decided what and when —
+that is what they are for. Code comments may not.
+
+## Tests
+
+`pytest n26` runs everything. The detailed conventions are in
+`n26/tests/CLAUDE.md`; the two rules worth knowing before you get there:
+
+- n26 tests use classes as narrative headings and sentence-length test
+  names. This deliberately differs from the platform's "module-level
+  functions only" rule; do not "fix" it.
+- There is no repo-root conftest for n26 and there must never be one:
+  the host repo's conftest defines fixtures with the same names, and the
+  nearer file would win silently. Shared fixtures live in
+  `n26/tests/fixtures.py`.

--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -2,8 +2,8 @@
 
 n26 is a new edition of Gyrinx, built alongside the existing app rather than
 on top of it. It is mounted at `/n26/` and fenced behind the "N26 Testers"
-group (staff always pass; everyone else gets a 404 — the beta is invisible,
-not locked).
+group: staff and members pass, anonymous visitors are sent to log in, and
+other signed-in users get a 404 — the beta is invisible, not locked.
 
 ## The map
 
@@ -13,7 +13,7 @@ not locked).
 | `n26/core/` | Player data (gangs, models, assignments, the money ledger) and the pure-Python layers that turn rows into cards, sheets, and shop listings. |
 | `n26/designsystem/` | The living component gallery at `/n26/design/`. Documents the components; owns none of them. |
 | `n26/tests/` | Shared fixtures and the sandbox suites — whole slices of real rulebook content built and exercised end to end. |
-| `n26/design/` | The specification. These markdown files are where design decisions are recorded and argued. Read the relevant one before a non-trivial change; `glossary.md` defines the vocabulary the code, the admin, and the docs all share. |
+| `n26/design/` | The specification. These markdown files are where design decisions are recorded and argued. **Git-ignored — they exist only in the maintainer's checkout.** When present, read the relevant one before a non-trivial change (`glossary.md` defines the shared vocabulary); when absent, module docstrings are the next-best source. Code cites them as `design/foo.md`. |
 
 Each package has its own CLAUDE.md with the detailed rules. This file holds
 what is true everywhere.
@@ -23,10 +23,11 @@ what is true everywhere.
 The dependency direction is: `library` holds content, `core` reads it.
 Concretely:
 
-- **Nothing in `n26/` imports `n23.*` or `gyrinx.*`.** n26 is a parallel
-  edition, not a layer on the old one. (One deliberate exception exists:
-  the dashboard reads `gyrinx.site.models.ChangelogEntry`, deferred inside
-  the view. Do not add a second.)
+- **No app code in `n26/` imports `n23.*` or `gyrinx.*`.** n26 is a
+  parallel edition, not a layer on the old one. Two deliberate
+  exceptions: the dashboard reads `gyrinx.site.models.ChangelogEntry`,
+  deferred inside the view, and `n26/tests/` may import platform pieces
+  to test the seam. Do not add others.
 - **`n26/core/models/` never imports `n26.library`.** It names library
   models by label string (`"library.Profile"`). This keeps the model graph
   one-way: core rows point at library rows, never the reverse.
@@ -44,18 +45,22 @@ Concretely:
 
 ## Vocabulary rules
 
-- **The word "cost" is banned**, in field names, dataclass names, and
-  properties. It blurs two numbers that part company at the first
-  discount: a **price** (what a surface asks right now) and a **rating**
-  (what a purchase added to the gang's worth, pinned forever). A test
-  discovers and rejects offenders (`n26/tests/sandbox/test_money_words.py`).
+- **The word "cost" is banned.** It blurs two numbers that part company
+  at the first discount: a **price** (what a surface asks right now) and
+  a **rating** (what a purchase added to the gang's worth, pinned
+  forever). A test discovers and rejects offenders in stored fields and
+  player-facing structures (`n26/tests/sandbox/test_money_words.py`);
+  the ban also applies where the test cannot see — class names, template
+  props, sample data.
 - The Python class is `Miniature` (to avoid Django's `Model`); every
   user-facing word is "model".
 - "Profile" on its own means a hireable fighter entry. A weapon's firing
   line is a `WeaponProfile`.
 - Use the words in `n26/design/glossary.md`. If you need a term that is
   not there, that is a design conversation, not a naming choice.
-- British spelling throughout (`colour`, `Specialisation`).
+- British spelling in prose and our own names (`colour`,
+  `Specialisation`); names that mirror CSS or an installed package's API
+  keep that spelling (`css_color`, a kit component's `color=` prop).
 
 ## Design stances that hold everywhere
 
@@ -108,7 +113,9 @@ docstring or a `n26/design/` doc, referenced by filename. Citing a
 design doc is fine; citing a person, a date, or an issue number is not.
 
 Design docs under `n26/design/` may record who decided what and when —
-that is what they are for. Code comments may not.
+that is what they are for. Code comments may not. The rule applies to
+everything written from here on; a handful of older comments predate it
+and may be cleaned when touched.
 
 ## Tests
 
@@ -118,7 +125,8 @@ that is what they are for. Code comments may not.
 - n26 tests use classes as narrative headings and sentence-length test
   names. This deliberately differs from the platform's "module-level
   functions only" rule; do not "fix" it.
-- There is no repo-root conftest for n26 and there must never be one:
-  the host repo's conftest defines fixtures with the same names, and the
-  nearer file would win silently. Shared fixtures live in
+- Never add n26 fixtures to the repo-root conftest, and never create a
+  conftest above `n26/tests/` for them: the host repo's root conftest
+  defines fixtures with the same names (`make_statline`), and whichever
+  file is nearer wins silently. Shared fixtures live in
   `n26/tests/fixtures.py`.

--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -6,7 +6,8 @@ stage has one job:
 ```
 models/        rows: Gang, Miniature, Assignment, LedgerEntry, Stash
 operations.py  the only writer — every change to player data goes through it
-card.py        loads a gang's rows into an in-memory tree, in one query
+card.py        loads a gang's rows into an in-memory tree, in a pinned
+               two queries
 effects.py     computes what the rules do to a card — pure, no queries
 render.py      plain dataclasses a template can draw (ModelCard, GangSheet)
 browse.py      collections as one rendered shape, whatever their species
@@ -51,11 +52,11 @@ underlying spec.
   came from.
 - **Mind the broadcast flag.** The gang's own rows ride every member's
   card (marked `broadcast=True`) so gang-wide rules reach them — they
-  draw no line and add no rating. Any new code walking a card's nodes
-  needs `if node.broadcast: continue` or it will double-count the
-  gang's kit onto every fighter.
+  draw no line, and gang rows carry no rating of their own. Any new code
+  walking a card's nodes needs `if node.broadcast: continue` or it will
+  double-count the gang's kit onto every fighter.
 - **Inform, never police.** Restrictions become `Note`s attached to
-  lines (`notes.py` — `about` is a real row, never a string). Nothing
+  lines (`notes.py` — `about` is a real object, never a string). Nothing
   blocks; `buy` deliberately never consults access.
 
 ## Wiring — steps that are easy to miss
@@ -65,7 +66,7 @@ underlying spec.
   on `Assignment`, and a migration. Startup checks (`n26.E001`/`E002`)
   refuse to boot if they disagree.
 - A new condition model must be named in its scope's `CONDITIONS` tuple
-  (`n26.E003`) or its rows are stored but never read.
+  (`n26.E003`/`E004`) or its rows are stored but never read.
 - `Has.as_q` needs a `register_lookup()` entry per (model, kind) pair,
   or it raises `NotExpressibleAsQuery`.
 - **`Assignment.save()` derives the denormalised roots.**
@@ -103,9 +104,10 @@ underlying spec.
     `django_cotton_ui` in `INSTALLED_APPS`; reordering silently reverts
     them.
 - **Every component opens with a `{% comment %}` block** (the tag, a
-  usage example, the reasoning, the props) **and declares its props in
-  `<c-vars>`** including `class=""`. The gallery reads both at runtime —
-  an undeclared prop is invisible in the docs.
+  usage example, the reasoning, the props), **and new components must
+  declare their public props in `<c-vars>`** — include `class=""` and
+  thread it through. The gallery reads both to build its docs, so an
+  undeclared prop is invisible there.
 - A new or renamed component must also be registered in
   `n26/designsystem/catalog.py` and given demos, or it will not appear
   in the gallery. See `n26/designsystem/CLAUDE.md`.
@@ -117,9 +119,9 @@ underlying spec.
 ## Tests
 
 Unit tests of one module's contract sit next to the code
-(`n26/core/test_*.py`, no `tests/` package). Anything that needs a gang
-and rulebook-shaped content belongs in `n26/tests/sandbox/` instead —
-see `n26/tests/CLAUDE.md`.
+(`n26/core/test_*.py` and `tests.py`, no `tests/` package). Anything
+that needs a gang and rulebook-shaped content belongs in
+`n26/tests/sandbox/` instead — see `n26/tests/CLAUDE.md`.
 
 ## Comments
 

--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -1,0 +1,131 @@
+# CLAUDE.md — n26/core
+
+Player data and the layers that read it. The shape is a pipeline, and each
+stage has one job:
+
+```
+models/        rows: Gang, Miniature, Assignment, LedgerEntry, Stash
+operations.py  the only writer — every change to player data goes through it
+card.py        loads a gang's rows into an in-memory tree, in one query
+effects.py     computes what the rules do to a card — pure, no queries
+render.py      plain dataclasses a template can draw (ModelCard, GangSheet)
+browse.py      collections as one rendered shape, whatever their species
+hire.py        the hire list, one entry per option
+```
+
+Read `models/assignment.py` and `operations.py` first — the module
+docstrings explain the design. `n26/design/assignables.md` is the
+underlying spec.
+
+## Writing player data
+
+- **Never create or modify an `Assignment`, `LedgerEntry`, or
+  `LedgerEvent` outside `operation(gang, actor=...)`.** A bare
+  `objects.create()` skips the ledger entry, the event, and the repin;
+  nothing notices until `reconcile` runs.
+- **Recompute, never delta.** `settle()` repins every touched total by
+  recomputing it. If a new thing contributes to rating or credits, make
+  sure `Operation.touched()` sees the affected model and
+  `reconcile.sum_rating` / `total_spent` cover it.
+- **Refuse at the boundary.** `NotEnoughCredits` is raised from
+  `settle()` so the whole transaction unwinds. Do not add mid-operation
+  affordability checks.
+- Display-only state (`AssignmentSet`) deliberately bypasses operations.
+  Keep the line clean: if a feature costs money or changes a rating, it
+  goes through an operation.
+- The ledger is append-only, and folding an entry's events must
+  reproduce the entry — `reconcile.check_entry` checks exactly that.
+
+## Reading player data
+
+- **`effects.compute()` issues no queries and must stay that way.**
+  Everything it needs is loaded by `card.py`. If compute needs a new
+  relation, add it to `build_modifier_index` or `card_rows`'s
+  `select_related` — then update the tests that pin exact query counts.
+- The query budget is an invariant, not a hope: a whole gang is a fixed
+  number of queries however many models and however much kit. Tests
+  check the count stays flat as the gang grows.
+- **Renderers get plain dataclasses.** Nothing in `render.py` knows HTML.
+  A new display fact is a new field, computed in Python.
+- Every assignable a card shows carries a `Provenance` saying where it
+  came from.
+- **Mind the broadcast flag.** The gang's own rows ride every member's
+  card (marked `broadcast=True`) so gang-wide rules reach them — they
+  draw no line and add no rating. Any new code walking a card's nodes
+  needs `if node.broadcast: continue` or it will double-count the
+  gang's kit onto every fighter.
+- **Inform, never police.** Restrictions become `Note`s attached to
+  lines (`notes.py` — `about` is a real row, never a string). Nothing
+  blocks; `buy` deliberately never consults access.
+
+## Wiring — steps that are easy to miss
+
+- **A new assignable kind is three edits**: an entry in
+  `ASSIGNABLE_FIELDS` (`models/assignment.py`), a matching nullable FK
+  on `Assignment`, and a migration. Startup checks (`n26.E001`/`E002`)
+  refuse to boot if they disagree.
+- A new condition model must be named in its scope's `CONDITIONS` tuple
+  (`n26.E003`) or its rows are stored but never read.
+- `Has.as_q` needs a `register_lookup()` entry per (model, kind) pair,
+  or it raises `NotExpressibleAsQuery`.
+- **`Assignment.save()` derives the denormalised roots.**
+  `objects.update()` / `bulk_update()` bypass it and the roots drift
+  silently — `Operation.move` re-saves every row in a subtree for
+  exactly this reason. Don't bulk-write assignments.
+- A membership assignment's `miniature_root` is set by hand in
+  `Operation.hire`, not by `save()` — it is hosted on the gang but
+  *about* the model. Anything else creating one must do the same.
+- A settings-group model registers itself on import; it must be reachable
+  from `models/__init__.py` or `SETTING_GROUPS` never sees it.
+- `archived=False` is never a default filter. Readers opt in explicitly
+  (`card_rows` does; `reconcile.sum_rating` also excludes assignments
+  whose model has left the roster).
+
+## Views, forms, templates
+
+- Views are thin function-based views: validate a plain `forms.Form`,
+  wrap side effects in `operation(...)`, `messages.success`, redirect.
+  `create_gang` is the shape to copy. No ModelForms in core.
+- Compute display logic in the view, not the template.
+- UI state lives in the URL. Alpine is allowed for presentation-only
+  narrowing of content already on the page (the gang table's filter is
+  the example to follow) — never for swapping form variants or anything
+  the server would render differently.
+- Template trees under `n26/core/templates/`:
+  - `n26/…` — pages and layouts.
+  - `cotton/n26/…` — this edition's components, used as `<c-n26.foo>`.
+    A directory is a namespace: `gang_table/index.html` is
+    `<c-n26.gang-table>`, `row.html` beside it is
+    `<c-n26.gang-table.row>`. Underscores in filenames become dashes in
+    tags.
+  - `cotton/ui/…` — deliberate overrides of the installed kit's
+    components. They win only because `n26.core` sits above
+    `django_cotton_ui` in `INSTALLED_APPS`; reordering silently reverts
+    them.
+- **Every component opens with a `{% comment %}` block** (the tag, a
+  usage example, the reasoning, the props) **and declares its props in
+  `<c-vars>`** including `class=""`. The gallery reads both at runtime —
+  an undeclared prop is invisible in the docs.
+- A new or renamed component must also be registered in
+  `n26/designsystem/catalog.py` and given demos, or it will not appear
+  in the gallery. See `n26/designsystem/CLAUDE.md`.
+- Cotton traps: a `{% block %}` inside a component attribute renders as
+  nothing (use `<c-slot>`); write `&amp;` not `&` in attributes; the
+  platform's cotton checker does not scan n26 templates, so the
+  `:field=` vs `field=` mistake is unguarded here — check your colons.
+
+## Tests
+
+Unit tests of one module's contract sit next to the code
+(`n26/core/test_*.py`, no `tests/` package). Anything that needs a gang
+and rulebook-shaped content belongs in `n26/tests/sandbox/` instead —
+see `n26/tests/CLAUDE.md`.
+
+## Comments
+
+A comment states a constraint, an invariant, or a consequence the code
+cannot show — briefly, in plain words. It must make sense to a reader
+who has never seen any earlier version of this code: no people, no
+tickets or PRs, no "used to", no "for now". Longer reasoning belongs in
+the module docstring or a `n26/design/` doc. The good examples to
+imitate are in `operations.py` and `models/assignment.py`.

--- a/n26/designsystem/CLAUDE.md
+++ b/n26/designsystem/CLAUDE.md
@@ -11,15 +11,16 @@ components; it owns none of them — they live in
    runtime from its own `<c-vars>` block; its documentation panel is its
    own leading `{% comment %}` block. The catalog never restates props.
 
-Read `demos.py` (101 lines) first, then `introspect.py`.
+Read `demos.py` (a hundred lines) first, then `introspect.py`.
 
 ## Adding or changing a component
 
 1. Write the cotton template in `n26/core/templates/cotton/n26/` (or a
    directory with `index.html` plus part templates). Two things are
-   mandatory because the gallery reads them: a `<c-vars … />` block
-   declaring every public prop, and a leading `{% comment %}` block
-   documenting the component.
+   mandatory for new components because the gallery reads them: a
+   `<c-vars … />` block declaring every public prop, and a leading
+   `{% comment %}` block documenting the component. (A few existing
+   tiny components skip `<c-vars>`; don't copy that.)
 2. Register it in `catalog.py` in the right `Group` — slug, tag,
    template path, summary, notes, `Part(...)` entries for
    subcomponents, `needs=(…)` for runtime dependencies. Do not restate
@@ -83,7 +84,7 @@ broke when you tried. Write new ones in that register.
 A comment states a constraint, an invariant, or a consequence the code
 cannot show — briefly, in plain words. It must make sense to a reader
 who has never seen any earlier version of this code: no people, no
-tickets or PRs, no changelog narration. This app is currently the
-cleanest in the repo by that rule — keep it that way. Django `{# #}`
-comments are single-line only; multi-line prose uses `{% comment %}`
-(a multi-line `{# #}` renders as literal page text).
+tickets or PRs, no changelog narration. This app comes closest to that
+standard already — keep it that way. Django `{# #}` comments are
+single-line only; multi-line prose uses `{% comment %}` (a multi-line
+`{# #}` renders as literal page text).

--- a/n26/designsystem/CLAUDE.md
+++ b/n26/designsystem/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md — n26/designsystem
+
+The living component gallery at `/n26/design/`. It documents the
+components; it owns none of them — they live in
+`n26/core/templates/cotton/`. Two principles carry the whole app:
+
+1. **The file you read is the file that rendered.** A demo page renders
+   a template *and* prints its source; there is no second copy to
+   drift.
+2. **Nothing is transcribed.** A component's props are parsed at
+   runtime from its own `<c-vars>` block; its documentation panel is its
+   own leading `{% comment %}` block. The catalog never restates props.
+
+Read `demos.py` (101 lines) first, then `introspect.py`.
+
+## Adding or changing a component
+
+1. Write the cotton template in `n26/core/templates/cotton/n26/` (or a
+   directory with `index.html` plus part templates). Two things are
+   mandatory because the gallery reads them: a `<c-vars … />` block
+   declaring every public prop, and a leading `{% comment %}` block
+   documenting the component.
+2. Register it in `catalog.py` in the right `Group` — slug, tag,
+   template path, summary, notes, `Part(...)` entries for
+   subcomponents, `needs=(…)` for runtime dependencies. Do not restate
+   props here.
+3. Create `templates/designsystem/demos/<slug>/` with at least one
+   `NN-name.html`. The directory name must match the catalog slug
+   exactly — nothing checks this, and a mismatch silently yields a
+   "No examples yet" page.
+4. If the component takes domain objects, add fixed sample data to
+   `sampledata.py` — real dataclasses built by the real functions, no
+   database (the gallery must render on an empty database).
+5. Add that context to *every* view that renders the demo — both the
+   component page and the plain preview. A form built in one and
+   forgotten in the other renders an empty select and looks like a
+   component bug.
+
+## Demo files
+
+```
+{# title: Solid and pill #}
+{# note: Both are spellings of variant, so you can't have a solid pill. #}
+{# layout: col #}
+<c-ui.badge variant="solid" color="green">solid</c-ui.badge>
+```
+
+- Metadata is a run of `{# key: value #}` comments at the top: `title`,
+  `note`, `layout` (`row` default, `col`, or `full` for whole screens).
+- The body must be a copy-pasteable fragment: no `{% extends %}`, no
+  wrapper markup a call site wouldn't have.
+- One demo per axis of variation. `demos/badge/` is the shape to copy
+  for a primitive; `demos/action-links/` for a composition;
+  `demos/view-gang-sheet/` for a whole screen.
+- Prefer rendering from a registry over writing instances out — the
+  icon demo loops the icon registry, so new icons appear without the
+  demo going stale.
+
+## The `notes` register
+
+A catalog entry's `notes` are not a description — they are the argument
+for the design decision: what you would have done instead, and what
+broke when you tried. Write new ones in that register.
+
+## Traps
+
+- Most failures here are silent by design: a missing demo directory, a
+  catalog path that doesn't resolve, and an undeclared prop all render
+  soft fallbacks, not errors. After any change, load the component's
+  gallery page and check the props table and demos actually appear.
+- A demo that raises takes the whole component page down with it.
+- Print styling is its own world: read the header comment in
+  `assets/print.css` before touching anything print-shaped, and use
+  `printlab` (every control is a query parameter) to test it.
+  `sampledata`, `printlab`, and the token pages deliberately hold no
+  values that live elsewhere — tokens are read from the browser,
+  geometry mirrors the stylesheet.
+- The gallery depends on `n26.core`; core must never import the
+  gallery.
+
+## Comments
+
+A comment states a constraint, an invariant, or a consequence the code
+cannot show — briefly, in plain words. It must make sense to a reader
+who has never seen any earlier version of this code: no people, no
+tickets or PRs, no changelog narration. This app is currently the
+cleanest in the repo by that rule — keep it that way. Django `{# #}`
+comments are single-line only; multi-line prose uses `{% comment %}`
+(a multi-line `{# #}` renders as literal page text).

--- a/n26/library/CLAUDE.md
+++ b/n26/library/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md — n26/library
+
+Game content, and the tools for writing it. Everything an author can put
+in the library flows through one chain, and nothing skips a layer:
+
+```
+models/          the content rows (Weapon, Skill, Profile, Collection, …)
+authoring.py     the verbs — the one API that writes content
+specs.py         each verb described as data (its fields, their types)
+forms.py         Django forms generated from the specs
+views.py         the staff authoring pages, driven by three registries
+ingest.py        spreadsheets in → a previewable plan → rows out
+standard_content.py  the seed rows nobody authors, planted idempotently
+offers.py        what a kind declares about itself; forms derive the rest
+```
+
+Read `models/base.py` (107 lines) first — it states the app's governing
+philosophy. Then `models/assignable.py` and `authoring.py`.
+
+## The model rules
+
+- **Managers do no implicit filtering.** `Profile.objects.all()` returns
+  every pack's content, archived included. Narrowing is opt-in
+  (`in_packs()`, `unarchived()`, `selectable(packs)`). Never add
+  `archived=False` to a read path a subscriber sees; discovery surfaces
+  use `selectable()`.
+- **`Assignable` is a mixin, not a table.** Each kind is its own model.
+  A new kind is: `class X(Content, Assignable[, UsableBy][, Optioned])`,
+  a class-level `family = Family.…`, a `Meta` with verbose names and
+  ordering, the standard constraints (unique per pack on lowercased
+  name + qualifier; exclusive items carry no trade-point price) — and a
+  column on `n26.core`'s `Assignment` plus an entry in
+  `ASSIGNABLE_FIELDS`, or the app refuses to boot.
+- **Help text lives on the model field, nowhere else.** Specs reference
+  it (`source=(Model, "field")`); forms read it through the spec. Model
+  docstrings are shown to authors on the authoring pages — write them as
+  product copy: a plain definition first, detail after.
+- **No rules text, ever.** Names, annotations, and numbers only; the
+  book's wording is copyrighted.
+- A `qualifier` is author-facing only — it tells two same-named things
+  apart in authoring screens and must never reach a player. A test
+  enforces this.
+- Validation is layered on purpose: database constraints for
+  exactly-one invariants; `clean()` for cross-row sense checks; form
+  errors in words for anything an author can trip. `save()` is for
+  canonicalising values only (it runs for importers too, which never
+  call `full_clean`) — never for validation.
+- Migrations are hand-edited and descriptively named. Prefer renames
+  over drop-and-add so authored data survives. `default_pack_id` is
+  referenced by name in migrations and must stay importable from
+  `models/pack.py`; the app label is pinned to `library` — don't touch
+  either.
+
+## Modifiers
+
+A modifier is one **scope** (who it reaches) plus one **effect** (what it
+does), each a small typed row with an exactly-one constraint. Narrowing
+lives in **condition rows** hung off the scope. The grammar:
+
+- Scopes compile to the shared selector algebra in `n26.core.select`
+  via `as_selector()`.
+- Effects split by when they happen: computed at read time (`ef_*`
+  verbs: adds, removes, changes a stat, offers a choice, places a
+  category) versus written at purchase time (`op_*` verbs, e.g. adds a
+  model).
+- A new condition model must be named in its scope's `CONDITIONS`
+  tuple, or its rows are stored but never read (a startup check
+  catches this).
+
+## Extending the authoring surface
+
+Adding a verb means touching, in order:
+
+1. The verb in `authoring.py` (naming: `create_*` for new things,
+   `add_*` for parts of a thing, `ef_*`/`op_*` for effects,
+   `targets_*` for scopes, predicates read as predicates).
+2. A `Spec` in `specs.py` — discovering tests refuse a verb without one.
+3. `LEAF_KINDS` in `views.py` if it gets a page; `DETAIL_KINDS` if the
+   thing has parts added to it over time.
+
+Several parallel lists are deliberate extension points, each guarded by
+a check or a generated constraint (`ASSIGNABLE_FIELDS`, `SCOPE_FIELDS`,
+`EFFECT_FIELDS`, `OFFERABLE_KINDS`, `GRANTABLE_FIELDS`, …). Widening one
+is one line plus a migration plus deliberate thought — never quietly.
+
+Kinds declare, forms derive: `ATTACHMENT_ASKS` and
+`SUGGESTED_BUILT_INS` sit on the model class and `offers.py` computes
+what a form shows. No form may know a kind by name. (Note:
+`ATTACHMENT_ASKS` replaces rather than merges — a kind that declares
+its own must restate the inherited asks it still wants.)
+
+## Ingest
+
+Three stages: read (CSV → dicts), plan (→ an `IngestPlan` of frozen
+rows plus problems; reads the database, never writes), perform (executes
+exactly the plan, through the authoring verbs, in one transaction).
+**The preview is the contract** — what `plan.preview()` shows is what
+`perform()` does. Standing rules: resolve, never create, across sheets;
+built-ins are free; a missing seed row is a loud error, never quietly
+re-planted. A new planned kind must be added to `PERFORM_ORDER`, or
+`perform()` skips it without a word.
+
+## The authoring templates
+
+`templates/authoring/` extends the edition's base layout and renders
+forms through a small dispatch chain: `_form.html` walks the fields,
+`_field.html` picks the right kit control from the widget's kind, using
+the filters in `n26/core/templatetags/formkit.py`. Rules:
+
+- The branches in `_field.html` exist because cotton attributes are
+  static per tag — a control that needs a marker attribute must be its
+  own branch, so unmarked controls never grow empty attributes.
+- The `data-union-*` attributes set by `forms.py` must survive the
+  dispatch byte-for-byte; the page's script and the tests read them.
+- Inside a kit field, shadow `label=""`, `description=""`, and
+  `error=""` explicitly — the kit declares them without defaults, and an
+  unshadowed lookup falls through to the include's context and draws
+  the field chrome twice.
+
+## Comments
+
+A comment states a constraint, an invariant, or a consequence the code
+cannot show — briefly, in plain words. It must make sense to a reader
+who has never seen any earlier version of this code: no people, no
+tickets or PRs, no "graduated from", no "used to be", no "for now".
+Longer reasoning belongs in the module docstring or a `n26/design/`
+doc, cited by filename — and never cite a design doc's section numbers
+in user-visible messages. The examples to imitate:
+`models/statline.py` (why canonicalising happens in `save`),
+`models/pack.py` (why a function must stay importable).

--- a/n26/library/CLAUDE.md
+++ b/n26/library/CLAUDE.md
@@ -8,7 +8,7 @@ models/          the content rows (Weapon, Skill, Profile, Collection, …)
 authoring.py     the verbs — the one API that writes content
 specs.py         each verb described as data (its fields, their types)
 forms.py         Django forms generated from the specs
-views.py         the staff authoring pages, driven by three registries
+views.py         the staff authoring pages, driven by small registries
 ingest.py        spreadsheets in → a previewable plan → rows out
 standard_content.py  the seed rows nobody authors, planted idempotently
 offers.py        what a kind declares about itself; forms derive the rest
@@ -74,9 +74,13 @@ Adding a verb means touching, in order:
 1. The verb in `authoring.py` (naming: `create_*` for new things,
    `add_*` for parts of a thing, `ef_*`/`op_*` for effects,
    `targets_*` for scopes, predicates read as predicates).
-2. A `Spec` in `specs.py` — discovering tests refuse a verb without one.
-3. `LEAF_KINDS` in `views.py` if it gets a page; `DETAIL_KINDS` if the
-   thing has parts added to it over time.
+2. A `Spec` in `specs.py` — discovering tests refuse a scope, effect,
+   or condition verb (`targets_*`, `ef_*`, `op_*`) without one; give
+   `create_*` and `add_*` verbs one too even though no guard forces it.
+3. The registries in `views.py`: `LEAF_KINDS` if it gets a page (and
+   `LEAF_DESCRIBE` for the page's blurb); `DETAIL_KINDS` if the thing
+   has parts added to it over time; `DETAIL_VIEWS` for a bespoke detail
+   page.
 
 Several parallel lists are deliberate extension points, each guarded by
 a check or a generated constraint (`ASSIGNABLE_FIELDS`, `SCOPE_FIELDS`,
@@ -85,9 +89,11 @@ is one line plus a migration plus deliberate thought — never quietly.
 
 Kinds declare, forms derive: `ATTACHMENT_ASKS` and
 `SUGGESTED_BUILT_INS` sit on the model class and `offers.py` computes
-what a form shows. No form may know a kind by name. (Note:
-`ATTACHMENT_ASKS` replaces rather than merges — a kind that declares
-its own must restate the inherited asks it still wants.)
+what a form shows — no form hardcodes a kind there (the inline-create
+shortcut for rules and subtypes in `forms.py` is the one deliberate
+exception). Note: `ATTACHMENT_ASKS` replaces rather than merges — a
+kind that declares its own must restate the inherited asks it still
+wants.
 
 ## Ingest
 
@@ -99,23 +105,6 @@ exactly the plan, through the authoring verbs, in one transaction).
 built-ins are free; a missing seed row is a loud error, never quietly
 re-planted. A new planned kind must be added to `PERFORM_ORDER`, or
 `perform()` skips it without a word.
-
-## The authoring templates
-
-`templates/authoring/` extends the edition's base layout and renders
-forms through a small dispatch chain: `_form.html` walks the fields,
-`_field.html` picks the right kit control from the widget's kind, using
-the filters in `n26/core/templatetags/formkit.py`. Rules:
-
-- The branches in `_field.html` exist because cotton attributes are
-  static per tag — a control that needs a marker attribute must be its
-  own branch, so unmarked controls never grow empty attributes.
-- The `data-union-*` attributes set by `forms.py` must survive the
-  dispatch byte-for-byte; the page's script and the tests read them.
-- Inside a kit field, shadow `label=""`, `description=""`, and
-  `error=""` explicitly — the kit declares them without defaults, and an
-  unshadowed lookup falls through to the include's context and draws
-  the field chrome twice.
 
 ## Comments
 

--- a/n26/tests/CLAUDE.md
+++ b/n26/tests/CLAUDE.md
@@ -3,17 +3,17 @@
 Three tiers, split by the kind of claim a test makes — not by which
 module changed:
 
-- **Colocated** (`n26/core/test_*.py`, `n26/library/test_*.py`) — unit
-  tests of one module's contract: field defaults, constraints, pure
-  functions. If it would still be true with no gang, no fighter, and no
-  rulebook, it belongs here.
+- **Colocated** (`n26/core/test_*.py`, `n26/library/test_*.py`, and
+  each app's `tests.py`) — unit tests of one module's contract: field
+  defaults, constraints, pure functions. If it would still be true with
+  no gang, no fighter, and no rulebook, it belongs here.
 - **`n26/tests/`** — the seam with the host platform. The only tests
   allowed to import from outside `n26.*` (the testers gate, the
   dashboard, the shell).
 - **`n26/tests/sandbox/`** — the bulk of the suite. Each file builds a
   slice of real rulebook content from scratch with the authoring verbs,
   founds a gang, plays with it, and asserts on the player-facing
-  structures. Sandbox files are executable design documents; most cite
+  structures. Sandbox files are executable design documents; many cite
   the `n26/design/` note they prove.
 
 ## The verbs
@@ -25,22 +25,26 @@ module changed:
   (`ef_adds`, `targets_model(has_subtypes(x))`, `attach_to=`); the old
   sandbox aliases exist only so existing suites read as written.
 - Player-side wrappers (`found_gang`, `hire`, `give_weapon`, `buy`,
-  `choose`, `tally`, `move`, `refund`, …) each open one
+  `choose`, `tally`, `move`, `refund`, …) wrap their writes in an
   `operation(...)` block. They default the actor to the gang's owner;
   the real API deliberately does not.
 
-**A sandbox test never reaches for the ORM directly.** The one file
-allowed to use `objects.create` is `test_content_authoring.py`, whose
-docstring exists to say so.
+**Prefer the verbs over the ORM.** Reach for `objects.create` in a
+sandbox test only where no verb covers the wiring — and check first,
+because verbs have grown to cover ground older tests built by hand.
+`test_content_authoring.py` alone uses the raw ORM throughout,
+deliberately: its docstring says it is the reference for what an ingest
+or the admin really does.
 
 ## Fixtures
 
 - Shared fixtures live in **`n26/tests/fixtures.py`** — an importable
   module, not a conftest. Each test-bearing tree has a one-line
-  conftest doing `from n26.tests.fixtures import *`. **Never create a
-  repo-root conftest and never flatten these**: the host repo's
-  conftest defines fixtures with the same names (`make_statline`), and
-  the nearer file wins silently.
+  conftest doing `from n26.tests.fixtures import *`. **Never add n26
+  fixtures to the repo-root conftest, and never flatten these into a
+  higher conftest**: the host repo's root conftest defines fixtures
+  with the same names (`make_statline`), and the nearer file wins
+  silently.
 - `fixtures.py` stays small. File-local fixtures composing the verbs
   are the norm — a sandbox file typically defines ten or so of its own.
 - Content shapes go in module-level data tables (a `GRID`, an
@@ -55,7 +59,9 @@ docstring exists to say so.
 ## Conventions
 
 - `pytestmark = pytest.mark.django_db` at module level, right after the
-  imports. Fixtures that need the database request `db`.
+  imports — or per-test decorators in files whose collection-time
+  discovery must stay database-free. Fixtures that need the database
+  request `db`.
 - Tests are grouped in bare classes used as narrative headings
   (`TestFoundingTheGang`), each with a docstring stating the contract.
   Test names are full sentences:
@@ -70,9 +76,10 @@ docstring exists to say so.
   on a few load-bearing substrings. Pick substrings the page can only
   contain if the behaviour worked — a test here once passed because a
   stylesheet happened to contain the word "complete".
-- Any test that spends money ends with `assert_reconciled(gang)`.
-- Query-count tests assert the count stays the same after adding more
-  fighters — never a bare magic number.
+- End any test that spends money with `assert_reconciled(gang)`.
+- For query counts, prefer asserting the count stays the same after
+  adding more fighters; a pinned literal count is acceptable for one
+  structure's fixed budget.
 - **Discovering guards, not lists.** A rule that must hold for every X
   enumerates the codebase by reflection, pairs with a
   `test_there_is_something_to_check`, and fails with prose saying what

--- a/n26/tests/CLAUDE.md
+++ b/n26/tests/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md — n26 tests
+
+Three tiers, split by the kind of claim a test makes — not by which
+module changed:
+
+- **Colocated** (`n26/core/test_*.py`, `n26/library/test_*.py`) — unit
+  tests of one module's contract: field defaults, constraints, pure
+  functions. If it would still be true with no gang, no fighter, and no
+  rulebook, it belongs here.
+- **`n26/tests/`** — the seam with the host platform. The only tests
+  allowed to import from outside `n26.*` (the testers gate, the
+  dashboard, the shell).
+- **`n26/tests/sandbox/`** — the bulk of the suite. Each file builds a
+  slice of real rulebook content from scratch with the authoring verbs,
+  founds a gang, plays with it, and asserts on the player-facing
+  structures. Sandbox files are executable design documents; most cite
+  the `n26/design/` note they prove.
+
+## The verbs
+
+`n26/tests/sandbox/actions.py` is the test-facing vocabulary:
+
+- Library-side verbs are re-exports of `n26.library.authoring` — the
+  real, shipped authoring API. Use the authoring names in new tests
+  (`ef_adds`, `targets_model(has_subtypes(x))`, `attach_to=`); the old
+  sandbox aliases exist only so existing suites read as written.
+- Player-side wrappers (`found_gang`, `hire`, `give_weapon`, `buy`,
+  `choose`, `tally`, `move`, `refund`, …) each open one
+  `operation(...)` block. They default the actor to the gang's owner;
+  the real API deliberately does not.
+
+**A sandbox test never reaches for the ORM directly.** The one file
+allowed to use `objects.create` is `test_content_authoring.py`, whose
+docstring exists to say so.
+
+## Fixtures
+
+- Shared fixtures live in **`n26/tests/fixtures.py`** — an importable
+  module, not a conftest. Each test-bearing tree has a one-line
+  conftest doing `from n26.tests.fixtures import *`. **Never create a
+  repo-root conftest and never flatten these**: the host repo's
+  conftest defines fixtures with the same names (`make_statline`), and
+  the nearer file wins silently.
+- `fixtures.py` stays small. File-local fixtures composing the verbs
+  are the norm — a sandbox file typically defines ten or so of its own.
+- Content shapes go in module-level data tables (a `GRID`, an
+  `ARCHETYPES` dict) that fixtures loop over. Importing another file's
+  table is fine.
+- The platform's fixtures (`content_fighter`, `make_list`, …) are the
+  other edition's models — never use them in n26 tests. Make users
+  inline with `User.objects.create_user(...)`.
+- Request `default_pack` in content-creating tests so the pack exists
+  before counting anything.
+
+## Conventions
+
+- `pytestmark = pytest.mark.django_db` at module level, right after the
+  imports. Fixtures that need the database request `db`.
+- Tests are grouped in bare classes used as narrative headings
+  (`TestFoundingTheGang`), each with a docstring stating the contract.
+  Test names are full sentences:
+  `test_the_house_list_arrives_without_anyone_assigning_it`. This
+  deliberately differs from the platform's module-level-functions rule;
+  do not "fix" it.
+- Drive domain behaviour through the verbs; drive view behaviour
+  through the test client with real URLs and full POST payloads
+  (including formset management data).
+- **No golden files.** Two patterns instead: pinned literal tables
+  ("pinned so it changes deliberately"), and print-the-text then assert
+  on a few load-bearing substrings. Pick substrings the page can only
+  contain if the behaviour worked — a test here once passed because a
+  stylesheet happened to contain the word "complete".
+- Any test that spends money ends with `assert_reconciled(gang)`.
+- Query-count tests assert the count stays the same after adding more
+  fighters — never a bare magic number.
+- **Discovering guards, not lists.** A rule that must hold for every X
+  enumerates the codebase by reflection, pairs with a
+  `test_there_is_something_to_check`, and fails with prose saying what
+  to do. `test_money_words.py` is the template. Never narrow a guard's
+  discovery to make a failure go away.
+- Discovery used in `parametrize` runs at collection time — keep it
+  import-safe, no database access.
+- Tests run with `--nomigrations`, so data migrations never ran: the
+  "N26 Testers" group does not exist unless a test creates it.
+- Rule names only, never the book's wording.
+
+## Exemplars
+
+- `test_escher_gang.py` — the canonical full-shape sandbox suite.
+- `test_budget.py` — the best small suite: one rule, four tests, 74
+  lines.
+- `test_gang_sheet.py` — one structure, one contract; asserts the plan
+  shows a scope was *skipped*, not merely that nothing happened.
+- `test_money_words.py` — the discovering-guard template.
+- `n26/core/test_printing.py` — the colocated exemplar: no database at
+  all.
+
+## Comments
+
+A comment states why the rule is the rule, in the domain's own words,
+for a reader who has never seen any earlier version of this code — so
+no people, no tickets or PRs, no dates, no changelog narration. Citing
+a `n26/design/` doc by filename is the right way to point at deeper
+reasoning. Regression tests describe the bug by what a player saw, in a
+sentence or two, not by its history.


### PR DESCRIPTION
Until now the root CLAUDE.md said nothing about the n26 edition, so agents working in the n26 tree had to infer every rule from code. This adds five CLAUDE.md files distilled from a full audit of the four packages, with the patterns verified with the maintainer before landing, then fact-checked claim-by-claim against the code.

## Summary

- Adds n26/CLAUDE.md: the package map, the import boundaries (no n23.*/gyrinx.* imports in app code; core models name library models by string; library imports core logic only inside functions), the banned word "cost", the design stances that hold everywhere (inform never police; no rules text; recompute never nudge), and where UI state lives (the URL, with a sanctioned Alpine exception for presentation-only filtering).
- Adds one file per package — n26/core/CLAUDE.md (operations as the only writer, the query-free compute layer and pinned query budgets, the broadcast-flag guard, the wiring steps that fail silently, cotton component conventions), n26/library/CLAUDE.md (the authoring-verb chain, sourced help text, the add-a-kind/add-a-verb checklists, ingest's preview-is-the-contract rule), n26/designsystem/CLAUDE.md (the gallery's two principles and the add-a-component checklist), and n26/tests/CLAUDE.md (the three test tiers, the actions verbs, the fixture layout, discovering guards).
- Every file carries the same comment rule: a comment must make sense to a reader who has never seen any earlier version of the code — no people, no tickets or PRs, no changelog narration, no disguised TODOs.

A guidance section for the authoring form-dispatch templates was drafted but held back: that layer isn't on any pushed branch yet, and docs describing files that don't exist would mislead. The section text is ready to add when that work lands.

The audit that produced these files also surfaced four live bugs, filed separately:

Refs #2151
Refs #2152
Refs #2153
Refs #2154

## Test plan

- [x] `markdownlint` passes on all five files (runs in pre-commit)
- [x] Full pre-commit hook suite passes on both commits
- [x] Claim-by-claim fact-check of the files against the code (~100 claims verified; every miss corrected in the second commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)