### PR TITLE
feat: n26 authoring on the design system, plus the modifier composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ playbooks/trace/output/*
 # live prod DB password; written 0o600 and deleted on exit — never commit it)
 gyrinx/_prodshell_settings.py
 _cotton_test_host/
+
+# The n26 edition's working design docs — local research material, never committed
+/n26/design/

--- a/n26/core/templatetags/formkit.py
+++ b/n26/core/templatetags/formkit.py
@@ -1,0 +1,50 @@
+"""Filters that let a template dispatch a bound field onto the kit.
+
+The authoring forms are spec-generated — nobody can hand-write a
+``<c-ui.field>`` per field the way a fixed page does — so a dispatch
+include renders each bound field through the right kit control. These
+filters answer the three questions the template cannot: what kind of
+control the widget wants, what a dash-keyed widget attribute holds, and
+which choice values are selected.
+"""
+
+from django import template
+from django.forms import widgets
+
+register = template.Library()
+
+
+@register.filter
+def widget_kind(field):
+    """One word naming the kit control this bound field wants."""
+    widget = field.field.widget
+    if isinstance(widget, widgets.SelectMultiple):
+        return "selectmultiple"
+    if isinstance(widget, widgets.Select):
+        return "select"
+    if isinstance(widget, widgets.CheckboxInput):
+        return "checkbox"
+    if isinstance(widget, widgets.Textarea):
+        return "textarea"
+    if isinstance(widget, widgets.NumberInput):
+        return "number"
+    return "text"
+
+
+@register.filter
+def widget_attr(field, name):
+    """A widget attribute by its real (often dash-keyed) name — the
+    union markers live in ``data-union-*``, which dot lookup can't reach."""
+    return field.field.widget.attrs.get(name, "")
+
+
+@register.filter
+def selected_values(field):
+    """The bound value(s) as strings, so an option template can ask
+    "am I selected?" the same way for single and multiple selects."""
+    value = field.value()
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value]
+    return [str(value)]

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -922,3 +922,10 @@ def attach_modifiers_to(assignable, modifiers):
     """Hang already-built (reusable) modifiers on a further carrier."""
     assignable.modifiers.add(*modifiers)
     return assignable
+
+
+def detach_modifier(assignable, modifier):
+    """Take a modifier off one carrier. The modifier itself survives —
+    it may hang on other carriers, or wait as a reusable."""
+    assignable.modifiers.remove(modifier)
+    return assignable

--- a/n26/library/forms.py
+++ b/n26/library/forms.py
@@ -415,16 +415,18 @@ def condition_chip_form(kinds):
     return type("ConditionChipForm", (forms.Form,), attrs)
 
 
-def condition_formset_for(spec, data=None, prefix="conditions"):
+def condition_formset_for(spec, data=None, prefix="conditions", extra=0):
     """The formset of condition chips a scope form carries, or ``None``
-    for scopes that take no conditions."""
+    for scopes that take no conditions. ``extra`` is how many empty
+    chips to draw — the composer page carries it in the URL, so "add a
+    condition" is a link and the state survives a refresh."""
     kinds = next(
         (kind.kinds for kind in spec.fields.values() if isinstance(kind, Conditions)),
         None,
     )
     if kinds is None:
         return None
-    formset_class = forms.formset_factory(condition_chip_form(kinds), extra=0)
+    formset_class = forms.formset_factory(condition_chip_form(kinds), extra=extra)
     return formset_class(data, prefix=prefix)
 
 
@@ -517,12 +519,41 @@ def suggestion_form_for(kind_model):
 # --- The modifier composer ----------------------------------------------------
 
 
+#: Which model each scope verb writes — the label source for the
+#: composer's WHO select. SCOPE_PRODUCES guards the key set by drift
+#: test, so a new scope verb shows up here or shows up loudly.
+SCOPE_MODELS = {
+    "targets_model": "TargetsMiniature",
+    "targets_weapons": "TargetsWeapons",
+    "targets_attached_weapon": "TargetsAttachedWeapon",
+    "targets_gang": "TargetsGang",
+}
+
+
+def _verb_label(name, model_label):
+    """A verb choice as an author reads it — the model's own verbose
+    name ("targets the model"), the verb name when nothing better is
+    known."""
+    if model_label is None:
+        return name
+    model = _model_class(model_label)
+    return str(model._meta.verbose_name)
+
+
 def _scope_choices():
-    return [(name, name) for name in specs() if name.startswith("targets_")]
+    return [
+        (name, _verb_label(name, SCOPE_MODELS.get(name)))
+        for name in specs()
+        if name.startswith("targets_")
+    ]
 
 
 def _effect_choices():
-    return [(name, name) for name in specs() if name.startswith(("ef_", "op_"))]
+    return [
+        (name, _verb_label(name, EFFECT_MODELS.get(name)))
+        for name in specs()
+        if name.startswith(("ef_", "op_"))
+    ]
 
 
 class ModifierComposerForm(forms.Form):
@@ -540,17 +571,18 @@ class ModifierComposerForm(forms.Form):
     where the auto-name is the modifier's own sentence.
     """
 
-    scope_kind = forms.ChoiceField(choices=_scope_choices)
-    effect_kind = forms.ChoiceField(choices=_effect_choices)
+    scope_kind = forms.ChoiceField(choices=_scope_choices, label="Who it reaches")
+    effect_kind = forms.ChoiceField(choices=_effect_choices, label="What it does")
     name = forms.CharField(
         required=False,
         help_text="Blank writes the modifier's own sentence as its name.",
     )
     keep_reusable = forms.BooleanField(
         required=False,
+        label="Keep reusable",
         help_text=(
-            "Save without attaching, so attach_modifiers_to can hang it "
-            "on several carriers later."
+            "Save without attaching here, so it can be attached to "
+            "several carriers later."
         ),
     )
 
@@ -561,6 +593,25 @@ class ModifierComposerForm(forms.Form):
         self.who_form = None
         self.what_form = None
         self.condition_formset = None
+
+    @classmethod
+    def unbound(cls, scope_kind, effect_kind, *, attach_to=None, chips=0):
+        """The composer ready to draw, before anything is submitted.
+
+        The bound path builds its panes in ``clean()`` from the posted
+        kinds; a page rendering step two of the flow has no data yet,
+        only the kinds carried in the URL. ``chips`` is how many empty
+        condition rows to offer — also URL state, so "add a condition"
+        is a plain link.
+        """
+        form = cls(
+            attach_to=attach_to,
+            initial={"scope_kind": scope_kind, "effect_kind": effect_kind},
+        )
+        form.who_form = generate_form(specs()[scope_kind])(prefix="who")
+        form.what_form = generate_form(specs()[effect_kind])(prefix="what")
+        form.condition_formset = condition_formset_for(specs()[scope_kind], extra=chips)
+        return form
 
     def clean(self):
         cleaned = super().clean()

--- a/n26/library/templates/authoring/_composer.html
+++ b/n26/library/templates/authoring/_composer.html
@@ -1,0 +1,62 @@
+{% comment %}
+The two-step composer, shared by every carrier page and the standalone
+modifiers page. Step one is a GET so the chosen kinds live in the URL —
+step two survives a refresh, and "add a condition" is a plain link.
+
+Takes kind_picker, composer, composer_scope, composer_effect,
+composer_chips, and show_keep_reusable (the standalone page hides the
+switch: with nothing to attach to, everything it makes is reusable).
+{% endcomment %}
+<c-n26.form-section title="Compose a new one"
+                    description="Pick who it reaches and what it does; the fields for both follow."
+                    class="rounded-box border border-box-border p-4">
+    {% comment %}
+    Step one, as a GET: the chosen kinds live in the URL, so
+    step two survives a refresh and "add a condition" can be
+    a plain link. Only once both kinds are chosen does the
+    composer itself render.
+    {% endcomment %}
+    <form method="get" class="max-w-xl space-y-4">
+        {% include "authoring/_field.html" with form=kind_picker field=kind_picker.scope_kind %}
+        {% include "authoring/_field.html" with form=kind_picker field=kind_picker.effect_kind %}
+        <div class="flex justify-end">
+            <c-ui.button type="submit" size="sm">
+                Continue
+            </c-ui.button>
+        </div>
+    </form>
+    {% if composer %}
+        <form method="post" class="max-w-xl space-y-5">
+            {% csrf_token %}
+            <input type="hidden" name="act" value="compose">
+            <input type="hidden" name="scope_kind" value="{{ composer_scope }}">
+            <input type="hidden" name="effect_kind" value="{{ composer_effect }}">
+            <c-ui.error :form="composer" name="__all__" />
+            <c-n26.form-section title="Who it reaches">
+                {% include "authoring/_form.html" with form=composer.who_form %}
+                {% if composer.condition_formset %}
+                    {{ composer.condition_formset.management_form }}
+                    {% for chip in composer.condition_formset %}
+                        <div class="rounded-box border border-box-border p-3">{% include "authoring/_form.html" with form=chip %}</div>
+                    {% endfor %}
+                    <c-n26.link href="?scope_kind={{ composer_scope }}&effect_kind={{ composer_effect }}&chips={{ composer_chips|add:1 }}"
+                                tone="muted">
+                        Add a condition
+                    </c-n26.link>
+                {% endif %}
+            </c-n26.form-section>
+            <c-n26.form-section title="What it does">
+                {% include "authoring/_form.html" with form=composer.what_form %}
+            </c-n26.form-section>
+            {% include "authoring/_field.html" with form=composer field=composer.name %}
+            {% if show_keep_reusable %}
+                {% include "authoring/_field.html" with form=composer field=composer.keep_reusable %}
+            {% endif %}
+            <div class="flex justify-end">
+                <c-ui.button type="submit" variant="success">
+                    Compose modifier
+                </c-ui.button>
+            </div>
+        </form>
+    {% endif %}
+</c-n26.form-section>

--- a/n26/library/templates/authoring/_extras.html
+++ b/n26/library/templates/authoring/_extras.html
@@ -1,0 +1,16 @@
+{% comment %}
+The two fields every assignable form carries but almost no submission
+needs: the qualifier (telling apart two same-named things) and the
+library author help. Grouped so _form.html can fold them behind one
+collapse, expanded only when one of them has an error to show.
+
+Takes `form`.
+{% endcomment %}
+<div class="mt-4 space-y-5">
+    {% if form.qualifier %}
+        {% include "authoring/_field.html" with field=form.qualifier %}
+    {% endif %}
+    {% if form.library_author_help %}
+        {% include "authoring/_field.html" with field=form.library_author_help %}
+    {% endif %}
+</div>

--- a/n26/library/templates/authoring/_field.html
+++ b/n26/library/templates/authoring/_field.html
@@ -1,0 +1,118 @@
+{% load formkit %}
+{% comment %}
+One bound field, dispatched onto the kit control its widget wants.
+
+The branches exist because cotton attributes are static per tag: a
+control that carries union markers (data-union-kind on the kind select,
+data-union-of + data-union-member on member pickers and their asks) is
+its own tag, so an unmarked control never grows empty marker
+attributes. The markers themselves come off the widget attrs the form
+layer set — the base layout's script and the tests read them wherever
+they land, so they must survive this dispatch byte-for-byte.
+
+Takes `field` (a BoundField) and `form`.
+{% endcomment %}
+{% with kind=field|widget_kind label=field.label|capfirst help=field.help_text %}
+    {% if kind == "checkbox" %}
+        <c-ui.field data-field
+                    variant="toggle"
+                    label="{{ label }}"
+                    description="{{ help }}"
+                    error="x"
+                    :form="form"
+                    name="{{ field.name }}"
+                    for="{{ field.auto_id }}">
+            <c-ui.switch label=""
+                         name="{{ field.html_name }}"
+                         id="{{ field.auto_id }}"
+                         :checked="field.value" />
+        </c-ui.field>
+    {% elif kind == "textarea" %}
+        <c-ui.field data-field
+                    label="{{ label }}{% if field.field.required %} *{% endif %}"
+                    description="{{ help }}"
+                    error="x"
+                    :form="form"
+                    name="{{ field.name }}"
+                    for="{{ field.auto_id }}">
+            {% comment %}
+            label/description/error shadowed empty: the kit declares them
+            without defaults, so an unshadowed lookup falls through to
+            this include's context and draws the field chrome twice.
+            {% endcomment %}
+            <c-ui.textarea label=""
+                           description=""
+                           error=""
+                           badge=""
+                           name="{{ field.html_name }}"
+                           id="{{ field.auto_id }}"
+                           height="xs">
+                {{ field.value|default:'' }}
+            </c-ui.textarea>
+        </c-ui.field>
+    {% elif kind == "select" or kind == "selectmultiple" %}
+        <c-ui.field data-field
+                    label="{{ label }}{% if field.field.required %} *{% endif %}"
+                    description="{{ help }}"
+                    error="x"
+                    :form="form"
+                    name="{{ field.name }}"
+                    for="{{ field.auto_id }}">
+            {% if field|widget_attr:"data-union-kind" %}
+                <c-ui.select.native name="{{ field.html_name }}"
+                                    id="{{ field.auto_id }}"
+                                    placeholder=""
+                                    data-union-kind="{{ field|widget_attr:'data-union-kind' }}">
+                    {% include "authoring/_options.html" %}
+                </c-ui.select.native>
+            {% elif field|widget_attr:"data-union-of" %}
+                <c-ui.select.native name="{{ field.html_name }}"
+                                    id="{{ field.auto_id }}"
+                                    placeholder=""
+                                    data-union-of="{{ field|widget_attr:'data-union-of' }}"
+                                    data-union-member="{{ field|widget_attr:'data-union-member' }}">
+                    {% include "authoring/_options.html" %}
+                </c-ui.select.native>
+            {% elif kind == "selectmultiple" %}
+                {% comment %}
+                multiple rides the attrs passthrough (size would shadow
+                the kit's size-class key); the browser draws the list box.
+                {% endcomment %}
+                <c-ui.select.native name="{{ field.html_name }}"
+                                    id="{{ field.auto_id }}"
+                                    placeholder=""
+                                    multiple>
+                    {% include "authoring/_options.html" %}
+                </c-ui.select.native>
+            {% else %}
+                <c-ui.select.native name="{{ field.html_name }}" id="{{ field.auto_id }}" placeholder="">
+                    {% include "authoring/_options.html" %}
+                </c-ui.select.native>
+            {% endif %}
+        </c-ui.field>
+    {% else %}
+        <c-ui.field data-field
+                    label="{{ label }}{% if field.field.required %} *{% endif %}"
+                    description="{{ help }}"
+                    error="x"
+                    :form="form"
+                    name="{{ field.name }}"
+                    for="{{ field.auto_id }}">
+            {% if field|widget_attr:"data-union-of" %}
+                <c-ui.input type="{% if kind == 'number' %}number{% else %}text{% endif %}"
+                            name="{{ field.html_name }}"
+                            id="{{ field.auto_id }}"
+                            value="{{ field.value|default:'' }}"
+                            placeholder="{{ field|widget_attr:'placeholder' }}"
+                            data-union-of="{{ field|widget_attr:'data-union-of' }}"
+                            data-union-member="{{ field|widget_attr:'data-union-member' }}" />
+            {% else %}
+                <c-ui.input type="{% if kind == 'number' %}number{% else %}text{% endif %}"
+                            name="{{ field.html_name }}"
+                            id="{{ field.auto_id }}"
+                            value="{{ field.value|default:'' }}"
+                            placeholder="{{ field|widget_attr:'placeholder' }}" />
+            {% endif %}
+        </c-ui.field>
+    {% endif %}
+{% endwith %}

--- a/n26/library/templates/authoring/_form.html
+++ b/n26/library/templates/authoring/_form.html
@@ -5,10 +5,35 @@ global form renderer — the other edition's markup. This walks the same
 fields and hands each to the dispatch include, so what an author sees
 is the design system and nothing else.
 
+The qualifier and the library author help ride every assignable form
+but almost no submission needs them, so they fold behind a collapse —
+closed by default, open when either arrived with an error, because a
+refusal hidden inside a closed box reads as a form that will not
+submit for no reason.
+
 Takes `form`.
 {% endcomment %}
 <c-ui.error :form="form" name="__all__" />
 {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
 {% for field in form.visible_fields %}
-    {% include "authoring/_field.html" %}
+    {% if field.name != "qualifier" and field.name != "library_author_help" %}
+        {% include "authoring/_field.html" %}
+    {% endif %}
 {% endfor %}
+{% if form.qualifier or form.library_author_help %}
+    <div class="rounded-box border border-box-border px-4 py-3">
+        {% firstof form.qualifier.errors form.library_author_help.errors as extras_open %}
+        {% if extras_open %}
+            <c-ui.collapse :expanded="True"
+                           trigger_text="Qualifier and author help — only if you need them"
+                           trigger_class="inline-flex items-center gap-1.5 text-sm font-medium text-muted">
+                {% include "authoring/_extras.html" %}
+            </c-ui.collapse>
+        {% else %}
+            <c-ui.collapse trigger_text="Qualifier and author help — only if you need them"
+                           trigger_class="inline-flex items-center gap-1.5 text-sm font-medium text-muted">
+                {% include "authoring/_extras.html" %}
+            </c-ui.collapse>
+        {% endif %}
+    </div>
+{% endif %}

--- a/n26/library/templates/authoring/_form.html
+++ b/n26/library/templates/authoring/_form.html
@@ -1,0 +1,14 @@
+{% comment %}
+One spec-generated form, rendered through the kit. The pages used to
+say {{ form.as_div }}, which routed every field through the platform's
+global form renderer — the other edition's markup. This walks the same
+fields and hands each to the dispatch include, so what an author sees
+is the design system and nothing else.
+
+Takes `form`.
+{% endcomment %}
+<c-ui.error :form="form" name="__all__" />
+{% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
+{% for field in form.visible_fields %}
+    {% include "authoring/_field.html" %}
+{% endfor %}

--- a/n26/library/templates/authoring/_options.html
+++ b/n26/library/templates/authoring/_options.html
@@ -1,0 +1,14 @@
+{% load formkit %}
+{% comment %}
+The options of one select field, selected state included — shared by
+every select branch of the dispatch. `selected_values` stringifies the
+bound value(s) so single and multiple selects ask the same question.
+
+Takes `field`.
+{% endcomment %}
+{% with picked=field|selected_values %}
+    {% for value, text in field.field.choices %}
+        <c-ui.select.option value="{{ value }}"
+                            selected="{% if value|stringformat:'s' in picked %}1{% endif %}">{{ text }}</c-ui.select.option>
+    {% endfor %}
+{% endwith %}

--- a/n26/library/templates/authoring/base.html
+++ b/n26/library/templates/authoring/base.html
@@ -11,6 +11,7 @@ layout owns; what remains is only what is authoring's.
 {% block nav_items %}
     <c-ui.navbar.item href="{% url 'authoring-index' %}">Authoring</c-ui.navbar.item>
     <c-ui.navbar.item href="{% url 'authoring-foundations' %}">Foundations</c-ui.navbar.item>
+    <c-ui.navbar.item href="{% url 'authoring-modifiers' %}">Modifiers</c-ui.navbar.item>
     <c-ui.navbar.item href="{% url 'n26-dashboard' %}">App</c-ui.navbar.item>
 {% endblock nav_items %}
 {% block extra_script %}

--- a/n26/library/templates/authoring/base.html
+++ b/n26/library/templates/authoring/base.html
@@ -1,86 +1,44 @@
+{% extends "n26/layouts/base.html" %}
 {% comment %}
-The authoring skeleton — deliberately plain. Structure now, styling at
-merge time; everything the pages say comes from specs and model help.
+The authoring shell: the edition's own layout, with the authoring nav
+and the one script the union pickers need. Everything this used to
+carry — a whole head, an inline stylesheet, message rendering — the
+layout owns; what remains is only what is authoring's.
 {% endcomment %}
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="The n26 content authoring surface.">
-        <title>{% block title %}Authoring{% endblock %} — n26</title>
-        <style>
-    body { font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 46rem;
-           padding: 0 1rem; line-height: 1.5; color: #222; }
-    a { color: #14532d; }
-    h1 { font-size: 1.4rem; } h2 { font-size: 1.1rem; margin-top: 2rem; }
-    nav { margin-bottom: 1.5rem; font-size: 0.9rem; }
-    form div { margin-bottom: 0.9rem; }
-    label { display: block; font-weight: 600; }
-    .helptext { display: block; font-size: 0.85rem; color: #666; }
-    input[type=text], input[type=number], select {
-      padding: 0.3rem 0.4rem; min-width: 16rem; font-size: 1rem; }
-    button { padding: 0.4rem 1rem; font-size: 1rem; cursor: pointer; }
-    ul.errorlist { color: #b91c1c; margin: 0.2rem 0; padding-left: 1.1rem; }
-    .messages { color: #14532d; }
-    table { border-collapse: collapse; width: 100%; }
-    td, th { text-align: left; padding: 0.25rem 0.6rem 0.25rem 0; }
-    tbody tr { border-top: 1px solid #eee; }
-    .count { color: #666; font-size: 0.9rem; text-align: right; }
-    .summary { display: block; color: #666; font-size: 0.85rem; max-width: 34rem; }
-    .kind-help { border-left: 3px solid #d7e3d9; padding: 0.1rem 0 0.1rem 1rem;
-                 margin-bottom: 1.5rem; color: #444; font-size: 0.94rem; }
-    .kind-help p:first-child { font-weight: 600; color: #222; }
-    .kind-help code { background: #f2f4f2; padding: 0 0.2rem; }
-    fieldset.suggestions { border: 1px solid #e3e6e3; padding: 0.6rem 1rem;
-                           margin-bottom: 1rem; }
-    fieldset.suggestions legend { font-size: 0.85rem; color: #666; }
-    fieldset.statline { border: 1px solid #e3e6e3; padding: 0.6rem 1rem;
-                        margin-bottom: 1rem; }
-    fieldset.statline legend { font-size: 0.85rem; color: #666; }
-    fieldset.statline div { display: inline-block; margin-right: 1rem; }
-    fieldset.statline input { min-width: 0; }
-    fieldset.statline .helptext { font-size: 0.75rem; }
-    .seed { border: 1px solid #e3e6e3; padding: 0.6rem 1rem; margin-bottom: 0.8rem; }
-    .seed p { margin: 0.2rem 0; }
-    .status { font-size: 0.8rem; padding: 0 0.35rem; border-radius: 3px; }
-    .status.complete { background: #dcf0e2; color: #14532d; }
-    .status.missing { background: #f6dcdc; color: #7f1d1d; }
-    .status.incomplete { background: #f6efd6; color: #713f12; }
-        </style>
-    </head>
-    <body>
-        <nav>
-            <a href="{% url 'authoring-index' %}">Authoring</a> ·
-            <a href="{% url 'authoring-foundations' %}">Foundations</a>
-        </nav>
-        {% if messages %}
-            <ul class="messages">{% for message in messages %}<li>{{ message }}</li>{% endfor %}</ul>
-        {% endif %}
-        {% block content %}{% endblock %}
-        <script>
-    // A union picker (forms.py) is one kind select plus a control per
-    // kind; only the chosen kind's is worth seeing. The form marks the
-    // parts (a control shared by several kinds lists them all), this
-    // only reads the markers — with no script, every control shows and
-    // the form still works. Two panes may carry the same union, told
-    // apart by the Django form prefix on the control names.
-    function syncUnionPickers() {
-      document.querySelectorAll("select[data-union-kind]").forEach(function (select) {
-        var union = select.dataset.unionKind;
-        var prefix = select.name.slice(0, select.name.length - (union + "_kind").length);
-        select.form.querySelectorAll('[data-union-of="' + union + '"]').forEach(function (control) {
-          if (control.name.slice(0, prefix.length) !== prefix) return;
-          if (!prefix && control.name.indexOf("-") !== -1) return;
-          control.closest("div").hidden =
-            control.dataset.unionMember.split(" ").indexOf(select.value) === -1;
+{% block nav_heading %}
+    Authoring
+{% endblock nav_heading %}
+{% block nav_items %}
+    <c-ui.navbar.item href="{% url 'authoring-index' %}">Authoring</c-ui.navbar.item>
+    <c-ui.navbar.item href="{% url 'authoring-foundations' %}">Foundations</c-ui.navbar.item>
+    <c-ui.navbar.item href="{% url 'n26-dashboard' %}">App</c-ui.navbar.item>
+{% endblock nav_items %}
+{% block extra_script %}
+    <script>
+        // A union picker (n26/library/forms.py) is one kind select plus a
+        // control per kind; only the chosen kind's is worth seeing. The form
+        // marks the parts (a control shared by several kinds lists them all),
+        // this only reads the markers — with no script, every control shows
+        // and the form still works. Two panes may carry the same union, told
+        // apart by the Django form prefix on the control names. What hides is
+        // the whole field block — label, help and all — which the dispatch
+        // marks with data-field.
+        function syncUnionPickers() {
+            document.querySelectorAll("select[data-union-kind]").forEach(function (select) {
+                var union = select.dataset.unionKind;
+                var prefix = select.name.slice(0, select.name.length - (union + "_kind").length);
+                select.form.querySelectorAll('[data-union-member]').forEach(function (control) {
+                    if (control.dataset.unionOf !== union) return;
+                    if (control.name.slice(0, prefix.length) !== prefix) return;
+                    if (!prefix && control.name.indexOf("-") !== -1) return;
+                    var holder = control.closest("[data-field]") || control.closest("div");
+                    holder.hidden = control.dataset.unionMember.split(" ").indexOf(select.value) === -1;
+                });
+            });
+        }
+        document.addEventListener("change", function (event) {
+            if (event.target.matches("select[data-union-kind]")) syncUnionPickers();
         });
-      });
-    }
-    document.addEventListener("change", function (event) {
-      if (event.target.matches("select[data-union-kind]")) syncUnionPickers();
-    });
-    syncUnionPickers();
-        </script>
-    </body>
-</html>
+        syncUnionPickers();
+    </script>
+{% endblock extra_script %}

--- a/n26/library/templates/authoring/collection.html
+++ b/n26/library/templates/authoring/collection.html
@@ -1,63 +1,91 @@
 {% extends "authoring/base.html" %}
-{% block title %}{{ thing }}{% endblock %}
+{% block head_title %}
+    {{ thing }}
+{% endblock head_title %}
 {% block content %}
-    <p class="count"><a href="{% url 'authoring-leaf' 'collection' %}">← all collections</a></p>
-    <h1>{{ thing }}</h1>
-    {% if thing.library_author_help %}<p>{{ thing.library_author_help }}</p>{% endif %}
-    <h2>Definition</h2>
-    {% if sweeps or entries %}
-        {% if sweeps %}
-            <ul>
-                {% for sweep in sweeps %}<li>{{ sweep }}</li>{% endfor %}
-            </ul>
+    <c-n26.page-header title="{{ thing }}">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Authoring</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' 'collection' %}">
+                    Collections
+                </c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    {{ thing }}
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    {% if thing.library_author_help %}
+        <c-n26.prose class="mt-3 max-w-2xl">
+            <p>{{ thing.library_author_help }}</p>
+        </c-n26.prose>
+    {% endif %}
+    <c-n26.form-section title="Definition" class="mt-8">
+        {% if sweeps or entries %}
+            {% if sweeps %}
+                <c-n26.prose>
+                    <ul>
+                        {% for sweep in sweeps %}<li>{{ sweep }}</li>{% endfor %}
+                    </ul>
+                </c-n26.prose>
+            {% endif %}
+            {% if entries %}
+                <c-ui.table>
+                    <tbody>
+                        {% for entry in entries %}
+                            <tr>
+                                <td>{{ entry.label }}</td>
+                                <td class="text-right text-muted">{{ entry.notes|join:" · " }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </c-ui.table>
+            {% endif %}
+        {% else %}
+            <c-ui.description>
+                Nothing defined yet — no sweeps, no entries.
+            </c-ui.description>
         {% endif %}
-        {% if entries %}
-            <table>
+    </c-n26.form-section>
+    <c-n26.form-section title="Preview ({{ line_count }} line{{ line_count|pluralize }})"
+                        description="What the definition means right now — author an item that fits and it appears here on the next load. Browsed as a plain list; a trading trip withholds “E” rows and charges the TP shown."
+                        class="mt-10">
+        {% for section in sections %}
+            <c-ui.table class="mt-2">
+                <thead>
+                    <tr>
+                        <th>{{ section.name|default:"(no section)" }}</th>
+                        <th class="text-right">credits</th>
+                        <th class="text-right">TP</th>
+                        <th></th>
+                    </tr>
+                </thead>
                 <tbody>
-                    {% for entry in entries %}
-                        <tr>
-                            <td>{{ entry.label }}</td>
-                            <td class="count">{{ entry.notes|join:" · " }}</td>
-                        </tr>
+                    {% for category in section.categories %}
+                        {% if category.name %}
+                            <tr>
+                                <th colspan="4">{{ category.name }}</th>
+                            </tr>
+                        {% endif %}
+                        {% for row in category.rows %}
+                            <tr>
+                                <td>
+                                    {% if row.nested %}<span class="text-muted">—</span>{% endif %}
+                                    {{ row.name }}
+                                </td>
+                                <td class="text-right tabular-nums">{{ row.credits }}</td>
+                                <td class="text-right tabular-nums">{{ row.tp }}</td>
+                                <td class="text-right text-muted">{{ row.notes|join:" · " }}</td>
+                            </tr>
+                        {% endfor %}
                     {% endfor %}
                 </tbody>
-            </table>
-        {% endif %}
-    {% else %}
-        <p class="count">Nothing defined yet — no sweeps, no entries.</p>
-    {% endif %}
-    <h2>Preview <span class="count">({{ line_count }} line{{ line_count|pluralize }})</span></h2>
-    <p class="count">
-        What the definition means right now — author an item that
-        fits and it appears here on the next load. Browsed as a plain list; a
-        trading trip withholds “E” rows and charges the TP shown.
-    </p>
-    {% for section in sections %}
-        <h3>{{ section.name|default:"(no section)" }}</h3>
-        <table>
-            <thead>
-                <tr>
-                    <th></th>
-                    <th class="count">credits</th>
-                    <th class="count">TP</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for category in section.categories %}
-                    {% if category.name %}<tr><th colspan="4">{{ category.name }}</th></tr>{% endif %}
-                    {% for row in category.rows %}
-                        <tr>
-                            <td>{% if row.nested %}<span class="count">—</span>{% endif %}{{ row.name }}</td>
-                            <td class="count">{{ row.credits }}</td>
-                            <td class="count">{{ row.tp }}</td>
-                            <td class="count">{{ row.notes|join:" · " }}</td>
-                        </tr>
-                    {% endfor %}
-                {% endfor %}
-            </tbody>
-        </table>
-    {% empty %}
-        <p class="count">Empty — nothing matches the definition yet.</p>
-    {% endfor %}
-{% endblock %}
+            </c-ui.table>
+        {% empty %}
+            <c-ui.description>
+                Empty — nothing matches the definition yet.
+            </c-ui.description>
+        {% endfor %}
+    </c-n26.form-section>
+{% endblock content %}

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -21,53 +21,158 @@
             <p>{{ thing.library_author_help }}</p>
         </c-n26.prose>
     {% endif %}
-    <c-n26.form-section title="{{ part_verbose_name_plural|capfirst }}" class="mt-8">
-        {% if parts %}
-            <c-ui.table>
-                <tbody>
-                    {% for part in parts %}
-                        <tr>
-                            <td>{{ part.label }}</td>
-                            <td class="text-right text-muted">{{ part.notes|join:" · " }}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </c-ui.table>
-        {% else %}
-            <c-ui.description>
-                None yet.
-            </c-ui.description>
-        {% endif %}
-    </c-n26.form-section>
-    <c-n26.form-section title="Add a {{ part_verbose_name }}" class="mt-10">
-        {% if part_help %}
-            <c-n26.prose class="max-w-2xl">
-                {% for paragraph in part_help %}<p>{{ paragraph }}</p>{% endfor %}
-            </c-n26.prose>
-        {% endif %}
-        <form method="post" class="max-w-xl space-y-5">
-            {% csrf_token %}
-            {% include "authoring/_form.html" %}
-            {% if statline_form %}
-                <c-n26.form-section title="{{ thing.statline_type }}"
-                                    class="rounded-box border border-box-border p-4">
-                    <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                        {% for field in statline_form %}
-                            {% include "authoring/_field.html" with form=statline_form %}
+    {% if has_parts %}
+        <c-n26.form-section title="{{ part_verbose_name_plural|capfirst }}" class="mt-8">
+            {% if parts %}
+                <c-ui.table>
+                    <tbody>
+                        {% for part in parts %}
+                            <tr>
+                                <td>{{ part.label }}</td>
+                                <td class="text-right text-muted">{{ part.notes|join:" · " }}</td>
+                            </tr>
                         {% endfor %}
-                    </div>
-                </c-n26.form-section>
-            {% elif wants_statline %}
+                    </tbody>
+                </c-ui.table>
+            {% else %}
                 <c-ui.description>
-                    This {{ verbose_name }} has no statline shape set, so its
-                    {{ part_verbose_name_plural }} carry no stats.
+                    None yet.
                 </c-ui.description>
             {% endif %}
-            <div class="flex justify-end">
-                <c-ui.button type="submit" variant="success">
-                    Add {{ part_verbose_name }}
-                </c-ui.button>
-            </div>
-        </form>
-    </c-n26.form-section>
+        </c-n26.form-section>
+        <c-n26.form-section title="Add a {{ part_verbose_name }}" class="mt-10">
+            {% if part_help %}
+                <c-n26.prose class="max-w-2xl">
+                    {% for paragraph in part_help %}<p>{{ paragraph }}</p>{% endfor %}
+                </c-n26.prose>
+            {% endif %}
+            <form method="post" class="max-w-xl space-y-5">
+                {% csrf_token %}
+                {% include "authoring/_form.html" %}
+                {% if statline_form %}
+                    <c-n26.form-section title="{{ thing.statline_type }}"
+                                        class="rounded-box border border-box-border p-4">
+                        <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                            {% for field in statline_form %}
+                                {% include "authoring/_field.html" with form=statline_form %}
+                            {% endfor %}
+                        </div>
+                    </c-n26.form-section>
+                {% elif wants_statline %}
+                    <c-ui.description>
+                        This {{ verbose_name }} has no statline shape set, so its
+                        {{ part_verbose_name_plural }} carry no stats.
+                    </c-ui.description>
+                {% endif %}
+                <div class="flex justify-end">
+                    <c-ui.button type="submit" variant="success">
+                        Add {{ part_verbose_name }}
+                    </c-ui.button>
+                </div>
+            </form>
+        </c-n26.form-section>
+    {% endif %}
+    {% if with_modifiers %}
+        <c-n26.form-section title="Modifiers"
+                            description="What this {{ verbose_name }} does once assigned — each modifier is one scope and one effect, computed onto cards."
+                            class="mt-10">
+            {% if modifier_rows %}
+                <c-ui.table>
+                    <tbody>
+                        {% for row in modifier_rows %}
+                            <tr>
+                                <td class="whitespace-nowrap">{{ row.label }}</td>
+                                <td class="w-full text-muted">{{ row.notes|join:" · " }}</td>
+                                <td class="text-right">
+                                    <form method="post">
+                                        {% csrf_token %}
+                                        <input type="hidden" name="act" value="detach">
+                                        <input type="hidden" name="modifier" value="{{ row.pk }}">
+                                        <c-ui.button type="submit" size="sm" variant="ghost">
+                                            Detach
+                                        </c-ui.button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </c-ui.table>
+            {% else %}
+                <c-ui.description>
+                    None yet — the {{ verbose_name }} does nothing special until a modifier hangs here.
+                </c-ui.description>
+            {% endif %}
+            {% if attachable_modifiers %}
+                <form method="post" class="flex max-w-xl items-end gap-3">
+                    {% csrf_token %}
+                    <input type="hidden" name="act" value="attach">
+                    <div class="grow">
+                        <c-ui.field data-field label="Attach an existing modifier" for="attach-modifier">
+                            <c-ui.select.native name="modifier" id="attach-modifier" placeholder="Pick a modifier">
+                                {% for mod in attachable_modifiers %}
+                                    <c-ui.select.option value="{{ mod.pk }}">
+                                        {{ mod.label }}
+                                    </c-ui.select.option>
+                                {% endfor %}
+                            </c-ui.select.native>
+                        </c-ui.field>
+                    </div>
+                    <c-ui.button type="submit">
+                        Attach
+                    </c-ui.button>
+                </form>
+            {% endif %}
+            <c-n26.form-section title="Compose a new one"
+                                description="Pick who it reaches and what it does; the fields for both follow."
+                                class="rounded-box border border-box-border p-4">
+                {% comment %}
+                Step one, as a GET: the chosen kinds live in the URL, so
+                step two survives a refresh and "add a condition" can be
+                a plain link. Only once both kinds are chosen does the
+                composer itself render.
+                {% endcomment %}
+                <form method="get" class="max-w-xl space-y-4">
+                    {% include "authoring/_field.html" with form=kind_picker field=kind_picker.scope_kind %}
+                    {% include "authoring/_field.html" with form=kind_picker field=kind_picker.effect_kind %}
+                    <div class="flex justify-end">
+                        <c-ui.button type="submit" size="sm">
+                            Continue
+                        </c-ui.button>
+                    </div>
+                </form>
+                {% if composer %}
+                    <form method="post" class="max-w-xl space-y-5">
+                        {% csrf_token %}
+                        <input type="hidden" name="act" value="compose">
+                        <input type="hidden" name="scope_kind" value="{{ composer_scope }}">
+                        <input type="hidden" name="effect_kind" value="{{ composer_effect }}">
+                        <c-ui.error :form="composer" name="__all__" />
+                        <c-n26.form-section title="Who it reaches">
+                            {% include "authoring/_form.html" with form=composer.who_form %}
+                            {% if composer.condition_formset %}
+                                {{ composer.condition_formset.management_form }}
+                                {% for chip in composer.condition_formset %}
+                                    <div class="rounded-box border border-box-border p-3">{% include "authoring/_form.html" with form=chip %}</div>
+                                {% endfor %}
+                                <c-n26.link href="?scope_kind={{ composer_scope }}&effect_kind={{ composer_effect }}&chips={{ composer_chips|add:1 }}"
+                                            tone="muted">
+                                    Add a condition
+                                </c-n26.link>
+                            {% endif %}
+                        </c-n26.form-section>
+                        <c-n26.form-section title="What it does">
+                            {% include "authoring/_form.html" with form=composer.what_form %}
+                        </c-n26.form-section>
+                        {% include "authoring/_field.html" with form=composer field=composer.name %}
+                        {% include "authoring/_field.html" with form=composer field=composer.keep_reusable %}
+                        <div class="flex justify-end">
+                            <c-ui.button type="submit" variant="success">
+                                Compose modifier
+                            </c-ui.button>
+                        </div>
+                    </form>
+                {% endif %}
+            </c-n26.form-section>
+        </c-n26.form-section>
+    {% endif %}
 {% endblock content %}

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -8,7 +8,7 @@
             <c-ui.breadcrumbs>
                 <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Authoring</c-ui.breadcrumbs.item>
                 <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' kind %}">
-                    {{ verbose_name|capfirst }}s
+                    {{ verbose_name_plural|capfirst }}
                 </c-ui.breadcrumbs.item>
                 <c-ui.breadcrumbs.item :current="True">
                     {{ thing }}

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -1,44 +1,73 @@
 {% extends "authoring/base.html" %}
-{% block title %}{{ thing }}{% endblock %}
+{% block head_title %}
+    {{ thing }}
+{% endblock head_title %}
 {% block content %}
-    <p class="count"><a href="{% url 'authoring-leaf' kind %}">← all {{ verbose_name }}s</a></p>
-    <h1>{{ thing }}</h1>
-    {% if thing.library_author_help %}<p>{{ thing.library_author_help }}</p>{% endif %}
-    <h2>{{ part_verbose_name_plural|capfirst }}</h2>
-    {% if parts %}
-        <table>
-            <tbody>
-                {% for part in parts %}
-                    <tr>
-                        <td>{{ part.label }}</td>
-                        <td class="count">{{ part.notes|join:" · " }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        <p class="count">None yet.</p>
+    <c-n26.page-header title="{{ thing }}">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Authoring</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' kind %}">
+                    {{ verbose_name|capfirst }}s
+                </c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    {{ thing }}
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    {% if thing.library_author_help %}
+        <c-n26.prose class="mt-3 max-w-2xl">
+            <p>{{ thing.library_author_help }}</p>
+        </c-n26.prose>
     {% endif %}
-    <h2>Add a {{ part_verbose_name }}</h2>
-    {% if part_help %}
-        <div class="kind-help">
-            {% for paragraph in part_help %}<p>{{ paragraph|safe }}</p>{% endfor %}
-        </div>
-    {% endif %}
-    <form method="post">
-        {% csrf_token %}
-        {{ form.as_div }}
-        {% if statline_form %}
-            <fieldset class="statline">
-                <legend>{{ thing.statline_type }}</legend>
-                {{ statline_form.as_div }}
-            </fieldset>
-        {% elif wants_statline %}
-            <p class="count">
-                This {{ verbose_name }} has no statline shape set, so its
-                {{ part_verbose_name_plural }} carry no stats.
-            </p>
+    <c-n26.form-section title="{{ part_verbose_name_plural|capfirst }}" class="mt-8">
+        {% if parts %}
+            <c-ui.table>
+                <tbody>
+                    {% for part in parts %}
+                        <tr>
+                            <td>{{ part.label }}</td>
+                            <td class="text-right text-muted">{{ part.notes|join:" · " }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </c-ui.table>
+        {% else %}
+            <c-ui.description>
+                None yet.
+            </c-ui.description>
         {% endif %}
-        <button type="submit">Add {{ part_verbose_name }}</button>
-    </form>
-{% endblock %}
+    </c-n26.form-section>
+    <c-n26.form-section title="Add a {{ part_verbose_name }}" class="mt-10">
+        {% if part_help %}
+            <c-n26.prose class="max-w-2xl">
+                {% for paragraph in part_help %}<p>{{ paragraph }}</p>{% endfor %}
+            </c-n26.prose>
+        {% endif %}
+        <form method="post" class="max-w-xl space-y-5">
+            {% csrf_token %}
+            {% include "authoring/_form.html" %}
+            {% if statline_form %}
+                <c-n26.form-section title="{{ thing.statline_type }}"
+                                    class="rounded-box border border-box-border p-4">
+                    <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                        {% for field in statline_form %}
+                            {% include "authoring/_field.html" with form=statline_form %}
+                        {% endfor %}
+                    </div>
+                </c-n26.form-section>
+            {% elif wants_statline %}
+                <c-ui.description>
+                    This {{ verbose_name }} has no statline shape set, so its
+                    {{ part_verbose_name_plural }} carry no stats.
+                </c-ui.description>
+            {% endif %}
+            <div class="flex justify-end">
+                <c-ui.button type="submit" variant="success">
+                    Add {{ part_verbose_name }}
+                </c-ui.button>
+            </div>
+        </form>
+    </c-n26.form-section>
+{% endblock content %}

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -122,57 +122,7 @@
                     </c-ui.button>
                 </form>
             {% endif %}
-            <c-n26.form-section title="Compose a new one"
-                                description="Pick who it reaches and what it does; the fields for both follow."
-                                class="rounded-box border border-box-border p-4">
-                {% comment %}
-                Step one, as a GET: the chosen kinds live in the URL, so
-                step two survives a refresh and "add a condition" can be
-                a plain link. Only once both kinds are chosen does the
-                composer itself render.
-                {% endcomment %}
-                <form method="get" class="max-w-xl space-y-4">
-                    {% include "authoring/_field.html" with form=kind_picker field=kind_picker.scope_kind %}
-                    {% include "authoring/_field.html" with form=kind_picker field=kind_picker.effect_kind %}
-                    <div class="flex justify-end">
-                        <c-ui.button type="submit" size="sm">
-                            Continue
-                        </c-ui.button>
-                    </div>
-                </form>
-                {% if composer %}
-                    <form method="post" class="max-w-xl space-y-5">
-                        {% csrf_token %}
-                        <input type="hidden" name="act" value="compose">
-                        <input type="hidden" name="scope_kind" value="{{ composer_scope }}">
-                        <input type="hidden" name="effect_kind" value="{{ composer_effect }}">
-                        <c-ui.error :form="composer" name="__all__" />
-                        <c-n26.form-section title="Who it reaches">
-                            {% include "authoring/_form.html" with form=composer.who_form %}
-                            {% if composer.condition_formset %}
-                                {{ composer.condition_formset.management_form }}
-                                {% for chip in composer.condition_formset %}
-                                    <div class="rounded-box border border-box-border p-3">{% include "authoring/_form.html" with form=chip %}</div>
-                                {% endfor %}
-                                <c-n26.link href="?scope_kind={{ composer_scope }}&effect_kind={{ composer_effect }}&chips={{ composer_chips|add:1 }}"
-                                            tone="muted">
-                                    Add a condition
-                                </c-n26.link>
-                            {% endif %}
-                        </c-n26.form-section>
-                        <c-n26.form-section title="What it does">
-                            {% include "authoring/_form.html" with form=composer.what_form %}
-                        </c-n26.form-section>
-                        {% include "authoring/_field.html" with form=composer field=composer.name %}
-                        {% include "authoring/_field.html" with form=composer field=composer.keep_reusable %}
-                        <div class="flex justify-end">
-                            <c-ui.button type="submit" variant="success">
-                                Compose modifier
-                            </c-ui.button>
-                        </div>
-                    </form>
-                {% endif %}
-            </c-n26.form-section>
+            {% include "authoring/_composer.html" with show_keep_reusable=True %}
         </c-n26.form-section>
     {% endif %}
 {% endblock content %}

--- a/n26/library/templates/authoring/foundations.html
+++ b/n26/library/templates/authoring/foundations.html
@@ -93,7 +93,8 @@
             <tbody>
                 {% for entry in kinds %}
                     <tr>
-                        <td>
+                        {# nowrap: the summary column takes the squeeze, never the name #}
+                        <td class="whitespace-nowrap">
                             <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
                         </td>
                         <td class="w-full text-muted">{{ entry.summary }}</td>

--- a/n26/library/templates/authoring/foundations.html
+++ b/n26/library/templates/authoring/foundations.html
@@ -1,62 +1,106 @@
 {% extends "authoring/base.html" %}
-{% block title %}Foundations{% endblock %}
+{% block head_title %}
+    Foundations
+{% endblock head_title %}
 {% block content %}
-    <h1>Foundations</h1>
-    <p>
-        The things content is built <em>from</em>. Each has its own page;
-        what the rulebook fixes can be filled in here in one go.
-    </p>
-    <h2>Standard content</h2>
-    {% for entry in entries %}
-        <div class="seed">
-            <form method="post">
-                {% csrf_token %}
-                <input type="hidden" name="create" value="{{ entry.key }}">
-                <p>
-                    <strong>{{ entry.name }}</strong>
-                    <span class="status {{ entry.status }}">{{ entry.status }}</span>
-                    <span class="count">{{ entry.present }} of {{ entry.total }} rows</span>
-                </p>
-                <p class="count">{{ entry.help }}</p>
-                <button type="submit">
-                    {% if entry.status == "complete" %}Create again{% else %}Create the missing rows{% endif %}
-                </button>
-            </form>
-        </div>
-    {% endfor %}
-    <h2>Types</h2>
-    <p class="count">
-        A model's Type is Fighter or Vehicle and nothing else, so
-        these are not authored — they arrive with the standard content above.
-        Everything else a model might be called is a
-        <a href="{% url 'authoring-leaf' 'subtype' %}">subtype</a>.</p>
-    {% if profile_types %}
-        <table>
+    <c-n26.page-header title="Foundations"
+                       lead="The things content is built from. Each has its own page; what the rulebook fixes can be filled in here in one go.">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Authoring</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    Foundations
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    <c-n26.form-section title="Standard content" class="mt-8">
+        <c-ui.table>
             <tbody>
-                {% for profile_type in profile_types %}
+                {% for entry in entries %}
                     <tr>
-                        <td>{{ profile_type.name }}</td>
-                        <td class="count">{{ profile_type.statline_type.name }}</td>
-                        <td class="count">lasting {{ profile_type.lasting_effect_term|lower }}</td>
+                        <td>
+                            <div class="flex items-center gap-2">
+                                <span class="font-medium text-ink-900 dark:text-ink-100">{{ entry.name }}</span>
+                                {% if entry.status == "complete" %}
+                                    <c-ui.badge color="green" size="sm">
+                                        complete
+                                    </c-ui.badge>
+                                {% elif entry.status == "incomplete" %}
+                                    <c-ui.badge color="amber" size="sm">
+                                        incomplete
+                                    </c-ui.badge>
+                                {% else %}
+                                    <c-ui.badge color="red" size="sm">
+                                        missing
+                                    </c-ui.badge>
+                                {% endif %}
+                                <span class="text-muted">{{ entry.present }} of {{ entry.total }} rows</span>
+                            </div>
+                            <c-ui.description class="mt-1 max-w-2xl">
+                                {{ entry.help }}
+                            </c-ui.description>
+                        </td>
+                        <td class="text-right align-top">
+                            <form method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="create" value="{{ entry.key }}">
+                                <c-ui.button type="submit"
+                                             size="sm"
+                                             variant="{% if entry.status == 'complete' %}default{% else %}success{% endif %}">
+                                    {% if entry.status == "complete" %}
+                                        Create again
+                                    {% else %}
+                                        Create the missing rows
+                                    {% endif %}
+                                </c-ui.button>
+                            </form>
+                        </td>
                     </tr>
                 {% endfor %}
             </tbody>
-        </table>
-    {% else %}
-        <p class="count">None yet.</p>
-    {% endif %}
-    <h2>Pages</h2>
-    <table>
-        <tbody>
-            {% for entry in kinds %}
-                <tr>
-                    <td>
-                        <a href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</a>
-                        <span class="summary">{{ entry.summary|safe }}</span>
-                    </td>
-                    <td class="count">{{ entry.count }}</td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-{% endblock %}
+        </c-ui.table>
+    </c-n26.form-section>
+    <c-n26.form-section title="Types"
+                        description="A model's Type is Fighter or Vehicle and nothing else, so these are not authored — they arrive with the standard content above."
+                        class="mt-10">
+        <c-n26.prose>
+            <p>
+                Everything else a model might be called is a
+                <c-n26.link href="{% url 'authoring-leaf' 'subtype' %}">subtype</c-n26.link>.
+            </p>
+        </c-n26.prose>
+        {% if profile_types %}
+            <c-ui.table>
+                <tbody>
+                    {% for profile_type in profile_types %}
+                        <tr>
+                            <td>{{ profile_type.name }}</td>
+                            <td class="text-muted">{{ profile_type.statline_type.name }}</td>
+                            <td class="text-right text-muted">lasting {{ profile_type.lasting_effect_term|lower }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </c-ui.table>
+        {% else %}
+            <c-ui.description>
+                None yet.
+            </c-ui.description>
+        {% endif %}
+    </c-n26.form-section>
+    <c-n26.form-section title="Pages" class="mt-10">
+        <c-ui.table>
+            <tbody>
+                {% for entry in kinds %}
+                    <tr>
+                        <td>
+                            <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
+                        </td>
+                        <td class="w-full text-muted">{{ entry.summary }}</td>
+                        <td class="text-right tabular-nums">{{ entry.count }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </c-ui.table>
+    </c-n26.form-section>
+{% endblock content %}

--- a/n26/library/templates/authoring/foundations.html
+++ b/n26/library/templates/authoring/foundations.html
@@ -90,6 +90,13 @@
     </c-n26.form-section>
     <c-n26.form-section title="Pages" class="mt-10">
         <c-ui.table>
+            <thead>
+                <tr>
+                    <th scope="col">Page</th>
+                    <th scope="col" class="w-full">What it is</th>
+                    <th scope="col" class="text-right">Rows</th>
+                </tr>
+            </thead>
             <tbody>
                 {% for entry in kinds %}
                     <tr>
@@ -97,7 +104,7 @@
                         <td class="whitespace-nowrap">
                             <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
                         </td>
-                        <td class="w-full text-muted">{{ entry.summary }}</td>
+                        <td class="text-muted">{{ entry.summary }}</td>
                         <td class="text-right tabular-nums">{{ entry.count }}</td>
                     </tr>
                 {% endfor %}

--- a/n26/library/templates/authoring/index.html
+++ b/n26/library/templates/authoring/index.html
@@ -11,29 +11,43 @@
             if the library is empty — stats and statline shapes are created there.
         </p>
     </c-n26.prose>
-    {% for family in families %}
-        <c-n26.form-section title="{{ family.label }}" class="mt-8">
-            <c-ui.table>
-                <thead>
+    {% comment %}
+    One table, a tbody per family, rather than a table per family: column
+    widths are a table's own, so separate tables mean every family sizes
+    its Kind column to its own longest name and nothing lines up down the
+    page. The family heading is a row spanning the width, which is what
+    scope="colgroup" says out loud.
+    {% endcomment %}
+    <c-ui.table class="mt-8">
+        <thead>
+            <tr>
+                <th scope="col">Kind</th>
+                <th scope="col" class="w-full">What it is</th>
+                <th scope="col" class="text-right">Rows</th>
+            </tr>
+        </thead>
+        {% for family in families %}
+            <tbody>
+                <tr>
+                    {# The ! wins over the kit's [&_th] colour rule, which #}
+                    {# out-specifies a plain utility on the cell itself. #}
+                    <th scope="colgroup"
+                        colspan="3"
+                        class="bg-ink-100 font-semibold! text-ink-900! dark:bg-ink-800 dark:text-ink-100!">
+                        {{ family.label }}
+                    </th>
+                </tr>
+                {% for entry in family.kinds %}
                     <tr>
-                        <th scope="col">Kind</th>
-                        <th scope="col" class="w-full">What it is</th>
-                        <th scope="col" class="text-right">Rows</th>
+                        {# nowrap: the summary column takes the squeeze, never the name #}
+                        <td class="whitespace-nowrap">
+                            <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
+                        </td>
+                        <td>{{ entry.summary }}</td>
+                        <td class="text-right tabular-nums">{{ entry.count }}</td>
                     </tr>
-                </thead>
-                <tbody>
-                    {% for entry in family.kinds %}
-                        <tr>
-                            {# nowrap: the summary column takes the squeeze, never the name #}
-                            <td class="whitespace-nowrap">
-                                <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
-                            </td>
-                            <td>{{ entry.summary }}</td>
-                            <td class="text-right tabular-nums">{{ entry.count }}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </c-ui.table>
-        </c-n26.form-section>
-    {% endfor %}
+                {% endfor %}
+            </tbody>
+        {% endfor %}
+    </c-ui.table>
 {% endblock content %}

--- a/n26/library/templates/authoring/index.html
+++ b/n26/library/templates/authoring/index.html
@@ -1,26 +1,31 @@
 {% extends "authoring/base.html" %}
-{% block title %}Authoring{% endblock %}
+{% block head_title %}
+    Authoring
+{% endblock head_title %}
 {% block content %}
-    <h1>Content authoring</h1>
-    <p>
-        The leaves: the fundamental things everything else references.
-        Start at <a href="{% url 'authoring-foundations' %}">Foundations</a> if the
-        library is empty — stats and statline shapes are created there.
-    </p>
+    <c-n26.page-header title="Content authoring"
+                       lead="The leaves: the fundamental things everything else references." />
+    <c-n26.prose class="mt-2">
+        <p>
+            Start at <c-n26.link href="{% url 'authoring-foundations' %}">Foundations</c-n26.link>
+            if the library is empty — stats and statline shapes are created there.
+        </p>
+    </c-n26.prose>
     {% for family in families %}
-        <h2>{{ family.label }}</h2>
-        <table>
-            <tbody>
-                {% for entry in family.kinds %}
-                    <tr>
-                        <td>
-                            <a href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</a>
-                            <span class="summary">{{ entry.summary|safe }}</span>
-                        </td>
-                        <td class="count">{{ entry.count }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+        <c-n26.form-section title="{{ family.label }}" class="mt-8">
+            <c-ui.table>
+                <tbody>
+                    {% for entry in family.kinds %}
+                        <tr>
+                            <td>
+                                <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
+                            </td>
+                            <td class="w-full">{{ entry.summary }}</td>
+                            <td class="text-right tabular-nums">{{ entry.count }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </c-ui.table>
+        </c-n26.form-section>
     {% endfor %}
-{% endblock %}
+{% endblock content %}

--- a/n26/library/templates/authoring/index.html
+++ b/n26/library/templates/authoring/index.html
@@ -14,6 +14,13 @@
     {% for family in families %}
         <c-n26.form-section title="{{ family.label }}" class="mt-8">
             <c-ui.table>
+                <thead>
+                    <tr>
+                        <th scope="col">Kind</th>
+                        <th scope="col" class="w-full">What it is</th>
+                        <th scope="col" class="text-right">Rows</th>
+                    </tr>
+                </thead>
                 <tbody>
                     {% for entry in family.kinds %}
                         <tr>
@@ -21,7 +28,7 @@
                             <td class="whitespace-nowrap">
                                 <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
                             </td>
-                            <td class="w-full">{{ entry.summary }}</td>
+                            <td>{{ entry.summary }}</td>
                             <td class="text-right tabular-nums">{{ entry.count }}</td>
                         </tr>
                     {% endfor %}

--- a/n26/library/templates/authoring/index.html
+++ b/n26/library/templates/authoring/index.html
@@ -17,7 +17,8 @@
                 <tbody>
                     {% for entry in family.kinds %}
                         <tr>
-                            <td>
+                            {# nowrap: the summary column takes the squeeze, never the name #}
+                            <td class="whitespace-nowrap">
                                 <c-n26.link href="{% url 'authoring-leaf' entry.kind %}">{{ entry.verbose_name|capfirst }}</c-n26.link>
                             </td>
                             <td class="w-full">{{ entry.summary }}</td>

--- a/n26/library/templates/authoring/leaf.html
+++ b/n26/library/templates/authoring/leaf.html
@@ -1,40 +1,62 @@
 {% extends "authoring/base.html" %}
-{% block title %}{{ verbose_name_plural|capfirst }}{% endblock %}
+{% block head_title %}
+    {{ verbose_name_plural|capfirst }}
+{% endblock head_title %}
 {% block content %}
-    <h1>New {{ verbose_name }}</h1>
+    <c-n26.page-header title="New {{ verbose_name }}">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Authoring</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    {{ verbose_name_plural|capfirst }}
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
     {% if kind_help %}
-        <div class="kind-help">
-            {% for paragraph in kind_help %}<p>{{ paragraph|safe }}</p>{% endfor %}
-        </div>
+        <c-n26.prose class="mt-3 max-w-2xl">
+            {% for paragraph in kind_help %}<p>{{ paragraph }}</p>{% endfor %}
+        </c-n26.prose>
     {% endif %}
-    <form method="post">
+    <form method="post" class="mt-6 max-w-xl space-y-5">
         {% csrf_token %}
-        {{ form.as_div }}
+        {% include "authoring/_form.html" %}
         {% if suggestion_form %}
-            <fieldset class="suggestions">
-                <legend>Comes with — blank to skip</legend>
-                {{ suggestion_form.as_div }}
-            </fieldset>
+            <c-n26.form-section title="Comes with"
+                                description="All optional — blank to skip."
+                                class="rounded-box border border-box-border p-4">
+                {% include "authoring/_form.html" with form=suggestion_form %}
+            </c-n26.form-section>
         {% endif %}
-        <button type="submit">Create {{ verbose_name }}</button>
+        <div class="flex justify-end">
+            <c-ui.button type="submit" variant="success">
+                Create {{ verbose_name }}
+            </c-ui.button>
+        </div>
     </form>
-    <h2>{{ verbose_name_plural|capfirst }} <span class="count">({{ count }})</span></h2>
-    {% if rows %}
-        <table>
-            <tbody>
-                {% for row in rows %}
-                    <tr>
-                        <td>
-                            {% if has_detail %}
-                                <a href="{% url 'authoring-detail' kind row.pk %}">{{ row.label }}</a>
-                {% else %}{{ row.label }}{% endif %}
-                    </td>
-                    <td class="count">{{ row.notes|join:" · " }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        <p class="count">None yet.</p>
-    {% endif %}
-{% endblock %}
+    <c-n26.form-section title="{{ verbose_name_plural|capfirst }} ({{ count }})"
+                        class="mt-10">
+        {% if rows %}
+            <c-ui.table>
+                <tbody>
+                    {% for row in rows %}
+                        <tr>
+                            <td>
+                                {% if has_detail %}
+                                    <c-n26.link href="{% url 'authoring-detail' kind row.pk %}">{{ row.label }}</c-n26.link>
+                                {% else %}
+                                    {{ row.label }}
+                                {% endif %}
+                            </td>
+                            <td class="text-right text-muted">{{ row.notes|join:" · " }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </c-ui.table>
+        {% else %}
+            <c-ui.description>
+                None yet.
+            </c-ui.description>
+        {% endif %}
+    </c-n26.form-section>
+{% endblock content %}

--- a/n26/library/templates/authoring/modifiers.html
+++ b/n26/library/templates/authoring/modifiers.html
@@ -1,0 +1,36 @@
+{% extends "authoring/base.html" %}
+{% block head_title %}
+    Modifiers
+{% endblock head_title %}
+{% block content %}
+    <c-n26.page-header title="Modifiers"
+                       lead="Every scope-and-effect pair in the pack — the payloads the carriers hang. Composed here, a modifier belongs to nothing yet; attach it from any carrier's page.">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Authoring</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    Modifiers
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    <c-n26.form-section title="Every modifier" class="mt-8">
+        {% if rows %}
+            <c-ui.table>
+                <tbody>
+                    {% for row in rows %}
+                        <tr>
+                            <td class="whitespace-nowrap">{{ row.label }}</td>
+                            <td class="w-full text-muted">{{ row.notes|join:" · " }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </c-ui.table>
+        {% else %}
+            <c-ui.description>
+                None yet — compose the first one below.
+            </c-ui.description>
+        {% endif %}
+    </c-n26.form-section>
+    <div class="mt-10">{% include "authoring/_composer.html" with show_keep_reusable=False %}</div>
+{% endblock content %}

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -145,11 +145,42 @@ DETAIL_KINDS = {
 }
 
 
+def _carries_modifiers(kind):
+    """Whether this kind's rows can carry modifiers — true for every
+    assignable (the mixin's M2M is the tell), never for the foundation
+    shapes. Derived, not enumerated: a new assignable kind gets its
+    modifier section without anyone remembering to say so."""
+    return hasattr(_model_for(_spec_for(kind)), "modifiers")
+
+
 def _has_detail(kind):
     """Whether this kind's listing rows link to a page of their own —
-    a parts-and-add-form page (DETAIL_KINDS) or a kind's own view
-    (DETAIL_VIEWS, defined below the views themselves)."""
-    return kind in DETAIL_KINDS or kind in DETAIL_VIEWS
+    a parts-and-add-form page (DETAIL_KINDS), a kind's own view
+    (DETAIL_VIEWS, defined below the views themselves), or any
+    assignable's modifier section."""
+    return kind in DETAIL_KINDS or kind in DETAIL_VIEWS or _carries_modifiers(kind)
+
+
+def _assignable_models():
+    """Every concrete kind that can carry modifiers."""
+    from django.apps import apps
+
+    return [
+        model
+        for model in apps.get_app_config("library").get_models()
+        if hasattr(model, "modifiers")
+    ]
+
+
+def _carrier_count(modifier):
+    """How many things carry this modifier, across every kind. The
+    kinds share no table, so this is one count per kind — fine at
+    authoring-page scale, and the number is what stops an author
+    editing a shared modifier thinking it is theirs alone."""
+    return sum(
+        model.objects.filter(modifiers=modifier).count()
+        for model in _assignable_models()
+    )
 
 
 def _label_for(row):
@@ -381,43 +412,45 @@ def detail(request, kind, pk):
     model = _model_for(spec)
     thing = get_object_or_404(model, pk=pk)
     detail_of = DETAIL_KINDS.get(kind)
-    if detail_of is None:
-        raise Http404(f"{kind} has no parts to add")
-    part_spec = specs()[detail_of["verb"]]
-    part_model = _model_for(part_spec)
-    form_class = generate_form(part_spec)
-    statline_class = (
-        statline_form_for(thing.statline_type)
-        if detail_of["statline"] and thing.statline_type
-        else None
-    )
+    with_modifiers = _carries_modifiers(kind)
+    if detail_of is None and not with_modifiers:
+        raise Http404(f"{kind} has no page of its own")
 
-    if request.method == "POST":
-        form = form_class(request.POST)
-        statline_form = statline_class(request.POST) if statline_class else None
-        forms_valid = form.is_valid() and (
-            statline_form is None or statline_form.is_valid()
+    composer = None
+    act = request.POST.get("act", "")
+    if request.method == "POST" and act and with_modifiers:
+        response, composer = _modifier_action(request, kind, thing, act)
+        if response is not None:
+            return response
+
+    if detail_of is not None:
+        part_spec = specs()[detail_of["verb"]]
+        part_model = _model_for(part_spec)
+        form_class = generate_form(part_spec)
+        statline_class = (
+            statline_form_for(thing.statline_type)
+            if detail_of["statline"] and thing.statline_type
+            else None
         )
-        if forms_valid:
-            with transaction.atomic():
-                part = part_spec.verb(thing, **form.verb_data())
-                if statline_form is not None:
-                    statline_form.save(part)
-            said, _ = detail_of["describe"](part)
-            messages.success(request, f"Added {said}.")
-            return redirect("authoring-detail", kind=kind, pk=pk)
-    else:
-        form = form_class()
-        statline_form = statline_class() if statline_class else None
-
-    return render(
-        request,
-        "authoring/detail.html",
-        {
-            "kind": kind,
-            "thing": thing,
-            "verbose_name": model._meta.verbose_name,
-            "kind_help": kind_help(model),
+        if request.method == "POST" and not act:
+            form = form_class(request.POST)
+            statline_form = statline_class(request.POST) if statline_class else None
+            forms_valid = form.is_valid() and (
+                statline_form is None or statline_form.is_valid()
+            )
+            if forms_valid:
+                with transaction.atomic():
+                    part = part_spec.verb(thing, **form.verb_data())
+                    if statline_form is not None:
+                        statline_form.save(part)
+                said, _ = detail_of["describe"](part)
+                messages.success(request, f"Added {said}.")
+                return redirect("authoring-detail", kind=kind, pk=pk)
+        else:
+            form = form_class()
+            statline_form = statline_class() if statline_class else None
+        part_context = {
+            "has_parts": True,
             "part_verbose_name": detail_of.get(
                 "part_name", part_model._meta.verbose_name
             ),
@@ -435,8 +468,121 @@ def detail(request, kind, pk):
             ],
             "form": form,
             "statline_form": statline_form,
+        }
+    else:
+        part_context = {"has_parts": False}
+
+    return render(
+        request,
+        "authoring/detail.html",
+        {
+            "kind": kind,
+            "thing": thing,
+            "verbose_name": model._meta.verbose_name,
+            "kind_help": kind_help(model),
+            **part_context,
+            **(
+                _modifier_section(request, thing, composer)
+                if with_modifiers
+                else {"with_modifiers": False}
+            ),
         },
     )
+
+
+def _modifier_action(request, kind, thing, act):
+    """One modifier action against a carrier: compose, attach, detach.
+
+    Returns ``(response, composer)`` — a redirect when the action
+    landed, or ``(None, bound_form)`` when a compose refused and the
+    page should redraw with its errors in place.
+    """
+    from n26.library import authoring
+    from n26.library.forms import ModifierComposerForm
+    from n26.library.models import Modifier
+
+    if act == "compose":
+        composer = ModifierComposerForm(request.POST, attach_to=thing)
+        if composer.is_valid():
+            try:
+                with transaction.atomic():
+                    made = composer.save()
+            except IntegrityError:
+                composer.add_error(
+                    "name",
+                    "A modifier with that name already exists in this pack — "
+                    "attach the existing one instead, or pick another name.",
+                )
+                return None, composer
+            if composer.cleaned_data.get("keep_reusable"):
+                messages.success(request, f"Saved {made.name} as a reusable modifier.")
+            else:
+                messages.success(request, f"Attached {made.name}.")
+            return redirect("authoring-detail", kind=kind, pk=thing.pk), None
+        return None, composer
+
+    modifier = get_object_or_404(Modifier, pk=request.POST.get("modifier", ""))
+    if act == "attach":
+        authoring.attach_modifiers_to(thing, [modifier])
+        messages.success(request, f"Attached {modifier.name}.")
+    elif act == "detach":
+        authoring.detach_modifier(thing, modifier)
+        messages.success(request, f"Detached {modifier.name} — it still exists.")
+    else:
+        raise Http404(f"No such action: {act}")
+    return redirect("authoring-detail", kind=kind, pk=thing.pk), None
+
+
+def _modifier_section(request, thing, bound_composer=None):
+    """Everything the modifiers section draws: what hangs here (with
+    its sentences and how shared it is), what could be attached, and
+    the composer — closed, open at the kinds the URL names, or bound
+    with errors after a refused submit."""
+    from n26.library.forms import ModifierComposerForm
+    from n26.library.models import Modifier
+
+    rows = []
+    attached = list(thing.modifiers.all())
+    for modifier in attached:
+        others = _carrier_count(modifier) - 1
+        notes = [str(modifier.scope), str(modifier.effect)]
+        if others:
+            notes.append(f"also on {others} other carrier{'' if others == 1 else 's'}")
+        rows.append({"pk": modifier.pk, "label": modifier.name, "notes": notes})
+
+    attachable = [
+        {
+            "pk": modifier.pk,
+            "label": f"{modifier.name} — {modifier.scope}: {modifier.effect}",
+        }
+        for modifier in Modifier.objects.exclude(pk__in=[m.pk for m in attached])
+    ]
+
+    scope_kind = request.POST.get("scope_kind", request.GET.get("scope_kind", ""))
+    effect_kind = request.POST.get("effect_kind", request.GET.get("effect_kind", ""))
+    try:
+        chips = max(0, int(request.GET.get("chips", 0)))
+    except ValueError:
+        chips = 0
+
+    composer = bound_composer
+    if composer is None and scope_kind in specs() and effect_kind in specs():
+        composer = ModifierComposerForm.unbound(
+            scope_kind, effect_kind, attach_to=thing, chips=chips
+        )
+
+    return {
+        "with_modifiers": True,
+        "modifier_rows": rows,
+        "attachable_modifiers": attachable,
+        "kind_picker": ModifierComposerForm(
+            initial={"scope_kind": scope_kind, "effect_kind": effect_kind}
+        ),
+        "composer": composer,
+        "composer_scope": scope_kind,
+        "composer_effect": effect_kind,
+        "composer_chips": chips,
+    }
 
 
 def _tp_words(line):

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -15,6 +15,7 @@ The composer and the preview pane hang off this same skeleton later
 
 import inspect
 import re
+from collections import Counter
 
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
@@ -161,6 +162,13 @@ def _has_detail(kind):
     return kind in DETAIL_KINDS or kind in DETAIL_VIEWS or _carries_modifiers(kind)
 
 
+#: The most empty condition rows a composer will offer at once. The
+#: count rides in the URL, where any number can be typed, and each row
+#: is a whole rendered form — a scope narrowed twenty ways is already
+#: past what an author can read.
+MAX_CHIPS = 20
+
+
 def _assignable_models():
     """Every concrete kind that can carry modifiers."""
     from django.apps import apps
@@ -172,15 +180,67 @@ def _assignable_models():
     ]
 
 
+def _carrier_counts(modifiers):
+    """How many things carry each of these modifiers, keyed by pk.
+
+    The number is what stops an author editing a shared modifier
+    thinking it is theirs alone. The kinds share no table, so the tally
+    costs one query per kind — per *page*, though, not per kind per
+    modifier: a page listing every modifier would otherwise spend
+    hundreds of queries counting.
+    """
+    counts = Counter()
+    pks = [modifier.pk for modifier in modifiers]
+    if not pks:
+        return counts
+    for model in _assignable_models():
+        counts.update(
+            model.objects.filter(modifiers__in=pks).values_list("modifiers", flat=True)
+        )
+    return counts
+
+
 def _carrier_count(modifier):
-    """How many things carry this modifier, across every kind. The
-    kinds share no table, so this is one count per kind — fine at
-    authoring-page scale, and the number is what stops an author
-    editing a shared modifier thinking it is theirs alone."""
-    return sum(
-        model.objects.filter(modifiers=modifier).count()
-        for model in _assignable_models()
-    )
+    """How many things carry this one modifier."""
+    return _carrier_counts([modifier])[modifier.pk]
+
+
+def _reading_sentences(modifiers):
+    """A modifier queryset with everything its sentences read loaded.
+
+    A modifier says itself by walking its scope and its effect, and
+    each of those walks further — the stat a change names, the subtypes
+    a condition lists. Unhinted that is several queries per row. The
+    paths are derived from the fields rather than listed, so a new
+    scope, effect or condition kind is covered the day it is added.
+    """
+    from n26.library.models import Modifier
+    from n26.library.models.modifier import EFFECT_FIELDS, SCOPE_FIELDS
+
+    def forward_relations(model):
+        return [
+            field.name
+            for field in model._meta.get_fields()
+            if field.concrete and (field.many_to_one or field.one_to_one)
+        ]
+
+    select, prefetch = [], []
+    for half in (*SCOPE_FIELDS, *EFFECT_FIELDS):
+        select.append(half)
+        related = Modifier._meta.get_field(half).related_model
+        select.extend(f"{half}__{name}" for name in forward_relations(related))
+        # Conditions hang off their scope the other way round, so they
+        # are fetched separately rather than joined.
+        for condition in getattr(related, "CONDITIONS", ()):
+            model = related._meta.get_field(condition).related_model
+            prefetch.append(f"{half}__{condition}")
+            prefetch.extend(
+                f"{half}__{condition}__{field.name}"
+                for field in model._meta.get_fields()
+                if field.concrete and (field.many_to_one or field.many_to_many)
+            )
+
+    return modifiers.select_related(*select).prefetch_related(*prefetch)
 
 
 def _label_for(row):
@@ -546,6 +606,7 @@ def _composer_state(request, attach_to=None, bound_composer=None):
         chips = max(0, int(request.GET.get("chips", 0)))
     except ValueError:
         chips = 0
+    chips = min(chips, MAX_CHIPS)
 
     composer = bound_composer
     if composer is None and scope_kind in specs() and effect_kind in specs():
@@ -570,10 +631,12 @@ def _modifier_section(request, thing, bound_composer=None):
     the composer."""
     from n26.library.models import Modifier
 
+    attached = list(_reading_sentences(thing.modifiers.all()))
+    counts = _carrier_counts(attached)
+
     rows = []
-    attached = list(thing.modifiers.all())
     for modifier in attached:
-        others = _carrier_count(modifier) - 1
+        others = counts[modifier.pk] - 1
         notes = [str(modifier.scope), str(modifier.effect)]
         if others:
             notes.append(f"also on {others} other carrier{'' if others == 1 else 's'}")
@@ -584,7 +647,9 @@ def _modifier_section(request, thing, bound_composer=None):
             "pk": modifier.pk,
             "label": f"{modifier.name} — {modifier.scope}: {modifier.effect}",
         }
-        for modifier in Modifier.objects.exclude(pk__in=[m.pk for m in attached])
+        for modifier in _reading_sentences(
+            Modifier.objects.exclude(pk__in=[m.pk for m in attached])
+        )
     ]
 
     return {
@@ -622,9 +687,12 @@ def modifiers(request):
                 )
                 return redirect("authoring-modifiers")
 
+    every = list(_reading_sentences(Modifier.objects.all()))
+    counts = _carrier_counts(every)
+
     rows = []
-    for modifier in Modifier.objects.all():
-        carriers = _carrier_count(modifier)
+    for modifier in every:
+        carriers = counts[modifier.pk]
         notes = [str(modifier.scope), str(modifier.effect)]
         notes.append(
             f"on {carriers} carrier{'' if carriers == 1 else 's'}"

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -533,12 +533,40 @@ def _modifier_action(request, kind, thing, act):
     return redirect("authoring-detail", kind=kind, pk=thing.pk), None
 
 
+def _composer_state(request, attach_to=None, bound_composer=None):
+    """The composer as the URL describes it: closed, open at the named
+    kinds, or bound with errors after a refused submit. Shared by the
+    carrier pages and the standalone modifiers page."""
+    from n26.library.forms import ModifierComposerForm
+
+    scope_kind = request.POST.get("scope_kind", request.GET.get("scope_kind", ""))
+    effect_kind = request.POST.get("effect_kind", request.GET.get("effect_kind", ""))
+    try:
+        chips = max(0, int(request.GET.get("chips", 0)))
+    except ValueError:
+        chips = 0
+
+    composer = bound_composer
+    if composer is None and scope_kind in specs() and effect_kind in specs():
+        composer = ModifierComposerForm.unbound(
+            scope_kind, effect_kind, attach_to=attach_to, chips=chips
+        )
+
+    return {
+        "kind_picker": ModifierComposerForm(
+            initial={"scope_kind": scope_kind, "effect_kind": effect_kind}
+        ),
+        "composer": composer,
+        "composer_scope": scope_kind,
+        "composer_effect": effect_kind,
+        "composer_chips": chips,
+    }
+
+
 def _modifier_section(request, thing, bound_composer=None):
     """Everything the modifiers section draws: what hangs here (with
     its sentences and how shared it is), what could be attached, and
-    the composer — closed, open at the kinds the URL names, or bound
-    with errors after a refused submit."""
-    from n26.library.forms import ModifierComposerForm
+    the composer."""
     from n26.library.models import Modifier
 
     rows = []
@@ -558,31 +586,60 @@ def _modifier_section(request, thing, bound_composer=None):
         for modifier in Modifier.objects.exclude(pk__in=[m.pk for m in attached])
     ]
 
-    scope_kind = request.POST.get("scope_kind", request.GET.get("scope_kind", ""))
-    effect_kind = request.POST.get("effect_kind", request.GET.get("effect_kind", ""))
-    try:
-        chips = max(0, int(request.GET.get("chips", 0)))
-    except ValueError:
-        chips = 0
-
-    composer = bound_composer
-    if composer is None and scope_kind in specs() and effect_kind in specs():
-        composer = ModifierComposerForm.unbound(
-            scope_kind, effect_kind, attach_to=thing, chips=chips
-        )
-
     return {
         "with_modifiers": True,
         "modifier_rows": rows,
         "attachable_modifiers": attachable,
-        "kind_picker": ModifierComposerForm(
-            initial={"scope_kind": scope_kind, "effect_kind": effect_kind}
-        ),
-        "composer": composer,
-        "composer_scope": scope_kind,
-        "composer_effect": effect_kind,
-        "composer_chips": chips,
+        **_composer_state(request, attach_to=thing, bound_composer=bound_composer),
     }
+
+
+@staff_member_required
+def modifiers(request):
+    """The modifiers themselves: every one in the pack, and the
+    composer with nothing to attach to — what it makes is reusable by
+    construction, waiting in every carrier page's attach picker."""
+    from n26.library.forms import ModifierComposerForm
+    from n26.library.models import Modifier
+
+    bound = None
+    if request.method == "POST":
+        bound = ModifierComposerForm(request.POST, attach_to=None)
+        if bound.is_valid():
+            try:
+                with transaction.atomic():
+                    made = bound.save()
+            except IntegrityError:
+                bound.add_error(
+                    "name",
+                    "A modifier with that name already exists in this pack.",
+                )
+            else:
+                messages.success(
+                    request,
+                    f"Composed {made.name} — attach it from any carrier's page.",
+                )
+                return redirect("authoring-modifiers")
+
+    rows = []
+    for modifier in Modifier.objects.all():
+        carriers = _carrier_count(modifier)
+        notes = [str(modifier.scope), str(modifier.effect)]
+        notes.append(
+            f"on {carriers} carrier{'' if carriers == 1 else 's'}"
+            if carriers
+            else "reusable — attached nowhere yet"
+        )
+        rows.append({"label": modifier.name, "notes": notes})
+
+    return render(
+        request,
+        "authoring/modifiers.html",
+        {
+            "rows": rows,
+            **_composer_state(request, bound_composer=bound),
+        },
+    )
 
 
 def _tp_words(line):

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -479,6 +479,7 @@ def detail(request, kind, pk):
             "kind": kind,
             "thing": thing,
             "verbose_name": model._meta.verbose_name,
+            "verbose_name_plural": model._meta.verbose_name_plural,
             "kind_help": kind_help(model),
             **part_context,
             **(

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -1518,3 +1518,80 @@ class TestTheModifierSection:
         body = client.get(f"/n26/authoring/weapon/{gun.pk}/").content.decode()
         assert "Add a weapon profile" in body
         assert "does nothing special until" in body
+
+
+class TestTheModifiersPage:
+    """The standalone page: every modifier in the pack listed with its
+    sentences and carrier count, and the composer with nothing to
+    attach to — what it makes is reusable by construction."""
+
+    def test_it_lists_every_modifier_with_its_reach(self, author, client, default_pack):
+        from n26.library.authoring import (
+            attach_modifiers_to,
+            create_rule,
+            create_subtype,
+            ef_adds,
+            modifier,
+            targets_model,
+        )
+
+        shared = modifier(
+            "Grants Mounted", targets_model(), ef_adds(create_subtype("Mounted"))
+        )
+        attach_modifiers_to(create_rule("Cutter"), [shared])
+        modifier("Grants Wyrd", targets_model(), ef_adds(create_subtype("Wyrd")))
+
+        body = client.get("/n26/authoring/modifiers/").content.decode()
+        assert "Grants Mounted" in body
+        assert "adds Mounted" in body
+        assert "on 1 carrier" in body
+        assert "reusable — attached nowhere yet" in body
+
+    def test_composing_here_attaches_nowhere(self, author, client, default_pack):
+        from n26.library.authoring import create_subtype
+        from n26.library.models import Modifier
+
+        mounted = create_subtype("Mounted")
+        response = client.post(
+            "/n26/authoring/modifiers/",
+            {
+                "scope_kind": "targets_model",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "subtype",
+                "what-thing_subtype": str(mounted.pk),
+                **TestTheModifierSection.NO_CONDITIONS,
+            },
+        )
+        assert response.status_code == 302
+        (made,) = Modifier.objects.all()
+        # Reusable by construction: no carrier anywhere holds it.
+        from n26.library.views import _carrier_count
+
+        assert _carrier_count(made) == 0
+
+    def test_the_two_step_flow_works_here_too(self, author, client, default_pack):
+        body = client.get(
+            "/n26/authoring/modifiers/"
+            "?scope_kind=targets_weapons&effect_kind=ef_adds&chips=1"
+        ).content.decode()
+        assert 'name="what-thing_kind"' in body
+        assert 'name="conditions-0-kind"' in body
+        # No keep-reusable switch: there is nothing to attach to.
+        assert 'name="keep_reusable"' not in body
+
+    def test_a_refusal_stays_on_the_page_in_words(self, author, client, default_pack):
+        from n26.library.authoring import create_trait
+
+        melee = create_trait("Melee")
+        response = client.post(
+            "/n26/authoring/modifiers/",
+            {
+                "scope_kind": "targets_model",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "trait",
+                "what-thing_trait": str(melee.pk),
+                **TestTheModifierSection.NO_CONDITIONS,
+            },
+        )
+        assert response.status_code == 200
+        assert "cannot apply" in response.content.decode()

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -15,6 +15,8 @@ them:
 * the surface is staff-only.
 """
 
+import re
+
 import pytest
 from django.contrib.auth.models import User
 
@@ -294,14 +296,14 @@ class TestFamilies:
     def test_the_index_groups_by_family(self, author, client, default_pack):
         body = client.get("/n26/authoring/").content.decode()
         # Every family has pages now, and they read in declaration order.
+        # The heading text, not its markup — the section component owns that.
         positions = [
-            body.index(f"<h2>{label}</h2>")
-            for label in ("Base", "Model", "Gear", "Gang")
+            body.index(f">{label}</h2>") for label in ("Base", "Model", "Gear", "Gang")
         ]
         assert positions == sorted(positions)
         # A kind sits under its family.
-        assert body.index("<h2>Gear</h2>") < body.index("wargear")
-        assert body.index("<h2>Gang</h2>") < body.index("archetype")
+        assert body.index(">Gear</h2>") < body.index("wargear")
+        assert body.index(">Gang</h2>") < body.index("archetype")
 
     def test_the_family_table(self):
         """The grouping as agreed, pinned so it changes deliberately."""
@@ -528,9 +530,9 @@ class TestWeapons:
             ("L", "lethality"),
         ):
             assert f'name="{field}"' in body
-            # The platform's form renderer draws the label (no ":" suffix,
-            # its own classes) — assert the words, not the chrome.
-            assert f">{short}</label>" in body
+            # The kit's label wraps its text in a whitespace-padded span —
+            # assert the words where they land, not the chrome around them.
+            assert re.search(rf">\s*{re.escape(short)}\s*</span>", body)
         assert 'placeholder="4&quot;"' in body  # the stat's own example
 
     def test_adding_the_mandatory_profile_with_its_stats_and_traits(

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -295,15 +295,16 @@ class TestFamilies:
 
     def test_the_index_groups_by_family(self, author, client, default_pack):
         body = client.get("/n26/authoring/").content.decode()
-        # Every family has pages now, and they read in declaration order.
-        # The heading text, not its markup — the section component owns that.
+        # One table, a group row per family, in declaration order. The
+        # heading text where it lands, not the markup around it.
         positions = [
-            body.index(f">{label}</h2>") for label in ("Base", "Model", "Gear", "Gang")
+            re.search(rf'scope="colgroup".*?>\s*{label}\s*<', body, re.S).start()
+            for label in ("Base", "Model", "Gear", "Gang")
         ]
         assert positions == sorted(positions)
         # A kind sits under its family.
-        assert body.index(">Gear</h2>") < body.index("wargear")
-        assert body.index(">Gang</h2>") < body.index("archetype")
+        assert positions[2] < body.index("wargear")
+        assert positions[3] < body.index("archetype")
 
     def test_the_family_table(self):
         """The grouping as agreed, pinned so it changes deliberately."""

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -1323,3 +1323,198 @@ class TestTheCollectionPage:
         assert "10cr here" in body  # the entry's own price, in the definition
         assert "priced by this list" in body  # and marked in the preview
         assert ">E<" in body  # the heirloom's TP cell
+
+
+class TestTheModifierSection:
+    """Every assignable kind's page carries its modifiers: what hangs
+    here in scope-and-effect sentences, an attach picker for reusables,
+    and the two-step composer — kinds first (carried in the URL, so
+    step two survives a refresh), then the panes those kinds call for.
+    The section is derived from the mixin's M2M, never enumerated, so
+    a new assignable kind gets it without anyone remembering to say so.
+    """
+
+    #: The empty condition formset's bookkeeping, present on every
+    #: compose POST the way the browser would send it.
+    NO_CONDITIONS = {
+        "conditions-TOTAL_FORMS": "0",
+        "conditions-INITIAL_FORMS": "0",
+        "conditions-MIN_NUM_FORMS": "0",
+        "conditions-MAX_NUM_FORMS": "1000",
+    }
+
+    @pytest.fixture
+    def rule(self, author, default_pack):
+        from n26.library.authoring import create_rule
+
+        return create_rule("Immovable Brutes")
+
+    def test_a_carrier_kind_gets_a_page_with_the_section(
+        self, rule, client, default_pack
+    ):
+        body = client.get(f"/n26/authoring/rule/{rule.pk}/").content.decode()
+        assert "does nothing special until" in body
+        assert 'name="scope_kind"' in body  # step one is always offered
+
+    def test_a_foundation_kind_does_not(self, author, client, default_pack):
+        from n26.library.authoring import create_stat
+
+        stat = create_stat("M", "Movement", is_inches=True)
+        assert client.get(f"/n26/authoring/stat/{stat.pk}/").status_code == 404
+
+    def test_step_two_renders_the_panes_the_kinds_call_for(
+        self, rule, client, default_pack
+    ):
+        body = client.get(
+            f"/n26/authoring/rule/{rule.pk}/"
+            "?scope_kind=targets_model&effect_kind=ef_changes_stat"
+        ).content.decode()
+        assert 'name="what-stat"' in body
+        assert 'name="what-amount"' in body
+        assert 'name="who-when_directly_assigned"' in body
+
+    def test_composing_attaches_here(self, rule, client, default_pack):
+        from n26.library.authoring import create_subtype
+
+        mounted = create_subtype("Mounted")
+        response = client.post(
+            f"/n26/authoring/rule/{rule.pk}/",
+            {
+                "act": "compose",
+                "scope_kind": "targets_model",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "subtype",
+                "what-thing_subtype": str(mounted.pk),
+                **self.NO_CONDITIONS,
+            },
+        )
+        assert response.status_code == 302
+
+        (modifier,) = rule.modifiers.all()
+        assert str(modifier.effect) == "adds Mounted"
+        body = client.get(f"/n26/authoring/rule/{rule.pk}/").content.decode()
+        assert "adds Mounted" in body
+
+    def test_a_condition_narrows_the_scope(self, rule, client, default_pack):
+        from n26.library.authoring import create_subtype
+
+        champion = create_subtype("Champion")
+        mounted = create_subtype("Mounted")
+        response = client.post(
+            f"/n26/authoring/rule/{rule.pk}/",
+            {
+                "act": "compose",
+                "scope_kind": "targets_model",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "subtype",
+                "what-thing_subtype": str(mounted.pk),
+                **self.NO_CONDITIONS,
+                "conditions-TOTAL_FORMS": "1",
+                "conditions-0-kind": "has_subtypes",
+                "conditions-0-subtypes": [str(champion.pk)],
+            },
+        )
+        assert response.status_code == 302
+        (modifier,) = rule.modifiers.all()
+        assert "Champion" in str(modifier.scope)
+
+    def test_adding_a_condition_is_a_link_not_a_widget(
+        self, rule, client, default_pack
+    ):
+        """URL-driven: chips rides the query string, so the empty chip
+        survives a refresh and needs no JavaScript."""
+        body = client.get(
+            f"/n26/authoring/rule/{rule.pk}/"
+            "?scope_kind=targets_model&effect_kind=ef_adds&chips=1"
+        ).content.decode()
+        assert 'name="conditions-0-kind"' in body
+        assert "chips=2" in body  # the next link is already offered
+
+    def test_an_incompatible_pair_refuses_in_words(self, rule, client, default_pack):
+        from n26.library.authoring import create_trait
+
+        melee = create_trait("Melee")
+        response = client.post(
+            f"/n26/authoring/rule/{rule.pk}/",
+            {
+                "act": "compose",
+                "scope_kind": "targets_model",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "trait",
+                "what-thing_trait": str(melee.pk),
+                **self.NO_CONDITIONS,
+            },
+        )
+        assert response.status_code == 200
+        assert "cannot apply" in response.content.decode()
+        assert rule.modifiers.count() == 0
+
+    def test_attach_existing_then_detach(self, rule, client, default_pack):
+        from n26.library.authoring import (
+            attach_modifiers_to,
+            create_hidden,
+            create_subtype,
+            ef_adds,
+            modifier,
+            targets_model,
+        )
+
+        shared = modifier(
+            "Grants Mounted", targets_model(), ef_adds(create_subtype("Mounted"))
+        )
+        other = create_hidden("Corruption token")
+        attach_modifiers_to(other, [shared])
+
+        response = client.post(
+            f"/n26/authoring/rule/{rule.pk}/",
+            {"act": "attach", "modifier": str(shared.pk)},
+        )
+        assert response.status_code == 302
+        assert list(rule.modifiers.all()) == [shared]
+
+        body = client.get(f"/n26/authoring/rule/{rule.pk}/").content.decode()
+        assert "also on 1 other carrier" in body
+
+        response = client.post(
+            f"/n26/authoring/rule/{rule.pk}/",
+            {"act": "detach", "modifier": str(shared.pk)},
+        )
+        assert response.status_code == 302
+        assert rule.modifiers.count() == 0
+        # Detached, not destroyed: the other carrier keeps it.
+        assert list(other.modifiers.all()) == [shared]
+
+    def test_keep_reusable_saves_without_attaching(self, rule, client, default_pack):
+        from n26.library.authoring import create_subtype
+        from n26.library.models import Modifier
+
+        mounted = create_subtype("Mounted")
+        response = client.post(
+            f"/n26/authoring/rule/{rule.pk}/",
+            {
+                "act": "compose",
+                "scope_kind": "targets_model",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "subtype",
+                "what-thing_subtype": str(mounted.pk),
+                "keep_reusable": "on",
+                **self.NO_CONDITIONS,
+            },
+        )
+        assert response.status_code == 302
+        assert rule.modifiers.count() == 0
+        (made,) = Modifier.objects.all()
+        # …and the page now offers it in the attach picker.
+        body = client.get(f"/n26/authoring/rule/{rule.pk}/").content.decode()
+        assert "Attach an existing modifier" in body
+        assert made.name in body
+
+    def test_the_weapon_page_keeps_its_parts_and_gains_the_section(
+        self, author, client, default_pack, weapon_statline_type
+    ):
+        from n26.library.authoring import create_weapon
+
+        gun = create_weapon("Autogun", statline_type=weapon_statline_type)
+        body = client.get(f"/n26/authoring/weapon/{gun.pk}/").content.decode()
+        assert "Add a weapon profile" in body
+        assert "does nothing special until" in body

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -1595,3 +1595,35 @@ class TestTheModifiersPage:
         )
         assert response.status_code == 200
         assert "cannot apply" in response.content.decode()
+
+    def test_more_modifiers_do_not_mean_more_queries(
+        self, author, client, default_pack, django_assert_num_queries
+    ):
+        """The page reads every modifier's sentence and counts every
+        carrier. Both are gathered for the whole page at once, so a pack
+        that grows costs rows, not round trips."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from n26.library.authoring import (
+            attach_modifiers_to,
+            create_rule,
+            create_subtype,
+            ef_adds,
+            modifier,
+            targets_model,
+        )
+
+        def compose(name):
+            made = modifier(name, targets_model(), ef_adds(create_subtype(name)))
+            attach_modifiers_to(create_rule(f"{name} rule"), [made])
+
+        for index in range(3):
+            compose(f"Grants {index}")
+        with CaptureQueriesContext(connection) as few:
+            assert client.get("/n26/authoring/modifiers/").status_code == 200
+
+        for index in range(3, 12):
+            compose(f"Grants {index}")
+        with django_assert_num_queries(len(few), exact=False):
+            assert client.get("/n26/authoring/modifiers/").status_code == 200

--- a/n26/tests/sandbox/test_foundations.py
+++ b/n26/tests/sandbox/test_foundations.py
@@ -160,7 +160,12 @@ class TestThePage:
         assert "missing" in body
         assert "Model characteristics" in body
 
-        client.post("/n26/authoring/foundations/", {"do": "seed:model-characteristics"})
+        # The button's own payload. This test once posted a key the view
+        # never read and still passed, because the old inline stylesheet
+        # happened to contain the word "complete" — the page said nothing
+        # of the sort. The styles are the design system's now, so the
+        # assertion finally means what it says.
+        client.post("/n26/authoring/foundations/", {"create": "model-characteristics"})
         body = client.get("/n26/authoring/foundations/").content.decode()
         assert "complete" in body
         assert "Fighter" in body  # the profile type it made

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -20,6 +20,11 @@ urlpatterns = [
     path("design/", include("n26.designsystem.urls")),
     path("authoring/", authoring_views.index, name="authoring-index"),
     path(
+        "authoring/modifiers/",
+        authoring_views.modifiers,
+        name="authoring-modifiers",
+    ),
+    path(
         "authoring/foundations/",
         authoring_views.foundations,
         name="authoring-foundations",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,9 @@ extend_exclude = "gyrinx/templates/cotton,n26/core/templates/cotton"
 exclude_dirs = [
     ".venv",
     ".git",
+    # Claude's working notes are untracked scratch, not shipped code — but
+    # bandit -r . reads them and fails commits on whatever they contain.
+    ".claude",
     "__pycache__",
     "*/migrations/*",
     "*/tests/*",


### PR DESCRIPTION
## Summary

- Converts the whole n26 authoring surface (index, foundations, leaf, detail pages) from hand-written markup to the design-system components, deleting the inline CSS and bespoke tables it replaced. Spec-generated forms now render through a single field dispatch (`n26/library/templates/authoring/_field.html`) that maps each widget kind onto the kit controls while preserving the `data-union-*` markers the union-toggle JS relies on.
- Adds the modifier UI: every assignable kind's detail page gains a Modifiers section (attach / detach / a two-step compose form whose state — scope kind, effect kind, condition-chip count — lives in the query string), and a standalone `/n26/authoring/modifiers/` page for composing reusable modifiers that aren't attached to anything yet. Both render one shared composer include.
- Smaller fixes along the way: the authoring index is one table with a tbody per family so columns align; kind names never wrap; the rarely-needed qualifier and author-help fields fold behind a collapse; detail breadcrumbs use the model's declared plural ("weapon accessories", not "weapon accessorys").

Net −1,475 lines. 14 new tests around the modifier UI; a rotten platform-integration test file that asserted on deleted inline CSS is gone.

## Test plan

- [x] `n26/tests/sandbox/test_authoring_views.py` — 190 passing, including compose/attach/detach, condition chips, incompatible-pair refusal, keep-reusable, and the standalone modifiers page
- [x] Browser-checked the authoring index, foundations, leaf forms (union toggle intact), a weapon detail page (parts + modifiers side by side), and the modifiers page on the dev server
- [ ] Full n26 suite green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WR57vDuCgpCHLJz7NfA7wb

## Review feedback

- **Query fan-out on the modifiers page** — fixed. Listing every modifier cost roughly two dozen queries per row (a carrier count per assignable kind per modifier, plus an unhinted walk of each modifier's scope and effect). Twelve modifiers took 297 queries; now 30, and flat as the pack grows. Guarded by `test_more_modifiers_do_not_mean_more_queries`.
- **Unbounded condition chips from the query string** — fixed, capped at 20.
- **Cross-pack modifier lookups** — not addressed here. The whole authoring surface is pack-blind, not just these lookups; scoping one corner would leave the real gap open. Tracked in #2157.

Refs #2157
