### PR TITLE
fix: a duplicate stat is refused in words, not with a 500

### DIFF
--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -147,6 +147,11 @@ class Spec:
     #: where there is one, named here where there isn't — a stat has a
     #: short name and a full one, and a through row has neither.
     model: type = None
+    #: The field an author reads as this thing's name, and so where a
+    #: refusal about a duplicate belongs. Every creating kind but one
+    #: calls it ``name``; a stat is told apart by its full name, which
+    #: is what its uniqueness is derived from.
+    identity: str = "name"
 
     @property
     def name(self):
@@ -451,6 +456,7 @@ def _build_registry():
                 "is_modifier": Bool(source=(Stat, "is_modifier")),
             },
             model=Stat,
+            identity="full_name",
         ),
         Spec(
             authoring.create_statline_type,

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -413,10 +413,14 @@ def leaf(request, kind):
                     if suggestions is not None:
                         suggestions.apply(created)
             except IntegrityError:
+                # Not every kind calls its name "name" — the spec says
+                # which field an author reads as one, so the refusal
+                # lands on a field the form actually has.
+                named = spec.identity
                 form.add_error(
-                    "name",
+                    named,
                     f"A {model._meta.verbose_name} named "
-                    f"“{form.cleaned_data['name']}” already exists in this pack.",
+                    f"“{form.cleaned_data[named]}” already exists in this pack.",
                 )
             else:
                 messages.success(request, f"Created {created}.")

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -45,6 +45,18 @@ class TestTheMenuIsBackedBySpecs:
         )
 
     @pytest.mark.parametrize("kind", sorted(LEAF_KINDS), ids=str)
+    def test_every_leaf_kind_can_say_which_field_is_its_name(self, kind):
+        """A duplicate is refused by writing the error onto the field an
+        author reads as the thing's name. A spec naming a field it does
+        not have would crash on that refusal instead of showing it."""
+        spec = specs()[LEAF_KINDS[kind]]
+        assert spec.identity in spec.fields, (
+            f"The {kind} spec says its name field is {spec.identity!r}, but "
+            f"its fields are {', '.join(spec.fields)}. Set identity= on the "
+            f"spec to whichever of those an author reads as the name."
+        )
+
+    @pytest.mark.parametrize("kind", sorted(LEAF_KINDS), ids=str)
     def test_every_leaf_page_renders(self, kind, author, client, default_pack):
         response = client.get(f"/n26/authoring/{kind}/")
         assert response.status_code == 200
@@ -136,6 +148,22 @@ class TestCreatingALeaf:
         assert response.status_code == 200  # back on the form, not a 500
         assert "already exists in this pack" in response.content.decode()
         assert Subtype.objects.filter(name="Mounted").count() == 1
+
+    def test_a_duplicate_stat_refuses_in_words_too(self, author, client, default_pack):
+        """A stat has no field called "name" — it has a short one and a
+        full one — and a second Movement used to crash the page rather
+        than say a Movement already existed."""
+        from n26.library.models import Stat
+
+        made = {"short_name": "M", "full_name": "Movement"}
+        client.post("/n26/authoring/stat/", made)
+        response = client.post("/n26/authoring/stat/", made)
+
+        assert response.status_code == 200  # back on the form, not a 500
+        body = response.content.decode()
+        assert "already exists in this pack" in body
+        assert "Movement" in body
+        assert Stat.objects.filter(full_name="Movement").count() == 1
 
     def test_a_missing_name_refuses_in_words(self, author, client, default_pack):
         from n26.library.models import Counter


### PR DESCRIPTION
## Summary

Creating a stat whose name is already taken crashed the page with a server error instead of showing the "already exists in this pack" message every other authoring page shows.

Every create page under `/n26/authoring/` catches the database's refusal of a duplicate and turns it into an error on the form. It wrote that error onto a field called `name` — and a stat is the one kind that has no such field, carrying a short name and a full name instead. So the handler meant to report the problem became the problem: `KeyError: 'name'`, and a 500 for the author.

The fix lets a spec say which of its fields an author reads as the thing's name, defaulting to `name` because twenty-one of the twenty-two kinds call it that. A stat says `full_name`, which is what its uniqueness is actually derived from (`field_name` is computed from it), so the refusal lands on the field the author needs to change.

A guard test over every leaf kind fails if a spec names a field it does not have, with a message saying what to set — so a future kind cannot reintroduce this by having an unusual shape.

## Test plan

- [x] `test_a_duplicate_stat_refuses_in_words_too` — a second Movement now returns 200 with the refusal on the form; fails with `KeyError: 'name'` against the old code
- [x] `test_every_leaf_kind_can_say_which_field_is_its_name` — the guard, run against all 22 leaf kinds
- [x] Full n26 suite: 1,295 passing

Closes #2152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WR57vDuCgpCHLJz7NfA7wb