### PR TITLE
chore: comments state the reasoning, not who gave it

### DIFF
--- a/n26/core/templates/cotton/n26/collection_picker/index.html
+++ b/n26/core/templates/cotton/n26/collection_picker/index.html
@@ -73,7 +73,7 @@ dispatches, and listens for `filter-reset` to be told.
     :categories="[]"
     :sections="[]"
     {% comment %}
-    Tabs by default (Tom, 2026-08-07). Two stacked collapsibles made you press
+    Tabs by default. Two stacked collapsibles made you press
     twice to reach the second section — once to shut the first, once to open it —
     and the tab strip leaves the category as the only thing that collapses, which
     is the level where having two open at once is actually useful.

--- a/n26/core/templates/cotton/n26/model_card/index.html
+++ b/n26/core/templates/cotton/n26/model_card/index.html
@@ -31,9 +31,9 @@ it, which is the only thing grey is for here.
 
   --- what it deliberately leaves out ---
 
-`card.collections` (which lists a fighter can shop at) and `card.effects` (what
-their kit does beyond this card) are both on the structure and neither is drawn
-(Tom, 2026-08-07). They are reference rather than identity: true of a fighter, and
+`card.collections` (the lists a fighter uses) and `card.effects` (what
+their kit does beyond this card) are both on the structure and neither is
+drawn. They are reference rather than identity: true of a fighter, and
 not what anyone is reading a card to find out. On a gang sheet of eleven cards
 they were two more rows between the statline and the weapons on every one of them.
 

--- a/n26/core/views.py
+++ b/n26/core/views.py
@@ -1,8 +1,8 @@
 """The preview endpoint: form state in, card state out.
 
-Tom's framing (design/authoring.md): the scratch-card UI is earnable if
-"an endpoint that takes the form state and gives back card state"
-exists. This is that endpoint, deliberately thin — everything it does
+The scratch-card UI becomes possible once an endpoint takes form state
+and gives back card state (design/authoring.md). This is that endpoint,
+deliberately thin — everything it does
 lives in :mod:`n26.preview`, and nothing it does survives the request:
 the preview rolls its own transaction back.
 """

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -1,11 +1,11 @@
 """Authoring verbs — the one vocabulary for building library content.
 
-Graduated from ``tests/sandbox/actions.py`` (2026-08-06): these verbs
-are the authoring API, and the admin's forms compile to exactly these
-calls — a form that can't be expressed as a verb here can't exist, and
-a verb here is what a spec describes (design/authoring.md).
+These verbs are the authoring API, and the admin's forms compile to
+exactly these calls — a form that can't be expressed as a verb here
+can't exist, and a verb here is what a spec describes
+(design/authoring.md).
 
-The grammar, agreed with Tom (design/authoring-build-plan.md):
+The grammar (design/authoring-build-plan.md):
 
 * **Scopes** say who a modifier reaches, and take nested **conditions**::
 

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -167,7 +167,7 @@ class Spec:
         Keys absent from ``data`` fall back to the verb's own defaults.
         A ``Conditions`` value is a list of ``(verb_name, payload)``
         pairs, each compiled by that condition's spec and passed
-        positionally — the nesting Tom's grammar asks for.
+        positionally — the nesting the grammar asks for.
         """
         signature = inspect.signature(self.verb)
         args, kwargs = [], {}

--- a/n26/tests/sandbox/test_collections.py
+++ b/n26/tests/sandbox/test_collections.py
@@ -133,7 +133,7 @@ class TestReferencePricing:
 
     def test_exclusive_with_a_tp_price_is_unauthorable(self, db):
         """TP "E" and a TP price are contradictory facts — refused at the
-        database, per Tom: is_exclusive wins if code ever has to choose."""
+        database; is_exclusive wins if code ever has to choose."""
         with pytest.raises(IntegrityError), transaction.atomic():
             create_wargear("Nonsense", trade_point_price=3, is_exclusive=True)
 
@@ -375,7 +375,7 @@ class TestHavingAList:
 
 
 class TestRatingFollowsTheRule:
-    """Tom's ruling: a discount leaves the rating at full price; a list's
+    """A discount leaves the rating at full price; a list's
     own price IS the price, so it is also the rating; and the number
     written at purchase is pinned on that assignment forever."""
 

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -1,6 +1,6 @@
 """Counters, with XP as the first one — and effects hanging off values.
 
-Tom's design (2026-08-05): XP is a Counter so that the machinery gets
+XP is a Counter so that the machinery gets
 proven on day one — a threshold-conditioned scope reveals a promotion
 offer at 5 XP and confers a title at 10, computed, withdrawn if the
 value drops. The definition is content; who has one is assignment (XP

--- a/n26/tests/sandbox/test_default_equipment.py
+++ b/n26/tests/sandbox/test_default_equipment.py
@@ -1,11 +1,9 @@
 """What a profile comes with, and what may be chosen instead.
 
-The Khimerix, from Tom's dictation:
-
-    A Khimerix is armed with chemical cloud breath and talons. They may
-    select from the below options when added to a Gang Roster:
-      · replace chemical cloud breath with gaseous eruption breath +25
-      · replace talons with razor-sharp talons +25
+The Khimerix is the shape this proves. It carries chemical cloud breath
+and talons as built-ins, and offers two swaps when it joins a roster:
+gaseous eruption breath for the breath, razor-sharp talons for the
+talons, each at +25.
 
 Nothing is ever *replaced*. A choice decides which set materialises at
 hire, and the option not taken simply never comes into being — which is
@@ -206,7 +204,7 @@ class TestPricingIsAdditive:
     def test_the_cost_may_live_on_the_built_ins_instead(
         self, gang, person_type, gang_type, weapons
     ):
-        """Tom's idea: every profile has built-ins, so they can carry the cost."""
+        """Every profile has built-ins, so they can carry the price."""
         profile = Profile.objects.create(
             name="Cheap beast",
             profile_type=person_type,

--- a/n26/tests/sandbox/test_enforcer_haunt.py
+++ b/n26/tests/sandbox/test_enforcer_haunt.py
@@ -1,8 +1,8 @@
 """The Enforcer Haunt: a chosen *type*, as a Subtype.
 
-Tom's modelling (2026-08-06): Psyrender and Bonecrusher are Subtypes —
-the book says the Haunt "selects one of the following **types**", and
-Subtype is the system's word for exactly that. The pick is then a
+Psyrender and Bonecrusher are Subtypes — the Haunt selects one of
+several types, and Subtype is the system's word for exactly that. The
+pick is then a
 matchable fact ("all Psyrender models…" is expressible), it reads in
 the type line, and the payload rides the subtype as ordinary modifiers:
 
@@ -79,7 +79,7 @@ def powers_collection(families):
 @pytest.fixture
 def wyrd_types(families, powers_collection):
     """Psyrender and Bonecrusher: each a Subtype carrying its placement
-    and its chained power pick — Tom's sketch, verbatim."""
+    and its chained power pick."""
     _, tiers = powers_collection
     made = {}
     for key, name in [("psyrender", "Psyrender"), ("bonecrusher", "Bonecrusher")]:

--- a/n26/tests/sandbox/test_gang_equipment.py
+++ b/n26/tests/sandbox/test_gang_equipment.py
@@ -1,10 +1,10 @@
 """Gang Equipment: the Trazior Pattern Sentry Gun spawns a vehicle.
 
-Tom's modelling (2026-08-06, design/gang-equipment.md): the wargear is
-bought into the Stash, and its weapon options don't sit on the wargear —
-they decide **which vehicle-shaped card is generated**. "The grenade
-launcher and the heavy stubber are option groups on the wargear
-purchase, which result in different vehicle cards."
+The wargear is bought into the Stash, and its weapon options don't sit
+on the wargear — they decide **which vehicle-shaped card is generated**
+(design/gang-equipment.md). The grenade launcher and the heavy stubber
+are option groups on the wargear purchase, and different picks result
+in different vehicle cards.
 
 Nothing here is new machinery — it composes three shipped pieces:
 

--- a/n26/tests/sandbox/test_gang_sheet.py
+++ b/n26/tests/sandbox/test_gang_sheet.py
@@ -1,9 +1,9 @@
 """The gang as a data structure of its own.
 
-Tom, 2026-08-06 (design/gang-sheet.md): "take the same approach we took
-to miniatures, and build a data structure for a gang that includes all
-its properties, so we have a test structure to work against. You can
-then derive a renderable version from that." So: ``GangCard`` is the
+A gang gets the same treatment a miniature does (design/gang-sheet.md):
+a data structure holding all its properties, so there is something to
+test against, with the renderable version derived from it. So:
+``GangCard`` is the
 fetch, ``ComputedGang`` is the test interface, and the grown
 ``GangSheet`` derives from both — the same three layers a miniature
 has, and the surface gang-level choices (a Venator's ranked skill

--- a/n26/tests/sandbox/test_screenshot_profiles.py
+++ b/n26/tests/sandbox/test_screenshot_profiles.py
@@ -1,7 +1,7 @@
 """Four printed cards, represented end to end — the four-card challenge.
 
-Tom's challenge (2026-08-04): prove the system can represent four real
-rulebook profiles, exactly as the book prints them. Each one leans on
+The challenge: prove the system can represent four real rulebook
+profiles, exactly as the book prints them. Each one leans on
 a different corner of the machinery:
 
 * **Van Saar Ash Wastes 'Arachni-Rig'** — a vehicle; an any-of option

--- a/n26/tests/sandbox/test_selector_dialects.py
+++ b/n26/tests/sandbox/test_selector_dialects.py
@@ -96,7 +96,7 @@ class TestEveryDialectCompiles:
 class TestRoundsBySpecificity:
     """Compute runs in rounds; a scope's round is its selector's specificity.
 
-    Tom's design (2026-08-05): unconditional modifiers (specificity 0)
+    Unconditional modifiers (specificity 0)
     settle first; filtered scopes (specificity 1+) then ask against the
     settled facts, all seeing the same snapshot. So a wargear's
     unconditional "grants Mounted" lands in round 0, and a rule for

--- a/n26/tests/sandbox/test_skills_and_powers.py
+++ b/n26/tests/sandbox/test_skills_and_powers.py
@@ -1,6 +1,6 @@
 """Skills, skill sets, placements, and Wyrd powers.
 
-The design, from Tom's sketch (design/collections.md gets the log):
+The design (design/collections.md gets the log):
 
 * a skill set is a **home category** — the taxonomy every collection
   shares; a skill's D6 number is its position within the set;
@@ -107,9 +107,9 @@ def library(sets):
 def catalogue(library):
     """The one collection: every skill and every power, by sweep.
 
-    This is Tom's proof point in fixture form — the powers arrive via a
-    second sweep line, and nothing downstream knows or cares that they
-    are a different kind.
+    The proof point in fixture form — the powers arrive via a second
+    sweep line, and nothing downstream knows or cares that they are a
+    different kind.
     """
     return create_collection("Skills & Powers", contains=[Skill, Power])
 

--- a/n26/tests/sandbox/test_stash.py
+++ b/n26/tests/sandbox/test_stash.py
@@ -1,12 +1,11 @@
 """The stash: the gang's store of surplus equipment.
 
 Rules facts this pins (core rules): the stash holds weapons and
-wargear; gear moves between it and models ("can be moved to any number of
-Model Cards"); Wealth counts models, cash, and the stash. And Tom's
-rulings (2026-08-05): the stash is a **fourth assignment host** — acts
-like a model, needs no profile, is never a card — and founding is
-unlimited spend: no budget unless somebody sets one, the gang's number is
-its rating.
+wargear; gear moves freely between it and any number of models; Wealth
+counts models, cash, and the stash. And the modelling decisions: the
+stash is a **fourth assignment host** — acts like a model, needs no
+profile, is never a card — and founding is unlimited spend: no budget
+unless somebody sets one, the gang's number is its rating.
 """
 
 import pytest
@@ -70,7 +69,7 @@ class TestTheStore:
         assert gang.rating == 135
 
     def test_buying_into_it_at_the_house_price(self, gang, house_list):
-        """Tom's forward-looking case, already expressible: the stash
+        """A forward-looking case, already expressible: the stash
         uses the gang's own list — a line is a complete purchase
         whoever the holder is."""
         bought = buy(gang.stash, lasgun_line(house_list))


### PR DESCRIPTION
## Summary

The n26 comment rule is that a comment must make sense to a reader who has never seen an earlier version of the code — so no people, no dates, no narration of where the code came from. Twenty comments and docstrings across the tree broke it, naming a person, stamping a date, or both.

Each now states the same design as a plain fact, keeping the `design/` citation where there was one. Nothing about the reasoning is lost; the sentences just stop pointing at who said it and when. Examples:

- `Tom's design (2026-08-05): XP is a Counter so that…` → `XP is a Counter so that…`
- `The grammar, agreed with Tom (design/authoring-build-plan.md):` → `The grammar (design/authoring-build-plan.md):`
- `…neither is drawn (Tom, 2026-08-07). They are reference rather than identity…` → `…neither is drawn. They are reference rather than identity…`

Two things fixed in passing, both in lines already being rewritten:

- A profile's rules entry sat quoted in full in a test docstring. It now states the same behaviour in names and numbers, which is all we are meant to keep.
- Two banned words: a card's collections are lists a fighter **uses**, not shops at, and built-ins carry a **price**, not a cost.

Comments only — no behaviour changes.

## Test plan

- [x] Full n26 suite: 1,272 passing
- [x] Swept the tree afterwards: no attributions or date stamps left in n26 comments, and none of this pattern exists in `gyrinx/` or `n23/`

Sample usernames are untouched — `create_user("tom")` in test fixtures and the design-system's demo account are content, not attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WR57vDuCgpCHLJz7NfA7wb