### PR TITLE
feat: ingest weapon accessories

### DIFF
--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -219,6 +219,7 @@ def create_weapon_accessory(
     name,
     price=0,
     trade_point_price=None,
+    is_exclusive=False,
     category=None,
     fits_category=None,
     fits_asterisked=False,
@@ -235,6 +236,7 @@ def create_weapon_accessory(
         name=name,
         price=price,
         trade_point_price=trade_point_price,
+        is_exclusive=is_exclusive,
         category=category,
         fits_category=fits_category,
         fits_asterisked=fits_asterisked,
@@ -719,11 +721,18 @@ def create_trading_post(name="Trading Post", contains=None, entries=(), **kwargs
     hand — plus entries for anything it prices its own way. Nothing
     here is about charging: browse it with ``browse(post, TRADING_POST)``
     and the *terms* charge Trade Points."""
-    from n26.library.models import CollectionSelector, Wargear, Weapon
+    from n26.library.models import CollectionSelector
 
     shared = {"pack": kwargs["pack"]} if "pack" in kwargs else {}
     collection = create_collection(name, entries=entries, **kwargs)
-    sweeps = contains if contains is not None else (Weapon, Wargear)
+    if contains is None:
+        # What the post sells is standard content's to say, so a bare
+        # call builds the real one rather than a subset that quietly
+        # leaves a kind off the shelf.
+        from n26.library.standard_content import trading_post_sweeps
+
+        contains = trading_post_sweeps()
+    sweeps = contains
     for position, sweep in enumerate(sweeps):
         model, category = sweep if isinstance(sweep, tuple) else (sweep, None)
         CollectionSelector.of(

--- a/n26/library/ingest.py
+++ b/n26/library/ingest.py
@@ -1041,21 +1041,34 @@ def _resolve_item(plan, name):
     if len(hits) > 1:
         return None  # ambiguous by name; the ID is what tells them apart
 
-    for kind, model in (
-        ("Weapon", Weapon),
-        ("Wargear", Wargear),
-        ("WeaponAccessory", WeaponAccessory),
-    ):
-        if existing := _exists(plan, model, name__iexact=_clean(name)):
-            return plan.add(
-                kind,
-                existing.name,
-                {"price": existing.price, "unpriced": False},
-                Source("resolution", 0),
-                key=f"{kind}:resolved|{wanted}",
-                action="exists",
-            ).key
-    return None
+    # Every kind at once, and every row of each: a sight and a piece of
+    # wargear may print one name, as may two rows of one kind told apart
+    # by their qualifier. Taking the first would answer by the order
+    # these are asked in, which is no answer at all.
+    found = [
+        (kind, row)
+        for kind, model in (
+            ("Weapon", Weapon),
+            ("Wargear", Wargear),
+            ("WeaponAccessory", WeaponAccessory),
+        )
+        for row in model.objects.filter(pack=plan.pack, name__iexact=_clean(name))
+    ]
+    if len(found) != 1:
+        return None
+    kind, existing = found[0]
+    return plan.add(
+        kind,
+        existing.name,
+        {
+            "price": existing.price,
+            "unpriced": False,
+            "qualifier": existing.qualifier,
+        },
+        Source("resolution", 0),
+        key=f"{kind}:resolved|{wanted}",
+        action="exists",
+    ).key
 
 
 #: What the ``Collection`` column says these rows build. One kind today;

--- a/n26/library/ingest.py
+++ b/n26/library/ingest.py
@@ -475,8 +475,14 @@ def _plan_trait(plan, token, source):
 EQUIPMENT_KINDS = {
     "weapon": "Weapon",
     "wargear": "Wargear",
+    "weapon accessory": "WeaponAccessory",
     "weapon profile": "WeaponProfile",
 }
+
+#: The kinds that are a name, a home and a price and nothing more. They
+#: differ only in which table they land in, so they are planned by one
+#: branch rather than one apiece.
+PLAIN_KINDS = ("Wargear", "WeaponAccessory")
 
 
 def _prices(row):
@@ -527,7 +533,7 @@ def _plan_equipment(plan, rows, statlined=frozenset()):
     profiles themselves are defined by their statlines, and this sheet
     only says what they cost.
     """
-    from n26.library.models import Wargear, Weapon
+    from n26.library.models import Wargear, Weapon, WeaponAccessory
 
     # Pass 1: which printed names does more than one item claim? Those
     # want the author-facing qualifier — a power fist is Exo kit
@@ -607,9 +613,10 @@ def _plan_equipment(plan, rows, statlined=frozenset()):
             kind = "Weapon"
             key = f"Weapon:{ident.key}"
 
-        if kind == "Wargear":
+        if kind in PLAIN_KINDS:
+            model = Wargear if kind == "Wargear" else WeaponAccessory
             plan.add(
-                "Wargear",
+                kind,
                 ident.name,
                 {
                     "category": category,
@@ -623,7 +630,7 @@ def _plan_equipment(plan, rows, statlined=frozenset()):
                 key=key,
                 action="exists"
                 if _exists(
-                    plan, Wargear, name__iexact=ident.name, qualifier__iexact=qualifier
+                    plan, model, name__iexact=ident.name, qualifier__iexact=qualifier
                 )
                 else "create",
             )
@@ -1021,20 +1028,24 @@ def _resolve_item(plan, name):
     rows share cannot be resolved that way and is refused rather than
     guessed at.
     """
-    from n26.library.models import Wargear, Weapon
+    from n26.library.models import Wargear, Weapon, WeaponAccessory
 
     wanted = _norm(name)
     hits = [
         planned
         for planned in plan.planned
-        if planned.kind in ("Weapon", "Wargear") and _norm(planned.name) == wanted
+        if planned.kind in ("Weapon", *PLAIN_KINDS) and _norm(planned.name) == wanted
     ]
     if len(hits) == 1:
         return hits[0].key
     if len(hits) > 1:
         return None  # ambiguous by name; the ID is what tells them apart
 
-    for kind, model in (("Weapon", Weapon), ("Wargear", Wargear)):
+    for kind, model in (
+        ("Weapon", Weapon),
+        ("Wargear", Wargear),
+        ("WeaponAccessory", WeaponAccessory),
+    ):
         if existing := _exists(plan, model, name__iexact=_clean(name)):
             return plan.add(
                 kind,
@@ -1191,7 +1202,12 @@ def _resolve_by_id(plan, ident):
     pack's alone does it fall back to that, which is what lets a
     hand-authored item filed under its own category still be found.
     """
-    from n26.library.models import Wargear, Weapon, WeaponProfile
+    from n26.library.models import (
+        Wargear,
+        Weapon,
+        WeaponAccessory,
+        WeaponProfile,
+    )
 
     if ident.profile:
         candidates = [
@@ -1213,6 +1229,12 @@ def _resolve_by_id(plan, ident):
         candidates = [
             ("Weapon", Weapon, {"name__iexact": ident.name}, homed),
             ("Wargear", Wargear, {"name__iexact": ident.name}, homed),
+            (
+                "WeaponAccessory",
+                WeaponAccessory,
+                {"name__iexact": ident.name},
+                homed,
+            ),
         ]
 
     for kind, _model, _by_name, _home in candidates:
@@ -1386,6 +1408,7 @@ def _entry_exists(plan, collection_name, item_key):
         "Weapon": "weapon",
         "WeaponProfile": "weapon_profile",
         "Wargear": "wargear",
+        "WeaponAccessory": "weapon_accessory",
     }[kind]
     planned = plan.get(item_key)
     filters = {f"{column}__name__iexact": planned.name}
@@ -1429,6 +1452,7 @@ PERFORM_ORDER = [
     "Weapon",
     "WeaponProfile",
     "Wargear",
+    "WeaponAccessory",
     "DefaultAssignmentSet",
     "Profile",
     "Collection",
@@ -1511,6 +1535,7 @@ class _Performer:
             Trait,
             Wargear,
             Weapon,
+            WeaponAccessory,
             WeaponProfile,
         )
         from n26.library.models.collection import Collection
@@ -1531,10 +1556,14 @@ class _Performer:
                 .objects.filter(name__iexact=planned.name, **self.shared)
                 .first()
             )
-        if kind in ("Weapon", "Wargear"):
+        if kind in ("Weapon", *PLAIN_KINDS):
             # Qualified: two catalogue rows may print one name, and the
             # qualifier is the only thing telling them apart.
-            model = Weapon if kind == "Weapon" else Wargear
+            model = {
+                "Weapon": Weapon,
+                "Wargear": Wargear,
+                "WeaponAccessory": WeaponAccessory,
+            }[kind]
             return model.objects.filter(
                 name__iexact=planned.name,
                 qualifier__iexact=planned.fields.get("qualifier", ""),
@@ -1667,6 +1696,23 @@ class _Performer:
         from n26.library import authoring
 
         return authoring.create_wargear(
+            planned.name,
+            price=planned.fields["price"],
+            trade_point_price=planned.fields["trade_point_price"],
+            is_exclusive=planned.fields["is_exclusive"],
+            qualifier=planned.fields.get("qualifier", ""),
+            category=self.resolve(planned.fields["category"]),
+            **self.shared,
+        )
+
+    def _create_weaponaccessory(self, planned):
+        from n26.library import authoring
+
+        # What an accessory fits — a category of weapon, or the
+        # asterisked ones — is not in the sheets, so it arrives fitting
+        # anything and is narrowed by hand. Importing it as unrestricted
+        # is the honest reading of a column that does not exist.
+        return authoring.create_weapon_accessory(
             planned.name,
             price=planned.fields["price"],
             trade_point_price=planned.fields["trade_point_price"],
@@ -1812,6 +1858,7 @@ def _imported(pack=None):
         Trait,
         Wargear,
         Weapon,
+        WeaponAccessory,
         WeaponProfile,
     )
     from n26.library.models.collection import Collection, CollectionEntry
@@ -1887,6 +1934,7 @@ def _imported(pack=None):
         ("weapon profiles", WeaponProfile.objects.filter(**scope)),
         ("weapons", Weapon.objects.filter(**scope)),
         ("wargear", Wargear.objects.filter(**scope)),
+        ("weapon accessories", WeaponAccessory.objects.filter(**scope)),
         ("special rules", Rule.objects.filter(**scope)),
         ("weapon traits", Trait.objects.filter(**scope)),
         (

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -450,12 +450,38 @@ def _check_specialisations():
     return present, 2 * len(names)
 
 
-def _create_trading_post():
-    from n26.library.authoring import create_trading_post
-    from n26.library.models import Collection
+def trading_post_sweeps():
+    """Every kind the post sells: whatever a fighter can buy with Trade
+    Points. An accessory is bought there as readily as the gun it bolts
+    onto, so a kind missing from here is a shelf nobody can reach."""
+    from n26.library.models import Wargear, Weapon, WeaponAccessory
 
-    if not Collection.objects.filter(name=TRADING_POST_COLLECTION).exists():
-        create_trading_post(TRADING_POST_COLLECTION)
+    return (Weapon, Wargear, WeaponAccessory)
+
+
+def _create_trading_post():
+    """The post, and one sweep per kind it sells.
+
+    Tops up rather than skipping: a post built before a kind existed is
+    the ordinary state of a library that has been running a while, and
+    leaving it short would quietly keep those items off the shelf.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    from n26.library.authoring import create_trading_post
+    from n26.library.models import Collection, CollectionSelector
+
+    post = Collection.objects.filter(name=TRADING_POST_COLLECTION).first()
+    if post is None:
+        create_trading_post(TRADING_POST_COLLECTION, contains=trading_post_sweeps())
+        return
+    for position, model in enumerate(trading_post_sweeps()):
+        CollectionSelector.objects.get_or_create(
+            collection=post,
+            of_kind=ContentType.objects.get_for_model(model),
+            with_trade_point_price=True,
+            defaults={"position": position},
+        )
 
 
 def _check_trading_post():
@@ -467,7 +493,7 @@ def _check_trading_post():
         collection__name=TRADING_POST_COLLECTION,
         with_trade_point_price=True,
     )
-    return present, 3  # the collection and its two sweeps
+    return present, 1 + len(trading_post_sweeps())
 
 
 def _create_gang_types():

--- a/n26/tests/sandbox/test_collections.py
+++ b/n26/tests/sandbox/test_collections.py
@@ -744,12 +744,12 @@ class TestTradingPostMembership:
         """The prefetch strategy under test: the count follows the
         post's *definition*, never its size. One for the selector rows,
         one per sweep, one for the weapon sweep's nested profiles, four
-        use-restriction prefetches per sweep (type, subtype, profile,
-        specialisation), one for the entries."""
+        use-restriction prefetches for each sweep whose kind can carry
+        them (an accessory cannot), one for the entries."""
         from n26.tests.sandbox.actions import create_trading_post
 
         post = create_trading_post()
-        with django_assert_num_queries(13):
+        with django_assert_num_queries(14):
             view = browse(post, TRADING_POST)
             for line in view.all_lines():
                 for part in line.parts:
@@ -771,4 +771,5 @@ class TestTradingPostMembership:
         assert sweeps == [
             "every weapon with a TP price",
             "every wargear with a TP price",
+            "every weapon accessory with a TP price",
         ]

--- a/n26/tests/sandbox/test_ingest.py
+++ b/n26/tests/sandbox/test_ingest.py
@@ -59,6 +59,8 @@ Weapon,Close combat weapons,Natural weapons,Ferocious jaws,,-,E,Ferocious jaws (
 Wargear,Wargear,Personal equipment,Respirator,,15,1,Respirator () (Personal equipment ← Wargear)
 Wargear,Wargear,Pets,Phelynx,,-,E,Phelynx () (Pets ← Wargear)
 Wargear,Wargear,Grenades,Frag grenades,,30,2,Frag grenades () (Grenades ← Wargear)
+Weapon Accessory,Wargear,Weapon accessories,Telescopic sight,,20,1,Telescopic sight () (Weapon accessories ← Wargear)
+Weapon Accessory,Wargear,Weapon accessories,Suspensors,,40,E,Suspensors () (Weapon accessories ← Wargear)
 """
 
 WEAPON_PROFILES_CSV = """
@@ -85,6 +87,7 @@ Equipment List,Goliath,Wargear,Personal equipment,Respirator,,20,,Respirator () 
 Equipment List,Goliath,Ranged weapons,Auto/stub weapons,Autogun,,20,,Autogun () (Auto/stub weapons ← Ranged weapons)
 Equipment List,Goliath,Ranged weapons,Auto/stub weapons,Autogun,warp round,10,,Autogun (warp round) (Auto/stub weapons ← Ranged weapons)
 Equipment List,Goliath,Close combat weapons,Exo weapons,Power fist,,105,Gunner specialist only,Power fist () (Exo weapons ← Close combat weapons)
+Equipment List,Escher,Wargear,Weapon accessories,Telescopic sight,,20,,Telescopic sight () (Weapon accessories ← Wargear)
 """
 
 PROFILES_CSV = """
@@ -127,6 +130,12 @@ RESPIRATOR = catalogue_key(
     "Wargear", "Respirator", category="Personal equipment", section=GEAR
 )
 PHELYNX = catalogue_key("Wargear", "Phelynx", category="Pets", section=GEAR)
+SIGHT = catalogue_key(
+    "WeaponAccessory", "Telescopic sight", category="Weapon accessories", section=GEAR
+)
+SUSPENSORS = catalogue_key(
+    "WeaponAccessory", "Suspensors", category="Weapon accessories", section=GEAR
+)
 # Typed Wargear on the sheet, but it has a firing line — so a weapon.
 FRAG_GRENADES = catalogue_key(
     "Weapon", "Frag grenades", category="Grenades", section=GEAR
@@ -258,6 +267,26 @@ class TestPlanning:
         assert own.fields["stats"]["LR"] == '6"'
         assert own.fields["position"] == 0
 
+    def test_an_accessory_is_its_own_kind(self, plan):
+        """A sight bolts onto a weapon rather than being carried, which
+        is a different table and a different thing on a card — so the
+        sheet says which, and it is not filed as wargear."""
+        sight = plan.get(SIGHT)
+        assert sight.kind == "WeaponAccessory"
+        assert sight.fields["price"] == 20
+        assert sight.fields["trade_point_price"] == 1
+        assert sight.fields["category"] == "Category:wargear:weapon accessories"
+
+        # And "E" reads the same on an accessory as on anything else.
+        assert plan.get(SUSPENSORS).fields["is_exclusive"] is True
+        assert plan.get(SUSPENSORS).fields["trade_point_price"] is None
+
+        assert not [
+            p
+            for p in plan.planned
+            if p.name == "Telescopic sight" and p.kind == "Wargear"
+        ]
+
     def test_ordinary_wargear_stays_wargear(self, plan):
         # Only a firing line makes the difference — a respirator has none.
         assert plan.get(RESPIRATOR).kind == "Wargear"
@@ -357,7 +386,8 @@ class TestPreview:
         assert preview["counts"]["Profile"] == 3
         assert preview["counts"]["Wargear"] == 2
         assert preview["counts"]["Collection"] == 3
-        assert preview["counts"]["CollectionEntry"] == 10
+        assert preview["counts"]["CollectionEntry"] == 11
+        assert preview["counts"]["WeaponAccessory"] == 2
         assert preview["actions"]["create"] == sum(
             1 for p in plan.planned if p.action == "create"
         )
@@ -708,6 +738,29 @@ class TestPerform:
         assert set(after.values_list("name", flat=True)) == before
         assert after.filter(name="Agility").count() == 1
 
+    def test_an_accessory_arrives_bolted_to_nothing_in_particular(self, plan):
+        """It lands in its own table, priced, and fitting anything —
+        which weapons it may bolt onto is not in the sheets, so it is
+        narrowed by hand afterwards rather than guessed at here."""
+        from n26.library.models import WeaponAccessory
+
+        perform(plan)
+        sight = WeaponAccessory.objects.get(name="Telescopic sight")
+        assert sight.price == 20
+        assert sight.trade_point_price == 1
+        assert sight.category.name == "Weapon accessories"
+        assert sight.fits_category is None
+        assert sight.fits_asterisked is False
+
+        # It is a listable thing like any other, so a list may offer it.
+        escher = Collection.objects.get(name="Escher Equipment List")
+        assert CollectionEntry.objects.filter(
+            collection=escher, weapon_accessory=sight
+        ).exists()
+
+        # And an exclusive one keeps out of the Trading Post.
+        assert WeaponAccessory.objects.get(name="Suspensors").is_exclusive is True
+
     def test_the_trading_post_fills_itself(self, plan):
         """Ingest builds no Trading Post, and the post is full anyway.
 
@@ -729,6 +782,9 @@ class TestPerform:
         }
         assert "Autogun" in swept  # TP 0 — free there, but offered
         assert "Respirator" in swept  # TP 1
+        # An accessory is bought there as readily as the gun it bolts
+        # onto, so its own sweep is part of what makes the post.
+        assert "Telescopic sight" in swept
         assert "Frag lance" not in swept  # TP "E" — list only
         assert "Phelynx" not in swept
 

--- a/n26/tests/sandbox/test_ingest.py
+++ b/n26/tests/sandbox/test_ingest.py
@@ -930,6 +930,67 @@ Equipment List,Cawdor,Ranged weapons,Somewhere else,Frag lance,,35,,x
         assert [p.kind for p in only_lists.planned if p.kind == "Weapon"] == ["Weapon"]
 
 
+class TestBuiltInsResolveByNameAlone:
+    """A fighter's built-in kit prints a bare name and no category, so
+    this is the one place resolution cannot use the sheets' ID — and
+    the one place a shared name has to be refused rather than guessed."""
+
+    FIGHTER = """
+Gang,Name,M,WS,BS,S,T,W,I,A,Sv,Ld,Cl,Wil,Int,Type,Subtype(s),Starting XP,Rating,Special Rules,Default skills,Default assignment,Primary Skill Sets,Secondary Skill Sets
+Escher,Scout,6",4+,4+,3,3,1,4,1,6+,6,7,7,6,Fighter,Ganger,4,25,,,Farsight,Agility,
+"""
+
+    def test_one_of_a_name_resolves_whatever_kind_it_is(self, foundation, default_pack):
+        from n26.library import authoring
+
+        accessory = authoring.create_weapon_accessory("Farsight", price=15)
+        plan = plan_ingest(profiles=read_csv(self.FIGHTER))
+
+        assert plan.ok
+        built_ins = plan.get(plan.get("Profile:scout").fields["built_ins"])
+        # The set also holds the subtype and the opening XP; the kit is
+        # whatever resolved to a catalogue row.
+        kit = [
+            plan.get(member["item"]).name
+            for member in built_ins.fields["members"]
+            if member["item"].startswith(("Weapon", "Wargear"))
+        ]
+        assert kit == [accessory.name]
+
+    def test_a_name_two_kinds_share_is_refused(self, foundation, default_pack):
+        """A sight and a piece of wargear may print one name. Answering
+        by whichever kind is looked up first is no answer."""
+        from n26.library import authoring
+
+        authoring.create_wargear("Farsight", price=10)
+        authoring.create_weapon_accessory("Farsight", price=15)
+
+        plan = plan_ingest(profiles=read_csv(self.FIGHTER))
+
+        assert plan.ok  # a note — the fighter still arrives
+        assert any("imported without it" in p.message for p in plan.problems)
+        # The fighter keeps its subtype and XP; only the kit is missing.
+        built_ins = plan.get(plan.get("Profile:scout").fields["built_ins"])
+        assert not [
+            member
+            for member in built_ins.fields["members"]
+            if member["item"].startswith(("Weapon", "Wargear"))
+        ]
+
+    def test_two_rows_of_one_kind_are_refused_too(self, foundation, default_pack):
+        """Same trap within a kind: a qualifier is what tells them
+        apart, and a bare name does not carry one."""
+        from n26.library import authoring
+
+        authoring.create_wargear("Farsight", price=10, qualifier="Escher")
+        authoring.create_wargear("Farsight", price=15, qualifier="Cawdor")
+
+        plan = plan_ingest(profiles=read_csv(self.FIGHTER))
+
+        assert plan.ok
+        assert any("imported without it" in p.message for p in plan.problems)
+
+
 class TestClearing:
     """Undoing an import, so the next one starts from the same ground.
 


### PR DESCRIPTION
The sheets now type a sight or a suspensor `Weapon Accessory`, which the
importer did not know. Those rows were landing as wargear — the wrong table,
and wrong on a card: an accessory bolts onto a weapon rather than being
carried, and the library has always had its own kind for it.

An accessory plans like wargear — a name, a home, a price — so the two share
one branch rather than getting one apiece, and it resolves, performs and
clears alongside everything else.

**What it fits is not in the sheets.** `fits_category` ("Las Weapons Only")
and `fits_asterisked` have no column, so an imported accessory fits anything
and is narrowed by hand afterwards. That is the honest reading of a column
that does not exist, rather than a guess.

## Two things the change dragged in

**Creating one could not say it was Trading Post exclusive** — `is_exclusive`
was missing from `create_weapon_accessory`, the same gap wargear had. Added.

**The Trading Post would have quietly lost them.** The post sweeps by kind, and
its two sweeps were weapons and wargear — so retyping seven accessories *out*
of wargear takes them off the shelf they are sold from. Caught by running the
retyping against the real export: sweeps dropped 94 → 87, exactly the seven.
The post now sweeps accessories too.

That seed also had to learn to top up rather than skip: it previously created
the post only when absent, so an existing post would never gain the new sweep.
It now adds any missing sweep, reports `incomplete` until it has them all — so
the Foundations page is how anyone finds out — and stays idempotent. Verified
against a real database: two selectors and `incomplete` before, three and
`complete` after, still three on a second run.

## How to try it

Against the current export with the eight accessory rows retyped:

```
errors: 0
WeaponAccessory: 7        (the eighth is the duplicate Mono-sight, noted)
wargear: 67 → 60
trading post sweeps: 94   (unchanged, once the seed is topped up)
```

`Mono-sight` and `Telescopic sight` land on 7 lists each, `Infra-sight` on 6.
A clear takes them with everything else.

## Notes for review

- No migrations. `WeaponAccessory` already existed, is already an entry kind on
  `CollectionEntry`, and is already sweepable.
- The Trading Post query budget moves 13 → 14: one query for the third sweep.
  An accessory is not `UsableBy`, so it adds no restriction prefetches. The
  budget test carries the new number and says why.
- `n26` suite: 1340 passing.
