### PR TITLE
chore: run all workflows on the free standard runner

### DIFF
--- a/.github/workflows/claude-code-improvement.yml
+++ b/.github/workflows/claude-code-improvement.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   code-improvement:
-    runs-on: default
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ jobs:
     if: |
       github.actor != 'dependabot[bot]'
 
-    runs-on: default
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude-docs-update.yml
+++ b/.github/workflows/claude-docs-update.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docs-update:
-    runs-on: [gyrinx-ubuntu-2]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -21,7 +21,7 @@ jobs:
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       )
 
-    runs-on: [gyrinx-ubuntu-2]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'tgvashworth') ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.login == 'tgvashworth') ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.login == 'tgvashworth')
-    runs-on: [gyrinx-ubuntu-2]
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write

--- a/.github/workflows/discord-issue.yml
+++ b/.github/workflows/discord-issue.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   create-issue:
-    runs-on: [gyrinx-ubuntu-2]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: [gyrinx-ubuntu-2]
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:16.4

--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   summary:
-    runs-on: [gyrinx-ubuntu-2]
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary

- Moves every workflow onto `ubuntu-latest`, off the paid larger runner (label `gyrinx-ubuntu-2`, plus a leftover `default` label on two workflows). Eight files, one line each.
- This repository is **public**, and public repositories get unlimited free minutes on GitHub's **standard** runners — but that allowance does **not** extend to **larger** runners, which bill per minute regardless of repository visibility. Running CI on one had made Actions the largest recurring cost in the project, ahead of all of Google Cloud.
- Most of that spend bought nothing: by wall-clock, over half the paid-runner time was Claude workflows (issue triage, docs update, weekly summary) that sit waiting on API calls and are no faster on eight cores than on one.

## Measured: the paid runner is currently buying nothing

The larger runner was recently resized from 8 cores to 4. Job-level execution times (queue time was ~0.1 min in every case, so this is pure compute):

| Runner | Suite exec time |
|---|---|
| Paid **8-core** (before the resize) | 7.6 – 12.8 min |
| Paid **4-core** (current `main`, last two runs) | 22.8 and 27.8 min |
| **Free `ubuntu-latest`** (this PR) | **26.4 min** ✅ |

At its current size the paid runner performs the same as the free one. So this PR is not a trade-off against the status quo — it is **the same CI speed for zero cost**, and the suite passes.

The genuine decision is a separate one: whether ~10 minute CI is worth going back to 8 cores for. If it is, that is an explicit choice to make on its own merits — and the `test.yaml` line here is the one to revert, keeping the other seven regardless.

## Test plan

- [x] `test.yaml` passes on `ubuntu-latest` (26.4 min, green)
- [x] Duration is no worse than the current paid 4-core configuration (22.8–27.8 min)
- [x] `ci-checks`, CodeQL and `Analyze (actions)` all pass
- [x] `claude-code-review` ran on this PR, confirming the `default` → `ubuntu-latest` switch works
- [ ] After merge, confirm Actions spend drops (Settings → Billing → Actions usage)

## Next steps

Not included here, deliberately — each is separate:

- Add concurrency cancellation to `test.yaml` so superseded pushes stop burning runs.
- If ~26 min CI is too slow, treat it as a test-suite performance problem rather than a machine-size one — the suite is the thing that got slower, and paying for cores only masks it.
- Once spend is confirmed down, decide whether the larger runner group is needed at all.
