### PR TITLE
perf: the print page builds the gang once, and kitted lines no longer cost a query each

### DIFF
--- a/n26/core/browse.py
+++ b/n26/core/browse.py
@@ -241,6 +241,10 @@ def browse(collection, terms=EQUIPMENT_LIST):
         collection.entries.prefetch_related(
             *ENTRY_ASSIGNABLE_FIELDS,
             *(f"{name}__category__section" for name in ENTRY_ASSIGNABLE_FIELDS),
+            # What each line always comes with: pricing a line composes
+            # the set's own price in, so a list of mounts prices the
+            # packages without a query per line.
+            *(f"{name}__built_ins" for name in ENTRY_ASSIGNABLE_FIELDS),
             # Use-restriction lists, derived for every kind carrying the
             # mixin — so noting a whole listing costs no extra queries,
             # whichever kind an author narrowed and however they narrowed it.

--- a/n26/core/card.py
+++ b/n26/core/card.py
@@ -222,12 +222,34 @@ class GangCard:
     #: both card kinds are computed by one function, and one that read
     #: its own grants on one card and not the other would be a trap.
     granted: list[Node] = field(default_factory=list)
+    #: The flat rows each member's card was dealt from, kept so a
+    #: selection can re-deal the cards without another fetch — see
+    #: ``members_under``.
+    member_rows: dict = field(default_factory=dict, repr=False)
+    #: The gang-hosted rows that ride every member's card as broadcast.
+    shared_rows: list = field(default_factory=list, repr=False)
 
     host_kind = GANG
 
     @property
     def stash_rating(self):
         return sum(node.rating_with_extras for node in self.stash_roots)
+
+    def members_under(self, assignment_set):
+        """Every member's card re-dealt under a selection — in memory.
+
+        The rows are already on this card; only the assembly differs, so
+        a print run's ticked weapons never pay for a second fetch. With
+        no selection the cards as dealt are the answer.
+        """
+        if assignment_set is None:
+            return self.members
+        return {
+            miniature_id: assemble(
+                None, rows, assignment_set=assignment_set, broadcast=self.shared_rows
+            )
+            for miniature_id, rows in self.member_rows.items()
+        }
 
     def all_nodes(self):
         for root in (*self.roots, *self.granted):
@@ -465,6 +487,8 @@ def build_gang_card(gang, with_statlines=True, assignment_set=None):
             )
             for miniature_id, rows in grouped.items()
         },
+        member_rows=grouped,
+        shared_rows=shared,
     )
 
 

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -1096,6 +1096,27 @@ def roster(gang):
     return sorted(members, key=key)
 
 
+def stash_lines(gang_card):
+    """The stash as drawable lines, from a gang card already built.
+
+    Derived from the card rather than fetched, so a page that has one —
+    the sheet, a print — pays nothing further for its stash block.
+    """
+    stash_provenance = _provenance_within(gang_card)
+    return [
+        StashLine(
+            name=node.name,
+            rating=node.rating_with_extras,
+            kind=kind_of(node.assignable),
+            provenance=stash_provenance(node),
+        )
+        for node in gang_card.stash_roots
+        # No row of its own is the kind's whole contract — a chosen
+        # option's Hidden carrier rides the stash invisibly.
+        if not isinstance(node.assignable, Hidden)
+    ]
+
+
 def render_gang(gang, with_effects=True):
     """A whole gang sheet. A fixed number of queries, whatever its size."""
     from n26.core.card import build_gang_card, build_modifier_index
@@ -1118,7 +1139,6 @@ def render_gang(gang, with_effects=True):
         computed = {model_id: compute(card, index) for model_id, card in cards.items()}
         gang_computed = compute_gang(gang_card, index)
 
-    stash_provenance = _provenance_within(gang_card)
     gang_rows, gang_rules = _gang_rows(gang_card, gang_computed)
     return GangSheet(
         name=gang.name,
@@ -1134,18 +1154,7 @@ def render_gang(gang, with_effects=True):
         counters=(
             gang_computed.counters if gang_computed else counter_readings(gang_card)
         ),
-        stash=[
-            StashLine(
-                name=node.name,
-                rating=node.rating_with_extras,
-                kind=kind_of(node.assignable),
-                provenance=stash_provenance(node),
-            )
-            for node in gang_card.stash_roots
-            # No row of its own is the kind's whole contract — a chosen
-            # option's Hidden carrier rides the stash invisibly.
-            if not isinstance(node.assignable, Hidden)
-        ],
+        stash=stash_lines(gang_card),
         stash_rating=gang_card.stash_rating,
         notes=gang_computed.notes if gang_computed else [],
         models=[

--- a/n26/core/templates/n26/print_gang.html
+++ b/n26/core/templates/n26/print_gang.html
@@ -24,31 +24,31 @@
                 worth. A card like any other so it obeys the same fragmentation
                 rules — it must arrive on paper whole, not straddle the fold.
                 {% endcomment %}
-                <c-n26.print.card title="{{ sheet.name }}"
-                                  subtitle="{{ sheet.gang_type }}"
-                                  badge="{{ sheet.wealth }}¢">
+                <c-n26.print.card title="{{ gang.name }}"
+                                  subtitle="{{ gang.gang_type.name }}"
+                                  badge="{{ gang.wealth }}¢">
                     <c-n26.print.columns>
                         <c-n26.print.column>
                             <c-n26.print.entry label="Rating">
-                                {{ sheet.rating }}¢
+                                {{ gang.rating }}¢
                             </c-n26.print.entry>
                             <c-n26.print.entry label="Credits">
-                                {{ sheet.credits }}¢
+                                {{ gang.credits }}¢
                             </c-n26.print.entry>
                         </c-n26.print.column>
                         <c-n26.print.column>
                             <c-n26.print.entry label="Stash">
-                                {{ sheet.stash_rating }}¢
+                                {{ stash_rating }}¢
                             </c-n26.print.entry>
                             <c-n26.print.entry label="Wealth">
-                                {{ sheet.wealth }}¢
+                                {{ gang.wealth }}¢
                             </c-n26.print.entry>
                         </c-n26.print.column>
                     </c-n26.print.columns>
                 </c-n26.print.card>
             {% endif %}
-            {% if include_stash and sheet.stash %}
-                <c-n26.print.card title="Stash" badge="{{ sheet.stash_rating }}¢">
+            {% if include_stash and stash %}
+                <c-n26.print.card title="Stash" badge="{{ stash_rating }}¢">
                     <c-n26.print.table>
                         <c-slot name="head">
                             <tr>
@@ -59,7 +59,7 @@
                                 {# djlint:on #}
                             </tr>
                         </c-slot>
-                        {% for line in sheet.stash %}
+                        {% for line in stash %}
                             <tr>
                                 <td>{{ line.name }}</td>
                                 <td>{{ line.kind|capfirst }}</td>

--- a/n26/core/test_views_print.py
+++ b/n26/core/test_views_print.py
@@ -202,6 +202,55 @@ class TestThePrintPage:
         assert "Vex" in body
         assert "Rating" not in body  # the header's figure strip
 
+    def test_a_bigger_roster_costs_no_more_queries_to_print(
+        self, client, tester, gang, roster, make_profile
+    ):
+        """The page derives the gang once — header, stash and every card
+        from one build — so printing costs the same queries however many
+        models are on the paper or how much they carry."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from n26.library.authoring import create_weapon
+
+        client.force_login(tester)
+        profile = make_profile("Reinforcement", price=40)
+        axe = create_weapon("Axe", price=10)
+
+        def measure():
+            with CaptureQueriesContext(connection) as captured:
+                assert client.get(print_url(gang)).status_code == 200
+            return len(captured.captured_queries)
+
+        # The first request pays one-time caches nothing after it does;
+        # what is measured is the page's own budget.
+        measure()
+        few = measure()
+        for index in range(3):
+            with operation(gang, actor=tester) as op:
+                hired = op.hire(profile, f"More {index}")
+                op.give_weapon(hired, axe, paid=10)
+        assert measure() == few
+
+    def test_the_page_fetches_the_gangs_rows_once(self, client, tester, gang, roster):
+        """One derivation serves the header, the stash and every card:
+        the gang's assignments are fetched exactly twice — its own rows
+        and its stash's — not once per block that draws them."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        client.force_login(tester)
+        client.get(print_url(gang))
+        with CaptureQueriesContext(connection) as captured:
+            assert client.get(print_url(gang)).status_code == 200
+        row_fetches = [
+            query["sql"]
+            for query in captured.captured_queries
+            if query["sql"].startswith("SELECT")
+            and 'FROM "n26_assignment"' in query["sql"]
+        ]
+        assert len(row_fetches) == 2
+
     def test_someone_elses_config_is_ignored(self, client, tester, gang, roster):
         """A config id belonging to another gang falls back to printing
         everything — the URL names a thing the viewer does not hold."""

--- a/n26/core/views/printing.py
+++ b/n26/core/views/printing.py
@@ -39,15 +39,17 @@ def _roster(gang):
     return roster(gang)
 
 
-def _print_rows(gang, miniatures, weapon_ids=None):
+def _print_rows(gang, gang_card, miniatures, weapon_ids=None):
     """A print card per model: filtered, computed, columned.
 
-    ``weapon_ids`` of None means everything; a set means only those
-    weapon assignments show. Wargear always rides — the selection is
-    about which guns clutter the card, so every wargear row of the
-    gang's joins the selected set before it filters anything.
+    ``gang_card`` is the gang already built — the same build the header
+    and stash blocks read, so a print derives the gang once however much
+    of it is ticked. ``weapon_ids`` of None means everything; a set means
+    only those weapon assignments show. Wargear always rides — the
+    selection is about which guns clutter the card, so every wargear row
+    of the gang's joins the selected set before it filters anything.
     """
-    from n26.core.card import build_card, build_gang_card, build_modifier_index
+    from n26.core.card import build_card, build_modifier_index
     from n26.core.effects import compute
     from n26.core.models import Assignment
     from n26.core.printing import detail_columns
@@ -60,12 +62,11 @@ def _print_rows(gang, miniatures, weapon_ids=None):
         ).values_list("pk", flat=True)
         selection = _Selection(set(weapon_ids) | set(wargear))
 
-    # One fetch for the whole run and one modifier index shared by every
-    # card: a card build pays for its queries mostly in planning, so a
-    # print that built each model's card alone would cost seconds on a
-    # full roster.
-    gang_card = build_gang_card(gang, with_statlines=True, assignment_set=selection)
-    cards = gang_card.members
+    # The selection re-deals the cards from rows already fetched, and one
+    # modifier index is shared by every card: a card build pays for its
+    # queries mostly in planning, so a print that built each model's card
+    # alone would cost seconds on a full roster.
+    cards = gang_card.members_under(selection)
     index = build_modifier_index(
         [node.assignable for card in cards.values() for node in card.all_nodes()]
         + [node.assignable for node in gang_card.all_nodes()]
@@ -202,24 +203,28 @@ def print_gang(request, pk):
     without one, everything.
     """
     from n26.analytics import EventVerb, N26Noun, record
-    from n26.core.render import render_gang
+    from n26.core.card import build_gang_card
+    from n26.core.render import stash_lines
 
     gang = _own_gang_or_404(request, pk)
     config = _config_for(request, gang)
-    sheet = render_gang(gang)
+    # One derivation serves the whole page — the header's figures, the
+    # stash block and every model's card all read this build.
+    gang_card = build_gang_card(gang)
+    miniatures = _roster(gang)
 
     if config is not None:
         wanted = {str(pk) for pk in config.miniatures.values_list("pk", flat=True)}
-        miniatures = [m for m in _roster(gang) if str(m.pk) in wanted]
         rows = _print_rows(
             gang,
-            miniatures,
+            gang_card,
+            [m for m in miniatures if str(m.pk) in wanted],
             weapon_ids=set(config.assignments.values_list("pk", flat=True)),
         )
         include_header = config.include_header
         include_stash = config.include_stash
     else:
-        rows = _print_rows(gang, _roster(gang))
+        rows = _print_rows(gang, gang_card, miniatures)
         include_header = True
         include_stash = True
 
@@ -240,8 +245,9 @@ def print_gang(request, pk):
         "n26/print_gang.html",
         {
             "gang": gang,
-            "sheet": sheet,
             "rows": rows,
+            "stash": stash_lines(gang_card),
+            "stash_rating": gang_card.stash_rating,
             "include_header": include_header,
             "include_stash": include_stash,
         },

--- a/n26/library/models/collection.py
+++ b/n26/library/models/collection.py
@@ -455,7 +455,11 @@ class CollectionSelector(Content):
 
         model = self.of_kind.model_class()
         found = model.objects.filter(self.as_selector().as_q(model)).select_related(
-            "category__section"
+            # built_ins because pricing a swept line composes the set's
+            # own price in — without it, a sweep full of kitted things
+            # pays a query per row at the till.
+            "category__section",
+            "built_ins",
         )
         if issubclass(model, UsableBy):
             # So marking a swept listing usable costs no extra queries.

--- a/n26/tests/sandbox/test_collections.py
+++ b/n26/tests/sandbox/test_collections.py
@@ -958,6 +958,41 @@ class TestScaling:
 
         assert measure(small) == measure(big)
 
+    def test_lines_that_come_with_kit_cost_no_more_queries_as_the_list_grows(
+        self, taxonomy
+    ):
+        """A line's advertised price composes its built-in kit's price
+        in. The kit's set loads with the listing, so a list of kitted
+        mounts prices the packages for the same queries as a list of
+        one — and each package really is priced as one."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        def stable(count):
+            mounts = []
+            for index in range(count):
+                saddle = create_wargear(f"Saddle {count}-{index}", price=15)
+                mount = create_wargear(
+                    f"Mount {count}-{index}", price=50, category=taxonomy["auto"]
+                )
+                mount.built_ins = create_default_set(
+                    f"Mount {count}-{index} kit", members=[saddle], price=15
+                )
+                mount.save()
+                mounts.append(mount)
+            return mounts
+
+        small = create_collection("Small stable", entries=stable(2))
+        big = create_collection("Big stable", entries=stable(12))
+
+        def measure(collection):
+            with CaptureQueriesContext(connection) as captured:
+                lines = list(browse(collection).all_lines())
+                assert lines and all(line.credits == 65 for line in lines)
+            return len(captured.captured_queries)
+
+        assert measure(small) == measure(big)
+
 
 class TestTradingPostMembership:
     """The Trading Post's membership is *having a trade point price* —


### PR DESCRIPTION
Two query fixes on n26 pages, found by profiling against a content-rich database.

- **The print page built the whole gang twice.** Printing derived the gang once to fill in the header and stash blocks, then derived it all over again — rows, statlines, modifier index — to lay out the cards. A gang card now keeps the flat rows its members' cards were dealt from, so a print config's ticked weapon selection re-deals those cards in memory instead of refetching, and one build serves the header, the stash and every card. The print view no longer calls `render_gang` at all: the template reads the gang's own figures, and the stash block is derived from the same card (`stash_lines` in `n26/core/render.py`). On a full roster the page drops from 84 queries to 47 and roughly halves its SQL time (81ms → 53ms); smaller gangs halve too.
- **A line that comes with kit cost a query to price.** An equipment line's advertised price composes in the price of the built-in set it ships with — a mount and its saddle, say — but neither a curated listing (`n26/core/browse.py`) nor a selector sweep (`n26/library/models/collection.py`) fetched that set, so every kitted line on a page paid a query of its own at the till. That is only two or three lines per equip page today, but it grows one-per-line as kitted content lands. Both paths now load the set with the listing.

Nothing changes on screen or on paper: same cards, same prices.

**Test plan**

- [x] Full suite green in CI
- [x] New guard in `n26/core/test_views_print.py`: the print page's query count stays flat as models and gear are added to the roster
- [x] New guard in `n26/core/test_views_print.py`: the page fetches assignment rows exactly twice — the gang's own and its stash's — which is what "derived once" looks like in queries
- [x] New guard in `n26/tests/sandbox/test_collections.py`: a listing of twelve kitted lines costs the same queries as a listing of two, and each package still prices correctly. Against the previous code this measured 12 vs 22.

Sheet and hire pages were profiled too and are already at their fixed budgets — their repeated query shapes are parallel prefetch paths sharing a table, not duplicate work.

**To try:** open a gang and hit Print, then print a saved config with a subset of models and weapons ticked. Both should look exactly as they did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
