### PR TITLE
perf: card builds hydrate rows in narrow passes instead of one wide join

### DIFF
--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -6,8 +6,8 @@ stage has one job:
 ```
 models/        rows: Gang, Miniature, Assignment, LedgerEntry, Stash
 operations.py  the only writer — every change to player data goes through it
-card.py        loads a gang's rows into an in-memory tree, in a pinned
-               two queries
+card.py        loads a gang's rows into an in-memory tree: a pinned two
+               row queries, one shared hydration pass
 effects.py     computes what the rules do to a card — pure, no queries
 render.py      plain dataclasses a template can draw (ModelCard, GangSheet)
 browse.py      collections as one rendered shape, whatever their species
@@ -41,8 +41,8 @@ underlying spec.
 
 - **`effects.compute()` issues no queries and must stay that way.**
   Everything it needs is loaded by `card.py`. If compute needs a new
-  relation, add it to `build_modifier_index` or `card_rows`'s
-  `select_related` — then update the tests that pin exact query counts.
+  relation, add it to `build_modifier_index` or `hydrate_rows`'s
+  paths — then update the tests that pin exact query counts.
 - The query budget is an invariant, not a hope: a whole gang is a fixed
   number of queries however many models and however much kit. Tests
   check the count stays flat as the gang grows.

--- a/n26/core/card.py
+++ b/n26/core/card.py
@@ -1,10 +1,13 @@
-"""Model cards — a model's assignments, in memory, in one query.
+"""Model cards — a model's assignments, in memory, from a fixed fetch.
 
 A card is what a model looks like: its profile, its weapons, the ammo and
-accessories hung off them. Building one costs **one** database query. The
-tree is not walked in the database; every assignment carries the model at
-the top of its chain, so they all come back flat and are reassembled here
-by parent.
+accessories hung off them. Building one costs **one** row query, then a
+fixed set of narrow hydration passes (``hydrate_rows``) — narrow because
+Postgres plans a join across every content kind in tens of milliseconds
+and executes it in one, and the planning is paid on every query. The tree
+is not walked in the database; every assignment carries the model at the
+top of its chain, so they all come back flat and are reassembled here by
+parent.
 
 The point of doing it this way is that the ergonomic reads — a node's
 rating, its children, its total with extras — are then plain Python on rows
@@ -299,17 +302,38 @@ class GangCard:
         )
 
 
-def card_rows(with_statlines=False, **filters):
-    """The flat fetch every card build starts from — one query.
+def _flat_rows(**filters):
+    """The bare row fetch a card build starts from — one query.
 
-    ``with_statlines`` pulls each profile's characteristics along too, which
-    rendering needs and plain assignment work does not. It costs a few more
-    queries, but a *fixed* few: without it, rendering a gang would query per
-    model.
+    Only the money rides the join: every build reads each row's ledger
+    entry and the table is narrow. The content a row names is loaded
+    afterwards, in narrow passes — see ``hydrate_rows``.
     """
-    rows = Assignment.objects.filter(archived=False, **filters).select_related(
+    return list(
+        Assignment.objects.filter(archived=False, **filters).select_related(
+            "ledger_entry"
+        )
+    )
+
+
+def hydrate_rows(rows, with_statlines=False):
+    """Load everything a card build reads off ``rows`` — narrow passes,
+    never a wide join.
+
+    Joined, the assignable kinds and their chains make a select so wide
+    that Postgres spends tens of milliseconds *planning* it and one
+    executing it — and with no prepared statements the planning is paid
+    on every query. As narrow prefetches each pass plans in microseconds,
+    a kind no row names never queries at all, and two row sets hydrated
+    together pay once.
+
+    ``with_statlines`` pulls each profile's characteristics along too,
+    which rendering needs and plain assignment work does not.
+    """
+    from django.db.models import prefetch_related_objects
+
+    paths = [
         *ASSIGNABLE_FIELDS,
-        "ledger_entry",
         "profile_role",
         "counter_value",
         "profile__profile_type",
@@ -320,26 +344,36 @@ def card_rows(with_statlines=False, **filters):
         # category asks each profile for its weapon. Without this the
         # asking is a query per profile, from inside compute.
         "weapon_profile__weapon",
-    )
+    ]
     if with_statlines:
-        rows = rows.prefetch_related(
+        paths += [
             "profile__statline__stats__statline_type_stat__stat",
             "weapon_profile__statline__stats__statline_type_stat__stat",
             "weapon_profile__traits",
-        )
-    return list(rows)
+        ]
+    prefetch_related_objects(rows, *paths)
+    return rows
 
 
-def gang_rows(gang, with_statlines=False):
-    """What the gang itself holds: its founding, and what that brought.
+def card_rows(with_statlines=False, **filters):
+    """The flat fetch every card build starts from: one row query,
+    hydrated. Builds fetching more than one row set hydrate them
+    together instead — one pass covers any number of fetches.
+    """
+    return hydrate_rows(_flat_rows(**filters), with_statlines=with_statlines)
+
+
+def gang_rows(gang):
+    """What the gang itself holds, bare: its founding, and what that
+    brought.
 
     Hosted on the gang with no model of their own, so they belong to
-    every member's card and to none of their ratings.
+    every member's card and to none of their ratings. Hydrate with the
+    rest of the build's rows — see ``hydrate_rows``.
     """
     if gang is None:
         return []
-    return card_rows(
-        with_statlines=with_statlines,
+    return _flat_rows(
         gang_root=gang,
         miniature_root__isnull=True,
         # The stash is the gang's too, but it is storage, not a fact
@@ -407,20 +441,17 @@ def assemble(miniature, rows, assignment_set=None, broadcast=()):
 def build_card(miniature, with_statlines=False, assignment_set=None):
     """A model's card: everything it owns, or one named selection.
 
-    Two queries rather than one: the model's own rows, then the gang's,
-    which ride along so gang-wide modifiers reach this card. A whole
-    gang's worth still costs a fixed number — see ``build_cards_for_gang``,
-    where both come back in the same fetch.
+    Two row queries rather than one — the model's own rows, then the
+    gang's, which ride along so gang-wide modifiers reach this card —
+    hydrated together in one pass. A whole gang's worth still costs a
+    fixed number — see ``build_cards_for_gang``, where both come back
+    in the same fetch.
     """
     membership = miniature.membership if miniature is not None else None
-    return assemble(
-        miniature,
-        card_rows(miniature_root=miniature, with_statlines=with_statlines),
-        assignment_set=assignment_set,
-        broadcast=gang_rows(
-            membership.gang if membership else None, with_statlines=with_statlines
-        ),
-    )
+    own = _flat_rows(miniature_root=miniature)
+    shared = gang_rows(membership.gang if membership else None)
+    hydrate_rows([*own, *shared], with_statlines=with_statlines)
+    return assemble(miniature, own, assignment_set=assignment_set, broadcast=shared)
 
 
 def build_cards_for_gang(gang, with_statlines=True):
@@ -450,10 +481,11 @@ def _forest(rows):
 def build_gang_card(gang, with_statlines=True, assignment_set=None):
     """The gang's own card, its stash, and every member's card.
 
-    The same fetch family as ever: one query for everything hosted under
-    the gang except the stash, plus one for its contents — kept
+    The same fetch family as ever: one row query for everything hosted
+    under the gang except the stash, plus one for its contents — kept
     apart because stash rows belong on no member's card and nothing in
-    them broadcasts (storage, not facts about anyone).
+    them broadcasts (storage, not facts about anyone) — then one shared
+    hydration pass over both.
 
     An ``assignment_set`` filters every member's card through the same
     seam ``build_card`` uses — a selection of equipment roots that may
@@ -461,9 +493,11 @@ def build_gang_card(gang, with_statlines=True, assignment_set=None):
     """
     grouped = {}
     shared = []
-    rows = card_rows(
-        gang_root=gang, stash_root__isnull=True, with_statlines=with_statlines
-    )
+    rows = _flat_rows(gang_root=gang, stash_root__isnull=True)
+    # Storage rows ride the same hydration pass as everyone's — a
+    # second pass would repeat every narrow query for a handful of rows.
+    stash_rows = _flat_rows(gang_root=gang, stash_root__isnull=False)
+    hydrate_rows([*rows, *stash_rows], with_statlines=with_statlines)
     for row in rows:
         if row.miniature_root_id is None:
             shared.append(row)
@@ -472,15 +506,7 @@ def build_gang_card(gang, with_statlines=True, assignment_set=None):
     return GangCard(
         gang=gang,
         roots=_forest(shared),
-        stash_roots=_forest(
-            card_rows(
-                gang_root=gang,
-                stash_root__isnull=False,
-                # Storage, drawn as names and ratings — nobody reads a
-                # statline off it, so its fetch never pays for them.
-                with_statlines=False,
-            )
-        ),
+        stash_roots=_forest(stash_rows),
         members={
             miniature_id: assemble(
                 None, rows, assignment_set=assignment_set, broadcast=shared

--- a/n26/tests/sandbox/test_card.py
+++ b/n26/tests/sandbox/test_card.py
@@ -1,8 +1,9 @@
 """The model card, built fully in memory and tested without rendering.
 
 The card is the hot read path: a model's profile, weapons, ammo and
-accessories. It must cost one query, and every ergonomic read on it —
-a line's rating, its children, its total with extras — must cost none.
+accessories. It must cost a fixed fetch that never grows with the card,
+and every ergonomic read on it — a line's rating, its children, its
+total with extras — must cost none.
 """
 
 import pytest
@@ -56,11 +57,16 @@ def yolanda(gang_type, player, library):
 
 
 class TestBuildingACard:
-    def test_it_costs_a_fixed_two_queries(self, yolanda, django_assert_num_queries):
+    def test_it_costs_two_row_queries_and_a_fixed_hydration(
+        self, yolanda, django_assert_num_queries
+    ):
         """The model's own rows, then its gang's — the latter ride every
-        member's card so gang-wide rules reach them. A whole gang costs
-        one fetch for both; see ``build_cards_for_gang``."""
-        with django_assert_num_queries(2):
+        member's card so gang-wide rules reach them — then one narrow
+        hydration pass per relation this card actually holds; a kind no
+        row names never queries. A whole gang costs one fetch for both;
+        see ``build_cards_for_gang``. Pinned so it changes deliberately;
+        the scaling test below is what holds it flat."""
+        with django_assert_num_queries(11):
             card = build_card(yolanda)
             # Walking the whole tree and reading every line costs nothing more.
             assert sum(node.rating for node in card.all_nodes()) == 255
@@ -146,17 +152,32 @@ class TestCardsFollowRemoval:
 
 
 class TestScaling:
-    def test_a_big_card_is_still_one_query(
-        self, gang_type, player, library, django_assert_num_queries
-    ):
-        """Query count is a function of the code, not of how much is on the card."""
+    def test_a_big_card_costs_what_a_small_one_does(self, gang_type, player, library):
+        """Query count is a function of the code, not of how much is on
+        the card. Both measurements hold the same *kinds* of thing — a
+        hydration pass only fires for kinds the card names, so the fair
+        comparison grows what is already there."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
         gang = found_gang("The Long Hunt", gang_type, owner=player, budget=5000)
         mini = hire(gang, library["hunt_champion"], "Yolanda", paid=130)
-        for _ in range(10):
+
+        def arm():
             shotgun = give_weapon(mini, library["shotgun"], paid=60)
             buy_weapon_profile(shotgun, library["shotgun"].profiles.get(price=30))
 
-        with django_assert_num_queries(2):
-            card = build_card(mini)
-            # 31 the model owns, plus the gang's founding riding along.
-            assert len(list(card.all_nodes())) == 32
+        def measure():
+            with CaptureQueriesContext(connection) as captured:
+                card = build_card(mini)
+                assert list(card.all_nodes())
+            return len(captured.captured_queries)
+
+        arm()
+        few = measure()
+        for _ in range(9):
+            arm()
+        many = measure()
+        assert few == many
+        # 31 the model owns, plus the gang's founding riding along.
+        assert len(list(build_card(mini).all_nodes())) == 32

--- a/n26/tests/sandbox/test_render.py
+++ b/n26/tests/sandbox/test_render.py
@@ -256,11 +256,11 @@ class TestTheGangSheet:
 
         assert (few_models, many_models) == (2, 12)
         assert few == many, f"{few} queries for 2 models, {many} for 12"
-        # Roughly: the models, the flat assignment fetch, the statline
+        # Roughly: the models, the two flat assignment fetches, a narrow
+        # hydration pass per relation the cards hold, the statline
         # prefetch chain, one per assignable kind for the modifier index,
-        # the stash read that wealth includes, and the stash *contents*
-        # fetch the sheet draws (design/gang-sheet.md).
-        assert many <= 18, f"{many} queries is more than this should ever need"
+        # and the stash read that wealth includes (design/gang-sheet.md).
+        assert many <= 30, f"{many} queries is more than this should ever need"
 
 
 class TestTheTextRenderer:

--- a/n26/tests/sandbox/test_stash.py
+++ b/n26/tests/sandbox/test_stash.py
@@ -171,6 +171,11 @@ class TestTheNumbers:
 
         profile = make_profile("Ganger", price=50)
         hire_with_option(gang, profile, "One")
+        # The first lasgun goes in before the first measurement: a
+        # hydration pass only fires for kinds the rows name, so a fair
+        # comparison grows what the stash already holds rather than
+        # putting a weapon in it for the first time.
+        buy(gang.stash, lasgun_line(house_list))
 
         def measure():
             with CaptureQueriesContext(connection) as captured:


### PR DESCRIPTION
Stacked on #2168 — merge that first; this retargets to `main` when the branch goes.

- **The fetch behind every card build was one enormous join.** `card_rows` pulled all eleven assignable kinds and their chains into a single select. Postgres spends roughly 19ms *planning* that select and roughly 1ms executing it, and Django issues no prepared statements, so the planning is paid again on every call — twice per gang build. The design's pinned "two queries" was honest, and the pin was the expensive part.
- **Rows now come back bare and hydrate afterwards.** `_flat_rows` fetches assignments with only their ledger entry joined; `hydrate_rows` then loads everything a build reads through one `prefetch_related_objects` pass per relation. Each pass is a single-table select that plans in microseconds, a kind no row names skips the database entirely, and a build's row sets (a model's plus its gang's, or a gang's plus its stash's) hydrate together so the passes are paid once. It is the same trade the modifier index and the browse listings already made; the card build was the last wide join standing.

**Effect:** `build_gang_card` drops from ~42ms to ~14ms (best of five, content-rich database). Sheet and print pages lose 30–70% of their SQL time, most visibly on small and medium gangs — a small gang's sheet goes from 62ms to 17ms of SQL. Query counts rise by a fixed ~12 narrow fetches per page, and total time falls everywhere cards are built.

One deliberate consequence: stash rows used to be fetched without statlines, since nothing reads a statline off storage. They now ride the shared hydration pass with the rest of the gang's rows, because a separate pass for a handful of rows would repeat every narrow query for them.

**Test plan**

- [x] Full suite green in CI
- [x] The tests that pin exact query counts re-pinned to the new budget — two row queries plus a fixed hydration — with the decomposition written into their docstrings
- [x] The two grow-and-compare tests now seed a weapon before their first measurement: hydration only queries for kinds actually present, so introducing a new kind mid-comparison would have measured the kind arriving rather than the scaling
- [x] Design language updated wherever it described the old shape — the `n26/core/card.py` module docstring, the `build_card` / `build_gang_card` docstrings, and `n26/core/CLAUDE.md`

**To try:** open a gang sheet and its print page. Nothing changes on screen; they simply spend a fraction of the database time getting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
