### PR TITLE
fix: the n26 banner stays closed

### DIFF
--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -113,11 +113,25 @@ banner, is_impersonating / impersonator, gtm_container_id, messages, user.
         component 500s the whole edition the moment someone sets a banner to an
         icon n26 does not draw.
         {% endcomment %}
+        {% comment %}
+        on_dismiss is what makes the close button stick. The component
+        deliberately does not remember being dismissed — only the application
+        can decide where that memory lives — so without this the bar is hidden
+        for the current page and back on the next one.
+
+        It lives in the session, which is where the site's own context
+        processor looks before it puts `banner` in the context at all, so the
+        reader is told once whichever edition they were in when they closed it.
+        The route is the platform's rather than an edition's: it operates on a
+        platform-owned Banner and writes a key both editions read.
+        {% endcomment %}
         {% if banner %}
+            {% url 'core:dismiss-banner' as banner_dismiss_url %}
             <c-n26.site.announcement tone="{{ banner.colour|banner_tone }}"
                                      icon="{{ banner.icon|banner_icon }}"
                                      cta_text="{{ banner.cta_text }}"
                                      cta_url="{{ banner.cta_url }}"
+                                     on_dismiss="fetch('{{ banner_dismiss_url }}', {method: 'POST', headers: {'X-CSRFToken': '{{ csrf_token }}', 'Content-Type': 'application/json'}, body: JSON.stringify({banner_id: '{{ banner.id }}'})})"
                                      id="site-banner-{{ banner.id }}">
                 {{ banner.text }}
             </c-n26.site.announcement>

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -924,6 +924,51 @@ class TestTheSiteBanner:
         assert "N26 support is coming." in bar
         assert skills_url not in bar
 
+    def test_closing_the_bar_is_remembered(
+        self, tester, client, default_pack, live_banner
+    ):
+        """A reader closed the bar, it went away, and it was back on the
+        next page they opened.
+
+        The component hides itself and stops there on purpose: where a
+        dismissal is remembered is the application's decision, not the
+        bar's, and the shell has to say. It says the session key the
+        site's own context processor reads before it hands the shell a
+        banner at all, so a bar closed in either edition stays closed in
+        both.
+
+        The close button is an Alpine expression rather than a form, so
+        the request under test is read out of the page and made here —
+        a shell that says nothing has nothing to read.
+        """
+        import json
+        import re
+
+        from django.urls import reverse
+
+        banner = live_banner()
+
+        body = client.get("/n26/").content.decode()
+        assert "N26 support is coming." in body
+
+        bar = body[body.index("n26-announcement") : body.index("</aside>")]
+        dismiss_url = reverse("core:dismiss-banner")
+        assert dismiss_url in bar
+        # The id the expression posts, not merely the one in the wrapper's
+        # own id attribute.
+        assert re.search(
+            rf"{re.escape(dismiss_url)}.*{re.escape(str(banner.id))}", bar, re.S
+        )
+
+        dismissed = client.post(
+            dismiss_url,
+            data=json.dumps({"banner_id": str(banner.id)}),
+            content_type="application/json",
+        )
+        assert dismissed.status_code == 200
+
+        assert "N26 support is coming." not in client.get("/n26/").content.decode()
+
 
 class TestTheSharedIconKeys:
     """gyrinx/site/icons.py names an n26 icon for every key, as a string,


### PR DESCRIPTION
Closing the site banner in n26 hid it, but it was back on the next page load. n23 does not have this bug.

The n26 banner component (`<c-n26.site.announcement>`) deliberately does not remember being dismissed — where that memory lives is the application's decision, so the component takes an `on_dismiss` expression and the embedding shell has to supply one. The n26 shell (`n26/core/templates/n26/layouts/base.html`) never did, so the close button only hid the bar client-side and told nobody.

- The shell now posts the dismissal to the platform's existing endpoint (`core:dismiss-banner`), which is the same one n23's banner uses.
- That writes the session key `gyrinx/context_processors.py` checks before it puts a banner in the context at all, so a bar closed in either edition stays closed in both.
- Added a regression test that renders the page, reads the dismiss request out of the bar, makes it, and asserts the banner is gone on the next load.

## Test plan

- [x] `pytest n26 gyrinx` — 3926 passed
- [x] New test fails without the template change and passes with it
- [x] Checked in a real browser: banner shows on `/n26/`, clicking the X hides it, reloading keeps it hidden, and the n23 pages no longer show it either

## To try it

Create a live banner in the admin with `live_n26` set, open `/n26/`, click the X, and reload.

## Not fixed here

n26's banner CTA links straight at `banner.cta_url`, while n23 routes it through `core:track-banner-click`. Clicks on the CTA from n26 pages are therefore not counted. Separate from dismissal — worth its own change.
