### PR TITLE
feat: an equipped mount says which guns it was bought with

### DIFF
--- a/n26/core/card.py
+++ b/n26/core/card.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from n26.core.effects import ModifierIndex
 from n26.core.models import Assignment, Reason
 from n26.core.models.assignment import ASSIGNABLE_FIELDS
-from n26.library.models.assignable import OPTION_OFFER_PATHS
+from n26.library.models.assignable import Family, Optioned
 from n26.library.models.modifier import GANG, MODEL
 
 
@@ -426,9 +426,29 @@ def hydrate_rows(rows, with_statlines=False, with_options=False):
             "weapon_profile__weapon__statline_type__stats__stat",
         ]
     if with_options:
-        paths += ["chosen_options", *(f"wargear__{p}" for p in OPTION_OFFER_PATHS)]
+        paths += ["chosen_options", *_option_offer_paths()]
     prefetch_related_objects(rows, *paths)
     return rows
+
+
+def _option_offer_paths():
+    """The offer a copy's recorded options are named from, per kind.
+
+    Asked of the library's own families rather than a list kept here, so
+    a kind of gear that gains options is described without a query per
+    copy the day it is authored. Only what a model *owns* is described,
+    which is the same question :func:`n26.core.owned.is_possession`
+    asks — a fighter's own entry offers options too, and nothing draws
+    them as kit.
+
+    The set each option brings is not pulled: naming an option reads the
+    key already on its own row, so the set itself would be a query for
+    something nobody looks at.
+    """
+    for name in ASSIGNABLE_FIELDS:
+        kind = Assignment._meta.get_field(name).related_model
+        if issubclass(kind, Optioned) and getattr(kind, "family", None) == Family.GEAR:
+            yield f"{name}__options__group"
 
 
 def set_by_hand(**filters):
@@ -450,14 +470,12 @@ def set_by_hand(**filters):
     return grouped
 
 
-def card_rows(with_statlines=False, with_options=False, **filters):
+def card_rows(with_statlines=False, **filters):
     """The flat fetch every card build starts from: one assignment query,
     hydrated. Builds fetching more than one list of assignments hydrate
     them together instead — one pass covers any number of fetches.
     """
-    return hydrate_rows(
-        _flat_rows(**filters), with_statlines=with_statlines, with_options=with_options
-    )
+    return hydrate_rows(_flat_rows(**filters), with_statlines=with_statlines)
 
 
 def gang_rows(gang):
@@ -612,7 +630,7 @@ def _forest(rows):
     return roots
 
 
-def build_gang_card(gang, with_statlines=True, assignment_set=None, with_options=False):
+def build_gang_card(gang, with_statlines=True, assignment_set=None):
     """The gang's own card, its stash, and every member's card.
 
     The same fetch family as ever: one assignment query for everything
@@ -631,9 +649,7 @@ def build_gang_card(gang, with_statlines=True, assignment_set=None, with_options
     # The stash's assignments ride the same hydration pass as everyone's
     # — a second pass would repeat every narrow query for a handful.
     stash_rows = _flat_rows(gang_root=gang, stash_root__isnull=False)
-    hydrate_rows(
-        [*rows, *stash_rows], with_statlines=with_statlines, with_options=with_options
-    )
+    hydrate_rows([*rows, *stash_rows], with_statlines=with_statlines)
     for row in rows:
         if row.miniature_root_id is None:
             shared.append(row)

--- a/n26/core/card.py
+++ b/n26/core/card.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from n26.core.effects import ModifierIndex
 from n26.core.models import Assignment, Reason
 from n26.core.models.assignment import ASSIGNABLE_FIELDS
+from n26.library.models.assignable import OPTION_OFFER_PATHS
 from n26.library.models.modifier import GANG, MODEL
 
 
@@ -378,7 +379,7 @@ def _flat_rows(**filters):
     )
 
 
-def hydrate_rows(rows, with_statlines=False):
+def hydrate_rows(rows, with_statlines=False, with_options=False):
     """Load everything a card build reads off ``rows`` — narrow passes,
     never a wide join.
 
@@ -391,6 +392,12 @@ def hydrate_rows(rows, with_statlines=False):
 
     ``with_statlines`` pulls each profile's characteristics along too,
     which rendering needs and plain assignment work does not.
+
+    ``with_options`` pulls what each copy was bought with — the sets
+    recorded against it and the offer they were picked from. Only the
+    screens that name a copy's options ask for it: a printed sheet says
+    what a fighter carries and never how it was chosen, and would pay
+    these passes for an answer it does not print.
     """
     from django.db.models import prefetch_related_objects
 
@@ -418,6 +425,8 @@ def hydrate_rows(rows, with_statlines=False):
             "profile__profile_type__statline_type__stats__stat",
             "weapon_profile__weapon__statline_type__stats__stat",
         ]
+    if with_options:
+        paths += ["chosen_options", *(f"wargear__{p}" for p in OPTION_OFFER_PATHS)]
     prefetch_related_objects(rows, *paths)
     return rows
 
@@ -441,12 +450,14 @@ def set_by_hand(**filters):
     return grouped
 
 
-def card_rows(with_statlines=False, **filters):
+def card_rows(with_statlines=False, with_options=False, **filters):
     """The flat fetch every card build starts from: one assignment query,
     hydrated. Builds fetching more than one list of assignments hydrate
     them together instead — one pass covers any number of fetches.
     """
-    return hydrate_rows(_flat_rows(**filters), with_statlines=with_statlines)
+    return hydrate_rows(
+        _flat_rows(**filters), with_statlines=with_statlines, with_options=with_options
+    )
 
 
 def gang_rows(gang):
@@ -536,7 +547,9 @@ def assemble(
     return card
 
 
-def build_card(miniature, with_statlines=False, assignment_set=None):
+def build_card(
+    miniature, with_statlines=False, assignment_set=None, with_options=False
+):
     """A model's card: everything it owns, or one named selection.
 
     Two assignment queries rather than one — the model's own, then the
@@ -554,7 +567,9 @@ def build_card(miniature, with_statlines=False, assignment_set=None):
     gang = membership.gang if membership else None
     own = _flat_rows(miniature_root=miniature)
     shared = gang_rows(gang)
-    hydrate_rows([*own, *shared], with_statlines=with_statlines)
+    hydrate_rows(
+        [*own, *shared], with_statlines=with_statlines, with_options=with_options
+    )
     return assemble(
         miniature,
         own,
@@ -597,7 +612,7 @@ def _forest(rows):
     return roots
 
 
-def build_gang_card(gang, with_statlines=True, assignment_set=None):
+def build_gang_card(gang, with_statlines=True, assignment_set=None, with_options=False):
     """The gang's own card, its stash, and every member's card.
 
     The same fetch family as ever: one assignment query for everything
@@ -616,7 +631,9 @@ def build_gang_card(gang, with_statlines=True, assignment_set=None):
     # The stash's assignments ride the same hydration pass as everyone's
     # — a second pass would repeat every narrow query for a handful.
     stash_rows = _flat_rows(gang_root=gang, stash_root__isnull=False)
-    hydrate_rows([*rows, *stash_rows], with_statlines=with_statlines)
+    hydrate_rows(
+        [*rows, *stash_rows], with_statlines=with_statlines, with_options=with_options
+    )
     for row in rows:
         if row.miniature_root_id is None:
             shared.append(row)

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -252,6 +252,11 @@ class OwnedCopyRow:
     #: the one act here that adds something rather than taking it away,
     #: and a chevron full of ways to lose a thing is no place for it.
     accessorise: Action | None = None
+    #: The options this copy was taken with, in the order the offer put
+    #: them — "Cutter plasma guns", "Smoke dispenser". Its price already
+    #: holds what they added, so what each one costs is not said again
+    #: here. Empty where nothing was ever asked.
+    chosen: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -427,6 +432,7 @@ def copy_row(copy, refunds=True):
             for part in copy.parts
         ),
         sell=Action("Sell", LINK, copy.sell_href, DANGER),
+        chosen=copy.chosen,
         accessorise=(
             Action("Add accessory", LINK, copy.accessorise_href, SECONDARY)
             if copy.accessorise_href

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -253,9 +253,9 @@ class OwnedCopyRow:
     #: and a chevron full of ways to lose a thing is no place for it.
     accessorise: Action | None = None
     #: The options this copy was taken with, in the order the offer put
-    #: them — "Cutter plasma guns", "Smoke dispenser". Its price already
-    #: holds what they added, so what each one costs is not said again
-    #: here. Empty where nothing was ever asked.
+    #: them — "Cutter plasma guns", "Smoke dispenser". What each added is
+    #: already inside the copy's rating, so no figure is said again
+    #: beside them. Empty where nothing was ever asked.
     chosen: tuple[str, ...] = ()
 
 

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -146,6 +146,34 @@ class OwnedThing:
     #: an accessory hangs off the gun it changes, so nothing else on a
     #: card is somewhere to fit one.
     accessorise_href: str = ""
+    #: What this copy was taken with, named as the buyer was offered it.
+    #: Per copy and not per content: two of the same mount may carry
+    #: different guns. Empty for anything that offered no choice, which
+    #: is most of what a model owns.
+    chosen: tuple[str, ...] = ()
+
+
+def _chosen_of(node):
+    """The options this copy was taken with, as the buyer was offered them.
+
+    The recorded sets say what was picked and the offer says what each
+    was called, and both are already in hand — describing a copy costs
+    no query. The set an option brings is what gets recorded, so two
+    options bringing the same set cannot be told apart afterwards; the
+    first is named.
+
+    The author's own label for a group is never read here. A reader is
+    shown the options themselves, in the order the offer puts them, and
+    a heading naming the group would be a second vocabulary they never
+    agreed to.
+    """
+    from n26.library.models.assignable import Optioned
+
+    thing = node.assignable
+    if not isinstance(thing, Optioned):
+        return ()
+    recorded = {row.default_set_id for row in node.assignment.chosen_options.all()}
+    return tuple(option.name for option in thing.options_taken(recorded))
 
 
 def _part_name(node):
@@ -260,6 +288,7 @@ def owned_things(card, at):
                     if isinstance(node.assignable, Weapon)
                     else ""
                 ),
+                chosen=_chosen_of(node),
             )
         )
     return index

--- a/n26/core/templates/cotton/n26/owned_lines.html
+++ b/n26/core/templates/cotton/n26/owned_lines.html
@@ -24,6 +24,12 @@ a gun — and Operation.move refuses a firing line, so the structure gives it no
 to draw. An accessory is the case that could be moved, but the way to re-fit one
 is from wherever it is being kept rather than from the gun it is already on.
 
+Something bought with a choice names what it was bought with, quietly, under its
+own name: a mount says which guns it carries. The options alone, run together —
+the sets an author filed them under are their own way of organising a page and
+are never shown, and no figure is repeated beside them, because what each one
+added is already inside the copy's rating on the right.
+
 A weapon carries one extra control, and it sits on the name's own line rather
 than among the acts: the way to bolt an accessory onto it. Which copies have one
 is the structure's answer — nothing else on a card is somewhere to fit one — so

--- a/n26/core/templates/cotton/n26/owned_lines.html
+++ b/n26/core/templates/cotton/n26/owned_lines.html
@@ -44,51 +44,67 @@ also keeps this out of the catalogue's own form, which wraps every row on the pa
 <div class="flex flex-col gap-1 {{ class }}">
     {% for copy in copies %}
         <div class="flex min-h-9 items-center gap-2">
-            <span class="min-w-0 flex-1 text-sm text-ink-900 dark:text-ink-100">
-                {{ copy.name }}
-                {% comment %}
-                Only a weapon carries this, which is the structure's word and
-                not a test made here. On the name's own line, after the words it
-                acts on, the way the sheet's rename pencil sits after a
-                fighter's name: it is about this gun, where everything on the
-                right of the row is about what to do with it — and everything
-                over there takes the thing away, which is no company for the one
-                control that adds to it. Quiet with it: a fighter's guns are
-                read for what they are, not for what could be bolted on.
+            <span class="flex min-w-0 flex-1 flex-col justify-center">
+                <span class="text-sm text-ink-900 dark:text-ink-100">
+                    {{ copy.name }}
+                    {% comment %}
+                    Only a weapon carries this, which is the structure's word and
+                    not a test made here. On the name's own line, after the words it
+                    acts on, the way the sheet's rename pencil sits after a
+                    fighter's name: it is about this gun, where everything on the
+                    right of the row is about what to do with it — and everything
+                    over there takes the thing away, which is no company for the one
+                    control that adds to it. Quiet with it: a fighter's guns are
+                    read for what they are, not for what could be bolted on.
 
-                A link to the address that draws the panel, and a click that
-                opens the panel already on the page. Both reach the same state;
-                the second does it without rebuilding a catalogue of several
-                hundred rows. Its own x-data because Alpine only walks into
-                elements a component contains, and a row is drawn in places
-                where nothing above it is one.
-                {% endcomment %}
+                    A link to the address that draws the panel, and a click that
+                    opens the panel already on the page. Both reach the same state;
+                    the second does it without rebuilding a catalogue of several
+                    hundred rows. Its own x-data because Alpine only walks into
+                    elements a component contains, and a row is drawn in places
+                    where nothing above it is one.
+                    {% endcomment %}
+                    {% comment %}
+                    An icon and the words, together: a bare plus beside a
+                    gun's name says nothing about what clicking it adds, and
+                    words without the plus don't read as a control that adds
+                    one. Ghost and small is what keeps it quiet.
+                    {% endcomment %}
+                    {% if copy.accessorise %}
+                        <c-ui.button variant="ghost"
+                                     size="xs"
+                                     class="ms-0.5 -mt-0.5 align-middle text-ink-500 dark:text-ink-400"
+                                     href="{{ copy.accessorise.target }}"
+                                     aria-label="{{ copy.accessorise.label }} to {{ copy.name }}"
+                                     x-data
+                                     x-on:click.prevent="$dispatch('n26-dialog-open', { id: 'n26-accessorise-{{ copy.id }}', url: $el.getAttribute('href') })">
+                            {% comment %}
+                            One flex line: the kit button is inline-block and
+                            the reset makes an svg a block, so bare icon-then-
+                            words stack. The span is what holds them together.
+                            {% endcomment %}
+                            <span class="inline-flex items-center gap-1 whitespace-nowrap">
+                                <c-n26.icon name="plus"
+                                            class="size-3.5"
+                                            stroke_width="2.5" />
+                                {{ copy.accessorise.label }}
+                            </span>
+                        </c-ui.button>
+                    {% endif %}
+                </span>
                 {% comment %}
-                An icon and the words, together: a bare plus beside a
-                gun's name says nothing about what clicking it adds, and
-                words without the plus don't read as a control that adds
-                one. Ghost and small is what keeps it quiet.
+                What this copy was bought with, under the name it was bought
+                under. Two of the same mount may carry different guns, so it
+                belongs to the copy and not to the row heading above it.
+
+                The options alone, run together: the sets they were picked
+                from are the author's way of organising their own page, and
+                naming them here would hand a reader a vocabulary they never
+                agreed to. No prices either — the figure to the right already
+                holds what they added.
                 {% endcomment %}
-                {% if copy.accessorise %}
-                    <c-ui.button variant="ghost"
-                                 size="xs"
-                                 class="ms-0.5 -mt-0.5 align-middle text-ink-500 dark:text-ink-400"
-                                 href="{{ copy.accessorise.target }}"
-                                 aria-label="{{ copy.accessorise.label }} to {{ copy.name }}"
-                                 x-data
-                                 x-on:click.prevent="$dispatch('n26-dialog-open', { id: 'n26-accessorise-{{ copy.id }}', url: $el.getAttribute('href') })">
-                        {% comment %}
-                        One flex line: the kit button is inline-block and
-                        the reset makes an svg a block, so bare icon-then-
-                        words stack. The span is what holds them together.
-                        {% endcomment %}
-                        <span class="inline-flex items-center gap-1 whitespace-nowrap">
-                            <c-n26.icon name="plus"
-                                        class="size-3.5"
-                                        stroke_width="2.5" />
-                            {{ copy.accessorise.label }}
-                        </span>
-                    </c-ui.button>
+                {% if copy.chosen %}
+                    <span class="text-xs text-muted">{{ copy.chosen|join:" · " }}</span>
                 {% endif %}
             </span>
             {% comment %}

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -419,7 +419,9 @@ def equip(request, pk):
     # One card build serves the whole page: which lists this fighter can
     # browse and how usable each line is are both read off the same
     # computed card.
-    card = build_card(miniature)
+    # ``with_options`` so each copy can name what it was bought with;
+    # nothing else on this page reads it.
+    card = build_card(miniature, with_options=True)
     index = build_modifier_index([node.assignable for node in card.all_nodes()])
     computed = compute(card, index)
 

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -419,8 +419,8 @@ def equip(request, pk):
     # One card build serves the whole page: which lists this fighter can
     # browse and how usable each line is are both read off the same
     # computed card.
-    # ``with_options`` so each copy can name what it was bought with;
-    # nothing else on this page reads it.
+    # The options ride along because this page names what each copy was
+    # bought with, which no other surface built from a card does.
     card = build_card(miniature, with_options=True)
     index = build_modifier_index([node.assignable for node in card.all_nodes()])
     computed = compute(card, index)

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1864,14 +1864,15 @@ def carried():
     owned rows because the real function said so, and not because a
     template drew them differently.
 
-    Two Stub guns and a Meltagun with a paid round: a count above one, a
-    part under a copy, and everything else on the list untouched. Those
-    are the states a row has, and one sample answers for every surface
-    that asks what this fighter is carrying.
+    Two Stub guns, a Meltagun with a paid round, and a mount bought with
+    two of its options taken: a count above one, a part under a copy, a
+    copy naming what it was bought with, and everything else on the list
+    untouched. Those are the states a row has, and one sample answers
+    for every surface that asks what this fighter is carrying.
     """
     from n26.core.owned import OwnedPart, OwnedThing, thing_key
 
-    def copy(name, rating, index=0, parts=()):
+    def copy(name, rating, index=0, parts=(), chosen=()):
         stock = _stock(name)
         pk = f"{stock.pk}-{index}"
         return thing_key(stock), OwnedThing(
@@ -1884,6 +1885,7 @@ def carried():
             reassign_href="#",
             refund_href="#",
             remove_href="#",
+            chosen=chosen,
         )
 
     round_ = OwnedPart(
@@ -1900,6 +1902,14 @@ def carried():
         copy("Meltagun", 135, parts=(round_,)),
         copy("Stub gun", 5, index=0),
         copy("Stub gun", 5, index=1),
+        # The mount the sample list offers alternatives on, bought with
+        # one taken from each of its two sets — the options themselves,
+        # never the author's name for the set they came from.
+        copy(
+            "Grav-cutter",
+            165,
+            chosen=("Grav-cutter plasma guns", "Smoke dispenser"),
+        ),
     ):
         held.setdefault(key, []).append(thing)
     return held

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -307,6 +307,7 @@ _CATALOGUE = [
         "Mounts",
         [
             ("Grav-cutter", 150, 12, False),
+            ("Ridge-runner", 90, 8, False),
         ],
     ),
 ]
@@ -361,6 +362,17 @@ OFFERED = {
             ],
         ),
         ("one-or-none", [("Smoke dispenser", 20)]),
+    ],
+    #: The mount the sample fighter already owns. A second optioned line
+    #: so that one can be drawn as a row still for sale, with its
+    #: controls, while the other is drawn as a row already bought,
+    #: naming what it was bought with.
+    "Ridge-runner": [
+        (
+            "one",
+            [("Ridge-runner scattergun", 0), ("Ridge-runner harpoon", 25)],
+        ),
+        ("one-or-none", [("Ridge-runner spikes", 10)]),
     ],
 }
 
@@ -1865,10 +1877,11 @@ def carried():
     template drew them differently.
 
     Two Stub guns, a Meltagun with a paid round, and a mount bought with
-    two of its options taken: a count above one, a part under a copy, a
-    copy naming what it was bought with, and everything else on the list
-    untouched. Those are the states a row has, and one sample answers
-    for every surface that asks what this fighter is carrying.
+    one option from each of its two sets: a count above one, a part
+    under a copy, a copy naming what it was bought with, and everything
+    else on the list untouched. Those are the states a row has, and one
+    sample answers for every surface that asks what this fighter is
+    carrying.
     """
     from n26.core.owned import OwnedPart, OwnedThing, thing_key
 
@@ -1902,13 +1915,14 @@ def carried():
         copy("Meltagun", 135, parts=(round_,)),
         copy("Stub gun", 5, index=0),
         copy("Stub gun", 5, index=1),
-        # The mount the sample list offers alternatives on, bought with
-        # one taken from each of its two sets — the options themselves,
-        # never the author's name for the set they came from.
+        # A mount bought with one option taken from each of its two sets
+        # — the options themselves, never the author's name for the set
+        # they came from. The list's other mount is left unbought, so one
+        # of the two draws its controls and the other draws its picks.
         copy(
-            "Grav-cutter",
-            165,
-            chosen=("Grav-cutter plasma guns", "Smoke dispenser"),
+            "Ridge-runner",
+            125,
+            chosen=("Ridge-runner harpoon", "Ridge-runner spikes"),
         ),
     ):
         held.setdefault(key, []).append(thing)

--- a/n26/library/models/assignable.py
+++ b/n26/library/models/assignable.py
@@ -503,10 +503,13 @@ class Optioned(models.Model):
         """The options something was acquired with, in the offer's own order.
 
         ``recorded_sets`` is the ids of the sets recorded against it,
-        because a set is what materialises. A pick-one group records
-        nothing where its head was taken, so a group with nothing
-        recorded answers with its head — that is what was taken, and a
-        reader asking what a thing has needs telling either way.
+        because a set is what materialises. Acquiring something records
+        every set it took, each pick-one group's head included, so what
+        comes back is what the thing actually has. Nothing is inferred
+        where nothing was recorded: something that arrived by another
+        road than a purchase — kit built into a profile, say — took no
+        options and had none materialised, and naming a group's head
+        would credit it with a weapon nobody ever gave it.
 
         Groups offering no choice are left out, the same test the buying
         screen makes: a pick-one set with a single option is taken
@@ -526,12 +529,10 @@ class Optioned(models.Model):
             one_of = (group.choose if group is not None else "one") == "one"
             if one_of and len(offered) < 2:
                 continue
-            here = []
             for option in offered:
                 if option.default_set_id in unspent:
                     unspent.discard(option.default_set_id)
-                    here.append(option)
-            taken.extend(here or (offered[:1] if one_of else []))
+                    taken.append(option)
         return taken
 
     def price_with(self, selection=None, base=None):

--- a/n26/library/models/assignable.py
+++ b/n26/library/models/assignable.py
@@ -499,6 +499,31 @@ class Optioned(models.Model):
             raise ValueError(f"{self.name} does not offer: {', '.join(strays)}.")
         return taken
 
+    def options_taken(self, recorded_sets):
+        """The options something was acquired with, in the offer's own order.
+
+        ``recorded_sets`` is the ids of the sets recorded against it,
+        because a set is what materialises. A pick-one group records
+        nothing where its head was taken, so a group with nothing
+        recorded answers with its head — that is what was taken, and a
+        reader asking what a thing has needs telling either way.
+
+        Groups offering no choice are left out, the same test the buying
+        screen makes: a pick-one set with a single option is taken
+        unasked, and naming it would tell a reader about a decision
+        nobody made.
+        """
+        taken = []
+        for group, offered in self.grouped_offers():
+            one_of = (group.choose if group is not None else "one") == "one"
+            if one_of and len(offered) < 2:
+                continue
+            here = [
+                option for option in offered if option.default_set_id in recorded_sets
+            ]
+            taken.extend(here or (offered[:1] if one_of else []))
+        return taken
+
     def price_with(self, selection=None, base=None):
         """This, its built-ins, and every set taken with it.
 

--- a/n26/library/models/assignable.py
+++ b/n26/library/models/assignable.py
@@ -512,15 +512,25 @@ class Optioned(models.Model):
         screen makes: a pick-one set with a single option is taken
         unasked, and naming it would tell a reader about a decision
         nobody made.
+
+        Nothing stops two options bringing the same set, and a taking
+        records the set rather than the wording that reached it. Each
+        recorded set is therefore spent on the first option offering it,
+        exactly as ``resolve_selection`` spends what a player named — a
+        set taken once is named once, however many ways there were to
+        ask for it.
         """
+        unspent = set(recorded_sets)
         taken = []
         for group, offered in self.grouped_offers():
             one_of = (group.choose if group is not None else "one") == "one"
             if one_of and len(offered) < 2:
                 continue
-            here = [
-                option for option in offered if option.default_set_id in recorded_sets
-            ]
+            here = []
+            for option in offered:
+                if option.default_set_id in unspent:
+                    unspent.discard(option.default_set_id)
+                    here.append(option)
             taken.extend(here or (offered[:1] if one_of else []))
         return taken
 

--- a/n26/tests/sandbox/test_buying_with_options.py
+++ b/n26/tests/sandbox/test_buying_with_options.py
@@ -435,6 +435,191 @@ class TestTakingNothingFromAnOptionalSet:
         assert_reconciled(gang)
 
 
+class TestWhatAnOwnedCopySays:
+    """A mount already bought names the guns it was bought with.
+
+    The row above it is about the content — every Cutter there could
+    be — so the answer belongs to the copy: two mounts on one fighter
+    may carry different guns and a heading cannot say both.
+    """
+
+    def buy(self, client, owner, fighter, house_list, cutter, **picked):
+        client.force_login(owner)
+        client.post(equip_url(fighter, house_list), {"thing": key_of(cutter), **picked})
+
+    def chosen(self, client, owner, fighter, house_list):
+        row = cutter_row(client, owner, fighter, house_list)
+        return [copy.chosen for copy in row.copies]
+
+    def test_a_swap_is_named_on_the_copy_that_took_it(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        self.buy(
+            client, owner, fighter, house_list, cutter, **{choice_field(cutter, 0): "2"}
+        )
+
+        assert self.chosen(client, owner, fighter, house_list) == [
+            ("Cutter plasma guns",)
+        ]
+
+    def test_the_standard_guns_are_named_though_nobody_picked_them(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        """Taking what comes as standard records nothing, because there
+        was nothing to record. A reader asking what this mount carries
+        still needs telling, so the set answers with its head."""
+        self.buy(client, owner, fighter, house_list, cutter)
+
+        assert self.chosen(client, owner, fighter, house_list) == [
+            ("Cutter grenade launchers",)
+        ]
+
+    def test_both_sets_are_named_in_the_order_the_offer_puts_them(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        self.buy(
+            client,
+            owner,
+            fighter,
+            house_list,
+            cutter,
+            **{choice_field(cutter, 0): "2", choice_field(cutter, 1): "0"},
+        )
+
+        assert self.chosen(client, owner, fighter, house_list) == [
+            ("Cutter plasma guns", "Smoke dispenser")
+        ]
+
+    def test_a_set_nobody_took_anything_from_says_nothing(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        """A one-or-none set left alone is a mount without a dispenser,
+        which is a thing it has not got — and a line saying so would be
+        the page listing everything nobody bought."""
+        self.buy(
+            client,
+            owner,
+            fighter,
+            house_list,
+            cutter,
+            **{choice_field(cutter, 0): "0", choice_field(cutter, 1): ""},
+        )
+
+        assert self.chosen(client, owner, fighter, house_list) == [
+            ("Cutter grenade launchers",)
+        ]
+
+    def test_two_copies_each_say_what_they_took(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        self.buy(
+            client, owner, fighter, house_list, cutter, **{choice_field(cutter, 0): "2"}
+        )
+        self.buy(
+            client,
+            owner,
+            fighter,
+            house_list,
+            cutter,
+            **{choice_field(cutter, 0): "1", choice_field(cutter, 1): "0"},
+        )
+
+        assert sorted(self.chosen(client, owner, fighter, house_list)) == [
+            ("Cutter heavy stubbers", "Smoke dispenser"),
+            ("Cutter plasma guns",),
+        ]
+
+    def test_something_that_asked_nothing_says_nothing(
+        self, client, owner, gang, fighter, house_list, default_pack
+    ):
+        knife = create_wargear("Stiletto knife", price=10)
+        house_list.entries.create(wargear=knife)
+
+        client.force_login(owner)
+        client.post(equip_url(fighter, house_list), {"thing": key_of(knife)})
+
+        row = row_named(client, owner, fighter, house_list, "Stiletto knife")
+        assert [copy.chosen for copy in row.copies] == [()]
+
+
+class TestWhatTheOwnedCopyDraws:
+    """The same, on the page — where the offer is drawn a second time."""
+
+    def test_the_page_prints_what_the_copy_took(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        """The picks run together, which is the substring the radios
+        below cannot make: "Buy another" redraws every option this mount
+        offers, so either name on its own proves nothing."""
+        client.force_login(owner)
+        client.post(
+            equip_url(fighter, house_list),
+            {
+                "thing": key_of(cutter),
+                choice_field(cutter, 0): "2",
+                choice_field(cutter, 1): "0",
+            },
+        )
+        body = client.get(equip_url(fighter, house_list)).content.decode()
+
+        assert "Cutter plasma guns · Smoke dispenser" in body
+
+    def test_the_label_the_author_gave_a_set_still_reaches_nobody(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        """Naming the sets would be the tidy way to draw two picks, and
+        it is the one way that is not ours to draw: the label is the
+        author's note to themselves."""
+        client.force_login(owner)
+        client.post(
+            equip_url(fighter, house_list),
+            {
+                "thing": key_of(cutter),
+                choice_field(cutter, 0): "2",
+                choice_field(cutter, 1): "0",
+            },
+        )
+        body = client.get(equip_url(fighter, house_list)).content.decode()
+
+        assert SET_LABEL not in body
+
+
+class TestNamingWhatIsOwnedCostsNothing:
+    """Describing a copy reads the recorded sets and the offer they came
+    from, both already in hand — so a fighter buying more mounts asks the
+    database no more than one who bought a single mount."""
+
+    def test_it_costs_no_query_per_copy(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from n26.core.card import build_card
+        from n26.core.owned import owned_things
+
+        def buy(pick):
+            client.force_login(owner)
+            client.post(
+                equip_url(fighter, house_list),
+                {"thing": key_of(cutter), choice_field(cutter, 0): pick},
+            )
+
+        def measure():
+            with CaptureQueriesContext(connection) as captured:
+                card = build_card(fighter, with_options=True)
+                owned = owned_things(card, "/equip")
+                named = [thing.chosen for thing in owned[key_of(cutter)]]
+                assert all(named), named
+            return len(captured.captured_queries)
+
+        buy("2")
+        one = measure()
+        for pick in ["0", "1", "2"]:
+            buy(pick)
+        assert measure() == one
+
+
 class TestAPickTheListingNeverOffered:
     """A tampered index is a broken link, not a rule to explain — and it
     buys nothing at all, not even the mount."""

--- a/n26/tests/sandbox/test_buying_with_options.py
+++ b/n26/tests/sandbox/test_buying_with_options.py
@@ -529,6 +529,34 @@ class TestWhatAnOwnedCopySays:
             ("Cutter plasma guns",),
         ]
 
+    def test_a_set_two_offers_share_is_named_once(
+        self, client, owner, gang, fighter, default_pack
+    ):
+        """A taking records the set, not the wording that reached it, so
+        an author offering one set from two places leaves nothing to
+        tell the two apart. It is named where it was spent — naming it
+        again under the second offer would credit the buyer with a
+        fitting they never took."""
+        rig = create_wargear("Grav rig", price=40)
+        offer_option(rig, "As standard", thing=create_wargear("Rig webbing", price=0))
+        offer_option(
+            rig, "With boosters", thing=create_wargear("Rig boosters", price=15)
+        )
+        boosters = rig.options.get(name="With boosters").default_set
+        spares = create_option_group(rig, "Spares", choose="one-or-none")
+        offer_option(rig, "Boosters again", default_set=boosters, group=spares)
+        collection = create_collection("Sundries", entries=[rig])
+        assign(collection, gang=gang)
+
+        client.force_login(owner)
+        client.post(
+            equip_url(fighter, collection),
+            {"thing": key_of(rig), choice_field(rig, 0): "1"},
+        )
+
+        row = row_named(client, owner, fighter, collection, "Grav rig")
+        assert [copy.chosen for copy in row.copies] == [("With boosters",)]
+
     def test_something_that_asked_nothing_says_nothing(
         self, client, owner, gang, fighter, house_list, default_pack
     ):

--- a/n26/tests/sandbox/test_buying_with_options.py
+++ b/n26/tests/sandbox/test_buying_with_options.py
@@ -465,9 +465,10 @@ class TestWhatAnOwnedCopySays:
     def test_the_standard_guns_are_named_though_nobody_picked_them(
         self, client, owner, fighter, house_list, cutter
     ):
-        """Taking what comes as standard records nothing, because there
-        was nothing to record. A reader asking what this mount carries
-        still needs telling, so the set answers with its head."""
+        """A purchase records every set it took, the head of a pick-one
+        set included, so taking what comes as standard is recorded like
+        any other pick. A reader asking what this mount carries is
+        answered whether or not they made a decision."""
         self.buy(client, owner, fighter, house_list, cutter)
 
         assert self.chosen(client, owner, fighter, house_list) == [
@@ -528,6 +529,64 @@ class TestWhatAnOwnedCopySays:
             ("Cutter heavy stubbers", "Smoke dispenser"),
             ("Cutter plasma guns",),
         ]
+
+    def test_an_any_of_set_names_every_option_taken_from_it(
+        self, client, owner, gang, fighter, default_pack
+    ):
+        """The third mode: a set a buyer may take as much of as they
+        like, which is the one place several names come from a single
+        set."""
+        belt = create_wargear("Grenade belt", price=20)
+        pouches = create_option_group(belt, "Pouches", choose="any")
+        for name, price in [("Frag", 15), ("Krak", 30), ("Smoke", 10)]:
+            offer_option(
+                belt,
+                f"{name} grenades",
+                price=price,
+                thing=create_weapon(f"{name} grenades", profiles=[("Thrown", 0)]),
+                group=pouches,
+            )
+        collection = create_collection("Munitions", entries=[belt])
+        assign(collection, gang=gang)
+
+        client.force_login(owner)
+        client.post(
+            equip_url(fighter, collection),
+            {"thing": key_of(belt), choice_field(belt, 0): ["0", "2"]},
+        )
+
+        row = row_named(client, owner, fighter, collection, "Grenade belt")
+        assert [copy.chosen for copy in row.copies] == [
+            ("Frag grenades", "Smoke grenades")
+        ]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_kit_that_arrived_without_options_names_none_of_them(
+        self, client, owner, gang, fighter, cutter, default_pack
+    ):
+        """A mount built into a fighter's own entry is granted whole,
+        with none of its sets resolved and nothing recorded. Answering
+        with a set's head would tell a reader the fighter has launchers
+        that were never assigned to them.
+        """
+        from n26.library.authoring import add_built_in
+
+        rider = create_wargear("Rider's rig", price=0)
+        add_built_in(rider, cutter)
+        collection = create_collection("Riders", entries=[rider])
+        assign(collection, gang=gang)
+
+        client.force_login(owner)
+        client.post(equip_url(fighter, collection), {"thing": key_of(rider)})
+
+        from n26.core.card import build_card
+        from n26.core.owned import owned_things
+
+        held = Assignment.objects.get(wargear=cutter, archived=False)
+        assert not held.chosen_options.exists()
+        owned = owned_things(build_card(fighter, with_options=True), "/equip")
+        assert [thing.chosen for thing in owned[key_of(cutter)]] == [()]
 
     def test_a_set_two_offers_share_is_named_once(
         self, client, owner, gang, fighter, default_pack
@@ -592,7 +651,7 @@ class TestWhatTheOwnedCopyDraws:
 
         assert "Cutter plasma guns · Smoke dispenser" in body
 
-    def test_the_label_the_author_gave_a_set_still_reaches_nobody(
+    def test_an_owned_copy_never_names_the_set_a_pick_came_from(
         self, client, owner, fighter, house_list, cutter
     ):
         """Naming the sets would be the tidy way to draw two picks, and


### PR DESCRIPTION
Some gear offers a choice when you buy it. The Escher Cutter is a mount that comes with grenade launchers and will swap them for heavy stubbers (+10¢) or plasma guns (+15¢), and it has a second, optional fitting — a smoke dispenser (+20¢). You pick all this at the moment of buying, and the picks are priced and charged correctly.

Afterwards, though, the equip page said nothing about them. A Cutter bought with plasma guns drew exactly like one bought as standard: same name, same row. The guns it was bought with reached the fighter's card and appeared nowhere on the page where you bought them, so there was no way to tell two mounts apart, or to remember what you had chosen.

## Summary

- An equipped copy now names what it was bought with, on a quiet line under its own name — `Cutter plasma guns · Smoke dispenser`. It belongs to the copy rather than to the row heading above it, because two of the same mount on one fighter may carry different guns.
- A purchase records every set it took, including the head of each pick-one group, so a mount bought as standard still says `Cutter grenade launchers`. Nothing is inferred where nothing was recorded: gear that arrived by another road — kit built into something else — took no options and had none materialised, so it names none rather than being credited with a weapon nobody gave it.
- The options are named on their own. The author's label for the set they came from stays where it is — it is a note to themselves, and a heading using it would hand a reader a vocabulary they never agreed to. No figures either: what each option added is already inside the copy's rating on the right.
- Where two offers bring the same set, the recording cannot tell them apart, so each recorded set is spent on the first option offering it — the way `resolve_selection` spends what a player named.
- What a copy was bought with is loaded behind a `with_options` flag that only the fighter's equip page asks for, derived by reflection over the kinds of gear that can carry options. Naming a copy costs no query per copy, and the printed gang sheet's query budget is unchanged.
- The design gallery gains a second mount, so one row demonstrates the picker while the other demonstrates a copy naming what it was bought with.

## Test plan

- [x] `pytest n26` — 3135 passed
- [x] Full suite — 7401 passed, 12 skipped
- [x] All three choice modes covered for the owned display: pick-one, one-or-none, and any-of (which is the one mode where several names come from a single set).
- [x] Regression guard: gear built into something else names no options.
- [x] Also covered: two copies each naming their own; two offers sharing a set named once; something that asked nothing saying nothing; the rendered page printing the picks run together; the author's set label never reaching the page; and naming what is owned costing no query per copy.
- [x] Checked in the browser at `/n26/design/c/owned-lines/` — the line renders muted under the copy's name and the Sell control stays centred against the two-line row.

## Next

Changing the options after the fact is the natural follow-up. `Operation.rechoose` already swaps a carrier's sets and lands the difference on paid, list price and rating in either direction, unwinding whole if the gang cannot afford an upgrade — but its page (`n26/core/views/options.py`) is wired to a model's hire options alone, so a bought mount has no way in. The intent is a "Change options" entry in the copy's existing chevron, beside Reassign and Delete.

A stash-held mount still names nothing: the gang's holdings are drawn by a different path than `owned_things`, which is where this would need repeating.