### PR TITLE
fix: n26 counts clicks on the site banner

### DIFF
--- a/n23/core/tests/test_banner_click_tracking.py
+++ b/n23/core/tests/test_banner_click_tracking.py
@@ -177,3 +177,18 @@ def test_track_banner_click_invalid_banner_id():
 
     # Should get 404
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_track_banner_click_id_that_is_not_an_id():
+    """A hand-typed address is a 404, not a server error.
+
+    The view looks the banner up by primary key. Handed something that is
+    not a UUID, that lookup raises instead of answering "no such banner",
+    so the address has to fail to route in the first place.
+    """
+    client = Client()
+
+    response = client.get("/banner/nonsense/click/")
+
+    assert response.status_code == 404

--- a/n23/core/urls/misc.py
+++ b/n23/core/urls/misc.py
@@ -43,9 +43,13 @@ patterns = [
         n23.core.views.dismiss_banner,
         name="dismiss-banner",
     ),
-    # Banner click tracking
+    # Banner click tracking. The id is matched as a UUID so that anything
+    # else fails to route: the view looks the banner up by primary key, and
+    # a lookup handed something that is not a UUID raises rather than
+    # answering "no such banner" — a hand-typed address should be a 404, not
+    # a server error.
     path(
-        "banner/<id>/click/",
+        "banner/<uuid:id>/click/",
         n23.core.views.track_banner_click,
         name="track-banner-click",
     ),

--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -137,14 +137,20 @@ banner, is_impersonating / impersonator, gtm_container_id, messages, user.
         tracker link unconditionally would turn "no call to action" into a
         button leading out of the edition.
         {% endcomment %}
+        {% comment %}
+        Both addresses are written inline rather than resolved into a variable
+        first. The `as` form of {% url %} answers an unknown route name with an
+        empty string, which here would mean a bar that quietly stops offering
+        its button, or a close button that posts nowhere and forgets — a route
+        renamed out from under this file would be noticed by nobody. Written
+        this way it raises on the spot.
+        {% endcomment %}
         {% if banner %}
-            {% url 'core:dismiss-banner' as banner_dismiss_url %}
-            {% url 'core:track-banner-click' banner.id as banner_cta_url %}
             <c-n26.site.announcement tone="{{ banner.colour|banner_tone }}"
                                      icon="{{ banner.icon|banner_icon }}"
                                      cta_text="{{ banner.cta_text }}"
-                                     cta_url="{% if banner.cta_url %}{{ banner_cta_url }}{% endif %}"
-                                     on_dismiss="fetch('{{ banner_dismiss_url }}', {method: 'POST', headers: {'X-CSRFToken': '{{ csrf_token }}', 'Content-Type': 'application/json'}, body: JSON.stringify({banner_id: '{{ banner.id }}'})})"
+                                     cta_url="{% if banner.cta_url %}{% url 'core:track-banner-click' banner.id %}{% endif %}"
+                                     on_dismiss="fetch('{% url 'core:dismiss-banner' %}', {method: 'POST', headers: {'X-CSRFToken': '{{ csrf_token }}', 'Content-Type': 'application/json'}, body: JSON.stringify({banner_id: '{{ banner.id }}'})})"
                                      id="site-banner-{{ banner.id }}">
                 {{ banner.text }}
             </c-n26.site.announcement>

--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -125,12 +125,25 @@ banner, is_impersonating / impersonator, gtm_container_id, messages, user.
         The route is the platform's rather than an edition's: it operates on a
         platform-owned Banner and writes a key both editions read.
         {% endcomment %}
+        {% comment %}
+        The call to action goes by way of the platform's click tracker, which
+        counts the click and then redirects to the banner's own address. Linked
+        straight at that address instead, the bar still works and the clicks
+        are simply never counted — so a banner advertising something reports
+        nothing from this edition's pages and reads as ignored.
+
+        Only when there is somewhere to go: the tracker redirects a banner with
+        no address of its own to the site's home, so handing the component a
+        tracker link unconditionally would turn "no call to action" into a
+        button leading out of the edition.
+        {% endcomment %}
         {% if banner %}
             {% url 'core:dismiss-banner' as banner_dismiss_url %}
+            {% url 'core:track-banner-click' banner.id as banner_cta_url %}
             <c-n26.site.announcement tone="{{ banner.colour|banner_tone }}"
                                      icon="{{ banner.icon|banner_icon }}"
                                      cta_text="{{ banner.cta_text }}"
-                                     cta_url="{{ banner.cta_url }}"
+                                     cta_url="{% if banner.cta_url %}{{ banner_cta_url }}{% endif %}"
                                      on_dismiss="fetch('{{ banner_dismiss_url }}', {method: 'POST', headers: {'X-CSRFToken': '{{ csrf_token }}', 'Content-Type': 'application/json'}, body: JSON.stringify({banner_id: '{{ banner.id }}'})})"
                                      id="site-banner-{{ banner.id }}">
                 {{ banner.text }}

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -298,18 +298,21 @@ class TestTheShellStillDraws:
         assert 'name="gang_type"' in page
         assert "Escher (HoB)" in page
 
-    def test_the_sample_banners_button_leads_somewhere_answerable(self, reader):
-        """The button is drawn from a banner nobody stored, so following
-        it finds nothing — but it has to be able to say so.
+    def test_the_sample_banner_draws_a_button_that_answers(self, reader):
+        """A bar with a call to action is the thing this page is here to
+        show, and the button has to survive being followed.
 
-        The shell sends the call to action by way of the click tracker,
-        which looks the banner up by primary key. Given an id that is not
-        shaped like one, that lookup raises instead of answering, and the
-        gallery's own demo button becomes a server error.
+        The shell sends it by way of the click tracker, whose address
+        accepts none but a real id — so a sample id that is merely a word
+        is an address that cannot be built, and takes every shell page
+        down with it. Nothing is stored under the sample's id, so
+        following it finds nothing, which it must be able to say.
         """
         page = reader.get("/n26/design/shell/").content.decode()
         start = page.index("n26-announcement")
         bar = page[start : page.index("</aside>", start)]
+
+        assert "n26-announcement-cta" in bar
         href = bar.split('href="')[1].split('"')[0]
 
         assert reader.get(href).status_code == 404

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -298,6 +298,22 @@ class TestTheShellStillDraws:
         assert 'name="gang_type"' in page
         assert "Escher (HoB)" in page
 
+    def test_the_sample_banners_button_leads_somewhere_answerable(self, reader):
+        """The button is drawn from a banner nobody stored, so following
+        it finds nothing — but it has to be able to say so.
+
+        The shell sends the call to action by way of the click tracker,
+        which looks the banner up by primary key. Given an id that is not
+        shaped like one, that lookup raises instead of answering, and the
+        gallery's own demo button becomes a server error.
+        """
+        page = reader.get("/n26/design/shell/").content.decode()
+        start = page.index("n26-announcement")
+        bar = page[start : page.index("</aside>", start)]
+        href = bar.split('href="')[1].split('"')[0]
+
+        assert reader.get(href).status_code == 404
+
     def test_the_equip_shell_draws_a_listing_with_a_group_of_options(self, reader):
         """One line in the sample catalogue offers alternatives at
         purchase — a mount and its weapon swaps — so this is where that

--- a/n26/designsystem/views.py
+++ b/n26/designsystem/views.py
@@ -202,8 +202,16 @@ def view_preview(request, slug):
 
 #: The banner every shell page carries, so the region above the nav is drawn
 #: rather than assumed. Nothing here is stored: a real site banner is a model.
+#:
+#: The id has to be shaped like a real one. The shell builds the call to
+#: action's address from it, and the route it builds leads to a lookup by
+#: primary key — handed something that is not a UUID, that lookup raises
+#: rather than answering "no such banner", so a word here turns the demo
+#: button into a server error. Nothing is stored under this id, so following
+#: it finds nothing, which is the right answer for a banner that is drawn to
+#: be looked at.
 _SHELL_BANNER = {
-    "id": "preview",
+    "id": "3f47d1a0-0000-4000-8000-000000000001",
     "colour": "info",
     "text": "The site banner sits above the nav, where it cannot be missed.",
     "cta_text": "Read the notes",

--- a/n26/designsystem/views.py
+++ b/n26/designsystem/views.py
@@ -204,12 +204,10 @@ def view_preview(request, slug):
 #: rather than assumed. Nothing here is stored: a real site banner is a model.
 #:
 #: The id has to be shaped like a real one. The shell builds the call to
-#: action's address from it, and the route it builds leads to a lookup by
-#: primary key — handed something that is not a UUID, that lookup raises
-#: rather than answering "no such banner", so a word here turns the demo
-#: button into a server error. Nothing is stored under this id, so following
-#: it finds nothing, which is the right answer for a banner that is drawn to
-#: be looked at.
+#: action's address from it, and that address accepts none but a UUID, so a
+#: word here is an address that cannot be built and every shell page raises.
+#: Nothing is stored under this id, so following it finds nothing, which is
+#: the right answer for a banner that is drawn to be looked at.
 _SHELL_BANNER = {
     "id": "3f47d1a0-0000-4000-8000-000000000001",
     "colour": "info",

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -781,6 +781,18 @@ class TestTheEditionToggle:
         assert 'aria-label="Edition"' not in client.get("/").content.decode()
 
 
+def announcement_bar(body):
+    """The site announcement's own markup, cut out of a rendered page.
+
+    The closing tag is searched for from the bar's start rather than
+    from the top of the document: an <aside> anywhere above it would
+    otherwise invert the slice into an empty string, and every "not in
+    the bar" assertion below would hold for the wrong reason.
+    """
+    start = body.index("n26-announcement")
+    return body[start : body.index("</aside>", start)]
+
+
 class TestTheSiteBanner:
     """The platform's banner, drawn in this edition's terms.
 
@@ -920,7 +932,7 @@ class TestTheSiteBanner:
         # The page is the one that holds an `action`, and its form still
         # posts there — the address belongs in the form, not in the bar.
         assert f'action="{skills_url}' in body
-        bar = body[body.index("n26-announcement") : body.index("</aside>")]
+        bar = announcement_bar(body)
         assert "N26 support is coming." in bar
         assert skills_url not in bar
 
@@ -951,7 +963,7 @@ class TestTheSiteBanner:
         body = client.get("/n26/").content.decode()
         assert "N26 support is coming." in body
 
-        bar = body[body.index("n26-announcement") : body.index("</aside>")]
+        bar = announcement_bar(body)
         dismiss_url = reverse("core:dismiss-banner")
         assert dismiss_url in bar
         # The id the expression posts, not merely the one in the wrapper's
@@ -990,7 +1002,7 @@ class TestTheSiteBanner:
         banner = live_banner(cta_text="Read the notes", cta_url="https://example.com")
 
         body = client.get("/n26/").content.decode()
-        bar = body[body.index("n26-announcement") : body.index("</aside>")]
+        bar = announcement_bar(body)
         tracked = reverse("core:track-banner-click", kwargs={"id": banner.id})
         assert f'href="{tracked}"' in bar
         assert 'href="https://example.com"' not in bar
@@ -1017,7 +1029,7 @@ class TestTheSiteBanner:
         live_banner(cta_text="Read the notes", cta_url="")
 
         body = client.get("/n26/").content.decode()
-        bar = body[body.index("n26-announcement") : body.index("</aside>")]
+        bar = announcement_bar(body)
         assert "Read the notes" not in bar
         assert "n26-announcement-cta" not in bar
 

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -969,6 +969,58 @@ class TestTheSiteBanner:
 
         assert "N26 support is coming." not in client.get("/n26/").content.decode()
 
+    def test_the_call_to_action_is_counted(
+        self, tester, client, default_pack, live_banner
+    ):
+        """A banner advertising something reported no interest from this
+        edition at all, however many readers followed it.
+
+        The bar's button pointed at the banner's own address, so the
+        click went straight there and the site counted nothing. It goes
+        by way of the platform's tracker instead, which records the click
+        against the banner and then sends the reader on. The count is the
+        site's — one banner is shown above both editions, and a click on
+        it is a click on it.
+        """
+        from django.urls import reverse
+
+        from gyrinx.analytics.models import Event, EventVerb
+        from gyrinx.analytics.nouns import PlatformNoun
+
+        banner = live_banner(cta_text="Read the notes", cta_url="https://example.com")
+
+        body = client.get("/n26/").content.decode()
+        bar = body[body.index("n26-announcement") : body.index("</aside>")]
+        tracked = reverse("core:track-banner-click", kwargs={"id": banner.id})
+        assert f'href="{tracked}"' in bar
+        assert 'href="https://example.com"' not in bar
+
+        # Following it still arrives where the banner said it would.
+        followed = client.get(tracked)
+        assert followed.status_code == 302
+        assert followed.url == "https://example.com"
+
+        assert Event.objects.filter(
+            noun=PlatformNoun.BANNER,
+            verb=EventVerb.CLICK,
+            object_id=banner.id,
+        ).exists()
+
+    def test_a_banner_with_nowhere_to_go_draws_no_button(
+        self, tester, client, default_pack, live_banner
+    ):
+        """The tracker sends a banner holding no address of its own to the
+        site's home, so a bar handed a tracker link regardless would offer
+        a button leading out of the edition to a page the banner never
+        named.
+        """
+        live_banner(cta_text="Read the notes", cta_url="")
+
+        body = client.get("/n26/").content.decode()
+        bar = body[body.index("n26-announcement") : body.index("</aside>")]
+        assert "Read the notes" not in bar
+        assert "n26-announcement-cta" not in bar
+
 
 class TestTheSharedIconKeys:
     """gyrinx/site/icons.py names an n26 icon for every key, as a string,


### PR DESCRIPTION
The site banner's call-to-action button in n26 linked straight at the banner's own address, so following it went directly there and the site recorded nothing. A banner advertising something therefore reported no interest at all from n26 pages, however many readers clicked it. n23 has always routed this through the click tracker.

- The n26 shell (`n26/core/templates/n26/layouts/base.html`) now points the CTA at `core:track-banner-click`, the same route n23 uses. It logs the click against the banner and redirects to the banner's address, so the reader ends up in the same place.
- The tracker is only used when the banner actually has an address. It redirects a banner with no address of its own to the site's home page, so linking there unconditionally would turn "this banner has no call to action" into a button leading out of the edition to a page nobody chose.
- Clicks are recorded against the platform rather than either edition, matching how the endpoint already behaves — one banner is shown above both editions.

Two related fixes came out of reviewing the above.

**The gallery's sample banner needed a real id.** The design-system shell pages feed the layout a sample banner that is a plain dict rather than a stored row, and its id was the word `preview`. Building the CTA from the tracker route turned that into `/banner/preview/click/`, and following it raised out of the banner lookup — a server error on every `/n26/design/shell/*` page. The sample now carries a UUID-shaped id, so the demo button finds nothing and says so.

**A hand-typed banner address returned a server error.** The tracker's route accepted any text where the id goes, and the view hands it straight to a lookup by primary key, which raises on anything that is not a UUID. `/banner/nonsense/click/` was a 500 rather than a 404, and filed an error report each time. The route now matches the id as a UUID, so anything else fails to route. Every real link carries a real id and is unaffected. This one was reachable in production before this branch existed.

## Test plan

- [x] `pytest` — 7731 passed, 12 skipped
- [x] Every new test checked against the unfixed code and confirmed to fail: the CTA tracking, the empty-address guard, the gallery's demo button, and the malformed address
- [x] Checked in a real browser: the CTA on `/n26/` points at `/banner/<id>/click/`, clicking it lands on the banner's destination, and one `banner`/`click` event is recorded

## To try it

Create a live banner in the admin with `live_n26` set and both a CTA text and CTA URL, open `/n26/`, and click the button. It should land on the CTA URL, and the click should show up as a banner click event.