### PR TITLE
feat: the content sync covers the n26 library, and the modifiers page filters by reach

### DIFF
--- a/docs/operations/content-data-management.md
+++ b/docs/operations/content-data-management.md
@@ -99,6 +99,7 @@ When you first set up Gyrinx locally:
 gsutil cp gs://gyrinx-app-bootstrap-dump/latest.json .
 
 # Import it
+manage migrate
 manage loaddata_overwrite latest.json --verbose
 ```
 
@@ -111,6 +112,7 @@ Need to investigate a content issue from production?
 gsutil cp gs://gyrinx-app-bootstrap-dump/latest.json .
 
 # Import with verbose output to see what's happening
+manage migrate
 manage loaddata_overwrite latest.json --verbose
 
 # Poke around

--- a/docs/operations/content-data-management.md
+++ b/docs/operations/content-data-management.md
@@ -121,7 +121,7 @@ manage shell
 
 ## Warnings
 
-- **This deletes all your local content data** - The command wipes content models before importing
+- **This deletes your local content data** - The command wipes every model the fixture names before importing. A kind with no rows in the export at all is absent from the fixture, so local rows of that kind survive — do not rely on the overwrite to clear content the production library has none of
 - **Local gangs that used locally-authored content dangle** - A gang built against content you authored locally will reference rows the overwrite deleted. Delete those gangs, or expect broken references
 - **Don't commit latest.json** - It's already in .gitignore, keep it that way
 - **Need access** - You must be a trusted developer with GCS permissions

--- a/docs/operations/content-data-management.md
+++ b/docs/operations/content-data-management.md
@@ -23,6 +23,19 @@ The export uses the `gyrinx-dumpdata` Cloud Run job in production:
 3. Find and run the `gyrinx-dumpdata` job
 4. The job exports all content data to `latest.json` in the `gyrinx-app-bootstrap-dump` bucket
 
+The job runs, inside the production app image:
+
+```bash
+manage dumpdata contenttypes content pages flatpages library -o /dump/latest.json
+```
+
+That covers both editions' content: `content` is the n23 content app, and
+`library` is the n26 content library (every kind, including modifiers,
+their scopes and conditions, statlines, collections, defaults, and the
+slots-and-picks models). If this list changes, change it with
+`gcloud run jobs update gyrinx-dumpdata --region=europe-west2 --command=manage --args=…`
+and update this page — the job's definition lives only in Cloud Run.
+
 Or use the gcloud CLI:
 
 ```bash
@@ -42,12 +55,28 @@ gsutil cp gs://gyrinx-app-bootstrap-dump/latest.json .
 The `loaddata_overwrite` command replaces your local content with the production data:
 
 ```bash
+# Migrate first: the fixture was dumped from production's schema, so your
+# database must be at least as new before loading
+manage migrate
+
 # Check what will be changed first
 manage loaddata_overwrite latest.json --dry-run
 
 # Actually import the data
 manage loaddata_overwrite latest.json
 ```
+
+### Worktrees
+
+Load into the **main** worktree, whose `gyrinx_main` database is the
+template every child worktree forks from. A child worktree picks the new
+content up with:
+
+```bash
+./scripts/dev.sh --reset-db
+```
+
+An existing child database keeps whatever it forked with until it is reset.
 
 ## What loaddata_overwrite Does
 
@@ -91,6 +120,7 @@ manage shell
 ## Warnings
 
 - **This deletes all your local content data** - The command wipes content models before importing
+- **Local gangs that used locally-authored content dangle** - A gang built against content you authored locally will reference rows the overwrite deleted. Delete those gangs, or expect broken references
 - **Don't commit latest.json** - It's already in .gitignore, keep it that way
 - **Need access** - You must be a trusted developer with GCS permissions
 - **Big file** - The export can be large, depending on how much content exists

--- a/docs/useful-scripts.md
+++ b/docs/useful-scripts.md
@@ -108,8 +108,11 @@ manage ensuresuperuser
 
 ### `manage loaddata_overwrite`
 
-Loads Django fixtures with overwrite capability.
+Loads Django fixtures with overwrite capability. Run `manage migrate`
+first: the fixture was dumped from production's schema, so the database
+must be at least as new before loading.
 
 ```bash
+manage migrate
 manage loaddata_overwrite <fixture_name>
 ```

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -2412,8 +2412,9 @@ def modifiers(request):
     narrow what is already here rather than asking the server again —
     the page's cost is the same whichever of them is on.
     """
+    from n26.library.forms import SCOPE_MODELS, _scope_verb, _verb_label
     from n26.library.models import Modifier
-    from n26.library.models.modifier import EFFECT_FIELDS, SCOPE_FIELDS
+    from n26.library.models.modifier import EFFECT_FIELDS
 
     every = list(_reading_sentences(Modifier.objects.all()))
     counts = _carrier_counts(every)
@@ -2433,7 +2434,11 @@ def modifiers(request):
                 "label": modifier.name,
                 "notes": notes,
                 "facets": {
-                    "scope": _which(modifier, SCOPE_FIELDS),
+                    # By the reach the author picked, not the column: one
+                    # scope model holds two options, and a filter lumping
+                    # "the gang carrying it" with "…and all models" would
+                    # filter for neither.
+                    "scope": _scope_verb(modifier.scope),
                     "effect": _which(modifier, EFFECT_FIELDS),
                     "carried": "carried" if carriers else "uncarried",
                     # What the search reads. Lowercased here so the
@@ -2449,7 +2454,15 @@ def modifiers(request):
         {
             "rows": rows,
             "count": len(rows),
-            "scope_options": _facet_options(rows, "scope", _kind_labels(SCOPE_FIELDS)),
+            "scope_options": _facet_options(
+                rows,
+                "scope",
+                # The composer's own card names, one option per reach.
+                [
+                    (name, capfirst(_verb_label(name, SCOPE_MODELS.get(name))))
+                    for name in SCOPE_MODELS
+                ],
+            ),
             "effect_options": _facet_options(
                 rows, "effect", _kind_labels(EFFECT_FIELDS)
             ),

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -28,7 +28,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.utils.text import capfirst
 
 from n26.library.forms import generate_form, statline_form_for, suggestion_form_for
 from n26.library.models.assignable import Family
@@ -2358,34 +2357,6 @@ CARRIED_LABELS = (
 )
 
 
-def _which(modifier, fields):
-    """Which of these columns holds this modifier's row.
-
-    Exactly one does — the database refuses anything else — and its
-    name is what a facet filters on. Read off the id, so naming it
-    costs nothing and does not depend on the sentence, which an
-    author's conditions can word any number of ways.
-    """
-    return next(name for name in fields if getattr(modifier, f"{name}_id") is not None)
-
-
-def _kind_labels(fields):
-    """How a facet names each scope or effect kind.
-
-    The models' own verbose names, so a new kind arrives on the filter
-    labelled as it is everywhere else and nobody writes the word twice.
-    """
-    from n26.library.models import Modifier
-
-    return [
-        (
-            name,
-            capfirst(Modifier._meta.get_field(name).related_model._meta.verbose_name),
-        )
-        for name in fields
-    ]
-
-
 def _facet_options(rows, key, labels):
     """The facet's options, narrowed to the values these rows actually
     hold.
@@ -2412,9 +2383,13 @@ def modifiers(request):
     narrow what is already here rather than asking the server again —
     the page's cost is the same whichever of them is on.
     """
-    from n26.library.forms import SCOPE_MODELS, _scope_verb, _verb_label
+    from n26.library.forms import (
+        _effect_choices,
+        _effect_verb,
+        _scope_choices,
+        _scope_verb,
+    )
     from n26.library.models import Modifier
-    from n26.library.models.modifier import EFFECT_FIELDS
 
     every = list(_reading_sentences(Modifier.objects.all()))
     counts = _carrier_counts(every)
@@ -2434,12 +2409,12 @@ def modifiers(request):
                 "label": modifier.name,
                 "notes": notes,
                 "facets": {
-                    # By the reach the author picked, not the column: one
-                    # scope model holds two options, and a filter lumping
-                    # "the gang carrying it" with "…and all models" would
-                    # filter for neither.
+                    # By the verb the author picked, not the column: one
+                    # model can hold two verbs — the two gang reaches,
+                    # the two placements — and a filter keyed on the
+                    # column would lump each pair and filter for neither.
                     "scope": _scope_verb(modifier.scope),
-                    "effect": _which(modifier, EFFECT_FIELDS),
+                    "effect": _effect_verb(modifier.effect),
                     "carried": "carried" if carriers else "uncarried",
                     # What the search reads. Lowercased here so the
                     # comparison is a plain substring test in the browser.
@@ -2454,18 +2429,10 @@ def modifiers(request):
         {
             "rows": rows,
             "count": len(rows),
-            "scope_options": _facet_options(
-                rows,
-                "scope",
-                # The composer's own card names, one option per reach.
-                [
-                    (name, capfirst(_verb_label(name, SCOPE_MODELS.get(name))))
-                    for name in SCOPE_MODELS
-                ],
-            ),
-            "effect_options": _facet_options(
-                rows, "effect", _kind_labels(EFFECT_FIELDS)
-            ),
+            # The composer's own choices, so the filter and the WHO/WHAT
+            # pickers stay one vocabulary.
+            "scope_options": _facet_options(rows, "scope", _scope_choices()),
+            "effect_options": _facet_options(rows, "effect", _effect_choices()),
             "carried_options": _facet_options(rows, "carried", CARRIED_LABELS),
         },
     )

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -4614,7 +4614,7 @@ class TestFindingAModifierAmongHundreds:
             "targets_model",
             "targets_weapons",
         }
-        assert {row["effect"] for row in rows} == {"adds_assignable", "changes_stat"}
+        assert {row["effect"] for row in rows} == {"ef_adds", "ef_changes_stat"}
 
     def test_every_row_says_whether_anything_holds_it(self, assorted, client):
         rows = self.facets(client)
@@ -4629,8 +4629,8 @@ class TestFindingAModifierAmongHundreds:
             "targets_weapons",
         ]
         assert [option["value"] for option in self.options(client, "effect")] == [
-            "adds_assignable",
-            "changes_stat",
+            "ef_adds",
+            "ef_changes_stat",
         ]
         assert [option["value"] for option in self.options(client, "carried")] == [
             "carried",
@@ -4672,7 +4672,64 @@ class TestFindingAModifierAmongHundreds:
 
         assert by_value["targets_model"] == "The model carrying it"
         assert by_value["targets_weapons"] == "The model's weapons"
-        assert by_value["changes_stat"] == "Changes stat"
+        assert by_value["ef_changes_stat"] == "Changes a stat"
+
+    def test_every_verb_wears_its_own_card_label(self, author, client, default_pack):
+        """One modifier per scope verb and one per placement verb: the
+        facet offers every option under its composer card name, keyed by
+        verb — a column-keyed facet would lump the pairs that share a
+        model."""
+        from n26.library.authoring import (
+            create_category,
+            create_collection,
+            create_rule,
+            create_trait,
+            ef_adds,
+            ef_places,
+            ef_places_choice,
+            modifier,
+            targets_attached_weapon,
+            targets_every_model,
+            targets_gang,
+            targets_gang_alone,
+            targets_model,
+            targets_weapons,
+        )
+        from n26.tests.sandbox.actions import section_of
+
+        scopes = {
+            "targets_model": targets_model(),
+            "targets_every_model": targets_every_model(),
+            "targets_weapons": targets_weapons(),
+            "targets_attached_weapon": targets_attached_weapon(),
+            "targets_gang": targets_gang(),
+            "targets_gang_alone": targets_gang_alone(),
+        }
+        for name, scope in scopes.items():
+            thing = (
+                create_trait(f"For {name}")
+                if name in ("targets_weapons", "targets_attached_weapon")
+                else create_rule(f"For {name}")
+            )
+            modifier(f"Via {name}", scope, ef_adds(thing))
+        collection = create_collection("Skills & Powers")
+        tier = section_of(collection, "Primary", 0, is_default=True)
+        family = create_category("Skills", "Combat")
+        modifier("Placed outright", targets_model(), ef_places(family, tier))
+        modifier("Placed as chosen", targets_model(), ef_places_choice(tier))
+
+        by_value = {
+            option["value"]: option["label"]
+            for option in self.options(client, "scope") + self.options(client, "effect")
+        }
+        assert by_value["targets_model"] == "The model carrying it"
+        assert by_value["targets_every_model"] == "All models in the gang"
+        assert by_value["targets_weapons"] == "The model's weapons"
+        assert by_value["targets_attached_weapon"] == "The weapon it's fitted to"
+        assert by_value["targets_gang"] == "The gang carrying it and all models"
+        assert by_value["targets_gang_alone"] == "The gang carrying it"
+        assert by_value["ef_places"] == "Puts a category into a section"
+        assert by_value["ef_places_choice"] == "Puts the player's choice into a section"
 
     def test_the_two_gang_reaches_filter_apart(self, author, client, default_pack):
         """A modifier kept the gang's alone is not found under the

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -4611,7 +4611,7 @@ class TestFindingAModifierAmongHundreds:
         rows = self.facets(client)
 
         assert {row["scope"] for row in rows} == {
-            "targets_miniature",
+            "targets_model",
             "targets_weapons",
         }
         assert {row["effect"] for row in rows} == {"adds_assignable", "changes_stat"}
@@ -4625,7 +4625,7 @@ class TestFindingAModifierAmongHundreds:
 
     def test_each_facet_offers_the_values_the_rows_hold(self, assorted, client):
         assert [option["value"] for option in self.options(client, "scope")] == [
-            "targets_miniature",
+            "targets_model",
             "targets_weapons",
         ]
         assert [option["value"] for option in self.options(client, "effect")] == [
@@ -4654,24 +4654,50 @@ class TestFindingAModifierAmongHundreds:
         modifier("Grants Mounted", targets_model(), ef_adds(create_subtype("Mounted")))
 
         assert [option["value"] for option in self.options(client, "scope")] == [
-            "targets_miniature"
+            "targets_model"
         ]
         body = client.get("/n26/authoring/modifiers/").content.decode()
         assert "Reaches" not in body
         assert "Does" not in body
 
-    def test_the_menus_are_named_in_the_models_own_words(self, assorted, client):
-        """A facet's labels are the scope and effect models' verbose
-        names, so a new kind arrives on the filter reading as it does
-        everywhere else."""
+    def test_the_menus_are_named_as_the_composer_names_them(self, assorted, client):
+        """The Reaches facet offers one option per reach, in the
+        composer's own card words — one scope model holds two reaches,
+        so the column's verbose name cannot tell them apart. Effects
+        keep the models' verbose names."""
         by_value = {
             option["value"]: option["label"]
             for option in self.options(client, "scope") + self.options(client, "effect")
         }
 
-        assert by_value["targets_miniature"] == "Targets the model"
-        assert by_value["targets_weapons"] == "Targets weapons"
+        assert by_value["targets_model"] == "The model carrying it"
+        assert by_value["targets_weapons"] == "The model's weapons"
         assert by_value["changes_stat"] == "Changes stat"
+
+    def test_the_two_gang_reaches_filter_apart(self, author, client, default_pack):
+        """A modifier kept the gang's alone is not found under the
+        gang-and-all-models filter, and each option wears its own card
+        label."""
+        from n26.library.authoring import (
+            create_rule,
+            ef_adds,
+            modifier,
+            targets_gang,
+            targets_gang_alone,
+        )
+
+        both = modifier("Gang rule", targets_gang(), ef_adds(create_rule("Loud")))
+        alone = modifier(
+            "Quiet rule", targets_gang_alone(), ef_adds(create_rule("Quiet"))
+        )
+
+        response = client.get("/n26/authoring/modifiers/")
+        facets = {row["pk"]: row["facets"]["scope"] for row in response.context["rows"]}
+        assert facets[both.pk] == "targets_gang"
+        assert facets[alone.pk] == "targets_gang_alone"
+        by_value = {o["value"]: o["label"] for o in self.options(client, "scope")}
+        assert by_value["targets_gang"] == "The gang carrying it and all models"
+        assert by_value["targets_gang_alone"] == "The gang carrying it"
 
     def test_the_readout_counts_what_was_rendered(self, assorted, client):
         """The number above the list and the rows in it are computed

--- a/n26/tests/sandbox/test_specs.py
+++ b/n26/tests/sandbox/test_specs.py
@@ -83,6 +83,41 @@ class TestTheDiscoveringGuard:
         )
 
 
+class TestVerbTablesCoverTheColumns:
+    """``_scope_verb`` and ``_effect_verb`` read stored rows back to the
+    verb an author picked, ending in a bare lookup over these tables —
+    a scope or effect model missing from its table would 500 every page
+    that names a modifier's kind, so drift is refused here."""
+
+    def test_every_scope_column_is_covered(self):
+        from n26.library.forms import SCOPE_MODELS
+        from n26.library.models import Modifier
+        from n26.library.models.modifier import SCOPE_FIELDS
+
+        columns = {
+            Modifier._meta.get_field(name).related_model.__name__
+            for name in SCOPE_FIELDS
+        }
+        assert columns == set(SCOPE_MODELS.values())
+
+    def test_every_effect_column_is_covered(self):
+        from n26.library.forms import EFFECT_MODELS
+        from n26.library.models import Modifier
+        from n26.library.models.modifier import EFFECT_FIELDS
+
+        columns = {
+            Modifier._meta.get_field(name).related_model.__name__
+            for name in EFFECT_FIELDS
+        }
+        assert columns == set(EFFECT_MODELS.values())
+
+    def test_every_table_verb_has_a_spec(self):
+        from n26.library.forms import EFFECT_MODELS, SCOPE_MODELS
+
+        assert set(SCOPE_MODELS) <= set(specs())
+        assert set(EFFECT_MODELS) <= set(specs())
+
+
 def scope_conditions():
     """Every ``(scope model, relation)`` a condition row hangs on."""
     from n26.library.models import Modifier


### PR DESCRIPTION
## Summary

- The prod-to-local content sync now covers the n26 library: the `gyrinx-dumpdata` Cloud Run job dumps `library` alongside `contenttypes content pages flatpages`, and `docs/operations/content-data-management.md` records the job's exact command (its definition lives only in Cloud Run), the migrate-before-load step, the worktree template flow, and a warning about local gangs built on locally-authored content.
- The modifiers page's Reaches filter offers one option per reach, in the composer's own card words — it keyed on the scope column, so "Targets the gang" lumped "The gang carrying it and all models" with "The gang carrying it" and could filter for neither.

## Why

Gyrinx is being readied for a careful migration of content onto the n26 slots-and-picks system, and step one is being able to replicate the production content library locally. The sync's export list predated n26, so every n26 kind — modifiers, scopes, conditions, statlines, collections, defaults, slots and picks — was silently absent from `latest.json`. The import side (`loaddata_overwrite`) needed no code change: it wipes and reloads exactly the models the fixture names, n26's ULID keys serialise canonically, and n26 has no fixture-hostile signals.

## Test plan

- [x] Lossless local round trip: dump with `library` (24,393 rows) → `loaddata_overwrite` → re-dump → per-row comparison; zero rows missing or added, zero semantic field changes (only `.000Z` vs `Z` timestamp serialisation and unordered M2M list order)
- [x] Prod job updated and executed; the export (58,179 rows, 9,587 n26 library) loaded into a local database and spot-checked (modifier, archetype and affiliation counts; reach values match the audited conversion)
- [x] Full n26 suite green (3,459), including a new test proving the two gang reaches filter apart and the facet labels match the composer's cards

No open issue covers this; it is the first step of the maintainer's n26 content-migration planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8
