### PR TITLE
feat: what a mount was bought with can be changed afterwards

### DIFF
--- a/n26/core/browse.py
+++ b/n26/core/browse.py
@@ -245,7 +245,7 @@ def browse(collection, terms=EQUIPMENT_LIST):
                     charges_trade_points=terms.charges_trade_points,
                     shows_trade_points=in_trade_points,
                     parts=_swept_parts(thing, terms, in_trade_points),
-                    choices=_offered_choices(thing),
+                    choices=offered_choices(thing),
                 ),
             )
 
@@ -310,7 +310,7 @@ def browse(collection, terms=EQUIPMENT_LIST):
                 parts=_entry_parts(
                     ammo.get(entry.weapon_id, ()), terms, in_trade_points
                 ),
-                choices=_offered_choices(thing),
+                choices=offered_choices(thing),
             ),
         )
 
@@ -385,14 +385,14 @@ def all_gear(name, terms=EQUIPMENT_LIST):
                         is_exclusive=price.is_exclusive,
                         charges_trade_points=terms.charges_trade_points,
                         parts=_swept_parts(thing, terms, False),
-                        choices=_offered_choices(thing),
+                        choices=offered_choices(thing),
                     ),
                 )
             )
     return _sectioned(name, lines)
 
 
-def _offered_choices(thing):
+def offered_choices(thing):
     """The sets of alternatives this thing puts to a buyer.
 
     Read off the same offer a hire reads (``Optioned.grouped_offers``), so

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -165,7 +165,14 @@ class GroupOption:
     name: str
     value: str
     surcharge: int
+    #: Whether this is the one its set takes unasked. A fact about the
+    #: offer, true wherever the offer is drawn.
     is_default: bool
+    #: Whether this control arrives already picked. A question about
+    #: *this* drawing rather than about the offer: buying starts on the
+    #: standard one, and changing what something already holds starts on
+    #: what it holds.
+    checked: bool = False
 
     @property
     def surcharge_label(self):
@@ -191,6 +198,11 @@ class PickGroup:
     #: The input every option in this group shares.
     field: str
     options: tuple[GroupOption, ...]
+    #: Whether the control for taking nothing from this set is the one
+    #: picked. Radios cannot be unclicked, so a one-or-none set draws a
+    #: "None" beside its options, and this says whether that is where it
+    #: starts.
+    nothing_taken: bool = True
 
 
 @dataclass(frozen=True)
@@ -347,12 +359,18 @@ def _options_of(line, key):
     )
 
 
-def _choices_of(line, key):
-    """The line's offered alternatives as controls, in the line's own order.
+def pick_groups(offered, key, taken=None):
+    """Offered alternatives as controls, in the offer's own order.
 
     The order is load-bearing: a control submits its place in the set and
-    the purchase reads that place against the line it re-derives, so this
-    walks the browsed line and never a second derivation of it.
+    whatever answers the form reads that place against the offer it
+    re-derives, so this walks one derivation of the offer and never a
+    second.
+
+    ``taken`` is the sets something already holds, where it holds any: the
+    same controls, starting on what it took rather than on what a buyer
+    would be handed. Left out — which is what a row for sale means — each
+    set starts on the one taken unasked.
     """
     return tuple(
         PickGroup(
@@ -364,11 +382,24 @@ def _choices_of(line, key):
                     value=str(position),
                     surcharge=option.surcharge,
                     is_default=option.is_default,
+                    checked=(
+                        option.is_default
+                        if taken is None
+                        else option.default_set is not None
+                        and option.default_set.pk in taken
+                    ),
                 )
                 for position, option in enumerate(group.options)
             ),
+            nothing_taken=(
+                taken is None
+                or not any(
+                    option.default_set is not None and option.default_set.pk in taken
+                    for option in group.options
+                )
+            ),
         )
-        for index, group in enumerate(line.choices)
+        for index, group in enumerate(offered)
     )
 
 
@@ -389,7 +420,7 @@ def listing_row(line):
         # collection and finds the line itself, so a tampered form can
         # name nothing that is not on the list.
         buy=Action(label="Buy", kind=SUBMIT, target=key, tone=PRIMARY),
-        choices=_choices_of(line, key),
+        choices=pick_groups(line.choices, key),
     )
 
 
@@ -439,6 +470,14 @@ def copy_row(copy, refunds=True):
             else None
         ),
         more=(
+            # First, and only where the content asks anything: the one act
+            # here that leaves the fighter holding what they held, so it
+            # reads before the ways of parting with it.
+            *(
+                (Action("Change options", LINK, copy.rechoose_href, SECONDARY),)
+                if copy.rechoose_href
+                else ()
+            ),
             Action("Reassign", LINK, copy.reassign_href, SECONDARY),
             *(
                 (Action("Refund", LINK, copy.refund_href, SECONDARY),)

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -44,13 +44,14 @@ from n26.library.models.assignable import Family
 #: the controls and the view that answers the URL behind them, so neither
 #: can invent a question the other does not know.
 #:
-#: Three of them confirm something about the assignment named. The fourth
-#: asks a question instead — which accessory to bolt onto the weapon named
-#: — and it sits here because it is the same sort of state: one assignment
-#: on this card, open because the address says so, closed by going back to the
-#: address without it. A screen draws one at a time, so a URL naming two
-#: draws whichever comes first here.
-DIALOGS = ("sell", "reassign", "refund", "remove", "accessorise")
+#: Three of them confirm something about the assignment named. The last
+#: two ask a question instead — which accessory to bolt onto the weapon
+#: named, and which of its alternatives a thing is taken with — and they
+#: sit here because they are the same sort of state: one assignment on
+#: this card, open because the address says so, closed by going back to
+#: the address without it. A screen draws one at a time, so a URL naming
+#: two draws whichever comes first here.
+DIALOGS = ("sell", "reassign", "refund", "remove", "accessorise", "rechoose")
 
 
 def with_query(url, **params):
@@ -146,11 +147,27 @@ class OwnedThing:
     #: an accessory hangs off the gun it changes, so nothing else on a
     #: card is somewhere to fit one.
     accessorise_href: str = ""
+    #: Where to go to take this with different options. Only something
+    #: whose content offers a choice has one: everything else would be a
+    #: click onto a panel with nothing to pick.
+    rechoose_href: str = ""
     #: What this copy was taken with, named as the buyer was offered it.
     #: Per copy and not per content: two of the same mount may carry
     #: different guns. Empty for anything that offered no choice, which
     #: is most of what a model owns.
     chosen: tuple[str, ...] = ()
+
+
+def _offers_a_choice(thing):
+    """Whether this content puts alternatives in front of anyone.
+
+    The same test the buying screen makes of a line, asked here of a copy
+    already held: a set with nothing to pick was taken unasked, and a way
+    to change it would open onto a panel offering one thing.
+    """
+    from n26.library.models.assignable import Optioned
+
+    return isinstance(thing, Optioned) and thing.offers_a_choice
 
 
 def _chosen_of(node):
@@ -286,6 +303,11 @@ def owned_things(card, at):
                 accessorise_href=(
                     with_query(at, accessorise=pk)
                     if isinstance(node.assignable, Weapon)
+                    else ""
+                ),
+                rechoose_href=(
+                    with_query(at, rechoose=pk)
+                    if _offers_a_choice(node.assignable)
                     else ""
                 ),
                 chosen=_chosen_of(node),

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -99,6 +99,8 @@ else about them is the same panel as the four confirmations.
                 {{ dialog.sum }} It leaves the card with anything attached to it,
                 and stops counting towards the gang's rating.
             {% endif %}
+        {% elif dialog.kind == "rechoose" %}
+            You will be charged or refunded the difference.
         {% elif dialog.kind == "reassign" %}
             Where it lives changes; what it is worth does not — a move never
             re-prices.
@@ -122,6 +124,18 @@ else about them is the same panel as the four confirmations.
     should land where the question was asked, not at the top of the first tab.
     {% endcomment %}
     {% if dialog.section %}<input type="hidden" name="section" value="{{ dialog.section }}">{% endif %}
+
+    {% comment %}
+    The same controls the row for sale draws, starting on what this copy took.
+    Drawn by the listing's own include so a set is asked about in one way
+    wherever it is asked about, and read back as places in the offer the server
+    re-derives.
+    {% endcomment %}
+    {% if dialog.kind == "rechoose" %}
+        <div class="-my-0.5">
+            {% include "n26/includes/equip_choices.html" with choices=dialog.choices %}
+        </div>
+    {% endif %}
 
     {% if dialog.kind == "accessorise" %}
         {% comment %}

--- a/n26/core/templates/n26/includes/equip_choices.html
+++ b/n26/core/templates/n26/includes/equip_choices.html
@@ -1,7 +1,12 @@
 {% comment %}
-The questions a row asks before it will sell you the thing: a mount's grenade
-launchers or, for a surcharge, its plasma guns. Expects `row` — an
-n26.core.listing.Listing.
+The questions asked about a thing with alternatives: a mount's grenade
+launchers or, for a surcharge, its plasma guns. Expects `choices` — a tuple of
+n26.core.listing.PickGroup.
+
+Drawn both where the thing is for sale and where one already held is being
+changed. Which control starts picked is the structure's answer either way
+(`option.checked`, `group.nothing_taken`), so the two readings are made in one
+place and this draws whichever it is handed.
 
 Controls rather than a second row on the list, because that is what they are: a
 mount's guns are not a thing you buy from this screen, they are a way the mount
@@ -11,9 +16,8 @@ page — same three modes, drawn the same way, read back the same way as indices
 into the row the server re-derives.
 
 Which control is not a style choice: the set's `choose` says whether exactly one
-is taken (radios, the standard one already selected), any number (tick boxes,
-none selected), or at most one (radios with a None row). Nothing here decides it
-again.
+is taken (radios), any number (tick boxes), or at most one (radios with a None
+row). Nothing here decides it again.
 
 A set is never named. The label the content carries is the author's word for
 their own page, and a player is here to pick — so a set is shown as grouping,
@@ -28,7 +32,7 @@ Works with no script running: every control posts its own value and the server
 does the arithmetic when the purchase is made. What is lost without one is the
 price box updating as the radios move.
 {% endcomment %}
-{% for group in row.choices %}
+{% for group in choices %}
     {% comment %}
     Every set after the first says how many to take, and its options step in
     from that label — the two together are how a reader is told where one set's
@@ -58,7 +62,7 @@ price box updating as the radios move.
             <input type="{% if group.choose == 'any' %}checkbox{% else %}radio{% endif %}"
                    name="{{ group.field }}"
                    value="{{ option.value }}"
-                   {% if option.is_default %}checked{% endif %}
+                   {% if option.checked %}checked{% endif %}
                    class="size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
             <span class="min-w-0 text-sm text-ink-900 dark:text-ink-100 sm:truncate">{{ option.name }}</span>
             {% if option.surcharge_label %}
@@ -67,17 +71,18 @@ price box updating as the radios move.
         </label>
     {% endfor %}
     {% comment %}
-    A one-or-none set starts with nothing taken, and radios cannot be unclicked
-    once clicked — so "None" is the option that makes taking nothing clickable,
-    checked from the start and adding nothing. Its empty value is what the
-    purchase skips.
+    Radios cannot be unclicked once clicked, so "None" is the option that makes
+    taking nothing clickable, and it adds nothing. Whether it is where the set
+    starts is the group's answer: a row for sale takes nothing from such a set,
+    and one already held starts on whatever it holds. Its empty value is what
+    the answer skips.
     {% endcomment %}
     {% if group.choose == "one-or-none" %}
         <label class="flex min-h-9 cursor-pointer items-center gap-2 rounded-control py-0.5 hover:bg-ink-500/5 {% if not forloop.first %}n26-cp-substep{% endif %}">
             <input type="radio"
                    name="{{ group.field }}"
                    value=""
-                   checked
+                   {% if group.nothing_taken %}checked{% endif %}
                    class="size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
             <span class="min-w-0 text-sm text-ink-900 dark:text-ink-100 sm:truncate">None</span>
         </label>

--- a/n26/core/templates/n26/includes/equip_line.html
+++ b/n26/core/templates/n26/includes/equip_line.html
@@ -40,7 +40,7 @@ every input in the list on the same column however many rows have one.
     {% if row.choices or row.options %}
         <c-slot name="rows">
             {% if row.choices %}
-                {% include "n26/includes/equip_choices.html" %}
+                {% include "n26/includes/equip_choices.html" with choices=row.choices %}
             {% endif %}
             {% if row.options %}
                 {% include "n26/includes/equip_options.html" %}

--- a/n26/core/templates/n26/includes/equip_owned_line.html
+++ b/n26/core/templates/n26/includes/equip_owned_line.html
@@ -79,7 +79,7 @@ reader might want belongs, with the click it feeds.
                 </span>
             </div>
             {% if row.buy.choices %}
-                {% include "n26/includes/equip_choices.html" with row=row.buy %}
+                {% include "n26/includes/equip_choices.html" with choices=row.buy.choices %}
             {% endif %}
             {% if row.buy.options %}
                 {% include "n26/includes/equip_options.html" with row=row.buy %}

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -398,7 +398,8 @@ class TestWhatMayBeClickedOn:
     """
 
     @pytest.mark.parametrize(
-        "route", ["n26-sell", "n26-reassign", "n26-refund", "n26-remove"]
+        "route",
+        ["n26-sell", "n26-reassign", "n26-refund", "n26-remove", "n26-rechoose"],
     )
     def test_a_fighter_is_not_kit(self, client, tester, gang, fighter, sword, route):
         client.force_login(tester)
@@ -421,7 +422,8 @@ class TestWhatMayBeClickedOn:
         assert_reconciled(gang)
 
     @pytest.mark.parametrize(
-        "route", ["n26-sell", "n26-reassign", "n26-refund", "n26-remove"]
+        "route",
+        ["n26-sell", "n26-reassign", "n26-refund", "n26-remove", "n26-rechoose"],
     )
     def test_the_gang_itself_is_not_kit(self, client, tester, gang, route):
         """The founding assignment carries the gang's type, its equipment
@@ -442,7 +444,8 @@ class TestWhatMayBeClickedOn:
         assert_reconciled(gang)
 
     @pytest.mark.parametrize(
-        "route", ["n26-sell", "n26-reassign", "n26-refund", "n26-remove"]
+        "route",
+        ["n26-sell", "n26-reassign", "n26-refund", "n26-remove", "n26-rechoose"],
     )
     def test_what_a_fighter_knows_is_not_kit(
         self, client, tester, gang, fighter, route
@@ -485,7 +488,8 @@ class TestWhoMayClick:
     none of them is a GET."""
 
     @pytest.mark.parametrize(
-        "route", ["n26-sell", "n26-reassign", "n26-refund", "n26-remove"]
+        "route",
+        ["n26-sell", "n26-reassign", "n26-refund", "n26-remove", "n26-rechoose"],
     )
     def test_a_stranger_finds_nothing(self, client, gang, sword, route):
         stranger = User.objects.create_user("stranger")
@@ -498,7 +502,8 @@ class TestWhoMayClick:
         assert_reconciled(gang)
 
     @pytest.mark.parametrize(
-        "route", ["n26-sell", "n26-reassign", "n26-refund", "n26-remove"]
+        "route",
+        ["n26-sell", "n26-reassign", "n26-refund", "n26-remove", "n26-rechoose"],
     )
     def test_signing_out_is_signing_out(self, client, sword, route):
         response = client.post(url(route, sword))
@@ -506,7 +511,8 @@ class TestWhoMayClick:
         assert "/accounts/login/" in response.url
 
     @pytest.mark.parametrize(
-        "route", ["n26-sell", "n26-reassign", "n26-refund", "n26-remove"]
+        "route",
+        ["n26-sell", "n26-reassign", "n26-refund", "n26-remove", "n26-rechoose"],
     )
     def test_a_get_writes_nothing(self, client, tester, gang, sword, route):
         """A link that spent money by being followed would be spent by a
@@ -525,7 +531,14 @@ class TestWhoMayClick:
 
     @pytest.mark.parametrize(
         "route",
-        ["n26-sell", "n26-reassign", "n26-refund", "n26-remove", "n26-accessorise"],
+        [
+            "n26-sell",
+            "n26-reassign",
+            "n26-refund",
+            "n26-remove",
+            "n26-accessorise",
+            "n26-rechoose",
+        ],
     )
     def test_a_pk_that_is_not_a_ulid_is_not_found(self, client, tester, route):
         client.force_login(tester)

--- a/n26/core/views/__init__.py
+++ b/n26/core/views/__init__.py
@@ -33,6 +33,7 @@ from n26.core.views.options import fighter_options
 from n26.core.views.owned import (
     accessorise_assignment,
     reassign_assignment,
+    rechoose_assignment,
     refund_assignment,
     remove_assignment,
     sell_assignment,
@@ -60,6 +61,7 @@ __all__ = [
     "print_gang",
     "print_setup",
     "reassign_assignment",
+    "rechoose_assignment",
     "refund_assignment",
     "refund_fighter",
     "remove_assignment",

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -65,12 +65,14 @@ def _parts_picked(data, key, line):
     return picked
 
 
-def _choices_picked(data, key, line):
-    """The alternatives a submission picked on this line, group by group.
+def _choices_picked(data, key, groups):
+    """The alternatives a submission picked, group by group.
 
     Values are indices into the sets the server has just re-derived, so a
-    tampered form can name nothing the line does not offer — and a group
-    the line does not draw has no field to pick from.
+    tampered form can name nothing the offer does not hold — and a group
+    that was not drawn has no field to pick from. The offer is passed in
+    rather than read off a line, because the same reading answers a row
+    being bought and a copy already held being changed.
 
     An empty value is a one-or-none set's "None": the reader took
     nothing, which is not a pick to pass on. A repeated index is refused
@@ -78,7 +80,7 @@ def _choices_picked(data, key, line):
     same swap.
     """
     picked = []
-    for index, group in enumerate(line.choices):
+    for index, group in enumerate(groups):
         seen = set()
         for value in data.getlist(_choice_field(key, index)):
             if value == "":
@@ -261,7 +263,7 @@ def _buy_clicked(request, gang, holder, view, back, *, into, collection, event=N
         messages.error(request, "That item is not on this list.")
         return redirect(back)
     picked = _parts_picked(request.POST, key, line)
-    picks = _choices_picked(request.POST, key, line)
+    picks = _choices_picked(request.POST, key, line.choices)
     surcharge = sum(option.surcharge for option in picks)
     # Every price the click carries, read and bounded before anything
     # is written: one bad box buys nothing at all, rather than a gun

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -1,6 +1,6 @@
 """What a fighter already owns — selling it, handing it on, taking it off.
 
-Five acts, five addresses, one shape each: a POST names the assignment
+Six acts, six addresses, one shape each: a POST names the assignment
 in its path, an ``operation`` writes it, and the reader lands back where
 they clicked. They are addressed by *assignment* rather than by
 fighter, because that is what they are about — a weapon on a fighter, a
@@ -38,7 +38,10 @@ The acts are deliberately distinct, and the ledger says which happened:
     Off the card, money stays spent.
 ``accessorise``
     A purchase, hosted on the weapon rather than on the fighter. The only
-    one of the five that adds something.
+    one that adds something.
+``rechoose``
+    Taking a thing with different alternatives to the ones it was bought
+    with. The difference settles either way, on the thing's own line.
 """
 
 from django.contrib import messages
@@ -49,7 +52,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
-from n26.core.owned import DIALOGS, is_possession, with_query
+from n26.core.owned import DIALOGS, is_possession, thing_key, with_query
 from n26.core.views.permissions import _own_assignment_or_404
 
 
@@ -345,6 +348,26 @@ def owned_dialog(request, card, *, at, miniature, gang):
             "submit_variant": "primary",
         }
 
+    if kind == "rechoose":
+        # The same controls the row for sale draws, starting on what this
+        # copy took rather than on what a buyer would be handed. What a
+        # swap adds is beside each option; what it settles to is on the
+        # copy's own line once it is saved, because that is where the
+        # figure it changes lives.
+        from n26.core.browse import offered_choices
+        from n26.core.listing import pick_groups
+
+        thing = assignment.assignable
+        taken = {row.default_set_id for row in assignment.chosen_options.all()}
+        return dialog | {
+            "title": f"Change {name}'s options",
+            "choices": pick_groups(
+                offered_choices(thing), thing_key(thing), taken=taken
+            ),
+            "submit_label": "Save options",
+            "submit_variant": "success",
+        }
+
     if kind == "refund":
         _, paid = refund_of(assignment)
         # The figure is what the ledger says was handed over, which is not
@@ -621,6 +644,85 @@ def reassign_assignment(request, pk):
         messages.success(request, f"Fitted {name} to {destination.assignable}.")
     else:
         messages.success(request, f"Moved {name} to {destination.name}.")
+    return redirect(back)
+
+
+@login_required
+@require_POST
+def rechoose_assignment(request, pk):
+    """Take something already owned with different options.
+
+    The alternatives were priced when it was bought and they are priced
+    the same way now, so changing them settles the difference either
+    way: a dearer set is charged, a cheaper one comes back, and the
+    figure lands on the thing's own line because an option is a way that
+    thing is built rather than a purchase beside it.
+
+    The picks arrive as places in the offer the server re-derives, read
+    back by the same parser a purchase uses, so a tampered form can name
+    nothing the content does not offer. A gang that cannot afford an
+    upgrade is refused and nothing changes — the whole swap unwinds
+    together, rather than leaving the old set gone and the new one
+    unpaid for.
+    """
+    from n26.analytics import EventVerb, N26Noun, record
+    from n26.core.browse import offered_choices
+    from n26.core.operations import Refusal, operation
+    from n26.core.views.equip import _choices_picked
+    from n26.library.models.assignable import Optioned
+
+    assignment = _possession_or_404(request, pk)
+    thing = assignment.assignable
+    if not isinstance(thing, Optioned) or not thing.offers_a_choice:
+        # No control draws this address for anything else, and there
+        # would be nothing on the panel behind it to pick.
+        raise Http404("Nothing to choose")
+    gang = assignment.gang_root
+    miniature = assignment.miniature_root
+    back = _back_to(request, miniature, gang)
+
+    picked = _choices_picked(request.POST, thing_key(thing), offered_choices(thing))
+    taken = {row.default_set_id for row in assignment.chosen_options.all()}
+    entry = getattr(assignment, "ledger_entry", None)
+    before = entry.paid if entry is not None else 0
+    try:
+        with operation(gang, actor=request.user) as op:
+            op.rechoose(assignment, option=[option.default_set for option in picked])
+    except Refusal as refusal:
+        messages.error(request, str(refusal))
+        return redirect(back)
+    if entry is not None:
+        entry.refresh_from_db()
+    after = entry.paid if entry is not None else 0
+
+    record(
+        request,
+        N26Noun.ASSIGNMENT,
+        EventVerb.UPDATE,
+        assignment,
+        gang_id=str(gang.pk),
+        miniature_id=str(miniature.pk) if miniature else None,
+        thing=str(thing),
+        action="rechoose",
+        delta=after - before,
+    )
+    # What changed is read from what is recorded rather than from the
+    # money: two options at one price are a real swap that costs nothing,
+    # and calling that unchanged would tell a reader their click did not
+    # land.
+    now = {row.default_set_id for row in assignment.chosen_options.all()}
+    if now == taken:
+        messages.success(request, f"{thing}'s options are unchanged.")
+        return redirect(back)
+    holds = ", ".join(option.name for option in thing.options_taken(now))
+    settled = (
+        f" — {after - before}¢ more."
+        if after > before
+        else f" — {before - after}¢ back."
+        if after < before
+        else "."
+    )
+    messages.success(request, f"{thing} now has {holds}{settled}")
     return redirect(back)
 
 

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1167,14 +1167,15 @@ GROUPS: list[Group] = [
                 summary=(
                     "Confirm a sale, a move, a refund or a removal of "
                     "something the gang owns — or ask which accessory to "
-                    "fit to a weapon."
+                    "fit to a weapon, or which alternatives it is taken "
+                    "with."
                 ),
                 needs=(ALPINE,),
                 notes=(
-                    "One panel for five questions, because the difference "
-                    "between them is a sentence and, for three of them, one "
-                    "control — five files "
-                    "would be five copies of the same dialog drifting apart a "
+                    "One panel for six questions, because the difference "
+                    "between them is a sentence and, for half of them, one "
+                    "control — six files "
+                    "would be six copies of the same dialog drifting apart a "
                     "fix at a time. Each says the thing a reader cannot work "
                     "out from the page: a sale states its arithmetic, because "
                     "the figure comes from rows nobody can see and it is money; "
@@ -1194,7 +1195,14 @@ GROUPS: list[Group] = [
                     "one; and fitting an accessory is the question here that "
                     "confirms nothing, sharing the panel because it is the same "
                     "sort of state — one row of a card, open because the "
-                    "address says so."
+                    "address says so. Changing what a thing was bought with "
+                    "is the second of those, and it draws the buying row's "
+                    "own controls rather than a second set: one set of "
+                    "alternatives asked about in two places is one place "
+                    "where the asking is written, with the loader deciding "
+                    "which control starts picked — a buyer is handed the "
+                    "standard one, and somebody changing a thing starts on "
+                    "what it holds."
                 ),
             ),
             Component(

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -377,13 +377,21 @@ OFFERED = {
 }
 
 
-def _offered_choices(name):
-    """The alternatives one line offers, as the structure browse builds.
+@dataclass(frozen=True)
+class _Set:
+    """What an option would bring, as far as a drawing needs to know.
 
-    ``default_set`` is what a purchase would materialise, and the gallery
-    buys nothing — so the sample names none, exactly as a line with no
-    alternatives carries none.
+    Only its identity is read here: a control starts picked when the
+    thing being drawn holds this set, and the gallery holds nothing that
+    could be fetched. The option's own name serves, because two options
+    of one offer never share it.
     """
+
+    pk: str
+
+
+def _offered_choices(name):
+    """The alternatives one line offers, as the structure browse builds."""
     return tuple(
         OfferedGroup(
             choose=choose,
@@ -392,7 +400,7 @@ def _offered_choices(name):
                     name=option,
                     surcharge=surcharge,
                     is_default=(choose == "one" and position == 0),
-                    default_set=None,
+                    default_set=_Set(option),
                 )
                 for position, (option, surcharge) in enumerate(options)
             ),
@@ -1988,7 +1996,7 @@ def _stock(name):
 
 def owned_context():
     """What a fighter is carrying, and the things that can happen to it."""
-    from n26.core.listing import copy_row
+    from n26.core.listing import copy_row, pick_groups
 
     named = {"cancel_url": "#", "action": "#", "list": "", "name": "Meltagun"}
     return {
@@ -2046,6 +2054,23 @@ def owned_context():
             "sell_all_detail": "Everything goes together. 91¢.",
             "submit_label": "Sell",
             "submit_variant": "danger",
+        },
+        # The mount the sample fighter owns, reopened on its alternatives.
+        # Built by the real loader from the real offer, so what starts
+        # picked here is decided the way the application decides it: the
+        # harpoon and the spikes, which is what the copy was bought with.
+        "owned_rechoose_dialog": {
+            **named,
+            "kind": "rechoose",
+            "name": "Ridge-runner",
+            "title": "Change Ridge-runner's options",
+            "choices": pick_groups(
+                _offered_choices("Ridge-runner"),
+                "library.wargear:ridge-runner",
+                taken={"Ridge-runner harpoon", "Ridge-runner spikes"},
+            ),
+            "submit_label": "Save options",
+            "submit_variant": "success",
         },
         "owned_accessorise_dialog": {
             **named,

--- a/n26/designsystem/templates/designsystem/demos/owned-dialog/50-rechoosing.html
+++ b/n26/designsystem/templates/designsystem/demos/owned-dialog/50-rechoosing.html
@@ -1,0 +1,4 @@
+{# title: Changing what something was bought with #}
+{# note: The second question here that confirms nothing, and the only one that can hand money back. The controls are the buying row's own, drawn from the same include, but they start on what this copy took rather than on what a buyer would be handed — so the panel opens showing what the thing is now and the reader changes it from there. Each option says what it adds; what the change settles to is on the copy's line afterwards, because that is the figure it moves. #}
+{# layout: full #}
+<c-n26.owned-dialog :dialog="owned_rechoose_dialog" modal="" />

--- a/n26/tests/sandbox/test_buying_with_options.py
+++ b/n26/tests/sandbox/test_buying_with_options.py
@@ -671,6 +671,278 @@ class TestWhatTheOwnedCopyDraws:
         assert SET_LABEL not in body
 
 
+class TestTheWayToChangeThem:
+    """A copy already bought offers a way back to its own alternatives."""
+
+    def test_the_chevron_offers_it_where_the_content_asks_anything(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        client.force_login(owner)
+        client.post(equip_url(fighter, house_list), {"thing": key_of(cutter)})
+
+        row = cutter_row(client, owner, fighter, house_list)
+        (copy,) = row.copies
+        assert [action.label for action in copy.more][0] == "Change options"
+        assert (
+            f"rechoose={copy.id}"
+            in dict((action.label, action.target) for action in copy.more)[
+                "Change options"
+            ]
+        )
+
+    def test_something_that_asked_nothing_offers_no_way_to_change_it(
+        self, client, owner, gang, fighter, house_list, default_pack
+    ):
+        """A set with nothing to pick was taken unasked, so the panel
+        behind such a control would offer one thing."""
+        knife = create_wargear("Stiletto knife", price=10)
+        house_list.entries.create(wargear=knife)
+
+        client.force_login(owner)
+        client.post(equip_url(fighter, house_list), {"thing": key_of(knife)})
+
+        row = row_named(client, owner, fighter, house_list, "Stiletto knife")
+        (copy,) = row.copies
+        assert "Change options" not in [action.label for action in copy.more]
+
+    def test_the_panel_starts_on_what_the_copy_took(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        """Not on what a buyer would be handed: the reader is changing
+        something, so the controls open on what it is now."""
+        client.force_login(owner)
+        client.post(
+            equip_url(fighter, house_list),
+            {"thing": key_of(cutter), choice_field(cutter, 0): "2"},
+        )
+        copy_id = cutter_row(client, owner, fighter, house_list).copies[0].id
+
+        response = client.get(f"{equip_url(fighter, house_list)}&rechoose={copy_id}")
+        guns, fittings = response.context["dialog"]["choices"]
+
+        assert [option.checked for option in guns.options] == [False, False, True]
+        assert fittings.nothing_taken
+
+    def test_a_set_the_copy_took_from_says_so(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        client.force_login(owner)
+        client.post(
+            equip_url(fighter, house_list),
+            {"thing": key_of(cutter), choice_field(cutter, 1): "0"},
+        )
+        copy_id = cutter_row(client, owner, fighter, house_list).copies[0].id
+
+        response = client.get(f"{equip_url(fighter, house_list)}&rechoose={copy_id}")
+        _, fittings = response.context["dialog"]["choices"]
+
+        assert not fittings.nothing_taken
+        assert [option.checked for option in fittings.options] == [True]
+
+
+class TestChangingThem:
+    """The swap settles on the thing's own line, in either direction."""
+
+    def bought(self, client, owner, fighter, house_list, cutter, **picked):
+        client.force_login(owner)
+        client.post(equip_url(fighter, house_list), {"thing": key_of(cutter), **picked})
+        return cutter_row(client, owner, fighter, house_list).copies[0].id
+
+    def change(self, client, fighter, house_list, copy_id, **picked):
+        return client.post(
+            reverse("n26-rechoose", args=[copy_id]),
+            {"list": str(house_list.pk), **picked},
+            follow=True,
+        )
+
+    def test_a_dearer_set_is_charged_the_difference(
+        self, client, owner, gang, fighter, house_list, cutter
+    ):
+        copy_id = self.bought(client, owner, fighter, house_list, cutter)
+        gang.refresh_from_db()
+        assert (gang.credits, gang.rating) == (850, 150)
+
+        self.change(
+            client, fighter, house_list, copy_id, **{choice_field(cutter, 0): "2"}
+        )
+
+        assert weapons_of(fighter) == ["Cutter plasma guns"]
+        gang.refresh_from_db()
+        assert (gang.credits, gang.rating) == (835, 165)
+        assert_reconciled(gang)
+
+    def test_a_cheaper_set_hands_the_difference_back(
+        self, client, owner, gang, fighter, house_list, cutter
+    ):
+        copy_id = self.bought(
+            client,
+            owner,
+            fighter,
+            house_list,
+            cutter,
+            **{choice_field(cutter, 0): "2", choice_field(cutter, 1): "0"},
+        )
+        gang.refresh_from_db()
+        assert (gang.credits, gang.rating) == (815, 185)
+
+        self.change(
+            client, fighter, house_list, copy_id, **{choice_field(cutter, 0): "0"}
+        )
+
+        assert weapons_of(fighter) == ["Cutter grenade launchers"]
+        gang.refresh_from_db()
+        assert (gang.credits, gang.rating) == (850, 150)
+        assert_reconciled(gang)
+
+    def test_the_copy_says_what_it_now_takes(
+        self, client, owner, fighter, house_list, cutter
+    ):
+        copy_id = self.bought(client, owner, fighter, house_list, cutter)
+        self.change(
+            client,
+            fighter,
+            house_list,
+            copy_id,
+            **{choice_field(cutter, 0): "1", choice_field(cutter, 1): "0"},
+        )
+
+        row = cutter_row(client, owner, fighter, house_list)
+        assert [copy.chosen for copy in row.copies] == [
+            ("Cutter heavy stubbers", "Smoke dispenser")
+        ]
+
+    def test_it_says_what_was_charged(self, client, owner, fighter, house_list, cutter):
+        copy_id = self.bought(client, owner, fighter, house_list, cutter)
+        response = self.change(
+            client, fighter, house_list, copy_id, **{choice_field(cutter, 0): "2"}
+        )
+
+        said = [str(message) for message in response.context["messages"]]
+        assert said == ["Escher Cutter now has Cutter plasma guns — 15¢ more."]
+
+    def test_it_says_what_came_back(self, client, owner, fighter, house_list, cutter):
+        copy_id = self.bought(
+            client, owner, fighter, house_list, cutter, **{choice_field(cutter, 0): "2"}
+        )
+        response = self.change(
+            client, fighter, house_list, copy_id, **{choice_field(cutter, 0): "0"}
+        )
+
+        said = [str(message) for message in response.context["messages"]]
+        assert said == ["Escher Cutter now has Cutter grenade launchers — 15¢ back."]
+
+    def test_a_swap_between_options_at_one_price_is_still_a_swap(
+        self, client, owner, gang, fighter, default_pack
+    ):
+        """Two options an author priced the same are a real change that
+        settles nothing. Read from the money, that is indistinguishable
+        from a click that did nothing — so it is read from what is
+        recorded, and the reader is told what they now have."""
+        rig = create_wargear("Duct rig", price=30)
+        for name in ["Left-handed", "Right-handed"]:
+            offer_option(
+                rig,
+                f"{name} fitting",
+                price=5,
+                thing=create_wargear(f"{name} bracket", is_exclusive=True),
+            )
+        collection = create_collection("Riggings", entries=[rig])
+        assign(collection, gang=gang)
+
+        client.force_login(owner)
+        client.post(equip_url(fighter, collection), {"thing": key_of(rig)})
+        copy_id = row_named(client, owner, fighter, collection, "Duct rig").copies[0].id
+
+        response = client.post(
+            reverse("n26-rechoose", args=[copy_id]),
+            {"list": str(collection.pk), choice_field(rig, 0): "1"},
+            follow=True,
+        )
+
+        said = [str(message) for message in response.context["messages"]]
+        assert said == ["Duct rig now has Right-handed fitting."]
+        row = row_named(client, owner, fighter, collection, "Duct rig")
+        assert [copy.chosen for copy in row.copies] == [("Right-handed fitting",)]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_changing_nothing_charges_nothing(
+        self, client, owner, gang, fighter, house_list, cutter
+    ):
+        copy_id = self.bought(client, owner, fighter, house_list, cutter)
+        response = self.change(
+            client, fighter, house_list, copy_id, **{choice_field(cutter, 0): "0"}
+        )
+
+        said = [str(message) for message in response.context["messages"]]
+        assert said == ["Escher Cutter's options are unchanged."]
+        gang.refresh_from_db()
+        assert (gang.credits, gang.rating) == (850, 150)
+        assert_reconciled(gang)
+
+    def test_the_guns_it_no_longer_takes_leave_with_the_swap(
+        self, client, owner, gang, fighter, house_list, cutter
+    ):
+        """Nothing is ever replaced: the departing set's rows go the way a
+        refund goes, so a mount is never carrying two sets of guns."""
+        copy_id = self.bought(client, owner, fighter, house_list, cutter)
+        self.change(
+            client, fighter, house_list, copy_id, **{choice_field(cutter, 0): "2"}
+        )
+
+        assert not Assignment.objects.filter(
+            weapon__name="Cutter grenade launchers", archived=False
+        ).exists()
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_pick_the_offer_never_made_is_refused(
+        self, client, owner, gang, fighter, house_list, cutter
+    ):
+        copy_id = self.bought(client, owner, fighter, house_list, cutter)
+        response = self.change(
+            client, fighter, house_list, copy_id, **{choice_field(cutter, 0): "9"}
+        )
+
+        assert response.status_code == 404
+        assert weapons_of(fighter) == ["Cutter grenade launchers"]
+        gang.refresh_from_db()
+        assert gang.credits == 850
+
+    def test_an_upgrade_the_gang_cannot_afford_changes_nothing(
+        self, client, owner, gang_type, make_profile, make_statline, cutter
+    ):
+        """The refusal unwinds the whole swap rather than leaving the old
+        guns gone and the new ones unpaid for."""
+        pauper = found_gang("The Skint", gang_type, owner=owner, budget=155)
+        profile = make_profile("Waif", price=0)
+        make_statline(profile, movement=5, weapon_skill=4, toughness=3)
+        fighter = hire(pauper, profile, "Nell")
+        collection = create_collection(
+            "Thin Pickings", entries=[(cutter, {"price_override": 150})]
+        )
+        assign(collection, gang=pauper)
+
+        client.force_login(owner)
+        client.post(equip_url(fighter, collection), {"thing": key_of(cutter)})
+        copy_id = (
+            row_named(client, owner, fighter, collection, "Escher Cutter").copies[0].id
+        )
+
+        response = client.post(
+            reverse("n26-rechoose", args=[copy_id]),
+            {"list": str(collection.pk), choice_field(cutter, 0): "2"},
+            follow=True,
+        )
+
+        said = [str(message) for message in response.context["messages"]]
+        assert said and "credits" in said[0].lower()
+        assert weapons_of(fighter) == ["Cutter grenade launchers"]
+        pauper.refresh_from_db()
+        assert pauper.credits == 5
+        assert_reconciled(pauper)
+
+
 class TestNamingWhatIsOwnedCostsNothing:
     """Describing a copy reads the recorded sets and the offer they came
     from, both already in hand — so a fighter buying more mounts asks the

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -80,6 +80,11 @@ urlpatterns = [
         views.accessorise_assignment,
         name="n26-accessorise",
     ),
+    path(
+        "assignments/<str:pk>/rechoose/",
+        views.rechoose_assignment,
+        name="n26-rechoose",
+    ),
     path("gangs/<str:pk>/print/setup/", views.print_setup, name="n26-print-setup"),
     path("gangs/<str:pk>/print/", views.print_gang, name="n26-print"),
     path("design/", include("n26.designsystem.urls")),


### PR DESCRIPTION
Some gear offers a choice when you buy it — an Escher Cutter comes with grenade launchers and will swap them for heavy stubbers (+10¢) or plasma guns (+15¢), with an optional smoke dispenser (+20¢) on top. An equipped copy now names what it was bought with, but nothing could change it: picking the wrong guns meant selling the mount and buying it again, at half its worth back and full price out.

## Summary

- **"Change options"** joins the equipped copy's chevron, first in the list and only where the content actually offers a choice. It opens a dialog over the equip page, the way Sell and Reassign do, so you watch the row change rather than leaving for a page of your own.
- The panel draws the buying row's own controls, starting on **what this copy holds** rather than on what a buyer would be handed. Which control starts picked is now the structure's answer rather than the template's guess, decided by one loader with two callers — buying starts on the standard option, changing starts on what you have.
- Saving hands the picks to `Operation.rechoose`, which already existed: the departing options leave the way a refund leaves, the arriving ones materialise exactly as at purchase, and the difference settles on the thing's own line in either direction. An upgrade the gang cannot afford is refused and the whole swap unwinds, rather than leaving the old guns gone and the new ones unpaid for.
- The picks are read back by the same parser a purchase uses, so a tampered form can name nothing the content does not offer.
- What counts as "changed" is read from what is recorded, not from the money — otherwise a swap between two options an author priced the same would report as nothing having happened.

## Test plan

- [x] `pytest n26` — 3491 passed
- [x] Full suite — 7759 passed, 12 skipped
- [x] Covered: both money directions; the panel starting on what the copy holds; a set the copy took nothing from; the chevron entry appearing only where the content asks something; the departing options leaving with the swap; a pick the offer never made refused; an upgrade the gang cannot afford changing nothing; and a swap between two equally-priced options.
- [x] The five existing dialog routes' permission guards extended to the new one.
- [x] Driven in a browser end to end: opened the chevron on a Cutter bought with plasma guns and a smoke dispenser, the panel opened already on those two, switched to heavy stubbers and None, saved. `Escher Cutter now has Cutter heavy stubbers — 25¢ back.`, rating 345→320, credits 655→680, the copy's line updated, the plasma guns and dispenser gone, the fighter's other Cutter untouched, gang reconciles.

## Note

Pulling this into a checkout that has not run main's slots-and-picks migrations needs `manage migrate` first.