### PR TITLE
perf: the app serves on one core, because it only ever used one

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -94,8 +94,13 @@ steps:
       # The DB connection pool in gyrinx/settings_prod.py and the gunicorn
       # worker/thread counts in docker/entrypoint.sh are sized against these
       # four values — revisit them together.
+      # --cpu=1: measured over 14,940 one-minute container samples, the service
+      # used 0.10 vCPU at p50, 0.36 at p95 and 0.86 at p99.9, exceeding 1.0 vCPU
+      # in a single sample and never reaching 1.5. The work is I/O-bound on
+      # Postgres, so the second core sat idle. startup-cpu-boost stays on, which
+      # covers the CPU spike of a cold Django boot.
       - "--max-instances=3"
-      - "--cpu=2"
+      - "--cpu=1"
       - "--memory=1Gi"
       - "--concurrency=40"
       # HTTP probe against the WSGI-level /healthz in gyrinx/wsgi.py, which only

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,7 +32,9 @@ manage ensuresuperuser --no-input
 # Deploys adding a task should confirm provisioning finished before relying on
 # it.
 { manage provision_tasks || true; } &
-# 2 workers: one busy core each on the 2-vCPU Cloud Run instances (GIL).
+# 2 workers: the instances are 1 vCPU, so the pair shares a core (GIL) — which
+#   the measured demand leaves ample room for (0.36 vCPU at p95). Two rather
+#   than one for availability, not throughput: see --max-requests below.
 # 20 threads each: 2 × 20 = 40 matches the service's containerConcurrency.
 # --timeout 0: gthread heartbeats are per-worker (not per-request), so the
 #   default 30s would never kill a slow page — but Cloud Run throttles CPU


### PR DESCRIPTION
## Summary

Cloud Run instances go from **2 vCPU to 1**. Saves roughly **£20/month** (~£235/year) with no expected latency change.

## Evidence

Aggregated from 14,940 one-minute container CPU samples — the raw distribution, not percentiles-of-percentiles:

| Percentile | CPU actually used |
|---|---|
| p50 | 0.10 vCPU |
| p90 | 0.28 vCPU |
| p95 | 0.36 vCPU |
| p99 | 0.54 vCPU |
| p99.9 | 0.86 vCPU |

**Above 1.0 vCPU: 1 sample in 14,940. Above 1.5 vCPU: none.** The work waits on Postgres rather than on a core, so the second one sat idle.

The figures above are from after the 2026-08-13 database scale-up, which raised CPU use slightly (p95 went 0.32 → 0.40 vCPU) because a faster database means less blocking and more work per unit of wall-clock. Even so, the tail stays under one core.

Billing is per allocated vCPU-second while a request is in flight, so halving the allocation halves that line. The model checks out against July's bill: 1,551,552 vCPU-seconds ÷ 2 vCPU = 775,776 instance-active-seconds, and the memory line independently implies 741,436 — agreeing within 4.6%, which is what startup boost would add.

## Deliberately not changed

- **`--max-instances` stays at 3.** The psycopg pool is sized instances × workers × max_size, so raising instance count multiplies through to the database. That is a separate decision with its own blast radius.
- **`--workers 2` stays.** The pair now shares a core, which measured demand leaves ample room for, and the second worker exists so one always serves during a graceful recycle — availability, not throughput.
- **`startup-cpu-boost` stays on.** A cold Django boot is the one genuinely CPU-hungry moment, and boost covers it.

## Test plan

- [ ] CI green
- [ ] After deploy, watch p95 request latency for a day. Baseline is ~25 ms p50 / ~78 ms p95.
- [ ] Confirm the Cloud Run CPU line drops on the next billing day (was £39.41/month)

Rollback is a one-line revert and redeploy.
