### PR TITLE
fix: a question with no address is asked and answerable, and one whose slot went is not asked

### DIFF
--- a/n26/core/effects.py
+++ b/n26/core/effects.py
@@ -560,14 +560,16 @@ def compute(card, index):
         },
     )
 
-    is_assigned = {
-        ModifierIndex.key(node.assignable): node.assignment is not None
-        for node in card.all_nodes()
-    }
-    anchors = {ModifierIndex.key(node.assignable): node for node in card.all_nodes()}
-    #: The card's written lines by their own identity, which is what a
-    #: chain of grants names when it says what it stands on.
-    lines = {node.key: node for node in card.all_nodes()}
+    # Three views of the card's own lines, taken in one pass: whether a
+    # thing is written down, the line carrying each thing, and the lines
+    # by their own identity — the last being what a chain of grants names
+    # when it says what it stands on.
+    is_assigned, anchors, lines = {}, {}, {}
+    for node in card.all_nodes():
+        carried = ModifierIndex.key(node.assignable)
+        is_assigned[carried] = node.assignment is not None
+        anchors[carried] = node
+        lines[node.key] = node
     offers = _Offers()
     given_slots = _Offers()
     log = _Log()

--- a/n26/core/effects.py
+++ b/n26/core/effects.py
@@ -893,7 +893,19 @@ def compute(card, index):
         if ModifierIndex.key(contribution.thing) not in dead
     ]
     _fill_choice_slots(computed, offers.items, by_cause)
-    _fill_slot_choices(computed, given_slots.items, by_choice)
+    # A question whose slot was itself taken away is not asked: the
+    # giver may stand, but the given thing is gone — the Subjugator
+    # pattern, where a profile removes the general slot its subtype
+    # grants and grants a narrower one of its own.
+    _fill_slot_choices(
+        computed,
+        [
+            given
+            for given in given_slots.items
+            if ModifierIndex.key(given[0]) not in dead
+        ],
+        by_choice,
+    )
     return computed
 
 

--- a/n26/core/effects.py
+++ b/n26/core/effects.py
@@ -560,15 +560,12 @@ def compute(card, index):
         },
     )
 
-    # Three views of the card's own lines, taken in one pass: whether a
-    # thing is written down, the line carrying each thing, and the lines
-    # by their own identity — the last being what a chain of grants names
-    # when it says what it stands on.
-    is_assigned, anchors, lines = {}, {}, {}
+    # Two views of the card's own lines, taken in one pass: whether a thing
+    # is written down, and the lines by their own identity — the latter
+    # being what a chain of grants names when it says what it stands on.
+    is_assigned, lines = {}, {}
     for node in card.all_nodes():
-        carried = ModifierIndex.key(node.assignable)
-        is_assigned[carried] = node.assignment is not None
-        anchors[carried] = node
+        is_assigned[ModifierIndex.key(node.assignable)] = node.assignment is not None
         lines[node.key] = node
     offers = _Offers()
     given_slots = _Offers()
@@ -823,11 +820,16 @@ def compute(card, index):
                             _Applied(source_key, holder, "stat_changes", change)
                         )
                     elif isinstance(effect, OffersChoice):
+                        # Addressed on the line the offerer stands on, as a
+                        # given slot is: an offer carried by something a
+                        # modifier granted — the hidden a profile hands its
+                        # own narrowed choice on — is answerable, where a
+                        # choice with no address could only ever be looked at.
                         offer = (
                             effect,
                             label,
                             label_kind,
-                            anchors.get(source_key),
+                            lines.get(step.root_key),
                         )
                         offers.items.append(offer)
                         log.applied.append(_Applied(source_key, offers, "items", offer))

--- a/n26/core/effects.py
+++ b/n26/core/effects.py
@@ -112,6 +112,12 @@ class Contribution:
     #: as the gang's guest — the granting scope's own say. Meaningless
     #: for a grant to a model, where there is nothing to echo.
     echoes: bool = True
+    #: The written line the chain of grants that brought this thing
+    #: stands on, however many grants deep it arrived. A grant writes
+    #: nothing down, so a choice one gives has no assignment of its own
+    #: to be addressed on; this is the one it hangs from instead, and
+    #: taking that line away takes the whole chain with it.
+    root_key: object = None
 
     @property
     def name(self):
@@ -285,6 +291,10 @@ class PlannedStep:
     #: The card node carrying this modifier — None for discovered
     #: carriers. What "the weapon I am attached to" anchors on.
     node: object = None
+    #: The written line this carrier stands on: its own where the card
+    #: holds it, and otherwise the one at the foot of the grants that
+    #: brought it here. What a choice it gives is addressed on.
+    root_key: object = None
 
     @property
     def scope(self):
@@ -555,6 +565,9 @@ def compute(card, index):
         for node in card.all_nodes()
     }
     anchors = {ModifierIndex.key(node.assignable): node for node in card.all_nodes()}
+    #: The card's written lines by their own identity, which is what a
+    #: chain of grants names when it says what it stands on.
+    lines = {node.key: node for node in card.all_nodes()}
     offers = _Offers()
     given_slots = _Offers()
     log = _Log()
@@ -584,7 +597,13 @@ def compute(card, index):
         AllowsAtMost: 6,
     }
 
-    def steps_for(source, discovered, found_in_round, node=None, echoed=False):
+    def steps_for(
+        source, discovered, found_in_round, node=None, echoed=False, root_key=None
+    ):
+        # A carrier the card holds stands on its own line; one a grant
+        # brought stands on whatever the granter stood on, so the foot of
+        # a chain however deep is the line somebody wrote down.
+        stands_on = node.key if node is not None else root_key
         for modifier, spec in index.for_thing(source):
             if modifier.scope is None or modifier.effect is None:
                 continue
@@ -596,6 +615,7 @@ def compute(card, index):
                 discovered=discovered,
                 node=node,
                 echoed=echoed,
+                root_key=stands_on,
             )
 
     # One run of a carrier's modifiers per NODE, not per distinct thing:
@@ -628,7 +648,18 @@ def compute(card, index):
     ]
     for contribution in echoed:
         seen.add(ModifierIndex.key(contribution.thing))
-        pending.extend(steps_for(contribution.thing, True, 0, echoed=True))
+        # The gang's guest keeps the line it stands on: the gang wrote
+        # that one down, and it rides this card as a broadcast line, so a
+        # choice the guest gives has an address here after all.
+        pending.extend(
+            steps_for(
+                contribution.thing,
+                True,
+                0,
+                echoed=True,
+                root_key=contribution.root_key,
+            )
+        )
 
     round_no = 0
     while pending and round_no <= MAX_CHAIN_DEPTH:
@@ -706,22 +737,23 @@ def compute(card, index):
                     # asked on each card its scope reached a model of —
                     # Water Guild, the gang's pick, opening a Guild Role
                     # on every fighter — and never repeated for merely
-                    # riding a card as the gang's copy. A gang *guest*
-                    # granting a slot has no stored assignment on this
-                    # card to hang the choice's address on, so its slot
-                    # is not asked yet: recording an anchorless row would
-                    # only be dropped further down.
-                    given_here = not (
-                        step.echoed or (step.node is not None and step.node.broadcast)
-                    ) or (
-                        step.node is not None
-                        and step.node.broadcast
-                        and any(target.kind == MODEL for target in targets)
+                    # riding a card as the gang's copy. The gang's guests
+                    # are gang-held too: a rule an alliance gave the gang
+                    # asks its choice on each fighter it reaches, and on
+                    # none if it reaches only the gang.
+                    gang_held = step.echoed or (
+                        step.node is not None and step.node.broadcast
                     )
-                    if given_here:
+                    if not gang_held or any(target.kind == MODEL for target in targets):
+                        # Addressed on the line the giver stands on. That
+                        # is the giver's own where the card holds it, and
+                        # otherwise the written line its chain of grants
+                        # hangs from — so what a grant gives can be asked
+                        # and answered like anything else, and un-writing
+                        # that line takes the answers with it.
                         given = (
                             effect.thing,
-                            anchors.get(source_key),
+                            lines.get(step.root_key),
                             label,
                             label_kind,
                         )
@@ -740,6 +772,7 @@ def compute(card, index):
                                     source=label,
                                     source_kind=label_kind,
                                     echoes=getattr(scope, "echoes", True),
+                                    root_key=step.root_key,
                                 ),
                                 step.node,
                                 source_key,
@@ -749,7 +782,9 @@ def compute(card, index):
                         thing_key = ModifierIndex.key(thing)
                         if thing_key not in seen:
                             seen.add(thing_key)
-                            pending.extend(steps_for(thing, True, round_no))
+                            pending.extend(
+                                steps_for(thing, True, round_no, root_key=step.root_key)
+                            )
                     elif isinstance(effect, RemovesAssignable):
                         removes.append(
                             (
@@ -1294,8 +1329,10 @@ def _fill_slot_choices(computed, given, by_choice):
     gave share an anchor, and only the slot tells their picks apart.
 
     ``given`` holds the slots a modifier handed over, which have no
-    assignment of their own — the choice they open is anchored on
-    whatever gave it, so un-choosing that retracts this one too.
+    assignment of their own — the choice they open is anchored on the
+    written line the giver stands on, so un-writing that retracts this
+    one too. A slot given by something standing on no written line at
+    all has nowhere to be asked, and is not.
     """
     from n26.library.models import Slot
 

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -720,20 +720,22 @@ class Operation:
         for chosen in taken:
             ChosenProfileOption.objects.create(assignment=carrier, default_set=chosen)
 
-    def choose(self, anchor, chosen, slot=None, **kwargs):
+    def choose(self, anchor, chosen, slot=None, offer=None, **kwargs):
         """Make a choice — pick a specialisation, pick a gang legacy.
 
         ``anchor`` is the assignment that asked: the one whose assignable
         carries a modifier offering the choice (the Specialist subtype's),
-        or a **slot's** own assignment. What was chosen is a free
+        the line a chain of grants stands on where the offerer was itself
+        granted, or a **slot's** own assignment. What was chosen is a free
         assignment caused by it, so removing what asked takes the answer
         along, and it points back through ``chosen_for`` so the card reads
         the choice as settled.
 
-        ``slot`` names which choice is being settled where the anchor
-        cannot say: a slot a modifier *gave* has no assignment of its
-        own, so the thing that gave it is the anchor and the slot is
-        named here.
+        ``slot`` and ``offer`` name which choice is being settled where
+        the anchor cannot say. What a modifier *gave* has no assignment of
+        its own, so the anchor is the written line it stands on — which
+        may carry no offer itself, and may carry several — and the one
+        being answered is named here.
 
         Something of a kind the choice does not name is refused
         (:class:`NotOnOffer`), because it would settle nothing: the row
@@ -746,16 +748,27 @@ class Operation:
         from n26.library.models import Slot
         from n26.library.models.modifier import OffersChoice
 
-        if slot is None and isinstance(anchor.assignable, Slot):
-            slot = anchor.assignable
-        if slot is not None:
-            return self._choose_for_slot(anchor, slot, chosen, **kwargs)
+        if offer is None:
+            # A slot's own assignment says which choice it is without being
+            # told; a named offer has already said.
+            if slot is None and isinstance(anchor.assignable, Slot):
+                slot = anchor.assignable
+            if slot is not None:
+                return self._choose_for_slot(anchor, slot, chosen, **kwargs)
 
+        asked = (
+            [offer]
+            if offer is not None
+            else [
+                modifier.effect
+                for modifier in anchor.assignable.modifiers.all()
+                if isinstance(modifier.effect, OffersChoice)
+            ]
+        )
         matched = [
-            modifier.effect
-            for modifier in anchor.assignable.modifiers.all()
-            if isinstance(modifier.effect, OffersChoice)
-            and modifier.effect.selector().matches(select.matchable(chosen))
+            effect
+            for effect in asked
+            if effect.selector().matches(select.matchable(chosen))
         ]
         if not matched:
             raise NotOnOffer(anchor, chosen)

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -242,6 +242,7 @@ def choose(request, pk, slot):
                         found.anchor,
                         picked.thing,
                         slot=found.slot.slot,
+                        offer=found.slot.offer,
                         **_host(found),
                     )
         except Refusal as refusal:

--- a/n26/tests/sandbox/test_offer_swap_probe.py
+++ b/n26/tests/sandbox/test_offer_swap_probe.py
@@ -7,8 +7,13 @@ general carrier away again and grants a narrower one of its own, so
 its card should ask the same question over a shorter list. The plain
 profile keeps the general offer untouched.
 
-This file is a probe, not a contract: it pins what the engine does with
-the pattern today, plan evidence and all.
+Both ways of building it are covered: the older shape, where a hidden
+carries a modifier offering the choice, and the slots-and-picks shape,
+where the subtype grants a slot. Each asks its question over the right
+menu and each can be answered, because a question a grant put on the
+card is addressed on the written line that chain of grants stands on.
+The plan evidence for the swap — the general offer reached and then
+retracted — is pinned here too.
 """
 
 import pytest
@@ -225,13 +230,11 @@ class TestTheSubjugatorPatrolOfficer:
 
 class TestTheSwapWithTheHiddenBuiltIn:
     """The other possible wiring of the original experiment: the general
-    hidden arrives as a *built-in* of each profile — a stored assignment.
-    Half of it works: the plain officer's question is anchored and
-    settleable, and the removal silences the stored hidden's question on
-    the Subjugator. The narrow half still cannot work, because the
-    narrow hidden has to arrive by the profile's own modifier — that is
-    the whole trick — and a granted hidden's question is anchorless.
-    Both wirings of the experiment fail at the same spot."""
+    hidden arrives as a *built-in* of each profile — a stored assignment
+    — rather than through the subtype. It behaves the same way: the
+    removal silences the stored hidden's question on the Subjugator, and
+    the narrow hidden the profile's own modifier grants asks an anchored
+    question of its own. Either wiring of the pattern works."""
 
     @pytest.fixture
     def built_in_profiles(self, person_type, gang_type, general_offer, narrow_offer):
@@ -276,31 +279,70 @@ class TestTheSwapWithTheHiddenBuiltIn:
         questions = questions_on(subjugator)
 
         assert [(names, slot.anchor is not None) for slot, names in questions] == [
-            ({"Gunner"}, False)
+            ({"Gunner"}, True)
         ]
 
 
 class TestWhetherTheQuestionCanBeSettled:
-    """Where the pattern comes apart today. A choice is settled against
-    the stored assignment that carries the offer — but a hidden that
-    arrives by grant is computed, so nothing on the card anchors its
-    question. The list is right on both ranks; neither slot has an
-    address, so no picker can be reached and no pick can ever resolve
-    it. The working shapes store the carrier instead: the offer sits on
-    the subtype itself (a built-in assignment), or the hidden is a
-    member of the profile's default set."""
+    """Both ranks' questions can be answered. A choice is settled against
+    a stored assignment, and a hidden that arrives by grant is computed
+    and has none — so the question is addressed on the written line its
+    chain of grants stands on: the Specialist subtype for the general
+    offer, and the profile itself for the narrow one the Subjugator
+    grants. The list is right on both ranks and so is the address."""
 
-    def test_neither_ranks_question_is_anchored_to_any_stored_row(self, officers):
-        for miniature in officers.values():
-            ((slot, _),) = questions_on(miniature)
-            assert slot.anchor is None
+    def test_each_ranks_question_is_anchored_on_what_its_chain_stands_on(
+        self, officers, specialist
+    ):
+        ((plain, _),) = questions_on(officers["plain"])
+        ((subjugator, _),) = questions_on(officers["subjugator"])
 
-    def test_the_drawn_line_carries_no_address(self, officers):
+        # The general offer hangs off the subtype that granted it; the
+        # narrow one off the profile whose modifier granted it.
+        assert plain.anchor.assignment.assignable == specialist
+        assert subjugator.anchor.assignment.assignable == (
+            officers["subjugator"].membership.profile
+        )
+
+    def test_the_drawn_line_carries_an_address(self, officers):
         from n26.core.render import choice_lines
 
         for miniature in officers.values():
             (line,) = choice_lines(computed_for(miniature), host=str(miniature.pk))
-            assert line.key == ""
+            assert line.key != ""
+
+    def test_the_narrow_question_settles_from_the_screen(
+        self, gang, officers, owner, client, specialisations
+    ):
+        """The whole point of an address: a player can click the question
+        and the pick lands."""
+        from n26.core.models import Assignment
+        from n26.core.reconcile import assert_reconciled
+        from n26.core.render import render_gang
+        from n26.core.views.choose import link_slots
+
+        subjugator = officers["subjugator"]
+        client.force_login(owner)
+        sheet = render_gang(gang)
+        link_slots(gang, sheet, *sheet.models)
+        card = next(drawn for drawn in sheet.models if drawn.name == "Kade")
+        (line,) = card.questions
+
+        body = client.get(line.href).content.decode()
+        assert "Gunner" in body and "Sniper" not in body
+        response = client.post(
+            line.href,
+            {"thing": f"library.specialisation:{specialisations['Gunner'].pk}"},
+        )
+
+        assert response.status_code == 302
+        (settled,) = computed_for(subjugator).choices
+        assert settled.chosen_name == "Gunner"
+        assert (
+            Assignment.objects.get(specialisation=specialisations["Gunner"]).miniature
+            == subjugator
+        )
+        assert_reconciled(gang)
 
 
 class TestTheSameSwapBuiltAsSlotsAndPicks:

--- a/n26/tests/sandbox/test_offer_swap_probe.py
+++ b/n26/tests/sandbox/test_offer_swap_probe.py
@@ -223,6 +223,63 @@ class TestTheSubjugatorPatrolOfficer:
         assert narrow.outcome == "reached"
 
 
+class TestTheSwapWithTheHiddenBuiltIn:
+    """The other possible wiring of the original experiment: the general
+    hidden arrives as a *built-in* of each profile — a stored assignment.
+    Half of it works: the plain officer's question is anchored and
+    settleable, and the removal silences the stored hidden's question on
+    the Subjugator. The narrow half still cannot work, because the
+    narrow hidden has to arrive by the profile's own modifier — that is
+    the whole trick — and a granted hidden's question is anchorless.
+    Both wirings of the experiment fail at the same spot."""
+
+    @pytest.fixture
+    def built_in_profiles(self, person_type, gang_type, general_offer, narrow_offer):
+        made = {}
+        for key, name in [
+            ("plain", "Stored Patrol Officer"),
+            ("subjugator", "Stored Subjugator"),
+        ]:
+            profile = create_profile(name, person_type, gang_type, price=0)
+            profile.built_ins = create_default_set(
+                f"{name} built-ins", members=[general_offer]
+            )
+            profile.save()
+            made[key] = profile
+        modifier(
+            "Stored Subjugator: the general offer goes",
+            targets_model(),
+            ef_removes(general_offer),
+            carried_by=made["subjugator"],
+        )
+        modifier(
+            "Stored Subjugator: the narrow offer arrives",
+            targets_model(),
+            ef_adds(narrow_offer),
+            carried_by=made["subjugator"],
+        )
+        return made
+
+    def test_the_plain_officers_question_is_anchored_and_whole(
+        self, gang, built_in_profiles
+    ):
+        officer = hire(gang, built_in_profiles["plain"], "Vex")
+
+        ((slot, names),) = questions_on(officer)
+
+        assert names == {"Sniper", "Gunner", "Medic", "Armourer"}
+        assert slot.anchor is not None and slot.anchor.assignment is not None
+
+    def test_the_subjugator_sees_only_the_short_menu(self, gang, built_in_profiles):
+        subjugator = hire(gang, built_in_profiles["subjugator"], "Kade")
+
+        questions = questions_on(subjugator)
+
+        assert [(names, slot.anchor is not None) for slot, names in questions] == [
+            ({"Gunner"}, False)
+        ]
+
+
 class TestWhetherTheQuestionCanBeSettled:
     """Where the pattern comes apart today. A choice is settled against
     the stored assignment that carries the offer — but a hidden that

--- a/n26/tests/sandbox/test_offer_swap_probe.py
+++ b/n26/tests/sandbox/test_offer_swap_probe.py
@@ -1,0 +1,344 @@
+"""Swapping one hidden offer for a narrower one, profile by profile.
+
+The Subjugator Patrol Officer pattern: a Specialist subtype grants a
+hidden carrier whose modifier offers the general choice of
+specialisation; one profile with that subtype built in takes the
+general carrier away again and grants a narrower one of its own, so
+its card should ask the same question over a shorter list. The plain
+profile keeps the general offer untouched.
+
+This file is a probe, not a contract: it pins what the engine does with
+the pattern today, plan evidence and all.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from n26.core.card import build_card, build_modifier_index
+from n26.core.effects import compute
+from n26.core.render import build_choice_offer
+from n26.library.models import Specialisation
+from n26.tests.sandbox.actions import (
+    create_collection,
+    create_default_set,
+    create_hidden,
+    create_profile,
+    create_specialisation,
+    create_subtype,
+    ef_adds,
+    ef_removes,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    section_of,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+# --- The content: one subtype, two hiddens, two profiles -------------------
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def specialisations(default_pack):
+    return {
+        name: create_specialisation(name)
+        for name in ("Sniper", "Gunner", "Medic", "Armourer")
+    }
+
+
+@pytest.fixture
+def general_menu(specialisations):
+    """The whole menu: all four, in one default section."""
+    collection = create_collection(
+        "Specialisation Offer", entries=list(specialisations.values())
+    )
+    return section_of(collection, "Specialisations", 0, is_default=True)
+
+
+@pytest.fixture
+def general_offer(general_menu):
+    """The hidden carrier every Specialist is granted."""
+    hidden = create_hidden("Specialisation Offer (general)")
+    modifier(
+        "General offer: a specialisation from the whole menu",
+        targets_model(),
+        offers_choice(
+            Specialisation, from_section=general_menu, label="specialisation"
+        ),
+        carried_by=hidden,
+    )
+    return hidden
+
+
+@pytest.fixture
+def specialist(general_offer):
+    """The subtype does not carry the offer itself — it grants the
+    hidden that does, which is the shape under probe."""
+    subtype = create_subtype("Specialist")
+    modifier(
+        "Specialist: the general offer arrives",
+        targets_model(),
+        ef_adds(general_offer),
+        carried_by=subtype,
+    )
+    return subtype
+
+
+@pytest.fixture
+def narrow_menu(specialisations):
+    collection = create_collection(
+        "Specialisation Offer (Subjugator)", entries=[specialisations["Gunner"]]
+    )
+    return section_of(collection, "Specialisations", 0, is_default=True)
+
+
+@pytest.fixture
+def narrow_offer(narrow_menu):
+    hidden = create_hidden("Specialisation offer (Subjugator)")
+    modifier(
+        "Subjugator offer: a specialisation from the short menu",
+        targets_model(),
+        offers_choice(Specialisation, from_section=narrow_menu, label="specialisation"),
+        carried_by=hidden,
+    )
+    return hidden
+
+
+@pytest.fixture
+def profiles(person_type, gang_type, specialist, general_offer, narrow_offer):
+    """Both ranks are Specialists; only the Subjugator swaps the offer."""
+    made = {}
+    for key, name in [
+        ("plain", "Patrol Officer"),
+        ("subjugator", "Subjugator Patrol Officer"),
+    ]:
+        profile = create_profile(name, person_type, gang_type, price=0)
+        profile.built_ins = create_default_set(
+            f"{name} built-ins", members=[specialist]
+        )
+        profile.save()
+        made[key] = profile
+    modifier(
+        "Subjugator: the general offer goes",
+        targets_model(),
+        ef_removes(general_offer),
+        carried_by=made["subjugator"],
+    )
+    modifier(
+        "Subjugator: the narrow offer arrives",
+        targets_model(),
+        ef_adds(narrow_offer),
+        carried_by=made["subjugator"],
+    )
+    return made
+
+
+@pytest.fixture
+def gang(gang_type, owner):
+    return found_gang("The Watch", gang_type, owner=owner)
+
+
+@pytest.fixture
+def officers(gang, profiles):
+    return {
+        "plain": hire(gang, profiles["plain"], "Vex"),
+        "subjugator": hire(gang, profiles["subjugator"], "Kade"),
+    }
+
+
+# --- Reading the card the way the pages do ---------------------------------
+
+
+def computed_for(miniature):
+    card = build_card(miniature)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return compute(card, index)
+
+
+def names_on(offer):
+    return {option.name for group in offer.groups for option in group.options}
+
+
+def questions_on(miniature):
+    """Each choice on the card, with the names its picker would list."""
+    computed = computed_for(miniature)
+    return [
+        (slot, names_on(build_choice_offer(slot, computed)))
+        for slot in computed.choices
+    ]
+
+
+class TestThePlainPatrolOfficer:
+    """The general offer arrives through the Specialist grant and lists
+    the whole menu."""
+
+    def test_the_card_asks_one_question_over_the_whole_menu(self, officers):
+        ((slot, names),) = questions_on(officers["plain"])
+        assert slot.kind_label == "Specialisation"
+        assert not slot.is_resolved
+        assert names == {"Sniper", "Gunner", "Medic", "Armourer"}
+
+
+class TestTheSubjugatorPatrolOfficer:
+    """Taking the granted carrier away cancels the question it put up,
+    and the narrow carrier's question stands alone."""
+
+    def test_the_card_asks_one_question_over_the_short_menu(self, officers):
+        ((slot, names),) = questions_on(officers["subjugator"])
+        assert slot.kind_label == "Specialisation"
+        assert names == {"Gunner"}
+
+    def test_the_plan_shows_the_general_offer_ran_and_was_then_retracted(
+        self, officers
+    ):
+        plan = computed_for(officers["subjugator"]).plan
+        removal = next(
+            step
+            for step in plan
+            if str(step.source) == "Subjugator Patrol Officer"
+            and "Specialisation Offer (general)" in step.effect
+        )
+        assert removal.outcome == "reached"
+        assert removal.took_away == ("Specialisation Offer (general)",)
+        general = next(
+            step
+            for step in plan
+            if str(step.source) == "Specialisation Offer (general)"
+        )
+        assert general.outcome == "retracted"
+        # The narrow carrier's own offer stands.
+        narrow = next(
+            step
+            for step in plan
+            if str(step.source) == "Specialisation offer (Subjugator)"
+        )
+        assert narrow.outcome == "reached"
+
+
+class TestWhetherTheQuestionCanBeSettled:
+    """Where the pattern comes apart today. A choice is settled against
+    the stored assignment that carries the offer — but a hidden that
+    arrives by grant is computed, so nothing on the card anchors its
+    question. The list is right on both ranks; neither slot has an
+    address, so no picker can be reached and no pick can ever resolve
+    it. The working shapes store the carrier instead: the offer sits on
+    the subtype itself (a built-in assignment), or the hidden is a
+    member of the profile's default set."""
+
+    def test_neither_ranks_question_is_anchored_to_any_stored_row(self, officers):
+        for miniature in officers.values():
+            ((slot, _),) = questions_on(miniature)
+            assert slot.anchor is None
+
+    def test_the_drawn_line_carries_no_address(self, officers):
+        from n26.core.render import choice_lines
+
+        for miniature in officers.values():
+            (line,) = choice_lines(computed_for(miniature), host=str(miniature.pk))
+            assert line.key == ""
+
+
+class TestTheSameSwapBuiltAsSlotsAndPicks:
+    """The migration's answer to the pattern: the general slot arrives
+    from the subtype, the Subjugator takes it away and grants its own
+    narrow slot. Every question is anchored on the stored assignment
+    that granted it, so — unlike the hidden-offer build above — the
+    picker has an address and the choice can actually be settled."""
+
+    @pytest.fixture
+    def slotted(self, person_type, gang_type, default_pack):
+        from n26.library.authoring import (
+            create_pickable,
+            create_picklist,
+            create_slot,
+            create_slot_type,
+        )
+
+        slot_type = create_slot_type("Specialisation")
+        picks = {
+            name: create_pickable(name, slot_type)
+            for name in ("Sniper", "Gunner", "Medic", "Armourer")
+        }
+        general = create_slot(
+            "Specialisation",
+            slot_type,
+            create_picklist("Specialisations", slot_type, members=list(picks.values())),
+        )
+        narrow = create_slot(
+            "Specialisation (Subjugator)",
+            slot_type,
+            create_picklist("Subjugator options", slot_type, members=[picks["Gunner"]]),
+            label="Specialisation",
+        )
+        subtype = create_subtype("Slotted Specialist")
+        modifier(
+            "Slotted Specialist: the general question arrives",
+            targets_model(),
+            ef_adds(general),
+            carried_by=subtype,
+        )
+        made = {}
+        for key, name in [("plain", "Officer"), ("subjugator", "Subjugator")]:
+            profile = create_profile(name, person_type, gang_type, price=0)
+            profile.built_ins = create_default_set(
+                f"{name} slotted built-ins", members=[subtype]
+            )
+            profile.save()
+            made[key] = profile
+        modifier(
+            "Subjugator: the general question goes",
+            targets_model(),
+            ef_removes(general),
+            carried_by=made["subjugator"],
+        )
+        modifier(
+            "Subjugator: the narrow question arrives",
+            targets_model(),
+            ef_adds(narrow),
+            carried_by=made["subjugator"],
+        )
+        return made, picks, narrow, subtype
+
+    def test_both_cards_ask_an_anchored_question(self, gang, slotted):
+        made, picks, narrow, subtype = slotted
+        plain = hire(gang, made["plain"], "Vosk")
+        subjugator = hire(gang, made["subjugator"], "Krell")
+
+        (plain_q,) = questions_on(plain)
+        (subjugator_q,) = questions_on(subjugator)
+        assert plain_q[1] == {"Sniper", "Gunner", "Medic", "Armourer"}
+        assert subjugator_q[1] == {"Gunner"}
+        for slot, _ in (plain_q, subjugator_q):
+            assert slot.anchor is not None
+            assert slot.anchor.assignment is not None
+
+    def test_the_narrow_question_settles_on_its_bearer(self, gang, slotted):
+        from n26.core.models import Assignment
+        from n26.core.reconcile import assert_reconciled
+        from n26.tests.sandbox.actions import choose
+
+        made, picks, narrow, subtype = slotted
+        subjugator = hire(gang, made["subjugator"], "Krell")
+        (slot_row,) = computed_for(subjugator).choices
+
+        choose(
+            slot_row.anchor.assignment,
+            picks["Gunner"],
+            slot=narrow,
+            miniature=subjugator,
+        )
+
+        (settled,) = computed_for(subjugator).choices
+        assert settled.chosen_name == "Gunner"
+        assert Assignment.objects.get(pickable=picks["Gunner"]).miniature == (
+            subjugator
+        )
+        assert_reconciled(gang)

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -29,8 +29,10 @@ from n26.tests.sandbox.actions import (
     assign,
     buy,
     choose,
+    create_affiliation,
     create_collection,
     create_gang_type,
+    create_hidden,
     create_pickable,
     create_picklist,
     create_profile,
@@ -45,8 +47,10 @@ from n26.tests.sandbox.actions import (
     has_subtypes,
     hire,
     modifier,
+    refund,
     remove,
     targets_every_model,
+    targets_gang,
     targets_model,
 )
 
@@ -870,6 +874,210 @@ class TestAGangPickOpensAChoiceOnEveryModel:
 
         profile, guild, nauticus, _ = guild_shape
         kaustos, _ = self.crew_with_the_pick(gang, profile, guild)
+        client.force_login(owner)
+        sheet = render_gang(gang)
+        link_slots(gang, sheet, *sheet.models)
+        card = next(drawn for drawn in sheet.models if drawn.name == "Kaustos")
+        (line,) = card.questions
+
+        body = client.get(line.href).content.decode()
+        assert "Nauticus" in body
+        response = client.post(line.href, {"thing": f"library.pickable:{nauticus.pk}"})
+
+        assert response.status_code == 302
+        assert Assignment.objects.get(pickable=nauticus).miniature == kaustos
+        assert_reconciled(gang)
+
+
+class TestAChoiceOpenedFurtherDownTheChain:
+    """The giver need not be a line the card holds. A wargear gives a
+    hidden carrier and the carrier opens the choice: nothing wrote the
+    carrier down, so the choice is addressed on the wargear the whole
+    chain stands on, and goes when the wargear does.
+    """
+
+    @pytest.fixture
+    def relic(self, person_type, gang_type, default_pack):
+        rite = create_slot_type("Rite")
+        vigil = create_pickable("The Vigil", rite)
+        modifier(
+            "The Vigil: its rule",
+            targets_model_with(),
+            ef_adds(create_rule("Keeps the Vigil")),
+            carried_by=vigil,
+        )
+        rites = create_picklist("Rites", rite, members=[vigil])
+        rite_slot = create_slot("Rite", rite, rites)
+        observances = create_hidden("The relic's observances")
+        modifier(
+            "The observances open the Rite choice",
+            targets_model(),
+            ef_adds(rite_slot),
+            carried_by=observances,
+        )
+        relic = create_wargear("Reliquary", price=30)
+        modifier(
+            "Reliquary: it carries its observances",
+            targets_model(),
+            ef_adds(observances),
+            carried_by=relic,
+        )
+        profile = create_profile("Devotee", person_type, gang_type, price=100)
+        return profile, relic, vigil, rite_slot
+
+    def test_the_choice_is_asked_and_addressed_on_the_wargear(self, gang, relic):
+        profile, wargear, _, _ = relic
+        kaustos = hire(gang, profile, "Kaustos", paid=100)
+        bought = buy(kaustos, thing=wargear, paid=30)
+
+        (rite_row,) = choices_of(kaustos)
+
+        assert rite_row.kind_label == "Rite"
+        assert rite_row.anchor.assignment == bought
+        assert_reconciled(gang)
+
+    def test_what_is_picked_lands_and_giving_the_wargear_back_takes_it(
+        self, gang, relic
+    ):
+        profile, wargear, vigil, rite_slot = relic
+        kaustos = hire(gang, profile, "Kaustos", paid=100)
+        bought = buy(kaustos, thing=wargear, paid=30)
+        (rite_row,) = choices_of(kaustos)
+        choose(rite_row.anchor.assignment, vigil, slot=rite_slot)
+        assert [line.name for line in card_of(kaustos)[1].rules] == ["Keeps the Vigil"]
+
+        refund(bought)
+
+        assert choices_of(kaustos) == []
+        assert not Assignment.objects.filter(pickable=vigil, archived=False).exists()
+        # The refund repinned the gang it reached through the assignment,
+        # which is not this instance.
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestAGangGuestOpensAChoiceOnEveryModel:
+    """The same shape one hop further down the chain: what opens the
+    choice is not a line the gang holds but a rule the gang was *given* —
+    an alliance's, written nowhere. The choice is asked on every fighter
+    all the same, addressed on the line the chain of grants stands on,
+    which is the alliance the gang signed.
+
+    A player who signed the alliance saw its rule arrive on the gang and
+    the Guild Role it opens arrive on nobody: every fighter had the role's
+    behaviour waiting and no card ever asked which role.
+    """
+
+    @pytest.fixture
+    def guild_shape(self, person_type, gang_type, default_pack):
+        role = create_slot_type("Guild Role")
+        nauticus = create_pickable("Nauticus", role)
+        modifier(
+            "Nauticus: its rule",
+            targets_model_with(),
+            ef_adds(create_rule("Master of Water")),
+            carried_by=nauticus,
+        )
+        roles = create_picklist("Guild Roles", role, members=[nauticus])
+        role_slot = create_slot("Guild Role", role, roles)
+        # What the gang is given, and what it opens. The rule is held by
+        # grant: no assignment names it anywhere.
+        pact = create_rule("The Water Pact")
+        modifier(
+            "The Water Pact: every hand has a role",
+            targets_every_model(),
+            ef_adds(role_slot),
+            carried_by=pact,
+        )
+        alliance = create_affiliation("Water Guild")
+        modifier(
+            "Water Guild: the gang has the Water Pact",
+            targets_gang(),
+            ef_adds(pact),
+            carried_by=alliance,
+        )
+        profile = create_profile("Hunter", person_type, gang_type, price=100)
+        return profile, alliance, nauticus, role_slot
+
+    @pytest.fixture
+    def gang(self, owner, gang_type):
+        return found_gang("The Long Hunt", gang_type, owner=owner, budget=1000)
+
+    def crew_and_alliance(self, gang, profile, alliance):
+        fighters = [
+            hire(gang, profile, name, paid=100) for name in ("Kaustos", "Grendel")
+        ]
+        return fighters, assign(alliance, gang=gang)
+
+    def test_the_gang_holds_the_rule_by_grant_and_nothing_writes_it_down(
+        self, gang, guild_shape
+    ):
+        profile, alliance, _, _ = guild_shape
+        (kaustos, _), _ = self.crew_and_alliance(gang, profile, alliance)
+
+        _, computed = card_of(kaustos)
+        assert [guest.name for guest in computed.echoed] == ["The Water Pact"]
+        assert not Assignment.objects.filter(rule__isnull=False).exists()
+
+    def test_every_model_is_asked_and_the_gang_is_not(self, gang, guild_shape):
+        profile, alliance, _, _ = guild_shape
+        fighters, _ = self.crew_and_alliance(gang, profile, alliance)
+
+        for fighter in fighters:
+            assert [row.kind_label for row in choices_of(fighter)] == ["Guild Role"]
+        assert [row.kind_label for row in gang_choices(gang).choices] == []
+        assert_reconciled(gang)
+
+    def test_the_choice_names_the_rule_and_is_asked_on_the_alliance(
+        self, gang, guild_shape
+    ):
+        profile, alliance, _, _ = guild_shape
+        (kaustos, _), signed = self.crew_and_alliance(gang, profile, alliance)
+
+        (role_row,) = choices_of(kaustos)
+
+        # The player is told what opened the choice; the address behind it
+        # is the written line that stands under the whole chain.
+        assert role_row.source == "The Water Pact"
+        assert role_row.anchor.assignment == signed
+
+    def test_the_role_settles_per_fighter_and_its_payload_lands(
+        self, gang, guild_shape
+    ):
+        profile, alliance, nauticus, role_slot = guild_shape
+        (kaustos, grendel), _ = self.crew_and_alliance(gang, profile, alliance)
+        (role_row,) = choices_of(kaustos)
+
+        choose(role_row.anchor.assignment, nauticus, slot=role_slot, miniature=kaustos)
+
+        # The guest itself draws no line on a fighter: what the pick gives
+        # is the fighter's, and the rule behind it stays the gang's.
+        assert [line.name for line in card_of(kaustos)[1].rules] == ["Master of Water"]
+        assert card_of(grendel)[1].rules == []
+        assert Assignment.objects.get(pickable=nauticus).miniature == kaustos
+        assert_reconciled(gang)
+
+    def test_dropping_the_alliance_takes_every_role_with_it(self, gang, guild_shape):
+        profile, alliance, nauticus, role_slot = guild_shape
+        (kaustos, _), signed = self.crew_and_alliance(gang, profile, alliance)
+        (role_row,) = choices_of(kaustos)
+        choose(role_row.anchor.assignment, nauticus, slot=role_slot, miniature=kaustos)
+
+        remove(signed)
+
+        assert choices_of(kaustos) == []
+        assert not Assignment.objects.filter(
+            pickable__isnull=False, archived=False
+        ).exists()
+        assert_reconciled(gang)
+
+    def test_the_screen_asks_on_the_fighters_card_and_the_click_lands(
+        self, gang, guild_shape, client, owner
+    ):
+        from n26.core.views.choose import link_slots
+
+        profile, alliance, nauticus, _ = guild_shape
+        (kaustos, _), _ = self.crew_and_alliance(gang, profile, alliance)
         client.force_login(owner)
         sheet = render_gang(gang)
         link_slots(gang, sheet, *sheet.models)

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -1017,7 +1017,9 @@ class TestAGangGuestOpensAChoiceOnEveryModel:
 
         _, computed = card_of(kaustos)
         assert [guest.name for guest in computed.echoed] == ["The Water Pact"]
-        assert not Assignment.objects.filter(rule__isnull=False).exists()
+        assert not Assignment.objects.filter(
+            rule__isnull=False, gang_root=gang
+        ).exists()
 
     def test_every_model_is_asked_and_the_gang_is_not(self, gang, guild_shape):
         profile, alliance, _, _ = guild_shape

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -1020,6 +1020,7 @@ class TestAGangGuestOpensAChoiceOnEveryModel:
         assert not Assignment.objects.filter(
             rule__isnull=False, gang_root=gang
         ).exists()
+        assert_reconciled(gang)
 
     def test_every_model_is_asked_and_the_gang_is_not(self, gang, guild_shape):
         profile, alliance, _, _ = guild_shape
@@ -1042,6 +1043,7 @@ class TestAGangGuestOpensAChoiceOnEveryModel:
         # is the written line that stands under the whole chain.
         assert role_row.source == "The Water Pact"
         assert role_row.anchor.assignment == signed
+        assert_reconciled(gang)
 
     def test_the_role_settles_per_fighter_and_its_payload_lands(
         self, gang, guild_shape


### PR DESCRIPTION
Closes #2181
Closes #2206 — that PR's commits are rebased onto this branch, so the halves of one problem land together.
Refs #2209 — a pre-existing collision this work makes reachable in more shapes, filed rather than fixed here.

## Summary

- **A question with no address.** A choice needs a stored assignment behind it: the link embeds its key, and the answer is filed against it. When the thing offering the choice arrived by *grant* rather than being written down, there was no such row — so the question either was never asked at all (a gang guest's), or drew on the card with nothing to click and no way to answer (an older-style offer's). Questions are now addressed on the written line their chain of grants stands on, which for a gang's guest is the gang's own assignment, already riding every member's card.
- **A question whose subject had gone.** Retraction dropped what a dead giver applied, but a slot removed by a still-live giver kept its question, so a card asked about something that no longer existed. A given slot's question now stands only while the slot does.
- Both ways content can ask a choice — the older "offers a choice" modifier and the newer slot — now share one rule for where a question is addressed.

## What changed

`n26/core/effects.py` threads the chain's root through the grant loop: `Contribution` and `PlannedStep` carry the key of the written line the carrier stands on — its own where the card holds it, inherited from the granter otherwise. Both choice kinds are addressed on that line, so the old lookup from a thing to its carrying line is gone entirely. Separately, given slots are filtered against the retraction set, so a removed slot takes its question with it.

`Operation.choose` gained one more thing to be told. The anchor is no longer necessarily the offerer, so it may carry no offer of its own or several, and the click now names which choice it answers — exactly what a slot's own assignment already did for the other kind. Without it the pick lands nowhere and the click silently does nothing; there is a test that fails in exactly that way if the argument is dropped.

## The pattern this unblocks

A Specialist subtype grants the general specialisation choice; a Subjugator Patrol Officer profile takes it away and grants a narrower one, so its card asks the same question over a shorter list. `n26/tests/sandbox/test_offer_swap_probe.py` pins that story in both possible builds — it was written to record why the pattern was tried and abandoned, and now records it working, including a test that clicks through the real screen and lands the pick.

## Test plan

- [x] Full repository suite green — 7787 passed, 12 skipped, 1 xfailed (the xfail is pre-existing)
- [x] Eight new tests in `n26/tests/sandbox/test_slots_and_picks.py`: a gang guest opening a choice on every model, and a local grant chain opening one on a single card
- [x] Reverting **only** the anchor change fails five of them exactly as the bug reads — no choice row, no question on the card, no link to click
- [x] Ten tests in `n26/tests/sandbox/test_offer_swap_probe.py` covering both builds of the swap pattern, plus the plan trace showing the removal reached
- [x] The write-path argument proven load-bearing: dropped from the view, the end-to-end test fails with the choice still unanswered
- [x] Nothing else in n26 depended on the old anchorless behaviour — the whole suite passes with the three pins rewritten
- [x] Seeded the guest shape into a development database and rendered the real gang page — both fighters show the question, each linking to the picker through the alliance's assignment

## Known, filed as #2209

Two same-kind choices on one carrier with overlapping menus share an answer: settling one makes both read as settled. Reproduced with **no grants involved**, so it predates this work and `_fill_choice_slots` is untouched here. This PR does widen the shapes that can reach it, because choices offered by a granted carrier previously had no address and could never be answered at all — nothing that worked before regresses. The fix is a per-offer discriminator mirroring the slot path's `chosen_for_slot`, which needs a migration; #2209 has the sketch.

## One edge left alone

If something *else* cancels a guest mid-chain, its question disappears while the stored pick remains — the pick hangs off the line at the foot of the chain, not off the cancelled grant. Not new and not specific to guests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
