### PR TITLE
fix: a bought subtype cannot be unticked, and adding one is the switcher shape

### DIFF
--- a/n26/core/effects.py
+++ b/n26/core/effects.py
@@ -1571,16 +1571,44 @@ def _suppress(card, thing):
     the gun stays. Answers with what it hid and what it left alone.
     """
     hidden, refused = [], []
-    wanted = ModifierIndex.key(thing)
-    for node in card.all_nodes():
-        if node.computed or ModifierIndex.key(node.assignable) != wanted:
-            continue
+    for node in _stored_lines(card, thing):
         if any(line.carries_money for line in node.walk()):
             refused.append(node)
         else:
             node.suppressed = True
             hidden.append(node)
     return tuple(hidden), tuple(refused)
+
+
+def _stored_lines(card, thing):
+    """The card's own written lines naming this thing — what a removal
+    reaches. Granted lines are the grants' own output and are retracted
+    through the log instead."""
+    wanted = ModifierIndex.key(thing)
+    return [
+        node
+        for node in card.all_nodes()
+        if not node.computed and ModifierIndex.key(node.assignable) == wanted
+    ]
+
+
+def stands_whatever_happens(card, thing):
+    """Whether taking this away would leave it on the card regardless.
+
+    The mirror of what :func:`_suppress` refuses: a written line nobody
+    paid for is hidden, and one with money behind it is left exactly
+    where it is. So a thing every line of which carries money cannot be
+    taken away at all, and a surface offering to do so has to ask this
+    first — otherwise it writes a removal that changes nothing and then
+    reports a loss the card denies.
+
+    Held twice, once paid for, counts as standing: the free line goes and
+    the thing is still there, doing everything it does.
+    """
+    lines = _stored_lines(card, thing)
+    if not lines:
+        return False
+    return any(any(line.carries_money for line in node.walk()) for node in lines)
 
 
 def _retract(computed, log):

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -307,6 +307,12 @@ class Choosable:
     #: surface offering things to tick draws it fixed: there is nothing a click
     #: could take away.
     granted_by: str = ""
+    #: Why this one cannot be changed, where something other than a grant
+    #: fixes it — money standing behind it. Drawn fixed like a granted
+    #: line, saying this instead of a giver. A surface must not offer an
+    #: act that would be refused: the refusal would arrive as a message
+    #: about a change the card then denies.
+    fixed_because: str = ""
     #: The other choice on this holder that has already settled on it,
     #: where the slot type says one pickable answers one choice. Marked
     #: and never withheld: the owner may still pick it, and the card says

--- a/n26/core/templates/cotton/n26/pick_list/box.html
+++ b/n26/core/templates/cotton/n26/pick_list/box.html
@@ -1,0 +1,40 @@
+{% comment %}
+<c-n26.pick-list.box> — one option of a pick list, as a box to tick.
+
+    <c-n26.pick-list.box :option="option" name="subtypes" />
+
+The row <c-n26.pick-list> draws, whether the thing is held or is one of the
+hundred the panel offers — one definition, so the two runs cannot come to look
+different. Binds to `picked` above it in the Alpine scope, which is what lets
+the panel tick a box and the list read what is ticked.
+
+Every line states its own size: `text-muted` is a colour and carries none, so a
+muted line without one inherits whatever it sits in and can come out larger
+than the name it belongs under.
+
+  :option — a n26.render.Choosable.
+  name — the input name this box submits under.
+{% endcomment %}
+<c-vars :option="None" name="thing" class="" />
+
+<label {{ attrs }}
+       class="flex items-start gap-2 py-0.5 {% if option.granted_by or option.fixed_because %}cursor-not-allowed opacity-60{% else %}cursor-pointer{% endif %} {{ class }}"
+       {% if option.granted_by %}title="From {{ option.granted_by }}"{% elif option.fixed_because %}title="{{ option.fixed_because }}"{% endif %}>
+    <input type="checkbox"
+           name="{{ name }}"
+           value="{{ option.key }}"
+           x-model="picked"
+           {% if option.is_current %}checked{% endif %}
+           {% if option.granted_by or option.fixed_because %}disabled{% endif %}
+           class="mt-1 size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
+    <span class="min-w-0 flex-1">
+        <span class="block text-base text-ink-900 dark:text-ink-100">{{ option.name }}</span>
+        {% if option.granted_by %}
+            <span class="block text-sm text-muted">From {{ option.granted_by }}</span>
+        {% elif option.fixed_because %}
+            <span class="block text-sm text-muted">{{ option.fixed_because }}</span>
+        {% elif option.detail %}
+            <span class="block text-sm text-muted">{{ option.detail }}</span>
+        {% endif %}
+    </span>
+</label>

--- a/n26/core/templates/cotton/n26/pick_list/index.html
+++ b/n26/core/templates/cotton/n26/pick_list/index.html
@@ -1,0 +1,137 @@
+{% comment %}
+<c-n26.pick-list> — what a thing has, and a searchable way to add to it.
+
+    <c-n26.pick-list :offer="held" :addable="rest" name="subtypes"
+                     add_label="Add a subtype" placeholder="Search subtypes">
+        <c-slot name="actions">…Reset and Save…</c-slot>
+    </c-n26.pick-list>
+
+A list of ticked boxes, and a button that opens the rest of the library as a
+searchable panel. Click a row in the panel and its box appears in the list
+above, already ticked; clear a box and the row is offered again. Nothing is
+fetched and nothing reloads, because every box was already on the page.
+
+The panel is <c-n26.quick-switcher>, which is where a reader has already met
+this shape — a chevron, a filter box, arrow keys, Enter on the highlighted row.
+Its rows are <c-n26.quick-switcher.choice>, which report a value rather than
+navigate; the value is the option's key, because two rows can read alike and
+mean different rows.
+
+  --- the boxes are the control ---
+
+Every option is a real checkbox with the same name, ticked or not by the
+server, and the form posts exactly what it always did. The panel only ticks
+them: it adds no input of its own, so there is nothing to post that nobody
+chose, and no value can arrive that was not already on the page.
+
+  --- with no script ---
+
+The addable boxes are hidden by an inline style and shown again by a <noscript>
+rule, so a reader with no script gets one plain list of every option — the
+whole library, ticked where it is held — and the form works. The panel is
+cloaked, because a filter box and a chevron that do nothing are worse than no
+control at all. With script the same style keeps the hundred unticked boxes
+from flashing up before Alpine folds them away.
+
+  --- Save says whether there is anything to save ---
+
+With script, Save is disabled until the ticked set differs from the one the
+page arrived with. The `actions` slot renders inside this component's Alpine
+scope, which is what lets a caller bind `::disabled="!dirty"` on its own
+button. Without script `dirty` is nothing, the attribute is never added, and
+Save stays live.
+
+  --- what a fixed box means ---
+
+An option the offer marks granted, or otherwise fixed, is drawn ticked and
+disabled saying why — as <c-n26.tick-list> draws them. A disabled box submits
+nothing, so whatever applies the difference must leave those out rather than
+read their silence as a clearing.
+
+  :offer — a n26.render.ChoiceOffer: what the thing has, and anything the owner
+    has touched. Always drawn, so a row saying "taken away by you" stays where
+    it can be put back.
+  :addable — the rest of the library, as n26.render.Choosable options. Each is
+    a box that appears once ticked, and a row in the panel until it is.
+  name — the input name every box submits under.
+  add_label — the panel's heading, and the words on the button that opens it.
+  placeholder — the filter's placeholder, and its accessible name.
+  actions — the form's buttons. Rendered inside the Alpine scope, so they may
+    read `dirty`.
+{% endcomment %}
+<c-vars :offer="None"
+        :addable="None"
+        name="thing"
+        add_label="Add"
+        placeholder="Search"
+        actions=""
+        class="" />
+
+{% comment %}
+`picked` is the ticked set and every box binds to it, so the boxes are the truth
+and this only reads them. `opened` is the set the page arrived with, kept so
+Save can say whether anything moved.
+{% endcomment %}
+<div {{ attrs }}
+     x-data="{
+         picked: [],
+         opened: [],
+         init() {
+             this.picked = Array.from(
+                 this.$root.querySelectorAll('input[type=checkbox]:checked')
+             ).map(box => box.value);
+             this.opened = [...this.picked];
+         },
+         isPicked(key) { return this.picked.includes(key) },
+         pick(key) { if (!this.isPicked(key)) this.picked.push(key) },
+         get dirty() {
+             return this.picked.length !== this.opened.length
+                 || this.picked.some(key => !this.opened.includes(key));
+         },
+     }"
+     @quick-switcher-choose="pick($event.detail.value)"
+     class="{{ class }}">
+    <noscript>
+        <style>.n26-addable { display: flex !important; }</style>
+    </noscript>
+    <div class="flex flex-col">
+        {% for group in offer.groups %}
+            {% for option in group.options %}
+                <c-n26.pick-list.box :option="option" name="{{ name }}" />
+            {% endfor %}
+        {% endfor %}
+        {% comment %}
+        Hidden until ticked, and hidden by a style rather than by x-show alone
+        so a hundred boxes do not flash up before Alpine folds them away. The
+        noscript rule above puts them back for a reader with no script, for
+        whom this list is the only way to add anything.
+        {% endcomment %}
+        {% for option in addable %}
+            <c-n26.pick-list.box :option="option"
+                                 name="{{ name }}"
+                                 class="n26-addable"
+                                 style="display: none"
+                                 x-show="isPicked('{{ option.key }}')" />
+        {% endfor %}
+    </div>
+    {% if addable %}
+        {% comment %}
+        Cloaked: without Alpine the panel cannot filter and its rows cannot
+        tick anything, and the full list of boxes above is the way in.
+        {% endcomment %}
+        <div x-cloak class="mt-2">
+            <c-n26.quick-switcher heading="{{ add_label }}"
+                                  menu_label="{{ add_label }}"
+                                  trigger_words="{{ add_label }}"
+                                  placeholder="{{ placeholder }}"
+                                  min_width="20rem">
+                {% for option in addable %}
+                    <c-n26.quick-switcher.choice label="{{ option.name }}"
+                                                 value="{{ option.key }}"
+                                                 available="!isPicked('{{ option.key }}')" />
+                {% endfor %}
+            </c-n26.quick-switcher>
+        </div>
+    {% endif %}
+    {% if actions.strip %}<div class="mt-3">{{ actions }}</div>{% endif %}
+</div>

--- a/n26/core/templates/cotton/n26/quick_switcher/choice.html
+++ b/n26/core/templates/cotton/n26/quick_switcher/choice.html
@@ -16,21 +16,25 @@ A <button>, not a link with a dead href: a link that goes nowhere is offered as
 a place, opens nothing in a new tab, and is read aloud as a lie. Enter still
 works, because the panel clicks the highlighted row.
 
-Clicking dispatches a bubbling `quick-switcher-choose` carrying this row's
-label, and the caller listens for it on whatever holds the switcher. Which row
-is current is bound rather than fixed at render, since the choice takes effect
-without a reload; the comparison is the caller's to write.
+Clicking dispatches a bubbling `quick-switcher-choose` carrying what this row
+stands for, and the caller listens for it on whatever holds the switcher. Which
+row is current is bound rather than fixed at render, since the choice takes
+effect without a reload; the comparison is the caller's to write.
 
-  label — what the row says, what the filter matches, and what it reports.
+  label — what the row says, and what the filter matches.
+  value — what the row reports and is compared on. Defaults to the label, which
+    is right where the words are the thing. Set it where they are not: two rows
+    may read alike and mean different things, and a caller acting on the words
+    would act on whichever it found first.
   current_value — an Alpine expression holding the choice in force. This row is
-    current while that equals its label; left out, no row is ever marked.
+    current while that equals its value; left out, no row is ever marked.
   available — an Alpine expression; the row is drawn only while it is true, and
     `label` is in scope so a caller can ask about this row. An unavailable row
     is still reachable by the arrow keys, so a caller offering rows that come
     and go must handle a choice it cannot honour.
   icon — a c-n26.icon name before the label.
 {% endcomment %}
-<c-vars label="" current_value="false" available="true" icon="" class="" />
+<c-vars label="" value="" current_value="false" available="true" icon="" class="" />
 
 {% comment %}
 register, matches, highlight, active and close all live above this row in the
@@ -44,18 +48,18 @@ emitted them, so this one is marked important.
 {% endcomment %}
 <button type="button"
         role="menuitem"
-        x-data="{ id: '', label: {{ label|json_dumps }}, facets: { search: {{ label|lower|json_dumps }} } }"
+        x-data="{ id: '', label: {{ label|json_dumps }}, value: {{ value|default:label|json_dumps }}, facets: { search: {{ label|lower|json_dumps }} } }"
         x-init="id = register($el, facets)"
         :id="id"
         x-show="matches(facets) &amp;&amp; ({{ available }})"
         x-cloak
-        @click="$dispatch('quick-switcher-choose', { value: label }); close()"
+        @click="$dispatch('quick-switcher-choose', { value: value }); close()"
         @mouseenter="highlight(id)"
-        :aria-current="({{ current_value }}) === label ? 'true' : 'false'"
+        :aria-current="({{ current_value }}) === value ? 'true' : 'false'"
         :class="{
             'bg-ink-200! dark:bg-ink-700!': active === id,
-            'bg-ink-100 font-medium text-ink-900 dark:bg-ink-800 dark:text-ink-100': ({{ current_value }}) === label,
-            'text-ink-700 dark:text-ink-300': ({{ current_value }}) !== label,
+            'bg-ink-100 font-medium text-ink-900 dark:bg-ink-800 dark:text-ink-100': ({{ current_value }}) === value,
+            'text-ink-700 dark:text-ink-300': ({{ current_value }}) !== value,
         }"
         {{ attrs }}
         class="flex w-full items-center gap-2.5 border-b border-box-border px-3 py-2 text-left text-sm
@@ -67,7 +71,7 @@ emitted them, so this one is marked important.
         <c-n26.icon name="{{ icon }}" class="size-4 shrink-0 text-ink-500 dark:text-ink-400" />
     {% endif %}
     <span class="min-w-0 flex-1 truncate">{{ label }}</span>
-    <span x-show="({{ current_value }}) === label" x-cloak class="shrink-0">
+    <span x-show="({{ current_value }}) === value" x-cloak class="shrink-0">
         <c-n26.icon name="check" class="size-4 text-accent-text" />
     </span>
 </button>

--- a/n26/core/templates/cotton/n26/tick_list.html
+++ b/n26/core/templates/cotton/n26/tick_list.html
@@ -20,6 +20,12 @@ Rows rather than cards, to sit in a box beside a model's card. An empty offer
 draws nothing; what to say instead depends on why it is empty, which the page
 knows and this does not.
 
+Every line states its own font size. `text-muted` is a colour and carries no
+size, so a muted line without one inherits whatever it sits in and can come out
+*larger* than the name it belongs under. The order here is the reading order: a
+heading and an option name at the base size, and the lines that qualify them —
+the tier caption, and where a thing came from — a step smaller.
+
   :offer — a n26.render.ChoiceOffer.
   name — the input name every box submits under. One name across every group.
 {% endcomment %}
@@ -33,9 +39,9 @@ knows and this does not.
         only where the list spans several — see n26.render.ChoosableGroup.
         {% endcomment %}
         <fieldset>
-            <legend class="mb-1 block text-sm font-semibold text-ink-900 dark:text-ink-100">
+            <legend class="mb-1 block text-base font-semibold text-ink-900 dark:text-ink-100">
                 {{ group.name }}
-                {% if group.caption %}<span class="font-normal text-muted">{{ group.caption }}</span>{% endif %}
+                {% if group.caption %}<span class="text-sm font-normal text-muted">{{ group.caption }}</span>{% endif %}
             </legend>
             <div class="space-y-1">
                 {% for option in group.options %}
@@ -46,13 +52,13 @@ knows and this does not.
                                value="{{ option.key }}"
                                {% if option.is_current %}checked{% endif %}
                                {% if option.granted_by %}disabled{% endif %}
-                               class="mt-0.5 size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
+                               class="mt-1 size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
                         <span class="min-w-0 flex-1">
-                            <span class="block text-sm text-ink-900 dark:text-ink-100">{{ option.name }}</span>
+                            <span class="block text-base text-ink-900 dark:text-ink-100">{{ option.name }}</span>
                             {% if option.granted_by %}
-                                <span class="block text-muted">From {{ option.granted_by }}</span>
+                                <span class="block text-sm text-muted">From {{ option.granted_by }}</span>
                             {% elif option.detail %}
-                                <span class="block text-muted">{{ option.detail }}</span>
+                                <span class="block text-sm text-muted">{{ option.detail }}</span>
                             {% endif %}
                         </span>
                     </label>

--- a/n26/core/templates/cotton/n26/tick_list.html
+++ b/n26/core/templates/cotton/n26/tick_list.html
@@ -11,10 +11,15 @@ each.
 Checkboxes and no script. What arrives ticked is what the server said, and a box
 that submits nothing has been cleared.
 
-An option the rules grant is drawn ticked and disabled, saying what grants it —
-nothing is stored behind it for a click to take away. A disabled box submits
-nothing, so whatever applies the difference must leave granted options out
-rather than read their silence as a clearing.
+Two kinds of option are drawn ticked and disabled, each saying why. One the
+rules grant says what grants it — nothing is stored behind it for a click to
+take away. One that is fixed for another reason says that reason instead: money
+standing behind it, which a removal would leave exactly where it is. Both are
+the same rule — never offer an act that would be refused, because the refusal
+arrives as a message about a change the card then denies.
+
+A disabled box submits nothing, so whatever applies the difference must leave
+both kinds out rather than read their silence as a clearing.
 
 Rows rather than cards, to sit in a box beside a model's card. An empty offer
 draws nothing; what to say instead depends on why it is empty, which the page
@@ -45,18 +50,20 @@ the tier caption, and where a thing came from — a step smaller.
             </legend>
             <div class="space-y-1">
                 {% for option in group.options %}
-                    <label class="flex items-start gap-2 {% if option.granted_by %}cursor-not-allowed opacity-60{% else %}cursor-pointer{% endif %}"
-                           {% if option.granted_by %}title="From {{ option.granted_by }}"{% endif %}>
+                    <label class="flex items-start gap-2 {% if option.granted_by or option.fixed_because %}cursor-not-allowed opacity-60{% else %}cursor-pointer{% endif %}"
+                           {% if option.granted_by %}title="From {{ option.granted_by }}"{% elif option.fixed_because %}title="{{ option.fixed_because }}"{% endif %}>
                         <input type="checkbox"
                                name="{{ name }}"
                                value="{{ option.key }}"
                                {% if option.is_current %}checked{% endif %}
-                               {% if option.granted_by %}disabled{% endif %}
+                               {% if option.granted_by or option.fixed_because %}disabled{% endif %}
                                class="mt-1 size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
                         <span class="min-w-0 flex-1">
                             <span class="block text-base text-ink-900 dark:text-ink-100">{{ option.name }}</span>
                             {% if option.granted_by %}
                                 <span class="block text-sm text-muted">From {{ option.granted_by }}</span>
+                            {% elif option.fixed_because %}
+                                <span class="block text-sm text-muted">{{ option.fixed_because }}</span>
                             {% elif option.detail %}
                                 <span class="block text-sm text-muted">{{ option.detail }}</span>
                             {% endif %}

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -93,60 +93,46 @@ is named by the page's own heading directly below.
             </form>
         </c-slot>
         {% comment %}
-        What the model is — its subtypes and its special rules. What the
-        card shows is a short list of boxes: clearing one takes the thing
-        away however it arrived (a paid-for one stays, and the page says
-        so). The rest of the library is a hundred rules nobody scans, so
-        it is a select with a filter box over it rather than a list —
-        picking from it adds in the owner's name.
-
-        The boxes and the select share an input name, so the browser
-        posts one list however a thing was chosen and the difference is
-        taken once. Both work with no script: the select renders as the
-        plain multiple select it is.
+        What the model is — its subtypes and its special rules, each the
+        whole library as boxes with what the card shows gathered on top
+        (see <c-n26.pick-list>). Ticking one adds it in the owner's name;
+        clearing one takes it away however it arrived. A thing money
+        stands behind is drawn fixed and says so, because a removal would
+        leave it exactly where it is — the equip screen's sale is the way
+        to be rid of it.
 
         Reset per section archives the owner's edits, so the content's
         own answer is always one act away — which is why Reset is drawn
-        only while there are edits to undo.
+        only while there are edits to undo. Save says whether there is
+        anything to save.
         {% endcomment %}
         <c-slot name="edits">
             {% if subtype_edits or subtype_more or rule_edits or rule_more %}
                 <div class="space-y-5">
                     {% if subtype_edits or subtype_more %}
                         <div>
+                            <h3 class="mb-1 text-base font-semibold text-ink-900 dark:text-ink-100">Subtypes</h3>
                             <form method="post" action="{{ edit_url }}">
                                 {% csrf_token %}
                                 <input type="hidden" name="act" value="subtypes">
-                                {% if subtype_edits %}
-                                    <c-n26.tick-list :offer="subtype_edits" name="subtypes" />
-                                {% endif %}
-                                {% if subtype_more %}
-                                    <div class="{% if subtype_edits %}mt-3{% endif %}">
-                                        <label for="add-subtype"
-                                               class="mb-1 block text-sm font-medium text-ink-700 dark:text-ink-300">
-                                            Add a subtype
-                                        </label>
-                                        <c-n26.filter-select placeholder="Type to filter subtypes">
-                                            <c-ui.select.native name="subtypes" id="add-subtype" placeholder="" multiple>
-                                                {% for option in subtype_more %}
-                                                    <c-ui.select.option value="{{ option.key }}">
-                                                        {{ option.name }}
-                                                    </c-ui.select.option>
-                                                {% endfor %}
-                                            </c-ui.select.native>
-                                        </c-n26.filter-select>
-                                    </div>
-                                {% endif %}
-                                <div class="mt-3 flex items-center justify-end gap-2">
-                                    {% if subtype_edits_dirty %}
-                                        <c-ui.button type="submit" form="reset-subtypes" variant="subtle" size="sm">
-                                            Reset
-                                        </c-ui.button>
-                                    {% endif %}
-                                    <c-ui.button type="submit" variant="success" size="sm">
-                                        Save subtypes
-                                    </c-ui.button>
-                                </div>
+                                <c-n26.pick-list :offer="subtype_edits"
+                                                 :addable="subtype_more"
+                                                 name="subtypes"
+                                                 add_label="Add a subtype"
+                                                 placeholder="Search subtypes">
+                                    <c-slot name="actions">
+                                        <div class="flex items-center justify-end gap-2">
+                                            {% if subtype_edits_dirty %}
+                                                <c-ui.button type="submit" form="reset-subtypes" variant="subtle" size="sm">
+                                                    Reset
+                                                </c-ui.button>
+                                            {% endif %}
+                                            <c-ui.button type="submit" variant="success" size="sm" ::disabled="!dirty">
+                                                Save subtypes
+                                            </c-ui.button>
+                                        </div>
+                                    </c-slot>
+                                </c-n26.pick-list>
                             </form>
                             {% if subtype_edits_dirty %}
                                 <form id="reset-subtypes" method="post" action="{{ edit_url }}">
@@ -159,39 +145,28 @@ is named by the page's own heading directly below.
                     {% endif %}
                     {% if rule_edits or rule_more %}
                         <div>
+                            <h3 class="mb-1 text-base font-semibold text-ink-900 dark:text-ink-100">Special rules</h3>
                             <form method="post" action="{{ edit_url }}">
                                 {% csrf_token %}
                                 <input type="hidden" name="act" value="rules">
-                                {% if rule_edits %}
-                                    <c-n26.tick-list :offer="rule_edits" name="rules" />
-                                {% endif %}
-                                {% if rule_more %}
-                                    <div class="{% if rule_edits %}mt-3{% endif %}">
-                                        <label for="add-rule"
-                                               class="mb-1 block text-sm font-medium text-ink-700 dark:text-ink-300">
-                                            Add a special rule
-                                        </label>
-                                        <c-n26.filter-select placeholder="Type to filter special rules">
-                                            <c-ui.select.native name="rules" id="add-rule" placeholder="" multiple>
-                                                {% for option in rule_more %}
-                                                    <c-ui.select.option value="{{ option.key }}">
-                                                        {{ option.name }}
-                                                    </c-ui.select.option>
-                                                {% endfor %}
-                                            </c-ui.select.native>
-                                        </c-n26.filter-select>
-                                    </div>
-                                {% endif %}
-                                <div class="mt-3 flex items-center justify-end gap-2">
-                                    {% if rule_edits_dirty %}
-                                        <c-ui.button type="submit" form="reset-rules" variant="subtle" size="sm">
-                                            Reset
-                                        </c-ui.button>
-                                    {% endif %}
-                                    <c-ui.button type="submit" variant="success" size="sm">
-                                        Save rules
-                                    </c-ui.button>
-                                </div>
+                                <c-n26.pick-list :offer="rule_edits"
+                                                 :addable="rule_more"
+                                                 name="rules"
+                                                 add_label="Add a special rule"
+                                                 placeholder="Search special rules">
+                                    <c-slot name="actions">
+                                        <div class="flex items-center justify-end gap-2">
+                                            {% if rule_edits_dirty %}
+                                                <c-ui.button type="submit" form="reset-rules" variant="subtle" size="sm">
+                                                    Reset
+                                                </c-ui.button>
+                                            {% endif %}
+                                            <c-ui.button type="submit" variant="success" size="sm" ::disabled="!dirty">
+                                                Save rules
+                                            </c-ui.button>
+                                        </div>
+                                    </c-slot>
+                                </c-n26.pick-list>
                             </form>
                             {% if rule_edits_dirty %}
                                 <form id="reset-rules" method="post" action="{{ edit_url }}">

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -93,13 +93,21 @@ is named by the page's own heading directly below.
             </form>
         </c-slot>
         {% comment %}
-        What the model is — its subtypes and its special rules, ticked
-        where the card shows them by any route. Clearing a box takes the
-        thing away however it arrived (a paid-for one stays, and the
-        page says so); ticking an absent one adds it in the owner's
-        name. Reset per section archives the owner's edits, so the
-        content's own answer is always one act away — which is why Reset
-        is drawn only while there are edits to undo.
+        What the model is — its subtypes and its special rules. What the
+        card shows is a short list of boxes: clearing one takes the thing
+        away however it arrived (a paid-for one stays, and the page says
+        so). The rest of the library is a hundred rules nobody scans, so
+        it is a select with a filter box over it rather than a list —
+        picking from it adds in the owner's name.
+
+        The boxes and the select share an input name, so the browser
+        posts one list however a thing was chosen and the difference is
+        taken once. Both work with no script: the select renders as the
+        plain multiple select it is.
+
+        Reset per section archives the owner's edits, so the content's
+        own answer is always one act away — which is why Reset is drawn
+        only while there are edits to undo.
         {% endcomment %}
         <c-slot name="edits">
             {% if subtype_edits or subtype_more or rule_edits or rule_more %}
@@ -113,12 +121,21 @@ is named by the page's own heading directly below.
                                     <c-n26.tick-list :offer="subtype_edits" name="subtypes" />
                                 {% endif %}
                                 {% if subtype_more %}
-                                    <details {% if subtype_edits %}class="mt-2"{% endif %}>
-                                        <summary class="cursor-pointer text-sm text-ink-500 dark:text-ink-400">All subtypes</summary>
-                                        <div class="mt-2">
-                                            <c-n26.tick-list :offer="subtype_more" name="subtypes" />
-                                        </div>
-                                    </details>
+                                    <div class="{% if subtype_edits %}mt-3{% endif %}">
+                                        <label for="add-subtype"
+                                               class="mb-1 block text-sm font-medium text-ink-700 dark:text-ink-300">
+                                            Add a subtype
+                                        </label>
+                                        <c-n26.filter-select placeholder="Type to filter subtypes">
+                                            <c-ui.select.native name="subtypes" id="add-subtype" placeholder="" multiple>
+                                                {% for option in subtype_more %}
+                                                    <c-ui.select.option value="{{ option.key }}">
+                                                        {{ option.name }}
+                                                    </c-ui.select.option>
+                                                {% endfor %}
+                                            </c-ui.select.native>
+                                        </c-n26.filter-select>
+                                    </div>
                                 {% endif %}
                                 <div class="mt-3 flex items-center justify-end gap-2">
                                     {% if subtype_edits_dirty %}
@@ -149,12 +166,21 @@ is named by the page's own heading directly below.
                                     <c-n26.tick-list :offer="rule_edits" name="rules" />
                                 {% endif %}
                                 {% if rule_more %}
-                                    <details {% if rule_edits %}class="mt-2"{% endif %}>
-                                        <summary class="cursor-pointer text-sm text-ink-500 dark:text-ink-400">All special rules</summary>
-                                        <div class="mt-2">
-                                            <c-n26.tick-list :offer="rule_more" name="rules" />
-                                        </div>
-                                    </details>
+                                    <div class="{% if rule_edits %}mt-3{% endif %}">
+                                        <label for="add-rule"
+                                               class="mb-1 block text-sm font-medium text-ink-700 dark:text-ink-300">
+                                            Add a special rule
+                                        </label>
+                                        <c-n26.filter-select placeholder="Type to filter special rules">
+                                            <c-ui.select.native name="rules" id="add-rule" placeholder="" multiple>
+                                                {% for option in rule_more %}
+                                                    <c-ui.select.option value="{{ option.key }}">
+                                                        {{ option.name }}
+                                                    </c-ui.select.option>
+                                                {% endfor %}
+                                            </c-ui.select.native>
+                                        </c-n26.filter-select>
+                                    </div>
                                 {% endif %}
                                 <div class="mt-3 flex items-center justify-end gap-2">
                                     {% if rule_edits_dirty %}

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -71,13 +71,14 @@ def _edits_offer(own, computed, field, heading):
     archives that removal, so the content's own answer is always one
     click away.
 
-    Two offers rather than one, because the library runs to a hundred
-    rules and a wall of clear boxes buries the handful that matter: the
-    first holds what the card shows and what the owner has touched, the
-    second everything else, for the page to fold away. A ticked box in
-    the folded half still submits, so the split changes nothing about
-    what a save means. Both are None where the library offers nothing,
-    so the page can skip the section rather than draw an empty list.
+    Two answers, because the two halves are read differently. What the
+    card shows is a short list to check over, and comes back as a
+    ``ChoiceOffer`` for the boxes to tick. The rest of the library runs
+    to a hundred rules that nobody scans, so it comes back as bare
+    options for a searchable select to add from. Both feed inputs of the
+    same name, so the browser posts one list and the difference is taken
+    once; either is empty where the library has nothing to offer, and the
+    page draws neither.
     """
     from n26.core.render import ChoiceOffer, Choosable, ChoosableGroup
     from n26.core.views.learn import _key
@@ -110,18 +111,12 @@ def _edits_offer(own, computed, field, heading):
         else:
             rest.append(option)
 
-    def boxed(options, name):
-        if not options:
-            return None
-        return ChoiceOffer(
-            label="", groups=[ChoosableGroup(name=name, options=options)]
-        )
-
-    return (
-        boxed(current, heading),
-        boxed(rest, ""),
-        bool(own_adds or removed),
+    held = (
+        ChoiceOffer(label="", groups=[ChoosableGroup(name=heading, options=current)])
+        if current
+        else None
     )
+    return held, rest, bool(own_adds or removed)
 
 
 def _apply_edits(op, miniature, own, computed, field, ticked):

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -1,5 +1,7 @@
 """One model's own page — the card, editable, and the owner's notes."""
 
+from dataclasses import dataclass
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import Http404
@@ -14,17 +16,46 @@ from n26.core.views.permissions import _own_miniature_or_404
 EDITABLE_KINDS = {"subtypes": "subtype", "rules": "rule"}
 
 
+@dataclass(frozen=True)
+class _EditState:
+    """How each thing of one kind stands on a card, keyed the way a pick
+    list keys its options.
+
+    Not "is it held" but *how* it is held, because each answer settles a
+    different write: an owner's own addition is archived, anything else
+    gains a removal, a standing removal is archived to bring the thing
+    back, and something fixed is not offered at all.
+    """
+
+    #: Every thing of the kind the live library offers.
+    offered: list
+    #: The written assignment showing each thing, by key.
+    stored: dict
+    #: The subset the owner added themselves.
+    own_adds: dict
+    #: Keys the gang holds, riding this card.
+    gang_held: set
+    #: Key -> what grants it, for things no assignment stands behind.
+    granted: dict
+    #: Key -> the owner's standing removal of it.
+    removed: dict
+    #: Keys a removal could not shift, because money stands behind them.
+    fixed: set
+
+
 def _edit_state(own, computed, field):
     """What the card currently says for one editable kind, keyed the way
     a tick list keys its options.
 
-    Six answers, because the diff needs to know not just whether a
-    thing is held but *how*: any stored assignment showing it, which of
-    those are the gang's riding this card, the subset that are the
-    owner's own additions, what a modifier grants, and the owner's
-    standing removals. A suppressed line is held by nobody — it has
-    been taken away, and the box for it opens clear.
+    The diff needs to know not just whether a thing is held but *how*:
+    any stored assignment showing it, which of those are the gang's
+    riding this card, the subset that are the owner's own additions,
+    what a modifier grants, the owner's standing removals — and which
+    could not be taken away at all, because money stands behind every
+    line of them. A suppressed line is held by nobody: it has been taken
+    away, and the box for it opens clear.
     """
+    from n26.core.effects import stands_whatever_happens
     from n26.core.models import Assignment, Reason
     from n26.core.views.learn import _key
 
@@ -58,44 +89,60 @@ def _edit_state(own, computed, field):
         for row in own.removals
         if isinstance(row.assignable, kind_class)
     }
-    return offered, stored, own_adds, gang_held, granted, removed
+    # Bought, so a removal would leave it exactly where it is. Asked of
+    # the engine's own rule rather than restated here, because a surface
+    # that disagreed would offer a clearing that quietly does nothing.
+    fixed = {
+        key
+        for key, assignment in stored.items()
+        if stands_whatever_happens(own, assignment.assignable)
+    }
+    return _EditState(
+        offered=offered,
+        stored=stored,
+        own_adds=own_adds,
+        gang_held=gang_held,
+        granted=granted,
+        removed=removed,
+        fixed=fixed,
+    )
 
 
 def _edits_offer(own, computed, field, heading):
-    """One section of the edits box, split into what the card shows and
-    the rest of the library.
+    """One section of the edits box: every thing of the kind, as options.
 
-    Nothing is drawn fixed — that is the section's whole point. A
-    granted thing says what grants it, but its box still clears: the
-    owner's clearing becomes a stored removal, and ticking it again
-    archives that removal, so the content's own answer is always one
-    click away.
+    A granted thing's box still clears — the owner's clearing becomes a
+    stored removal, and ticking it again archives that removal, so the
+    content's own answer is always one click away. What does *not* clear
+    is a thing money stands behind: a removal would leave it exactly
+    where it is, so it is drawn fixed and says so rather than being
+    offered and refused.
 
-    Two answers, because the two halves are read differently. What the
-    card shows is a short list to check over, and comes back as a
-    ``ChoiceOffer`` for the boxes to tick. The rest of the library runs
-    to a hundred rules that nobody scans, so it comes back as bare
-    options for a searchable select to add from. Both feed inputs of the
-    same name, so the browser posts one list and the difference is taken
-    once; either is empty where the library has nothing to offer, and the
-    page draws neither.
+    Two answers, because the page draws them differently. What the card
+    shows — and anything the owner has touched, so a thing they took
+    away stays where it can be put back — is the list of boxes. The rest
+    of the library is what the search panel offers: a box each, which
+    appears in the list above once it is ticked.
     """
     from n26.core.render import ChoiceOffer, Choosable, ChoosableGroup
     from n26.core.views.learn import _key
 
-    offered, stored, own_adds, gang_held, granted, removed = _edit_state(
-        own, computed, field
-    )
+    state = _edit_state(own, computed, field)
     current, rest = [], []
-    for thing in offered:
+    for thing in state.offered:
         key = _key(thing)
-        if key in own_adds:
+        fixed_because = ""
+        if key in state.fixed:
+            # Named as a price rather than a rule: the owner can sell it
+            # from the equip screen, which is the way back.
+            fixed_because = "bought — sell it to take it away"
+        if key in state.own_adds:
             detail = "added by you"
-        elif key in removed:
+        elif key in state.removed:
             detail = "taken away by you"
-        elif key in granted and key not in stored:
-            detail = f"from {granted[key]}"
-        elif key in gang_held:
+        elif key in state.granted and key not in state.stored:
+            detail = f"from {state.granted[key]}"
+        elif key in state.gang_held:
             detail = "the gang's"
         else:
             detail = ""
@@ -103,8 +150,9 @@ def _edits_offer(own, computed, field, heading):
             key=key,
             name=str(thing),
             thing=thing,
-            is_current=key in stored or key in granted,
+            is_current=key in state.stored or key in state.granted,
             detail=detail,
+            fixed_because=fixed_because,
         )
         if option.is_current or detail:
             current.append(option)
@@ -116,7 +164,7 @@ def _edits_offer(own, computed, field, heading):
         if current
         else None
     )
-    return held, rest, bool(own_adds or removed)
+    return held, rest, bool(state.own_adds or state.removed)
 
 
 def _apply_edits(op, miniature, own, computed, field, ticked):
@@ -132,33 +180,33 @@ def _apply_edits(op, miniature, own, computed, field, ticked):
     from n26.core.models import Reason
     from n26.core.views.learn import _key
 
-    offered, stored, own_adds, _gang_held, granted, removed = _edit_state(
-        own, computed, field
-    )
+    state = _edit_state(own, computed, field)
     added, taken, restored = [], [], []
-    for thing in offered:
+    for thing in state.offered:
         key = _key(thing)
-        # A standing removal the money refused: the thing still shows,
-        # its box opens ticked, and saving the section untouched must
-        # move nothing — neither restoring the removal nor stacking a
-        # second one.
-        shown = key in stored or key in granted
+        if key in state.fixed:
+            # Drawn fixed, and a fixed box submits nothing — so its
+            # silence is not a clearing. Nothing here may act on it: a
+            # removal would leave the thing on the card and the page
+            # would report a loss the card denies.
+            continue
+        shown = key in state.stored or key in state.granted
         if key in ticked:
-            if key in removed and not shown:
-                op.remove(removed[key], note="restored")
+            if key in state.removed and not shown:
+                op.remove(state.removed[key], note="restored")
                 restored.append(str(thing))
-            elif not shown and key not in removed:
+            elif not shown and key not in state.removed:
                 op.assign(thing, miniature=miniature, paid=0, reason=Reason.EDITED)
                 added.append(str(thing))
-        elif key in own_adds:
-            op.remove(own_adds[key])
-            if key in granted and key not in removed:
+        elif key in state.own_adds:
+            op.remove(state.own_adds[key])
+            if key in state.granted and key not in state.removed:
                 # A grant also supplies it, and archiving the owner's
                 # addition leaves that standing — clearing means gone by
                 # every route, so the grant is cancelled too.
                 op.take_away(miniature, thing)
             taken.append(str(thing))
-        elif shown and key not in removed:
+        elif shown and key not in state.removed:
             op.take_away(miniature, thing)
             taken.append(str(thing))
     return added, taken, restored
@@ -289,28 +337,14 @@ def edit_fighter(request, pk):
             taken=len(taken),
             restored=len(restored),
         )
-        # A paid-for thing is never hidden by a removal, so its box
-        # would silently re-tick on the redraw — find those out first,
-        # say why each stays, and keep them out of the sentence saying
-        # what was lost: a message claiming a loss the card denies would
-        # be worse than no message at all.
-        refused = set()
-        if taken:
-            fresh = build_card(miniature)
-            fresh_index = build_modifier_index(
-                [node.assignable for node in fresh.all_nodes()]
-            )
-            refused = {
-                name
-                for step in compute(fresh, fresh_index).plan
-                for name in step.refused
-            }
-        lost = [name for name in taken if name not in refused]
+        # Everything named here really moved: a thing a removal could not
+        # shift is drawn fixed and never acted on, so the sentence cannot
+        # claim a loss the card denies.
         moved = [
             phrase
             for phrase in (
                 f"gained {', '.join(added)}" if added else "",
-                f"lost {', '.join(lost)}" if lost else "",
+                f"lost {', '.join(taken)}" if taken else "",
                 f"got {', '.join(restored)} back" if restored else "",
             )
             if phrase
@@ -319,8 +353,6 @@ def edit_fighter(request, pk):
             request,
             f"{miniature.name} {' and '.join(moved)}." if moved else "Saved.",
         )
-        for name in [name for name in taken if name in refused]:
-            messages.warning(request, f"{name} stays on the card — it was paid for.")
         return redirect("n26-edit-fighter", pk=miniature.pk)
     elif request.method == "POST" and request.POST.get("act") == "reset-edits":
         field = request.POST.get("kind")

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1467,6 +1467,17 @@ GROUPS: list[Group] = [
                     "slot renders inside this component's scope, which is what "
                     'lets a caller bind ::disabled="!dirty" on its own button.'
                 ),
+                parts=(
+                    Part(
+                        "c-n26.pick-list.box",
+                        "n26/pick_list/box.html",
+                        "One option as a box to tick — the same row whether the "
+                        "thing is held or is one the panel offers, so the two "
+                        "runs cannot come to look different. Binds to `picked` "
+                        "above it in the Alpine scope, which is what lets the "
+                        "panel tick a box and the list read what is ticked.",
+                    ),
+                ),
             ),
             Component(
                 slug="tick-list",

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1444,6 +1444,31 @@ GROUPS: list[Group] = [
                 ),
             ),
             Component(
+                slug="pick-list",
+                tag="c-n26.pick-list",
+                template="n26/pick_list/index.html",
+                summary="What a thing has, and a searchable way to add to it.",
+                notes=(
+                    "For a library too long to scan — every subtype, every "
+                    "special rule — without becoming a different control: the "
+                    "held things are ticked boxes, and a button opens the rest "
+                    "as a c-n26.quick-switcher panel, the shape a reader has "
+                    "already met. Click a row and its box appears above, "
+                    "ticked; clear a box and the row is offered again. Nothing "
+                    "reloads, because every box was already on the page — the "
+                    "panel only ticks them, so it adds no input of its own and "
+                    "no value can arrive that nobody chose. Its rows report a "
+                    "key rather than their words, because two rows can read "
+                    "alike and mean different rows. With no script the addable "
+                    "boxes are put back by a noscript rule and the panel is "
+                    "cloaked, so what is left is one plain list of every "
+                    "option that works. Save is disabled until the ticked set "
+                    "differs from the one the page opened with: the actions "
+                    "slot renders inside this component's scope, which is what "
+                    'lets a caller bind ::disabled="!dirty" on its own button.'
+                ),
+            ),
+            Component(
                 slug="tick-list",
                 tag="c-n26.tick-list",
                 template="n26/tick_list.html",

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -813,6 +813,10 @@ def context():
         # The same list a fighter's edit page ticks: what they hold, and
         # the one thing a rule gives them that no click can clear.
         "tick_list_offer": tick_list_offer(),
+        # The two halves a pick list draws: what is held, and the rest of
+        # the library its panel offers.
+        "pick_list_held": pick_list_held(),
+        "pick_list_addable": pick_list_addable(),
         "editable_statline": editable_statline(),
         # A profile nobody has typed a statline for yet, and one where a
         # value was refused: the two states the editor has that a card
@@ -974,6 +978,71 @@ def choice_picks_offer(full=False):
         takes_several=True,
         groups=[ChoosableGroup(name="", options=held if full else [*held, *rest])],
     )
+
+
+def pick_list_held():
+    """What the thing has, as a pick list draws it: one the owner added,
+    one a rule gives that no click can clear, and one money stands behind
+    that a removal would leave exactly where it is."""
+    return ChoiceOffer(
+        label="",
+        groups=[
+            ChoosableGroup(
+                name="Skills",
+                options=[
+                    Choosable(
+                        key="library.skill:1",
+                        name="Catfall",
+                        is_current=True,
+                        detail="added by you",
+                    ),
+                    Choosable(
+                        key="library.skill:3",
+                        name="Dodge",
+                        is_current=True,
+                        granted_by="Keen-eyed",
+                    ),
+                    Choosable(
+                        key="library.skill:9",
+                        name="Sprint",
+                        is_current=True,
+                        fixed_because="bought — sell it to take it away",
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def pick_list_addable():
+    """The rest of the library the panel offers — enough rows that the
+    filter box is the way through them rather than the eye."""
+    names = [
+        "Backstab",
+        "Ballistic Expert",
+        "Berserker",
+        "Bull Charge",
+        "Clamber",
+        "Combat Master",
+        "Escape Artist",
+        "Fearsome",
+        "Gunfighter",
+        "Headbutt",
+        "Infiltrate",
+        "Iron Jaw",
+        "Lie Low",
+        "Mighty Leap",
+        "Nerves of Steel",
+        "Overwatch",
+        "Parry",
+        "Precision Shot",
+        "Spring Up",
+        "Unstoppable",
+    ]
+    return [
+        Choosable(key=f"library.skill:{100 + at}", name=name)
+        for at, name in enumerate(names)
+    ]
 
 
 def tick_list_offer():

--- a/n26/designsystem/templates/designsystem/demos/pick-list/10-long.html
+++ b/n26/designsystem/templates/designsystem/demos/pick-list/10-long.html
@@ -1,0 +1,18 @@
+{# title: What it has, and a way to add #}
+{# note: The held things are boxes; the button opens the rest as a searchable panel, the same shape as the quick switcher elsewhere. Click a row and its box appears above, ticked; clear a box and the row is offered again. Nothing reloads — every box was already on the page, and the panel only ticks them. Save is disabled until the ticked set differs from the one the page opened with. #}
+{# layout: col #}
+<form>
+    <c-n26.pick-list :offer="pick_list_held"
+                     :addable="pick_list_addable"
+                     name="skills"
+                     add_label="Add a skill"
+                     placeholder="Search skills">
+        <c-slot name="actions">
+            <div class="flex items-center justify-end gap-2">
+                <c-ui.button type="submit" variant="success" size="sm" ::disabled="!dirty">
+                    Save skills
+                </c-ui.button>
+            </div>
+        </c-slot>
+    </c-n26.pick-list>
+</form>

--- a/n26/tests/sandbox/test_editing_what_a_model_is.py
+++ b/n26/tests/sandbox/test_editing_what_a_model_is.py
@@ -312,58 +312,53 @@ class TestTheEditPage:
 
         return client.post(reverse("n26-edit-fighter", args=[miniature.pk]), data)
 
-    def test_the_box_offers_the_library_ticked_where_held(self, client, yolanda):
+    def _held(self, page, key):
+        """The section's held options, keyed. None where nothing is."""
+        offer = page.context[key]
+        return (
+            {}
+            if offer is None
+            else {
+                option.key: option for group in offer.groups for option in group.options
+            }
+        )
+
+    def _addable(self, page, key):
+        return {option.key: option for option in page.context[key]}
+
+    def test_what_is_held_is_a_box_and_the_rest_is_the_panel(self, client, yolanda):
+        """Two halves: what the card shows is a box to clear, and the
+        rest of the library is what the search panel offers."""
         mounted = create_subtype("Mounted")
         gaunt = create_rule("Gaunt")
         assign(gaunt, miniature=yolanda, paid=0)
         client.force_login(yolanda.membership.gang.owner)
         page = self._page(client, yolanda)
-        body = page.content.decode()
-        assert "Subtypes &amp; Rules" in body
-        assert 'value="library.subtype:' in body
-        assert 'value="library.rule:' in body
-        # Read off what the view built rather than the markup. The held
-        # rule is a box, opened ticked; the unheld subtype is not a box
-        # at all — it is an option in the select the section adds from.
-        boxed = {
-            option.key: option.is_current
-            for offer in (page.context["rule_edits"], page.context["subtype_edits"])
-            if offer
-            for group in offer.groups
-            for option in group.options
-        }
-        assert boxed[f"library.rule:{gaunt.pk}"]
-        assert f"library.subtype:{mounted.pk}" not in boxed
-        addable = {
-            option.key
-            for options in (page.context["rule_more"], page.context["subtype_more"])
-            for option in options
-        }
-        assert f"library.subtype:{mounted.pk}" in addable
 
-    def test_what_the_card_lacks_is_a_real_select_of_real_keys(self, client, yolanda):
-        """The rest of the library is a select rather than a list of
-        boxes, and it is rendered complete: a reader with no script gets
-        a working multiple select, and what it posts is the same key a
-        box would have posted."""
+        assert self._held(page, "rule_edits")[f"library.rule:{gaunt.pk}"].is_current
+        assert f"library.subtype:{mounted.pk}" in self._addable(page, "subtype_more")
+        assert f"library.subtype:{mounted.pk}" not in self._held(page, "subtype_edits")
+
+    def test_every_option_is_a_box_in_the_page_so_no_script_can_add(
+        self, client, yolanda
+    ):
+        """The panel only ticks boxes that are already there, so every
+        addable thing is a box in the HTML — which is also the whole of
+        the fallback for a reader with no script."""
         mounted = create_subtype("Mounted")
+        gaunt = create_rule("Gaunt")
+        assign(gaunt, miniature=yolanda, paid=0)
         client.force_login(yolanda.membership.gang.owner)
         body = self._page(client, yolanda).content.decode()
-        assert 'name="subtypes"' in body and "multiple" in body
-        # The option carries the key, not the name: a label cannot say
-        # which row was meant.
+        assert "Subtypes &amp; Rules" in body
+        # A box carries the key, never the name: a rule's identity takes
+        # in its annotation, and two Leashes differ by nothing else.
         assert f'value="library.subtype:{mounted.pk}"' in body
-        # The unheld subtype is offered by the select, not as a box.
-        offered = [
-            option.key
-            for offer in [self._page(client, yolanda).context["subtype_more"]]
-            for option in offer
-        ]
-        assert f"library.subtype:{mounted.pk}" in offered
+        assert f'value="library.rule:{gaunt.pk}"' in body
+        # The panel's own row reports that same key rather than the words.
+        assert f"isPicked('library.subtype:{mounted.pk}')" in body
 
-    def test_choosing_from_the_select_adds_the_thing(self, client, yolanda):
-        """The select and the boxes share an input name, so a pick posts
-        exactly as a tick does."""
+    def test_ticking_a_subtype_from_the_list_adds_it(self, client, yolanda):
         mounted = create_subtype("Mounted")
         client.force_login(yolanda.membership.gang.owner)
         self._post(
@@ -416,21 +411,42 @@ class TestTheEditPage:
         )
         assert [line.name for line in card_for(rehired).rules] == ["Gaunt"]
 
-    def test_a_paid_for_thing_is_said_to_stay(self, client, yolanda):
-        """The warning says why it stays, and the saved message never
-        claims a loss the card denies."""
+    def test_a_paid_for_thing_is_not_offered_to_be_taken_away(self, client, yolanda):
+        """A removal could not shift it, so its box is fixed and says
+        why. Offering the act and then refusing it wrote a removal that
+        changed nothing and reported a loss the card denied."""
         mounted = create_subtype("Mounted")
         assign(mounted, miniature=yolanda, paid=75)
         client.force_login(yolanda.membership.gang.owner)
-        response = self._post(
-            client,
-            yolanda,
-            {"act": "subtypes"},
-        )
-        page = client.get(response.url)
+        page = self._page(client, yolanda)
+        option = self._held(page, "subtype_edits")[f"library.subtype:{mounted.pk}"]
+        assert option.is_current
+        assert option.fixed_because
+        assert "sell" in option.fixed_because
+        # Drawn disabled, so the browser never submits it.
         body = page.content.decode()
+        box = body.split(f'value="library.subtype:{mounted.pk}"')[1][:200]
+        assert "disabled" in box
+
+    def test_a_fixed_box_submitting_nothing_is_not_read_as_a_clearing(
+        self, client, yolanda
+    ):
+        """A disabled box posts nothing, and its silence must not be
+        taken for a clearing — the whole reason granted things are left
+        out of the difference too."""
+        mounted = create_subtype("Mounted")
+        assign(mounted, miniature=yolanda, paid=75)
+        client.force_login(yolanda.membership.gang.owner)
+        response = self._post(client, yolanda, {"act": "subtypes"})
+
+        assert card_for(yolanda).type_line == "Fighter (Mounted)"
+        assert not Assignment.objects.filter(
+            miniature_root=yolanda, subtype=mounted, removes=True
+        ).exists()
+        body = client.get(response.url).content.decode()
         assert "lost Mounted" not in body
-        assert "Mounted stays on the card — it was paid for." in body
+        # Nothing moved, so the page says exactly that.
+        assert "Saved." in body
 
     def test_clearing_a_thing_both_added_and_granted_takes_it_fully_away(
         self, client, yolanda

--- a/n26/tests/sandbox/test_editing_what_a_model_is.py
+++ b/n26/tests/sandbox/test_editing_what_a_model_is.py
@@ -322,23 +322,56 @@ class TestTheEditPage:
         assert "Subtypes &amp; Rules" in body
         assert 'value="library.subtype:' in body
         assert 'value="library.rule:' in body
-        # The held rule opens ticked; the unheld subtype does not. Read
-        # off the offers the view built rather than the markup, which is
-        # the structure the boxes are drawn from.
-        ticked = {
+        # Read off what the view built rather than the markup. The held
+        # rule is a box, opened ticked; the unheld subtype is not a box
+        # at all — it is an option in the select the section adds from.
+        boxed = {
             option.key: option.is_current
-            for offer in (
-                page.context["rule_edits"],
-                page.context["subtype_edits"],
-                page.context["rule_more"],
-                page.context["subtype_more"],
-            )
+            for offer in (page.context["rule_edits"], page.context["subtype_edits"])
             if offer
             for group in offer.groups
             for option in group.options
         }
-        assert ticked[f"library.rule:{gaunt.pk}"]
-        assert not ticked[f"library.subtype:{mounted.pk}"]
+        assert boxed[f"library.rule:{gaunt.pk}"]
+        assert f"library.subtype:{mounted.pk}" not in boxed
+        addable = {
+            option.key
+            for options in (page.context["rule_more"], page.context["subtype_more"])
+            for option in options
+        }
+        assert f"library.subtype:{mounted.pk}" in addable
+
+    def test_what_the_card_lacks_is_a_real_select_of_real_keys(self, client, yolanda):
+        """The rest of the library is a select rather than a list of
+        boxes, and it is rendered complete: a reader with no script gets
+        a working multiple select, and what it posts is the same key a
+        box would have posted."""
+        mounted = create_subtype("Mounted")
+        client.force_login(yolanda.membership.gang.owner)
+        body = self._page(client, yolanda).content.decode()
+        assert 'name="subtypes"' in body and "multiple" in body
+        # The option carries the key, not the name: a label cannot say
+        # which row was meant.
+        assert f'value="library.subtype:{mounted.pk}"' in body
+        # The unheld subtype is offered by the select, not as a box.
+        offered = [
+            option.key
+            for offer in [self._page(client, yolanda).context["subtype_more"]]
+            for option in offer
+        ]
+        assert f"library.subtype:{mounted.pk}" in offered
+
+    def test_choosing_from_the_select_adds_the_thing(self, client, yolanda):
+        """The select and the boxes share an input name, so a pick posts
+        exactly as a tick does."""
+        mounted = create_subtype("Mounted")
+        client.force_login(yolanda.membership.gang.owner)
+        self._post(
+            client,
+            yolanda,
+            {"act": "subtypes", "subtypes": [f"library.subtype:{mounted.pk}"]},
+        )
+        assert card_for(yolanda).type_line == "Fighter (Mounted)"
 
     def test_ticking_a_subtype_adds_it_in_the_owners_name(self, client, yolanda):
         mounted = create_subtype("Mounted")


### PR DESCRIPTION
Three changes to the Subtypes & Rules box on a model's edit page: a bug where the page offered a removal it could not perform, a new way to add from a long library, and a font-size fix.

## A paid-for thing could be unticked, and the result was incoherent

Unticking a bought subtype showed two messages at once — "Saved." and "Mounted stays on the card — it was paid for." — and then labelled the row "taken away by you" while the card went on showing it. Underneath, a removal had been written that could never take effect: the engine leaves a line alone when money stands behind it, so the row sat there doing nothing and the page reported a loss the card denied.

The fix is not to warn better but not to offer the act. Such a box is now drawn ticked and disabled, saying **"bought — sell it to take it away"** — the equip screen's sale is the real way to be rid of it. Nothing acts on it either: a disabled box submits nothing, and reading that silence as a clearing is exactly how the bad row got written, so those keys are skipped when the difference is applied — the same reasoning that already keeps granted skills out of it.

Whether a removal would achieve anything is asked of the engine rather than restated in the view (`stands_whatever_happens`, beside the `_suppress` it mirrors), so the surface and the removal cannot come to disagree. The old post-hoc warning is gone, along with the second card build and compute it needed per save.

## Adding is the shape a reader has already met

The "All subtypes" and "All special rules" collapsibles held the whole library as a wall of checkboxes — 27 subtypes, 114 rules. Now the held things are boxes, and a button opens the rest as a **quick-switcher panel**: filter box, arrow keys, Enter on the highlighted row. Click a row and its box appears in the list above, already ticked. Clear a box and the row is offered again.

Nothing is fetched and nothing reloads, because **every box was already on the page** — the panel only ticks them. It adds no input of its own, so no value can arrive that nobody chose. Its rows report the option's key rather than its words: two rows can read alike and mean different rows (four rules named *Leash*, separated only by annotation; two packs could each offer a "Mounted"), so `c-n26.quick-switcher.choice` takes an optional `value`, defaulting to the label so existing callers are unchanged.

**Save is disabled until something differs** from the set the page opened with, and enables and disables symmetrically as boxes move.

With no script the addable boxes are put back by a `<noscript>` rule and the panel is cloaked, so what remains is one plain list of every option that works and posts correctly. The same inline style keeps a hundred boxes from flashing up before Alpine folds them away.

New component `c-n26.pick-list` (with `c-n26.pick-list.box`), registered in the gallery with a demo and sample data.

## The muted lines were bigger than the names above them

`text-muted` is a colour and carries no size, so a muted line without one inherited the base 16px while the option name beside it was `text-sm` at 14px — "added by you" shouting over "Wyrd". Every line now states its own size: heading and option name at 16px, the tier caption and the provenance line at 14px. The checkbox moves to `mt-1`, centring it on the first line at the larger size (measured at 0px offset).

## Test plan

- [x] `pytest n26` — 3559 passed
- [x] Driven in a browser on a seeded gang: Save disabled at rest; opened the panel, typed "wyr", clicked Wyrd, its box appeared above ticked and Save enabled; unticked it and Save disabled again; added a rule the same way and saved — "gained Fixed Loadout"
- [x] The bought subtype renders checked, disabled and "bought — sell it to take it away", and posting the section without it writes no removal and reports no loss
- [x] Server output checked directly: all 30 subtypes are real boxes, the addable ones carry the hide class, and the `<noscript>` rule that restores them is present
- [x] Gallery page `/n26/design/c/pick-list/` shows the props, the demo and the box part; the quick-switcher page still renders with its new `value` prop
- [x] `check-cotton`, `check-raw-markup`, `djlint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
