### PR TITLE
chore: add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,19 @@
+{
+  "name": "Gyrinx",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "dev-server",
+      "command": "cd /workspace && source .venv/bin/activate && export PATH=\"$HOME/.local/bin:$PATH\" && manage runserver 0.0.0.0:8000",
+      "description": "Django development server (gyrinx.settings_dev) on http://localhost:8000"
+    }
+  ],
+  "ports": [
+    {
+      "name": "web",
+      "port": 8000
+    }
+  ]
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -6,8 +6,8 @@
   "terminals": [
     {
       "name": "dev-server",
-      "command": "cd /workspace && source .venv/bin/activate && export PATH=\"$HOME/.local/bin:$PATH\" && manage runserver 0.0.0.0:8000",
-      "description": "Django development server (gyrinx.settings_dev) on http://localhost:8000"
+      "command": "bash /workspace/.cursor/start.sh && cd /workspace && source .venv/bin/activate && export PATH=\"$HOME/.local/bin:$PATH\" && manage runserver 0.0.0.0:8000",
+      "description": "Django development server (gyrinx.settings_dev) on http://localhost:8000. Ensures PostgreSQL is up first (start.sh is idempotent) so the server has a database even if the per-boot start step has not run yet."
     }
   ],
   "ports": [

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for Gyrinx.
+#
+# Runs after the repository is checked out. Idempotent: every step is a no-op
+# when it has already been done, so it is safe to re-run (and to run against a
+# build snapshot that already has most of this in place).
+#
+# System services (PostgreSQL) are STARTED here only so migrations can run; the
+# per-boot start lives in .cursor/start.sh.
+
+set -euo pipefail
+
+# Always operate from the repository root (the dir that contains this .cursor/).
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() { echo "=== $* ==="; }
+
+# ---------------------------------------------------------------------------
+# 1. uv — manages the Python interpreter (3.14, per .python-version) and deps.
+# ---------------------------------------------------------------------------
+if ! command -v uv >/dev/null 2>&1; then
+  log "Installing uv"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+log "uv $(uv --version)"
+
+# ---------------------------------------------------------------------------
+# 2. PostgreSQL 16 — a system dependency that is not in the base image.
+# ---------------------------------------------------------------------------
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  log "Installing PostgreSQL 16"
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq postgresql-16 postgresql-client-16
+fi
+
+# Default max_locks_per_transaction (64) is too low for pytest-xdist, which runs
+# many workers that each build every table via syncdb (--nomigrations). Mirrors
+# docker-compose.yml and scripts/setup_web.sh.
+PG_CONF="/etc/postgresql/16/main/postgresql.conf"
+if [ -f "$PG_CONF" ] && ! grep -q 'max_locks_per_transaction = 256' "$PG_CONF"; then
+  log "Tuning PostgreSQL max_locks_per_transaction"
+  echo "max_locks_per_transaction = 256" | sudo tee -a "$PG_CONF" >/dev/null
+fi
+
+# Bring PostgreSQL up so migrations can run (start.sh does this on every boot).
+sudo pg_ctlcluster 16 main start 2>/dev/null || sudo service postgresql start 2>/dev/null || true
+for _ in $(seq 1 30); do pg_isready -q && break; sleep 1; done
+pg_isready -q || { echo "PostgreSQL failed to start" >&2; exit 1; }
+sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+# 3. Python environment — uv creates .venv and installs exactly what uv.lock
+#    pins (including the CPython 3.14 interpreter).
+# ---------------------------------------------------------------------------
+log "Syncing Python environment (uv sync --locked)"
+UV_PROJECT_ENVIRONMENT=.venv uv sync --locked
+# shellcheck disable=SC1091
+source .venv/bin/activate
+log "Python $(python --version)"
+
+# ---------------------------------------------------------------------------
+# 4. .env — random SECRET_KEY + superuser password. DB settings come from
+#    .env.example (DB_NAME=postgres, user/password postgres on localhost:5432).
+#    setupenv only fills in what is missing, so re-runs keep the existing keys.
+# ---------------------------------------------------------------------------
+log "Configuring .env"
+manage setupenv
+
+# ---------------------------------------------------------------------------
+# 5. Database + migrations.
+# ---------------------------------------------------------------------------
+DB_NAME=$(grep '^DB_NAME=' .env | cut -d= -f2)
+DB_NAME=${DB_NAME:-postgres}
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1; then
+  log "Creating database '${DB_NAME}'"
+  sudo -u postgres createdb "${DB_NAME}"
+fi
+
+# Migration ordering on a FRESH database. Two things go wrong with a plain
+# `manage migrate` here:
+#   * analytics.0002 performs the real ALTER on the core_event table, but the
+#     migration plan schedules it BEFORE the core migration that physically
+#     creates core_event -> "relation core_event does not exist".
+#   * Migrating a single app first (to force core_event to exist) only pulls
+#     auth.0001, whose auth_permission.name is varchar(50); the post_migrate
+#     permission creation for long-named historical models then overflows it.
+# Fully migrating auth first, then core (which creates core_event and pulls in
+# analytics.0001 as a state-only dependency), then everything, avoids both.
+# Each command is a no-op once its migrations are applied, so this is idempotent.
+log "Running migrations"
+manage migrate auth
+manage migrate core
+manage migrate
+
+# ---------------------------------------------------------------------------
+# 6. Frontend assets + static files.
+# ---------------------------------------------------------------------------
+log "Installing Node dependencies and building assets"
+npm install
+npm run build
+manage collectstatic --noinput
+
+log "Install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent per-boot start script for Gyrinx.
+#
+# Brings PostgreSQL up on every boot (its data directory is captured in the
+# build snapshot, so the migrated schema is already present) and returns once
+# the server is accepting connections. The Django dev server itself runs as the
+# "dev-server" terminal (see environment.json), so its logs stay visible.
+
+set -euo pipefail
+
+sudo pg_ctlcluster 16 main start 2>/dev/null \
+  || sudo service postgresql start 2>/dev/null \
+  || true
+
+for _ in $(seq 1 30); do
+  if pg_isready -q; then
+    echo "PostgreSQL is ready."
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "PostgreSQL did not become ready within 30s" >&2
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

A `.cursor/` environment config so this repo boots as a working Cloud Agent development environment (Django app + PostgreSQL + built frontend), with no manual setup.

- `.cursor/environment.json` — base-image defaults, an `install` step, a per-boot `start` step, a `dev-server` terminal running Django on `http://localhost:8000`, and port `8000` exposed.
- `.cursor/install.sh` — idempotent bootstrap: installs `uv` and PostgreSQL 16, `uv sync --locked` (which pulls the pinned CPython 3.14 and all deps into `.venv`), `manage setupenv` for `.env`, runs migrations, `npm install` + `npm run build`, and `collectstatic`.
- `.cursor/start.sh` — starts PostgreSQL on every boot and waits for it to accept connections. The `dev-server` terminal also runs it first (it is idempotent), so the server always has a database even if the per-boot `start` step has not fired.

This mirrors the Linux path the repo already documents (`scripts/setup_web.sh`, the CI workflow, `docker-compose.yml`) rather than the macOS-only `scripts/dev.sh`.

## One non-obvious detail: migration ordering on a fresh database

A plain `manage migrate` fails on an empty database:

- `analytics.0002` runs the real `ALTER` on the `core_event` table, but the migration plan schedules it *before* the `core` migration that physically creates `core_event`, so it errors with `relation "core_event" does not exist`.
- Forcing a single app to migrate first only pulls `auth.0001` (whose `auth_permission.name` is `varchar(50)`), and the `post_migrate` permission creation for long-named historical models then overflows that column.

`install.sh` sidesteps both by migrating `auth` fully, then `core` (which creates `core_event` and pulls `analytics.0001` in as a state-only dependency), then everything. All three steps are no-ops once applied, so the script stays idempotent. No application code is changed. (This ordering quirk affects any fresh `manage migrate`, e.g. the devcontainer and `scripts/setup_web.sh`, and may be worth fixing at the migration-dependency level separately.)

## How to try it

Once merged, a fresh Cloud Agent boots with PostgreSQL running and the Django dev server on `http://localhost:8000`. The home page and gang list render immediately; `manage createsuperuser` plus some content data lets you exercise the full gang-building flow.

## Validation

- **From-scratch environment build**: triggered a draft build of this config from a clean base image — it ran the whole `install.sh` (uv, PostgreSQL 16, Python 3.14.6, migrations, `npm run build`, `collectstatic`) and finished green (`Install complete`), ~5 minutes, no errors.
- **Fresh Cloud Agent boot from that build**: 7/7 checks passed — Python 3.14.6 / uv 0.12.5 / node v22.14 / PostgreSQL 16.14, `.venv` + `staticfiles` + `node_modules` + built `styles.css` all present, `manage migrate --check` clean, dev server returns HTTP 200, and an ORM write created a gang row in PostgreSQL. The boot also showed the platform `start` step did not always fire on its own — hence the `dev-server` terminal now runs `start.sh` itself.
- **Idempotence**: `install.sh` run twice — the second run is a no-op (`No migrations to apply` ×3, `npm up to date`).
- **End-to-end product flow in a real browser**: logged in, created a gang ("Escher Cloud Runners", House Escher), and confirmed it on the gang detail page and the gang list — server + PostgreSQL + templates + built CSS + auth all working together.

[gyrinx_login_and_create_gang_demo.mp4](https://cursor.com/agents/bc-12764e49-cfe4-46a3-b6da-4d4b2419b9ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgyrinx_login_and_create_gang_demo.mp4)

[Gyrinx gang detail page for the created gang](https://cursor.com/agents/bc-12764e49-cfe4-46a3-b6da-4d4b2419b9ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_gang_detail.png)

Note: UI login goes through `django-recaptcha` v3, and the stock dev config ships empty reCAPTCHA keys — so a local developer must supply keys to log in via the browser (a pre-existing repo characteristic, unchanged here). The authenticated flow above was verified with a local, throwaway reCAPTCHA bypass that is not part of this environment.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12764e49-cfe4-46a3-b6da-4d4b2419b9ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12764e49-cfe4-46a3-b6da-4d4b2419b9ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

