### PR TITLE
feat: the Cawdor Paths become picks — the first converted system

### DIFF
--- a/n26/core/capture.py
+++ b/n26/core/capture.py
@@ -4,11 +4,14 @@ states of the world.
 A conversion that moves content from one shape to another must leave
 every page saying the same things. The capture holds exactly the facts
 that must not change — names, numbers, the questions asked and what
-settled them — as sorted primitives, so two captures compare with ``==``
-and any difference is a mistake by definition. Addresses, ids and
-provenance wording are deliberately absent: a conversion may change
-where a control leads and which machinery asks a question, never what
-the reader is told.
+settled them — as plain primitives, sorted wherever the page's own
+order carries no meaning (a statline keeps its printed order; a run of
+rules does not), so two captures compare with ``==`` and any difference
+is a mistake by definition. Addresses and provenance wording are
+deliberately absent — a conversion may change where a control leads and
+which machinery asks a question, never what the reader is told — and
+the one id kept is the model key, so a difference names the fighter it
+is about.
 
 Built on ``render_gang``, the same derivation every screen uses, so the
 capture cannot agree with a broken page.

--- a/n26/core/capture.py
+++ b/n26/core/capture.py
@@ -24,6 +24,11 @@ def _names(lines):
     return sorted(str(line.name) for line in lines)
 
 
+def _rated(lines):
+    """Lines whose printed figure matters as much as their name."""
+    return sorted((str(line.name), line.rating) for line in lines)
+
+
 def _choices(lines):
     """Each question as (what the card calls it, what settled it)."""
     return sorted((line.kind_label, line.chosen or "") for line in lines)
@@ -37,10 +42,17 @@ def _weapons(lines):
     return sorted(
         (
             weapon.name,
+            weapon.base_rating,
             tuple(
-                (profile.name, tuple(sorted(t.name for t in profile.traits)))
+                (
+                    profile.name,
+                    profile.rating,
+                    _statline(profile.statline),
+                    tuple(sorted(t.name for t in profile.traits)),
+                )
                 for profile in weapon.profiles
             ),
+            tuple(sorted(a.name for a in weapon.accessories)),
         )
         for weapon in lines
     )
@@ -62,11 +74,12 @@ def _model_state(card):
         "skills": _names(card.skills),
         "powers": _names(card.powers),
         "rules": _names(card.rules),
-        "equipment": _names(card.equipment),
+        "equipment": _rated(card.equipment),
         "collections": _names(card.collections),
         "choices": _choices([*card.choices, *card.skill_choices, *card.power_choices]),
         "remarks": _remarks(card.remarks),
         "xp": card.xp,
+        "xp_target": card.xp_target,
     }
 
 
@@ -86,7 +99,7 @@ def gang_state(gang):
         "counters": sorted(
             (str(counter.name), str(counter.value)) for counter in sheet.counters
         ),
-        "stash": _names(sheet.stash),
+        "stash": _rated(sheet.stash),
         "stash_rating": sheet.stash_rating,
         "notes": _remarks(sheet.notes),
         "models": {card.id: _model_state(card) for card in sheet.models},

--- a/n26/core/capture.py
+++ b/n26/core/capture.py
@@ -1,0 +1,113 @@
+"""What a gang's pages say, captured as plain data for comparing two
+states of the world.
+
+A conversion that moves content from one shape to another must leave
+every page saying the same things. The capture holds exactly the facts
+that must not change — names, numbers, the questions asked and what
+settled them — as sorted primitives, so two captures compare with ``==``
+and any difference is a mistake by definition. Addresses, ids and
+provenance wording are deliberately absent: a conversion may change
+where a control leads and which machinery asks a question, never what
+the reader is told.
+
+Built on ``render_gang``, the same derivation every screen uses, so the
+capture cannot agree with a broken page.
+"""
+
+from n26.core.render import render_gang
+
+
+def _names(lines):
+    return sorted(str(line.name) for line in lines)
+
+
+def _choices(lines):
+    """Each question as (what the card calls it, what settled it)."""
+    return sorted((line.kind_label, line.chosen or "") for line in lines)
+
+
+def _statline(statline):
+    return [(cell.short_name, str(cell.value)) for cell in statline.cells]
+
+
+def _weapons(lines):
+    return sorted(
+        (
+            weapon.name,
+            tuple(
+                (profile.name, tuple(sorted(t.name for t in profile.traits)))
+                for profile in weapon.profiles
+            ),
+        )
+        for weapon in lines
+    )
+
+
+def _remarks(notes):
+    return sorted(str(note.text) for note in notes)
+
+
+def _model_state(card):
+    return {
+        "name": card.name,
+        "rating": card.rating,
+        "profile": card.profile_name,
+        "type_line": card.type_line,
+        "statline": _statline(card.statline),
+        "subtypes": _names(card.subtypes),
+        "weapons": _weapons(card.weapons),
+        "skills": _names(card.skills),
+        "powers": _names(card.powers),
+        "rules": _names(card.rules),
+        "equipment": _names(card.equipment),
+        "collections": _names(card.collections),
+        "choices": _choices([*card.choices, *card.skill_choices, *card.power_choices]),
+        "remarks": _remarks(card.remarks),
+        "xp": card.xp,
+    }
+
+
+def gang_state(gang):
+    """One gang's pages, as comparable data. Models are keyed by their
+    stored ids, so a diff names the fighter rather than an index."""
+    sheet = render_gang(gang)
+    return {
+        "name": sheet.name,
+        "gang_type": sheet.gang_type,
+        "rating": sheet.rating,
+        "credits": sheet.credits,
+        "wealth": sheet.wealth,
+        "rows": _names(sheet.rows),
+        "rules": _names(sheet.rules),
+        "choices": _choices(sheet.choices),
+        "counters": sorted(
+            (str(counter.name), str(counter.value)) for counter in sheet.counters
+        ),
+        "stash": _names(sheet.stash),
+        "stash_rating": sheet.stash_rating,
+        "notes": _remarks(sheet.notes),
+        "models": {card.id: _model_state(card) for card in sheet.models},
+    }
+
+
+def differences(before, after, at=""):
+    """Every place two captures disagree, as readable paths.
+
+    Empty means the pages say the same things. Listed rather than a bare
+    boolean so a refusing conversion can say exactly what it would have
+    changed.
+    """
+    if isinstance(before, dict) and isinstance(after, dict):
+        found = []
+        for key in sorted(set(before) | set(after)):
+            here = f"{at}.{key}" if at else str(key)
+            if key not in before:
+                found.append(f"{here}: appears ({after[key]!r})")
+            elif key not in after:
+                found.append(f"{here}: vanishes ({before[key]!r})")
+            else:
+                found.extend(differences(before[key], after[key], here))
+        return found
+    if before != after:
+        return [f"{at}: {before!r} -> {after!r}"]
+    return []

--- a/n26/library/conversion/__init__.py
+++ b/n26/library/conversion/__init__.py
@@ -1,0 +1,20 @@
+"""Conversions — moving hand-built choice systems onto slots and picks.
+
+Each system the content library built out of offers, hiddens and menu
+collections is converted by one module here, through one discipline
+(``base.py``): ``plan()`` reads the world and returns a frozen plan that
+says everything it would do; ``apply(plan)`` performs exactly that in
+one transaction and proves, before committing, that every affected
+gang's pages still say the same things. The preview is the contract.
+"""
+
+from n26.library.conversion.base import ConversionRefused, Plan, apply
+from n26.library.conversion.paths import plan_paths
+
+#: Every convertible system, by the name the command and the migrations
+#: use. Ordered as the systems are meant to ship.
+SYSTEMS = {
+    "paths": plan_paths,
+}
+
+__all__ = ["ConversionRefused", "Plan", "SYSTEMS", "apply", "plan_paths"]

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -29,6 +29,20 @@ from dataclasses import dataclass, field
 from django.db import transaction
 
 
+def carriers_of(modifier):
+    """Everything carrying this modifier, across every library kind — a
+    plan that detaches or deletes one must know it is not shared."""
+    from django.apps import apps as django_apps
+
+    found = []
+    for model in django_apps.get_app_config("library").get_models():
+        if not any(f.name == "modifiers" for f in model._meta.many_to_many):
+            continue
+        for row in model.objects.filter(modifiers=modifier):
+            found.append((model.__name__, row))
+    return found
+
+
 class ConversionRefused(Exception):
     """The apply found the world changed by its own hand — or not shaped
     the way the plan promised — and unwound. The message says exactly
@@ -283,11 +297,24 @@ def apply(plan):
 
     report = list(plan.preview())
     with transaction.atomic():
-        gangs = list(Gang.objects.filter(pk__in=plan.gang_ids))
-        before = {str(gang.pk): gang_state(gang) for gang in gangs}
+        before = {
+            str(gang.pk): gang_state(gang)
+            for gang in Gang.objects.filter(pk__in=plan.gang_ids)
+        }
         made = _Made()
         for step in plan.steps:
-            step.perform(made)
+            try:
+                step.perform(made)
+            except Exception as failed:
+                # A step that cannot be performed is a refusal too: the
+                # command and the migration both promise words, never a
+                # traceback, and the transaction unwinds either way.
+                raise ConversionRefused(
+                    f"[{plan.system}] failed at “{step.say()}”: {failed}"
+                ) from failed
+        # Fresh instances: the steps may have moved column-backed facts,
+        # and a stale row would compare stale with stale.
+        gangs = list(Gang.objects.filter(pk__in=plan.gang_ids))
         after = {str(gang.pk): gang_state(gang) for gang in gangs}
         changed = differences(before, after)
         if changed:
@@ -296,6 +323,11 @@ def apply(plan):
                 + "\n  ".join(changed)
             )
         for gang in gangs:
-            assert_reconciled(gang)
+            try:
+                assert_reconciled(gang)
+            except Exception as failed:
+                raise ConversionRefused(
+                    f"[{plan.system}] refused — {gang} no longer reconciles: {failed}"
+                ) from failed
     report.append(f"[{plan.system}] applied; every page reads the same")
     return report

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -1,0 +1,301 @@
+"""The conversion discipline: plan, check, apply — the preview is the contract.
+
+A conversion moves one hand-built choice system (an offer, its menu
+collection, its chosen-kind rows) onto slots and picks without changing
+what any page says. Three stages, the ingest discipline:
+
+* ``plan()`` — each system's module reads the database and returns a
+  frozen :class:`Plan`: typed steps, the gangs the system touches, and
+  any problems. It never writes. ``plan.preview()`` says everything the
+  apply would do, one line per step.
+* ``apply(plan)`` — performs exactly the plan's steps in one
+  transaction. Before writing it captures what every affected gang's
+  pages say (``n26.core.capture``); after writing it captures again and
+  **refuses** — unwinding the whole transaction — on any difference, and
+  on any touched gang that no longer reconciles. A conversion that would
+  change what a reader is told never lands.
+* A plan whose system is absent (``plan.nothing_here``) applies as a
+  no-op, so the migration that ships a conversion is safe on databases
+  that never held the system — a fresh environment, a pack without it.
+
+Pick rewrites touch ``Assignment`` rows outside ``operation()`` — the
+one sanctioned place: a conversion moves no money. Nothing is created or
+priced, columns change on existing free rows, the ledger is untouched,
+and the reconcile assertion proves it gang by gang.
+"""
+
+from dataclasses import dataclass, field
+
+from django.db import transaction
+
+
+class ConversionRefused(Exception):
+    """The apply found the world changed by its own hand — or not shaped
+    the way the plan promised — and unwound. The message says exactly
+    what differed."""
+
+
+@dataclass(frozen=True)
+class CreateSlotType:
+    name: str
+    plural_name: str = ""
+    allows_repeats: bool = True
+
+    def say(self):
+        return f"create slot type “{self.name}”"
+
+    def perform(self, made):
+        from n26.library.authoring import create_slot_type
+
+        made.slot_types[self.name] = create_slot_type(
+            self.name, plural_name=self.plural_name, allows_repeats=self.allows_repeats
+        )
+
+
+@dataclass(frozen=True)
+class CreatePickable:
+    name: str
+    slot_type: str
+    #: Modifier rows to move from the old kind's row onto the pickable —
+    #: the same rows, so scopes, conditions and effects are untouched.
+    moved_modifier_ids: tuple = ()
+    #: The old row the modifiers come off, as (model label, pk).
+    moved_from: tuple = ()
+
+    def say(self):
+        n = len(self.moved_modifier_ids)
+        moved = f", moving {n} modifier{'' if n == 1 else 's'}" if n else ""
+        return f"create pickable “{self.name}” ({self.slot_type}){moved}"
+
+    def perform(self, made):
+        from django.apps import apps
+
+        from n26.library.authoring import create_pickable
+        from n26.library.models import Modifier
+
+        pickable = create_pickable(self.name, made.slot_types[self.slot_type])
+        if self.moved_modifier_ids:
+            app_label, model_name = self.moved_from[0].split(".")
+            old = apps.get_model(app_label, model_name).objects.get(
+                pk=self.moved_from[1]
+            )
+            for modifier in Modifier.objects.filter(pk__in=self.moved_modifier_ids):
+                old.modifiers.remove(modifier)
+                pickable.modifiers.add(modifier)
+        made.pickables[self.name] = pickable
+
+
+@dataclass(frozen=True)
+class CreatePicklist:
+    name: str
+    slot_type: str
+    members: tuple = ()
+
+    def say(self):
+        return f"create picklist “{self.name}” offering {', '.join(self.members)}"
+
+    def perform(self, made):
+        from n26.library.authoring import create_picklist
+
+        made.picklists[self.name] = create_picklist(
+            self.name,
+            made.slot_types[self.slot_type],
+            members=[made.pickables[name] for name in self.members],
+        )
+
+
+@dataclass(frozen=True)
+class CreateSlot:
+    name: str
+    slot_type: str
+    picklist: str
+    label: str = ""
+    assigned_to: str = "bearer"
+    min_picks: int = 1
+    max_picks: int = 1
+
+    def say(self):
+        return (
+            f"create slot “{self.name}” drawing on “{self.picklist}”, "
+            f"pick landing on the {self.assigned_to}"
+        )
+
+    def perform(self, made):
+        from n26.library.authoring import create_slot
+
+        made.slots[self.name] = create_slot(
+            self.name,
+            made.slot_types[self.slot_type],
+            made.picklists[self.picklist],
+            label=self.label,
+            assigned_to=self.assigned_to,
+            min_picks=self.min_picks,
+            max_picks=self.max_picks,
+        )
+
+
+@dataclass(frozen=True)
+class SwapCarrier:
+    """The carrier stops offering and starts granting the slot."""
+
+    carrier: tuple  # (model label, pk)
+    carrier_name: str
+    drop_modifier_id: object
+    drop_modifier_name: str
+    grant_name: str
+    slot: str
+    #: The scope the grant reaches with — "gang_alone" for a question the
+    #: gang's card asks, "model" for one each bearer's card asks.
+    reach: str = "gang_alone"
+
+    def say(self):
+        return (
+            f"on {self.carrier_name}: replace “{self.drop_modifier_name}” "
+            f"with a grant of the “{self.slot}” slot"
+        )
+
+    def perform(self, made):
+        from django.apps import apps
+
+        from n26.library.authoring import (
+            ef_adds,
+            modifier,
+            targets_gang_alone,
+            targets_model,
+        )
+        from n26.library.models import Modifier
+
+        app_label, model_name = self.carrier[0].split(".")
+        carrier = apps.get_model(app_label, model_name).objects.get(pk=self.carrier[1])
+        dropped = Modifier.objects.get(pk=self.drop_modifier_id)
+        scope_row, effect_row = dropped.scope, dropped.effect
+        carrier.modifiers.remove(dropped)
+        dropped.delete()
+        scope_row.delete()
+        effect_row.delete()
+        scope = targets_gang_alone() if self.reach == "gang_alone" else targets_model()
+        modifier(
+            self.grant_name,
+            scope,
+            ef_adds(made.slots[self.slot]),
+            attach_to=carrier,
+        )
+
+
+@dataclass(frozen=True)
+class RewritePick:
+    """One stored choice, re-said as a pick: the old kind's column moves
+    to ``pickable``, the anchor it already hangs from (``caused_by``)
+    becomes the choice it settles, and the slot is named."""
+
+    assignment_id: object
+    old_column: str
+    pickable: str
+    slot: str
+    gang: str
+
+    def say(self):
+        return f"rewrite pick {self.assignment_id} ({self.gang}) -> “{self.pickable}”"
+
+    def perform(self, made):
+        from n26.core.models import Assignment
+
+        row = Assignment.objects.get(pk=self.assignment_id)
+        row.pickable = made.pickables[self.pickable]
+        row.chosen_for_id = row.caused_by_id
+        row.chosen_for_slot = made.slots[self.slot]
+        setattr(row, self.old_column, None)
+        row.save()
+
+
+@dataclass(frozen=True)
+class Retire:
+    """An old row the system no longer needs, deleted by identity."""
+
+    model: str  # app_label.ModelName
+    pk: object
+    name: str
+
+    def say(self):
+        return f"retire {self.model} “{self.name}”"
+
+    def perform(self, made):
+        from django.apps import apps
+
+        app_label, model_name = self.model.split(".")
+        apps.get_model(app_label, model_name).objects.get(pk=self.pk).delete()
+
+
+@dataclass
+class _Made:
+    """What the apply has created so far, by the plan's own names."""
+
+    slot_types: dict = field(default_factory=dict)
+    picklists: dict = field(default_factory=dict)
+    pickables: dict = field(default_factory=dict)
+    slots: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Plan:
+    system: str
+    steps: tuple = ()
+    #: Primary keys of every gang whose pages this system touches — the
+    #: capture set the apply proves unchanged.
+    gang_ids: tuple = ()
+    problems: tuple = ()
+    #: True when the system simply is not here — nothing to convert and
+    #: nothing wrong: the apply is a clean no-op.
+    nothing_here: bool = False
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    def preview(self):
+        if self.nothing_here:
+            return [f"[{self.system}] nothing to convert — the system is not here"]
+        lines = [f"[{self.system}] {step.say()}" for step in self.steps]
+        lines.append(
+            f"[{self.system}] prove {len(self.gang_ids)} gang"
+            f"{'' if len(self.gang_ids) == 1 else 's'} read the same, or refuse"
+        )
+        return lines
+
+
+def apply(plan):
+    """Perform exactly the plan, prove the pages unchanged, or refuse.
+
+    Returns the report lines. Raises :class:`ConversionRefused` — after
+    unwinding everything — if the plan carries problems, any affected
+    gang's pages change, or any touched gang stops reconciling.
+    """
+    from n26.core.capture import differences, gang_state
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+
+    if plan.problems:
+        raise ConversionRefused(
+            f"[{plan.system}] not applied: " + "; ".join(plan.problems)
+        )
+    if plan.nothing_here:
+        return list(plan.preview())
+
+    report = list(plan.preview())
+    with transaction.atomic():
+        gangs = list(Gang.objects.filter(pk__in=plan.gang_ids))
+        before = {str(gang.pk): gang_state(gang) for gang in gangs}
+        made = _Made()
+        for step in plan.steps:
+            step.perform(made)
+        after = {str(gang.pk): gang_state(gang) for gang in gangs}
+        changed = differences(before, after)
+        if changed:
+            raise ConversionRefused(
+                f"[{plan.system}] refused — the pages would change:\n  "
+                + "\n  ".join(changed)
+            )
+        for gang in gangs:
+            assert_reconciled(gang)
+    report.append(f"[{plan.system}] applied; every page reads the same")
+    return report

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -255,7 +255,10 @@ class Plan:
     system: str
     steps: tuple = ()
     #: Primary keys of every gang whose pages this system touches — the
-    #: capture set the apply proves unchanged.
+    #: capture set the apply proves unchanged. Derived from stored rows,
+    #: which every carrier so far is; a system whose carrier arrives by
+    #: grant has no row to find, and its plan must widen this set the
+    #: renderer's way.
     gang_ids: tuple = ()
     problems: tuple = ()
     #: True when the system simply is not here — nothing to convert and

--- a/n26/library/conversion/paths.py
+++ b/n26/library/conversion/paths.py
@@ -34,11 +34,11 @@ def plan_paths():
 
     problems = []
 
-    if SlotType.objects.filter(name=SLOT_TYPE).exists():
+    if SlotType.objects.filter(name=SLOT_TYPE, archived=False).exists():
         # Applied already — the slot type is this conversion's own mark.
         return Plan(system="paths", nothing_here=True)
 
-    hiddens = list(Hidden.objects.filter(name=CARRIER_NAME))
+    hiddens = list(Hidden.objects.filter(name=CARRIER_NAME, archived=False))
     if not hiddens:
         return Plan(system="paths", nothing_here=True)
     if len(hiddens) > 1:
@@ -63,6 +63,21 @@ def plan_paths():
             ),
         )
     offer = offers[0]
+    from n26.library.conversion.base import carriers_of
+
+    other_carriers = [
+        f"{kind} “{row}”"
+        for kind, row in carriers_of(offer)
+        if not (kind == "Hidden" and row.pk == carrier.pk)
+    ]
+    if other_carriers:
+        return Plan(
+            system="paths",
+            problems=(
+                "the Path offer is shared — also carried by "
+                + ", ".join(other_carriers),
+            ),
+        )
     section = offer.offers_choice.from_section
     if section is None:
         return Plan(
@@ -82,8 +97,11 @@ def plan_paths():
             f"the “{menu.name}” menu lists {len(old_paths)} affiliations — expected exactly the two paths"
         )
 
+    # Archived picks too: a gang that switched its path keeps the row it
+    # took back, still naming the affiliation — left behind, it would
+    # PROTECT the retirement. The same rewrite keeps the history coherent.
     picks = list(
-        Assignment.objects.filter(archived=False, affiliation__in=old_paths)
+        Assignment.objects.filter(affiliation__in=old_paths)
         .select_related("affiliation", "gang_root")
         .order_by("created")
     )

--- a/n26/library/conversion/paths.py
+++ b/n26/library/conversion/paths.py
@@ -1,0 +1,166 @@
+"""The Cawdor Paths conversion — the pilot system.
+
+Today: a hidden "Path" (built into the Cawdor gang type) carries a
+gang-scoped *offers a choice of affiliation* over the "Paths" menu
+collection; two affiliations (Path of the Fanatic, Path of the Pious)
+each carry the gang rules their path grants.
+
+After: a "Path" slot type with the two paths as pickables on a "Paths"
+picklist, one gang slot; the hidden grants the slot instead of carrying
+the offer; every stored path pick becomes a pick of the pickable,
+settling the slot it already hangs from.
+"""
+
+from n26.library.conversion.base import (
+    CreatePickable,
+    CreatePicklist,
+    CreateSlot,
+    CreateSlotType,
+    Plan,
+    Retire,
+    RewritePick,
+    SwapCarrier,
+)
+
+CARRIER_NAME = "Path"
+OFFER_LABEL = "Path"
+SLOT_TYPE = "Path"
+PICKLIST = "Paths"
+
+
+def plan_paths():
+    from n26.core.models import Assignment
+    from n26.library.models import Hidden, SlotType
+
+    problems = []
+
+    if SlotType.objects.filter(name=SLOT_TYPE).exists():
+        # Applied already — the slot type is this conversion's own mark.
+        return Plan(system="paths", nothing_here=True)
+
+    hiddens = list(Hidden.objects.filter(name=CARRIER_NAME))
+    if not hiddens:
+        return Plan(system="paths", nothing_here=True)
+    if len(hiddens) > 1:
+        return Plan(
+            system="paths",
+            problems=(f"{len(hiddens)} hiddens named “{CARRIER_NAME}” — expected one",),
+        )
+    carrier = hiddens[0]
+
+    offers = [
+        m
+        for m in carrier.modifiers.all()
+        if getattr(m, "offers_choice", None) is not None
+        and m.offers_choice.label == OFFER_LABEL
+    ]
+    if len(offers) != 1:
+        return Plan(
+            system="paths",
+            problems=(
+                f"the “{CARRIER_NAME}” hidden carries {len(offers)} offers "
+                f"labelled “{OFFER_LABEL}” — expected one",
+            ),
+        )
+    offer = offers[0]
+    section = offer.offers_choice.from_section
+    if section is None:
+        return Plan(
+            system="paths",
+            problems=("the Path offer names no menu section",),
+        )
+    menu = section.collection
+
+    entries = list(
+        menu.entries.filter(affiliation__isnull=False)
+        .select_related("affiliation")
+        .order_by("position", "affiliation__name")
+    )
+    old_paths = [entry.affiliation for entry in entries]
+    if len(old_paths) < 2:
+        problems.append(
+            f"the “{menu.name}” menu lists {len(old_paths)} affiliations — expected the two paths"
+        )
+
+    picks = list(
+        Assignment.objects.filter(archived=False, affiliation__in=old_paths)
+        .select_related("affiliation", "gang_root")
+        .order_by("created")
+    )
+    unanchored = [str(pick.pk) for pick in picks if pick.caused_by_id is None]
+    if unanchored:
+        problems.append(
+            "picks with no caused_by to settle against: " + ", ".join(unanchored)
+        )
+
+    if problems:
+        return Plan(system="paths", problems=tuple(problems))
+
+    steps = [
+        CreateSlotType(name=SLOT_TYPE, plural_name="Paths"),
+        *[
+            CreatePickable(
+                name=old.name,
+                slot_type=SLOT_TYPE,
+                moved_modifier_ids=tuple(m.pk for m in old.modifiers.all()),
+                moved_from=("library.Affiliation", old.pk),
+            )
+            for old in old_paths
+        ],
+        CreatePicklist(
+            name=PICKLIST,
+            slot_type=SLOT_TYPE,
+            members=tuple(old.name for old in old_paths),
+        ),
+        CreateSlot(
+            name=SLOT_TYPE,
+            slot_type=SLOT_TYPE,
+            picklist=PICKLIST,
+            assigned_to="gang",
+            # The offer never nagged an open choice, so neither may the
+            # slot: every converted system arrives expecting no picks.
+            # Tightening a minimum is a content decision for later,
+            # never the conversion's.
+            min_picks=0,
+        ),
+        SwapCarrier(
+            carrier=("library.Hidden", carrier.pk),
+            carrier_name=f"the “{carrier.name}” hidden",
+            drop_modifier_id=offer.pk,
+            drop_modifier_name=offer.name,
+            grant_name="Path: the gang is asked its Path",
+            slot=SLOT_TYPE,
+            reach="gang_alone",
+        ),
+        *[
+            RewritePick(
+                assignment_id=pick.pk,
+                old_column="affiliation",
+                pickable=pick.affiliation.name,
+                slot=SLOT_TYPE,
+                gang=str(pick.gang_root),
+            )
+            for pick in picks
+        ],
+        # The menu and the old rows, last: nothing references them once
+        # the picks are rewritten and the modifiers moved. Deleting the
+        # collection takes its entries and sections with it.
+        Retire(model="library.Collection", pk=menu.pk, name=menu.name),
+        *[
+            Retire(model="library.Affiliation", pk=old.pk, name=old.name)
+            for old in old_paths
+        ],
+    ]
+
+    gang_ids = sorted(
+        {
+            *(
+                Assignment.objects.filter(archived=False, hidden=carrier)
+                .values_list("gang_root_id", flat=True)
+                .distinct()
+            ),
+            *(pick.gang_root_id for pick in picks),
+        },
+        key=str,
+    )
+    return Plan(system="paths", steps=tuple(steps), gang_ids=tuple(gang_ids))

--- a/n26/library/conversion/paths.py
+++ b/n26/library/conversion/paths.py
@@ -77,9 +77,9 @@ def plan_paths():
         .order_by("position", "affiliation__name")
     )
     old_paths = [entry.affiliation for entry in entries]
-    if len(old_paths) < 2:
+    if len(old_paths) != 2:
         problems.append(
-            f"the “{menu.name}” menu lists {len(old_paths)} affiliations — expected the two paths"
+            f"the “{menu.name}” menu lists {len(old_paths)} affiliations — expected exactly the two paths"
         )
 
     picks = list(

--- a/n26/library/management/commands/n26_convert.py
+++ b/n26/library/management/commands/n26_convert.py
@@ -1,0 +1,40 @@
+"""Plan or apply a slots-and-picks conversion, from the shell.
+
+The rehearsal tool: point it at a database holding the system (a fork
+of the prod mirror, a restore of a full dump) and read the plan; add
+``--apply`` to perform it, with the conversion's own refusal standing
+between the plan and a committed write. Production runs the same
+conversions through migrations — this command is how one is checked
+before it ships.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from n26.library.conversion import SYSTEMS, ConversionRefused, apply
+
+
+class Command(BaseCommand):
+    help = "Plan (default) or apply a slots-and-picks conversion."
+
+    def add_arguments(self, parser):
+        parser.add_argument("system", choices=sorted(SYSTEMS))
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Perform the plan. Without this, the plan is printed and nothing is written.",
+        )
+
+    def handle(self, *args, **options):
+        plan = SYSTEMS[options["system"]]()
+        for line in plan.preview():
+            self.stdout.write(line)
+        for problem in plan.problems:
+            self.stdout.write(self.style.ERROR(f"problem: {problem}"))
+        if not options["apply"]:
+            self.stdout.write("(planned only — nothing written)")
+            return
+        try:
+            for line in apply(plan):
+                self.stdout.write(line)
+        except ConversionRefused as refused:
+            raise CommandError(str(refused)) from None

--- a/n26/library/management/commands/n26_convert.py
+++ b/n26/library/management/commands/n26_convert.py
@@ -26,13 +26,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         plan = SYSTEMS[options["system"]]()
-        for line in plan.preview():
-            self.stdout.write(line)
         for problem in plan.problems:
             self.stdout.write(self.style.ERROR(f"problem: {problem}"))
         if not options["apply"]:
+            for line in plan.preview():
+                self.stdout.write(line)
             self.stdout.write("(planned only — nothing written)")
             return
+        # The apply report opens with the preview, so it is not said twice.
         try:
             for line in apply(plan):
                 self.stdout.write(line)

--- a/n26/library/migrations/0062_the_paths_become_picks.py
+++ b/n26/library/migrations/0062_the_paths_become_picks.py
@@ -1,0 +1,30 @@
+# The Cawdor Paths move onto slots and picks — the first converted
+# system. The conversion module owns the whole discipline (plan, prove
+# the pages unchanged, apply or refuse); this migration only runs it, so
+# the rehearsal command and production perform the identical steps. On a
+# database that never held the system — a fresh environment — the plan
+# says nothing_here and this is a clean no-op.
+#
+# Deliberately irreversible: the forward run's report (printed to the
+# migrate output) records every rewritten pick and retired row, and
+# going back is a restore, not a migration.
+
+from django.db import migrations
+
+
+def convert(apps, schema_editor):
+    from n26.library.conversion import apply, plan_paths
+
+    for line in apply(plan_paths()):
+        print(line)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0061_reach_is_said_not_implied"),
+        ("n26", "0012_a_pick_names_the_slot_it_settles"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert, migrations.RunPython.noop),
+    ]

--- a/n26/tests/sandbox/test_conversion_paths.py
+++ b/n26/tests/sandbox/test_conversion_paths.py
@@ -222,6 +222,59 @@ class TestTheRefusals:
         stray.refresh_from_db()
         assert stray.affiliation == paths["Path of the Fanatic"]
 
+    def test_a_shared_offer_is_a_problem_not_a_silent_detach(
+        self, gangs, prod_shape, default_pack
+    ):
+        """The offer modifier is deleted, so a second carrier would
+        silently lose its question — and its gangs sit outside the
+        proof. Shared is refused."""
+        from n26.library.authoring import attach_modifiers_to
+
+        _, carrier, _ = prod_shape
+        offer = next(
+            m
+            for m in carrier.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(create_hidden("Another door"), [offer])
+
+        plan = plan_paths()
+
+        assert not plan.ok
+        assert "shared" in plan.problems[0]
+
+
+class TestAGangThatSwitchedItsPath:
+    """A taken-back pick is archived, not deleted, and still names the
+    affiliation — left behind it would PROTECT the retirement. It is
+    rewritten like the live one, so the history stays coherent."""
+
+    def test_the_archived_pick_is_rewritten_and_the_retirement_lands(
+        self, gangs, prod_shape
+    ):
+        settled, _ = gangs
+        _, carrier, paths = prod_shape
+        anchor = Assignment.objects.get(hidden=carrier, gang=settled)
+        remove(Assignment.objects.get(affiliation__isnull=False, gang=settled))
+        choose(anchor, paths["Path of the Fanatic"])
+        archived = Assignment.objects.get(
+            affiliation__name="Path of the Pious", gang=settled, archived=True
+        )
+
+        report = apply(plan_paths())
+
+        assert not Affiliation.objects.filter(name__startswith="Path of").exists()
+        archived.refresh_from_db()
+        assert archived.affiliation_id is None
+        assert archived.pickable == Pickable.objects.get(name="Path of the Pious")
+        assert archived.archived is True
+        live = Assignment.objects.get(pickable__isnull=False, archived=False)
+        assert live.pickable.name == "Path of the Fanatic"
+        assert report[-1] == "[paths] applied; every page reads the same"
+        assert_reconciled(settled)
+
+
+class TestNothingToConvert:
     def test_an_empty_world_is_nothing_to_convert(self, default_pack):
         plan = plan_paths()
 

--- a/n26/tests/sandbox/test_conversion_paths.py
+++ b/n26/tests/sandbox/test_conversion_paths.py
@@ -1,0 +1,229 @@
+"""The Paths conversion, proven end to end on a prod-shaped world.
+
+Builds the Cawdor Paths system exactly as production holds it — the
+"Path" hidden built into the gang type, its gang-scoped offer over the
+"Paths" menu, two path affiliations carrying gang rules — plays gangs
+against it, and proves the conversion's whole discipline: the plan says
+everything, the apply changes no page, the picks are rewritten in
+place, choosing still works afterwards, a second run is a no-op, and a
+world the plan does not recognise is refused without a single write.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from n26.core.capture import differences, gang_state
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.conversion import ConversionRefused, apply, plan_paths
+from n26.library.models import Affiliation, Collection, Pickable, Slot, SlotType
+from n26.tests.sandbox.actions import (
+    choose,
+    create_affiliation,
+    create_collection,
+    create_default_set,
+    create_gang_type,
+    create_hidden,
+    create_profile,
+    create_rule,
+    ef_adds,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    remove,
+    section_of,
+    targets_gang,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def prod_shape(default_pack):
+    """The system as production holds it, names and all."""
+    paths = {
+        "Path of the Fanatic": ("Fanatic Warriors", "Fanatical"),
+        "Path of the Pious": ("Pious Warriors", "Without Number"),
+    }
+    made = {}
+    for name, rules in paths.items():
+        made[name] = create_affiliation(
+            name,
+            effects=[(targets_gang(), ef_adds(create_rule(rule))) for rule in rules],
+        )
+    menu = create_collection("Paths", entries=list(made.values()))
+    section = section_of(menu, "Paths", 0, is_default=True)
+    carrier = create_hidden("Path")
+    modifier(
+        "the gang: offers a choice of affiliation from Paths (Paths)",
+        targets_gang(),
+        offers_choice(Affiliation, from_section=section, label="Path"),
+        carried_by=carrier,
+    )
+    gang_type = create_gang_type("Cawdor", starting_credits=1000)
+    gang_type.built_ins = create_default_set("Cawdor founding", members=[carrier])
+    gang_type.save()
+    return gang_type, carrier, made
+
+
+@pytest.fixture
+def cawdor_profile(prod_shape, person_type):
+    gang_type, _, _ = prod_shape
+    return create_profile("Brother", person_type, gang_type, price=50)
+
+
+@pytest.fixture
+def gangs(prod_shape, cawdor_profile, owner):
+    """Two gangs with members: one settled on the Pious path, one that
+    never picked."""
+    gang_type, carrier, paths = prod_shape
+    settled = found_gang("The Devout", gang_type, owner=owner, budget=1000)
+    open_gang = found_gang("The Waverers", gang_type, owner=owner, budget=1000)
+    for gang in (settled, open_gang):
+        hire(gang, cawdor_profile, f"Brother of {gang.name}", paid=50)
+    anchor = Assignment.objects.get(hidden=carrier, gang=settled)
+    choose(anchor, paths["Path of the Pious"])
+    return settled, open_gang
+
+
+class TestThePlan:
+    def test_it_says_everything_it_would_do(self, gangs):
+        plan = plan_paths()
+
+        assert plan.ok and not plan.nothing_here
+        said = "\n".join(plan.preview())
+        assert "create slot type “Path”" in said
+        assert "create pickable “Path of the Fanatic” (Path), moving 2 modifiers" in (
+            said
+        )
+        assert "create picklist “Paths” offering" in said
+        assert "pick landing on the gang" in said
+        assert "replace “the gang: offers a choice of affiliation" in said
+        assert said.count("rewrite pick") == 1
+        assert "retire library.Collection “Paths”" in said
+        assert said.count("retire library.Affiliation") == 2
+        assert "prove 2 gangs read the same, or refuse" in said
+
+    def test_it_writes_nothing(self, gangs):
+        before = Assignment.objects.count()
+
+        plan_paths()
+
+        assert Assignment.objects.count() == before
+        assert not SlotType.objects.filter(name="Path").exists()
+
+
+class TestTheApply:
+    def test_every_page_reads_the_same(self, gangs):
+        settled, open_gang = gangs
+        before = {g.pk: gang_state(g) for g in gangs}
+
+        apply(plan_paths())
+
+        for gang in gangs:
+            assert differences(before[gang.pk], gang_state(gang)) == []
+            assert_reconciled(gang)
+
+    def test_the_pick_is_rewritten_in_place(self, gangs, prod_shape):
+        settled, _ = gangs
+        _, carrier, _ = prod_shape
+        old = Assignment.objects.get(
+            affiliation__name="Path of the Pious", gang=settled
+        )
+
+        apply(plan_paths())
+
+        old.refresh_from_db()
+        assert old.affiliation_id is None
+        assert old.pickable == Pickable.objects.get(name="Path of the Pious")
+        assert old.chosen_for_id == old.caused_by_id
+        assert old.chosen_for == Assignment.objects.get(hidden=carrier, gang=settled)
+        assert old.chosen_for_slot == Slot.objects.get(name="Path")
+
+    def test_the_old_system_is_gone(self, gangs):
+        apply(plan_paths())
+
+        assert not Affiliation.objects.filter(name__startswith="Path of").exists()
+        assert not Collection.objects.filter(name="Paths").exists()
+
+    def test_the_report_says_what_happened(self, gangs):
+        report = apply(plan_paths())
+
+        assert report[-1] == "[paths] applied; every page reads the same"
+
+    def test_rechoosing_works_on_the_new_machinery(self, gangs, prod_shape):
+        settled, _ = gangs
+        _, carrier, _ = prod_shape
+        apply(plan_paths())
+        anchor = Assignment.objects.get(hidden=carrier, gang=settled)
+
+        remove(Assignment.objects.get(pickable__name="Path of the Pious"))
+        choose(
+            anchor,
+            Pickable.objects.get(name="Path of the Fanatic"),
+            slot=Slot.objects.get(name="Path"),
+        )
+
+        state = gang_state(settled)
+        assert ("Path", "Path of the Fanatic") in state["choices"]
+        assert "Fanatical" in state["rules"]
+        assert "Without Number" not in state["rules"]
+        assert_reconciled(settled)
+
+    def test_a_second_run_is_a_clean_no_op(self, gangs):
+        apply(plan_paths())
+
+        plan = plan_paths()
+
+        assert plan.nothing_here
+        assert apply(plan) == plan.preview()
+
+
+class TestTheRefusals:
+    def test_a_world_the_plan_does_not_recognise_is_a_problem_not_a_write(
+        self, gangs, default_pack
+    ):
+        create_hidden("Path", qualifier="an impostor")
+
+        plan = plan_paths()
+
+        assert not plan.ok
+        assert "expected one" in plan.problems[0]
+        with pytest.raises(ConversionRefused):
+            apply(plan)
+        assert not SlotType.objects.filter(name="Path").exists()
+
+    def test_a_pick_anchored_on_the_wrong_row_refuses_and_unwinds(
+        self, gangs, prod_shape, owner
+    ):
+        """The safety net proves itself: a hand-made pick whose cause is
+        not the offer's carrier would stop reading as chosen after the
+        rewrite — the apply sees the page change and unwinds everything."""
+        from n26.tests.sandbox.actions import assign
+
+        gang_type, carrier, paths = prod_shape
+        _, open_gang = gangs
+        stray = assign(paths["Path of the Fanatic"], gang=open_gang)
+        stray.caused_by = Assignment.objects.get(
+            gang_type__isnull=False, gang=open_gang
+        )
+        stray.save()
+
+        with pytest.raises(ConversionRefused, match="pages would change"):
+            apply(plan_paths())
+
+        assert not SlotType.objects.filter(name="Path").exists()
+        stray.refresh_from_db()
+        assert stray.affiliation == paths["Path of the Fanatic"]
+
+    def test_an_empty_world_is_nothing_to_convert(self, default_pack):
+        plan = plan_paths()
+
+        assert plan.nothing_here
+        assert "nothing to convert" in apply(plan)[0]


### PR DESCRIPTION
## What this is

The pilot of the content migration onto slots and picks (plan: .claude/notes/chosen-kinds-migration-plan.md on the chosen-kinds-plan branch; survey: chosen-kinds-map.md beside it). It ships the conversion discipline and converts the smallest production system — Cawdor Paths — with it.

## The discipline: current state → transformed state → apply, checkable before shipping

- **`n26/core/capture.py`** — what a gang's pages say, as plain comparable data built on `render_gang`. The invariant set *is* the capture: names, numbers, questions and what settled them; never addresses, ids or provenance wording. Two captures compare with `==`.
- **`n26/library/conversion/`** — `plan()` reads the world and returns frozen, typed steps plus problems, and never writes; `plan.preview()` says everything the apply would do. `apply(plan)` performs exactly those steps in one transaction, captures every affected gang before and after, and **refuses — unwinding everything — on any page difference or any gang that stops reconciling**. A database that never held the system is a stated no-op.
- **`manage n26_convert <system> [--apply]`** — the rehearsal tool. Production runs the identical code through a migration, so rehearsal and deploy are provably one operation.

## Paths itself

The Path slot type; the two paths as pickables carrying **the same modifier rows** (moved, not copied — scopes and conditions untouched); the Paths picklist; one gang slot **granted by the same founding hidden** that used to carry the offer. Every stored pick is rewritten in place: old kind column → `pickable`, `chosen_for` = the `caused_by` it already had, slot named. The old affiliations and the menu collection are retired. The slot expects no picks (`min_picks=0`): the offer never nagged an open choice, so neither may the slot — **the capture check caught exactly that on its first run**, which is the discipline doing its job.

## Test plan

- [x] Sandbox suite (11 tests) on a prod-shaped world: the plan says everything and writes nothing; apply leaves every page identical and reconciled; the pick is rewritten in place; re-choosing works on the new machinery; a second run is a clean no-op; a world the plan does not recognise is a problem, not a write; a mis-anchored pick makes the apply refuse and unwind
- [x] Rehearsed against the production content mirror: the plan resolved the real rows, apply converted them, and the shipping migration then recognised the conversion's mark and no-opped
- [x] Migration is graceful on a database without the system (fresh environments)
- [x] Full n26 suite: 3,567 passed, 1 xfailed (pre-existing)

At production deploy, the migration will additionally list the 26 live pick rewrites and prove every Cawdor gang's pages unchanged inside the transaction — the deploy aborts rather than commit a difference.

Known limitation, stated on purpose: the migration is irreversible (going back is a restore; the migrate output records every rewritten pick and retired row).

Refs the chosen-kinds migration plan; next systems reuse this engine with a spec module each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8