### PR TITLE
feat: the specialisations become picks

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -103,6 +103,15 @@ steps:
       - "--cpu=1"
       - "--memory=1Gi"
       - "--concurrency=40"
+      # A cap, not a target: nothing serves slower for having a longer one.
+      # The default 300s is below what the longest background task needs — a
+      # library conversion holds a single transaction while it proves every
+      # affected gang's pages unchanged, measured at ~165s over 634 gangs on
+      # a developer machine and slower on one vCPU. Being cut off writes
+      # nothing, so the conversion would simply never finish rather than
+      # finish badly, and it arrives here as a Pub/Sub push, which is a
+      # request like any other.
+      - "--timeout=900"
       # HTTP probe against the WSGI-level /healthz in gyrinx/wsgi.py, which only
       # answers once a gunicorn worker has fully imported the app. A TCP probe
       # passes as soon as the master binds the port, which lets Cloud Run send

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -108,10 +108,18 @@ steps:
       # library conversion holds a single transaction while it proves every
       # affected gang's pages unchanged, measured at ~165s over 634 gangs on
       # a developer machine and slower on one vCPU. Being cut off writes
-      # nothing, so the conversion would simply never finish rather than
-      # finish badly, and it arrives here as a Pub/Sub push, which is a
-      # request like any other.
-      - "--timeout=900"
+      # nothing, so such a task would simply never finish rather than finish
+      # badly.
+      #
+      # 600s because a task arrives as a Pub/Sub push, and that is the longest
+      # acknowledgement deadline Pub/Sub allows. The two must not part company:
+      # a request outliving its deadline is delivered a second time while the
+      # first is still working, and the second copy — finding the work already
+      # in hand and standing down — answers successfully, which acknowledges
+      # the message. The first then dies against the longer cap with nothing
+      # left to retry it. Equal deadlines mean a request that runs too long is
+      # cut off and redelivered honestly instead.
+      - "--timeout=600"
       # HTTP probe against the WSGI-level /healthz in gyrinx/wsgi.py, which only
       # answers once a gunicorn worker has fully imported the app. A TCP probe
       # passes as soon as the master binds the port, which lets Cloud Run send

--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -27,14 +27,16 @@ The dependency direction is: `library` holds content, `core` reads it.
 Concretely:
 
 - **No app code in `n26/` imports `n23.*` or `gyrinx.*`.** n26 is a
-  parallel edition, not a layer on the old one. Six deliberate
+  parallel edition, not a layer on the old one. Seven deliberate
   exceptions: the dashboard reads `gyrinx.site.models.ChangelogEntry`,
   deferred inside the view; the gangs view searches with
   `gyrinx.querysets.search_queryset`; the artwork tag cleans SVG with
   `gyrinx.svg.sanitize_inline_svg`; `n26/library/artwork.py` stores and
   reads uploads through `gyrinx.artwork`; `n26/analytics.py` records
-  events through `gyrinx.analytics`; and `n26/tests/` may import platform
-  pieces to test the seam. Do not add others.
+  events through `gyrinx.analytics`; `n26/maintenance.py` offers this
+  edition's repairs through `gyrinx.maintenance` and runs them on
+  `gyrinx.tasks`; and `n26/tests/` may import platform pieces to test the
+  seam. Do not add others.
 - **`n26/analytics.py` is the third platform module n26 may call, and
   the only file allowed to.** Activity tracking is the site's: one
   events table, one log stream, one dashboard, and every question asked
@@ -76,6 +78,23 @@ Concretely:
   This edition keeps only the folder its uploads land in
   (`n26/library/artwork.py` binds the prefix); every rule about what may
   be stored and what an address may name lives in the platform module.
+- **`n26/maintenance.py` is the other single-file seam, and it works the
+  way `n26/analytics.py` does.** The maintenance console is site
+  furniture — a superuser-gated index, one audit record per run, a detail
+  page, a cancel button — and it deliberately knows nothing about either
+  edition; what there is to repair is edition knowledge, so an edition
+  registers its operations rather than the console naming them. A second
+  console here would give the two editions separate histories of what was
+  repaired and when, which is the same argument as for analytics. The
+  whole dependency is one file: the registry, the audit record, the page
+  helpers and the background-task route are imported there and nowhere
+  else in `n26/`, and `n26/core/tasks.py` only re-exports its
+  `task_routes` because the task registry insists on reading them from an
+  app's own `tasks` module. One import is forbidden outright:
+  `gyrinx.maintenance.admin` installs the console's admin site and must
+  run after the platform's own — an edition importing it during
+  autodiscovery would install it too early and every maintenance route
+  would be silently dropped.
 - **Templates may `{% load %}` a platform tag library** where the thing
   it answers is genuinely the platform's and not an edition's — today
   that is `badge_tags`, because which badge a person shows follows from

--- a/n26/core/admin.py
+++ b/n26/core/admin.py
@@ -251,3 +251,10 @@ class PrintConfigAdmin(admin.ModelAdmin):
     list_select_related = ["gang"]
     # As on AssignmentSet: the ticking happens on the print setup screen.
     exclude = ["miniatures", "assignments"]
+
+
+# Registering this edition's maintenance operations happens on import, and
+# admin autodiscovery is when it must happen. Importing the seam here — and
+# never gyrinx.maintenance.admin, which installs the console's admin site and
+# must run after the platform's own admin — is what puts them on the console.
+import n26.maintenance  # noqa: E402,F401  (imported for its registrations)

--- a/n26/core/tasks.py
+++ b/n26/core/tasks.py
@@ -1,0 +1,11 @@
+"""This app's background tasks, as the task registry expects to find them.
+
+The registry reads ``task_routes`` from each app's ``tasks`` module. The
+tasks themselves live in :mod:`n26.maintenance`, which is this edition's
+one door onto the platform's maintenance console and task route — a task
+declared here would be a second place importing them.
+"""
+
+from n26.maintenance import task_routes
+
+__all__ = ["task_routes"]

--- a/n26/core/templates/admin/maintenance/n26/_convert_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_convert_detail.html
@@ -1,0 +1,23 @@
+{% comment %}
+    The summary of one conversion run, on the Backfill detail page: what
+    it was going to do, and — once it has finished — what it did.
+{% endcomment %}
+{% if backfill.summary.report %}
+    <h2>What it did</h2>
+    <ul>
+        {% for line in backfill.summary.report %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% elif backfill.summary.preview %}
+    <h2>What it is doing</h2>
+    <p>
+        These are the steps it planned. The conversion writes nothing until every
+        affected gang has been proven to read the same, so a run still working has
+        changed nothing yet.
+    </p>
+    <ul>
+        {% for line in backfill.summary.preview %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+{% if backfill.summary.attempts %}
+    <p>Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }}.</p>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/_convert_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_convert_detail.html
@@ -2,6 +2,13 @@
     The summary of one conversion run, on the Backfill detail page: what
     it was going to do, and — once it has finished — what it did.
 {% endcomment %}
+{% if backfill.summary.kept is False %}
+    <h2>A rehearsal — nothing was kept</h2>
+    <p>
+        This run performed the whole conversion, proved every affected gang's
+        pages, and then unwound it. The library is exactly as it was.
+    </p>
+{% endif %}
 {% if backfill.summary.report %}
     <h2>What it did</h2>
     <ul>

--- a/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
+++ b/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
@@ -42,10 +42,26 @@
         <ul class="mt-plan">
             {% for line in preview %}<li>{{ line }}</li>{% endfor %}
         </ul>
+        <h2>Rehearse it first</h2>
+        <p>
+            A rehearsal does the whole conversion — every step, every page
+            proven — and then unwinds it on purpose. It answers whether this
+            works on this database without changing it, which is worth asking
+            of one holding real gangs. It takes as long as the real run.
+        </p>
         <form method="post"
               class="mt-form"
-              onsubmit="return confirm('Run the Specialisation conversion over {{ gangs }} gang(s)? It writes nothing unless every page reads the same.')">
+              onsubmit="return confirm('Rehearse the conversion over {{ gangs }} gang(s)? Nothing will be kept.')">
             {% csrf_token %}
+            <input type="hidden" name="keep" value="no">
+            <button type="submit" class="button">Rehearse — change nothing</button>
+        </form>
+        <h2>Apply it</h2>
+        <form method="post"
+              class="mt-form"
+              onsubmit="return confirm('Convert {{ gangs }} gang(s) for real? It writes nothing unless every page reads the same.')">
+            {% csrf_token %}
+            <input type="hidden" name="keep" value="yes">
             <button type="submit" class="button default">Apply conversion</button>
         </form>
     {% endif %}

--- a/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
+++ b/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
@@ -1,0 +1,75 @@
+{% extends "admin/base_site.html" %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-plan { font-family: monospace; line-height: 1.6; }
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    .mt-problems { color: var(--error-fg, #ba2121); }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        This is the plan. Nothing has been changed. Every line below is a step
+        the conversion would perform, in order; the last line says how many
+        gangs it would prove unchanged before committing anything.
+    </p>
+    <p>
+        Applying runs the whole conversion in one transaction. It captures what
+        every affected gang's pages say, performs the steps, captures again, and
+        commits only if the two readings match and every gang still reconciles.
+        Anything else — a difference, a refusal, an interruption — writes nothing
+        at all, so a run that does not finish can simply be run again.
+    </p>
+    {% if plan.nothing_here %}
+        <h2>Nothing to convert</h2>
+        <p>This system is not here. It has been converted already, or was never present.</p>
+    {% elif not plan.ok %}
+        <h2 class="mt-problems">The conversion refuses</h2>
+        <ul class="mt-problems">
+            {% for problem in plan.problems %}<li>{{ problem }}</li>{% endfor %}
+        </ul>
+        <p>Nothing can be applied while any of these stands.</p>
+    {% else %}
+        <h2>What it would do</h2>
+        <ul class="mt-plan">
+            {% for line in preview %}<li>{{ line }}</li>{% endfor %}
+        </ul>
+        <form method="post"
+              class="mt-form"
+              onsubmit="return confirm('Run the Specialisation conversion over {{ gangs }} gang(s)? It writes nothing unless every page reads the same.')">
+            {% csrf_token %}
+            <button type="submit" class="button default">Apply conversion</button>
+        </form>
+    {% endif %}
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/library/conversion/__init__.py
+++ b/n26/library/conversion/__init__.py
@@ -12,8 +12,9 @@ from n26.library.conversion.base import ConversionRefused, Plan, apply
 from n26.library.conversion.paths import plan_paths
 from n26.library.conversion.specialisation import plan_specialisation
 
-#: Every convertible system, by the name the command and the migrations
-#: use. Ordered as the systems are meant to ship.
+#: Every convertible system, by the name the command — and any
+#: migration that ships one — uses. Ordered as the systems are meant
+#: to ship.
 SYSTEMS = {
     "paths": plan_paths,
     "specialisation": plan_specialisation,

--- a/n26/library/conversion/__init__.py
+++ b/n26/library/conversion/__init__.py
@@ -10,11 +10,20 @@ gang's pages still say the same things. The preview is the contract.
 
 from n26.library.conversion.base import ConversionRefused, Plan, apply
 from n26.library.conversion.paths import plan_paths
+from n26.library.conversion.specialisation import plan_specialisation
 
 #: Every convertible system, by the name the command and the migrations
 #: use. Ordered as the systems are meant to ship.
 SYSTEMS = {
     "paths": plan_paths,
+    "specialisation": plan_specialisation,
 }
 
-__all__ = ["ConversionRefused", "Plan", "SYSTEMS", "apply", "plan_paths"]
+__all__ = [
+    "ConversionRefused",
+    "Plan",
+    "SYSTEMS",
+    "apply",
+    "plan_paths",
+    "plan_specialisation",
+]

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -336,17 +336,20 @@ class Plan:
         return lines
 
 
-def apply(plan):
+def apply(plan, *, keep=True):
     """Perform exactly the plan, prove the pages unchanged, or refuse.
 
     Returns the report lines. Raises :class:`ConversionRefused` — after
     unwinding everything — if the plan carries problems, any affected
     gang's pages change, or any touched gang stops reconciling.
-    """
-    from n26.core.capture import differences, gang_state
-    from n26.core.models import Gang
-    from n26.core.reconcile import assert_reconciled
 
+    With ``keep=False`` it does the whole thing and then throws it away:
+    every step performed, every page proven, and the transaction unwound
+    on purpose. That is the closest a live database can be asked "would
+    this work here?" without being changed by the answer, and it is worth
+    asking of one holding real players' gangs, where the surprises are.
+    A rehearsal that would have refused refuses, in the same words.
+    """
     if plan.problems:
         raise ConversionRefused(
             f"[{plan.system}] not applied: " + "; ".join(plan.problems)
@@ -355,6 +358,26 @@ def apply(plan):
         return list(plan.preview())
 
     report = list(plan.preview())
+    try:
+        _perform(plan, report, keep=keep)
+    except _Rehearsed:
+        report.append(
+            f"[{plan.system}] rehearsed; every page reads the same; nothing kept"
+        )
+        return report
+    report.append(f"[{plan.system}] applied; every page reads the same")
+    return report
+
+
+class _Rehearsed(Exception):
+    """Raised at the end of a rehearsal to unwind it. Never escapes."""
+
+
+def _perform(plan, report, *, keep):
+    from n26.core.capture import differences, gang_state
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+
     with transaction.atomic():
         before = {
             str(gang.pk): gang_state(gang)
@@ -388,5 +411,6 @@ def apply(plan):
                 raise ConversionRefused(
                     f"[{plan.system}] refused — {gang} no longer reconciles: {failed}"
                 ) from failed
-    report.append(f"[{plan.system}] applied; every page reads the same")
-    return report
+        if not keep:
+            # Everything held true. Unwind it anyway — that was the ask.
+            raise _Rehearsed

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -198,9 +198,10 @@ class SwapCarrier:
 
 @dataclass(frozen=True)
 class DropModifier:
-    """A modifier retired outright — for a carrier whose behaviour is
-    ending, not moving. The plan must have proven nothing holds the
-    carrier, or a page would change."""
+    """A modifier retired outright — for behaviour that is ending, not
+    moving. The plan must have proven the modifier does nothing on any
+    page: either nothing holds its carrier, or the modifier itself is
+    inert wherever the carrier appears."""
 
     carrier: tuple  # (model label, pk)
     carrier_name: str

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -267,15 +267,15 @@ class RewritePick:
     def perform(self, made):
         from n26.core.models import Assignment
 
-        row = Assignment.objects.get(pk=self.assignment_id)
-        row.pickable = made.pickables[self.pickable]
-        row.chosen_for_id = row.caused_by_id
-        row.chosen_for_slot = made.slots[self.slot]
+        pick = Assignment.objects.get(pk=self.assignment_id)
+        pick.pickable = made.pickables[self.pickable]
+        pick.chosen_for_id = pick.caused_by_id
+        pick.chosen_for_slot = made.slots[self.slot]
         # The question it used to answer is not the one it answers now,
         # and a pick naming both a slot and an offer says two things.
-        row.chosen_for_offer = None
-        setattr(row, self.old_column, None)
-        row.save()
+        pick.chosen_for_offer = None
+        setattr(pick, self.old_column, None)
+        pick.save()
 
 
 @dataclass(frozen=True)

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -197,6 +197,58 @@ class SwapCarrier:
 
 
 @dataclass(frozen=True)
+class DropModifier:
+    """A modifier retired outright — for a carrier whose behaviour is
+    ending, not moving. The plan must have proven nothing holds the
+    carrier, or a page would change."""
+
+    carrier: tuple  # (model label, pk)
+    carrier_name: str
+    modifier_id: object
+    modifier_name: str
+
+    def say(self):
+        return f"on {self.carrier_name}: retire “{self.modifier_name}”"
+
+    def perform(self, made):
+        from django.apps import apps
+
+        from n26.library.models import Modifier
+
+        app_label, model_name = self.carrier[0].split(".")
+        carrier = apps.get_model(app_label, model_name).objects.get(pk=self.carrier[1])
+        dropped = Modifier.objects.get(pk=self.modifier_id)
+        scope_row, effect_row = dropped.scope, dropped.effect
+        carrier.modifiers.remove(dropped)
+        dropped.delete()
+        scope_row.delete()
+        effect_row.delete()
+
+
+@dataclass(frozen=True)
+class RetireModifier:
+    """A modifier nothing carries, deleted with its scope and effect
+    rows. A detached modifier does nothing on any page, but its effect
+    row still names whatever it granted or removed — and protects that
+    thing from retiring."""
+
+    modifier_id: object
+    modifier_name: str
+
+    def say(self):
+        return f"retire the carrierless modifier “{self.modifier_name}”"
+
+    def perform(self, made):
+        from n26.library.models import Modifier
+
+        dropped = Modifier.objects.get(pk=self.modifier_id)
+        scope_row, effect_row = dropped.scope, dropped.effect
+        dropped.delete()
+        scope_row.delete()
+        effect_row.delete()
+
+
+@dataclass(frozen=True)
 class RewritePick:
     """One stored choice, re-said as a pick: the old kind's column moves
     to ``pickable``, the anchor it already hangs from (``caused_by``)

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -40,22 +40,44 @@ SLOT_TYPE = "Specialisation"
 PICKLIST = "Specialisations"
 NARROW_HIDDEN = "Specialisation offer"
 GENERAL_HIDDEN = "Specialisation Offer"
+NARROW_PICKLIST = "Subjugator Patrol Officer options"
+NARROW_SLOT = "Specialisation (Subjugator Patrol Officer)"
 
 
-def _the_offer(carrier, problems, said):
-    """The carrier's one specialisation offer, or a stated problem."""
-    offers = [
+def _offers_of(carrier):
+    return [
         m
         for m in carrier.modifiers.all()
         if getattr(m, "offers_choice", None) is not None
         and m.offers_choice.of_kind.model == "specialisation"
     ]
+
+
+def _the_offer(carrier, problems, said):
+    """The carrier's one specialisation offer, or a stated problem."""
+    offers = _offers_of(carrier)
     if len(offers) != 1:
         problems.append(
             f"{said} carries {len(offers)} specialisation offers — expected one"
         )
         return None
     return offers[0]
+
+
+def _solely_carried(offer, carrier, problems):
+    """Deleting an offer's modifier detaches it from every carrier at
+    once, so the plan must know no third thing shares it — a sharer's
+    gangs are outside the capture set and would lose their question
+    unproven."""
+    others = [
+        f"{kind} “{row}”"
+        for kind, row in carriers_of(offer)
+        if not (kind == type(carrier).__name__ and row.pk == carrier.pk)
+    ]
+    if others:
+        problems.append(
+            f"“{offer.name}” is shared — also carried by " + ", ".join(others)
+        )
 
 
 def plan_specialisation():
@@ -83,14 +105,19 @@ def plan_specialisation():
             problems.append(
                 "the Specialist offer names a section — expected the whole kind"
             )
-        others = [
-            f"{kind} “{row}”"
-            for kind, row in carriers_of(offer)
-            if not (kind == "Subtype" and row.pk == subtype.pk)
-        ]
-        if others:
+        _solely_carried(offer, subtype, problems)
+
+    # The capture set is found through stored assignments, so a
+    # Specialist subtype arriving by grant would reach gangs the plan
+    # cannot enumerate.
+    from n26.library.models import AddsAssignable, Modifier, RemovesAssignable
+
+    for effect_row in AddsAssignable.objects.filter(subtype=subtype):
+        granter = Modifier.objects.filter(adds_assignable=effect_row).first()
+        if granter is not None and carriers_of(granter):
             problems.append(
-                "the Specialist offer is shared — also carried by " + ", ".join(others)
+                f"“{granter.name}” grants the “{SUBTYPE}” subtype — the plan "
+                "cannot find the gangs that reaches"
             )
 
     old_rows = list(Specialisation.objects.filter(archived=False).order_by("name"))
@@ -109,7 +136,7 @@ def plan_specialisation():
 
     picks = list(
         Assignment.objects.filter(specialisation__isnull=False)
-        .select_related("specialisation", "gang_root")
+        .select_related("specialisation", "gang_root", "caused_by")
         .order_by("created")
     )
     unanchored = [str(pick.pk) for pick in picks if pick.caused_by_id is None]
@@ -137,6 +164,7 @@ def plan_specialisation():
     if narrow is not None:
         narrow_offer = _the_offer(narrow, problems, f"the “{NARROW_HIDDEN}” hidden")
         if narrow_offer is not None:
+            _solely_carried(narrow_offer, narrow, problems)
             section = narrow_offer.offers_choice.from_section
             if section is None:
                 problems.append(f"the “{NARROW_HIDDEN}” offer names no menu")
@@ -161,40 +189,77 @@ def plan_specialisation():
     general_offer = None
     general_menu = None
     stray_effects = []
+    drop_carrier_gangs = set()
     if general is not None:
         if Assignment.objects.filter(hidden=general).exists():
             problems.append(
                 f"the “{GENERAL_HIDDEN}” hidden is held by someone — it cannot retire"
             )
-        general_offer = _the_offer(general, problems, f"the “{GENERAL_HIDDEN}” hidden")
-        if general_offer is not None and general_offer.offers_choice.from_section_id:
-            general_menu = general_offer.offers_choice.from_section.collection
+        general_offers = _offers_of(general)
+        if len(general_offers) > 1:
+            problems.append(
+                f"the “{GENERAL_HIDDEN}” hidden carries "
+                f"{len(general_offers)} specialisation offers — expected at most one"
+            )
+        # A fossil that lost its offer already is simply retirable.
+        general_offer = general_offers[0] if general_offers else None
+        if general_offer is not None:
+            _solely_carried(general_offer, general, problems)
+            if general_offer.offers_choice.from_section_id:
+                general_menu = general_offer.offers_choice.from_section.collection
         # The abandoned narrowing experiment left wiring behind that
         # still names the hidden, and would protect it from retiring. A
         # bare effect row, or a whole modifier nothing carries, is dead
         # and retires with it. A carried modifier that only *removes*
         # the hidden is a read-time no-op — nothing grants the hidden
         # and nobody holds it, both proven above — so it drops from its
-        # carrier without changing a page. A carried modifier that
+        # one carrier, and that carrier's gangs join the capture set so
+        # the no-op is proven, not assumed. A carried modifier that
         # grants the hidden is live wiring, and a problem.
-        from n26.library.models import AddsAssignable, Modifier, RemovesAssignable
-
+        assignment_columns = {
+            label: column for column, label in Assignment.ASSIGNABLE_FIELDS.items()
+        }
         for model, label, column in (
             (AddsAssignable, "library.AddsAssignable", "adds_assignable"),
             (RemovesAssignable, "library.RemovesAssignable", "removes_assignable"),
         ):
-            for row in model.objects.filter(hidden=general):
-                alive = Modifier.objects.filter(**{column: row}).first()
+            for effect_row in model.objects.filter(hidden=general):
+                alive = Modifier.objects.filter(**{column: effect_row}).first()
                 if alive is None:
-                    stray_effects.append(Retire(model=label, pk=row.pk, name=str(row)))
+                    stray_effects.append(
+                        Retire(model=label, pk=effect_row.pk, name=str(effect_row))
+                    )
                     continue
                 holders = carriers_of(alive)
                 if not holders:
                     stray_effects.append(
                         RetireModifier(modifier_id=alive.pk, modifier_name=alive.name)
                     )
-                elif column == "removes_assignable" and len(holders) == 1:
+                elif column == "adds_assignable":
+                    problems.append(
+                        f"“{alive.name}” still grants the “{GENERAL_HIDDEN}” "
+                        "hidden — it cannot retire"
+                    )
+                elif len(holders) != 1:
+                    problems.append(
+                        f"“{alive.name}” removes the “{GENERAL_HIDDEN}” hidden "
+                        f"from {len(holders)} carriers — the plan only drops "
+                        "it from one"
+                    )
+                else:
                     kind, holder = holders[0]
+                    holder_column = assignment_columns.get(f"library.{kind}")
+                    if holder_column is None:
+                        problems.append(
+                            f"“{alive.name}” is carried by {kind} “{holder}” — "
+                            "the plan cannot find that carrier's gangs"
+                        )
+                        continue
+                    drop_carrier_gangs.update(
+                        Assignment.objects.filter(
+                            **{holder_column: holder}
+                        ).values_list("gang_root_id", flat=True)
+                    )
                     stray_effects.append(
                         DropModifier(
                             carrier=(f"library.{kind}", holder.pk),
@@ -203,11 +268,24 @@ def plan_specialisation():
                             modifier_name=alive.name,
                         )
                     )
-                else:
-                    problems.append(
-                        f"“{alive.name}” still names the “{GENERAL_HIDDEN}” "
-                        "hidden — it cannot retire"
-                    )
+
+    # Each pick settles onto the slot its own anchor grants: the
+    # subtype's holders answer the general question, the narrow
+    # hidden's holders answer their narrowed one. An anchor the plan
+    # does not recognise has no slot to settle on.
+    pick_slots = {}
+    for pick in picks:
+        if pick.caused_by_id is None:
+            continue
+        if pick.caused_by.subtype_id == subtype.pk:
+            pick_slots[pick.pk] = SLOT_TYPE
+        elif narrow is not None and pick.caused_by.hidden_id == narrow.pk:
+            pick_slots[pick.pk] = NARROW_SLOT
+        else:
+            problems.append(
+                f"pick {pick.pk} is anchored on “{pick.caused_by}”, which "
+                "the plan does not recognise"
+            )
 
     if problems:
         return Plan(system="specialisation", problems=tuple(problems))
@@ -248,14 +326,14 @@ def plan_specialisation():
     if narrow is not None and narrow_offer is not None:
         steps += [
             CreatePicklist(
-                name="Subjugator Patrol Officer options",
+                name=NARROW_PICKLIST,
                 slot_type=SLOT_TYPE,
                 members=tuple(narrow_names),
             ),
             CreateSlot(
-                name="Specialisation (Subjugator Patrol Officer)",
+                name=NARROW_SLOT,
                 slot_type=SLOT_TYPE,
-                picklist="Subjugator Patrol Officer options",
+                picklist=NARROW_PICKLIST,
                 label="Specialisation",
                 assigned_to="bearer",
                 min_picks=0,
@@ -268,7 +346,7 @@ def plan_specialisation():
                 grant_name=(
                     "Subjugator Patrol Officer: the model is asked its Specialisation"
                 ),
-                slot="Specialisation (Subjugator Patrol Officer)",
+                slot=NARROW_SLOT,
                 reach="model",
             ),
         ]
@@ -277,7 +355,7 @@ def plan_specialisation():
             assignment_id=pick.pk,
             old_column="specialisation",
             pickable=pick.specialisation.name,
-            slot=SLOT_TYPE,
+            slot=pick_slots[pick.pk],
             gang=str(pick.gang_root),
         )
         for pick in picks
@@ -324,6 +402,7 @@ def plan_specialisation():
                     archived=False, hidden__in=[h for h in (narrow,) if h]
                 ).values_list("gang_root_id", flat=True)
             ),
+            *drop_carrier_gangs,
         },
         key=str,
     )

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -15,10 +15,9 @@ hidden keeps its purpose — its offer becomes a grant of a second slot
 over its own narrow picklist, so a holder's page asks the same
 question. The general hidden and both menu collections retire.
 
-This system ships without a migration: proving several hundred gangs
-inside the container-boot window would gamble with the startup probe's
-ceiling, so production runs the rehearsal command itself, as a one-off
-Cloud Run job, after the code deploys.
+Production converts from the maintenance console, once, after the code
+deploys — see :mod:`n26.maintenance`. Elsewhere the command does it
+(``manage n26_convert specialisation``).
 """
 
 from n26.library.conversion.base import (

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -1,0 +1,310 @@
+"""The Specialisation conversion — the volume system.
+
+Today: the "Specialist" subtype carries a bearer offer of the whole
+specialisation kind; eight specialisations each add one skill to the
+bearer. Two hiddens are the fossil of an abandoned narrowing
+experiment: "Specialisation Offer" [(general)] — held by nothing,
+granted by a modifier nothing carries, and removed by a live no-op on
+the Subjugator Patrol Officer profile — and "Specialisation offer"
+[(Subjugator Patrol Officer)], whose narrowed menu is still held by
+whoever an owner gave it to.
+
+After: a "Specialisation" slot type; the eight as pickables on one
+picklist; a bearer slot granted by the same subtype. The Subjugator
+hidden keeps its purpose — its offer becomes a grant of a second slot
+over its own narrow picklist, so a holder's page asks the same
+question. The general hidden and both menu collections retire.
+
+This system ships without a migration: proving several hundred gangs
+inside the container-boot window would gamble with the startup probe's
+ceiling, so production runs the rehearsal command itself, as a one-off
+Cloud Run job, after the code deploys.
+"""
+
+from n26.library.conversion.base import (
+    CreatePickable,
+    CreatePicklist,
+    CreateSlot,
+    CreateSlotType,
+    DropModifier,
+    Plan,
+    Retire,
+    RetireModifier,
+    RewritePick,
+    SwapCarrier,
+    carriers_of,
+)
+
+SUBTYPE = "Specialist"
+SLOT_TYPE = "Specialisation"
+PICKLIST = "Specialisations"
+NARROW_HIDDEN = "Specialisation offer"
+GENERAL_HIDDEN = "Specialisation Offer"
+
+
+def _the_offer(carrier, problems, said):
+    """The carrier's one specialisation offer, or a stated problem."""
+    offers = [
+        m
+        for m in carrier.modifiers.all()
+        if getattr(m, "offers_choice", None) is not None
+        and m.offers_choice.of_kind.model == "specialisation"
+    ]
+    if len(offers) != 1:
+        problems.append(
+            f"{said} carries {len(offers)} specialisation offers — expected one"
+        )
+        return None
+    return offers[0]
+
+
+def plan_specialisation():
+    from n26.core.models import Assignment
+    from n26.library.models import Hidden, SlotType, Specialisation, Subtype
+
+    problems = []
+
+    if SlotType.objects.filter(name=SLOT_TYPE, archived=False).exists():
+        return Plan(system="specialisation", nothing_here=True)
+
+    subtypes = list(Subtype.objects.filter(name=SUBTYPE, archived=False))
+    if not subtypes:
+        return Plan(system="specialisation", nothing_here=True)
+    if len(subtypes) > 1:
+        return Plan(
+            system="specialisation",
+            problems=(f"{len(subtypes)} subtypes named “{SUBTYPE}” — expected one",),
+        )
+    subtype = subtypes[0]
+
+    offer = _the_offer(subtype, problems, f"the “{SUBTYPE}” subtype")
+    if offer is not None:
+        if offer.offers_choice.from_section_id is not None:
+            problems.append(
+                "the Specialist offer names a section — expected the whole kind"
+            )
+        others = [
+            f"{kind} “{row}”"
+            for kind, row in carriers_of(offer)
+            if not (kind == "Subtype" and row.pk == subtype.pk)
+        ]
+        if others:
+            problems.append(
+                "the Specialist offer is shared — also carried by " + ", ".join(others)
+            )
+
+    old_rows = list(Specialisation.objects.filter(archived=False).order_by("name"))
+    if not old_rows:
+        problems.append("no specialisations to convert")
+
+    picks = list(
+        Assignment.objects.filter(specialisation__isnull=False)
+        .select_related("specialisation", "gang_root")
+        .order_by("created")
+    )
+    unanchored = [str(pick.pk) for pick in picks if pick.caused_by_id is None]
+    if unanchored:
+        problems.append(
+            "picks with no caused_by to settle against: " + ", ".join(unanchored)
+        )
+
+    # The Subjugator fossil: kept, converted — its holder's page must go
+    # on asking the same narrowed question.
+    narrow = Hidden.objects.filter(name=NARROW_HIDDEN, archived=False).first()
+    narrow_offer = None
+    narrow_menu = None
+    narrow_names = []
+    if narrow is not None:
+        narrow_offer = _the_offer(narrow, problems, f"the “{NARROW_HIDDEN}” hidden")
+        if narrow_offer is not None:
+            section = narrow_offer.offers_choice.from_section
+            if section is None:
+                problems.append(f"the “{NARROW_HIDDEN}” offer names no menu")
+            else:
+                narrow_menu = section.collection
+                narrow_names = [
+                    entry.specialisation.name
+                    for entry in narrow_menu.entries.filter(
+                        specialisation__isnull=False
+                    ).select_related("specialisation")
+                ]
+                strangers = set(narrow_names) - {row.name for row in old_rows}
+                if strangers:
+                    problems.append(
+                        "the narrow menu lists specialisations the kind does "
+                        "not: " + ", ".join(sorted(strangers))
+                    )
+
+    # The general fossil: retired — the plan must know nothing holds it,
+    # nothing grants it, and every stray reference is itself dead.
+    general = Hidden.objects.filter(name=GENERAL_HIDDEN, archived=False).first()
+    general_offer = None
+    general_menu = None
+    stray_effects = []
+    if general is not None:
+        if Assignment.objects.filter(hidden=general).exists():
+            problems.append(
+                f"the “{GENERAL_HIDDEN}” hidden is held by someone — it cannot retire"
+            )
+        general_offer = _the_offer(general, problems, f"the “{GENERAL_HIDDEN}” hidden")
+        if general_offer is not None and general_offer.offers_choice.from_section_id:
+            general_menu = general_offer.offers_choice.from_section.collection
+        # The abandoned narrowing experiment left wiring behind that
+        # still names the hidden, and would protect it from retiring. A
+        # bare effect row, or a whole modifier nothing carries, is dead
+        # and retires with it. A carried modifier that only *removes*
+        # the hidden is a read-time no-op — nothing grants the hidden
+        # and nobody holds it, both proven above — so it drops from its
+        # carrier without changing a page. A carried modifier that
+        # grants the hidden is live wiring, and a problem.
+        from n26.library.models import AddsAssignable, Modifier, RemovesAssignable
+
+        for model, label, column in (
+            (AddsAssignable, "library.AddsAssignable", "adds_assignable"),
+            (RemovesAssignable, "library.RemovesAssignable", "removes_assignable"),
+        ):
+            for row in model.objects.filter(hidden=general):
+                alive = Modifier.objects.filter(**{column: row}).first()
+                if alive is None:
+                    stray_effects.append(Retire(model=label, pk=row.pk, name=str(row)))
+                    continue
+                holders = carriers_of(alive)
+                if not holders:
+                    stray_effects.append(
+                        RetireModifier(modifier_id=alive.pk, modifier_name=alive.name)
+                    )
+                elif column == "removes_assignable" and len(holders) == 1:
+                    kind, holder = holders[0]
+                    stray_effects.append(
+                        DropModifier(
+                            carrier=(f"library.{kind}", holder.pk),
+                            carrier_name=f"the “{holder}” {kind.lower()}",
+                            modifier_id=alive.pk,
+                            modifier_name=alive.name,
+                        )
+                    )
+                else:
+                    problems.append(
+                        f"“{alive.name}” still names the “{GENERAL_HIDDEN}” "
+                        "hidden — it cannot retire"
+                    )
+
+    if problems:
+        return Plan(system="specialisation", problems=tuple(problems))
+
+    steps = [
+        CreateSlotType(name=SLOT_TYPE, plural_name="Specialisations"),
+        *[
+            CreatePickable(
+                name=row.name,
+                slot_type=SLOT_TYPE,
+                moved_modifier_ids=tuple(m.pk for m in row.modifiers.all()),
+                moved_from=("library.Specialisation", row.pk),
+            )
+            for row in old_rows
+        ],
+        CreatePicklist(
+            name=PICKLIST,
+            slot_type=SLOT_TYPE,
+            members=tuple(row.name for row in old_rows),
+        ),
+        CreateSlot(
+            name=SLOT_TYPE,
+            slot_type=SLOT_TYPE,
+            picklist=PICKLIST,
+            assigned_to="bearer",
+            min_picks=0,
+        ),
+        SwapCarrier(
+            carrier=("library.Subtype", subtype.pk),
+            carrier_name=f"the “{SUBTYPE}” subtype",
+            drop_modifier_id=offer.pk,
+            drop_modifier_name=offer.name,
+            grant_name="Specialist: the model is asked its Specialisation",
+            slot=SLOT_TYPE,
+            reach="model",
+        ),
+    ]
+    if narrow is not None and narrow_offer is not None:
+        steps += [
+            CreatePicklist(
+                name="Subjugator Patrol Officer options",
+                slot_type=SLOT_TYPE,
+                members=tuple(narrow_names),
+            ),
+            CreateSlot(
+                name="Specialisation (Subjugator Patrol Officer)",
+                slot_type=SLOT_TYPE,
+                picklist="Subjugator Patrol Officer options",
+                label="Specialisation",
+                assigned_to="bearer",
+                min_picks=0,
+            ),
+            SwapCarrier(
+                carrier=("library.Hidden", narrow.pk),
+                carrier_name=f"the “{NARROW_HIDDEN}” hidden",
+                drop_modifier_id=narrow_offer.pk,
+                drop_modifier_name=narrow_offer.name,
+                grant_name=(
+                    "Subjugator Patrol Officer: the model is asked its Specialisation"
+                ),
+                slot="Specialisation (Subjugator Patrol Officer)",
+                reach="model",
+            ),
+        ]
+    steps += [
+        RewritePick(
+            assignment_id=pick.pk,
+            old_column="specialisation",
+            pickable=pick.specialisation.name,
+            slot=SLOT_TYPE,
+            gang=str(pick.gang_root),
+        )
+        for pick in picks
+    ]
+    if general is not None:
+        if general_offer is not None:
+            steps.append(
+                DropModifier(
+                    carrier=("library.Hidden", general.pk),
+                    carrier_name=f"the “{GENERAL_HIDDEN}” hidden",
+                    modifier_id=general_offer.pk,
+                    modifier_name=general_offer.name,
+                )
+            )
+        steps += stray_effects
+        if general_menu is not None:
+            steps.append(
+                Retire(
+                    model="library.Collection",
+                    pk=general_menu.pk,
+                    name=general_menu.name,
+                )
+            )
+        steps.append(Retire(model="library.Hidden", pk=general.pk, name=str(general)))
+    if narrow_menu is not None:
+        steps.append(
+            Retire(model="library.Collection", pk=narrow_menu.pk, name=narrow_menu.name)
+        )
+    steps += [
+        Retire(model="library.Specialisation", pk=row.pk, name=row.name)
+        for row in old_rows
+    ]
+
+    gang_ids = sorted(
+        {
+            *(
+                Assignment.objects.filter(archived=False, subtype=subtype)
+                .values_list("gang_root_id", flat=True)
+                .distinct()
+            ),
+            *(pick.gang_root_id for pick in picks),
+            *(
+                Assignment.objects.filter(
+                    archived=False, hidden__in=[h for h in (narrow,) if h]
+                ).values_list("gang_root_id", flat=True)
+            ),
+        },
+        key=str,
+    )
+    return Plan(system="specialisation", steps=tuple(steps), gang_ids=tuple(gang_ids))

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -108,9 +108,19 @@ def plan_specialisation():
             "picks with no caused_by to settle against: " + ", ".join(unanchored)
         )
 
+    # Hidden names are unique only together with their qualifier, so a
+    # name here must resolve to one row or the plan cannot know which
+    # it is converting.
+    def _the_hidden(name):
+        found = list(Hidden.objects.filter(name=name, archived=False))
+        if len(found) > 1:
+            problems.append(f"{len(found)} hiddens named “{name}” — expected one")
+            return None
+        return found[0] if found else None
+
     # The Subjugator fossil: kept, converted — its holder's page must go
     # on asking the same narrowed question.
-    narrow = Hidden.objects.filter(name=NARROW_HIDDEN, archived=False).first()
+    narrow = _the_hidden(NARROW_HIDDEN)
     narrow_offer = None
     narrow_menu = None
     narrow_names = []
@@ -137,7 +147,7 @@ def plan_specialisation():
 
     # The general fossil: retired — the plan must know nothing holds it,
     # nothing grants it, and every stray reference is itself dead.
-    general = Hidden.objects.filter(name=GENERAL_HIDDEN, archived=False).first()
+    general = _the_hidden(GENERAL_HIDDEN)
     general_offer = None
     general_menu = None
     stray_effects = []

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -96,6 +96,16 @@ def plan_specialisation():
     old_rows = list(Specialisation.objects.filter(archived=False).order_by("name"))
     if not old_rows:
         problems.append("no specialisations to convert")
+    # An archived row would escape every step — not a pickable, not
+    # retired, and any stored pick naming it only failing at apply.
+    # Whether it should convert or die is a content decision, so the
+    # plan refuses rather than deciding.
+    ghosts = Specialisation.objects.filter(archived=True).order_by("name")
+    if ghosts:
+        problems.append(
+            "archived specialisations the plan does not convert: "
+            + ", ".join(row.name for row in ghosts)
+        )
 
     picks = list(
         Assignment.objects.filter(specialisation__isnull=False)

--- a/n26/library/management/commands/n26_convert.py
+++ b/n26/library/management/commands/n26_convert.py
@@ -1,14 +1,15 @@
 """Plan or apply a slots-and-picks conversion, from the shell.
 
-The rehearsal tool, and for the larger systems the production tool too:
-point it at a database holding the system (a fork of the prod mirror, a
-restore of a full dump) and read the plan; add ``--apply`` to perform
-it, with the conversion's own refusal standing between the plan and a
-committed write. A small system may ship as a migration that runs its
-plan at deploy; a system proving many gangs would gamble with the
-container-boot window, so production runs this command instead, as a
-one-off job after the code deploys. Either way this is how a conversion
-is checked before it ships.
+The rehearsal tool: point it at a database holding the system (a fork of
+the prod mirror, a restore of a full dump) and read the plan; add
+``--apply`` to perform it, with the conversion's own refusal standing
+between the plan and a committed write.
+
+This is how a conversion is checked before it ships, and how a database
+nobody runs a console against — a developer's, an old fork — is brought
+across. Production is not one of those: it converts from the maintenance
+console (see :mod:`n26.maintenance`), which runs the same plan and apply
+and writes down what happened.
 """
 
 from django.core.management.base import BaseCommand, CommandError

--- a/n26/library/management/commands/n26_convert.py
+++ b/n26/library/management/commands/n26_convert.py
@@ -1,11 +1,14 @@
 """Plan or apply a slots-and-picks conversion, from the shell.
 
-The rehearsal tool: point it at a database holding the system (a fork
-of the prod mirror, a restore of a full dump) and read the plan; add
-``--apply`` to perform it, with the conversion's own refusal standing
-between the plan and a committed write. Production runs the same
-conversions through migrations — this command is how one is checked
-before it ships.
+The rehearsal tool, and for the larger systems the production tool too:
+point it at a database holding the system (a fork of the prod mirror, a
+restore of a full dump) and read the plan; add ``--apply`` to perform
+it, with the conversion's own refusal standing between the plan and a
+committed write. A small system may ship as a migration that runs its
+plan at deploy; a system proving many gangs would gamble with the
+container-boot window, so production runs this command instead, as a
+one-off job after the code deploys. Either way this is how a conversion
+is checked before it ships.
 """
 
 from django.core.management.base import BaseCommand, CommandError
@@ -26,9 +29,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         plan = SYSTEMS[options["system"]]()
-        for problem in plan.problems:
-            self.stdout.write(self.style.ERROR(f"problem: {problem}"))
         if not options["apply"]:
+            for problem in plan.problems:
+                self.stdout.write(self.style.ERROR(f"problem: {problem}"))
             for line in plan.preview():
                 self.stdout.write(line)
             self.stdout.write("(planned only — nothing written)")

--- a/n26/library/management/commands/n26_convert.py
+++ b/n26/library/management/commands/n26_convert.py
@@ -27,9 +27,25 @@ class Command(BaseCommand):
             action="store_true",
             help="Perform the plan. Without this, the plan is printed and nothing is written.",
         )
+        parser.add_argument(
+            "--rehearse",
+            action="store_true",
+            help=(
+                "Perform the whole plan, prove every page, then unwind it. "
+                "Answers whether the conversion works on this database "
+                "without changing it."
+            ),
+        )
 
     def handle(self, *args, **options):
         plan = SYSTEMS[options["system"]]()
+        if options["rehearse"]:
+            try:
+                for line in apply(plan, keep=False):
+                    self.stdout.write(line)
+            except ConversionRefused as refused:
+                raise CommandError(str(refused)) from None
+            return
         if not options["apply"]:
             for problem in plan.problems:
                 self.stdout.write(self.style.ERROR(f"problem: {problem}"))

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -227,6 +227,14 @@ def convert_specialisation_view(request):
                 reverse("admin:maintenance_backfill_detail", args=[running.id])
             )
         plan = _plan()
+        if plan.nothing_here:
+            # A page left open across someone else's run, most likely.
+            # Recording a run that would do nothing only clutters the
+            # history of what was really done.
+            messages.info(request, "There is nothing to convert.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_n26_convert_specialisation")
+            )
         if not plan.ok:
             # Refusing here rather than in the task keeps the reason on
             # the screen of whoever asked for it.

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -85,20 +85,30 @@ def _plan():
 def _write(backfill_id, *, status=None, summary_patch=None, error=""):
     """Record what happened, under the row's own lock.
 
-    A cancelled run stays cancelled: an operator's stop always wins, even
-    over a run still finishing its work. A record that has already
-    finished is never reopened by a straggler.
+    A record that has reached an ending keeps it. Only one copy of a run
+    ever works — the lock sees to that — so whatever wrote the ending was
+    the run itself, and anything arriving afterwards is a redelivery with
+    nothing new to say. A long run finishes close to the moment its
+    delivery is retried, so the copy that finds the work already done is
+    the likely case, not the exotic one: were it allowed to write, it
+    would file a successful conversion as a failure.
+
+    An operator's stop counts as an ending too, and outranks the rest.
     """
+    ENDINGS = (Backfill.Status.DONE, Backfill.Status.FAILED, Backfill.Status.CANCELLED)
     with transaction.atomic():
         try:
             backfill = Backfill.objects.select_for_update().get(pk=backfill_id)
         except Backfill.DoesNotExist:
             logger.warning("Backfill record %s missing; progress dropped", backfill_id)
             return False
-        if backfill.status == Backfill.Status.CANCELLED:
-            return False
-        finished = backfill.status in (Backfill.Status.DONE, Backfill.Status.FAILED)
-        if finished and status in (None, Backfill.Status.RUNNING):
+        if backfill.status in ENDINGS:
+            logger.info(
+                "Backfill %s is already %s; dropping write (attempted %s)",
+                backfill_id,
+                backfill.status,
+                status or "progress",
+            )
             return False
         if summary_patch:
             backfill.summary = {**backfill.summary, **summary_patch}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -279,8 +279,11 @@ register_operation(
 )
 
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
-#: The deadline is the longest Pub/Sub allows: a conversion holds one
-#: transaction for as long as proving every affected gang takes, and a
-#: redelivery arriving mid-run would find the lock held and stand down —
-#: paying for a wasted delivery this avoids in the first place.
+#: The deadline is the longest Pub/Sub allows, because a conversion holds one
+#: transaction for as long as proving every affected gang takes. It is also
+#: the request timeout the service is deployed with, and the two belong
+#: together: a run outliving its deadline is delivered again while the first
+#: copy is still working, and the second — standing down at the lock — answers
+#: successfully and acknowledges the message out from under it. Change one and
+#: change the other (``--timeout`` in ``cloudbuild.yaml``).
 task_routes = [TaskRoute(convert_specialisation, ack_deadline=600, min_retry_delay=60)]

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -165,8 +165,13 @@ def _claim(backfill_id):
 
 
 @task
-def convert_specialisation(backfill_id):
+def convert_specialisation(backfill_id, keep=True):
     """Run the Specialisation conversion, once, and write down the outcome.
+
+    With ``keep=False`` it rehearses: the whole conversion performed and
+    every page proven, then unwound on purpose, so a database holding
+    real gangs can be asked whether this works without being changed by
+    the answer.
 
     Never raises: a task that fails is redelivered, and there is nowhere
     for a raised error to go but round again. Every ending — refused,
@@ -196,7 +201,7 @@ def convert_specialisation(backfill_id):
             return
 
         try:
-            report = apply(_plan())
+            report = apply(_plan(), keep=keep)
         except ConversionRefused as refused:
             # A refusal is the discipline working: nothing was written,
             # and the reason is already in words.
@@ -214,7 +219,7 @@ def convert_specialisation(backfill_id):
         _write(
             backfill_id,
             status=Backfill.Status.DONE,
-            summary_patch={"report": list(report)},
+            summary_patch={"report": list(report), "kept": bool(keep)},
         )
 
 
@@ -244,15 +249,23 @@ def convert_specialisation_view(request):
             return HttpResponseRedirect(
                 reverse("admin:maintenance_n26_convert_specialisation")
             )
+        # Keeping the work is the thing that must be asked for. A request
+        # that does not say so — a page from before there were two
+        # buttons, something calling the address directly — rehearses,
+        # which is the ending nobody has to undo.
+        keep = request.POST.get("keep") == "yes"
         backfill = Backfill.objects.create(
             operation=Operation.CONVERT_SPECIALISATION,
             triggered_by=request.user,
             status=Backfill.Status.RUNNING,
-            summary={"preview": list(plan.preview()), "attempts": 0},
+            summary={"preview": list(plan.preview()), "attempts": 0, "kept": keep},
         )
-        convert_specialisation.enqueue(backfill_id=str(backfill.id))
+        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=keep)
         messages.success(
-            request, "The conversion is running. This page shows what it did."
+            request,
+            "The conversion is running. This page shows what it did."
+            if keep
+            else "The rehearsal is running. Nothing will be kept.",
         )
         return HttpResponseRedirect(
             reverse("admin:maintenance_backfill_detail", args=[backfill.id])

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -1,0 +1,276 @@
+"""The repairs this edition offers the maintenance console, and the one
+door it offers them through.
+
+The console is the site's: a superuser-gated index, one audit record per
+run, a detail page, a cancel button. What there is to repair is edition
+knowledge, so an edition registers its own operations rather than the
+console knowing about either of them. This module is the whole of n26's
+dependency on it — the registry, the audit record, the page furniture and
+the background-task route are imported here and nowhere else in ``n26/``,
+so the seam can be read and moved in one place.
+
+What it registers today is the Specialisation conversion. A conversion
+moves a hand-built choice system onto slots and picks and proves, before
+committing, that every affected gang's pages still say the same things;
+:mod:`n26.library.conversion` owns that discipline entirely, and this
+module only gives it somewhere to be triggered from and somewhere to
+write down what happened.
+
+Conversions do not travel as migrations. A migration that runs live code
+inherits a dependency on every column that code will ever read, and the
+pin needed to express that contradicts the recorded history of any
+database that already ran it — so they run after a deploy instead, on a
+schema that is fully migrated by construction.
+
+The run is one transaction, and it is deliberately all-or-nothing: the
+carrier swap changes every affected page at the same instant, so there is
+no gang-by-gang chunking to be had. That shapes everything here. A run
+that is interrupted — a killed request, a lost connection — rolls back
+whole, so an interrupted conversion is a no-op that can simply be run
+again, never a half-converted library. Delivery is at-least-once, so two
+guards stand between that promise and a second copy running alongside the
+first: a lock only one run can hold, and a cap on how many times an
+attempt may be started before the record gives up and says so.
+"""
+
+import logging
+import traceback
+from contextlib import contextmanager
+
+from django.contrib import messages
+from django.db import connection, models, transaction
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.tasks import task
+from django.urls import reverse
+
+from gyrinx.maintenance.models import Backfill
+from gyrinx.maintenance.registry import MaintenanceOperation, register_operation
+from gyrinx.maintenance.views import page_context, running_guard
+from gyrinx.tasks import TaskRoute
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["Operation", "convert_specialisation", "task_routes"]
+
+#: How many times a run may be started before the record gives up. A
+#: conversion that exhausts the request budget leaves nothing behind and
+#: is redelivered, so without a cap a run too large to finish would
+#: repeat for ever, each attempt paying the whole cost again.
+MAX_ATTEMPTS = 2
+
+#: The lock a run holds for as long as it is working. Postgres releases
+#: it when the connection goes, so a killed run frees it without anyone
+#: intervening.
+LOCK_KEY = 826_020_601
+
+
+class Operation(models.TextChoices):
+    """The repairs this edition offers, by the slug written into each
+    audit record. A slug is permanent: changing one orphans every
+    historical record that carries it."""
+
+    CONVERT_SPECIALISATION = (
+        "n26_convert_specialisation",
+        "n26: the specialisations become picks",
+    )
+
+
+def _plan():
+    from n26.library.conversion import plan_specialisation
+
+    return plan_specialisation()
+
+
+def _write(backfill_id, *, status=None, summary_patch=None, error=""):
+    """Record what happened, under the row's own lock.
+
+    A cancelled run stays cancelled: an operator's stop always wins, even
+    over a run still finishing its work. A record that has already
+    finished is never reopened by a straggler.
+    """
+    with transaction.atomic():
+        try:
+            backfill = Backfill.objects.select_for_update().get(pk=backfill_id)
+        except Backfill.DoesNotExist:
+            logger.warning("Backfill record %s missing; progress dropped", backfill_id)
+            return False
+        if backfill.status == Backfill.Status.CANCELLED:
+            return False
+        finished = backfill.status in (Backfill.Status.DONE, Backfill.Status.FAILED)
+        if finished and status in (None, Backfill.Status.RUNNING):
+            return False
+        if summary_patch:
+            backfill.summary = {**backfill.summary, **summary_patch}
+        if status:
+            backfill.status = status
+        if error:
+            backfill.error = error
+        backfill.save()
+        return True
+
+
+@contextmanager
+def _single_flight():
+    """Hold the lock for the length of a run, or yield False.
+
+    Postgres frees an advisory lock when the connection goes, so a run
+    killed mid-flight leaves nothing to clean up by hand.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_try_advisory_lock(%s)", [LOCK_KEY])
+        held = cursor.fetchone()[0]
+    try:
+        yield held
+    finally:
+        if held:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_advisory_unlock(%s)", [LOCK_KEY])
+
+
+def _claim(backfill_id):
+    """Count this attempt and say whether it may start.
+
+    Written outside the conversion's own transaction, so the count
+    survives a run that rolls back — which is how a run too large to
+    finish is noticed rather than repeated for ever.
+    """
+    with transaction.atomic():
+        try:
+            backfill = Backfill.objects.select_for_update().get(pk=backfill_id)
+        except Backfill.DoesNotExist:
+            return False, "the record this run would write to is gone"
+        if backfill.status != Backfill.Status.RUNNING:
+            return False, f"the record is already {backfill.get_status_display()}"
+        attempts = int(backfill.summary.get("attempts", 0)) + 1
+        backfill.summary = {**backfill.summary, "attempts": attempts}
+        backfill.save()
+        if attempts > MAX_ATTEMPTS:
+            return False, (
+                f"started {attempts} times without finishing — each attempt "
+                "left nothing behind. The conversion needs longer than one "
+                "request allows; raise the limit before running it again."
+            )
+        return True, ""
+
+
+@task
+def convert_specialisation(backfill_id):
+    """Run the Specialisation conversion, once, and write down the outcome.
+
+    Never raises: a task that fails is redelivered, and there is nowhere
+    for a raised error to go but round again. Every ending — refused,
+    broken, already running — is recorded on the audit record instead.
+    """
+    from n26.library.conversion import ConversionRefused, apply
+
+    # The lock comes first, and nothing is recorded before it is held. A
+    # redelivery arriving while the first copy is still working must leave
+    # no trace at all: count its arrival as an attempt and a long run could
+    # be declared failed out from under itself.
+    with _single_flight() as mine:
+        if not mine:
+            logger.info(
+                "Specialisation conversion already running; this copy stands down"
+            )
+            return
+
+        may_start, why_not = _claim(backfill_id)
+        if not may_start:
+            logger.info("Specialisation conversion not started: %s", why_not)
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"Not started: {why_not}",
+            )
+            return
+
+        try:
+            report = apply(_plan())
+        except ConversionRefused as refused:
+            # A refusal is the discipline working: nothing was written,
+            # and the reason is already in words.
+            _write(backfill_id, status=Backfill.Status.FAILED, error=str(refused))
+            return
+        except Exception as broke:  # noqa: BLE001 — the ending must be recorded
+            logger.exception("Specialisation conversion broke")
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"{broke}\n\n{traceback.format_exc()}",
+            )
+            return
+
+        _write(
+            backfill_id,
+            status=Backfill.Status.DONE,
+            summary_patch={"report": list(report)},
+        )
+
+
+def convert_specialisation_view(request):
+    if request.method == "POST":
+        running = running_guard(Operation.CONVERT_SPECIALISATION)
+        if running is not None:
+            messages.warning(request, "That conversion is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        plan = _plan()
+        if not plan.ok:
+            # Refusing here rather than in the task keeps the reason on
+            # the screen of whoever asked for it.
+            messages.error(
+                request, "The conversion refuses: " + "; ".join(plan.problems)
+            )
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_n26_convert_specialisation")
+            )
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"preview": list(plan.preview()), "attempts": 0},
+        )
+        convert_specialisation.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The conversion is running. This page shows what it did."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+
+    plan = _plan()
+    context = page_context(
+        request,
+        Operation.CONVERT_SPECIALISATION.label,
+        plan=plan,
+        preview=list(plan.preview()),
+        gangs=len(plan.gang_ids),
+        apply_url=reverse("admin:maintenance_n26_convert_specialisation"),
+        recent=Backfill.objects.filter(operation=Operation.CONVERT_SPECIALISATION)[:10],
+    )
+    return render(request, "admin/maintenance/n26/convert_specialisation.html", context)
+
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.CONVERT_SPECIALISATION.value,
+        name=Operation.CONVERT_SPECIALISATION.label,
+        description=(
+            "Move the specialisations onto slots and picks: the Specialist "
+            "subtype grants a slot instead of offering a choice, and every "
+            "stored choice is re-said as a pick. Proves every affected "
+            "gang's pages read the same, or writes nothing."
+        ),
+        view=convert_specialisation_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
+#: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
+#: The deadline is the longest Pub/Sub allows: a conversion holds one
+#: transaction for as long as proving every affected gang takes, and a
+#: redelivery arriving mid-run would find the lock held and stand down —
+#: paying for a wasted delivery this avoids in the first place.
+task_routes = [TaskRoute(convert_specialisation, ack_deadline=600, min_retry_delay=60)]

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -313,6 +313,16 @@ class TestTheRefusals:
             apply(plan)
         assert not SlotType.objects.filter(name="Specialisation").exists()
 
+    def test_an_archived_specialisation_is_refused_not_skipped(self, world):
+        ghost = create_specialisation("Forgotten")
+        ghost.archived = True
+        ghost.save()
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any("Forgotten" in problem for problem in plan.problems)
+
     def test_two_hiddens_sharing_a_name_are_refused(self, world):
         create_hidden("Specialisation offer", qualifier="(a second one)")
 

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -313,6 +313,14 @@ class TestTheRefusals:
             apply(plan)
         assert not SlotType.objects.filter(name="Specialisation").exists()
 
+    def test_two_hiddens_sharing_a_name_are_refused(self, world):
+        create_hidden("Specialisation offer", qualifier="(a second one)")
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any("2 hiddens named" in problem for problem in plan.problems)
+
     def test_a_live_modifier_naming_the_general_fossil_is_refused(
         self, world, prod_shape
     ):

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -1,0 +1,359 @@
+"""The Specialisation conversion, proven on a prod-shaped world.
+
+The Specialist subtype's whole-kind offer becomes a granted bearer
+slot; the specialisations become pickables carrying their same skill
+grants; the two fossil hiddens are handled each their own way — the
+narrowed Subjugator one converts so its holder's page keeps asking the
+same question, the unheld general one retires with its menu.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from n26.core.capture import differences, gang_state
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.conversion import ConversionRefused, apply, plan_specialisation
+from n26.library.models import (
+    Collection,
+    Hidden,
+    Pickable,
+    Slot,
+    SlotType,
+    Specialisation,
+)
+from n26.tests.sandbox.actions import (
+    assign,
+    choose,
+    create_collection,
+    create_default_set,
+    create_gang_type,
+    create_hidden,
+    create_profile,
+    create_skill,
+    create_specialisation,
+    create_subtype,
+    ef_adds,
+    ef_removes,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    remove,
+    section_of,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def prod_shape(default_pack):
+    """The system as production holds it: the subtype's whole-kind
+    offer, four specialisations, and the two fossil hiddens."""
+    specs = {}
+    for name, skill in [
+        ("Gunner", "Hip-shooting"),
+        ("Medic", "Medicate"),
+        ("Scout", "Clamber"),
+        ("Sniper", "Precision Shot"),
+    ]:
+        specs[name] = create_specialisation(name)
+        modifier(
+            f"{name}: its skill",
+            targets_model(),
+            ef_adds(create_skill(skill)),
+            carried_by=specs[name],
+        )
+    specialist = create_subtype("Specialist")
+    modifier(
+        "Specialist: offers a choice of specialisation",
+        targets_model(),
+        offers_choice(Specialisation),
+        carried_by=specialist,
+    )
+
+    narrow_menu = create_collection(
+        "Specialisations for Subjugator Patrol Officer",
+        entries=[specs["Gunner"], specs["Medic"]],
+    )
+    narrow_section = section_of(narrow_menu, "Options", 0, is_default=True)
+    narrow = create_hidden("Specialisation offer", qualifier="(Subjugator)")
+    modifier(
+        "Subjugator offer",
+        targets_model(),
+        offers_choice(
+            Specialisation, from_section=narrow_section, label="Specialisation"
+        ),
+        carried_by=narrow,
+    )
+
+    general_menu = create_collection(
+        "Specialisation Offer", entries=list(specs.values())
+    )
+    general_section = section_of(general_menu, "Specialisation", 0, is_default=True)
+    general = create_hidden("Specialisation Offer", qualifier="(general)")
+    modifier(
+        "General offer",
+        targets_model(),
+        offers_choice(
+            Specialisation, from_section=general_section, label="Specialisation"
+        ),
+        carried_by=general,
+    )
+    # The abandoned narrowing experiment left wiring that still names
+    # the general hidden and protects it from retiring: a grant whose
+    # modifier nothing carries any more, and bare effect rows whose
+    # modifiers are gone entirely.
+    from n26.library.models import AddsAssignable, RemovesAssignable
+
+    modifier(
+        "Specialist: adds Specialisation Offer",
+        targets_model(),
+        ef_adds(general),
+    )
+    AddsAssignable.objects.create(hidden=general)
+    RemovesAssignable.objects.create(hidden=general)
+    return specialist, specs, narrow, general
+
+
+@pytest.fixture
+def world(prod_shape, person_type, owner, default_pack):
+    """Two gangs of specialists: a settled pick, a switched pick, an
+    open question, and one fighter holding the Subjugator fossil."""
+    specialist, specs, narrow, general = prod_shape
+    gang_type = create_gang_type("Enforcers", starting_credits=2000)
+    profile = create_profile("Patrol Officer", person_type, gang_type, price=50)
+    profile.built_ins = create_default_set("Officer kit", members=[specialist])
+    profile.save()
+    # The experiment's live leftover: the profile still removes the
+    # general hidden, which nothing grants — a read-time no-op.
+    modifier(
+        "Patrol Officer: removes Specialisation Offer",
+        targets_model(),
+        ef_removes(general),
+        carried_by=profile,
+    )
+
+    first = found_gang("The Watch", gang_type, owner=owner, budget=2000)
+    second = found_gang("The Patrol", gang_type, owner=owner, budget=2000)
+    fighters = {
+        "settled": hire(first, profile, "Vex", paid=50),
+        "switched": hire(first, profile, "Kade", paid=50),
+        "open": hire(second, profile, "Mara", paid=50),
+        "subjugator": hire(second, profile, "Odo", paid=50),
+    }
+
+    def anchor(fighter):
+        return Assignment.objects.get(subtype=specialist, miniature=fighter)
+
+    choose(anchor(fighters["settled"]), specs["Sniper"])
+    choose(anchor(fighters["switched"]), specs["Medic"])
+    remove(
+        Assignment.objects.get(
+            specialisation=specs["Medic"], miniature=fighters["switched"]
+        )
+    )
+    choose(anchor(fighters["switched"]), specs["Gunner"])
+    assign(narrow, miniature=fighters["subjugator"])
+    return (first, second), fighters
+
+
+class TestThePlan:
+    def test_it_says_everything_it_would_do(self, world):
+        plan = plan_specialisation()
+
+        assert plan.ok and not plan.nothing_here
+        said = "\n".join(plan.preview())
+        assert "create slot type “Specialisation”" in said
+        assert said.count("create pickable") == 4
+        assert "pick landing on the bearer" in said
+        assert "replace “Specialist: offers a choice of specialisation”" in said
+        assert (
+            "create picklist “Subjugator Patrol Officer options” offering Gunner, Medic"
+            in said
+        )
+        assert "replace “Subjugator offer”" in said
+        assert said.count("rewrite pick") == 3
+        assert "retire “General offer”" in said
+        assert (
+            "retire the carrierless modifier "
+            "“Specialist: adds Specialisation Offer”" in said
+        )
+        assert (
+            "on the “Patrol Officer” profile: retire "
+            "“Patrol Officer: removes Specialisation Offer”" in said
+        )
+        assert "retire library.AddsAssignable" in said
+        assert "retire library.RemovesAssignable" in said
+        assert "retire library.Hidden “Specialisation Offer" in said
+        assert said.count("retire library.Collection") == 2
+        assert said.count("retire library.Specialisation") == 4
+        assert "prove 2 gangs read the same, or refuse" in said
+
+
+class TestTheApply:
+    def test_every_page_reads_the_same(self, world):
+        gangs, _ = world
+        before = {g.pk: gang_state(g) for g in gangs}
+
+        apply(plan_specialisation())
+
+        for gang in gangs:
+            assert differences(before[gang.pk], gang_state(gang)) == []
+            assert_reconciled(gang)
+
+    def test_live_and_archived_picks_are_rewritten(self, world, prod_shape):
+        specialist, _, _, _ = prod_shape
+        _, fighters = world
+
+        apply(plan_specialisation())
+
+        live = Assignment.objects.get(
+            miniature=fighters["switched"], pickable__isnull=False, archived=False
+        )
+        assert live.pickable.name == "Gunner"
+        archived = Assignment.objects.get(
+            miniature=fighters["switched"], pickable__isnull=False, archived=True
+        )
+        assert archived.pickable.name == "Medic"
+        for row in (live, archived):
+            assert row.specialisation_id is None
+            assert row.chosen_for_id == row.caused_by_id
+            assert row.chosen_for_slot == Slot.objects.get(name="Specialisation")
+
+    def test_the_fossils_end_their_own_ways(self, world):
+        apply(plan_specialisation())
+
+        from n26.library.models import Modifier
+
+        assert not Hidden.objects.filter(qualifier="(general)").exists()
+        assert not Modifier.objects.filter(
+            name__icontains="Specialisation Offer"
+        ).exists()
+        subjugator = Hidden.objects.get(name="Specialisation offer")
+        grants = [m for m in subjugator.modifiers.all() if m.effect.slot is not None]
+        assert len(grants) == 1
+        assert not Collection.objects.filter(name__startswith="Specialisation").exists()
+        assert not Specialisation.objects.exists()
+
+    def test_the_subjugator_holder_still_asks_a_narrow_question(self, world):
+        _, fighters = world
+        before = [
+            (slot.kind_label, slot.is_resolved)
+            for slot in _choices_of(fighters["subjugator"])
+        ]
+
+        apply(plan_specialisation())
+
+        after = _choices_of(fighters["subjugator"])
+        assert [(s.kind_label, s.is_resolved) for s in after] == before
+        from n26.core.render import build_choice_offer
+
+        card_computed = _computed_for(fighters["subjugator"])
+        narrow_q = next(
+            s
+            for s in card_computed.choices
+            if s.slot is not None and "Subjugator" in s.slot.name
+        )
+        names = {
+            option.name
+            for group in build_choice_offer(narrow_q, card_computed).groups
+            for option in group.options
+            if option.key != "none"
+        }
+        assert names == {"Gunner", "Medic"}
+
+    def test_rechoosing_works_on_the_new_machinery(self, world, prod_shape):
+        specialist, _, _, _ = prod_shape
+        _, fighters = world
+        apply(plan_specialisation())
+        fighter = fighters["settled"]
+        anchor = Assignment.objects.get(subtype=specialist, miniature=fighter)
+
+        remove(Assignment.objects.get(pickable__name="Sniper", miniature=fighter))
+        choose(
+            anchor,
+            Pickable.objects.get(name="Scout"),
+            slot=Slot.objects.get(name="Specialisation"),
+            miniature=fighter,
+        )
+
+        gang = fighter.gang
+        state = gang_state(gang)
+        card = state["models"][str(fighter.pk)]
+        assert ("Specialisation", "Scout") in card["choices"]
+        assert "Clamber" in card["skills"]
+        assert_reconciled(gang)
+
+    def test_a_second_run_is_a_clean_no_op(self, world):
+        apply(plan_specialisation())
+
+        plan = plan_specialisation()
+
+        assert plan.nothing_here
+
+
+class TestTheRefusals:
+    def test_a_held_general_fossil_cannot_retire(self, world, prod_shape, owner):
+        _, _, _, general = prod_shape
+        _, fighters = world
+        assign(general, miniature=fighters["open"])
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert "held by someone" in plan.problems[0]
+        with pytest.raises(ConversionRefused):
+            apply(plan)
+        assert not SlotType.objects.filter(name="Specialisation").exists()
+
+    def test_a_live_modifier_naming_the_general_fossil_is_refused(
+        self, world, prod_shape
+    ):
+        _, _, _, general = prod_shape
+        modifier(
+            "Something grants the offer",
+            targets_model(),
+            ef_adds(general),
+            carried_by=create_subtype("Latecomer"),
+        )
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any("Something grants the offer" in problem for problem in plan.problems)
+
+    def test_a_shared_offer_is_refused(self, world, prod_shape):
+        from n26.library.authoring import attach_modifiers_to
+
+        specialist, _, _, _ = prod_shape
+        offer = next(
+            m
+            for m in specialist.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(create_subtype("Understudy"), [offer])
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert "shared" in plan.problems[0]
+
+
+def _computed_for(miniature):
+    from n26.core.card import build_card, build_modifier_index
+    from n26.core.effects import compute
+
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return compute(card, index)
+
+
+def _choices_of(miniature):
+    return _computed_for(miniature).choices

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -325,6 +325,7 @@ class TestTheApply:
 
         assert plan.ok
         assert bystander.pk in plan.gang_ids
+        assert_reconciled(bystander)
 
     def test_rechoosing_works_on_the_new_machinery(self, world, prod_shape):
         specialist, _, _, _ = prod_shape

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -54,6 +54,15 @@ def owner(db):
 
 @pytest.fixture
 def prod_shape(default_pack):
+    return build_prod_shape()
+
+
+@pytest.fixture
+def world(prod_shape, person_type, owner, default_pack):
+    return build_world(prod_shape, person_type, owner)
+
+
+def build_prod_shape():
     """The system as production holds it: the subtype's whole-kind
     offer, four specialisations, and the two fossil hiddens."""
     specs = {}
@@ -122,8 +131,7 @@ def prod_shape(default_pack):
     return specialist, specs, narrow, general
 
 
-@pytest.fixture
-def world(prod_shape, person_type, owner, default_pack):
+def build_world(prod_shape, person_type, owner):
     """Two gangs of specialists: a settled pick, a switched pick, an
     open question, and one fighter holding the Subjugator fossil."""
     specialist, specs, narrow, general = prod_shape

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -161,6 +161,12 @@ def world(prod_shape, person_type, owner, default_pack):
     )
     choose(anchor(fighters["switched"]), specs["Gunner"])
     assign(narrow, miniature=fighters["subjugator"])
+    # Odo answers the narrowed question, so the world holds a pick
+    # anchored on the hidden rather than the subtype.
+    choose(
+        Assignment.objects.get(hidden=narrow, miniature=fighters["subjugator"]),
+        specs["Gunner"],
+    )
     return (first, second), fighters
 
 
@@ -179,7 +185,7 @@ class TestThePlan:
             in said
         )
         assert "replace “Subjugator offer”" in said
-        assert said.count("rewrite pick") == 3
+        assert said.count("rewrite pick") == 4
         assert "retire “General offer”" in said
         assert (
             "retire the carrierless modifier "
@@ -244,15 +250,15 @@ class TestTheApply:
 
     def test_the_subjugator_holder_still_asks_a_narrow_question(self, world):
         _, fighters = world
-        before = [
+        before = sorted(
             (slot.kind_label, slot.is_resolved)
             for slot in _choices_of(fighters["subjugator"])
-        ]
+        )
 
         apply(plan_specialisation())
 
         after = _choices_of(fighters["subjugator"])
-        assert [(s.kind_label, s.is_resolved) for s in after] == before
+        assert sorted((s.kind_label, s.is_resolved) for s in after) == before
         from n26.core.render import build_choice_offer
 
         card_computed = _computed_for(fighters["subjugator"])
@@ -268,6 +274,57 @@ class TestTheApply:
             if option.key != "none"
         }
         assert names == {"Gunner", "Medic"}
+
+    def test_an_answered_narrow_question_settles_on_the_narrow_slot(self, world):
+        _, fighters = world
+
+        apply(plan_specialisation())
+
+        pick = Assignment.objects.get(
+            miniature=fighters["subjugator"], pickable__isnull=False
+        )
+        assert pick.pickable.name == "Gunner"
+        assert pick.chosen_for_slot == Slot.objects.get(
+            name="Specialisation (Subjugator Patrol Officer)"
+        )
+
+    def test_a_general_fossil_with_no_offer_still_retires(self, world, prod_shape):
+        _, _, _, general = prod_shape
+        offer = next(
+            m
+            for m in general.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        scope_row, effect_row = offer.scope, offer.effect
+        general.modifiers.remove(offer)
+        offer.delete()
+        scope_row.delete()
+        effect_row.delete()
+        Collection.objects.get(name="Specialisation Offer").delete()
+
+        apply(plan_specialisation())
+
+        assert not Hidden.objects.filter(qualifier="(general)").exists()
+
+    def test_a_dropped_removes_carriers_gangs_join_the_capture_set(
+        self, world, prod_shape, person_type, owner
+    ):
+        _, _, _, general = prod_shape
+        watch = create_gang_type("The Watch Rotation", starting_credits=1000)
+        watchman = create_profile("Watchman", person_type, watch, price=50)
+        modifier(
+            "Watchman: removes Specialisation Offer",
+            targets_model(),
+            ef_removes(general),
+            carried_by=watchman,
+        )
+        bystander = found_gang("The Shift", watch, owner=owner, budget=1000)
+        hire(bystander, watchman, "Silas", paid=50)
+
+        plan = plan_specialisation()
+
+        assert plan.ok
+        assert bystander.pk in plan.gang_ids
 
     def test_rechoosing_works_on_the_new_machinery(self, world, prod_shape):
         specialist, _, _, _ = prod_shape
@@ -362,6 +419,52 @@ class TestTheRefusals:
 
         assert not plan.ok
         assert "shared" in plan.problems[0]
+
+    def test_a_shared_narrow_offer_is_refused(self, world, prod_shape):
+        from n26.library.authoring import attach_modifiers_to
+
+        _, _, narrow, _ = prod_shape
+        offer = next(
+            m
+            for m in narrow.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(create_hidden("Bystander"), [offer])
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any("shared" in problem for problem in plan.problems)
+
+    def test_a_shared_general_offer_is_refused(self, world, prod_shape):
+        from n26.library.authoring import attach_modifiers_to
+
+        _, _, _, general = prod_shape
+        offer = next(
+            m
+            for m in general.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(create_hidden("Another bystander"), [offer])
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any("shared" in problem for problem in plan.problems)
+
+    def test_a_granted_specialist_subtype_is_refused(self, world, prod_shape):
+        specialist, _, _, _ = prod_shape
+        modifier(
+            "Rank grants Specialist",
+            targets_model(),
+            ef_adds(specialist),
+            carried_by=create_subtype("Sergeant"),
+        )
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any("cannot find the gangs" in problem for problem in plan.problems)
 
 
 def _computed_for(miniature):

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -241,6 +241,25 @@ class TestTheRunsOwnGuards:
         assert backfill.summary["attempts"] == MAX_ATTEMPTS
         assert backfill.error == ""
 
+    def test_a_delivery_arriving_after_success_cannot_unsay_it(
+        self, client, superuser, world
+    ):
+        """A run finishes close to the moment its delivery is retried, so
+        the copy that arrives to find the work already done is the likely
+        one. It must not file a successful conversion as a failure."""
+        client.force_login(superuser)
+        client.post(reverse(URL_NAME))
+        backfill = Backfill.objects.get()
+        assert backfill.status == Backfill.Status.DONE
+        report = backfill.summary["report"]
+
+        convert_specialisation.enqueue(backfill_id=str(backfill.id))
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.DONE
+        assert backfill.error == ""
+        assert backfill.summary["report"] == report
+
     def test_a_cancelled_run_stays_cancelled(self, world):
         backfill = Backfill.objects.create(
             operation=Operation.CONVERT_SPECIALISATION,

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -165,6 +165,18 @@ class TestApplying:
 
         assert "Nothing to convert" in response.content.decode()
 
+    def test_applying_twice_records_only_the_run_that_did_something(
+        self, client, superuser, world
+    ):
+        """A page left open across someone else's run: submitting it
+        again must not file a record for work there is none of."""
+        client.force_login(superuser)
+        client.post(reverse(URL_NAME))
+
+        client.post(reverse(URL_NAME), follow=True)
+
+        assert Backfill.objects.count() == 1
+
     def test_a_run_already_going_is_not_started_again(self, client, superuser, world):
         Backfill.objects.create(
             operation=Operation.CONVERT_SPECIALISATION,

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -1,0 +1,253 @@
+"""This edition's repairs, as the maintenance console offers them.
+
+A seam test: the console is the platform's, the conversion is ours, and
+what is proven here is that the two meet — the operation is registered and
+gated, the page shows the plan without writing, applying records what
+happened, and every way a run can end leaves an honest record behind.
+
+The conversion's own discipline is proven in
+``n26/tests/sandbox/test_conversion_specialisation.py``; this file cares
+only about the door it is triggered through.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from gyrinx.maintenance.models import Backfill
+from gyrinx.maintenance.registry import operations, resolve_operation
+from n26.core.models import Assignment
+from n26.maintenance import (
+    MAX_ATTEMPTS,
+    Operation,
+    convert_specialisation,
+    convert_specialisation_view,
+)
+from n26.tests.sandbox.test_conversion_specialisation import (
+    build_prod_shape,
+    build_world,
+)
+
+pytestmark = pytest.mark.django_db
+
+URL_NAME = "admin:maintenance_n26_convert_specialisation"
+
+
+@contextmanager
+def _lock_held_elsewhere():
+    """Hold the run's lock on another connection, as a run in flight does."""
+    from django.db import connections
+
+    from n26.maintenance import LOCK_KEY
+
+    other = connections.create_connection("default")
+    try:
+        with other.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_lock(%s)", [LOCK_KEY])
+        yield
+        with other.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_unlock(%s)", [LOCK_KEY])
+    finally:
+        other.close()
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def prod_shape(default_pack):
+    return build_prod_shape()
+
+
+@pytest.fixture
+def world(prod_shape, person_type, owner, default_pack):
+    return build_world(prod_shape, person_type, owner)
+
+
+@pytest.fixture
+def superuser(db):
+    return User.objects.create_superuser("boss", "boss@example.com", "password")
+
+
+@pytest.fixture
+def staffer(db):
+    return User.objects.create_user(
+        "clerk", "clerk@example.com", "password", is_staff=True
+    )
+
+
+class TestTheConsoleOffersIt:
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.CONVERT_SPECIALISATION.value in registered
+        found = resolve_operation(Operation.CONVERT_SPECIALISATION.value)
+        assert found.name == Operation.CONVERT_SPECIALISATION.label
+        assert found.view is convert_specialisation_view
+
+    def test_only_a_superuser_may_reach_it(self, client, staffer):
+        client.force_login(staffer)
+
+        assert client.get(reverse(URL_NAME)).status_code == 403
+
+    def test_a_stranger_is_sent_to_the_login(self, client):
+        response = client.get(reverse(URL_NAME))
+
+        assert response.status_code in (302, 403)
+
+
+class TestThePage:
+    def test_it_shows_the_plan_and_writes_nothing(self, client, superuser, world):
+        client.force_login(superuser)
+
+        response = client.get(reverse(URL_NAME))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "create slot type “Specialisation”" in page
+        assert "prove 2 gangs read the same" in page
+        assert not Backfill.objects.exists()
+        assert Assignment.objects.filter(specialisation__isnull=False).exists()
+
+    def test_a_refusal_is_said_on_the_page_not_applied(
+        self, client, superuser, world, prod_shape
+    ):
+        _, _, _, general = prod_shape
+        from n26.tests.sandbox.actions import assign
+
+        _, fighters = world
+        assign(general, miniature=fighters["open"])
+        client.force_login(superuser)
+
+        response = client.post(reverse(URL_NAME), follow=True)
+
+        assert "held by someone" in response.content.decode()
+        assert not Backfill.objects.exists()
+
+
+class TestApplying:
+    def test_it_records_what_it_did(self, client, superuser, world):
+        client.force_login(superuser)
+
+        response = client.post(reverse(URL_NAME), follow=True)
+
+        backfill = Backfill.objects.get()
+        assert backfill.operation == Operation.CONVERT_SPECIALISATION.value
+        assert backfill.triggered_by == superuser
+        assert backfill.status == Backfill.Status.DONE
+        assert "applied; every page reads the same" in backfill.summary["report"][-1]
+        assert backfill.summary["attempts"] == 1
+        # The run really converted: the picks now name pickables.
+        assert not Assignment.objects.filter(specialisation__isnull=False).exists()
+        assert Assignment.objects.filter(pickable__isnull=False).exists()
+        assert str(backfill.id) in response.redirect_chain[-1][0]
+
+    def test_the_detail_page_says_what_happened(self, client, superuser, world):
+        client.force_login(superuser)
+        client.post(reverse(URL_NAME))
+        backfill = Backfill.objects.get()
+
+        response = client.get(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+
+        assert "What it did" in response.content.decode()
+
+    def test_a_second_run_finds_nothing_to_convert(self, client, superuser, world):
+        client.force_login(superuser)
+        client.post(reverse(URL_NAME))
+
+        response = client.get(reverse(URL_NAME))
+
+        assert "Nothing to convert" in response.content.decode()
+
+    def test_a_run_already_going_is_not_started_again(self, client, superuser, world):
+        Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.RUNNING,
+        )
+        client.force_login(superuser)
+
+        client.post(reverse(URL_NAME), follow=True)
+
+        assert Backfill.objects.count() == 1
+        assert Assignment.objects.filter(specialisation__isnull=False).exists()
+
+
+class TestTheRunsOwnGuards:
+    def test_a_refusal_is_written_down_never_raised(self, world, prod_shape):
+        """A raised error would be redelivered for ever, so every ending
+        lands on the record instead."""
+        from n26.library.authoring import attach_modifiers_to
+        from n26.tests.sandbox.actions import create_subtype
+
+        specialist, _, _, _ = prod_shape
+        offer = next(
+            m
+            for m in specialist.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(create_subtype("Understudy"), [offer])
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.RUNNING,
+        )
+
+        convert_specialisation.enqueue(backfill_id=str(backfill.id))
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.FAILED
+        assert "shared" in backfill.error
+        assert Assignment.objects.filter(specialisation__isnull=False).exists()
+
+    def test_a_run_that_keeps_being_restarted_gives_up(self, world):
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": MAX_ATTEMPTS},
+        )
+
+        convert_specialisation.enqueue(backfill_id=str(backfill.id))
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.FAILED
+        assert "without finishing" in backfill.error
+        assert Assignment.objects.filter(specialisation__isnull=False).exists()
+
+    def test_a_second_copy_arriving_mid_run_leaves_no_trace(self, world):
+        """Delivery is at-least-once, so a copy can arrive while the first
+        is still working. It must not touch the record at all — counting
+        its arrival would let a long run be failed out from under itself.
+
+        The run in flight is held on its own connection, as a second
+        delivery really is: Postgres hands the same session a lock it
+        already holds, so a same-connection stand-in would prove nothing.
+        """
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": MAX_ATTEMPTS},
+        )
+
+        with _lock_held_elsewhere():
+            convert_specialisation.enqueue(backfill_id=str(backfill.id))
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.RUNNING
+        assert backfill.summary["attempts"] == MAX_ATTEMPTS
+        assert backfill.error == ""
+
+    def test_a_cancelled_run_stays_cancelled(self, world):
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.CANCELLED,
+        )
+
+        convert_specialisation.enqueue(backfill_id=str(backfill.id))
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.CANCELLED

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import operations, resolve_operation
 from n26.core.models import Assignment
+from n26.library.models import SlotType, Specialisation
 from n26.maintenance import (
     MAX_ATTEMPTS,
     Operation,
@@ -133,7 +134,7 @@ class TestApplying:
     def test_it_records_what_it_did(self, client, superuser, world):
         client.force_login(superuser)
 
-        response = client.post(reverse(URL_NAME), follow=True)
+        response = client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
 
         backfill = Backfill.objects.get()
         assert backfill.operation == Operation.CONVERT_SPECIALISATION.value
@@ -148,7 +149,7 @@ class TestApplying:
 
     def test_the_detail_page_says_what_happened(self, client, superuser, world):
         client.force_login(superuser)
-        client.post(reverse(URL_NAME))
+        client.post(reverse(URL_NAME), {"keep": "yes"})
         backfill = Backfill.objects.get()
 
         response = client.get(
@@ -159,7 +160,7 @@ class TestApplying:
 
     def test_a_second_run_finds_nothing_to_convert(self, client, superuser, world):
         client.force_login(superuser)
-        client.post(reverse(URL_NAME))
+        client.post(reverse(URL_NAME), {"keep": "yes"})
 
         response = client.get(reverse(URL_NAME))
 
@@ -171,9 +172,9 @@ class TestApplying:
         """A page left open across someone else's run: submitting it
         again must not file a record for work there is none of."""
         client.force_login(superuser)
-        client.post(reverse(URL_NAME))
+        client.post(reverse(URL_NAME), {"keep": "yes"})
 
-        client.post(reverse(URL_NAME), follow=True)
+        client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
 
         assert Backfill.objects.count() == 1
 
@@ -184,10 +185,86 @@ class TestApplying:
         )
         client.force_login(superuser)
 
-        client.post(reverse(URL_NAME), follow=True)
+        client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
 
         assert Backfill.objects.count() == 1
         assert Assignment.objects.filter(specialisation__isnull=False).exists()
+
+
+class TestRehearsing:
+    """The whole conversion, proven and then thrown away — so a database
+    holding real gangs can be asked whether this works without being
+    changed by the answer."""
+
+    def test_it_proves_everything_and_keeps_nothing(self, client, superuser, world):
+        client.force_login(superuser)
+
+        client.post(reverse(URL_NAME), {"keep": "no"}, follow=True)
+
+        backfill = Backfill.objects.get()
+        assert backfill.status == Backfill.Status.DONE
+        assert backfill.summary["kept"] is False
+        assert "rehearsed" in backfill.summary["report"][-1]
+        assert "nothing kept" in backfill.summary["report"][-1]
+        # The library is exactly as it was.
+        assert not SlotType.objects.filter(name="Specialisation").exists()
+        assert Specialisation.objects.filter(archived=False).count() == 4
+        assert Assignment.objects.filter(specialisation__isnull=False).count() == 4
+        assert not Assignment.objects.filter(pickable__isnull=False).exists()
+
+    def test_the_page_says_a_rehearsal_kept_nothing(self, client, superuser, world):
+        client.force_login(superuser)
+        client.post(reverse(URL_NAME), {"keep": "no"})
+        backfill = Backfill.objects.get()
+
+        response = client.get(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+
+        assert "nothing was kept" in response.content.decode()
+
+    def test_not_saying_which_rehearses(self, client, superuser, world):
+        """Keeping the work is the thing that must be asked for, so a
+        request that says nothing gets the ending nobody has to undo."""
+        client.force_login(superuser)
+
+        client.post(reverse(URL_NAME), follow=True)
+
+        assert Backfill.objects.get().summary["kept"] is False
+        assert Assignment.objects.filter(specialisation__isnull=False).exists()
+
+    def test_a_rehearsal_refuses_for_the_same_reasons(self, world, prod_shape):
+        from n26.library.authoring import attach_modifiers_to
+        from n26.tests.sandbox.actions import create_subtype
+
+        specialist, _, _, _ = prod_shape
+        offer = next(
+            m
+            for m in specialist.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(create_subtype("Understudy"), [offer])
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.RUNNING,
+        )
+
+        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=False)
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.FAILED
+        assert "shared" in backfill.error
+
+    def test_converting_after_a_rehearsal_still_works(self, client, superuser, world):
+        client.force_login(superuser)
+        client.post(reverse(URL_NAME), {"keep": "no"})
+
+        client.post(reverse(URL_NAME), {"keep": "yes"})
+
+        applied = Backfill.objects.filter(summary__kept=True).get()
+        assert applied.status == Backfill.Status.DONE
+        assert "applied" in applied.summary["report"][-1]
+        assert not Assignment.objects.filter(specialisation__isnull=False).exists()
 
 
 class TestTheRunsOwnGuards:
@@ -260,7 +337,7 @@ class TestTheRunsOwnGuards:
         the copy that arrives to find the work already done is the likely
         one. It must not file a successful conversion as a failure."""
         client.force_login(superuser)
-        client.post(reverse(URL_NAME))
+        client.post(reverse(URL_NAME), {"keep": "yes"})
         backfill = Backfill.objects.get()
         assert backfill.status == Backfill.Status.DONE
         report = backfill.summary["report"]


### PR DESCRIPTION
## Summary

Moves the **Specialisation** system onto slots and picks, and gives production a way to run it.

### The conversion

Same discipline as the Paths pilot: plan says everything it would do, apply performs it in one transaction and proves every affected gang's pages read the same — or refuses and unwinds.

- The **Specialist subtype's** whole-kind offer becomes a granted bearer slot; the eight specialisations (Brawler … Tech) become pickables on one picklist, each carrying its same skill-grant modifier — the identical rows, moved. An offer shared by any other carrier refuses the plan, since deleting it would reach gangs outside the capture set.
- The **Subjugator Patrol Officer hidden** converts rather than retires: its narrowed offer becomes a grant of a second slot over its own three-option picklist, so a holder keeps being asked the same narrow question — and a holder who already answered keeps their answer, because each rewritten pick settles onto the slot its own anchor grants.
- The **general "Specialisation Offer" hidden** retires with the fossil wiring the rehearsal found still naming it: a grant whose modifier nothing carries (a new `RetireModifier` step) and a live read-time-no-op *remove* on the Subjugator profile, dropped only because the plan proves nothing grants the hidden and nobody holds it — with that carrier's gangs joining the capture set so the no-op is proven, not assumed.
- Stored picks — live and archived — are rewritten in place; no rows created, no money moved, reconcile proven per gang.
- Refusals, in words, for: a shared offer (any of the three), a held fossil, a live grant of the fossil, duplicate hidden names, archived specialisations, an unrecognised pick anchor, and a Specialist subtype arriving by grant.

### How production runs it

Conversions cannot ship as migrations (see #2220 / #2228: a migration running live code inherits a dependency on every column that code reads, and the pin needed to express that contradicts the recorded history of any database that already ran it). Production also cannot be handed a `manage` command. So this edition joins the **maintenance console**:

- `n26/maintenance.py` is a single seam file registering the conversion as a console operation — the whole of n26's dependency on `gyrinx.maintenance` and `gyrinx.tasks`, exactly as `n26/analytics.py` is for analytics. The console stays edition-agnostic; `n26/CLAUDE.md` records the new sanctioned boundary crossing.
- The page shows the plan and writes nothing. Applying hands the work to a background task and records the outcome on the `Backfill` audit record: the planned steps, the report, or the refusal.
- **Two guards** where at-least-once delivery meets an all-or-nothing transaction: a lock only one run may hold (taken before anything is written, so a redelivered copy leaves no trace and cannot fail a run out from under itself), and an attempt counter written outside the conversion's transaction so a run too large to finish is noticed rather than repeated for ever. An interrupted run rolls back whole — the worst case is a conversion that has not happened yet.

### The one infra line (separate commits, `aa442a27` + `282c62f3`)

Cloud Run's default request timeout is 300s and Pub/Sub pushes are requests, but the conversion measured **~165s over 634 gangs on a developer machine** and is slower on one vCPU. Those commits raise the service timeout to **600s** — matched deliberately to the task's Pub/Sub acknowledgement deadline, the longest Pub/Sub allows. The two must be equal: a request allowed to outlive its deadline gets delivered a second time while the first copy is still working, and the second copy — standing down at the lock — answers successfully and acknowledges the message, leaving the original to die with nothing to retry it. Drop those commits if you would rather decide differently; the rest still merges.

## Measured at production scale

Built a local database with the real production content library plus a synthetic population of specialist gangs, and ran the actual conversion over it:

| | |
|---|---|
| Affected gangs in production | 634 (631 subtype holders ∪ 399 pick holders) |
| Picks to rewrite | 1,297 (1,053 live, 244 archived) |
| Measured | 0.251s and 90 queries per gang; 26s for 100 gangs |
| Dry run | 0.8s, writes nothing |

## Test plan

- [x] `pytest n26` plus the platform's maintenance, tasks and admin-registration guards — 3,651 passed
- [x] 18 sandbox tests on the conversion; 13 seam tests on the console (registration, superuser gating, dry run writes nothing, applying records the report, detail page, second run finds nothing, refusal recorded not raised, attempt cap, cancelled stays cancelled, and a redelivered copy holding the lock on a *separate connection* leaving no trace)
- [x] Smoke-tested through the real admin view with `RequestFactory` against a 100-gang database: dry run 200 and no record written, apply → `done`, zero old-column rows left
- [x] Rehearsed end-to-end on forks of the production library mirror, re-run after each review round and after rebasing

Refs #2177, #2220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8
