### PR TITLE
fix: clearer wording for the hire dialog's rate-at-price checkbox

### DIFF
--- a/n26/core/templates/cotton/n26/hire_dialog.html
+++ b/n26/core/templates/cotton/n26/hire_dialog.html
@@ -87,10 +87,12 @@ itself.
                {% if rate_at_paid %}checked{% endif %}
                class="mt-0.5 size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
         <span class="text-sm text-ink-900 dark:text-ink-100">
-            Use the price-paid as their rating
+            Match rating to price
             <span class="block text-muted">
-                You can hire this fighter at their usual rating ({{ price }}¢) for a
-                discount, or use the price-paid as their rating.
+                By default, this fighter's rating follows the price you pay — take
+                them on for free and they're rated at nothing. Untick this box to
+                keep their usual rating of {{ price }}¢ and record what you save as
+                a discount.
             </span>
         </span>
     </label>

--- a/n26/core/templates/cotton/n26/hire_dialog.html
+++ b/n26/core/templates/cotton/n26/hire_dialog.html
@@ -89,10 +89,10 @@ itself.
         <span class="text-sm text-ink-900 dark:text-ink-100">
             Match rating to price
             <span class="block text-muted">
-                By default, this fighter's rating follows the price you pay — take
-                them on for free and they're rated at nothing. Untick this box to
-                keep their usual rating of {{ price }}¢ and record what you save as
-                a discount.
+                By default, this fighter's rating matches the price you pay. If
+                you're paying less but they're still worth their full rating — for
+                example, one given to you for free — set the price accordingly and
+                untick this box to keep their rating at {{ price }}¢.
             </span>
         </span>
     </label>

--- a/n26/core/test_views_hire.py
+++ b/n26/core/test_views_hire.py
@@ -756,8 +756,8 @@ class TestRatingTheHire:
         out what the box does from its label alone."""
         client.force_login(tester)
         body = client.get(dialog_url(gang, ganger)).content.decode()
-        assert "usual rating (55¢)" in body
-        assert "price-paid as their rating" in body
+        assert "rating follows the price you pay" in body
+        assert "usual rating of 55¢" in body
 
     def test_ticked_the_price_paid_becomes_the_rating(
         self, client, tester, gang, ganger

--- a/n26/core/test_views_hire.py
+++ b/n26/core/test_views_hire.py
@@ -756,8 +756,8 @@ class TestRatingTheHire:
         out what the box does from its label alone."""
         client.force_login(tester)
         body = client.get(dialog_url(gang, ganger)).content.decode()
-        assert "rating follows the price you pay" in body
-        assert "usual rating of 55¢" in body
+        assert "rating matches the price you pay" in body
+        assert "keep their rating at 55¢" in body
 
     def test_ticked_the_price_paid_becomes_the_rating(
         self, client, tester, gang, ganger


### PR DESCRIPTION
Closes #2218.

Rewords the n26 hire dialog's "rate at price" checkbox so the two readings are clearer.

**Before**
- Heading: "Use the price-paid as their rating"
- Help text: "You can hire this fighter at their usual rating (55¢) for a discount, or use the price-paid as their rating."

**After**
- Heading: "Match rating to price"
- Help text: "By default, this fighter's rating matches the price you pay. If you're paying less but they're still worth their full rating — for example, one given to you for free — set the price accordingly and untick this box to keep their rating at 55¢."

Notes:
- The n26 edition bans the word "cost" (it's the exact price-vs-rating ambiguity this checkbox resolves), so the wording uses "price" rather than the "cost" phrasing from the Slack suggestion. The substance of the suggestion is preserved: a fighter given for free keeps their full rating — set the price to zero and untick the box.
- Updated the test that pins this copy (`test_the_offer_is_worded_for_both_readings`).

Slack thread: https://gyrinx.slack.com/archives/C0BQDG3RRN2/p1786913731760609?thread_ts=1786911692.787279&cid=C0BQDG3RRN2