### PR TITLE
fix: the paths conversion migration orders itself after every head it runs on

### DIFF
--- a/n26/library/migrations/0062_the_paths_become_picks.py
+++ b/n26/library/migrations/0062_the_paths_become_picks.py
@@ -20,9 +20,13 @@ def convert(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
+    # A conversion migration runs live code, so it must order itself
+    # after every migration that code's queries need — the heads at the
+    # time it was written, not merely the columns it touches. A stale
+    # database otherwise runs it too early and crashes mid-graph.
     dependencies = [
         ("library", "0061_reach_is_said_not_implied"),
-        ("n26", "0012_a_pick_names_the_slot_it_settles"),
+        ("n26", "0014_the_owner_edits_what_a_model_is"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary

- `library/0062_the_paths_become_picks` runs live conversion code, so it depends on every migration that code's ORM queries need — not merely the columns its own operations touch. Its dependencies pinned `n26.0012`, letting Django order it ahead of `n26.0014` on any database not already past both, and the conversion's `Assignment` reads then crash on the missing `removes` column.
- The fix is the one the issue names: depend on `n26.0014` (and `library.0061`), the heads at the time the conversion shipped. Editing an already-applied migration's dependencies is a no-op for every database past it (production, the local template) and the fix for every database that is not.

On the issue's broader point: this shape is why the next conversion (Specialisation, #2219) ships without a migration at all — production runs the rehearsal command as a one-off job instead. Reading through `.values(...)` or historical models isn't open to conversions, since they deliberately run the live renderer to prove pages unchanged; the dependency pin is the honest price of that, paid per conversion migration, and #2219 records the rule in 0062's comment.

## Test plan

- [x] Reproduced the crash by forking a database at `n26.0013` and migrating: 0062 ran first and crashed on `n26_assignment.removes`
- [x] With the pin, the same fork migrates clean: `n26.0013`, `n26.0014`, then `library.0062` converting the fork's Paths
- [x] `pytest n26` green (the suite runs `--nomigrations`, so this is belt only — the fork rehearsal above is the real proof)

Closes #2220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8