### PR TITLE
fix: conversions no longer ship as migrations — the paths one is retired to the command

### DIFF
--- a/n26/core/migrations/0015_a_pick_names_the_offer_it_settles.py
+++ b/n26/core/migrations/0015_a_pick_names_the_offer_it_settles.py
@@ -5,8 +5,12 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
+    # The library dependency is only for the offerschoice table the new
+    # column points at — deliberately not the library head: the Paths
+    # conversion (library.0062) runs live code that reads this column,
+    # so it must come after this migration, not before.
     dependencies = [
-        ("library", "0062_the_paths_become_picks"),
+        ("library", "0061_reach_is_said_not_implied"),
         ("n26", "0014_the_owner_edits_what_a_model_is"),
     ]
 

--- a/n26/library/migrations/0062_the_paths_become_picks.py
+++ b/n26/library/migrations/0062_the_paths_become_picks.py
@@ -1,34 +1,29 @@
-# The Cawdor Paths move onto slots and picks — the first converted
-# system. The conversion module owns the whole discipline (plan, prove
-# the pages unchanged, apply or refuse); this migration only runs it, so
-# the rehearsal command and production perform the identical steps. On a
-# database that never held the system — a fresh environment — the plan
-# says nothing_here and this is a clean no-op.
+# Deliberately inert. The Paths conversion ran here once, but a
+# conversion runs live code, and live code keeps moving: every new
+# column the conversion's queries touch would need adding to this
+# migration's dependencies, while any database that already applied the
+# two in the other order — as production did — would refuse the same
+# dependency as inconsistent history. No dependency list can be true on
+# every database at once, so conversions do not ship as migrations.
 #
-# Deliberately irreversible: the forward run's report (printed to the
-# migrate output) records every rewritten pick and retired row, and
-# going back is a restore, not a migration.
+# The conversion itself lives on:
+#
+#     manage n26_convert paths --apply
+#
+# A database still holding the old system converts then, with the plan
+# previewed first and every affected gang's pages proven unchanged; one
+# already converted answers that there is nothing here.
 
 from django.db import migrations
 
 
-def convert(apps, schema_editor):
-    from n26.library.conversion import apply, plan_paths
-
-    for line in apply(plan_paths()):
-        print(line)
-
-
 class Migration(migrations.Migration):
-    # A conversion migration runs live code, so it must order itself
-    # after every migration that code's queries need — the heads at the
-    # time it was written, not merely the columns it touches. A stale
-    # database otherwise runs it too early and crashes mid-graph.
+    # The loosest dependencies this migration ever declared, so that no
+    # database's recorded history — whichever order it applied things in
+    # — reads as inconsistent.
     dependencies = [
         ("library", "0061_reach_is_said_not_implied"),
-        ("n26", "0014_the_owner_edits_what_a_model_is"),
+        ("n26", "0012_a_pick_names_the_slot_it_settles"),
     ]
 
-    operations = [
-        migrations.RunPython(convert, migrations.RunPython.noop),
-    ]
+    operations = []


### PR DESCRIPTION
## Summary

The #2220 hazard recurred within hours of its fix, from the other side — and the recurrence proves the dependency-pin approach cannot work at all.

**What broke:** `n26.0015_a_pick_names_the_offer_it_settles` (the choice-anchoring work) added `Assignment.chosen_for_offer` and pinned itself *after* `library.0062`. But 0062's live conversion code reads and writes that column (the ORM selects every field the current model declares, and `RewritePick` nulls `chosen_for_offer` explicitly), so a database not past both — a rebuilt worktree, a fresh fork — ran the conversion before the column existed and crashed mid-graph: `column n26_assignment.chosen_for_offer does not exist`.

**Why the pin cannot be turned around:** production applied 0062 *before* 0015, so declaring 0062 → depends-on → 0015 makes Django's `check_consistent_history` refuse every future `migrate` in production with `InconsistentMigrationHistory`. A straggler needs one order, production's recorded history is the other; no dependency list satisfies both. This is structural: a migration running live code inherits a dependency on every column that code will *ever* touch.

**The fix:** conversions stop shipping as migrations, full stop — the decision #2219 already made for Specialisation, now applied retroactively:

- `library.0062` is inert: no operations, the loosest dependencies it ever declared (so no database's recorded history reads as inconsistent), and a comment stating the rule and pointing at the command.
- The Paths conversion lives on as `manage n26_convert paths --apply` — plan previewed first, every affected gang's pages proven unchanged, second run answers nothing here. Production and any database that already converted are untouched; a straggler converts by command.
- `n26.0015` now depends on `library.0061` (its FK only needs the `offerschoice` table) with a comment saying why a data-reading migration must not pin the library head.

## Test plan

- [x] Reproduced on a fork of the stale local template: crash on the missing column; then `InconsistentMigrationHistory` when the pin was tried the other way (the same refusal production would hit)
- [x] With this change the same fork migrates clean end-to-end (0062 applies early, inert), `manage n26_convert paths --apply` converts it proving pages unchanged, and a second run reports nothing to convert
- [x] `pytest n26` — 3580 passed

Refs #2220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8