### PR TITLE
fix: the page the gangs pager cannot turn to is dead, not a link to nowhere

### DIFF
--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -144,8 +144,15 @@ underlying spec.
   nothing (use `<c-slot>`); write `&amp;` not `&` in attributes; the
   platform's cotton checker does not scan n26 templates, so the
   `:field=` vs `field=` mistake is unguarded here — check your colons.
-  A template filter inside a `:attribute` (`:count="roster|length"`)
-  silently evaluates to nothing — compute the value in the view.
+  A `:attribute` takes a **variable, not an expression**: a filter
+  (`:count="roster|length"`), a comparison (`:selected="kind == value"`)
+  and a negation (`:disabled="not pages.next"`) all silently evaluate to
+  nothing, so the box never draws as ticked and the pager's end never
+  draws as disabled — each reads as a working control that is quietly
+  inert or quietly live. Plain lookups (`:current="number.current"`) and
+  literals (`:current="True"`) are the two forms that do work. Compute
+  the flag in the view, or draw the cases with `{% if %}`; and check the
+  rendered markup rather than the source, because nothing raises.
   Passing `class=` to a component whose `<c-vars>` does not declare it
   (the kit's `c-ui.badge`, for one) renders a *second* class attribute
   via `{{ attrs }}` — the browser keeps the first and silently drops

--- a/n26/core/templates/n26/gangs.html
+++ b/n26/core/templates/n26/gangs.html
@@ -82,11 +82,20 @@ places — the same pattern a gang's screens use for their siblings.
         asked for everybody's gangs would lose that by turning the page.
         A gap in a long run is marked and not linked — there is no one
         page it leads to.
+
+        The ends are drawn as two cases rather than one with a computed
+        `disabled`: a component attribute takes a variable, not an
+        expression, so a comparison there evaluates to nothing and the
+        control draws as a live link with an empty address.
         {% endcomment %}
         {% if pages %}
             <div class="flex flex-wrap items-center justify-between gap-3">
                 <c-ui.pagination>
-                    <c-ui.pagination.prev href="{{ pages.previous }}" :disabled="not pages.previous" />
+                    {% if pages.previous %}
+                        <c-ui.pagination.prev href="{{ pages.previous }}" />
+                    {% else %}
+                        <c-ui.pagination.prev :disabled="True" />
+                    {% endif %}
                     {% for number in pages.numbers %}
                         {% if number.elided %}
                             <c-ui.pagination.ellipsis />
@@ -96,7 +105,11 @@ places — the same pattern a gang's screens use for their siblings.
                             </c-ui.pagination.item>
                         {% endif %}
                     {% endfor %}
-                    <c-ui.pagination.next href="{{ pages.next }}" :disabled="not pages.next" />
+                    {% if pages.next %}
+                        <c-ui.pagination.next href="{{ pages.next }}" />
+                    {% else %}
+                        <c-ui.pagination.next :disabled="True" />
+                    {% endif %}
                 </c-ui.pagination>
                 <p class="text-sm text-muted">Page {{ pages.number }} of {{ pages.of }}</p>
             </div>

--- a/n26/core/test_views_gangs.py
+++ b/n26/core/test_views_gangs.py
@@ -326,6 +326,37 @@ def test_the_second_page_holds_the_rest(client, tester, make_gang):
     assert "Page 2 of 2" in body
 
 
+def test_the_page_the_pager_cannot_turn_to_is_dead(client, tester, make_gang):
+    """At either end the control is inert, not a live link to nowhere.
+
+    The kit draws a disabled end as a `#` address it cannot follow; an
+    enabled one carries a real address. A control offering to go back
+    from the first page is a link a keyboard reader is invited to take,
+    and its empty address would drop whatever question was asked.
+    """
+    from n26.core.views.gangs import GANGS_PER_PAGE
+
+    for number in range(GANGS_PER_PAGE + 5):
+        make_gang(f"Gang {number:02d}")
+
+    client.force_login(tester)
+    first = client.get(reverse("n26-gangs")).content.decode()
+    back = _control(first, "Previous page")
+    assert "pointer-events-none" in back
+    assert 'href=""' not in back
+
+    last = client.get(reverse("n26-gangs"), {"page": "2"}).content.decode()
+    forward = _control(last, "Next page")
+    assert "pointer-events-none" in forward
+    assert 'href=""' not in forward
+
+
+def _control(body, label):
+    """The markup of the pager control named ``label``."""
+    at = body.index(f'aria-label="{label}"')
+    return body[max(0, at - 400) : at + 200]
+
+
 def test_a_short_list_is_not_paged_at_all(client, tester, make_gang):
     make_gang("The Ashen Choir")
 


### PR DESCRIPTION
On the gangs list, the pager's end controls were never disabled: on page one the "Previous page" arrow drew as a live, hover-styled link, and on the last page so did "Next page".

## Why

The markup asked for the disabled state with an expression:

```django
<c-ui.pagination.prev href="{{ pages.previous }}" :disabled="not pages.previous" />
```

A component attribute resolves its value as a template variable lookup, not as a Python expression. `not pages.previous` is not a valid lookup, so it evaluates to nothing — falsy — and `disabled` is never true. The control then renders with the enabled classes and `href=""`.

What a reader gets at either end is an arrow that looks available, is reachable by keyboard, and whose empty address reloads the current page while dropping any `?q=` or `?everyone=1` they had asked for.

## The change

Both ends are drawn as two cases, which is what the kit's `disabled` needs to actually arrive:

```django
{% if pages.previous %}
    <c-ui.pagination.prev href="{{ pages.previous }}" />
{% else %}
    <c-ui.pagination.prev :disabled="True" />
{% endif %}
```

A literal is fine in an attribute; only expressions evaporate. The disabled end now renders as the kit intends — a `#` address with `pointer-events-none` and greyed text.

Swept every template in the edition: these two lines were the only expressions inside component attributes.

## The rule, written down

`n26/core/CLAUDE.md` already warned that a filter inside a `:attribute` evaluates to nothing. The same holds for comparisons and negations, and both had just been found in the wild — a tick box that never drew as ticked, and this pager end that never drew as disabled — so that entry now covers all three, names the two forms that do work (a plain lookup and a literal), and says to check the rendered markup, since nothing raises.

## Test plan

- [x] New test `test_the_page_the_pager_cannot_turn_to_is_dead` asserts both ends are inert, and that neither carries an empty address
- [x] Confirmed it **fails against the old markup** before the fix, so it really pins the behaviour
- [x] `pytest n26` — 3610 passed
