### PR TITLE
fix: the conversion reads one snapshot, refuses a doubled answer, and drops the rehearsal

### DIFF
--- a/n26/core/templates/admin/maintenance/n26/_convert_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_convert_detail.html
@@ -2,13 +2,6 @@
     The summary of one conversion run, on the Backfill detail page: what
     it was going to do, and — once it has finished — what it did.
 {% endcomment %}
-{% if backfill.summary.kept is False %}
-    <h2>A rehearsal — nothing was kept</h2>
-    <p>
-        This run performed the whole conversion, proved every affected gang's
-        pages, and then unwound it. The library is exactly as it was.
-    </p>
-{% endif %}
 {% if backfill.summary.report %}
     <h2>What it did</h2>
     <ul>

--- a/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
+++ b/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
@@ -42,26 +42,10 @@
         <ul class="mt-plan">
             {% for line in preview %}<li>{{ line }}</li>{% endfor %}
         </ul>
-        <h2>Rehearse it first</h2>
-        <p>
-            A rehearsal does the whole conversion — every step, every page
-            proven — and then unwinds it on purpose. It answers whether this
-            works on this database without changing it, which is worth asking
-            of one holding real gangs. It takes as long as the real run.
-        </p>
         <form method="post"
               class="mt-form"
-              onsubmit="return confirm('Rehearse the conversion over {{ gangs }} gang(s)? Nothing will be kept.')">
+              onsubmit="return confirm('Convert {{ gangs }} gang(s)? It writes nothing unless every page reads the same.')">
             {% csrf_token %}
-            <input type="hidden" name="keep" value="no">
-            <button type="submit" class="button">Rehearse — change nothing</button>
-        </form>
-        <h2>Apply it</h2>
-        <form method="post"
-              class="mt-form"
-              onsubmit="return confirm('Convert {{ gangs }} gang(s) for real? It writes nothing unless every page reads the same.')">
-            {% csrf_token %}
-            <input type="hidden" name="keep" value="yes">
             <button type="submit" class="button default">Apply conversion</button>
         </form>
     {% endif %}

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -24,6 +24,7 @@ priced, columns change on existing free rows, the ledger is untouched,
 and the reconcile assertion proves it gang by gang.
 """
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 from django.db import transaction
@@ -336,19 +337,12 @@ class Plan:
         return lines
 
 
-def apply(plan, *, keep=True):
+def apply(plan):
     """Perform exactly the plan, prove the pages unchanged, or refuse.
 
     Returns the report lines. Raises :class:`ConversionRefused` — after
     unwinding everything — if the plan carries problems, any affected
     gang's pages change, or any touched gang stops reconciling.
-
-    With ``keep=False`` it does the whole thing and then throws it away:
-    every step performed, every page proven, and the transaction unwound
-    on purpose. That is the closest a live database can be asked "would
-    this work here?" without being changed by the answer, and it is worth
-    asking of one holding real players' gangs, where the surprises are.
-    A rehearsal that would have refused refuses, in the same words.
     """
     if plan.problems:
         raise ConversionRefused(
@@ -358,27 +352,60 @@ def apply(plan, *, keep=True):
         return list(plan.preview())
 
     report = list(plan.preview())
-    try:
-        _perform(plan, report, keep=keep)
-    except _Rehearsed:
-        report.append(
-            f"[{plan.system}] rehearsed; every page reads the same; nothing kept"
-        )
-        return report
+    _perform(plan, report)
     report.append(f"[{plan.system}] applied; every page reads the same")
     return report
 
 
-class _Rehearsed(Exception):
-    """Raised at the end of a rehearsal to unwind it. Never escapes."""
+@contextmanager
+def _one_snapshot():
+    """Ask for the whole run to read one unchanging view of the database.
+
+    The proof compares what the pages said before with what they say
+    after, and takes any difference to be this conversion's doing. On a
+    live database that only holds if both readings are of the same world.
+    Proving hundreds of gangs takes minutes and players go on playing
+    throughout, so reading whatever is committed at the time — the
+    ordinary way — puts their purchases in the second reading, and the
+    conversion is blamed for a hazard suit somebody bought while it
+    worked, refusing for a reason nobody can act on.
+
+    Reading from one snapshot instead, what differs is what the run did.
+    Somebody changing a row it also writes ends it in a refusal rather
+    than a guess, which is the right ending for work that cannot be half
+    done. Set on the session, because a transaction's isolation can only
+    be chosen before it has read anything, and put back afterwards so a
+    pooled connection is handed on as it was found.
+    """
+    from django.db import connection
+
+    outermost = not connection.in_atomic_block
+    if not (outermost and connection.vendor == "postgresql"):
+        # Nested inside someone else's transaction — a test, a shell.
+        # Their snapshot is already the one this reads from.
+        yield
+        return
+    with connection.cursor() as cursor:
+        cursor.execute("SHOW default_transaction_isolation")
+        was = cursor.fetchone()[0]
+        cursor.execute(
+            "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ"
+        )
+    try:
+        yield
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL {was}"
+            )
 
 
-def _perform(plan, report, *, keep):
+def _perform(plan, report):
     from n26.core.capture import differences, gang_state
     from n26.core.models import Gang
     from n26.core.reconcile import assert_reconciled
 
-    with transaction.atomic():
+    with _one_snapshot(), transaction.atomic():
         before = {
             str(gang.pk): gang_state(gang)
             for gang in Gang.objects.filter(pk__in=plan.gang_ids)
@@ -411,6 +438,3 @@ def _perform(plan, report, *, keep):
                 raise ConversionRefused(
                     f"[{plan.system}] refused — {gang} no longer reconciles: {failed}"
                 ) from failed
-        if not keep:
-            # Everything held true. Unwind it anyway — that was the ask.
-            raise _Rehearsed

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -80,6 +80,8 @@ def _solely_carried(offer, carrier, problems):
 
 
 def plan_specialisation():
+    from django.db.models import Count
+
     from n26.core.models import Assignment
     from n26.library.models import Hidden, SlotType, Specialisation, Subtype
 
@@ -142,6 +144,27 @@ def plan_specialisation():
     if unanchored:
         problems.append(
             "picks with no caused_by to settle against: " + ", ".join(unanchored)
+        )
+
+    # A model holding the same question's answer twice. The offer showed
+    # one of them and left the rest lying on the card as free lines; a
+    # slot says every pick it holds, so the page would gain a repeated
+    # answer and lose those lines. That is a change to what a reader is
+    # told, and not one a conversion may make unasked — the spare
+    # assignments are for their owner to part with first.
+    crowded = list(
+        Assignment.objects.filter(specialisation__isnull=False, archived=False)
+        .values("miniature_id")
+        .annotate(held=Count("id"))
+        .filter(held__gt=1)
+    )
+    if crowded:
+        named = ", ".join(
+            f"{row['miniature_id']} ({row['held']})" for row in crowded[:10]
+        )
+        problems.append(
+            f"{len(crowded)} model(s) hold more than one specialisation, which "
+            f"one slot cannot say the same way: {named}"
         )
 
     # Hidden names are unique only together with their qualifier, so a

--- a/n26/library/management/commands/n26_convert.py
+++ b/n26/library/management/commands/n26_convert.py
@@ -1,9 +1,9 @@
 """Plan or apply a slots-and-picks conversion, from the shell.
 
-The rehearsal tool: point it at a database holding the system (a fork of
-the prod mirror, a restore of a full dump) and read the plan; add
-``--apply`` to perform it, with the conversion's own refusal standing
-between the plan and a committed write.
+Point it at a database holding the system (a fork of the prod mirror, a
+restore of a full dump) and read the plan; add ``--apply`` to perform
+it, with the conversion's own refusal standing between the plan and a
+committed write.
 
 This is how a conversion is checked before it ships, and how a database
 nobody runs a console against — a developer's, an old fork — is brought
@@ -27,25 +27,9 @@ class Command(BaseCommand):
             action="store_true",
             help="Perform the plan. Without this, the plan is printed and nothing is written.",
         )
-        parser.add_argument(
-            "--rehearse",
-            action="store_true",
-            help=(
-                "Perform the whole plan, prove every page, then unwind it. "
-                "Answers whether the conversion works on this database "
-                "without changing it."
-            ),
-        )
 
     def handle(self, *args, **options):
         plan = SYSTEMS[options["system"]]()
-        if options["rehearse"]:
-            try:
-                for line in apply(plan, keep=False):
-                    self.stdout.write(line)
-            except ConversionRefused as refused:
-                raise CommandError(str(refused)) from None
-            return
         if not options["apply"]:
             for problem in plan.problems:
                 self.stdout.write(self.style.ERROR(f"problem: {problem}"))

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -165,13 +165,8 @@ def _claim(backfill_id):
 
 
 @task
-def convert_specialisation(backfill_id, keep=True):
+def convert_specialisation(backfill_id):
     """Run the Specialisation conversion, once, and write down the outcome.
-
-    With ``keep=False`` it rehearses: the whole conversion performed and
-    every page proven, then unwound on purpose, so a database holding
-    real gangs can be asked whether this works without being changed by
-    the answer.
 
     Never raises: a task that fails is redelivered, and there is nowhere
     for a raised error to go but round again. Every ending — refused,
@@ -201,7 +196,7 @@ def convert_specialisation(backfill_id, keep=True):
             return
 
         try:
-            report = apply(_plan(), keep=keep)
+            report = apply(_plan())
         except ConversionRefused as refused:
             # A refusal is the discipline working: nothing was written,
             # and the reason is already in words.
@@ -219,7 +214,7 @@ def convert_specialisation(backfill_id, keep=True):
         _write(
             backfill_id,
             status=Backfill.Status.DONE,
-            summary_patch={"report": list(report), "kept": bool(keep)},
+            summary_patch={"report": list(report)},
         )
 
 
@@ -249,23 +244,15 @@ def convert_specialisation_view(request):
             return HttpResponseRedirect(
                 reverse("admin:maintenance_n26_convert_specialisation")
             )
-        # Keeping the work is the thing that must be asked for. A request
-        # that does not say so — a page from before there were two
-        # buttons, something calling the address directly — rehearses,
-        # which is the ending nobody has to undo.
-        keep = request.POST.get("keep") == "yes"
         backfill = Backfill.objects.create(
             operation=Operation.CONVERT_SPECIALISATION,
             triggered_by=request.user,
             status=Backfill.Status.RUNNING,
-            summary={"preview": list(plan.preview()), "attempts": 0, "kept": keep},
+            summary={"preview": list(plan.preview()), "attempts": 0},
         )
-        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=keep)
+        convert_specialisation.enqueue(backfill_id=str(backfill.id))
         messages.success(
-            request,
-            "The conversion is running. This page shows what it did."
-            if keep
-            else "The rehearsal is running. Nothing will be kept.",
+            request, "The conversion is running. This page shows what it did."
         )
         return HttpResponseRedirect(
             reverse("admin:maintenance_backfill_detail", args=[backfill.id])

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -389,6 +389,24 @@ class TestTheRefusals:
         assert not plan.ok
         assert any("Forgotten" in problem for problem in plan.problems)
 
+    def test_a_model_holding_two_specialisations_is_refused(self, world, prod_shape):
+        """The offer showed one answer and left the spare lying on the
+        card as a free line; a slot would say both. Production holds a
+        few models like this."""
+        specialist, specs, _, _ = prod_shape
+        _, fighters = world
+        anchor = Assignment.objects.get(
+            subtype=specialist, miniature=fighters["settled"]
+        )
+        choose(anchor, specs["Scout"])
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any(
+            "more than one specialisation" in problem for problem in plan.problems
+        )
+
     def test_two_hiddens_sharing_a_name_are_refused(self, world):
         create_hidden("Specialisation offer", qualifier="(a second one)")
 

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -19,7 +19,6 @@ from django.urls import reverse
 from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import operations, resolve_operation
 from n26.core.models import Assignment
-from n26.library.models import SlotType, Specialisation
 from n26.maintenance import (
     MAX_ATTEMPTS,
     Operation,
@@ -134,7 +133,7 @@ class TestApplying:
     def test_it_records_what_it_did(self, client, superuser, world):
         client.force_login(superuser)
 
-        response = client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
+        response = client.post(reverse(URL_NAME), follow=True)
 
         backfill = Backfill.objects.get()
         assert backfill.operation == Operation.CONVERT_SPECIALISATION.value
@@ -149,7 +148,7 @@ class TestApplying:
 
     def test_the_detail_page_says_what_happened(self, client, superuser, world):
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
         backfill = Backfill.objects.get()
 
         response = client.get(
@@ -160,7 +159,7 @@ class TestApplying:
 
     def test_a_second_run_finds_nothing_to_convert(self, client, superuser, world):
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
 
         response = client.get(reverse(URL_NAME))
 
@@ -172,9 +171,9 @@ class TestApplying:
         """A page left open across someone else's run: submitting it
         again must not file a record for work there is none of."""
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
 
-        client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
+        client.post(reverse(URL_NAME), follow=True)
 
         assert Backfill.objects.count() == 1
 
@@ -185,86 +184,10 @@ class TestApplying:
         )
         client.force_login(superuser)
 
-        client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
+        client.post(reverse(URL_NAME), follow=True)
 
         assert Backfill.objects.count() == 1
         assert Assignment.objects.filter(specialisation__isnull=False).exists()
-
-
-class TestRehearsing:
-    """The whole conversion, proven and then thrown away — so a database
-    holding real gangs can be asked whether this works without being
-    changed by the answer."""
-
-    def test_it_proves_everything_and_keeps_nothing(self, client, superuser, world):
-        client.force_login(superuser)
-
-        client.post(reverse(URL_NAME), {"keep": "no"}, follow=True)
-
-        backfill = Backfill.objects.get()
-        assert backfill.status == Backfill.Status.DONE
-        assert backfill.summary["kept"] is False
-        assert "rehearsed" in backfill.summary["report"][-1]
-        assert "nothing kept" in backfill.summary["report"][-1]
-        # The library is exactly as it was.
-        assert not SlotType.objects.filter(name="Specialisation").exists()
-        assert Specialisation.objects.filter(archived=False).count() == 4
-        assert Assignment.objects.filter(specialisation__isnull=False).count() == 4
-        assert not Assignment.objects.filter(pickable__isnull=False).exists()
-
-    def test_the_page_says_a_rehearsal_kept_nothing(self, client, superuser, world):
-        client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "no"})
-        backfill = Backfill.objects.get()
-
-        response = client.get(
-            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
-        )
-
-        assert "nothing was kept" in response.content.decode()
-
-    def test_not_saying_which_rehearses(self, client, superuser, world):
-        """Keeping the work is the thing that must be asked for, so a
-        request that says nothing gets the ending nobody has to undo."""
-        client.force_login(superuser)
-
-        client.post(reverse(URL_NAME), follow=True)
-
-        assert Backfill.objects.get().summary["kept"] is False
-        assert Assignment.objects.filter(specialisation__isnull=False).exists()
-
-    def test_a_rehearsal_refuses_for_the_same_reasons(self, world, prod_shape):
-        from n26.library.authoring import attach_modifiers_to
-        from n26.tests.sandbox.actions import create_subtype
-
-        specialist, _, _, _ = prod_shape
-        offer = next(
-            m
-            for m in specialist.modifiers.all()
-            if getattr(m, "offers_choice", None) is not None
-        )
-        attach_modifiers_to(create_subtype("Understudy"), [offer])
-        backfill = Backfill.objects.create(
-            operation=Operation.CONVERT_SPECIALISATION,
-            status=Backfill.Status.RUNNING,
-        )
-
-        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=False)
-
-        backfill.refresh_from_db()
-        assert backfill.status == Backfill.Status.FAILED
-        assert "shared" in backfill.error
-
-    def test_converting_after_a_rehearsal_still_works(self, client, superuser, world):
-        client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "no"})
-
-        client.post(reverse(URL_NAME), {"keep": "yes"})
-
-        applied = Backfill.objects.filter(summary__kept=True).get()
-        assert applied.status == Backfill.Status.DONE
-        assert "applied" in applied.summary["report"][-1]
-        assert not Assignment.objects.filter(specialisation__isnull=False).exists()
 
 
 class TestTheRunsOwnGuards:
@@ -337,7 +260,7 @@ class TestTheRunsOwnGuards:
         the copy that arrives to find the work already done is the likely
         one. It must not file a successful conversion as a failure."""
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
         backfill = Backfill.objects.get()
         assert backfill.status == Backfill.Status.DONE
         report = backfill.summary["report"]


### PR DESCRIPTION
Off current main, 105 added / 169 removed. The rehearsal goes; the two logic fixes it turned up stay.

## Rehearsal removed

Proving every gang inside the transaction held the library for eighteen minutes on a live app. That is a bad trade for a conversion whose writes take seconds — the length was all proof, not work. Gone: the `keep` flag, the second button, `--rehearse`, and their tests.

## The two things the failed production run found

Both are true of any conversion, so they stay.

**1. It must read one snapshot.** Reading the ordinary way (READ COMMITTED), the second reading picked up what players did while the run worked — a hazard suit and a cult icon bought for exactly the 30 credits that vanished, a riot shield parted with — and the conversion was blamed for all of it:

    01M085V6TZMGBEBRYXHHMQVTY3.credits: 290 -> 260
    01M085V6TZMGBEBRYXHHMQVTY3.models.01M086257RX7NE0GQ4X9Q0D50M.equipment: [] -> [('Hazard suit', 10)]

It now reads one snapshot start to finish (`REPEATABLE READ`, set on the session because a transaction's isolation can only be chosen before it reads anything, and put back so a pooled connection is handed on as found). What differs is what the run did; someone changing a row it also writes ends it in a refusal rather than a guess.

Reproduced deliberately at scale — a 100-gang conversion with a hire committed on another connection 12 seconds in. With the fix it applies; with the fix disabled the same race reproduces the production shape (`credits: 999685 -> 999640`, `rating: 315 -> 360`, a model "appears").

**2. Three models hold the same specialisation twice.** The offer showed one answer and left the spares on the card as free lines rating 0; a slot says every pick it holds, so those pages would gain `Sniper, Sniper` and lose the lines. The plan now names them and refuses immediately instead of the proof finding it much later.

(Details of the affected models are not recorded here.)

Under investigation. Until those four spare assignments go, the conversion refuses.

## Test plan

- [x] `pytest n26` plus the platform's maintenance tests — 3,656 passed
- [x] New test: a model holding two specialisations refuses
- [x] Concurrency race reproduced both ways at scale

Refs #2177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8
