### PR TITLE
fix: a category name shared by two sections counts apart in the picker

### DIFF
--- a/n26/core/templates/cotton/n26/collection_picker/category.html
+++ b/n26/core/templates/cotton/n26/collection_picker/category.html
@@ -13,6 +13,10 @@ A category is the stable half of the pair — Pistols is Pistols for everyone,
 while library.PlacesCategory files the same category under different sections
 for different models — which is why the category filter keys off this one.
 
+Its count is asked for by section as well as by name: one name can be two
+categories, filed under two sections, and the header must count only the rows
+beneath it.
+
 It hides itself at zero matches, so filtering leaves no labelled gaps.
 
   name — the category's name: what items register against, and what the
@@ -22,7 +26,7 @@ It hides itself at zero matches, so filtering leaves no labelled gaps.
 <c-vars name="" :open="True" />
 
 <div x-data="{ open: {{ open|lower }}, categoryName: {{ name|json_dumps }} }"
-     x-show="categoryOn(categoryName) && countIn(categoryName) > 0"
+     x-show="categoryOn(categoryName) && countIn(sectionName, categoryName) > 0"
      @collection-picker-toggle.window="open = $event.detail.open"
      x-cloak>
 
@@ -42,7 +46,7 @@ It hides itself at zero matches, so filtering leaves no labelled gaps.
         <span class="min-w-0 flex-1 truncate text-xs font-semibold uppercase tracking-wide text-muted">{{ name }}</span>
 
         <span class="shrink-0 text-xs tabular-nums text-muted" aria-hidden="true"
-              x-text="countIn(categoryName)"></span>
+              x-text="countIn(sectionName, categoryName)"></span>
     </button>
 
     <div x-show="open || query.length > 0" x-collapse>{{ slot }}</div>

--- a/n26/core/templates/cotton/n26/collection_picker/index.html
+++ b/n26/core/templates/cotton/n26/collection_picker/index.html
@@ -96,6 +96,11 @@ event and is told to clear itself by `filter-reset`.
         A category's number ignores the category filter, so the filter menu
         can show what each choice would yield; a section's number respects
         it, so a section with every category unticked hides itself.
+
+        Categories are counted per section, because a category name is only
+        unique within one — the rulebook files Primitive Weapons under both
+        Ranged and Close Combat. Counted by name alone, one section's
+        matches draw the other section a header with nothing behind it.
         {% endcomment %}
         counts: { section: {}, category: {}, sectionTotal: {}, shown: 0, total: 0 },
         recount() {
@@ -104,7 +109,8 @@ event and is told to clear itself by `filter-reset`.
             for (const facets of this.items) {
                 sectionTotal[facets.section] = (sectionTotal[facets.section] || 0) + 1;
                 if (!this.matches(facets)) continue;
-                byCategory[facets.category] = (byCategory[facets.category] || 0) + 1;
+                const inSection = byCategory[facets.section] || (byCategory[facets.section] = {});
+                inSection[facets.category] = (inSection[facets.category] || 0) + 1;
                 if (this.categoryOn(facets.category)) {
                     bySection[facets.section] = (bySection[facets.section] || 0) + 1;
                     shown += 1;
@@ -139,7 +145,7 @@ event and is told to clear itself by `filter-reset`.
         },
 
         categoryOn(name) { return this.categories.includes(name) },
-        countIn(name) { return this.counts.category[name] || 0 },
+        countIn(section, name) { return (this.counts.category[section] || {})[name] || 0 },
         {% comment %}
         Which section is on screen is derived, never stored: chosenSection is
         only what was last clicked, and what shows is that section if it still

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1172,6 +1172,36 @@ def test_the_section_menu_asks_the_catalogue_and_not_the_menu(
     assert "picker.visibleSection" in body
 
 
+def test_two_sections_sharing_a_category_name_count_apart(
+    client, tester, gang, fighter
+):
+    """A category name is only unique inside its section — the rulebook
+    files Primitive Weapons under both Ranged and Close Combat. Counted by
+    name alone, the knife's match lands on both, and the ranged tab draws a
+    Primitive Weapons header with a 1 beside it and nothing underneath. So
+    each header asks for its own section's tally, while the filter keeps
+    the one entry for the name it is still filtering on."""
+    ranged = create_category("Ranged weapons", "Primitive weapons", position=0)
+    melee = create_category("Close combat weapons", "Primitive weapons", position=1)
+    collection = create_collection(
+        "Primitives",
+        entries=[
+            create_wargear("Blunderbuss", price=30, category=ranged),
+            create_wargear("Fighting knife", price=5, category=melee),
+        ],
+    )
+    with operation(gang, actor=tester) as op:
+        op.assign(collection, gang=gang)
+
+    client.force_login(tester)
+    response = client.get(equip_url(fighter, collection))
+    body = response.content.decode()
+
+    assert response.context["categories"].count("Primitive weapons") == 1
+    assert body.count('x-text="countIn(sectionName, categoryName)"') == 2
+    assert "countIn(categoryName)" not in body
+
+
 def test_the_count_above_the_list_counts_the_section_on_screen(
     client, tester, fighter, house_list
 ):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Filtering the Trading Post by price showed a category heading with a count beside it and no rows underneath — a "Primitive weapons" heading reading 1 on the Ranged weapons tab, while the only item at that price was the fighting knife, over on Close combat weapons.

The collection picker keeps every count on the page in one table that a single effect rebuilds. Category counts in that table were keyed by category name alone, but a category name is only unique within its section — the rulebook files Primitive Weapons under both Ranged and Close Combat, and `library.Category`'s uniqueness constraint says so explicitly. The knife's match therefore counted towards both sections' Primitive Weapons, and the ranged tab drew a header for a category that had nothing left in it.

The counts are now keyed by the section and the category name together, and a category header asks `countIn(sectionName, categoryName)` for its own section's tally. The category *filter* still keys on the name alone, which is deliberate: a category is the stable half of the pair, so ticking Primitive Weapons means it in both sections.

Nothing on the server changed; this affects both equip pages and the hire page, which share the picker.

## Testing

A gang holding a list whose Ranged weapons and Close combat weapons sections both have a Primitive weapons category, with the only cheap primitive weapon in the close-combat one. Price filtered to 5¢, on the Ranged weapons tab.

Before — the empty heading, counted from the other section's knife:

[Ranged weapons tab filtered to 5 credits, showing an empty Primitive weapons heading counting 1](https://cursor.com/agents/bc-fce71b4f-3432-5b69-9f41-9fbb53f1106e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fghost_category_before.png)

After — the heading goes with its rows:

[The same tab after the fix, with only Auto/stub weapons and Las weapons drawn](https://cursor.com/agents/bc-fce71b4f-3432-5b69-9f41-9fbb53f1106e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fghost_category_after.png)

And the category still draws where it does have a row — the same filter, on the Close combat weapons tab:

[Close combat weapons tab showing Primitive weapons with the fighting knife](https://cursor.com/agents/bc-fce71b4f-3432-5b69-9f41-9fbb53f1106e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprimitive_weapons_still_shown_where_it_has_rows.png)

`test_two_sections_sharing_a_category_name_count_apart` pins the wiring server-side, and fails on `main`. Full suite green (7955 passed).

## How to try it

Open a fighter's equip page on a list whose sections repeat a category name, set the price filter low enough that one section's copy of the name empties out, and check that its heading goes with it.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQDG3RRN2/p1786977416853919?thread_ts=1786977416.853919&cid=C0BQDG3RRN2)

<div><a href="https://cursor.com/agents/bc-fce71b4f-3432-5b69-9f41-9fbb53f1106e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fce71b4f-3432-5b69-9f41-9fbb53f1106e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

