### PR TITLE
feat: the specialisations become picks, without deleting anything

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,15 @@ Keep the fully technical version for commit messages and code comments.
 
 - Manually test changes through the running app (dev server + browser) before
   shipping — skip only when the change is trivial
+- **Always smoke-test a migration, backfill, or any data-touching feature on a
+  real database before shipping it.** Fork the content mirror
+  (`createdb -T gyrinx_main gyrinx_smoke`), build a population at production's
+  measured volume — read the counts off `manage prodshell` first rather than
+  guessing them — run the real code path, and time it. Then verify from
+  *outside* the change: compare every affected record yourself, before and
+  after, instead of trusting whatever the feature checks internally. Tests
+  prove the logic on a handful of rows; this is what catches the volume, the
+  runtime, and the data shapes nobody thought to write a fixture for.
 
 **In CI/GitHub Actions:** MUST commit and push before finishing or work is lost.
 

--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -84,6 +84,17 @@ underlying spec.
 
 ## Wiring — steps that are easy to miss
 
+- **The gang's history reads through the row, so changing a row rewrites
+  the past.** `history.py` describes an old event by looking up what its
+  assignment names *now* (`_name`, `_kindword`), not by any wording
+  stored at the time. So anything that moves an assignment from one kind
+  to another — a conversion onto slots and picks, a new kind replacing an
+  old one — silently changes what already-written history says. Check the
+  history page against a converted row before shipping such a change, and
+  keep the words the same: a pick reports the question it answered (its
+  slot's `choice_label`), because "pickable" is plumbing no player has
+  seen. The same goes for any new kind: decide what it calls itself in a
+  story before it can appear in one.
 - **A new assignable kind is three edits**: an entry in
   `ASSIGNABLE_FIELDS` (`models/assignment.py`), a matching nullable FK
   on `Assignment`, and a migration. Startup checks (`n26.E001`/`E002`)

--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -84,13 +84,14 @@ underlying spec.
 
 ## Wiring — steps that are easy to miss
 
-- **The gang's history reads through the row, so changing a row rewrites
-  the past.** `history.py` describes an old event by looking up what its
-  assignment names *now* (`_name`, `_kindword`), not by any wording
-  stored at the time. So anything that moves an assignment from one kind
-  to another — a conversion onto slots and picks, a new kind replacing an
-  old one — silently changes what already-written history says. Check the
-  history page against a converted row before shipping such a change, and
+- **The gang's history reads through the assignment, so changing one
+  rewrites the past.** `history.py` describes an old event by looking up
+  what its assignment names *now* (`_name`, `_kindword`), not by any
+  wording stored at the time. So anything that moves an assignment from
+  one kind to another — a conversion onto slots and picks, a new kind
+  replacing an old one — silently changes what already-written history
+  says. Check the history page against a converted assignment before
+  shipping such a change, and
   keep the words the same: a pick reports the question it answered (its
   slot's `choice_label`), because "pickable" is plumbing no player has
   seen. The same goes for any new kind: decide what it calls itself in a

--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -140,7 +140,12 @@ def _rows_for(events):
     wanted = {e.assignment_id for e in events if e.assignment_id}
     fetched = Assignment.with_assignables(
         Assignment.objects.filter(pk__in=wanted).select_related(
-            "ledger_entry", "miniature", "miniature_root", "stash"
+            "ledger_entry",
+            "miniature",
+            "miniature_root",
+            "stash",
+            # A pick says its kind through the question it answered.
+            "chosen_for_slot",
         )
     )
     return {row.pk: row for row in fetched}
@@ -473,10 +478,19 @@ def _name(row):
 
 def _kindword(row):
     """What sort of thing this is, in the library's own word — empty
-    for the kinds a player's page never names."""
+    for the kinds a player's page never names.
+
+    A pick is one of those: "pickable" is plumbing, and no player has
+    ever seen the word. What they know it as is the question it answered
+    — a Specialisation, a Path — so the slot says it instead. Without
+    this a story that read "Sniper, specialisation" before its system
+    moved onto slots would afterwards read only "Sniper".
+    """
     thing = row.assignable if row else None
     if thing is None:
         return ""
+    if row.chosen_for_slot_id is not None and row.chosen_for_slot is not None:
+        return row.chosen_for_slot.choice_label.lower()
     return kind_of(thing)
 
 

--- a/n26/core/templates/admin/maintenance/n26/_convert_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_convert_detail.html
@@ -2,13 +2,6 @@
     The summary of one conversion run, on the Backfill detail page: what
     it was going to do, and — once it has finished — what it did.
 {% endcomment %}
-{% if backfill.summary.kept is False %}
-    <h2>A rehearsal — nothing was kept</h2>
-    <p>
-        This run performed the whole conversion, proved every affected gang's
-        pages, and then unwound it. The library is exactly as it was.
-    </p>
-{% endif %}
 {% if backfill.summary.report %}
     <h2>What it did</h2>
     <ul>

--- a/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
+++ b/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
@@ -20,20 +20,6 @@
         This is the plan. Nothing has been changed. Every line below is a step
         the conversion would perform, in order.
     </p>
-    <p>
-        It reaches <strong>{{ reaches }}</strong> gang{{ reaches|pluralize }}, and
-        proves <strong>{{ proven }}</strong> of them unchanged before committing —
-        a spread wide enough to hold every shape the system comes in. Proving all
-        of them would mean holding the whole library for minutes while players are
-        using it.
-    </p>
-    <p>
-        Applying runs the whole conversion in one transaction. It captures what
-        every affected gang's pages say, performs the steps, captures again, and
-        commits only if the two readings match and every gang still reconciles.
-        Anything else — a difference, a refusal, an interruption — writes nothing
-        at all, so a run that does not finish can simply be run again.
-    </p>
     {% if plan.nothing_here %}
         <h2>Nothing to convert</h2>
         <p>This system is not here. It has been converted already, or was never present.</p>
@@ -44,6 +30,20 @@
         </ul>
         <p>Nothing can be applied while any of these stands.</p>
     {% else %}
+        <p>
+            It reaches <strong>{{ reaches }}</strong> gang{{ reaches|pluralize }}, and
+            proves <strong>{{ proven }}</strong> of them unchanged before committing —
+            a spread wide enough to hold every shape the system comes in. Proving all
+            of them would mean holding the whole library for minutes while players are
+            using it.
+        </p>
+        <p>
+            Applying runs the whole conversion in one transaction. It captures what
+            every affected gang's pages say, performs the steps, captures again, and
+            commits only if the two readings match and every gang still reconciles.
+            Anything else — a difference, a refusal, an interruption — writes nothing
+            at all, so a run that does not finish can simply be run again.
+        </p>
         <h2>What it would do</h2>
         <ul class="mt-plan">
             {% for line in preview %}<li>{{ line }}</li>{% endfor %}

--- a/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
+++ b/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
@@ -42,26 +42,10 @@
         <ul class="mt-plan">
             {% for line in preview %}<li>{{ line }}</li>{% endfor %}
         </ul>
-        <h2>Rehearse it first</h2>
-        <p>
-            A rehearsal does the whole conversion — every step, every page
-            proven — and then unwinds it on purpose. It answers whether this
-            works on this database without changing it, which is worth asking
-            of one holding real gangs. It takes as long as the real run.
-        </p>
         <form method="post"
               class="mt-form"
-              onsubmit="return confirm('Rehearse the conversion over {{ gangs }} gang(s)? Nothing will be kept.')">
+              onsubmit="return confirm('Convert {{ gangs }} gang(s)? It writes nothing unless every page reads the same.')">
             {% csrf_token %}
-            <input type="hidden" name="keep" value="no">
-            <button type="submit" class="button">Rehearse — change nothing</button>
-        </form>
-        <h2>Apply it</h2>
-        <form method="post"
-              class="mt-form"
-              onsubmit="return confirm('Convert {{ gangs }} gang(s) for real? It writes nothing unless every page reads the same.')">
-            {% csrf_token %}
-            <input type="hidden" name="keep" value="yes">
             <button type="submit" class="button default">Apply conversion</button>
         </form>
     {% endif %}

--- a/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
+++ b/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
@@ -39,10 +39,11 @@
         </p>
         <p>
             Applying runs the whole conversion in one transaction. It captures what
-            every affected gang's pages say, performs the steps, captures again, and
-            commits only if the two readings match and every gang still reconciles.
-            Anything else — a difference, a refusal, an interruption — writes nothing
-            at all, so a run that does not finish can simply be run again.
+            the gangs it proves say on their pages, performs the steps, captures them
+            again, and commits only if the two readings match and each of them still
+            reconciles. Anything else — a difference, a refusal, an interruption —
+            writes nothing at all, so a run that does not finish can simply be run
+            again.
         </p>
         <h2>What it would do</h2>
         <ul class="mt-plan">

--- a/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
+++ b/n26/core/templates/admin/maintenance/n26/convert_specialisation.html
@@ -18,8 +18,14 @@
     <h1>{{ title }}</h1>
     <p>
         This is the plan. Nothing has been changed. Every line below is a step
-        the conversion would perform, in order; the last line says how many
-        gangs it would prove unchanged before committing anything.
+        the conversion would perform, in order.
+    </p>
+    <p>
+        It reaches <strong>{{ reaches }}</strong> gang{{ reaches|pluralize }}, and
+        proves <strong>{{ proven }}</strong> of them unchanged before committing —
+        a spread wide enough to hold every shape the system comes in. Proving all
+        of them would mean holding the whole library for minutes while players are
+        using it.
     </p>
     <p>
         Applying runs the whole conversion in one transaction. It captures what
@@ -44,7 +50,7 @@
         </ul>
         <form method="post"
               class="mt-form"
-              onsubmit="return confirm('Convert {{ gangs }} gang(s)? It writes nothing unless every page reads the same.')">
+              onsubmit="return confirm('Convert {{ reaches }} gang(s)? It writes nothing unless every page it proves reads the same.')">
             {% csrf_token %}
             <button type="submit" class="button default">Apply conversion</button>
         </form>

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -22,6 +22,13 @@ Pick rewrites touch ``Assignment`` rows outside ``operation()`` — the
 one sanctioned place: a conversion moves no money. Nothing is created or
 priced, columns change on existing free rows, the ledger is untouched,
 and the reconcile assertion proves it gang by gang.
+
+What the ledger *says*, though, is not untouched, and the captures do
+not see it. The gang's history describes an old event by looking up what
+its assignment names now, so moving a row from one kind to another
+rewrites the wording of things that already happened. Every conversion
+must check the history page against a converted row and keep those words
+the same — see the note in ``n26/core/CLAUDE.md``.
 """
 
 from contextlib import contextmanager
@@ -311,13 +318,19 @@ class _Made:
 class Plan:
     system: str
     steps: tuple = ()
-    #: Primary keys of every gang whose pages this system touches — the
-    #: capture set the apply proves unchanged. Derived from stored rows,
-    #: which every carrier so far is; a system whose carrier arrives by
-    #: grant has no row to find, and its plan must widen this set the
-    #: renderer's way.
+    #: The gangs the apply proves unchanged before committing — a spread
+    #: chosen by the system's own plan to hold every shape it comes in,
+    #: not every gang it reaches. Proving all of them means rendering for
+    #: minutes with the transaction open, which on a live app costs more
+    #: than it buys: what goes wrong is nearly always shaped by the
+    #: content, so it shows in any gang the change touches, and what is
+    #: particular to one gang is cheaper to ask the database outright.
     gang_ids: tuple = ()
     problems: tuple = ()
+    #: How many gangs the change reaches in all, proven or not.
+    reaches: int = 0
+    #: Rows the plan deliberately leaves as they are.
+    left_alone: int = 0
     #: True when the system simply is not here — nothing to convert and
     #: nothing wrong: the apply is a clean no-op.
     nothing_here: bool = False
@@ -330,9 +343,15 @@ class Plan:
         if self.nothing_here:
             return [f"[{self.system}] nothing to convert — the system is not here"]
         lines = [f"[{self.system}] {step.say()}" for step in self.steps]
+        if self.left_alone:
+            lines.append(
+                f"[{self.system}] leave {self.left_alone} spare assignment"
+                f"{'' if self.left_alone == 1 else 's'} exactly as they are"
+            )
+        reaches = self.reaches or len(self.gang_ids)
         lines.append(
-            f"[{self.system}] prove {len(self.gang_ids)} gang"
-            f"{'' if len(self.gang_ids) == 1 else 's'} read the same, or refuse"
+            f"[{self.system}] prove {len(self.gang_ids)} of {reaches} reached "
+            "gangs read the same, or refuse"
         )
         return lines
 

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -24,6 +24,7 @@ priced, columns change on existing free rows, the ledger is untouched,
 and the reconcile assertion proves it gang by gang.
 """
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 from django.db import transaction
@@ -336,19 +337,12 @@ class Plan:
         return lines
 
 
-def apply(plan, *, keep=True):
+def apply(plan):
     """Perform exactly the plan, prove the pages unchanged, or refuse.
 
     Returns the report lines. Raises :class:`ConversionRefused` — after
     unwinding everything — if the plan carries problems, any affected
     gang's pages change, or any touched gang stops reconciling.
-
-    With ``keep=False`` it does the whole thing and then throws it away:
-    every step performed, every page proven, and the transaction unwound
-    on purpose. That is the closest a live database can be asked "would
-    this work here?" without being changed by the answer, and it is worth
-    asking of one holding real players' gangs, where the surprises are.
-    A rehearsal that would have refused refuses, in the same words.
     """
     if plan.problems:
         raise ConversionRefused(
@@ -358,27 +352,60 @@ def apply(plan, *, keep=True):
         return list(plan.preview())
 
     report = list(plan.preview())
-    try:
-        _perform(plan, report, keep=keep)
-    except _Rehearsed:
-        report.append(
-            f"[{plan.system}] rehearsed; every page reads the same; nothing kept"
-        )
-        return report
+    _perform(plan, report)
     report.append(f"[{plan.system}] applied; every page reads the same")
     return report
 
 
-class _Rehearsed(Exception):
-    """Raised at the end of a rehearsal to unwind it. Never escapes."""
+@contextmanager
+def _one_snapshot():
+    """Ask for the whole run to read one unchanging view of the database.
+
+    The proof compares what the pages said before with what they say
+    after, and takes any difference to be this conversion's doing. On a
+    live database that only holds if both readings are of the same world.
+    Proving hundreds of gangs takes minutes and players go on playing
+    throughout, so reading whatever is committed at the time — the
+    ordinary way — puts their purchases in the second reading, and the
+    conversion is blamed for a hazard suit somebody bought while it
+    worked, refusing for a reason nobody can act on.
+
+    Reading from one snapshot instead, what differs is what the run did.
+    Somebody changing a row it also writes ends it in a refusal rather
+    than a guess, which is the right ending for work that cannot be half
+    done. Set on the session, because a transaction's isolation can only
+    be chosen before it has read anything, and put back afterwards so a
+    pooled connection is handed on as it was found.
+    """
+    from django.db import connection
+
+    outermost = not connection.in_atomic_block
+    if not (outermost and connection.vendor == "postgresql"):
+        # Nested inside someone else's transaction — a test, a shell.
+        # Their snapshot is already the one this reads from.
+        yield
+        return
+    with connection.cursor() as cursor:
+        cursor.execute("SHOW default_transaction_isolation")
+        was = cursor.fetchone()[0]
+        cursor.execute(
+            "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ"
+        )
+    try:
+        yield
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL {was}"
+            )
 
 
-def _perform(plan, report, *, keep):
+def _perform(plan, report):
     from n26.core.capture import differences, gang_state
     from n26.core.models import Gang
     from n26.core.reconcile import assert_reconciled
 
-    with transaction.atomic():
+    with _one_snapshot(), transaction.atomic():
         before = {
             str(gang.pk): gang_state(gang)
             for gang in Gang.objects.filter(pk__in=plan.gang_ids)
@@ -411,6 +438,3 @@ def _perform(plan, report, *, keep):
                 raise ConversionRefused(
                     f"[{plan.system}] refused — {gang} no longer reconciles: {failed}"
                 ) from failed
-        if not keep:
-            # Everything held true. Unwind it anyway — that was the ask.
-            raise _Rehearsed

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -25,16 +25,19 @@ and the reconcile assertion proves it gang by gang.
 
 What the ledger *says*, though, is not untouched, and the captures do
 not see it. The gang's history describes an old event by looking up what
-its assignment names now, so moving a row from one kind to another
-rewrites the wording of things that already happened. Every conversion
-must check the history page against a converted row and keep those words
-the same — see the note in ``n26/core/CLAUDE.md``.
+its assignment names now, so moving an assignment from one kind to
+another rewrites the wording of things that already happened. Every
+conversion must check the history page against a converted assignment
+and keep those words the same — see the note in ``n26/core/CLAUDE.md``.
 """
 
+import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 from django.db import transaction
+
+logger = logging.getLogger(__name__)
 
 
 def carriers_of(modifier):
@@ -329,7 +332,7 @@ class Plan:
     problems: tuple = ()
     #: How many gangs the change reaches in all, proven or not.
     reaches: int = 0
-    #: Rows the plan deliberately leaves as they are.
+    #: Assignments the plan deliberately leaves as they are.
     left_alone: int = 0
     #: True when the system simply is not here — nothing to convert and
     #: nothing wrong: the apply is a clean no-op.
@@ -399,9 +402,9 @@ def _one_snapshot():
     worked, refusing for a reason nobody can act on.
 
     Reading from one snapshot instead, what differs is what the run did.
-    Somebody changing a row it also writes ends it in a refusal rather
-    than a guess, which is the right ending for work that cannot be half
-    done. Set on the session, because a transaction's isolation can only
+    Somebody changing an assignment it also writes ends it in a refusal
+    rather than a guess, which is the right ending for work that cannot
+    be half done. Set on the session, because a transaction's isolation can only
     be chosen before it has read anything, and put back afterwards so a
     pooled connection is handed on as it was found.
     """
@@ -433,9 +436,19 @@ def _one_snapshot():
     try:
         yield
     finally:
-        with connection.cursor() as cursor:
-            cursor.execute(
-                f"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL {was}"
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL {was}"
+                )
+        except Exception:
+            # Putting the setting back is courtesy to the next borrower of
+            # this connection, and must never be the thing the caller hears
+            # about. A run that ended badly can leave the connection unable
+            # to answer at all — and one that cannot answer is also one
+            # nobody will be handed again.
+            logger.warning(
+                "could not put the isolation level back to %s", was, exc_info=True
             )
 
 

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -352,9 +352,10 @@ class Plan:
                 f"{'' if self.left_alone == 1 else 's'} exactly as they are"
             )
         reaches = self.reaches or len(self.gang_ids)
+        many = "gangs read" if reaches != 1 else "gang reads"
         lines.append(
             f"[{self.system}] prove {len(self.gang_ids)} of {reaches} reached "
-            "gangs read the same, or refuse"
+            f"{many} the same, or refuse"
         )
         return lines
 

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -376,6 +376,15 @@ def apply(plan):
     return report
 
 
+#: What Postgres may call an isolation level. The restore has to be
+#: written into the statement rather than passed as a value, so what
+#: goes in is checked against this rather than trusted — an answer
+#: nobody expected should stop the run, not travel into SQL.
+ISOLATION_LEVELS = frozenset(
+    {"read uncommitted", "read committed", "repeatable read", "serializable"}
+)
+
+
 @contextmanager
 def _one_snapshot():
     """Ask for the whole run to read one unchanging view of the database.
@@ -413,6 +422,11 @@ def _one_snapshot():
     with connection.cursor() as cursor:
         cursor.execute("SHOW default_transaction_isolation")
         was = cursor.fetchone()[0]
+        if was.lower() not in ISOLATION_LEVELS:
+            raise ConversionRefused(
+                f"the database calls its isolation “{was}”, which is not a "
+                "level this knows how to put back"
+            )
         cursor.execute(
             "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ"
         )

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -400,8 +400,14 @@ def _one_snapshot():
 
     outermost = not connection.in_atomic_block
     if not (outermost and connection.vendor == "postgresql"):
-        # Nested inside someone else's transaction — a test, a shell.
-        # Their snapshot is already the one this reads from.
+        # Nested inside a transaction somebody else opened — a test, a
+        # shell. Isolation can only be chosen before a transaction reads
+        # anything, so it is theirs to set and too late to ask here. That
+        # is not the same as being safe: at the ordinary level each
+        # statement reads afresh, so a caller nesting this while players
+        # are writing would not get the one snapshot promised above.
+        # Nothing does that today — a conversion from the console or the
+        # command opens the transaction itself.
         yield
         return
     with connection.cursor() as cursor:

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -80,6 +80,8 @@ def _solely_carried(offer, carrier, problems):
 
 
 def plan_specialisation():
+    from django.db.models import Count
+
     from n26.core.models import Assignment
     from n26.library.models import Hidden, SlotType, Specialisation, Subtype
 
@@ -142,6 +144,27 @@ def plan_specialisation():
     if unanchored:
         problems.append(
             "picks with no caused_by to settle against: " + ", ".join(unanchored)
+        )
+
+    # A model holding the same question's answer twice. The offer showed
+    # one of them and left the rest lying on the card as free lines; a
+    # slot says every pick it holds, so the page would gain a repeated
+    # answer and lose those lines. That is a change to what a reader is
+    # told, and not one a conversion may make unasked — the spare
+    # assignments are for their owner to part with first.
+    crowded = list(
+        Assignment.objects.filter(specialisation__isnull=False, archived=False)
+        .values("miniature_id")
+        .annotate(held=Count("id"))
+        .filter(held__gt=1)
+    )
+    if crowded:
+        named = ", ".join(
+            f"{row['miniature_id']} ({row['held']})" for row in crowded[:10]
+        )
+        problems.append(
+            f"{len(crowded)} model(s) hold more than one specialisation, which "
+            f"one slot cannot say the same way: {named}"
         )
 
     # Hidden names are unique only together with their qualifier, so a

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -2,18 +2,27 @@
 
 Today: the "Specialist" subtype carries a bearer offer of the whole
 specialisation kind; eight specialisations each add one skill to the
-bearer. Two hiddens are the fossil of an abandoned narrowing
-experiment: "Specialisation Offer" [(general)] — held by nothing,
-granted by a modifier nothing carries, and removed by a live no-op on
-the Subjugator Patrol Officer profile — and "Specialisation offer"
-[(Subjugator Patrol Officer)], whose narrowed menu is still held by
-whoever an owner gave it to.
+bearer. A second, narrowed offer rides the "Specialisation offer"
+hidden, which an owner gave to a Subjugator Patrol Officer.
 
 After: a "Specialisation" slot type; the eight as pickables on one
-picklist; a bearer slot granted by the same subtype. The Subjugator
+picklist; a bearer slot granted by the same subtype. The narrowed
 hidden keeps its purpose — its offer becomes a grant of a second slot
-over its own narrow picklist, so a holder's page asks the same
-question. The general hidden and both menu collections retire.
+over its own narrow picklist, so a holder's page asks the same question.
+
+**Nothing is deleted.** The switch is what the pages read from, and no
+page reads anything from an old row once nothing offers it. Retiring
+those rows is tidiness, and tidiness is what made this hard: every
+protected reference, every fossil of an abandoned experiment, every
+stray assignment nobody meant to make had to be reasoned about before a
+single pick could move. Left alone, they go on saying exactly what they
+say now, and can be cleared away later by someone with time to look at
+them one at a time.
+
+That is why a doubled answer — the same specialisation assigned twice,
+which the page shows as the answer plus a spare line in the gear list —
+needs nothing from this conversion. The answer becomes a pick; the spare
+stays as it is and goes on drawing the line it draws today.
 
 Production converts from the maintenance console, once, after the code
 deploys — see :mod:`n26.maintenance`. Elsewhere the command does it
@@ -25,10 +34,7 @@ from n26.library.conversion.base import (
     CreatePicklist,
     CreateSlot,
     CreateSlotType,
-    DropModifier,
     Plan,
-    Retire,
-    RetireModifier,
     RewritePick,
     SwapCarrier,
     carriers_of,
@@ -38,9 +44,22 @@ SUBTYPE = "Specialist"
 SLOT_TYPE = "Specialisation"
 PICKLIST = "Specialisations"
 NARROW_HIDDEN = "Specialisation offer"
-GENERAL_HIDDEN = "Specialisation Offer"
 NARROW_PICKLIST = "Subjugator Patrol Officer options"
 NARROW_SLOT = "Specialisation (Subjugator Patrol Officer)"
+
+#: How many gangs the apply proves unchanged before committing.
+#:
+#: Not all of them, deliberately. Rendering every affected gang twice
+#: takes minutes, and minutes inside a transaction on a live app is a
+#: worse thing to be than incompletely proven — it holds rows players
+#: are using and collides with what they do meanwhile. The failures this
+#: has actually caught were all shaped by the content, not by one gang's
+#: data, so they show up in any gang the change reaches; and the ones
+#: that *are* particular to a gang are found by asking the database
+#: plainly, which costs a second. So: a spread wide enough to include
+#: every shape the system comes in, proven with the lock held for
+#: seconds.
+PROVEN = 25
 
 
 def _offers_of(carrier):
@@ -66,8 +85,8 @@ def _the_offer(carrier, problems, said):
 def _solely_carried(offer, carrier, problems):
     """Deleting an offer's modifier detaches it from every carrier at
     once, so the plan must know no third thing shares it — a sharer's
-    gangs are outside the capture set and would lose their question
-    unproven."""
+    gangs are outside the proven set and would lose their question
+    unnoticed."""
     others = [
         f"{kind} “{row}”"
         for kind, row in carriers_of(offer)
@@ -79,9 +98,45 @@ def _solely_carried(offer, carrier, problems):
         )
 
 
-def plan_specialisation():
-    from django.db.models import Count
+def _answers(picks):
+    """One pick per question, and the spares left behind.
 
+    The same question answered twice — a click that landed twice — shows
+    on the page as the answer plus a spare line in the gear list. Moving
+    the answer keeps the page: the pick becomes a pick, and the spare
+    goes on being the ordinary assignment it already is.
+    """
+    answers, spares, seen = [], [], set()
+    for pick in picks:
+        question = (pick.miniature_id, pick.caused_by_id)
+        if question in seen:
+            spares.append(pick)
+        else:
+            seen.add(question)
+            answers.append(pick)
+    return answers, spares
+
+
+def _spread(gang_ids, kinds, limit):
+    """A sample wide enough to hold every shape, in a stable order.
+
+    Takes from each kind in turn so no one kind crowds the others out,
+    and keeps the gangs that are odd in some way — the ones a wider
+    sweep would have been for.
+    """
+    chosen, used = [], set()
+    for wanted in kinds:
+        for gang_id in wanted:
+            if gang_id in used or gang_id not in gang_ids:
+                continue
+            used.add(gang_id)
+            chosen.append(gang_id)
+            if len(chosen) >= limit:
+                return chosen
+    return chosen
+
+
+def plan_specialisation():
     from n26.core.models import Assignment
     from n26.library.models import Hidden, SlotType, Specialisation, Subtype
 
@@ -108,68 +163,13 @@ def plan_specialisation():
             )
         _solely_carried(offer, subtype, problems)
 
-    # The capture set is found through stored assignments, so a
-    # Specialist subtype arriving by grant would reach gangs the plan
-    # cannot enumerate.
-    from n26.library.models import AddsAssignable, Modifier, RemovesAssignable
-
-    for effect_row in AddsAssignable.objects.filter(subtype=subtype):
-        granter = Modifier.objects.filter(adds_assignable=effect_row).first()
-        if granter is not None and carriers_of(granter):
-            problems.append(
-                f"“{granter.name}” grants the “{SUBTYPE}” subtype — the plan "
-                "cannot find the gangs that reaches"
-            )
-
     old_rows = list(Specialisation.objects.filter(archived=False).order_by("name"))
     if not old_rows:
         problems.append("no specialisations to convert")
-    # An archived row would escape every step — not a pickable, not
-    # retired, and any stored pick naming it only failing at apply.
-    # Whether it should convert or die is a content decision, so the
-    # plan refuses rather than deciding.
-    ghosts = Specialisation.objects.filter(archived=True).order_by("name")
-    if ghosts:
-        problems.append(
-            "archived specialisations the plan does not convert: "
-            + ", ".join(row.name for row in ghosts)
-        )
-
-    picks = list(
-        Assignment.objects.filter(specialisation__isnull=False)
-        .select_related("specialisation", "gang_root", "caused_by")
-        .order_by("created")
-    )
-    unanchored = [str(pick.pk) for pick in picks if pick.caused_by_id is None]
-    if unanchored:
-        problems.append(
-            "picks with no caused_by to settle against: " + ", ".join(unanchored)
-        )
-
-    # A model holding the same question's answer twice. The offer showed
-    # one of them and left the rest lying on the card as free lines; a
-    # slot says every pick it holds, so the page would gain a repeated
-    # answer and lose those lines. That is a change to what a reader is
-    # told, and not one a conversion may make unasked — the spare
-    # assignments are for their owner to part with first.
-    crowded = list(
-        Assignment.objects.filter(specialisation__isnull=False, archived=False)
-        .values("miniature_id")
-        .annotate(held=Count("id"))
-        .filter(held__gt=1)
-    )
-    if crowded:
-        named = ", ".join(
-            f"{row['miniature_id']} ({row['held']})" for row in crowded[:10]
-        )
-        problems.append(
-            f"{len(crowded)} model(s) hold more than one specialisation, which "
-            f"one slot cannot say the same way: {named}"
-        )
 
     # Hidden names are unique only together with their qualifier, so a
-    # name here must resolve to one row or the plan cannot know which
-    # it is converting.
+    # name here must resolve to one row or the plan cannot know which it
+    # is converting.
     def _the_hidden(name):
         found = list(Hidden.objects.filter(name=name, archived=False))
         if len(found) > 1:
@@ -177,11 +177,8 @@ def plan_specialisation():
             return None
         return found[0] if found else None
 
-    # The Subjugator fossil: kept, converted — its holder's page must go
-    # on asking the same narrowed question.
     narrow = _the_hidden(NARROW_HIDDEN)
     narrow_offer = None
-    narrow_menu = None
     narrow_names = []
     if narrow is not None:
         narrow_offer = _the_offer(narrow, problems, f"the “{NARROW_HIDDEN}” hidden")
@@ -191,10 +188,9 @@ def plan_specialisation():
             if section is None:
                 problems.append(f"the “{NARROW_HIDDEN}” offer names no menu")
             else:
-                narrow_menu = section.collection
                 narrow_names = [
                     entry.specialisation.name
-                    for entry in narrow_menu.entries.filter(
+                    for entry in section.collection.entries.filter(
                         specialisation__isnull=False
                     ).select_related("specialisation")
                 ]
@@ -205,108 +201,36 @@ def plan_specialisation():
                         "not: " + ", ".join(sorted(strangers))
                     )
 
-    # The general fossil: retired — the plan must know nothing holds it,
-    # nothing grants it, and every stray reference is itself dead.
-    general = _the_hidden(GENERAL_HIDDEN)
-    general_offer = None
-    general_menu = None
-    stray_effects = []
-    drop_carrier_gangs = set()
-    if general is not None:
-        if Assignment.objects.filter(hidden=general).exists():
-            problems.append(
-                f"the “{GENERAL_HIDDEN}” hidden is held by someone — it cannot retire"
-            )
-        general_offers = _offers_of(general)
-        if len(general_offers) > 1:
-            problems.append(
-                f"the “{GENERAL_HIDDEN}” hidden carries "
-                f"{len(general_offers)} specialisation offers — expected at most one"
-            )
-        # A fossil that lost its offer already is simply retirable.
-        general_offer = general_offers[0] if general_offers else None
-        if general_offer is not None:
-            _solely_carried(general_offer, general, problems)
-            if general_offer.offers_choice.from_section_id:
-                general_menu = general_offer.offers_choice.from_section.collection
-        # The abandoned narrowing experiment left wiring behind that
-        # still names the hidden, and would protect it from retiring. A
-        # bare effect row, or a whole modifier nothing carries, is dead
-        # and retires with it. A carried modifier that only *removes*
-        # the hidden is a read-time no-op — nothing grants the hidden
-        # and nobody holds it, both proven above — so it drops from its
-        # one carrier, and that carrier's gangs join the capture set so
-        # the no-op is proven, not assumed. A carried modifier that
-        # grants the hidden is live wiring, and a problem.
-        assignment_columns = {
-            label: column for column, label in Assignment.ASSIGNABLE_FIELDS.items()
-        }
-        for model, label, column in (
-            (AddsAssignable, "library.AddsAssignable", "adds_assignable"),
-            (RemovesAssignable, "library.RemovesAssignable", "removes_assignable"),
-        ):
-            for effect_row in model.objects.filter(hidden=general):
-                alive = Modifier.objects.filter(**{column: effect_row}).first()
-                if alive is None:
-                    stray_effects.append(
-                        Retire(model=label, pk=effect_row.pk, name=str(effect_row))
-                    )
-                    continue
-                holders = carriers_of(alive)
-                if not holders:
-                    stray_effects.append(
-                        RetireModifier(modifier_id=alive.pk, modifier_name=alive.name)
-                    )
-                elif column == "adds_assignable":
-                    problems.append(
-                        f"“{alive.name}” still grants the “{GENERAL_HIDDEN}” "
-                        "hidden — it cannot retire"
-                    )
-                elif len(holders) != 1:
-                    problems.append(
-                        f"“{alive.name}” removes the “{GENERAL_HIDDEN}” hidden "
-                        f"from {len(holders)} carriers — the plan only drops "
-                        "it from one"
-                    )
-                else:
-                    kind, holder = holders[0]
-                    holder_column = assignment_columns.get(f"library.{kind}")
-                    if holder_column is None:
-                        problems.append(
-                            f"“{alive.name}” is carried by {kind} “{holder}” — "
-                            "the plan cannot find that carrier's gangs"
-                        )
-                        continue
-                    drop_carrier_gangs.update(
-                        Assignment.objects.filter(
-                            **{holder_column: holder}
-                        ).values_list("gang_root_id", flat=True)
-                    )
-                    stray_effects.append(
-                        DropModifier(
-                            carrier=(f"library.{kind}", holder.pk),
-                            carrier_name=f"the “{holder}” {kind.lower()}",
-                            modifier_id=alive.pk,
-                            modifier_name=alive.name,
-                        )
-                    )
+    # Only live answers move. An archived pick is history nothing draws,
+    # and with no old row being deleted there is nothing to make it
+    # follow.
+    picks = list(
+        Assignment.objects.filter(specialisation__isnull=False, archived=False)
+        .exclude(removes=True)
+        .select_related("specialisation", "gang_root", "caused_by")
+        .order_by("created")
+    )
+    answers, spares = _answers(picks)
 
-    # Each pick settles onto the slot its own anchor grants: the
-    # subtype's holders answer the general question, the narrow
-    # hidden's holders answer their narrowed one. An anchor the plan
-    # does not recognise has no slot to settle on.
+    # Each pick settles on the slot its own anchor grants.
+    becoming = {row.name for row in old_rows}
     pick_slots = {}
-    for pick in picks:
+    for pick in answers:
+        if pick.specialisation.name not in becoming:
+            problems.append(
+                f"pick {pick.pk} names “{pick.specialisation.name}”, which is "
+                "not becoming a pickable"
+            )
         if pick.caused_by_id is None:
-            continue
-        if pick.caused_by.subtype_id == subtype.pk:
+            problems.append(f"pick {pick.pk} has no caused_by to settle against")
+        elif pick.caused_by.subtype_id == subtype.pk:
             pick_slots[pick.pk] = SLOT_TYPE
         elif narrow is not None and pick.caused_by.hidden_id == narrow.pk:
             pick_slots[pick.pk] = NARROW_SLOT
         else:
             problems.append(
-                f"pick {pick.pk} is anchored on “{pick.caused_by}”, which "
-                "the plan does not recognise"
+                f"pick {pick.pk} is anchored on “{pick.caused_by}”, which the "
+                "plan does not recognise"
             )
 
     if problems:
@@ -380,52 +304,43 @@ def plan_specialisation():
             slot=pick_slots[pick.pk],
             gang=str(pick.gang_root),
         )
-        for pick in picks
-    ]
-    if general is not None:
-        if general_offer is not None:
-            steps.append(
-                DropModifier(
-                    carrier=("library.Hidden", general.pk),
-                    carrier_name=f"the “{GENERAL_HIDDEN}” hidden",
-                    modifier_id=general_offer.pk,
-                    modifier_name=general_offer.name,
-                )
-            )
-        steps += stray_effects
-        if general_menu is not None:
-            steps.append(
-                Retire(
-                    model="library.Collection",
-                    pk=general_menu.pk,
-                    name=general_menu.name,
-                )
-            )
-        steps.append(Retire(model="library.Hidden", pk=general.pk, name=str(general)))
-    if narrow_menu is not None:
-        steps.append(
-            Retire(model="library.Collection", pk=narrow_menu.pk, name=narrow_menu.name)
-        )
-    steps += [
-        Retire(model="library.Specialisation", pk=row.pk, name=row.name)
-        for row in old_rows
+        for pick in answers
     ]
 
-    gang_ids = sorted(
-        {
-            *(
-                Assignment.objects.filter(archived=False, subtype=subtype)
-                .values_list("gang_root_id", flat=True)
-                .distinct()
-            ),
-            *(pick.gang_root_id for pick in picks),
-            *(
-                Assignment.objects.filter(
-                    archived=False, hidden__in=[h for h in (narrow,) if h]
-                ).values_list("gang_root_id", flat=True)
-            ),
-            *drop_carrier_gangs,
-        },
-        key=str,
+    # Every gang the change can reach, and then the spread actually
+    # proven: one holding a doubled answer, one holding the narrowed
+    # question, one that never answered, and ordinary ones.
+    holders = set(
+        Assignment.objects.filter(archived=False, subtype=subtype)
+        .values_list("gang_root_id", flat=True)
+        .distinct()
     )
-    return Plan(system="specialisation", steps=tuple(steps), gang_ids=tuple(gang_ids))
+    if narrow is not None:
+        holders |= set(
+            Assignment.objects.filter(archived=False, hidden=narrow).values_list(
+                "gang_root_id", flat=True
+            )
+        )
+    answered = {pick.gang_root_id for pick in answers}
+    holders |= answered
+    proven = _spread(
+        holders,
+        [
+            [pick.gang_root_id for pick in spares],
+            [
+                pick.gang_root_id
+                for pick in answers
+                if pick_slots.get(pick.pk) == NARROW_SLOT
+            ],
+            sorted(holders - answered, key=str),
+            sorted(answered, key=str),
+        ],
+        PROVEN,
+    )
+    return Plan(
+        system="specialisation",
+        steps=tuple(steps),
+        gang_ids=tuple(proven),
+        reaches=len(holders),
+        left_alone=len(spares),
+    )

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -310,16 +310,20 @@ def plan_specialisation():
     # Every gang the change can reach, and then the spread actually
     # proven: one holding a doubled answer, one holding the narrowed
     # question, one that never answered, and ordinary ones.
+    # Removal machinery is not a holding: a subtype taken away would
+    # otherwise read as one held, and count a gang the change never
+    # reaches.
     holders = set(
         Assignment.objects.filter(archived=False, subtype=subtype)
+        .exclude(removes=True)
         .values_list("gang_root_id", flat=True)
         .distinct()
     )
     if narrow is not None:
         holders |= set(
-            Assignment.objects.filter(archived=False, hidden=narrow).values_list(
-                "gang_root_id", flat=True
-            )
+            Assignment.objects.filter(archived=False, hidden=narrow)
+            .exclude(removes=True)
+            .values_list("gang_root_id", flat=True)
         )
     answered = {pick.gang_root_id for pick in answers}
     holders |= answered

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -236,7 +236,11 @@ def plan_specialisation():
     # the change, and pages nothing checked would move. Refuse instead:
     # nothing grants either of these today, and whoever makes one should
     # decide what this ought to do.
-    for held, said in ((subtype, f"the “{SUBTYPE}” subtype"), (narrow, NARROW_HIDDEN)):
+    granted = (
+        (subtype, f"the “{SUBTYPE}” subtype"),
+        (narrow, f"the “{NARROW_HIDDEN}” hidden"),
+    )
+    for held, said in granted:
         if held is None:
             continue
         for granter in Modifier.objects.filter(

--- a/n26/library/conversion/specialisation.py
+++ b/n26/library/conversion/specialisation.py
@@ -138,7 +138,14 @@ def _spread(gang_ids, kinds, limit):
 
 def plan_specialisation():
     from n26.core.models import Assignment
-    from n26.library.models import Hidden, SlotType, Specialisation, Subtype
+    from n26.library.models import (
+        AddsAssignable,
+        Hidden,
+        Modifier,
+        SlotType,
+        Specialisation,
+        Subtype,
+    )
 
     problems = []
 
@@ -166,6 +173,17 @@ def plan_specialisation():
     old_rows = list(Specialisation.objects.filter(archived=False).order_by("name"))
     if not old_rows:
         problems.append("no specialisations to convert")
+    # A pick is matched to its pickable by name, and a name is only unique
+    # within a pack and qualifier — so two live rows called the same thing
+    # would quietly become one pickable, and half the picks would land on
+    # the wrong one.
+    twice = sorted(
+        {row.name for row in old_rows if [r.name for r in old_rows].count(row.name) > 1}
+    )
+    if twice:
+        problems.append(
+            "more than one live specialisation is called: " + ", ".join(twice)
+        )
 
     # Hidden names are unique only together with their qualifier, so a
     # name here must resolve to one row or the plan cannot know which it
@@ -211,6 +229,26 @@ def plan_specialisation():
         .order_by("created")
     )
     answers, spares = _answers(picks)
+
+    # A carrier that arrives by grant has no assignment to find it by,
+    # so the gangs it reaches cannot be counted and cannot be drawn into
+    # the spread this proves. The number on the apply page would understate
+    # the change, and pages nothing checked would move. Refuse instead:
+    # nothing grants either of these today, and whoever makes one should
+    # decide what this ought to do.
+    for held, said in ((subtype, f"the “{SUBTYPE}” subtype"), (narrow, NARROW_HIDDEN)):
+        if held is None:
+            continue
+        for granter in Modifier.objects.filter(
+            adds_assignable__in=AddsAssignable.objects.filter(
+                **{type(held).__name__.lower(): held}
+            )
+        ):
+            if carriers_of(granter):
+                problems.append(
+                    f"“{granter.name}” grants {said}, so the gangs it reaches "
+                    "cannot be counted or proven"
+                )
 
     # Each pick settles on the slot its own anchor grants.
     becoming = {row.name for row in old_rows}

--- a/n26/library/management/commands/n26_convert.py
+++ b/n26/library/management/commands/n26_convert.py
@@ -1,9 +1,9 @@
 """Plan or apply a slots-and-picks conversion, from the shell.
 
-The rehearsal tool: point it at a database holding the system (a fork of
-the prod mirror, a restore of a full dump) and read the plan; add
-``--apply`` to perform it, with the conversion's own refusal standing
-between the plan and a committed write.
+Point it at a database holding the system (a fork of the prod mirror, a
+restore of a full dump) and read the plan; add ``--apply`` to perform
+it, with the conversion's own refusal standing between the plan and a
+committed write.
 
 This is how a conversion is checked before it ships, and how a database
 nobody runs a console against — a developer's, an old fork — is brought
@@ -27,25 +27,9 @@ class Command(BaseCommand):
             action="store_true",
             help="Perform the plan. Without this, the plan is printed and nothing is written.",
         )
-        parser.add_argument(
-            "--rehearse",
-            action="store_true",
-            help=(
-                "Perform the whole plan, prove every page, then unwind it. "
-                "Answers whether the conversion works on this database "
-                "without changing it."
-            ),
-        )
 
     def handle(self, *args, **options):
         plan = SYSTEMS[options["system"]]()
-        if options["rehearse"]:
-            try:
-                for line in apply(plan, keep=False):
-                    self.stdout.write(line)
-            except ConversionRefused as refused:
-                raise CommandError(str(refused)) from None
-            return
         if not options["apply"]:
             for problem in plan.problems:
                 self.stdout.write(self.style.ERROR(f"problem: {problem}"))

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -165,8 +165,13 @@ def _claim(backfill_id):
 
 
 @task
-def convert_specialisation(backfill_id):
+def convert_specialisation(backfill_id, **said_by_whoever_enqueued_it):
     """Run the Specialisation conversion, once, and write down the outcome.
+
+    Takes whatever else it is handed and ignores it. Delivery outlives a
+    deploy, so a message can arrive naming arguments the version that
+    enqueued it had and this one does not — and a task that refuses its
+    own message is retried for ever, there being nowhere for it to go.
 
     Never raises: a task that fails is redelivered, and there is nowhere
     for a raised error to go but round again. Every ending — refused,

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -179,6 +179,23 @@ def convert_specialisation(backfill_id, **said_by_whoever_enqueued_it):
     """
     from n26.library.conversion import ConversionRefused, apply
 
+    # A message from a version that could be told not to keep its work.
+    # Ignoring the instruction would turn the careful thing somebody asked
+    # for into the committing one, which is the opposite of what they
+    # wanted; there is no rehearsing any more, so the honest answer is to
+    # decline it.
+    if said_by_whoever_enqueued_it.get("keep") is False:
+        _write(
+            backfill_id,
+            status=Backfill.Status.FAILED,
+            error=(
+                "This asked to be rehearsed and then thrown away, which this "
+                "version cannot do. Nothing was run. Ask for it again from "
+                "the page."
+            ),
+        )
+        return
+
     # The lock comes first, and nothing is recorded before it is held. A
     # redelivery arriving while the first copy is still working must leave
     # no trace at all: count its arrival as an attempt and a long run could
@@ -245,6 +262,17 @@ def convert_specialisation_view(request):
             # the screen of whoever asked for it.
             messages.error(
                 request, "The conversion refuses: " + "; ".join(plan.problems)
+            )
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_n26_convert_specialisation")
+            )
+        if request.POST.get("keep") == "no":
+            # A page open since before the rehearsal was taken away. Its
+            # gentler button would land here and convert for real.
+            messages.warning(
+                request,
+                "That page offered a rehearsal, which no longer exists. "
+                "Nothing has been run — reload and apply if you mean to.",
             )
             return HttpResponseRedirect(
                 reverse("admin:maintenance_n26_convert_specialisation")

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -165,13 +165,8 @@ def _claim(backfill_id):
 
 
 @task
-def convert_specialisation(backfill_id, keep=True):
+def convert_specialisation(backfill_id):
     """Run the Specialisation conversion, once, and write down the outcome.
-
-    With ``keep=False`` it rehearses: the whole conversion performed and
-    every page proven, then unwound on purpose, so a database holding
-    real gangs can be asked whether this works without being changed by
-    the answer.
 
     Never raises: a task that fails is redelivered, and there is nowhere
     for a raised error to go but round again. Every ending — refused,
@@ -201,7 +196,7 @@ def convert_specialisation(backfill_id, keep=True):
             return
 
         try:
-            report = apply(_plan(), keep=keep)
+            report = apply(_plan())
         except ConversionRefused as refused:
             # A refusal is the discipline working: nothing was written,
             # and the reason is already in words.
@@ -219,7 +214,7 @@ def convert_specialisation(backfill_id, keep=True):
         _write(
             backfill_id,
             status=Backfill.Status.DONE,
-            summary_patch={"report": list(report), "kept": bool(keep)},
+            summary_patch={"report": list(report)},
         )
 
 
@@ -249,23 +244,15 @@ def convert_specialisation_view(request):
             return HttpResponseRedirect(
                 reverse("admin:maintenance_n26_convert_specialisation")
             )
-        # Keeping the work is the thing that must be asked for. A request
-        # that does not say so — a page from before there were two
-        # buttons, something calling the address directly — rehearses,
-        # which is the ending nobody has to undo.
-        keep = request.POST.get("keep") == "yes"
         backfill = Backfill.objects.create(
             operation=Operation.CONVERT_SPECIALISATION,
             triggered_by=request.user,
             status=Backfill.Status.RUNNING,
-            summary={"preview": list(plan.preview()), "attempts": 0, "kept": keep},
+            summary={"preview": list(plan.preview()), "attempts": 0},
         )
-        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=keep)
+        convert_specialisation.enqueue(backfill_id=str(backfill.id))
         messages.success(
-            request,
-            "The conversion is running. This page shows what it did."
-            if keep
-            else "The rehearsal is running. Nothing will be kept.",
+            request, "The conversion is running. This page shows what it did."
         )
         return HttpResponseRedirect(
             reverse("admin:maintenance_backfill_detail", args=[backfill.id])

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -264,7 +264,12 @@ def convert_specialisation_view(request):
         Operation.CONVERT_SPECIALISATION.label,
         plan=plan,
         preview=list(plan.preview()),
-        gangs=len(plan.gang_ids),
+        # Two different numbers, and confusing them on a page with an
+        # apply button would tell an operator the change is smaller than
+        # it is: one is how many gangs it reaches, the other how many of
+        # them it proves before committing.
+        reaches=plan.reaches,
+        proven=len(plan.gang_ids),
         apply_url=reverse("admin:maintenance_n26_convert_specialisation"),
         recent=Backfill.objects.filter(operation=Operation.CONVERT_SPECIALISATION)[:10],
     )

--- a/n26/tests/sandbox/test_conversion_paths.py
+++ b/n26/tests/sandbox/test_conversion_paths.py
@@ -108,7 +108,7 @@ class TestThePlan:
         assert said.count("rewrite pick") == 1
         assert "retire library.Collection “Paths”" in said
         assert said.count("retire library.Affiliation") == 2
-        assert "prove 2 gangs read the same, or refuse" in said
+        assert "prove 2 of 2 reached gangs read the same, or refuse" in said
 
     def test_it_writes_nothing(self, gangs):
         before = Assignment.objects.count()

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -360,6 +360,22 @@ class TestTheApply:
 
 
 class TestTheRefusals:
+    def test_a_granted_carrier_is_refused(self, world, prod_shape):
+        """A carrier that arrives by grant has no assignment to find it
+        by, so the gangs it reaches can be neither counted nor proven."""
+        specialist, _, _, _ = prod_shape
+        modifier(
+            "Rank grants Specialist",
+            targets_model(),
+            ef_adds(specialist),
+            carried_by=create_subtype("Sergeant"),
+        )
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any("cannot be counted" in problem for problem in plan.problems)
+
     def test_two_hiddens_sharing_a_name_are_refused(self, world):
         create_hidden("Specialisation offer", qualifier="(a second one)")
 
@@ -421,3 +437,45 @@ def _story(acts):
         told.append("".join(span.text for span in act.spans))
         told.extend(f"{sub.name}|{sub.kind}|{sub.note}" for sub in act.subs)
     return told
+
+
+class TestTheSpread:
+    """Which gangs get proven, when there are more than the run will
+    prove. The world above holds two, so the choosing never bites there —
+    and this is the part carrying the claim that a sample is enough."""
+
+    def test_it_takes_from_every_kind_before_filling_up(self):
+        from n26.library.conversion.specialisation import _spread
+
+        odd, narrow, quiet, ordinary = ["a"], ["b"], ["c", "d"], list("efghijkl")
+        reached = set(odd + narrow + quiet + ordinary)
+
+        chosen = _spread(reached, [odd, narrow, quiet, ordinary], 5)
+
+        # The odd ones first, in the order the kinds were given.
+        assert chosen[:4] == ["a", "b", "c", "d"]
+        assert len(chosen) == 5
+
+    def test_it_stops_at_the_limit_and_repeats_nobody(self):
+        from n26.library.conversion.specialisation import _spread
+
+        everyone = [str(n) for n in range(40)]
+
+        chosen = _spread(set(everyone), [everyone, everyone], 25)
+
+        assert len(chosen) == 25
+        assert len(set(chosen)) == 25
+
+    def test_it_offers_nobody_the_change_does_not_reach(self):
+        from n26.library.conversion.specialisation import _spread
+
+        chosen = _spread({"a"}, [["a", "stranger"]], 25)
+
+        assert chosen == ["a"]
+
+    def test_it_takes_everyone_when_there_are_fewer_than_the_limit(self):
+        from n26.library.conversion.specialisation import _spread
+
+        chosen = _spread({"a", "b"}, [["a"], ["b"]], 25)
+
+        assert sorted(chosen) == ["a", "b"]

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -1,10 +1,14 @@
 """The Specialisation conversion, proven on a prod-shaped world.
 
-The Specialist subtype's whole-kind offer becomes a granted bearer
-slot; the specialisations become pickables carrying their same skill
-grants; the two fossil hiddens are handled each their own way — the
-narrowed Subjugator one converts so its holder's page keeps asking the
-same question, the unheld general one retires with its menu.
+The Specialist subtype's whole-kind offer becomes a granted bearer slot
+and the specialisations become pickables carrying their same skill
+grants. The narrowed Subjugator hidden converts too, so its holder's
+page keeps asking the same question.
+
+Nothing is deleted, which is most of what these tests are for: the old
+rows, the abandoned experiment's fossil and its stray wiring, an
+archived answer, and a spare left by a click that landed twice are all
+still there afterwards, saying exactly what they said before.
 """
 
 import pytest
@@ -13,13 +17,12 @@ from django.contrib.auth.models import User
 from n26.core.capture import differences, gang_state
 from n26.core.models import Assignment
 from n26.core.reconcile import assert_reconciled
-from n26.library.conversion import ConversionRefused, apply, plan_specialisation
+from n26.library.conversion import apply, plan_specialisation
 from n26.library.models import (
     Collection,
     Hidden,
     Pickable,
     Slot,
-    SlotType,
     Specialisation,
 )
 from n26.tests.sandbox.actions import (
@@ -193,22 +196,17 @@ class TestThePlan:
             in said
         )
         assert "replace “Subjugator offer”" in said
-        assert said.count("rewrite pick") == 4
-        assert "retire “General offer”" in said
-        assert (
-            "retire the carrierless modifier "
-            "“Specialist: adds Specialisation Offer”" in said
-        )
-        assert (
-            "on the “Patrol Officer” profile: retire "
-            "“Patrol Officer: removes Specialisation Offer”" in said
-        )
-        assert "retire library.AddsAssignable" in said
-        assert "retire library.RemovesAssignable" in said
-        assert "retire library.Hidden “Specialisation Offer" in said
-        assert said.count("retire library.Collection") == 2
-        assert said.count("retire library.Specialisation") == 4
-        assert "prove 2 gangs read the same, or refuse" in said
+        # The three live answers. The switched fighter's archived one
+        # stays where it is: nothing is deleted, so nothing makes it move.
+        assert said.count("rewrite pick") == 3
+        assert "prove 2 of 2 reached gangs read the same, or refuse" in said
+
+    def test_it_deletes_nothing(self, world):
+        """Retiring the old rows is tidiness, and tidiness is what made
+        this hard. Left alone they go on saying what they say now."""
+        said = "\n".join(plan_specialisation().preview())
+
+        assert "retire" not in said
 
 
 class TestTheApply:
@@ -222,8 +220,9 @@ class TestTheApply:
             assert differences(before[gang.pk], gang_state(gang)) == []
             assert_reconciled(gang)
 
-    def test_live_and_archived_picks_are_rewritten(self, world, prod_shape):
-        specialist, _, _, _ = prod_shape
+    def test_the_live_answer_moves_and_the_archived_one_stays(self, world):
+        """History is not drawn, and nothing is being deleted out from
+        under it, so it keeps the shape it was written in."""
         _, fighters = world
 
         apply(plan_specialisation())
@@ -232,29 +231,63 @@ class TestTheApply:
             miniature=fighters["switched"], pickable__isnull=False, archived=False
         )
         assert live.pickable.name == "Gunner"
-        archived = Assignment.objects.get(
-            miniature=fighters["switched"], pickable__isnull=False, archived=True
-        )
-        assert archived.pickable.name == "Medic"
-        for row in (live, archived):
-            assert row.specialisation_id is None
-            assert row.chosen_for_id == row.caused_by_id
-            assert row.chosen_for_slot == Slot.objects.get(name="Specialisation")
+        assert live.specialisation_id is None
+        assert live.chosen_for_id == live.caused_by_id
+        assert live.chosen_for_slot == Slot.objects.get(name="Specialisation")
 
-    def test_the_fossils_end_their_own_ways(self, world):
+        archived = Assignment.objects.get(
+            miniature=fighters["switched"], archived=True, specialisation__isnull=False
+        )
+        assert archived.specialisation.name == "Medic"
+        assert archived.pickable_id is None
+
+    def test_a_doubled_answer_keeps_its_spare_untouched(self, world, prod_shape):
+        """A click that landed twice leaves the answer plus a spare line
+        in the gear list. Moving the answer must leave that page alone."""
+        specialist, specs, _, _ = prod_shape
+        _, fighters = world
+        anchor = Assignment.objects.get(
+            subtype=specialist, miniature=fighters["settled"]
+        )
+        choose(anchor, specs["Sniper"])  # the same answer, a second time
+        gang = fighters["settled"].gang
+        before = gang_state(gang)
+
+        plan = plan_specialisation()
+        apply(plan)
+
+        assert plan.ok
+        assert plan.left_alone == 1
+        assert differences(before, gang_state(gang)) == []
+        spare = Assignment.objects.get(
+            miniature=fighters["settled"], specialisation__isnull=False, archived=False
+        )
+        assert spare.specialisation.name == "Sniper"
+        assert spare.pickable_id is None
+
+    def test_the_story_already_written_says_the_same_words(self, world):
+        """History describes an old event by what its assignment names
+        now, so a conversion can rewrite the past by accident. The pick
+        reports the question it answered, which is the word it always
+        had."""
+        from n26.core import history
+
+        gang = world[0][0]
+        said = _story(history.build(gang))
+
         apply(plan_specialisation())
 
-        from n26.library.models import Modifier
+        assert _story(history.build(gang)) == said
+        assert any("Sniper" in line for line in said)
 
-        assert not Hidden.objects.filter(qualifier="(general)").exists()
-        assert not Modifier.objects.filter(
-            name__icontains="Specialisation Offer"
-        ).exists()
-        subjugator = Hidden.objects.get(name="Specialisation offer")
-        grants = [m for m in subjugator.modifiers.all() if m.effect.slot is not None]
-        assert len(grants) == 1
-        assert not Collection.objects.filter(name__startswith="Specialisation").exists()
-        assert not Specialisation.objects.exists()
+    def test_the_old_rows_and_the_fossil_are_left_alone(self, world, prod_shape):
+        _, _, _, general = prod_shape
+
+        apply(plan_specialisation())
+
+        assert Specialisation.objects.filter(archived=False).count() == 4
+        assert Hidden.objects.filter(pk=general.pk).exists()
+        assert Collection.objects.filter(name__icontains="specialisation").count() == 2
 
     def test_the_subjugator_holder_still_asks_a_narrow_question(self, world):
         _, fighters = world
@@ -296,45 +329,6 @@ class TestTheApply:
             name="Specialisation (Subjugator Patrol Officer)"
         )
 
-    def test_a_general_fossil_with_no_offer_still_retires(self, world, prod_shape):
-        _, _, _, general = prod_shape
-        offer = next(
-            m
-            for m in general.modifiers.all()
-            if getattr(m, "offers_choice", None) is not None
-        )
-        scope_row, effect_row = offer.scope, offer.effect
-        general.modifiers.remove(offer)
-        offer.delete()
-        scope_row.delete()
-        effect_row.delete()
-        Collection.objects.get(name="Specialisation Offer").delete()
-
-        apply(plan_specialisation())
-
-        assert not Hidden.objects.filter(qualifier="(general)").exists()
-
-    def test_a_dropped_removes_carriers_gangs_join_the_capture_set(
-        self, world, prod_shape, person_type, owner
-    ):
-        _, _, _, general = prod_shape
-        watch = create_gang_type("The Watch Rotation", starting_credits=1000)
-        watchman = create_profile("Watchman", person_type, watch, price=50)
-        modifier(
-            "Watchman: removes Specialisation Offer",
-            targets_model(),
-            ef_removes(general),
-            carried_by=watchman,
-        )
-        bystander = found_gang("The Shift", watch, owner=owner, budget=1000)
-        hire(bystander, watchman, "Silas", paid=50)
-
-        plan = plan_specialisation()
-
-        assert plan.ok
-        assert bystander.pk in plan.gang_ids
-        assert_reconciled(bystander)
-
     def test_rechoosing_works_on_the_new_machinery(self, world, prod_shape):
         specialist, _, _, _ = prod_shape
         _, fighters = world
@@ -366,47 +360,6 @@ class TestTheApply:
 
 
 class TestTheRefusals:
-    def test_a_held_general_fossil_cannot_retire(self, world, prod_shape, owner):
-        _, _, _, general = prod_shape
-        _, fighters = world
-        assign(general, miniature=fighters["open"])
-
-        plan = plan_specialisation()
-
-        assert not plan.ok
-        assert "held by someone" in plan.problems[0]
-        with pytest.raises(ConversionRefused):
-            apply(plan)
-        assert not SlotType.objects.filter(name="Specialisation").exists()
-
-    def test_an_archived_specialisation_is_refused_not_skipped(self, world):
-        ghost = create_specialisation("Forgotten")
-        ghost.archived = True
-        ghost.save()
-
-        plan = plan_specialisation()
-
-        assert not plan.ok
-        assert any("Forgotten" in problem for problem in plan.problems)
-
-    def test_a_model_holding_two_specialisations_is_refused(self, world, prod_shape):
-        """The offer showed one answer and left the spare lying on the
-        card as a free line; a slot would say both. Production holds a
-        few models like this."""
-        specialist, specs, _, _ = prod_shape
-        _, fighters = world
-        anchor = Assignment.objects.get(
-            subtype=specialist, miniature=fighters["settled"]
-        )
-        choose(anchor, specs["Scout"])
-
-        plan = plan_specialisation()
-
-        assert not plan.ok
-        assert any(
-            "more than one specialisation" in problem for problem in plan.problems
-        )
-
     def test_two_hiddens_sharing_a_name_are_refused(self, world):
         create_hidden("Specialisation offer", qualifier="(a second one)")
 
@@ -414,22 +367,6 @@ class TestTheRefusals:
 
         assert not plan.ok
         assert any("2 hiddens named" in problem for problem in plan.problems)
-
-    def test_a_live_modifier_naming_the_general_fossil_is_refused(
-        self, world, prod_shape
-    ):
-        _, _, _, general = prod_shape
-        modifier(
-            "Something grants the offer",
-            targets_model(),
-            ef_adds(general),
-            carried_by=create_subtype("Latecomer"),
-        )
-
-        plan = plan_specialisation()
-
-        assert not plan.ok
-        assert any("Something grants the offer" in problem for problem in plan.problems)
 
     def test_a_shared_offer_is_refused(self, world, prod_shape):
         from n26.library.authoring import attach_modifiers_to
@@ -463,36 +400,6 @@ class TestTheRefusals:
         assert not plan.ok
         assert any("shared" in problem for problem in plan.problems)
 
-    def test_a_shared_general_offer_is_refused(self, world, prod_shape):
-        from n26.library.authoring import attach_modifiers_to
-
-        _, _, _, general = prod_shape
-        offer = next(
-            m
-            for m in general.modifiers.all()
-            if getattr(m, "offers_choice", None) is not None
-        )
-        attach_modifiers_to(create_hidden("Another bystander"), [offer])
-
-        plan = plan_specialisation()
-
-        assert not plan.ok
-        assert any("shared" in problem for problem in plan.problems)
-
-    def test_a_granted_specialist_subtype_is_refused(self, world, prod_shape):
-        specialist, _, _, _ = prod_shape
-        modifier(
-            "Rank grants Specialist",
-            targets_model(),
-            ef_adds(specialist),
-            carried_by=create_subtype("Sergeant"),
-        )
-
-        plan = plan_specialisation()
-
-        assert not plan.ok
-        assert any("cannot find the gangs" in problem for problem in plan.problems)
-
 
 def _computed_for(miniature):
     from n26.core.card import build_card, build_modifier_index
@@ -505,3 +412,12 @@ def _computed_for(miniature):
 
 def _choices_of(miniature):
     return _computed_for(miniature).choices
+
+
+def _story(acts):
+    """Every word a gang's history page puts on the screen."""
+    told = []
+    for act in acts:
+        told.append("".join(span.text for span in act.spans))
+        told.extend(f"{sub.name}|{sub.kind}|{sub.note}" for sub in act.subs)
+    return told

--- a/n26/tests/sandbox/test_conversion_specialisation.py
+++ b/n26/tests/sandbox/test_conversion_specialisation.py
@@ -389,6 +389,24 @@ class TestTheRefusals:
         assert not plan.ok
         assert any("Forgotten" in problem for problem in plan.problems)
 
+    def test_a_model_holding_two_specialisations_is_refused(self, world, prod_shape):
+        """The offer showed one answer and left the spare lying on the
+        card as a free line; a slot would say both. Production holds a
+        few models like this."""
+        specialist, specs, _, _ = prod_shape
+        _, fighters = world
+        anchor = Assignment.objects.get(
+            subtype=specialist, miniature=fighters["settled"]
+        )
+        choose(anchor, specs["Scout"])
+
+        plan = plan_specialisation()
+
+        assert not plan.ok
+        assert any(
+            "more than one specialisation" in problem for problem in plan.problems
+        )
+
     def test_two_hiddens_sharing_a_name_are_refused(self, world):
         create_hidden("Specialisation offer", qualifier="(a second one)")
 

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -109,24 +109,9 @@ class TestThePage:
         page = response.content.decode()
         assert response.status_code == 200
         assert "create slot type “Specialisation”" in page
-        assert "prove 2 gangs read the same" in page
+        assert "prove 2 of 2 reached gangs read the same" in page
         assert not Backfill.objects.exists()
         assert Assignment.objects.filter(specialisation__isnull=False).exists()
-
-    def test_a_refusal_is_said_on_the_page_not_applied(
-        self, client, superuser, world, prod_shape
-    ):
-        _, _, _, general = prod_shape
-        from n26.tests.sandbox.actions import assign
-
-        _, fighters = world
-        assign(general, miniature=fighters["open"])
-        client.force_login(superuser)
-
-        response = client.post(reverse(URL_NAME), follow=True)
-
-        assert "held by someone" in response.content.decode()
-        assert not Backfill.objects.exists()
 
 
 class TestApplying:
@@ -142,7 +127,9 @@ class TestApplying:
         assert "applied; every page reads the same" in backfill.summary["report"][-1]
         assert backfill.summary["attempts"] == 1
         # The run really converted: the picks now name pickables.
-        assert not Assignment.objects.filter(specialisation__isnull=False).exists()
+        assert not Assignment.objects.filter(
+            specialisation__isnull=False, archived=False
+        ).exists()
         assert Assignment.objects.filter(pickable__isnull=False).exists()
         assert str(backfill.id) in response.redirect_chain[-1][0]
 

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -19,7 +19,6 @@ from django.urls import reverse
 from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import operations, resolve_operation
 from n26.core.models import Assignment
-from n26.library.models import SlotType, Specialisation
 from n26.maintenance import (
     MAX_ATTEMPTS,
     Operation,
@@ -134,7 +133,7 @@ class TestApplying:
     def test_it_records_what_it_did(self, client, superuser, world):
         client.force_login(superuser)
 
-        response = client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
+        response = client.post(reverse(URL_NAME), follow=True)
 
         backfill = Backfill.objects.get()
         assert backfill.operation == Operation.CONVERT_SPECIALISATION.value
@@ -149,7 +148,7 @@ class TestApplying:
 
     def test_the_detail_page_says_what_happened(self, client, superuser, world):
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
         backfill = Backfill.objects.get()
 
         response = client.get(
@@ -160,7 +159,7 @@ class TestApplying:
 
     def test_a_second_run_finds_nothing_to_convert(self, client, superuser, world):
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
 
         response = client.get(reverse(URL_NAME))
 
@@ -172,9 +171,9 @@ class TestApplying:
         """A page left open across someone else's run: submitting it
         again must not file a record for work there is none of."""
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
 
-        client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
+        client.post(reverse(URL_NAME), follow=True)
 
         assert Backfill.objects.count() == 1
 
@@ -185,86 +184,10 @@ class TestApplying:
         )
         client.force_login(superuser)
 
-        client.post(reverse(URL_NAME), {"keep": "yes"}, follow=True)
+        client.post(reverse(URL_NAME), follow=True)
 
         assert Backfill.objects.count() == 1
         assert Assignment.objects.filter(specialisation__isnull=False).exists()
-
-
-class TestRehearsing:
-    """The whole conversion, proven and then thrown away — so a database
-    holding real gangs can be asked whether this works without being
-    changed by the answer."""
-
-    def test_it_proves_everything_and_keeps_nothing(self, client, superuser, world):
-        client.force_login(superuser)
-
-        client.post(reverse(URL_NAME), {"keep": "no"}, follow=True)
-
-        backfill = Backfill.objects.get()
-        assert backfill.status == Backfill.Status.DONE
-        assert backfill.summary["kept"] is False
-        assert "rehearsed" in backfill.summary["report"][-1]
-        assert "nothing kept" in backfill.summary["report"][-1]
-        # The library is exactly as it was.
-        assert not SlotType.objects.filter(name="Specialisation").exists()
-        assert Specialisation.objects.filter(archived=False).count() == 4
-        assert Assignment.objects.filter(specialisation__isnull=False).count() == 4
-        assert not Assignment.objects.filter(pickable__isnull=False).exists()
-
-    def test_the_page_says_a_rehearsal_kept_nothing(self, client, superuser, world):
-        client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "no"})
-        backfill = Backfill.objects.get()
-
-        response = client.get(
-            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
-        )
-
-        assert "nothing was kept" in response.content.decode()
-
-    def test_not_saying_which_rehearses(self, client, superuser, world):
-        """Keeping the work is the thing that must be asked for, so a
-        request that says nothing gets the ending nobody has to undo."""
-        client.force_login(superuser)
-
-        client.post(reverse(URL_NAME), follow=True)
-
-        assert Backfill.objects.get().summary["kept"] is False
-        assert Assignment.objects.filter(specialisation__isnull=False).exists()
-
-    def test_a_rehearsal_refuses_for_the_same_reasons(self, world, prod_shape):
-        from n26.library.authoring import attach_modifiers_to
-        from n26.tests.sandbox.actions import create_subtype
-
-        specialist, _, _, _ = prod_shape
-        offer = next(
-            m
-            for m in specialist.modifiers.all()
-            if getattr(m, "offers_choice", None) is not None
-        )
-        attach_modifiers_to(create_subtype("Understudy"), [offer])
-        backfill = Backfill.objects.create(
-            operation=Operation.CONVERT_SPECIALISATION,
-            status=Backfill.Status.RUNNING,
-        )
-
-        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=False)
-
-        backfill.refresh_from_db()
-        assert backfill.status == Backfill.Status.FAILED
-        assert "shared" in backfill.error
-
-    def test_converting_after_a_rehearsal_still_works(self, client, superuser, world):
-        client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "no"})
-
-        client.post(reverse(URL_NAME), {"keep": "yes"})
-
-        applied = Backfill.objects.filter(summary__kept=True).get()
-        assert applied.status == Backfill.Status.DONE
-        assert "applied" in applied.summary["report"][-1]
-        assert not Assignment.objects.filter(specialisation__isnull=False).exists()
 
 
 class TestTheRunsOwnGuards:
@@ -337,7 +260,7 @@ class TestTheRunsOwnGuards:
         the copy that arrives to find the work already done is the likely
         one. It must not file a successful conversion as a failure."""
         client.force_login(superuser)
-        client.post(reverse(URL_NAME), {"keep": "yes"})
+        client.post(reverse(URL_NAME))
         backfill = Backfill.objects.get()
         assert backfill.status == Backfill.Status.DONE
         report = backfill.summary["report"]

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -263,6 +263,20 @@ class TestTheRunsOwnGuards:
         assert backfill.error == ""
         assert backfill.summary["report"] == report
 
+    def test_it_survives_a_message_from_another_version(self, world):
+        """Delivery outlives a deploy: a message can name arguments this
+        version no longer has, and a task that refuses its own message is
+        retried for ever."""
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.RUNNING,
+        )
+
+        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=False)
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.DONE
+
     def test_a_cancelled_run_stays_cancelled(self, world):
         backfill = Backfill.objects.create(
             operation=Operation.CONVERT_SPECIALISATION,

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -272,10 +272,36 @@ class TestTheRunsOwnGuards:
             status=Backfill.Status.RUNNING,
         )
 
-        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=False)
+        convert_specialisation.enqueue(backfill_id=str(backfill.id), unheard_of=1)
 
         backfill.refresh_from_db()
         assert backfill.status == Backfill.Status.DONE
+
+    def test_a_message_asking_not_to_keep_its_work_does_not_keep_it(self, world):
+        """A version ago this could be told to do the whole thing and
+        throw it away. Ignoring that instruction would commit what
+        somebody asked to be careful about."""
+        backfill = Backfill.objects.create(
+            operation=Operation.CONVERT_SPECIALISATION,
+            status=Backfill.Status.RUNNING,
+        )
+
+        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=False)
+
+        backfill.refresh_from_db()
+        assert backfill.status == Backfill.Status.FAILED
+        assert "cannot do" in backfill.error
+        assert Assignment.objects.filter(specialisation__isnull=False).exists()
+
+    def test_the_gentler_button_of_an_old_page_converts_nothing(
+        self, client, superuser, world
+    ):
+        client.force_login(superuser)
+
+        client.post(reverse(URL_NAME), {"keep": "no"}, follow=True)
+
+        assert not Backfill.objects.exists()
+        assert Assignment.objects.filter(specialisation__isnull=False).exists()
 
     def test_a_cancelled_run_stays_cancelled(self, world):
         backfill = Backfill.objects.create(

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -126,11 +126,15 @@ class TestApplying:
         assert backfill.status == Backfill.Status.DONE
         assert "applied; every page reads the same" in backfill.summary["report"][-1]
         assert backfill.summary["attempts"] == 1
-        # The run really converted: the picks now name pickables.
-        assert not Assignment.objects.filter(
-            specialisation__isnull=False, archived=False
-        ).exists()
-        assert Assignment.objects.filter(pickable__isnull=False).exists()
+        # The run really converted: every answer this world holds now
+        # names a pickable. Said of the answers rather than of the column,
+        # because a spare left by a doubled click keeps the old one and is
+        # meant to.
+        answers = Assignment.objects.filter(
+            chosen_for_slot__isnull=False, archived=False
+        )
+        assert answers.count() == 3
+        assert all(row.pickable_id is not None for row in answers)
         assert str(backfill.id) in response.redirect_chain[-1][0]
 
     def test_the_detail_page_says_what_happened(self, client, superuser, world):


### PR DESCRIPTION
Moves the Specialisation system onto slots and picks. Off current main, 348 added / 541 removed — net negative, because most of this PR is deleting an earlier, worse approach.

## What it does

1. Creates the new machinery: a "Specialisation" slot type, eight pickables, a list holding them, a slot.
2. Moves each specialisation's skill-granting rule onto its matching pickable — the same rule record, now carried by something new.
3. Tells the "Specialist" subtype to grant the slot instead of offering the old choice. Same for the narrowed Subjugator one, so its holder keeps being asked the same narrower question.
4. Rewrites each answered pick: it names a pickable instead of a specialisation, and records which question it answers.

## What it does not do: delete anything

No old specialisation rows, no menus, no leftovers from the abandoned narrowing experiment. This is the change that makes the whole thing simple, and it is worth stating plainly because the previous attempts foundered on it.

Every hard problem came from the tidying, not the switch. Protected references only mattered because something was being deleted. Doubled answers — the same specialisation assigned twice, from a click that landed twice — only mattered because deleting their target forced the conversion to touch them. Left alone, all of it goes on saying exactly what it says today, and can be cleared away later by someone with time to look at it slowly.

The cost is a wart worth accepting: an author will see eight dead specialisation entries beside the new pickables until that tidy-up happens.

## What it proves before committing, and what it does not

The apply renders a spread of gangs, performs the steps, renders them again, and refuses on any difference to what a reader can see. It proves **25 gangs, not all 641** — chosen to include a doubled answer, the narrowed question, a gang that never answered, and ordinary ones.

Proving all of them means rendering for minutes with the transaction open, which on a live app costs far more than it buys: it holds rows players are using, and it collides with what they do meanwhile. What actually goes wrong here is shaped by the content, so it shows up in any gang the change reaches; what is particular to one gang is cheaper to ask the database outright, and the plan does that for all 641 in under a second.

Two supporting fixes, both found by running the old version against production:

- **The run reads one snapshot.** Read the ordinary way, the second reading picked up what players did while the run worked — a purchase here, a sale there — and the conversion was blamed for it. Reproduced deliberately at scale: with the fix a conversion survives a hire committed on another connection mid-run; with it disabled the same race reproduces the failure.
- **A pick keeps its word in the gang's story.** History describes an old event by looking up what its assignment names *now*, so moving a pick to a new kind silently rewrote wording already written: entries lost the "specialisation" label, because the code prints nothing for a pickable on the grounds that it is internal jargon. A pick now reports the question it answered instead. This also fixes Paths, converted last week, which have been showing no label at all. `n26/core/CLAUDE.md` and the conversion module now carry the warning.

## Measured on real databases

Forked from the production content mirror, populated to production's measured volume, run end to end. A separate script then compared **every** gang's pages itself, before and after, from outside the run — the check the conversion no longer performs internally.

| | 100 gangs, 63 picks | 150 gangs, 1,050 picks |
|---|---|---|
| Apply time | 6.2s | **11.4s** |
| Pages changed, all gangs | 0 | 0 |
| Gang histories changed | 0 | 0 |
| Rows deleted | 0 | 0 |

1,050 is production's real number of live answers, so the second row is the realistic figure. The proof cost is fixed rather than proportional — going from 100 to 150 gangs added nothing to it, since it always proves 25 — so this does not get slower as the estate grows. The previous version took eighteen minutes against production and refused.

Both runs included a deliberately manufactured doubled answer, which came through untouched with its gang's page unchanged.

## Test plan

- [x] `pytest n26` plus the platform's maintenance tests — 3,651 passed
- [x] Two scale smoke tests as above, with an independent full-estate comparison
- [x] Concurrency race reproduced with the isolation fix on and off
- [x] A test captures a gang's entire history before the conversion and requires it to read identically afterwards

## Not in this PR

- The eight old specialisation rows, two menus and the fossil hidden, left in place deliberately.
- The double-submit bug in the pick handler that creates the doubled answers in the first place — three models affected, four spare rows. It will keep happening; worth its own issue.
- The Cloud Run request timeout raised to 600s, already on main. It was raised for the eighteen-minute version and is now unnecessary; harmless as a ceiling, but happy to revert it separately.

Refs #2177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8
