### PR TITLE
fix: gear stored twice as wargear and weapon becomes one weapon

### DIFF
--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -23,7 +23,13 @@ underlying spec.
 - **Never create or modify an `Assignment`, `LedgerEntry`, or
   `LedgerEvent` outside `operation(gang, actor=...)`.** A bare
   `objects.create()` skips the ledger entry, the event, and the repin;
-  nothing notices until `reconcile` runs.
+  nothing notices until `reconcile` runs. Two places in `n26.library`
+  are sanctioned exceptions, and both earn it the same way: a
+  conversion and a duplicate-content repair move no money, write their
+  own zero-valued entries where they must, and prove every affected
+  gang still reconciles or unwind whole. Neither writes an event —
+  what they change is how something was recorded, not something the
+  owner did.
 - **Removing an assignment cascades down its cause chain.** Everything
   `caused_by` the removed assignment goes too, recursively — hire,
   built-ins, and grants all rely on this to unwind cleanly.

--- a/n26/core/templates/admin/maintenance/n26/_merge_wargear_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_merge_wargear_detail.html
@@ -8,8 +8,10 @@
         {{ backfill.summary.entries_moved }} equipment-list line{{ backfill.summary.entries_moved|pluralize }} moved,
         {{ backfill.summary.entries_dropped }} dropped as duplicates, and
         {{ backfill.summary.assignments_moved }} purchase{{ backfill.summary.assignments_moved|pluralize }} across
-        {{ backfill.summary.gangs }} gang{{ backfill.summary.gangs|pluralize }}. Every one of those gangs was
-        reconciled afterwards.
+        {{ backfill.summary.gangs }} gang{{ backfill.summary.gangs|pluralize }}.
+        {{ backfill.summary.gangs_proved }} of those balanced before the run and were held to their
+        numbers afterwards; any not counted there did not balance beforehand, which is not this
+        repair's to answer for.
     </p>
     <table>
         <thead>

--- a/n26/core/templates/admin/maintenance/n26/_merge_wargear_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_merge_wargear_detail.html
@@ -1,0 +1,41 @@
+{% comment %}
+    The summary of one wargear merge, on the Backfill detail page: which
+    gear stopped being two things, and what moved onto the weapon.
+{% endcomment %}
+{% if backfill.summary.merged %}
+    <h2>What it merged</h2>
+    <p>
+        {{ backfill.summary.entries_moved }} equipment-list line{{ backfill.summary.entries_moved|pluralize }} moved,
+        {{ backfill.summary.entries_dropped }} dropped as duplicates, and
+        {{ backfill.summary.assignments_moved }} purchase{{ backfill.summary.assignments_moved|pluralize }} across
+        {{ backfill.summary.gangs }} gang{{ backfill.summary.gangs|pluralize }}. Every one of those gangs was
+        reconciled afterwards.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Gear</th>
+                <th>Category</th>
+                <th>Equipment lists</th>
+                <th>Purchases</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in backfill.summary.merged %}
+                <tr>
+                    <td>{{ row.name }}</td>
+                    <td>{{ row.wargear_category }}</td>
+                    <td>{{ row.entries }}</td>
+                    <td>{{ row.assignments }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+{% if backfill.summary.skipped %}
+    <h2>Left alone</h2>
+    <p>These share a name but not everything else, so the run did not touch them.</p>
+    <ul>
+        {% for row in backfill.summary.skipped %}<li>{{ row.name }} — {{ row.reason }}</li>{% endfor %}
+    </ul>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/merge_wargear_into_weapon.html
+++ b/n26/core/templates/admin/maintenance/n26/merge_wargear_into_weapon.html
@@ -7,7 +7,7 @@
     <style>
     .mt-form { margin-top: 2rem; }
     .mt-table { width: 100%; margin-top: 1rem; }
-    .mt-skip { color: var(--error-fg, #ba2121); }
+    .mt-skip { color: var(--body-quiet-color, #666); }
     </style>
 {% endblock extrahead %}
 {% block content %}

--- a/n26/core/templates/admin/maintenance/n26/merge_wargear_into_weapon.html
+++ b/n26/core/templates/admin/maintenance/n26/merge_wargear_into_weapon.html
@@ -26,8 +26,10 @@
         equipment lists and the purchases onto the weapon and drops the wargear
         row, all in one transaction. It moves no money: the two agree on price,
         and what a purchase was worth lives on its ledger entry, which is not
-        touched. Every affected gang is reconciled afterwards and the whole run
-        unwinds if any of them stops balancing.
+        touched. Every affected gang whose books balance beforehand is reconciled
+        again afterwards, and the whole run unwinds if any of them stops
+        balancing. A gang already drifting is left out of that proof rather than
+        allowed to block the repair.
     </p>
     <p>
         One thing does change for a reader: a gang's history says what an

--- a/n26/core/templates/admin/maintenance/n26/merge_wargear_into_weapon.html
+++ b/n26/core/templates/admin/maintenance/n26/merge_wargear_into_weapon.html
@@ -1,0 +1,127 @@
+{% extends "admin/base_site.html" %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    .mt-skip { color: var(--error-fg, #ba2121); }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        Some gear is stored twice: once as wargear, and once as the weapon
+        carrying its firing line. Both are priced, so both list in the Trading
+        Post, and the wargear copy can hold no statline — anything bought
+        through it prints as a bare name.
+    </p>
+    <p>
+        This is a preview. Nothing has been changed. Applying moves the
+        equipment lists and the purchases onto the weapon and drops the wargear
+        row, all in one transaction. It moves no money: the two agree on price,
+        and what a purchase was worth lives on its ledger entry, which is not
+        touched. Every affected gang is reconciled afterwards and the whole run
+        unwinds if any of them stops balancing.
+    </p>
+    <p>
+        One thing does change for a reader: a gang's history says what an
+        assignment names now, so these purchases will start reading "weapon"
+        where they read "wargear".
+    </p>
+    {% if not merges %}
+        <h2>Nothing to merge</h2>
+        <p>No wargear shares a pack and a name with a weapon that could hold its firing line.</p>
+    {% else %}
+        <h2>What it would merge</h2>
+        <p>
+            {{ merges|length }} piece{{ merges|length|pluralize }} of gear,
+            {{ entries }} equipment-list line{{ entries|pluralize }} and
+            {{ assignments }} purchase{{ assignments|pluralize }} across
+            {{ gangs }} gang{{ gangs|pluralize }}.
+        </p>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>Gear</th>
+                    <th>Category</th>
+                    <th>Equipment lists</th>
+                    <th>Purchases</th>
+                    <th>Gangs</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for candidate in merges %}
+                    <tr>
+                        <td>{{ candidate.wargear.name }}</td>
+                        <td>{{ candidate.wargear.category }}</td>
+                        <td>{{ candidate.entries }}</td>
+                        <td>{{ candidate.assignments }}</td>
+                        <td>{{ candidate.gangs }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <form method="post"
+              class="mt-form"
+              onsubmit="return confirm('Merge {{ merges|length }} piece(s) of gear across {{ gangs }} gang(s)? It writes nothing unless every gang still balances.')">
+            {% csrf_token %}
+            <button type="submit" class="button default">Apply merge</button>
+        </form>
+    {% endif %}
+    {% if skips %}
+        <h2>Left alone</h2>
+        <p>
+            These share a name but not everything else, so they are not
+            obviously one thing. Each needs a decision rather than a sweep.
+        </p>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>Gear</th>
+                    <th>As wargear</th>
+                    <th>As weapon</th>
+                    <th>Why</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for candidate in skips %}
+                    <tr>
+                        <td>{{ candidate.wargear.name }}</td>
+                        <td>{{ candidate.wargear.category }}</td>
+                        <td>{{ candidate.weapon.category }}</td>
+                        <td class="mt-skip">{{ candidate.reason }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/library/repair.py
+++ b/n26/library/repair.py
@@ -122,6 +122,10 @@ class Result:
     assignments_moved: int = 0
     lines_granted: int = 0
     gangs: int = 0
+    #: Of those, the ones actually held to their numbers afterwards. A gang
+    #: whose books did not balance before the run is exempt, so the two
+    #: differ and the record must not claim otherwise.
+    gangs_proved: int = 0
 
     def as_dict(self):
         return {
@@ -132,6 +136,7 @@ class Result:
             "assignments_moved": self.assignments_moved,
             "lines_granted": self.lines_granted,
             "gangs": self.gangs,
+            "gangs_proved": self.gangs_proved,
         }
 
 
@@ -276,6 +281,7 @@ def apply():
             problems = check_gang(gang)
             if problems:
                 raise Refused("; ".join(problems))
+            result.gangs_proved += 1
         result.gangs = len(gangs)
     return result
 

--- a/n26/library/repair.py
+++ b/n26/library/repair.py
@@ -1,0 +1,344 @@
+"""Gear stored twice — once as wargear, once as the weapon it already is.
+
+A thing with a firing line is a weapon. ``WeaponProfile`` points at
+``Weapon`` and at nothing else, so a grenade — which the books type as
+wargear because it does not count against the weapons a fighter holds —
+is kept as a weapon taking no slots, homed in its wargear category. That
+is what lets it print a statline while still sitting under Grenades.
+
+Where the same gear also survives as a wargear row, the two stand for
+one thing and only one of them can carry the firing line. The wargear
+row is the one to lose: everything naming it moves onto the weapon, and
+it goes.
+
+**It moves no money.** The matching rule makes the two agree on price,
+and what a purchase was worth is pinned on its ledger entry, which is
+never rewritten. ``apply`` proves that gang by gang and unwinds the
+whole repair on any disagreement. The proof survives players acting
+while it runs: reconcile compares a gang's pinned numbers against its
+own ledger, and a purchase committed midway moves both.
+
+**It writes the weapon's firing lines.** Those lines are assignments of
+their own, made when a weapon is acquired, and a purchase made against
+the wargear row never had any — so moving one onto the weapon without
+them would leave the card as blank as before. They are free, so they
+add nothing to what anyone owns, and they are written directly rather
+than through an operation: the gang's history must not claim its owner
+did something today.
+
+**It does change one word.** A gang's history asks what an assignment
+names *now*, so these purchases start reading "weapon" where they read
+"wargear". The name, the price and the sums are untouched; the kind is
+the thing that was wrong and is now right.
+
+The matching rule is deliberately narrow, because the seam is not
+symmetric. A ceiling on how many may be held, and option groups, can
+name a wargear but not a weapon — and option groups cascade, so a
+careless delete would empty them in silence. A wargear row carrying any
+of that is reported and left alone for someone to settle.
+"""
+
+from dataclasses import dataclass, field
+
+from django.db import transaction
+
+__all__ = [
+    "Candidate",
+    "MERGE",
+    "Refused",
+    "Result",
+    "SKIP_REASONS",
+    "apply",
+    "find_candidates",
+    "gangs_holding",
+]
+
+#: The decision meaning "these are one thing, and the wargear row goes".
+MERGE = "merge"
+
+#: Why a same-named pair is left alone, in the words the console prints.
+SKIP_REASONS = {
+    "no_firing_line": (
+        "the weapon has no firing line, so these are two different things"
+    ),
+    "different_category": "the two are homed in different categories",
+    "different_price": "the two disagree on what they price at",
+    "carries_options": "the wargear offers options, which a weapon cannot hold",
+    "carries_rules": (
+        "the wargear carries modifiers, use restrictions or built-in kit"
+    ),
+    "spoken_for": (
+        "something names the wargear: a ceiling on how many may be held, "
+        "or a default assignment"
+    ),
+}
+
+
+class Refused(Exception):
+    """The repair unwound: a number it must not move, moved."""
+
+
+@dataclass
+class Candidate:
+    """One wargear row and the weapon sharing its pack and name."""
+
+    wargear: object
+    weapon: object
+    decision: str
+    entries: int = 0
+    assignments: int = 0
+    gangs: int = 0
+
+    @property
+    def merges(self):
+        return self.decision == MERGE
+
+    @property
+    def reason(self):
+        return SKIP_REASONS.get(self.decision, "")
+
+    def as_dict(self):
+        return {
+            "name": self.wargear.name,
+            "pack": str(self.wargear.pack),
+            "wargear_category": str(self.wargear.category),
+            "weapon_category": str(self.weapon.category),
+            "decision": self.decision,
+            "reason": self.reason,
+            "entries": self.entries,
+            "assignments": self.assignments,
+            "gangs": self.gangs,
+        }
+
+
+@dataclass
+class Result:
+    """What a run did, for the record it is written onto."""
+
+    merged: list = field(default_factory=list)
+    skipped: list = field(default_factory=list)
+    entries_moved: int = 0
+    entries_dropped: int = 0
+    assignments_moved: int = 0
+    lines_granted: int = 0
+    gangs: int = 0
+
+    def as_dict(self):
+        return {
+            "merged": self.merged,
+            "skipped": self.skipped,
+            "entries_moved": self.entries_moved,
+            "entries_dropped": self.entries_dropped,
+            "assignments_moved": self.assignments_moved,
+            "lines_granted": self.lines_granted,
+            "gangs": self.gangs,
+        }
+
+
+def find_candidates():
+    """Every wargear row sharing a pack, a name and a qualifier with a
+    weapon, each carrying the decision made about it. Reads only."""
+    from n26.library.models import Wargear, Weapon
+
+    found = []
+    for wargear in Wargear.objects.select_related("category__section", "pack").order_by(
+        "name"
+    ):
+        weapon = (
+            Weapon.objects.filter(
+                pack=wargear.pack,
+                name__iexact=wargear.name,
+                qualifier__iexact=wargear.qualifier,
+            )
+            .select_related("category__section")
+            .first()
+        )
+        if weapon is not None:
+            found.append(_judge(wargear, weapon))
+    return found
+
+
+def gangs_holding(candidates):
+    """The gangs holding any of this gear — each counted once, however
+    many pieces of it they hold."""
+    from n26.core.models import Assignment
+
+    found = set(
+        Assignment.objects.filter(
+            wargear__in=[candidate.wargear.pk for candidate in candidates]
+        ).values_list("gang_root", flat=True)
+    )
+    found.discard(None)
+    return found
+
+
+def _judge(wargear, weapon):
+    from n26.core.models import Assignment
+    from n26.library.models.collection import CollectionEntry
+
+    assignments = Assignment.objects.filter(wargear=wargear)
+    gangs = set(assignments.values_list("gang_root", flat=True))
+    gangs.discard(None)
+    return Candidate(
+        wargear=wargear,
+        weapon=weapon,
+        decision=_decide(wargear, weapon),
+        entries=CollectionEntry.objects.filter(wargear=wargear).count(),
+        assignments=assignments.count(),
+        gangs=len(gangs),
+    )
+
+
+def _decide(wargear, weapon):
+    """One name in two tables is not proof they are one thing. Everything
+    that could make them differ is asked, and the first answer wins."""
+    from n26.library.models.assignable import USABLE_BY_LISTS
+    from n26.library.models.defaults import DefaultAssignment
+    from n26.library.models.modifier import AllowsAtMost
+
+    if not weapon.profiles.exists():
+        return "no_firing_line"
+    if wargear.category_id != weapon.category_id:
+        return "different_category"
+    priced = (wargear.price, wargear.trade_point_price, wargear.is_exclusive)
+    if priced != (weapon.price, weapon.trade_point_price, weapon.is_exclusive):
+        return "different_price"
+    if wargear.option_groups.exists() or wargear.options.exists():
+        return "carries_options"
+    if (
+        wargear.built_ins_id
+        or wargear.modifiers.exists()
+        or any(getattr(wargear, listed).exists() for listed in USABLE_BY_LISTS)
+    ):
+        return "carries_rules"
+    if (
+        AllowsAtMost.objects.filter(wargear=wargear).exists()
+        or DefaultAssignment.objects.filter(wargear=wargear).exists()
+    ):
+        return "spoken_for"
+    return MERGE
+
+
+def apply():
+    """Merge every matched wargear row into its weapon, or write nothing.
+
+    One transaction. The deletes go last on purpose: what still names a
+    wargear row is protected, so anything the moves missed stops the
+    repair whole rather than letting it half-finish.
+    """
+    from n26.core.models import Assignment, Gang
+    from n26.core.reconcile import check_gang
+
+    candidates = find_candidates()
+    merges = [c for c in candidates if c.merges]
+    result = Result(
+        skipped=[c.as_dict() for c in candidates if not c.merges],
+    )
+    if not merges:
+        return result
+
+    gang_ids = gangs_holding(merges)
+
+    with transaction.atomic():
+        gangs = list(Gang.objects.filter(pk__in=gang_ids))
+        # Only a gang whose books already balance can be held to them
+        # afterwards. Drift that was there beforehand is somebody else's
+        # to answer for, and refusing over it would block the repair.
+        balanced = {gang.pk for gang in gangs if not check_gang(gang)}
+
+        for candidate in merges:
+            _move_entries(candidate, result)
+            moved = list(
+                Assignment.objects.filter(wargear=candidate.wargear).values_list(
+                    "pk", flat=True
+                )
+            )
+            # Both columns in one statement, so the constraint that
+            # exactly one assignable is named holds throughout. A bulk
+            # write is safe here where it usually is not: an assignment's
+            # denormalised roots follow its host, and the host is not
+            # what changes.
+            Assignment.objects.filter(pk__in=moved).update(
+                wargear=None, weapon=candidate.weapon
+            )
+            result.assignments_moved += len(moved)
+            result.lines_granted += _grant_firing_lines(candidate, moved)
+            result.merged.append(candidate.as_dict())
+            candidate.wargear.delete()
+
+        for gang in gangs:
+            if gang.pk not in balanced:
+                continue
+            # The pinned numbers are read from the database rather than
+            # from the instance the pre-check ran against, which is stale
+            # by now.
+            gang.refresh_from_db()
+            problems = check_gang(gang)
+            if problems:
+                raise Refused("; ".join(problems))
+        result.gangs = len(gangs)
+    return result
+
+
+def _grant_firing_lines(candidate, moved):
+    """Give each moved purchase the weapon's free firing lines.
+
+    A weapon's free lines are assignments of their own, written when it
+    is acquired — without them its card line has no statline and no
+    traits, which is the whole of what the wargear copy got wrong. A
+    purchase made against the wargear row never had any.
+
+    They are free, and they are written directly rather than through an
+    operation: nothing is bought, so the gang's history must not claim
+    its owner did something today. A line on a sold weapon is sold with
+    it, so it arrives archived where its weapon is.
+    """
+    from n26.core.models import Assignment, LedgerEntry, Reason
+
+    free = list(candidate.weapon.profiles.filter(price=0))
+    granted = 0
+    for assignment in Assignment.objects.filter(pk__in=moved):
+        held = set(
+            Assignment.objects.filter(parent=assignment).values_list(
+                "weapon_profile_id", flat=True
+            )
+        )
+        for profile in free:
+            if profile.pk in held:
+                continue
+            line = Assignment.objects.create(
+                weapon_profile=profile,
+                parent=assignment,
+                caused_by=assignment,
+                archived=assignment.archived,
+                archived_at=assignment.archived_at,
+            )
+            LedgerEntry.objects.create(assignment=line, reason=Reason.DEFAULT)
+            granted += 1
+    return granted
+
+
+def _move_entries(candidate, result):
+    """Point this gear's equipment-list lines at the weapon.
+
+    A list already offering the weapon would show the same gear twice, so
+    that line goes instead of moving — but the money bought through it
+    keeps its provenance, which means pointing those purchases at the
+    line that survives before this one does not.
+    """
+    from n26.core.models import LedgerEntry
+    from n26.library.models.collection import CollectionEntry
+
+    for entry in CollectionEntry.objects.filter(wargear=candidate.wargear):
+        standing = CollectionEntry.objects.filter(
+            collection_id=entry.collection_id, weapon=candidate.weapon
+        ).first()
+        if standing is None:
+            CollectionEntry.objects.filter(pk=entry.pk).update(
+                wargear=None, weapon=candidate.weapon
+            )
+            result.entries_moved += 1
+        else:
+            LedgerEntry.objects.filter(bought_from=entry).update(bought_from=standing)
+            entry.delete()
+            result.entries_dropped += 1

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -51,7 +51,12 @@ from gyrinx.tasks import TaskRoute
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["Operation", "convert_specialisation", "task_routes"]
+__all__ = [
+    "Operation",
+    "convert_specialisation",
+    "merge_wargear_into_weapon_view",
+    "task_routes",
+]
 
 #: How many times a run may be started before the record gives up. A
 #: conversion that exhausts the request budget leaves nothing behind and
@@ -73,6 +78,10 @@ class Operation(models.TextChoices):
     CONVERT_SPECIALISATION = (
         "n26_convert_specialisation",
         "n26: the specialisations become picks",
+    )
+    MERGE_WARGEAR_INTO_WEAPON = (
+        "n26_merge_wargear_into_weapon",
+        "n26: duplicated wargear becomes its weapon",
     )
 
 
@@ -333,3 +342,96 @@ register_operation(
 #: successfully and acknowledges the message out from under it. Change one and
 #: change the other (``--timeout`` in ``cloudbuild.yaml``).
 task_routes = [TaskRoute(convert_specialisation, ack_deadline=600, min_retry_delay=60)]
+
+
+def merge_wargear_into_weapon_view(request):
+    """Preview the merge, or perform it.
+
+    Small enough to answer in the request, unlike the conversion above: a
+    few hundred rows move, and what proves the run is a reconcile per
+    affected gang rather than a render of every page.
+    """
+    from n26.library.repair import Refused, apply, find_candidates, gangs_holding
+
+    address = reverse("admin:maintenance_n26_merge_wargear_into_weapon")
+    if request.method == "POST":
+        try:
+            result = apply()
+        except Refused as refused:
+            # The repair unwound itself rather than move a number it must
+            # not. Nothing was written, and the reason is already in words.
+            Backfill.objects.create(
+                operation=Operation.MERGE_WARGEAR_INTO_WEAPON,
+                triggered_by=request.user,
+                status=Backfill.Status.FAILED,
+                error=str(refused),
+            )
+            messages.error(request, f"The repair refuses: {refused}")
+            return HttpResponseRedirect(address)
+        except Exception as broke:  # noqa: BLE001 — the ending must be recorded
+            logger.exception("Wargear merge broke")
+            Backfill.objects.create(
+                operation=Operation.MERGE_WARGEAR_INTO_WEAPON,
+                triggered_by=request.user,
+                status=Backfill.Status.FAILED,
+                error=f"{broke}\n\n{traceback.format_exc()}",
+            )
+            messages.error(request, f"The repair failed: {broke}")
+            return HttpResponseRedirect(address)
+
+        if not result.merged:
+            # A page left open across someone else's run, most likely.
+            # Recording a run that did nothing only clutters the history.
+            messages.info(request, "There is nothing to merge.")
+            return HttpResponseRedirect(address)
+
+        backfill = Backfill.objects.create(
+            operation=Operation.MERGE_WARGEAR_INTO_WEAPON,
+            triggered_by=request.user,
+            status=Backfill.Status.DONE,
+            summary=result.as_dict(),
+        )
+        messages.success(
+            request,
+            f"Merged {len(result.merged)} piece(s) of gear across "
+            f"{result.gangs} gang(s).",
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+
+    candidates = find_candidates()
+    merges = [c for c in candidates if c.merges]
+    context = page_context(
+        request,
+        Operation.MERGE_WARGEAR_INTO_WEAPON.label,
+        merges=merges,
+        skips=[c for c in candidates if not c.merges],
+        entries=sum(c.entries for c in merges),
+        assignments=sum(c.assignments for c in merges),
+        gangs=len(gangs_holding(merges)),
+        apply_url=address,
+        recent=Backfill.objects.filter(
+            operation=Operation.MERGE_WARGEAR_INTO_WEAPON
+        ).order_by("-created")[:10],
+    )
+    return render(
+        request, "admin/maintenance/n26/merge_wargear_into_weapon.html", context
+    )
+
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.MERGE_WARGEAR_INTO_WEAPON.value,
+        name=Operation.MERGE_WARGEAR_INTO_WEAPON.label,
+        description=(
+            "Some gear is stored twice — once as wargear, once as the "
+            "weapon carrying its firing line — so it lists twice and the "
+            "wargear copy prints no statline. Moves the equipment lists "
+            "and the purchases onto the weapon and drops the wargear row. "
+            "Moves no money, and proves it gang by gang."
+        ),
+        view=merge_wargear_into_weapon_view,
+        detail_template="admin/maintenance/n26/_merge_wargear_detail.html",
+    )
+)

--- a/n26/tests/sandbox/test_repair_wargear.py
+++ b/n26/tests/sandbox/test_repair_wargear.py
@@ -131,7 +131,11 @@ def armed(grenades, gang_type, fighter, equipment_list, owner):
     model = hire(gang, fighter, "Scarred", paid=50)
     entry = equipment_list.entries.get()
     bought = buy(model, thing=stray, entry=entry)
-    return gang, model, bought
+    yield gang, model, bought
+    # Whatever the test did, the gang's books must still fold — including
+    # where the repair refused and unwound.
+    gang.refresh_from_db()
+    assert_reconciled(gang)
 
 
 class TestWhatItFinds:
@@ -315,6 +319,8 @@ class TestTheMerge:
         assert result.gangs == 1
         assert result.gangs_proved == 0
         assert result.merged
+        # The real check has to be back before the gang is held to it.
+        monkeypatch.undo()
 
     def test_running_it_again_does_nothing(self, armed):
         apply()
@@ -512,3 +518,6 @@ class TestWhenItRefuses:
 
         assert Wargear.objects.filter(pk=stray.pk).exists()
         assert Assignment.objects.filter(wargear=stray).count() == 1
+        # The real check has to be back before the gang is held to it — an
+        # unwound run must leave the books exactly as it found them.
+        monkeypatch.undo()

--- a/n26/tests/sandbox/test_repair_wargear.py
+++ b/n26/tests/sandbox/test_repair_wargear.py
@@ -1,0 +1,495 @@
+"""Gear stored twice, merged back into one weapon.
+
+Builds the shape production holds — a grenade kept both as wargear and
+as the weapon carrying its firing line, listed on an equipment list and
+bought by gangs — and proves the repair's whole discipline: the
+duplicate stops listing twice, every purchase follows onto the weapon
+and starts printing a statline, no gang's numbers move, the money keeps
+its provenance, a second run does nothing, and anything that is not
+plainly one thing is reported and left exactly as it was.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from n26.core.browse import TRADING_POST, browse
+from n26.core.models import Assignment, LedgerEntry
+from n26.core.reconcile import assert_reconciled, recomputed_rating
+from n26.library.models import StatlineType, StatlineTypeStat, Wargear, Weapon
+from n26.library.repair import Refused, apply, find_candidates
+from n26.tests.sandbox.actions import (
+    add_entry,
+    allows_at_most,
+    buy,
+    create_category,
+    create_collection,
+    create_default_set,
+    create_gang_type,
+    create_option_group,
+    create_profile,
+    create_rule,
+    create_stat,
+    create_trading_post,
+    create_wargear,
+    create_weapon,
+    ef_adds,
+    found_gang,
+    hire,
+    modifier,
+    offer_option,
+    remove,
+    set_statline,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def weapon_shape(db):
+    """SR / LR / Str / AP / L — the shape every weapon profile prints in."""
+    shape = StatlineType.objects.create(name="Weapon")
+    for position, (short, full, flags) in enumerate(
+        [
+            ("SR", "Short Range", {"is_inches": True}),
+            ("LR", "Long Range", {"is_inches": True}),
+            ("Str", "Weapon Strength", {}),
+            ("AP", "Armour Piercing", {"is_modifier": True}),
+            ("L", "Lethality", {}),
+        ]
+    ):
+        StatlineTypeStat.objects.create(
+            statline_type=shape,
+            stat=create_stat(short, full, **flags),
+            position=position,
+            is_first_of_group=(position == 0),
+        )
+    return shape
+
+
+@pytest.fixture
+def grenades(default_pack, weapon_shape):
+    """A grenade as production holds it: a wargear row left over from
+    before it had a firing line, and the weapon that now carries one.
+    Both priced, both homed under Grenades."""
+    category = create_category("Wargear", "Grenades", 0)
+    stray = create_wargear(
+        "Frag grenades", price=30, trade_point_price=2, category=category
+    )
+    weapon = create_weapon(
+        "Frag grenades",
+        profiles=[("", 0)],
+        slots=0,
+        price=30,
+        trade_point_price=2,
+        category=category,
+        statline_type=weapon_shape,
+    )
+    set_statline(
+        weapon.profiles.get(),
+        short_range="6",
+        long_range="",
+        weapon_strength="3",
+        armour_piercing="-1",
+        lethality="4+",
+    )
+    return stray, weapon
+
+
+@pytest.fixture
+def gang_type(db):
+    return create_gang_type("Escher", starting_credits=1000)
+
+
+@pytest.fixture
+def fighter(gang_type, person_type):
+    return create_profile("Ganger", person_type, gang_type, price=50)
+
+
+@pytest.fixture
+def equipment_list(grenades, fighter):
+    """The fighter's own list, offering the stray — which is how every
+    one of these was bought."""
+    stray, _ = grenades
+    listing = create_collection("Escher equipment")
+    add_entry(listing, stray)
+    fighter.built_ins = create_default_set("Ganger kit", members=[])
+    fighter.save()
+    return listing
+
+
+@pytest.fixture
+def armed(grenades, gang_type, fighter, equipment_list, owner):
+    """A gang whose model bought the grenade through its equipment list."""
+    stray, _ = grenades
+    gang = found_gang("The Wild Ones", gang_type, owner=owner, budget=1000)
+    model = hire(gang, fighter, "Scarred", paid=50)
+    entry = equipment_list.entries.get()
+    bought = buy(model, thing=stray, entry=entry)
+    return gang, model, bought
+
+
+class TestWhatItFinds:
+    def test_a_grenade_kept_as_both_is_one_thing_to_merge(self, grenades):
+        stray, weapon = grenades
+
+        found = find_candidates()
+
+        assert len(found) == 1
+        assert found[0].merges
+        assert found[0].wargear == stray
+        assert found[0].weapon == weapon
+
+    def test_it_counts_what_would_move(self, armed, equipment_list):
+        found = find_candidates()
+
+        assert found[0].entries == 1
+        assert found[0].assignments == 1
+        assert found[0].gangs == 1
+
+    def test_a_name_shared_with_a_weapon_that_has_no_firing_line_is_not_a_pair(
+        self, default_pack
+    ):
+        category = create_category("Wargear", "Field gear", 0)
+        create_wargear("Bedroll", price=10, category=category)
+        create_weapon("Bedroll", price=10, category=category)
+
+        found = find_candidates()
+
+        assert [c.decision for c in found] == ["no_firing_line"]
+
+
+class TestTheMerge:
+    def test_the_wargear_goes_and_the_weapon_stays(self, grenades):
+        stray, weapon = grenades
+
+        apply()
+
+        assert not Wargear.objects.filter(pk=stray.pk).exists()
+        assert Weapon.objects.filter(pk=weapon.pk).exists()
+
+    def test_the_equipment_list_offers_the_weapon_instead(
+        self, armed, equipment_list, grenades
+    ):
+        _, weapon = grenades
+
+        apply()
+
+        entry = equipment_list.entries.get()
+        assert entry.assignable == weapon
+
+    def test_a_purchase_follows_onto_the_weapon(self, armed, grenades):
+        _, weapon = grenades
+        _, _, bought = armed
+
+        apply()
+
+        bought.refresh_from_db()
+        assert bought.assignable == weapon
+        assert bought.wargear_id is None
+
+    def test_the_ledger_now_names_the_weapon_too(self, armed, grenades):
+        _, weapon = grenades
+        _, _, bought = armed
+
+        apply()
+
+        entry = LedgerEntry.objects.get(assignment=bought)
+        assert entry.assignable == weapon
+
+    def test_the_money_keeps_its_provenance(self, armed, equipment_list):
+        _, _, bought = armed
+        was = LedgerEntry.objects.get(assignment=bought).bought_from_id
+
+        apply()
+
+        entry = LedgerEntry.objects.get(assignment=bought)
+        assert entry.bought_from_id == was
+        assert entry.bought_from == equipment_list.entries.get()
+
+    def test_a_sold_grenade_follows_too(self, armed, grenades):
+        """An archived purchase is still part of the gang's story, so it
+        must name the row that survives."""
+        _, weapon = grenades
+        _, _, bought = armed
+        remove(bought)
+
+        apply()
+
+        bought.refresh_from_db()
+        assert bought.archived
+        assert bought.assignable == weapon
+
+    def test_the_grenade_starts_printing_its_statline(self, armed):
+        """The whole point: bought as wargear it was a bare name, because
+        a firing line can hang off nothing but a weapon."""
+        from n26.core.render import build_model_card
+
+        _, model, _ = armed
+        before = build_model_card(model)
+        assert [line.name for line in before.weapons] == []
+        assert "Frag grenades" in [str(line.name) for line in before.equipment]
+
+        apply()
+
+        after = build_model_card(model)
+        (grenade,) = after.weapons
+        assert str(grenade.name) == "Frag grenades"
+        assert grenade.slots == 0
+        assert grenade.profiles[0].statline is not None
+
+    def test_the_firing_line_is_written_onto_the_purchase(self, armed, grenades):
+        """The statline is not a property of the weapon alone: its free
+        lines are assignments, and a purchase made against the wargear
+        row never had any."""
+        _, weapon = grenades
+        _, _, bought = armed
+
+        result = apply()
+
+        assert result.lines_granted == 1
+        (line,) = Assignment.objects.filter(parent=bought)
+        assert line.assignable == weapon.profiles.get()
+        assert line.caused_by_id == bought.pk
+
+    def test_a_sold_grenade_gets_its_line_sold_too(self, armed):
+        """A line on a weapon that has gone must not come back live."""
+        _, _, bought = armed
+        remove(bought)
+
+        apply()
+
+        (line,) = Assignment.objects.filter(parent=bought)
+        assert line.archived
+
+    def test_a_granted_line_is_worth_nothing(self, armed):
+        """A weapon's own line is free, so it moves no rating — and the
+        ledger has to say so, or the gang stops balancing."""
+        gang, _, bought = armed
+
+        apply()
+
+        line = Assignment.objects.get(parent=bought)
+        entry = LedgerEntry.objects.get(assignment=line)
+        assert (entry.paid, entry.rating_contribution, entry.list_price) == (0, 0, 0)
+        assert line.ledger_events.count() == 0
+
+    def test_no_gang_numbers_move(self, armed):
+        gang, _, _ = armed
+        before = (gang.rating, gang.credits, recomputed_rating(gang))
+
+        apply()
+
+        gang.refresh_from_db()
+        assert (gang.rating, gang.credits, recomputed_rating(gang)) == before
+        assert_reconciled(gang)
+
+    def test_it_says_what_it_did(self, armed):
+        result = apply()
+
+        assert result.entries_moved == 1
+        assert result.assignments_moved == 1
+        assert result.gangs == 1
+        assert [row["name"] for row in result.merged] == ["Frag grenades"]
+
+    def test_running_it_again_does_nothing(self, armed):
+        apply()
+
+        again = apply()
+
+        assert again.merged == []
+        assert again.assignments_moved == 0
+
+
+class TestTheTradingPost:
+    def test_the_grenade_listed_twice_now_lists_once(self, grenades, default_pack):
+        post = create_trading_post()
+        before = [line.name for line in browse(post, TRADING_POST).all_lines()]
+        assert before.count("Frag grenades") == 2
+
+        apply()
+
+        after = [line.name for line in browse(post, TRADING_POST).all_lines()]
+        assert after.count("Frag grenades") == 1
+
+
+class TestWhatItLeavesAlone:
+    def test_gear_homed_in_a_different_category_is_reported_not_merged(
+        self, default_pack
+    ):
+        """Two things may share a name. Where the books file them apart,
+        that is the sheet saying they are not one thing."""
+        mutations = create_category("Wargear", "Mutations", 0)
+        natural = create_category("Close combat weapons", "Natural weapons", 0)
+        stray = create_wargear("Tentacles", price=0, category=mutations)
+        create_weapon("Tentacles", profiles=[("", 0)], price=0, category=natural)
+
+        result = apply()
+
+        assert result.merged == []
+        assert result.skipped[0]["decision"] == "different_category"
+        assert Wargear.objects.filter(pk=stray.pk).exists()
+
+    def test_gear_the_two_price_differently_is_reported_not_merged(self, default_pack):
+        category = create_category("Wargear", "Grenades", 0)
+        stray = create_wargear("Krak grenades", price=45, category=category)
+        create_weapon("Krak grenades", profiles=[("", 0)], price=50, category=category)
+
+        result = apply()
+
+        assert result.skipped[0]["decision"] == "different_price"
+        assert Wargear.objects.filter(pk=stray.pk).exists()
+
+    def test_wargear_offering_options_is_reported_not_merged(self, grenades):
+        """A weapon cannot hold option groups, and they cascade — so a
+        careless merge would empty them in silence."""
+        stray, _ = grenades
+        group = create_option_group(stray, "Choose a fuse")
+        offer_option(stray, "Timed", group=group)
+
+        result = apply()
+
+        assert result.merged == []
+        assert result.skipped[0]["decision"] == "carries_options"
+        assert Wargear.objects.filter(pk=stray.pk).exists()
+        assert stray.option_groups.count() == 1
+
+    def test_wargear_carrying_a_modifier_is_reported_not_merged(self, grenades):
+        stray, _ = grenades
+        modifier(
+            "the model: gains Blast",
+            targets_model(),
+            ef_adds(create_rule("Blast")),
+            carried_by=stray,
+        )
+
+        result = apply()
+
+        assert result.skipped[0]["decision"] == "carries_rules"
+        assert Wargear.objects.filter(pk=stray.pk).exists()
+
+    def test_wargear_with_a_ceiling_on_it_is_reported_not_merged(self, grenades):
+        """How many may be held can name a wargear and nothing else, so
+        merging would leave the ceiling nowhere to go."""
+        stray, _ = grenades
+        modifier(
+            "the model: at most two",
+            targets_model(),
+            allows_at_most(2, stray),
+        )
+
+        result = apply()
+
+        assert result.skipped[0]["decision"] == "spoken_for"
+        assert Wargear.objects.filter(pk=stray.pk).exists()
+
+    def test_a_skip_writes_nothing_at_all(self, armed, grenades):
+        """A pair left alone keeps every purchase it had."""
+        stray, _ = grenades
+        _, _, bought = armed
+        create_option_group(stray, "Choose a fuse")
+
+        apply()
+
+        bought.refresh_from_db()
+        assert bought.assignable == stray
+
+
+class TestTheConsoleDoor:
+    """The console is the platform's and the repair is ours; what is
+    proven here is that the two meet."""
+
+    URL = "admin:maintenance_n26_merge_wargear_into_weapon"
+
+    @pytest.fixture
+    def superuser(self, db):
+        return User.objects.create_superuser("boss", "boss@example.com", "password")
+
+    @pytest.fixture
+    def staffer(self, db):
+        return User.objects.create_user("assistant", is_staff=True)
+
+    def test_only_a_superuser_may_reach_it(self, client, staffer):
+        from django.urls import reverse
+
+        client.force_login(staffer)
+
+        assert client.get(reverse(self.URL)).status_code == 403
+
+    def test_it_shows_what_it_would_do_and_writes_nothing(
+        self, client, superuser, armed, grenades
+    ):
+        from django.urls import reverse
+
+        from gyrinx.maintenance.models import Backfill
+
+        stray, _ = grenades
+        client.force_login(superuser)
+
+        response = client.get(reverse(self.URL))
+
+        assert response.status_code == 200
+        assert b"Frag grenades" in response.content
+        assert Wargear.objects.filter(pk=stray.pk).exists()
+        assert not Backfill.objects.exists()
+
+    def test_applying_records_what_happened(self, client, superuser, armed, grenades):
+        from django.urls import reverse
+
+        from gyrinx.maintenance.models import Backfill
+
+        stray, _ = grenades
+        client.force_login(superuser)
+
+        response = client.post(reverse(self.URL))
+
+        assert response.status_code == 302
+        assert not Wargear.objects.filter(pk=stray.pk).exists()
+        record = Backfill.objects.get()
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["assignments_moved"] == 1
+        assert record.summary["gangs"] == 1
+
+    def test_a_run_with_nothing_to_do_records_nothing(self, client, superuser):
+        from django.urls import reverse
+
+        from gyrinx.maintenance.models import Backfill
+
+        client.force_login(superuser)
+
+        client.post(reverse(self.URL))
+
+        assert not Backfill.objects.exists()
+
+
+class TestWhenItRefuses:
+    def test_a_gang_whose_numbers_move_unwinds_the_whole_run(
+        self, armed, grenades, monkeypatch
+    ):
+        """The proof is not decoration: if a gang stops balancing, nothing
+        lands — not even the moves that were fine."""
+        from n26.core import reconcile
+
+        stray, _ = grenades
+        asked = []
+
+        def drifting(gang):
+            # Balanced the first time it is asked and broken the second,
+            # so the pre-check passes and the proof afterwards does not.
+            asked.append(gang.pk)
+            if asked.count(gang.pk) == 1:
+                return []
+            return ["rating pinned 100, ledger sums to 130"]
+
+        monkeypatch.setattr(reconcile, "check_gang", drifting)
+
+        with pytest.raises(Refused):
+            apply()
+
+        assert Wargear.objects.filter(pk=stray.pk).exists()
+        assert Assignment.objects.filter(wargear=stray).count() == 1

--- a/n26/tests/sandbox/test_repair_wargear.py
+++ b/n26/tests/sandbox/test_repair_wargear.py
@@ -295,7 +295,26 @@ class TestTheMerge:
         assert result.entries_moved == 1
         assert result.assignments_moved == 1
         assert result.gangs == 1
+        assert result.gangs_proved == 1
         assert [row["name"] for row in result.merged] == ["Frag grenades"]
+
+    def test_a_gang_already_drifting_is_counted_but_not_proved(
+        self, armed, monkeypatch
+    ):
+        """Books that did not balance before the run are not this repair's
+        to answer for — so it neither refuses over them nor claims to have
+        proved them."""
+        from n26.core import reconcile
+
+        monkeypatch.setattr(
+            reconcile, "check_gang", lambda gang: ["rating pinned 100, ledger sums 130"]
+        )
+
+        result = apply()
+
+        assert result.gangs == 1
+        assert result.gangs_proved == 0
+        assert result.merged
 
     def test_running_it_again_does_nothing(self, armed):
         apply()


### PR DESCRIPTION
Grenades list twice in the Trading Post, and one of the two prints no statline.

## What is wrong

The equipment sheet types grenades as wargear, and the ingest promotes any wargear that has a firing line into a weapon taking no slots — correctly, because `WeaponProfile` points at `Weapon` and nothing else, so a statline can hang off nothing but a weapon. That promotion is what lets a grenade print its stats while still sitting under Grenades.

On a re-ingest, the planned weapon did not find the wargear row already standing for that grenade, so a second row was written beside the first. Both are priced, so both Trading Post sweeps list them, adjacent and identical. The wargear copy cannot carry a firing line, so anything bought through it renders as a bare name on card, sheet and print.

Every equipment-list line in the library points at the wargear copy and none at the weapon, which is why it is the one players keep buying.

## What this adds

A maintenance operation. It moves the equipment-list lines and the purchases onto the weapon, writes the weapon's free firing lines onto each moved purchase, and drops the wargear row — one transaction, with the deletes last so that a protected reference the moves missed stops the repair whole rather than letting it half-finish.

The firing lines matter as much as the move. A weapon's statline does not come from the weapon row: it comes from child assignments naming its firing lines, written by `_grant_free_profiles` when a weapon is acquired. A purchase made against the wargear row never had any, so moving one onto the weapon without them would leave the card as blank as it was.

**It moves no money.** The matching rule makes the two agree on price, and what a purchase was worth is pinned on its ledger entry, which is never rewritten; the granted lines are free and carry zero-valued entries. Every affected gang is reconciled before the moves and again after, and any gang that stops balancing unwinds the whole run. Gangs that were already drifting are exempted rather than allowed to block the repair.

**One thing does change for a reader.** A gang's history asks what an assignment names now, so these purchases start reading "weapon" where they read "wargear". The name, the price and the sums are untouched.

## The matching rule, and why it is narrow

Same pack, name and qualifier; the weapon has a firing line; the two agree on category and on price; and the wargear carries nothing that cannot cross the seam. That last clause is the important one — the seam is not symmetric. A held-at-most ceiling and option groups can name a wargear but not a weapon, and option groups cascade, so a careless delete would empty them in silence.

Anything matching on name but failing the rest is reported with its reason and left alone. One same-named pair in the library is filed under two different categories and is left for a content decision rather than swept in.

## Measured on a real database

Forked from the content mirror and populated to production's measured volume — 99 gangs, 181 grenade purchases (38 of them sold), all bought through the 64 equipment-list lines that point at the duplicates. A separate script compared every gang and every card itself, before and after, from outside the run.

| | measured |
|---|---|
| Apply time | 7.8s |
| Gangs whose rating or credits moved | 0 |
| Ledger rating sum | unchanged |
| History events written | 0 |
| Purchases that lost their provenance | 0 |
| Grenades drawn as a bare name | 143 → 0 |
| Grenades drawn as a weapon with a statline | 0 → 143 |
| Wargear duplicates left | 1, the mismatched pair, deliberately |

The ledger grew by exactly 181 entries — the free firing lines, all zero-valued — and by no events at all, which is the point: this changes how something was recorded, not something an owner did.

## Test plan

- [x] `pytest n26` plus the platform maintenance tests — 3,688 passed
- [x] 28 tests covering the merge, the firing lines, each skip reason, provenance, idempotency, the refusal path, and the console door
- [x] End to end: a grenade that listed twice in a browsed Trading Post lists once afterwards, and a model that bought it goes from a bare equipment line to a weapon line with its statline
- [x] Volume smoke test on a real database as above, verified externally
- [x] Rebased onto main after #2242; `n26/maintenance.py` merged without conflict

## How to try it

The operation appears in the maintenance console as "n26: duplicated wargear becomes its weapon". Opening it previews what would move and what is left alone, and writes nothing.