### PR TITLE
feat: the Venator gang legacies become picks, and the slot pilot retires

### DIFF
--- a/.claude/notes/archetype-today.md
+++ b/.claude/notes/archetype-today.md
@@ -1,0 +1,173 @@
+# Archetype today — what the column holds, and why
+
+Written before the Archetype conversion, from the content mirror, the
+production database (read-only), `n26/design/outcasts.md`, and the
+sandbox suites. Counts are production, 2026-08-18.
+
+## The headline
+
+The `archetype` column holds **two unrelated systems** that happen to
+share a kind: the Outcast archetypes (the system the kind was built
+for) and the Venator "House Legacies" (a different concept that
+borrowed the kind because it was there). 164 live picks across 69
+gangs, split almost exactly in half — 83 Outcast, 81 Venator.
+
+A third implementation is also standing: the **Gang Legacy slot type**
+(the slots-and-picks pilot), with 2 pickables, 2 gangs holding the
+slot, 2 answers — and **its pickables are empty**: no modifiers, no
+linked category. A gang that answered the pilot slot got nothing;
+a gang that answered the archetype offer got the house equipment list.
+
+## System 1 — Outcast archetypes (the designed one)
+
+Five heavy rows — Brawler, Gunslinger, Mastermind, Survivor, Wyrd —
+each carrying its whole printed table as 10–11 modifiers:
+
+- fixed `PlacesCategory` rows per rank ("Brawler: Leader models —
+  Combat is Primary"), hung off the shared rank subtypes so every
+  profile variant receives them;
+- the Champion rows scoped **bearer-only** ("(own pick)") — inert in
+  the gang's radiated copy, active only on a Champion who picked it
+  personally;
+- Wyrd additionally grants the Wyrd subtype per rank and places Wyrd
+  Powers under Primary.
+
+This is the deliberate design (`design/outcasts.md`, decided
+2026-08-06): where a Venator skill-tree slot carries the meaning and
+the pick contributes one datum, an Outcast archetype token **knows its
+whole payload** — no indirection, one carrier per printed archetype,
+the whole table aboard.
+
+### The leader/champion behaviour, precisely
+
+Two offers, two hosts:
+
+1. **The gang's archetype.** "Chosen when a Leader is recruited": the
+   Leader *profile* carries the offer, and the answer lands **on the
+   gang** (`will_be_assigned_to="gang"` was added for exactly this).
+   The pick is a gang row *caused by the Leader's own assignment*, so
+   it radiates to every fighter through the ordinary broadcast and
+   **dies with the Leader** through the caused-by cascade. This
+   superseded an earlier gang-built-in-slot draft, deliberately: the
+   cascade is what makes "chosen when a Leader is recruited" data
+   rather than prose. 35 live picks sit on gangs this way.
+2. **A Champion's own archetype.** "All models except Champions;
+   Champions may choose a different Archetype": the Champion profile
+   carries its own offer landing on the **bearer**. The token's
+   bearer-only rows are what a Champion gets from their personal pick.
+   48 live picks — Champions answer more often than Leaders.
+
+### The wart in system 1
+
+There are **four Outcast Leader profiles** ("Leader 1"–"Leader 4", all
+135cr — the printed list's four builds), and the gang-archetype offer
+is **duplicated four times, one copy per profile**. Four identical
+modifiers saying "chooses the gang's Archetype". Meanwhile the
+archetype *tables* hang off the one shared Leader subtype. So the
+content already knows the right factoring for the payload but not for
+the question. Contrast the Venator side, where one offer modifier is
+shared across all twelve profiles — the same authoring decision made
+both ways in one library.
+
+Four copies means four questions that are really one: each Leader
+profile's line asks its own copy, and only the cascade's practical
+shape (one Leader hired) keeps a gang from being asked twice. A gang
+that hires two Leaders (owner freedom — nothing polices it) gets two
+live archetype questions.
+
+## System 2 — Venator "House Legacies" (the borrowed kind)
+
+Seven light rows — Cawdor, Delaque, Escher, Goliath, Ironhead Squat,
+Orlock, Van Saar — each carrying exactly one modifier: *adds that
+house's equipment list to the bearer*. That is the entire payload
+("really all it gives is access to an equipment list").
+
+One offer modifier, shared by all **twelve** Venator hunt profiles
+(House Hunt Leader 1–4, House Hunt Champion 1–4, House Hunter 1–4),
+labelled **"Gang Legacy"**, narrowed to the "House Legacies" menu,
+landing on the **bearer** — each fighter takes their own legacy.
+81 live picks. (Ironhead Squat has never been picked.)
+
+Why it is an Archetype: when this was authored the Gang Legacy concept
+had no kind of its own, `Archetype` was the nearest chosen-carrier
+kind, and the label override ("Gang Legacy") papered over the name.
+The card says "Gang Legacy: Van Saar" while the database says
+Archetype — the vocabulary and the storage disagree.
+
+There is also **one fossil**: a detached duplicate of the offer
+("House Hunt Leader 1: offers a choice of archetype from House
+Legacies") that no carrier holds. It does nothing on any page.
+
+## System 3 — the Gang Legacy slot pilot (standing, hollow)
+
+`SlotType "Gang Legacy"` (repeats refused), picklist "All Gang
+Legacies" with **two** pickables (Cawdor, Ironhead Squat), one slot,
+nothing granting it — the two gangs holding it were assigned the slot
+directly. Both answered. **The pickables carry no payload**: no
+equipment-list grant, no linked category. The two pilot answers
+display a choice that does nothing the archetype twin would do.
+
+## What was decided (2026-08-18, after discussion)
+
+- **The pilot retires, nothing reuses it** — a dedicated audited
+  maintenance operation deletes it whole (the admin refuses the
+  cascade and the UI cannot; this is the sanctioned backfill route).
+  The Gang Legacy conversion refuses while any pilot remnant stands.
+- **The conversion builds fresh Gang Legacy machinery** from the offer
+  and its menu — which lists **six** houses, not seven: Ironhead Squat
+  was never offered (its pilot pickable was evidently the start of
+  Squat legacies on the new system). Re-offering Squat legacies is
+  content work after conversion, as is extending the new slot grant to
+  the three Squat Hunt profiles, which today carry no legacy question.
+- **Outcast Leader offers stay per-profile** when that half converts.
+- **The gang's archetype reaches every fighter except Champions; a
+  Champion's own pick affects only them.** The content already builds
+  this (bearer-only Champion rows) and any conversion preserves it by
+  moving modifiers wholesale.
+- History turns out to change nothing: these picks stand as their own
+  acts and never draw a kind word, pinned by the story tests.
+
+## The original proposal (superseded above)
+
+Two systems, so **two conversions** — and they are different shapes:
+
+1. **House Legacies → the Gang Legacy slot type**, finishing what the
+   pilot started: seven pickables (created from the archetype rows,
+   moving their one equipment-list modifier each), the picklist grown
+   from 2 to 7, the twelve profiles' one shared offer swapped for a
+   grant of a per-model slot, 81 picks rewritten. The two hollow
+   pilot pickables must gain their payload (or be replaced), and the
+   two pilot answers must end up indistinguishable from converted
+   ones. This also retires the vocabulary lie: the thing called
+   "Gang Legacy" on cards stops being an Archetype underneath.
+2. **Outcast archetypes → an "Archetype" slot type.** The tokens'
+   payloads move to pickables wholesale (the modifiers move; the
+   bearer-only Champion rows ride along unchanged). Two slots: the
+   gang's (granted by the Leader — see below) and the Champion's
+   personal one. The pick-lands-on-gang and dies-with-the-Leader
+   behaviour must survive conversion exactly: the rewritten pick keeps
+   its `caused_by` (the Leader's line), so the cascade is untouched.
+
+The **fix-while-migrating** candidate for the leader wart: the four
+per-profile offer copies become **one** slot grant carried by the
+shared Leader subtype — the same factoring the tables already use.
+That changes where the question is anchored (subtype assignment vs
+profile assignment), so the existing 35 gang picks' `caused_by` would
+need re-anchoring — or the four copies become four grants of the
+*same* slot (no re-anchoring, wart preserved but harmless: same slot,
+same question). The second is the conversion-safe choice; the first
+is the content fix. Decide before building.
+
+Open questions:
+
+- Does the Champion's personal slot and the gang's slot share one
+  "Archetype" slot type (repeats allowed — a Champion may legitimately
+  duplicate the gang's archetype) or two types? One type, repeats
+  allowed, looks right — the doubled-pick note must not fire when a
+  Champion picks what the gang has.
+- The chosen-mode machinery is untouched here — no `the_chosen`
+  placements read archetype picks, so no linked categories are needed:
+  every payload is ordinary modifiers on the pickable.
+- The Venator slot is per-model ("Gang Legacy" on each hunt fighter);
+  its grant rides the twelve profiles (or their shared subtype, if one
+  exists — check before building).

--- a/.claude/notes/backfill-lessons.md
+++ b/.claude/notes/backfill-lessons.md
@@ -1,0 +1,119 @@
+# Lessons learned: building good backfill operations
+
+Distilled from the Paths, Specialisation and Skill Tree conversions
+and the wargear merge (2026-07 to 2026-08). The short version: **plan
+frozen, prove sampled, delete nothing, run as a task, hold one narrow
+lock, and verify from outside.**
+
+## Shape
+
+1. **Plan / apply, and the preview is the contract.** The plan reads
+   the world and returns frozen, typed steps plus problems; it never
+   writes. The apply performs exactly those steps. Whatever the
+   preview page says is precisely what happens — no judgement calls at
+   apply time.
+2. **Refuse in words, in the plan.** Every assumption the apply relies
+   on is a plan check that appends a human sentence to `problems`
+   ("…is shared — also carried by X"). A conversion that can be
+   surprised at apply time was underchecked at plan time. The refusal
+   reaches the operator's screen from the view, before anything is
+   enqueued.
+3. **Delete nothing.** Every hard problem in the early attempts —
+   PROTECT errors, fossil wiring, doubled answers — came from retiring
+   old rows, which is tidiness, not the switch. Old rows left alone go
+   on saying what they said; retire them later, one at a time, by
+   hand. The switch is only ever *what the pages read from*.
+4. **Never ship a conversion as a migration.** A migration running
+   live ORM code inherits a dependency on every column that code will
+   ever read, and the pin needed to say so can contradict the recorded
+   history of a database that already ran it. Conversions run from the
+   maintenance console after deploy, on a schema that is fully
+   migrated by construction. (`manage n26_convert <system>` covers
+   dev databases.)
+
+## Proving
+
+5. **Capture pages, not intentions.** Before writing, capture what
+   every proven gang's pages say (`gang_state`); after writing,
+   capture again; refuse and unwind on any difference, and on any
+   gang that stops reconciling. "Every page reads the same" is the
+   only claim worth making.
+6. **Prove a spread, not the estate.** Proving every gang holds the
+   transaction for minutes on a live app — worse than incompletely
+   proven. Prove a fixed-size sample chosen to hold every *shape* the
+   system comes in (the doubled answer, the repeat, the partial, the
+   never-answered, the ordinary), one from each kind per round so a
+   plentiful kind cannot crowd a rare one out. What breaks is shaped
+   by the content, not by one gang's data.
+7. **One snapshot for the whole run.** On a live database the proof's
+   two readings must see one world, or a player's mid-run purchase
+   reads as the conversion's doing and the run refuses for a reason
+   nobody can act on. REPEATABLE READ, set on the session before the
+   transaction reads anything, restored afterwards, non-masking on
+   failure.
+8. **The captures don't see the ledger's wording.** History describes
+   old events by what their assignments name *now*, so moving an
+   assignment between kinds rewrites already-written stories
+   silently. Check the history page against a converted assignment;
+   pin the story with a same-words test.
+
+## Running
+
+9. **The work runs on the task runner, never in the request** —
+   however small it looks. A request that does the work holds a
+   worker and a transaction for its whole duration, dies at the
+   timeout with no record of how far it got, and shows a spinning tab
+   instead of a page to come back to. The audit record is created
+   *before* enqueue (status RUNNING), so an in-flight run is visible.
+10. **Design for at-least-once delivery.** The task never raises (a
+    raised error just goes round again); every ending is written to
+    the record. A redelivery must leave no trace while the first copy
+    works, and must not be able to unwrite a recorded ending —
+    terminal statuses are immutable, and the ending-writer drops late
+    writes.
+11. **One advisory lock per operation, never shared.** The lock
+    fences redeliveries of *one operation's own run*. Shared, one
+    conversion enqueued while another runs stands down at the lock
+    without writing, acks its message, and strands its record in
+    RUNNING forever — with the per-operation running-guard then
+    refusing every retry. Postgres frees advisory locks with the
+    connection, so a killed run cleans up itself.
+12. **Cap the attempts.** Count each start on the record, outside the
+    conversion's transaction so the count survives a rollback. A run
+    too large to finish gets noticed and says so instead of repeating
+    forever at full cost.
+13. **The ack deadline equals the request timeout.** A run outliving
+    its deadline is redelivered while the first copy works; the second
+    copy stands down, answers 200, and acks the message out from under
+    the first. Change one, change the other.
+
+## Verifying (before shipping)
+
+14. **Smoke-test on a real database at production's measured volume.**
+    Fork the content mirror, read the counts off prodshell rather
+    than guessing, build the population — including the weird shapes
+    (the gang that answered everything with one thing, the doubled
+    click, the archived re-choice) — run the real code path, and time
+    it. Tests prove the logic on a handful of rows; the smoke run
+    catches the volume, the runtime, and the shapes nobody wrote a
+    fixture for. The Specialisation rehearsal failed in production
+    for a reason (concurrent writes) that no test database could show.
+15. **Verify from outside the run.** After the smoke apply, diff
+    *every* affected gang's pages and history stories yourself — not
+    just the sample the run proves for itself — instead of trusting
+    what the feature checks internally.
+16. **Rehearse the failure you fixed.** The snapshot-isolation fix was
+    proven by deliberately racing a purchase mid-run with the fix on
+    (applies) and off (reproduces the production failure). A fix
+    whose failure you can't reproduce isn't known to be a fix.
+
+## Writing it down
+
+17. **The record is the report.** Preview into the record at enqueue,
+    report lines into it at DONE, refusal words into `error` at
+    FAILED. The detail page should answer "what happened" without
+    anyone reading logs.
+18. **Retire an operation by keeping its slug registered with no
+    view.** The old audit records keep reading as a name; the console
+    index stops offering the operation; the code that could be copied
+    is gone.

--- a/n26/core/templates/admin/maintenance/n26/retire_pilot.html
+++ b/n26/core/templates/admin/maintenance/n26/retire_pilot.html
@@ -1,0 +1,76 @@
+{% extends "admin/base_site.html" %}
+{% comment %}
+The pilot retirement's console page: what stands, what deleting it
+means, an apply button, and the recent runs. Context from
+retire_gang_legacy_pilot_view (n26/maintenance.py): title, pilot,
+preview, apply_url, recent.
+{% endcomment %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-plan { font-family: monospace; line-height: 1.6; }
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    .mt-problems { color: var(--error-fg, #ba2121); }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        This deletes — the one operation that does. The pilot was a hand-built
+        experiment whose pickables carry nothing, and its rows squat on the
+        names the real Gang Legacy conversion needs. Every row it would
+        delete is listed below; it refuses if anything outside the pilot has
+        come to depend on them.
+    </p>
+    {% if pilot.nothing_here %}
+        <h2>Nothing to retire</h2>
+        <p>No slot type of the pilot's name stands. It has been retired already, or was never here.</p>
+    {% elif not pilot.ok %}
+        <h2 class="mt-problems">The retirement refuses</h2>
+        <ul class="mt-problems">
+            {% for problem in pilot.problems %}<li>{{ problem }}</li>{% endfor %}
+        </ul>
+        <p>Nothing can be applied while any of these stands.</p>
+    {% else %}
+        <h2>What it would do</h2>
+        <ul class="mt-plan">
+            {% for line in preview %}<li>{{ line }}</li>{% endfor %}
+        </ul>
+        <form method="post"
+              class="mt-form"
+              onsubmit="return confirm('Delete the pilot? This cannot be undone.')">
+            {% csrf_token %}
+            <button type="submit" class="button default">Retire the pilot</button>
+        </form>
+    {% endif %}
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/library/conversion/__init__.py
+++ b/n26/library/conversion/__init__.py
@@ -9,6 +9,7 @@ gang's pages still say the same things. The preview is the contract.
 """
 
 from n26.library.conversion.base import ConversionRefused, Plan, apply
+from n26.library.conversion.gang_legacy import plan_gang_legacy
 from n26.library.conversion.paths import plan_paths
 from n26.library.conversion.skill_tree import plan_skill_tree
 from n26.library.conversion.specialisation import plan_specialisation
@@ -20,6 +21,7 @@ SYSTEMS = {
     "paths": plan_paths,
     "specialisation": plan_specialisation,
     "skill_tree": plan_skill_tree,
+    "gang_legacy": plan_gang_legacy,
 }
 
 __all__ = [
@@ -27,6 +29,7 @@ __all__ = [
     "Plan",
     "SYSTEMS",
     "apply",
+    "plan_gang_legacy",
     "plan_paths",
     "plan_skill_tree",
     "plan_specialisation",

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -313,6 +313,16 @@ class SwapCarrier:
         app_label, model_name = self.carrier[0].split(".")
         carrier = apps.get_model(app_label, model_name).objects.get(pk=self.carrier[1])
         dropped = Modifier.objects.get(pk=self.drop_modifier_id)
+        # The plan proved this modifier solely carried, but the plan was
+        # read outside this transaction: a carrier attached since would
+        # be detached silently by the delete below. Prove it again here,
+        # where the snapshot holds.
+        holders = {(kind, row.pk) for kind, row in carriers_of(dropped)}
+        if holders != {(model_name, self.carrier[1])}:
+            raise ConversionRefused(
+                f"“{self.drop_modifier_name}” is no longer carried only by "
+                f"{self.carrier_name} — the world moved since the plan was made"
+            )
         scope_row, effect_row = dropped.scope, dropped.effect
         carrier.modifiers.remove(dropped)
         dropped.delete()
@@ -370,6 +380,17 @@ class SwapSharedCarrier:
             for label, pk in self.carriers
         ]
         dropped = Modifier.objects.get(pk=self.drop_modifier_id)
+        # The plan proved exactly these carriers, but the plan was read
+        # outside this transaction: a carrier attached since would be
+        # detached silently by the delete below. Prove it again here,
+        # where the snapshot holds.
+        holders = {(kind, row.pk) for kind, row in carriers_of(dropped)}
+        named = {(label.split(".")[1], pk) for label, pk in self.carriers}
+        if holders != named:
+            raise ConversionRefused(
+                f"“{self.drop_modifier_name}” is no longer carried by exactly "
+                f"{self.carriers_said} — the world moved since the plan was made"
+            )
         scope_row, effect_row = dropped.scope, dropped.effect
         for carrier in rows:
             carrier.modifiers.remove(dropped)

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -328,6 +328,66 @@ class SwapCarrier:
 
 
 @dataclass(frozen=True)
+class SwapSharedCarrier:
+    """One offer shared by many carriers becomes one shared grant.
+
+    The offer modifier is a single row every carrier holds, so dropping
+    it detaches all of them at once — which is why the plan proves the
+    carriers are exactly the ones named here before this step exists.
+    The grant is one shared modifier too, so the factoring the authors
+    chose is preserved: one question's wiring, held in one place.
+    """
+
+    carriers: tuple  # ((model label, pk), ...) — every carrier, proven
+    carriers_said: str
+    drop_modifier_id: object
+    drop_modifier_name: str
+    grant_name: str
+    slot: str
+    reach: str = "model"
+
+    def say(self):
+        return (
+            f"on {self.carriers_said}: replace the shared "
+            f"“{self.drop_modifier_name}” with a shared grant of the "
+            f"“{self.slot}” slot"
+        )
+
+    def perform(self, made):
+        from django.apps import apps
+
+        from n26.library.authoring import (
+            attach_modifiers_to,
+            ef_adds,
+            modifier,
+            targets_gang_alone,
+            targets_model,
+        )
+        from n26.library.models import Modifier
+
+        rows = [
+            apps.get_model(*label.split(".")).objects.get(pk=pk)
+            for label, pk in self.carriers
+        ]
+        dropped = Modifier.objects.get(pk=self.drop_modifier_id)
+        scope_row, effect_row = dropped.scope, dropped.effect
+        for carrier in rows:
+            carrier.modifiers.remove(dropped)
+        dropped.delete()
+        scope_row.delete()
+        effect_row.delete()
+        scope = targets_gang_alone() if self.reach == "gang_alone" else targets_model()
+        grant = modifier(
+            self.grant_name,
+            scope,
+            ef_adds(made.slots[self.slot]),
+            attach_to=rows[0],
+        )
+        for carrier in rows[1:]:
+            attach_modifiers_to(carrier, [grant])
+
+
+@dataclass(frozen=True)
 class DropModifier:
     """A modifier retired outright — for behaviour that is ending, not
     moving. The plan must have proven the modifier does nothing on any

--- a/n26/library/conversion/gang_legacy.py
+++ b/n26/library/conversion/gang_legacy.py
@@ -1,8 +1,8 @@
 """The Gang Legacy conversion — the Venator house-legacy system.
 
-Today: the twelve Venator hunt profiles share one offer of the
-archetype kind, labelled "Gang Legacy" and narrowed to the "House
-Legacies" menu; seven house-named archetype rows each carry one
+Today: the Venator hunt profiles share one offer of the archetype
+kind, labelled "Gang Legacy" and narrowed to the "House Legacies"
+menu; the house-named archetype rows it offers each carry one
 modifier — that house's equipment list, granted to the bearer. The
 kind is borrowed: when this was authored the concept had no kind of
 its own, and the label papered over the name — the card says
@@ -11,15 +11,15 @@ never says the borrowed word (these picks stand as their own acts), so
 no written story changes; where a surface asks a pick its sort, the
 answer becomes the card's word.
 
-After: a "Gang Legacy" slot type; the seven houses as pickables, each
-carrying its equipment-list modifier — moved, not copied; one picklist;
-one per-bearer slot granted by the same twelve profiles through one
+After: a "Gang Legacy" slot type; the menu's houses as pickables,
+each carrying its equipment-list modifier — moved, not copied; one
+picklist; one per-bearer slot granted by the same profiles through one
 shared modifier, preserving the factoring the authors chose. Every
 stored choice is re-said as a pick on its same anchor.
 
-**Nothing is deleted.** The emptied archetype rows, the old menu
-collection, and the one detached fossil offer stay where they are,
-saying what they say now.
+**Nothing is deleted.** The emptied archetype rows, any house the
+menu never offered, the old menu collection, and any detached fossil
+offer stay where they are, saying what they say now.
 
 This plan expects a clean field: the earlier slot pilot — a hollow
 slot type of the same name — must be retired first (the console offers
@@ -62,6 +62,7 @@ PROVEN = 25
 def plan_gang_legacy():
     from n26.core.models import Assignment
     from n26.library.models import Modifier, SlotType
+    from n26.library.models.pack import default_pack_id
 
     problems = []
 
@@ -95,7 +96,10 @@ def plan_gang_legacy():
     # The pilot must be retired before this can build: the names are
     # unique per pack, and a half-built slot type standing in this one's
     # place would make every step below a collision.
-    if SlotType.objects.filter(name=SLOT_TYPE).exists():
+    # Scoped to the default pack, where this builds: a custom pack's
+    # own slot type of the same name is somebody's content, not a
+    # collision.
+    if SlotType.objects.filter(name=SLOT_TYPE, pack_id=default_pack_id()).exists():
         problems.append(
             f"a slot type named “{SLOT_TYPE}” already stands — retire the "
             "pilot first (the console offers it)"

--- a/n26/library/conversion/gang_legacy.py
+++ b/n26/library/conversion/gang_legacy.py
@@ -121,11 +121,16 @@ def plan_gang_legacy():
         problems.append("the offer names no menu — expected the house list")
         old_rows = []
     else:
+        # Live entries of live houses only: an archived row on the menu
+        # is content somebody retired, and a conversion must not
+        # resurrect it as a pickable.
         old_rows = sorted(
             (
                 entry.archetype
                 for entry in section.collection.entries.filter(
-                    archetype__isnull=False
+                    archetype__isnull=False,
+                    archetype__archived=False,
+                    archived=False,
                 ).select_related("archetype", "archetype__category")
             ),
             key=lambda row: row.name,
@@ -135,6 +140,23 @@ def plan_gang_legacy():
     twice = duplicate_names(old_rows)
     if twice:
         problems.append("more than one live house is called: " + ", ".join(twice))
+
+    # The names the steps would create must be free in the default pack
+    # — a survivor of the pilot, or anything else wearing one, would
+    # turn a valid-looking plan into a mid-apply integrity error.
+    from n26.library.models import Pickable, Picklist, Slot
+
+    taken = Pickable.objects.filter(
+        pack_id=default_pack_id(), name__in=[row.name for row in old_rows]
+    ).values_list("name", flat=True)
+    if taken:
+        problems.append(
+            "pickables already wear these names: " + ", ".join(sorted(taken))
+        )
+    if Picklist.objects.filter(pack_id=default_pack_id(), name=PICKLIST).exists():
+        problems.append(f"a picklist named “{PICKLIST}” already stands")
+    if Slot.objects.filter(pack_id=default_pack_id(), name=SLOT).exists():
+        problems.append(f"a slot named “{SLOT}” already stands")
 
     # No granted-carrier check here: a profile is never granted by a
     # modifier — a fighter arrives by hire (or as a pet's model), and
@@ -153,6 +175,27 @@ def plan_gang_legacy():
         .order_by("created")
     )
     answers, spares = one_answer_per_question(picks)
+
+    # A live archetype pick anchored on a carrying profile but naming a
+    # house the menu does not offer would keep its line and lose its
+    # question when the offer is swapped — refuse, and let somebody
+    # decide what it means.
+    strays = (
+        Assignment.objects.filter(
+            archetype__isnull=False,
+            archived=False,
+            caused_by__profile__in=profile_pks,
+        )
+        .exclude(removes=True)
+        .exclude(archetype__in=list(becoming))
+        .select_related("archetype")
+    )
+    for stray in strays:
+        problems.append(
+            f"pick {stray.pk} names “{stray.archetype.name}”, which the "
+            "menu does not offer — it would lose its question unanswered"
+        )
+
     for pick in answers:
         if pick.caused_by_id is None:
             problems.append(f"pick {pick.pk} has no caused_by to settle against")

--- a/n26/library/conversion/gang_legacy.py
+++ b/n26/library/conversion/gang_legacy.py
@@ -1,0 +1,241 @@
+"""The Gang Legacy conversion — the Venator house-legacy system.
+
+Today: the twelve Venator hunt profiles share one offer of the
+archetype kind, labelled "Gang Legacy" and narrowed to the "House
+Legacies" menu; seven house-named archetype rows each carry one
+modifier — that house's equipment list, granted to the bearer. The
+kind is borrowed: when this was authored the concept had no kind of
+its own, and the label papered over the name — the card says
+"Gang Legacy" while the storage says archetype. The gang's history
+never says the borrowed word (these picks stand as their own acts), so
+no written story changes; where a surface asks a pick its sort, the
+answer becomes the card's word.
+
+After: a "Gang Legacy" slot type; the seven houses as pickables, each
+carrying its equipment-list modifier — moved, not copied; one picklist;
+one per-bearer slot granted by the same twelve profiles through one
+shared modifier, preserving the factoring the authors chose. Every
+stored choice is re-said as a pick on its same anchor.
+
+**Nothing is deleted.** The emptied archetype rows, the old menu
+collection, and the one detached fossil offer stay where they are,
+saying what they say now.
+
+This plan expects a clean field: the earlier slot pilot — a hollow
+slot type of the same name — must be retired first (the console offers
+that as its own operation), because slot-type and pickable names are
+unique per pack and the pilot's rows hold them.
+
+Production converts from the maintenance console, once, after the code
+deploys — see :mod:`n26.maintenance`. Elsewhere the command does it
+(``manage n26_convert gang_legacy``).
+"""
+
+from n26.library.conversion.base import (
+    CreatePickable,
+    CreatePicklist,
+    CreateSlot,
+    CreateSlotType,
+    Plan,
+    RewritePick,
+    SwapSharedCarrier,
+    carriers_of,
+    duplicate_names,
+    one_answer_per_question,
+    spread,
+)
+
+SLOT_TYPE = "Gang Legacy"
+PLURAL = "Gang Legacies"
+PICKLIST = "House Legacies"
+SLOT = "Gang Legacy"
+OFFER_LABEL = "Gang Legacy"
+
+#: How many gangs the apply proves unchanged before committing — the
+#: same reasoning as every conversion: a spread wide enough to hold
+#: every shape the system comes in, proven with the lock held for
+#: seconds, where proving everyone would hold rows players are using
+#: for minutes.
+PROVEN = 25
+
+
+def plan_gang_legacy():
+    from n26.core.models import Assignment
+    from n26.library.models import Modifier, SlotType
+
+    problems = []
+
+    # Every archetype-kind offer wearing this system's label, split into
+    # the one the profiles carry and any detached fossils. The fossil is
+    # left alone — carried by nothing, it does nothing on any page — but
+    # it must not be mistaken for the offer being converted.
+    wearing = [
+        m
+        for m in Modifier.objects.filter(
+            offers_choice__isnull=False,
+            offers_choice__of_kind__model="archetype",
+        ).select_related("offers_choice", "offers_choice__from_section")
+        if m.offers_choice.label == OFFER_LABEL
+    ]
+    carried = [(m, carriers_of(m)) for m in wearing]
+    live_offers = [(m, held) for m, held in carried if held]
+
+    if not live_offers:
+        return Plan(system="gang_legacy", nothing_here=True)
+    if len(live_offers) > 1:
+        return Plan(
+            system="gang_legacy",
+            problems=(
+                f"{len(live_offers)} carried offers wear the label "
+                f"“{OFFER_LABEL}” — expected one",
+            ),
+        )
+    offer, held_by = live_offers[0]
+
+    # The pilot must be retired before this can build: the names are
+    # unique per pack, and a half-built slot type standing in this one's
+    # place would make every step below a collision.
+    if SlotType.objects.filter(name=SLOT_TYPE).exists():
+        problems.append(
+            f"a slot type named “{SLOT_TYPE}” already stands — retire the "
+            "pilot first (the console offers it)"
+        )
+
+    strangers = [kind for kind, _ in held_by if kind != "Profile"]
+    if strangers:
+        problems.append(
+            "the offer is carried by things that are not profiles: "
+            + ", ".join(sorted(set(strangers)))
+        )
+    profiles = sorted(
+        (row for kind, row in held_by if kind == "Profile"),
+        key=lambda row: row.name,
+    )
+
+    section = offer.offers_choice.from_section
+    if section is None:
+        problems.append("the offer names no menu — expected the house list")
+        old_rows = []
+    else:
+        old_rows = sorted(
+            (
+                entry.archetype
+                for entry in section.collection.entries.filter(
+                    archetype__isnull=False
+                ).select_related("archetype", "archetype__category")
+            ),
+            key=lambda row: row.name,
+        )
+        if not old_rows:
+            problems.append("the house menu offers no archetypes to convert")
+    twice = duplicate_names(old_rows)
+    if twice:
+        problems.append("more than one live house is called: " + ", ".join(twice))
+
+    # No granted-carrier check here: a profile is never granted by a
+    # modifier — a fighter arrives by hire (or as a pet's model), and
+    # either way its line is an assignment the counting below sees.
+
+    # Only live answers of the houses this menu offers move. Picks of
+    # the other system sharing the column — the Outcast archetypes —
+    # are not this conversion's to touch, and their anchors are how the
+    # two are told apart.
+    becoming = {row.pk: row.name for row in old_rows}
+    profile_pks = {p.pk for p in profiles}
+    picks = list(
+        Assignment.objects.filter(archetype__in=list(becoming), archived=False)
+        .exclude(removes=True)
+        .select_related("archetype", "gang_root", "caused_by")
+        .order_by("created")
+    )
+    answers, spares = one_answer_per_question(picks)
+    for pick in answers:
+        if pick.caused_by_id is None:
+            problems.append(f"pick {pick.pk} has no caused_by to settle against")
+        elif pick.caused_by.profile_id not in profile_pks:
+            problems.append(
+                f"pick {pick.pk} is anchored on “{pick.caused_by}”, which is "
+                "not one of the profiles carrying the offer"
+            )
+
+    if problems:
+        return Plan(system="gang_legacy", problems=tuple(problems))
+
+    steps = [
+        CreateSlotType(name=SLOT_TYPE, plural_name=PLURAL, allows_repeats=False),
+        *[
+            CreatePickable(
+                name=row.name,
+                slot_type=SLOT_TYPE,
+                moved_modifier_ids=tuple(m.pk for m in row.modifiers.all()),
+                moved_from=("library.Archetype", row.pk),
+            )
+            for row in old_rows
+        ],
+        CreatePicklist(
+            name=PICKLIST,
+            slot_type=SLOT_TYPE,
+            members=tuple(row.name for row in old_rows),
+        ),
+        CreateSlot(
+            name=SLOT,
+            slot_type=SLOT_TYPE,
+            picklist=PICKLIST,
+            assigned_to="bearer",
+            min_picks=0,
+        ),
+        SwapSharedCarrier(
+            carriers=tuple(("library.Profile", p.pk) for p in profiles),
+            carriers_said=f"the {len(profiles)} hunt profiles",
+            drop_modifier_id=offer.pk,
+            drop_modifier_name=offer.name,
+            grant_name="Hunt profiles: the model is asked its Gang Legacy",
+            slot=SLOT,
+            reach="model",
+        ),
+        *[
+            RewritePick(
+                assignment_id=pick.pk,
+                old_column="archetype",
+                pickable=becoming[pick.archetype_id],
+                slot=SLOT,
+                gang=str(pick.gang_root),
+            )
+            for pick in answers
+        ],
+    ]
+
+    # Every gang the change can reach: one holding a fighter of any of
+    # the carrying profiles, whether or not it ever answered. A
+    # detached fossil offer reaches nobody and is left alone.
+    holders = set(
+        Assignment.objects.filter(archived=False, profile__in=profile_pks)
+        .exclude(removes=True)
+        .values_list("gang_root_id", flat=True)
+        .distinct()
+    )
+    answered = {pick.gang_root_id for pick in answers}
+    holders |= answered
+
+    by_gang = {}
+    for pick in answers:
+        by_gang.setdefault(pick.gang_root_id, []).append(pick)
+    crowded = [gang_id for gang_id, held in by_gang.items() if len(held) >= 3]
+
+    proven = spread(
+        holders,
+        [
+            [pick.gang_root_id for pick in spares],
+            sorted(crowded, key=str),
+            sorted(holders - answered, key=str),
+            sorted(answered, key=str),
+        ],
+        PROVEN,
+    )
+    return Plan(
+        system="gang_legacy",
+        steps=tuple(steps),
+        gang_ids=tuple(proven),
+        reaches=len(holders),
+        left_alone=len(spares),
+    )

--- a/n26/library/gang_legacy_pilot.py
+++ b/n26/library/gang_legacy_pilot.py
@@ -77,8 +77,14 @@ def find():
     """Read the pilot as it stands. Never writes."""
     from n26.core.models import Assignment, LedgerEvent
     from n26.library.models import Pickable, Picklist, Slot, SlotType
+    from n26.library.models.pack import default_pack_id
 
-    slot_type = SlotType.objects.filter(name=SLOT_TYPE).first()
+    # Scoped to the default pack: names are only unique per pack, and a
+    # custom pack's own slot type of this name is somebody's content,
+    # never the pilot.
+    slot_type = SlotType.objects.filter(
+        name=SLOT_TYPE, pack_id=default_pack_id()
+    ).first()
     if slot_type is None:
         return Pilot(nothing_here=True)
 
@@ -88,10 +94,11 @@ def find():
     pickables = list(Pickable.objects.filter(slot_type=slot_type))
 
     for pickable in pickables:
-        if pickable.modifiers.exists():
+        if pickable.modifiers.exists() or pickable.category_id is not None:
             problems.append(
-                f"pickable “{pickable.name}” carries modifiers — the pilot "
-                "was hollow, so this has grown a purpose and is not it"
+                f"pickable “{pickable.name}” carries modifiers or links a "
+                "category — the pilot was hollow, so this has grown a "
+                "purpose and is not it"
             )
 
     doomed = list(

--- a/n26/library/gang_legacy_pilot.py
+++ b/n26/library/gang_legacy_pilot.py
@@ -1,0 +1,172 @@
+"""Retiring the Gang Legacy slot pilot — a one-shot deletion.
+
+An early experiment built a "Gang Legacy" slot type by hand: one slot,
+one picklist, two pickables carrying nothing — no modifiers, no linked
+category — and a handful of hand-placed assignments answering it on one
+test gang. The pickables being hollow, those answers grant nothing; the
+machinery is a name-squatter, and the names matter: slot types and
+pickables are unique per pack, so the real Gang Legacy conversion
+cannot build until these rows are gone.
+
+Deletion is exactly why this is its own operation rather than part of
+the conversion: conversions delete nothing, and the admin refuses the
+cascade (player rows are registered read-only there, deliberately).
+The rows die here instead, once, with an audit record, and with the
+checks below standing between this and ever deleting anything that has
+grown a purpose:
+
+* every referencing assignment — archived included — must belong to
+  **one** gang;
+* every pickable must still be hollow;
+* nothing outside the pilot may hang off the doomed assignments.
+
+The plan/apply split is the conversion discipline's: ``find()`` reads
+and describes, ``apply()`` performs exactly that, and the gang must
+still reconcile afterwards — slots and picks are free, so retiring
+them must not move its rating by a credit.
+"""
+
+from dataclasses import dataclass
+
+from django.db import transaction
+
+
+class Refused(Exception):
+    """The retirement found the world grown past what it may delete."""
+
+
+SLOT_TYPE = "Gang Legacy"
+
+
+@dataclass(frozen=True)
+class Pilot:
+    """What stands, and what retiring it would delete."""
+
+    slot_type_id: object = None
+    slot_ids: tuple = ()
+    picklist_ids: tuple = ()
+    pickable_ids: tuple = ()
+    assignment_ids: tuple = ()
+    gang_id: object = None
+    gang_said: str = ""
+    events: int = 0
+    problems: tuple = ()
+    nothing_here: bool = False
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    def preview(self):
+        if self.nothing_here:
+            return ["nothing to retire — no slot type of the pilot's name stands"]
+        lines = [
+            f"delete {len(self.assignment_ids)} assignment"
+            f"{'' if len(self.assignment_ids) == 1 else 's'} on {self.gang_said}, "
+            f"and the {self.events} history event"
+            f"{'' if self.events == 1 else 's'} that describe them",
+            f"delete the pilot's slot, its picklist, its "
+            f"{len(self.pickable_ids)} hollow pickables, and the "
+            f"“{SLOT_TYPE}” slot type",
+            "prove the gang still reconciles, or refuse",
+        ]
+        return lines
+
+
+def find():
+    """Read the pilot as it stands. Never writes."""
+    from n26.core.models import Assignment, LedgerEvent
+    from n26.library.models import Pickable, Picklist, Slot, SlotType
+
+    slot_type = SlotType.objects.filter(name=SLOT_TYPE).first()
+    if slot_type is None:
+        return Pilot(nothing_here=True)
+
+    problems = []
+    slots = list(Slot.objects.filter(slot_type=slot_type))
+    picklists = list(Picklist.objects.filter(slot_type=slot_type))
+    pickables = list(Pickable.objects.filter(slot_type=slot_type))
+
+    for pickable in pickables:
+        if pickable.modifiers.exists():
+            problems.append(
+                f"pickable “{pickable.name}” carries modifiers — the pilot "
+                "was hollow, so this has grown a purpose and is not it"
+            )
+
+    doomed = list(
+        Assignment.objects.filter(slot__in=slots)
+        | Assignment.objects.filter(chosen_for_slot__in=slots)
+        | Assignment.objects.filter(pickable__in=pickables)
+    )
+    gangs = {row.gang_root_id for row in doomed}
+    if len(gangs) > 1:
+        problems.append(
+            f"the pilot's rows sit on {len(gangs)} gangs — expected one test "
+            "gang, so somebody else has answered it"
+        )
+
+    # Nothing outside the pilot may be hanging off what dies: a child
+    # assignment would cascade with its cause, and this must never
+    # delete a row it has not named.
+    doomed_pks = {row.pk for row in doomed}
+    for row in doomed:
+        for child in Assignment.objects.filter(caused_by=row):
+            if child.pk not in doomed_pks:
+                problems.append(
+                    f"assignment {child.pk} hangs off the pilot's rows but "
+                    "is not part of the pilot"
+                )
+        for child in Assignment.objects.filter(chosen_for=row):
+            if child.pk not in doomed_pks:
+                problems.append(
+                    f"pick {child.pk} answers the pilot's rows but is not "
+                    "part of the pilot"
+                )
+
+    events = LedgerEvent.objects.filter(assignment__in=doomed_pks).count()
+    gang_id = next(iter(gangs), None)
+    gang_said = str(doomed[0].gang_root) if doomed else "no gang at all"
+    return Pilot(
+        slot_type_id=slot_type.pk,
+        slot_ids=tuple(s.pk for s in slots),
+        picklist_ids=tuple(p.pk for p in picklists),
+        pickable_ids=tuple(p.pk for p in pickables),
+        assignment_ids=tuple(sorted(doomed_pks, key=str)),
+        gang_id=gang_id,
+        gang_said=gang_said,
+        events=events,
+        problems=tuple(problems),
+    )
+
+
+def apply(pilot):
+    """Delete exactly what the pilot names, and prove the gang whole."""
+    from n26.core.models import Assignment, Gang
+    from n26.core.reconcile import assert_reconciled
+    from n26.library.models import Pickable, Picklist, Slot, SlotType
+
+    if pilot.problems:
+        raise Refused("not retired: " + "; ".join(pilot.problems))
+    if pilot.nothing_here:
+        return list(pilot.preview())
+
+    report = list(pilot.preview())
+    with transaction.atomic():
+        Assignment.objects.filter(pk__in=pilot.assignment_ids).delete()
+        Slot.objects.filter(pk__in=pilot.slot_ids).delete()
+        # Members ride their picklist down; the pickables must outlive
+        # them, so the order here is the constraint order.
+        Picklist.objects.filter(pk__in=pilot.picklist_ids).delete()
+        Pickable.objects.filter(pk__in=pilot.pickable_ids).delete()
+        SlotType.objects.filter(pk=pilot.slot_type_id).delete()
+        if pilot.gang_id is not None:
+            gang = Gang.objects.get(pk=pilot.gang_id)
+            try:
+                assert_reconciled(gang)
+            except Exception as failed:
+                raise Refused(
+                    f"refused — {gang} no longer reconciles: {failed}"
+                ) from failed
+    report.append("retired; the field is clean")
+    return report

--- a/n26/library/gang_legacy_pilot.py
+++ b/n26/library/gang_legacy_pilot.py
@@ -114,22 +114,54 @@ def find():
         )
 
     # Nothing outside the pilot may be hanging off what dies: a child
-    # assignment would cascade with its cause, and this must never
-    # delete a row it has not named.
+    # assignment would cascade with its cause, its question, or its
+    # parent, and this must never delete anything it has not named.
     doomed_pks = {row.pk for row in doomed}
     for row in doomed:
-        for child in Assignment.objects.filter(caused_by=row):
+        hanging = (
+            Assignment.objects.filter(caused_by=row)
+            | Assignment.objects.filter(chosen_for=row)
+            | Assignment.objects.filter(parent=row)
+        )
+        for child in hanging:
             if child.pk not in doomed_pks:
                 problems.append(
-                    f"assignment {child.pk} hangs off the pilot's rows but "
-                    "is not part of the pilot"
+                    f"assignment {child.pk} hangs off what the pilot would "
+                    "delete but is not part of the pilot"
                 )
-        for child in Assignment.objects.filter(chosen_for=row):
-            if child.pk not in doomed_pks:
-                problems.append(
-                    f"pick {child.pk} answers the pilot's rows but is not "
-                    "part of the pilot"
-                )
+
+    # Library content naming the doomed machinery protects it from
+    # deletion — and means something has been authored against the
+    # pilot, which is a purpose. Refuse in words rather than let the
+    # delete crash.
+    from n26.library.models import (
+        AddsAssignable,
+        DefaultAssignment,
+        HasPickable,
+        RemovesAssignable,
+    )
+
+    for said, found in (
+        ("a built-in", DefaultAssignment.objects.filter(slot__in=slots)),
+        (
+            "a starting pick",
+            DefaultAssignment.objects.filter(default_pickable__in=pickables),
+        ),
+        ("a grant", AddsAssignable.objects.filter(slot__in=slots)),
+        ("a take-away", RemovesAssignable.objects.filter(slot__in=slots)),
+        ("a condition", HasPickable.objects.filter(pickables__in=pickables)),
+        (
+            "another slot",
+            Slot.objects.filter(picklist__in=picklists).exclude(
+                pk__in=[s.pk for s in slots]
+            ),
+        ),
+    ):
+        if found.exists():
+            problems.append(
+                f"{said} names the pilot's machinery — something has been "
+                "authored against it, which is a purpose"
+            )
 
     events = LedgerEvent.objects.filter(assignment__in=doomed_pks).count()
     gang_id = next(iter(gangs), None)
@@ -158,22 +190,36 @@ def apply(pilot):
     if pilot.nothing_here:
         return list(pilot.preview())
 
+    from django.db.models import ProtectedError
+
     report = list(pilot.preview())
-    with transaction.atomic():
-        Assignment.objects.filter(pk__in=pilot.assignment_ids).delete()
-        Slot.objects.filter(pk__in=pilot.slot_ids).delete()
-        # Members ride their picklist down; the pickables must outlive
-        # them, so the order here is the constraint order.
-        Picklist.objects.filter(pk__in=pilot.picklist_ids).delete()
-        Pickable.objects.filter(pk__in=pilot.pickable_ids).delete()
-        SlotType.objects.filter(pk=pilot.slot_type_id).delete()
-        if pilot.gang_id is not None:
-            gang = Gang.objects.get(pk=pilot.gang_id)
-            try:
-                assert_reconciled(gang)
-            except Exception as failed:
-                raise Refused(
-                    f"refused — {gang} no longer reconciles: {failed}"
-                ) from failed
+    try:
+        with transaction.atomic():
+            # The history events describing these assignments ride the
+            # deletion: ``LedgerEvent.assignment`` cascades, which is what
+            # lets the preview promise them by count.
+            Assignment.objects.filter(pk__in=pilot.assignment_ids).delete()
+            Slot.objects.filter(pk__in=pilot.slot_ids).delete()
+            # Members ride their picklist down; the pickables must outlive
+            # them, so the order here is the constraint order.
+            Picklist.objects.filter(pk__in=pilot.picklist_ids).delete()
+            Pickable.objects.filter(pk__in=pilot.pickable_ids).delete()
+            SlotType.objects.filter(pk=pilot.slot_type_id).delete()
+            if pilot.gang_id is not None:
+                gang = Gang.objects.get(pk=pilot.gang_id)
+                try:
+                    assert_reconciled(gang)
+                except Exception as failed:
+                    raise Refused(
+                        f"refused — {gang} no longer reconciles: {failed}"
+                    ) from failed
+    except ProtectedError as protected:
+        # The backstop behind find()'s enumerated checks: whatever this
+        # names is a referent nobody listed, and the answer is the same
+        # refusal in words, never a crash.
+        raise Refused(
+            "refused — something still names what the pilot would delete: "
+            f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}"
+        ) from protected
     report.append("retired; the field is clean")
     return report

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -201,6 +201,56 @@ def _plan(system):
     return SYSTEMS[system]()
 
 
+def _run_recorded(backfill_id, operation, what, work, refusals):
+    """Run one operation's work, once, under the full runner discipline.
+
+    The discipline is the part that must never regress, so it is held
+    here once for everything the console runs: take the operation's own
+    lock and stand down silently if another copy holds it; count the
+    attempt on the record and give up past the cap; record a refusal in
+    its own words, an unexpected failure with its traceback, and a
+    finished report — and never raise, because a task that fails is
+    redelivered and there is nowhere for a raised error to go but round
+    again.
+    """
+    with _single_flight(LOCK_KEYS[operation]) as mine:
+        if not mine:
+            logger.info("%s already running; this copy stands down", what)
+            return
+
+        may_start, why_not = _claim(backfill_id)
+        if not may_start:
+            logger.info("%s not started: %s", what, why_not)
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"Not started: {why_not}",
+            )
+            return
+
+        try:
+            report = work()
+        except refusals as refused:
+            # A refusal is the discipline working: nothing was written,
+            # and the reason is already in words.
+            _write(backfill_id, status=Backfill.Status.FAILED, error=str(refused))
+            return
+        except Exception as broke:  # noqa: BLE001 — the ending must be recorded
+            logger.exception("%s broke", what)
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"{broke}\n\n{traceback.format_exc()}",
+            )
+            return
+
+        _write(
+            backfill_id,
+            status=Backfill.Status.DONE,
+            summary_patch={"report": list(report)},
+        )
+
+
 def _run_conversion(backfill_id, operation, system, **said_by_whoever_enqueued_it):
     """Run one conversion, once, and write down the outcome.
 
@@ -208,10 +258,6 @@ def _run_conversion(backfill_id, operation, system, **said_by_whoever_enqueued_i
     deploy, so a message can arrive naming arguments the version that
     enqueued it had and this one does not — and a task that refuses its
     own message is retried for ever, there being nowhere for it to go.
-
-    Never raises: a task that fails is redelivered, and there is nowhere
-    for a raised error to go but round again. Every ending — refused,
-    broken, already running — is recorded on the audit record instead.
     """
     from n26.library.conversion import ConversionRefused, apply
 
@@ -232,47 +278,13 @@ def _run_conversion(backfill_id, operation, system, **said_by_whoever_enqueued_i
         )
         return
 
-    # The lock comes first, and nothing is recorded before it is held. A
-    # redelivery arriving while the first copy is still working must leave
-    # no trace at all: count its arrival as an attempt and a long run could
-    # be declared failed out from under itself.
-    what = system.replace("_", " ").capitalize()
-    with _single_flight(LOCK_KEYS[operation]) as mine:
-        if not mine:
-            logger.info("%s conversion already running; this copy stands down", what)
-            return
-
-        may_start, why_not = _claim(backfill_id)
-        if not may_start:
-            logger.info("%s conversion not started: %s", what, why_not)
-            _write(
-                backfill_id,
-                status=Backfill.Status.FAILED,
-                error=f"Not started: {why_not}",
-            )
-            return
-
-        try:
-            report = apply(_plan(system))
-        except ConversionRefused as refused:
-            # A refusal is the discipline working: nothing was written,
-            # and the reason is already in words.
-            _write(backfill_id, status=Backfill.Status.FAILED, error=str(refused))
-            return
-        except Exception as broke:  # noqa: BLE001 — the ending must be recorded
-            logger.exception("%s conversion broke", what)
-            _write(
-                backfill_id,
-                status=Backfill.Status.FAILED,
-                error=f"{broke}\n\n{traceback.format_exc()}",
-            )
-            return
-
-        _write(
-            backfill_id,
-            status=Backfill.Status.DONE,
-            summary_patch={"report": list(report)},
-        )
+    _run_recorded(
+        backfill_id,
+        operation,
+        f"{system.replace('_', ' ').capitalize()} conversion",
+        lambda: apply(_plan(system)),
+        ConversionRefused,
+    )
 
 
 @task
@@ -318,40 +330,13 @@ def retire_gang_legacy_pilot(backfill_id, **said_by_whoever_enqueued_it):
     """
     from n26.library.gang_legacy_pilot import Refused, apply, find
 
-    with _single_flight(LOCK_KEYS[Operation.RETIRE_GANG_LEGACY_PILOT]) as mine:
-        if not mine:
-            logger.info("Pilot retirement already running; this copy stands down")
-            return
-
-        may_start, why_not = _claim(backfill_id)
-        if not may_start:
-            logger.info("Pilot retirement not started: %s", why_not)
-            _write(
-                backfill_id,
-                status=Backfill.Status.FAILED,
-                error=f"Not started: {why_not}",
-            )
-            return
-
-        try:
-            report = apply(find())
-        except Refused as refused:
-            _write(backfill_id, status=Backfill.Status.FAILED, error=str(refused))
-            return
-        except Exception as broke:  # noqa: BLE001 — the ending must be recorded
-            logger.exception("Pilot retirement broke")
-            _write(
-                backfill_id,
-                status=Backfill.Status.FAILED,
-                error=f"{broke}\n\n{traceback.format_exc()}",
-            )
-            return
-
-        _write(
-            backfill_id,
-            status=Backfill.Status.DONE,
-            summary_patch={"report": list(report)},
-        )
+    _run_recorded(
+        backfill_id,
+        Operation.RETIRE_GANG_LEGACY_PILOT,
+        "Pilot retirement",
+        lambda: apply(find()),
+        Refused,
+    )
 
 
 def _conversion_view(request, operation, system, task_fn):

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -546,11 +546,11 @@ register_operation(
         name=Operation.CONVERT_GANG_LEGACY.label,
         description=(
             "Move the Venator house legacies onto slots and picks: the "
-            "twelve hunt profiles grant a Gang Legacy slot instead of "
-            "offering an archetype, the seven houses become pickables "
-            "carrying their equipment lists, and every stored choice is "
-            "re-said as a pick. Proves every affected gang's pages read "
-            "the same, or writes nothing."
+            "hunt profiles grant a Gang Legacy slot instead of offering "
+            "an archetype, the menu's houses become pickables carrying "
+            "their equipment lists, and every stored choice is re-said "
+            "as a pick. Proves every affected gang's pages read the "
+            "same, or writes nothing."
         ),
         view=convert_gang_legacy_view,
         detail_template="admin/maintenance/n26/_convert_detail.html",

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -53,8 +53,10 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "Operation",
+    "convert_gang_legacy",
     "convert_skill_tree",
     "convert_specialisation",
+    "retire_gang_legacy_pilot",
     "task_routes",
 ]
 
@@ -88,6 +90,14 @@ class Operation(models.TextChoices):
         "n26_convert_skill_tree",
         "n26: the Venator skill trees become picks",
     )
+    CONVERT_GANG_LEGACY = (
+        "n26_convert_gang_legacy",
+        "n26: the Venator gang legacies become picks",
+    )
+    RETIRE_GANG_LEGACY_PILOT = (
+        "n26_retire_gang_legacy_pilot",
+        "n26: the gang legacy slot pilot retires",
+    )
     MERGE_WARGEAR_INTO_WEAPON = (
         "n26_merge_wargear_into_weapon",
         "n26: duplicated wargear becomes its weapon",
@@ -98,6 +108,8 @@ class Operation(models.TextChoices):
 LOCK_KEYS = {
     Operation.CONVERT_SPECIALISATION: 826_020_601,
     Operation.CONVERT_SKILL_TREE: 826_020_602,
+    Operation.CONVERT_GANG_LEGACY: 826_020_603,
+    Operation.RETIRE_GANG_LEGACY_PILOT: 826_020_604,
 }
 
 
@@ -285,6 +297,63 @@ def convert_skill_tree(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def convert_gang_legacy(backfill_id, **said_by_whoever_enqueued_it):
+    """The Gang Legacy conversion, as a task — see ``_run_conversion``."""
+    _run_conversion(
+        backfill_id,
+        Operation.CONVERT_GANG_LEGACY,
+        "gang_legacy",
+        **said_by_whoever_enqueued_it,
+    )
+
+
+@task
+def retire_gang_legacy_pilot(backfill_id, **said_by_whoever_enqueued_it):
+    """Retire the Gang Legacy slot pilot, once, and write down the outcome.
+
+    The same runner discipline as a conversion — the lock, the claim,
+    every ending recorded — but the work is the pilot module's own
+    find/apply: this deletes, which a conversion never does.
+    """
+    from n26.library.gang_legacy_pilot import Refused, apply, find
+
+    with _single_flight(LOCK_KEYS[Operation.RETIRE_GANG_LEGACY_PILOT]) as mine:
+        if not mine:
+            logger.info("Pilot retirement already running; this copy stands down")
+            return
+
+        may_start, why_not = _claim(backfill_id)
+        if not may_start:
+            logger.info("Pilot retirement not started: %s", why_not)
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"Not started: {why_not}",
+            )
+            return
+
+        try:
+            report = apply(find())
+        except Refused as refused:
+            _write(backfill_id, status=Backfill.Status.FAILED, error=str(refused))
+            return
+        except Exception as broke:  # noqa: BLE001 — the ending must be recorded
+            logger.exception("Pilot retirement broke")
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"{broke}\n\n{traceback.format_exc()}",
+            )
+            return
+
+        _write(
+            backfill_id,
+            status=Backfill.Status.DONE,
+            summary_patch={"report": list(report)},
+        )
+
+
 def _conversion_view(request, operation, system, task_fn):
     """Preview a conversion (GET), or record a run and enqueue it (POST)."""
     address = reverse(f"admin:maintenance_{operation.value}")
@@ -368,6 +437,63 @@ def convert_skill_tree_view(request):
     )
 
 
+def convert_gang_legacy_view(request):
+    return _conversion_view(
+        request,
+        Operation.CONVERT_GANG_LEGACY,
+        "gang_legacy",
+        convert_gang_legacy,
+    )
+
+
+def retire_gang_legacy_pilot_view(request):
+    """Preview the pilot retirement (GET), or record a run and enqueue it."""
+    from n26.library.gang_legacy_pilot import find
+
+    operation = Operation.RETIRE_GANG_LEGACY_PILOT
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That retirement is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        pilot = find()
+        if pilot.nothing_here:
+            messages.info(request, "There is nothing to retire.")
+            return HttpResponseRedirect(address)
+        if not pilot.ok:
+            messages.error(
+                request, "The retirement refuses: " + "; ".join(pilot.problems)
+            )
+            return HttpResponseRedirect(address)
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"preview": list(pilot.preview()), "attempts": 0},
+        )
+        retire_gang_legacy_pilot.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The retirement is running. This page shows what it did."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+
+    pilot = find()
+    context = page_context(
+        request,
+        operation.label,
+        pilot=pilot,
+        preview=list(pilot.preview()),
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+    )
+    return render(request, "admin/maintenance/n26/retire_pilot.html", context)
+
+
 register_operation(
     MaintenanceOperation(
         operation=Operation.CONVERT_SPECIALISATION.value,
@@ -398,6 +524,39 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.RETIRE_GANG_LEGACY_PILOT.value,
+        name=Operation.RETIRE_GANG_LEGACY_PILOT.label,
+        description=(
+            "Delete the hand-built Gang Legacy slot experiment: its hollow "
+            "pickables, its slot machinery, and the one test gang's "
+            "assignments answering it. Runs before the Gang Legacy "
+            "conversion, which needs the names it squats on. Refuses if "
+            "anything outside the pilot has come to depend on it."
+        ),
+        view=retire_gang_legacy_pilot_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.CONVERT_GANG_LEGACY.value,
+        name=Operation.CONVERT_GANG_LEGACY.label,
+        description=(
+            "Move the Venator house legacies onto slots and picks: the "
+            "twelve hunt profiles grant a Gang Legacy slot instead of "
+            "offering an archetype, the seven houses become pickables "
+            "carrying their equipment lists, and every stored choice is "
+            "re-said as a pick. Proves every affected gang's pages read "
+            "the same, or writes nothing."
+        ),
+        view=convert_gang_legacy_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a conversion holds one
 #: transaction for as long as proving its spread of gangs takes. It is also
@@ -409,6 +568,8 @@ register_operation(
 task_routes = [
     TaskRoute(convert_specialisation, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_skill_tree, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(convert_gang_legacy, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(retire_gang_legacy_pilot, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/tests/fixtures.py
+++ b/n26/tests/fixtures.py
@@ -16,6 +16,14 @@ from n26.library.standard_content import MODEL_CHARACTERISTICS, MODEL_STATLINE
 
 
 @pytest.fixture
+def owner(db):
+    """A player to own the gangs a test founds."""
+    from django.contrib.auth.models import User
+
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
 def default_pack(db):
     """The N26 pack."""
     return get_default_pack()

--- a/n26/tests/sandbox/test_conversion_gang_legacy.py
+++ b/n26/tests/sandbox/test_conversion_gang_legacy.py
@@ -1,0 +1,394 @@
+"""The Gang Legacy conversion, proven on a prod-shaped world.
+
+The twelve hunt profiles' one shared archetype offer — labelled
+"Gang Legacy", the borrowed kind papered over — becomes one shared
+grant of a Gang Legacy slot; the house tokens become pickables carrying
+their equipment-list modifiers, moved not copied.
+
+Two things distinguish this world from the other conversions': a
+second, unrelated system shares the archetype column (an Outcast-shaped
+gang whose picks must not move), and the kind was borrowed — though the
+story never says it out loud, so no written history changes at all.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from n26.core.capture import differences, gang_state
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.authoring import attach_modifiers_to
+from n26.library.conversion import apply, plan_gang_legacy
+from n26.library.models import Archetype, Collection, Pickable, Slot
+from n26.tests.sandbox.actions import (
+    choose,
+    create_archetype,
+    create_collection,
+    create_gang_type,
+    create_profile,
+    create_slot_type,
+    create_subtype,
+    ef_adds,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    remove,
+    section_of,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def prod_shape(default_pack, person_type):
+    return build_prod_shape(person_type)
+
+
+@pytest.fixture
+def world(prod_shape, owner):
+    return build_world(prod_shape, owner)
+
+
+def build_prod_shape(person_type):
+    """The system as production holds it: hunt profiles sharing one
+    offer over a menu of house tokens, each token carrying one
+    equipment-list grant — plus the other system on the same column (an
+    Outcast-shaped Leader) and a detached fossil copy of the offer."""
+    gang_type = create_gang_type("Venators", starting_credits=2000)
+    houses = {}
+    for name in ["Cawdor", "Escher", "Goliath", "Van Saar"]:
+        token = create_archetype(name)
+        kit_list = create_collection(f"{name} Equipment List")
+        modifier(
+            f"{name}: adds {name} Equipment List",
+            targets_model(),
+            ef_adds(kit_list),
+            carried_by=token,
+        )
+        houses[name] = token
+    menu = create_collection("House Legacies", entries=list(houses.values()))
+    section = section_of(menu, "Houses", 0, is_default=True)
+
+    profiles = [
+        create_profile(name, person_type, gang_type, price=50)
+        for name in ["House Hunt Leader 1", "House Hunter 1", "House Hunter 2"]
+    ]
+    shared = modifier(
+        "the model: offers a choice of archetype from House Legacies",
+        targets_model(),
+        offers_choice(Archetype, from_section=section, label="Gang Legacy"),
+        carried_by=profiles[0],
+    )
+    for profile in profiles[1:]:
+        attach_modifiers_to(profile, [shared])
+
+    # The fossil: a second copy of the offer that nothing carries.
+    modifier(
+        "House Hunt Leader 1: offers a choice of archetype from House Legacies",
+        targets_model(),
+        offers_choice(Archetype, from_section=section, label="Gang Legacy"),
+    )
+
+    # The other system on the same column: an Outcast-shaped Leader
+    # whose own archetype pick lands on the gang and must not move.
+    outcasts = create_gang_type("Outcast", starting_credits=2000)
+    brawler = create_archetype("Brawler")
+    modifier(
+        "Brawler: Leader models — Combat is Primary",
+        targets_model(),
+        ef_adds(create_subtype("Brawler-led")),
+        carried_by=brawler,
+    )
+    leader = create_profile("Leader 1", person_type, outcasts, price=135)
+    modifier(
+        "Leader 1: chooses the gang's Archetype",
+        targets_model(),
+        offers_choice(Archetype, label="Archetype", will_be_assigned_to="gang"),
+        carried_by=leader,
+    )
+    return gang_type, houses, profiles, (outcasts, leader, brawler)
+
+
+def build_world(prod_shape, owner):
+    """Three Venator gangs — answered (one house twice over, and a
+    doubled click), partly answered, never answered — and one Outcast
+    gang whose pick shares the column and stays put."""
+    gang_type, houses, profiles, (outcasts, leader, brawler) = prod_shape
+    hunt_leader, hunter_1, hunter_2 = profiles
+
+    gangs = {
+        "answered": found_gang("The Long Watch", gang_type, owner=owner, budget=2000),
+        "partial": found_gang("The Half Made", gang_type, owner=owner, budget=2000),
+        "quiet": found_gang("The Unsworn", gang_type, owner=owner, budget=2000),
+        "outcast": found_gang("The Cast Out", outcasts, owner=owner, budget=2000),
+    }
+    fighters = {
+        "sworn": hire(gangs["answered"], hunt_leader, "Vex", paid=50),
+        "second": hire(gangs["answered"], hunter_1, "Kade", paid=50),
+        "third": hire(gangs["answered"], hunter_2, "Mara", paid=50),
+        "partial_a": hire(gangs["partial"], hunter_1, "Odo", paid=50),
+        "partial_b": hire(gangs["partial"], hunter_2, "Nyx", paid=50),
+        "quiet_one": hire(gangs["quiet"], hunter_1, "Sol", paid=50),
+        "outcast_leader": hire(gangs["outcast"], leader, "Grim", paid=135),
+    }
+
+    def anchor(fighter, profile):
+        return Assignment.objects.get(profile=profile, miniature_root=fighter)
+
+    # The answered gang: a re-choice leaving an archived answer, two
+    # fighters sworn to one house (ordinary, never a repeat — each
+    # fighter answers their own question), and a doubled click.
+    choose(anchor(fighters["sworn"], hunt_leader), houses["Cawdor"])
+    remove(
+        Assignment.objects.get(
+            archetype=houses["Cawdor"],
+            miniature_root=fighters["sworn"],
+            archived=False,
+        )
+    )
+    choose(anchor(fighters["sworn"], hunt_leader), houses["Van Saar"])
+    choose(anchor(fighters["second"], hunter_1), houses["Van Saar"])
+    choose(anchor(fighters["third"], hunter_2), houses["Escher"])
+    choose(
+        anchor(fighters["third"], hunter_2), houses["Escher"]
+    )  # the same click, twice
+
+    choose(anchor(fighters["partial_a"], hunter_1), houses["Goliath"])
+
+    # The Outcast gang answers its own system's question.
+    choose(anchor(fighters["outcast_leader"], leader), brawler)
+    return gangs, fighters
+
+
+class TestThePlan:
+    def test_it_says_everything_it_would_do(self, world):
+        plan = plan_gang_legacy()
+
+        assert plan.ok and not plan.nothing_here
+        said = "\n".join(plan.preview())
+        assert "create slot type “Gang Legacy”, refusing repeats" in said
+        assert said.count("create pickable") == 4
+        assert "moving 1 modifier" in said
+        assert "create picklist “House Legacies”" in said
+        assert "replace the shared" in said
+        assert "the 3 hunt profiles" in said
+        # Four live Venator answers move. The archived re-choice, the
+        # doubled click's spare, and the Outcast gang's pick all stay.
+        assert said.count("rewrite pick") == 4
+        assert "leave 1 spare assignment exactly as they are" in said
+        # Three gangs hold the carrying profiles; the Outcast gang is
+        # not reached — no step can touch it.
+        assert "prove 3 of 3 reached gangs read the same, or refuse" in said
+
+    def test_it_deletes_nothing(self, world):
+        said = "\n".join(plan_gang_legacy().preview())
+
+        assert "retire" not in said
+
+    def test_a_standing_pilot_is_refused(self, world):
+        create_slot_type("Gang Legacy")
+
+        plan = plan_gang_legacy()
+
+        assert not plan.ok
+        assert any("retire the pilot first" in problem for problem in plan.problems)
+
+
+class TestTheApply:
+    def test_every_page_reads_the_same(self, world):
+        gangs, _ = world
+        before = {key: gang_state(g) for key, g in gangs.items()}
+
+        apply(plan_gang_legacy())
+
+        for key, gang in gangs.items():
+            assert differences(before[key], gang_state(gang)) == []
+            assert_reconciled(gang)
+
+    def test_the_live_answer_moves_and_the_archived_one_stays(self, world):
+        gangs, fighters = world
+
+        apply(plan_gang_legacy())
+
+        live = Assignment.objects.get(
+            miniature_root=fighters["sworn"], pickable__isnull=False, archived=False
+        )
+        assert live.pickable.name == "Van Saar"
+        assert live.archetype_id is None
+        assert live.chosen_for_id == live.caused_by_id
+        assert live.chosen_for_slot == Slot.objects.get(name="Gang Legacy")
+
+        archived = Assignment.objects.get(
+            miniature_root=fighters["sworn"], archived=True, archetype__isnull=False
+        )
+        assert archived.archetype.name == "Cawdor"
+        assert archived.pickable_id is None
+        assert_reconciled(gangs["answered"])
+
+    def test_the_other_system_on_the_column_is_untouched(self, world):
+        """The Outcast pick shares the archetype column and nothing
+        else; the conversion must not even look at it."""
+        gangs, _ = world
+
+        apply(plan_gang_legacy())
+
+        untouched = Assignment.objects.get(
+            gang_root=gangs["outcast"], archetype__isnull=False, archived=False
+        )
+        assert untouched.archetype.name == "Brawler"
+        assert untouched.pickable_id is None
+        assert Archetype.objects.filter(name="Brawler").exists()
+
+    def test_a_doubled_answer_keeps_its_spare_untouched(self, world):
+        gangs, fighters = world
+        before = gang_state(gangs["answered"])
+
+        plan = plan_gang_legacy()
+        apply(plan)
+
+        assert plan.left_alone == 1
+        assert differences(before, gang_state(gangs["answered"])) == []
+        spare = Assignment.objects.get(
+            miniature_root=fighters["third"], archetype__isnull=False, archived=False
+        )
+        assert spare.archetype.name == "Escher"
+        assert spare.pickable_id is None
+
+    def test_the_house_list_still_arrives_with_the_pick(self, world):
+        """The pickable carries the moved equipment-list modifier, so a
+        sworn fighter's access reads the same — proven by the page
+        parity above, and pinned here on the modifier itself."""
+        _, fighters = world
+
+        apply(plan_gang_legacy())
+
+        pickable = Pickable.objects.get(name="Van Saar")
+        assert [type(m.effect).__name__ for m in pickable.modifiers.all()] == [
+            "AddsAssignable"
+        ]
+        emptied = Archetype.objects.get(name="Van Saar")
+        assert not emptied.modifiers.exists()
+        assert Collection.objects.filter(name="Van Saar Equipment List").exists()
+
+    def test_the_story_already_written_says_the_same_words(self, world):
+        """These picks stand in the story as their own acts ("gained
+        Van Saar on Vex") and never draw a kind word, so the borrowed
+        kind was never said out loud — and the conversion changes no
+        written word at all. Where a surface does ask a pick its sort,
+        the answer becomes the card's word."""
+        from n26.core import history
+        from n26.core.history import _kindword
+
+        gangs, _ = world
+        said = _story(history.build(gangs["answered"]))
+
+        apply(plan_gang_legacy())
+
+        assert _story(history.build(gangs["answered"])) == said
+        assert any("Van Saar" in line for line in said)
+        pick = Assignment.objects.filter(
+            pickable__isnull=False, gang_root=gangs["answered"]
+        ).first()
+        assert _kindword(pick) == "gang legacy"
+
+    def test_rechoosing_works_on_the_new_machinery(self, world, prod_shape):
+        _, _, profiles, _ = prod_shape
+        gangs, fighters = world
+        apply(plan_gang_legacy())
+        anchor = Assignment.objects.get(
+            profile=profiles[1], miniature_root=fighters["partial_a"]
+        )
+
+        remove(
+            Assignment.objects.get(
+                pickable__name="Goliath", miniature_root=fighters["partial_a"]
+            )
+        )
+        choose(
+            anchor,
+            Pickable.objects.get(name="Cawdor"),
+            slot=Slot.objects.get(name="Gang Legacy"),
+            miniature=fighters["partial_a"],
+        )
+
+        state = gang_state(gangs["partial"])
+        card = state["models"][str(fighters["partial_a"].pk)]
+        assert ("Gang Legacy", "Cawdor") in card["choices"]
+        assert_reconciled(gangs["partial"])
+
+    def test_a_second_run_is_a_clean_no_op(self, world):
+        apply(plan_gang_legacy())
+
+        assert plan_gang_legacy().nothing_here
+
+
+class TestTheRefusals:
+    def test_a_second_carried_offer_wearing_the_label_is_refused(
+        self, world, prod_shape
+    ):
+        _, _, profiles, _ = prod_shape
+        menu = Collection.objects.get(name="House Legacies")
+        modifier(
+            "another Gang Legacy offer",
+            targets_model(),
+            offers_choice(
+                Archetype,
+                from_section=menu.sections.first(),
+                label="Gang Legacy",
+            ),
+            carried_by=profiles[2],
+        )
+
+        plan = plan_gang_legacy()
+
+        assert not plan.ok or plan.problems  # refused, never guessed
+        assert any("expected one" in problem for problem in plan.problems)
+
+    def test_an_offer_carried_off_a_profile_is_refused(self, world):
+        from n26.library.conversion.base import carriers_of
+        from n26.library.models import Modifier
+
+        offer = next(
+            m
+            for m in Modifier.objects.filter(offers_choice__isnull=False)
+            if m.offers_choice.label == "Gang Legacy" and carriers_of(m)
+        )
+        attach_modifiers_to(create_subtype("Bystander"), [offer])
+
+        plan = plan_gang_legacy()
+
+        assert not plan.ok
+        assert any("not profiles" in problem for problem in plan.problems)
+
+    def test_a_pick_anchored_off_the_profiles_is_refused(self, world, prod_shape):
+        """A house answered from an anchor the plan does not know means
+        a page the spread cannot promise to have proven."""
+        gang_type, houses, _, (_, leader, _) = prod_shape
+        gangs, _ = world
+        stray = hire(gangs["outcast"], leader, "Wanderer", paid=135)
+        anchor = Assignment.objects.get(profile=leader, miniature_root=stray)
+        choose(anchor, houses["Cawdor"])
+
+        plan = plan_gang_legacy()
+
+        assert not plan.ok
+        assert any(
+            "not one of the profiles carrying the offer" in problem
+            for problem in plan.problems
+        )
+
+
+def _story(acts):
+    """Every word a gang's history page puts on the screen."""
+    told = []
+    for act in acts:
+        told.append("".join(span.text for span in act.spans))
+        told.extend(f"{sub.name}|{sub.kind}|{sub.note}" for sub in act.subs)
+    return told

--- a/n26/tests/sandbox/test_conversion_gang_legacy.py
+++ b/n26/tests/sandbox/test_conversion_gang_legacy.py
@@ -12,7 +12,6 @@ story never says it out loud, so no written history changes at all.
 """
 
 import pytest
-from django.contrib.auth.models import User
 
 from n26.core.capture import differences, gang_state
 from n26.core.models import Assignment
@@ -39,11 +38,6 @@ from n26.tests.sandbox.actions import (
 )
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def owner(db):
-    return User.objects.create_user("player")
 
 
 @pytest.fixture
@@ -348,7 +342,7 @@ class TestTheRefusals:
 
         plan = plan_gang_legacy()
 
-        assert not plan.ok or plan.problems  # refused, never guessed
+        assert not plan.ok
         assert any("expected one" in problem for problem in plan.problems)
 
     def test_an_offer_carried_off_a_profile_is_refused(self, world):
@@ -366,6 +360,82 @@ class TestTheRefusals:
 
         assert not plan.ok
         assert any("not profiles" in problem for problem in plan.problems)
+
+    def test_a_surviving_name_squatter_is_refused(self, world, prod_shape):
+        """A stray pickable wearing a house's name — a pilot remnant, a
+        hand experiment — would turn a valid-looking plan into a
+        mid-apply integrity error. The plan refuses it in words."""
+        from n26.tests.sandbox.actions import create_pickable
+
+        other_type = create_slot_type("Something Else")
+        create_pickable("Cawdor", other_type)
+
+        plan = plan_gang_legacy()
+
+        assert not plan.ok
+        assert any("already wear these names" in problem for problem in plan.problems)
+
+    def test_a_pick_the_menu_does_not_offer_is_refused(self, world, prod_shape):
+        """A live pick of an off-menu house anchored on a carrying
+        profile would keep its line and lose its question when the
+        offer is swapped — refused, never stranded."""
+        gang_type, houses, profiles, _ = prod_shape
+        gangs, fighters = world
+        offmenu = create_archetype("Ironhead Squat")
+        line = Assignment.objects.get(
+            profile=profiles[1], miniature_root=fighters["quiet_one"]
+        )
+        Assignment.objects.create(
+            archetype=offmenu,
+            miniature=fighters["quiet_one"],
+            caused_by=line,
+            chosen_for=line,
+            gang_root=gangs["quiet"],
+        )
+
+        plan = plan_gang_legacy()
+
+        assert not plan.ok
+        assert any("the menu does not offer" in problem for problem in plan.problems)
+
+    def test_an_archived_house_is_not_resurrected(self, world, prod_shape):
+        """A retired house on the menu must not come back as a live
+        pickable — and its standing picks refuse rather than strand."""
+        _, houses, _, _ = prod_shape
+        houses["Goliath"].archived = True
+        houses["Goliath"].save()
+
+        plan = plan_gang_legacy()
+
+        assert not plan.ok
+        assert any("Goliath" in problem for problem in plan.problems)
+
+    def test_a_carrier_arriving_after_the_plan_refuses_the_apply(
+        self, world, prod_shape
+    ):
+        """The plan proves the shared offer's carriers, but the world
+        can move between plan and apply — a carrier attached since must
+        end the run in a refusal, never lose its question silently."""
+        from n26.library.conversion import ConversionRefused
+        from n26.library.conversion.base import carriers_of
+        from n26.library.models import Modifier
+
+        plan = plan_gang_legacy()
+        offer = next(
+            m
+            for m in Modifier.objects.filter(offers_choice__isnull=False)
+            if m.offers_choice.label == "Gang Legacy" and carriers_of(m)
+        )
+        # Another profile of the same gang type: a carrier the plan
+        # would have accepted, arriving too late for it to know.
+        _, _, profiles, _ = prod_shape
+        latecomer = create_profile(
+            "House Hunter 3", profiles[0].profile_type, profiles[0].gang_type, price=50
+        )
+        attach_modifiers_to(latecomer, [offer])
+
+        with pytest.raises(ConversionRefused, match="the world moved"):
+            apply(plan)
 
     def test_a_pick_anchored_off_the_profiles_is_refused(self, world, prod_shape):
         """A house answered from an anchor the plan does not know means

--- a/n26/tests/sandbox/test_gang_legacy_pilot.py
+++ b/n26/tests/sandbox/test_gang_legacy_pilot.py
@@ -1,0 +1,145 @@
+"""Retiring the Gang Legacy slot pilot — the one operation that deletes.
+
+The pilot is a hand-built slot type whose pickables carry nothing,
+answered on one test gang. Retiring it must delete exactly what it
+names, refuse the moment anything outside the pilot depends on it, and
+leave the gang reconciling — a slot and its picks are free, so the
+rating must not move by a credit.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from n26.core.models import Assignment, LedgerEvent
+from n26.core.reconcile import assert_reconciled
+from n26.library.gang_legacy_pilot import Refused, apply, find
+from n26.library.models import Pickable, Picklist, Slot, SlotType
+from n26.tests.sandbox.actions import (
+    choose,
+    create_gang_type,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_slot,
+    create_slot_type,
+    found_gang,
+    hire,
+    modifier,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def pilot_world(db, default_pack, person_type, owner):
+    """The pilot as production holds it: hollow machinery, and one test
+    gang holding the slot by hand with answers behind it."""
+    slot_type = create_slot_type("Gang Legacy")
+    hollow = [create_pickable(name, slot_type) for name in ["Cawdor", "Ironhead Squat"]]
+    picklist = create_picklist("All Gang Legacies", slot_type, members=hollow)
+    slot = create_slot("Gang Legacy", slot_type, picklist, min_picks=0)
+
+    gang_type = create_gang_type("Venators", starting_credits=2000)
+    profile = create_profile("Squat Hunt Leader", person_type, gang_type, price=50)
+    gang = found_gang("The Pilot Yard", gang_type, owner=owner, budget=2000)
+    fighter = hire(gang, profile, "Grombrindal", paid=50)
+    line = Assignment.objects.get(profile=profile, miniature_root=fighter)
+    # The hand-placed experiment: the slot assigned directly under the
+    # fighter's own line, then answered.
+    held = Assignment.objects.create(
+        slot=slot, miniature=fighter, caused_by=line, gang_root=gang
+    )
+    choose(held, hollow[0], slot=slot, miniature=fighter)
+    return gang, fighter, slot_type, hollow, slot
+
+
+class TestFindingThePilot:
+    def test_it_names_everything_it_would_delete(self, pilot_world):
+        pilot = find()
+
+        assert pilot.ok and not pilot.nothing_here
+        assert len(pilot.pickable_ids) == 2
+        assert len(pilot.assignment_ids) == 2  # the held slot and its answer
+        said = "\n".join(pilot.preview())
+        assert "delete 2 assignments on The Pilot Yard" in said
+        assert "2 hollow pickables" in said
+        assert "prove the gang still reconciles" in said
+
+    def test_no_pilot_means_nothing_to_retire(self, db, default_pack):
+        pilot = find()
+
+        assert pilot.nothing_here
+        assert apply(pilot) == pilot.preview()
+
+    def test_a_pickable_grown_a_purpose_is_refused(self, pilot_world):
+        _, _, _, hollow, _ = pilot_world
+        modifier(
+            "Cawdor: does something now",
+            targets_model(),
+            _any_effect(),
+            carried_by=hollow[0],
+        )
+
+        pilot = find()
+
+        assert not pilot.ok
+        assert any("grown a purpose" in problem for problem in pilot.problems)
+        with pytest.raises(Refused):
+            apply(pilot)
+
+    def test_a_second_gang_answering_is_refused(self, pilot_world, person_type, owner):
+        _, _, _, hollow, slot = pilot_world
+        gang_type = create_gang_type("More Venators", starting_credits=2000)
+        profile = create_profile("Another Hunter", person_type, gang_type, price=50)
+        other = found_gang("Somebody Else", gang_type, owner=owner, budget=2000)
+        fighter = hire(other, profile, "Stranger", paid=50)
+        line = Assignment.objects.get(profile=profile, miniature_root=fighter)
+        Assignment.objects.create(
+            slot=slot, miniature=fighter, caused_by=line, gang_root=other
+        )
+
+        pilot = find()
+
+        assert not pilot.ok
+        assert any("2 gangs" in problem for problem in pilot.problems)
+
+
+class TestRetiring:
+    def test_it_deletes_exactly_the_pilot_and_the_gang_survives(self, pilot_world):
+        gang, fighter, slot_type, hollow, slot = pilot_world
+        events_before = LedgerEvent.objects.filter(gang=gang).count()
+
+        report = apply(find())
+
+        assert report[-1] == "retired; the field is clean"
+        assert not SlotType.objects.filter(name="Gang Legacy").exists()
+        assert not Slot.objects.filter(pk=slot.pk).exists()
+        assert not Picklist.objects.filter(name="All Gang Legacies").exists()
+        assert not Pickable.objects.filter(pk__in=[p.pk for p in hollow]).exists()
+        assert not Assignment.objects.filter(slot=slot.pk).exists()
+        # The fighter, the hire, and every unrelated event survive.
+        assert Assignment.objects.filter(miniature_root=fighter).exists()
+        assert LedgerEvent.objects.filter(gang=gang).count() < events_before
+        assert LedgerEvent.objects.filter(gang=gang, kind="purchased").exists()
+        assert_reconciled(gang)
+
+    def test_the_field_is_clean_for_the_conversion(self, pilot_world):
+        """The retirement exists so the Gang Legacy conversion can
+        build; afterwards the name it needed is free."""
+        apply(find())
+
+        assert find().nothing_here
+        assert not SlotType.objects.filter(name="Gang Legacy").exists()
+
+
+def _any_effect():
+    from n26.library.authoring import ef_adds
+    from n26.tests.sandbox.actions import create_rule
+
+    return ef_adds(create_rule("Suddenly Real"))

--- a/n26/tests/sandbox/test_gang_legacy_pilot.py
+++ b/n26/tests/sandbox/test_gang_legacy_pilot.py
@@ -8,7 +8,6 @@ rating must not move by a credit.
 """
 
 import pytest
-from django.contrib.auth.models import User
 
 from n26.core.models import Assignment, LedgerEvent
 from n26.core.reconcile import assert_reconciled
@@ -32,12 +31,11 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def owner(db):
-    return User.objects.create_user("player")
-
-
-@pytest.fixture
 def pilot_world(db, default_pack, person_type, owner):
+    return build_pilot(person_type, owner)
+
+
+def build_pilot(person_type, owner):
     """The pilot as production holds it: hollow machinery, and one test
     gang holding the slot by hand with answers behind it."""
     slot_type = create_slot_type("Gang Legacy")
@@ -45,7 +43,7 @@ def pilot_world(db, default_pack, person_type, owner):
     picklist = create_picklist("All Gang Legacies", slot_type, members=hollow)
     slot = create_slot("Gang Legacy", slot_type, picklist, min_picks=0)
 
-    gang_type = create_gang_type("Venators", starting_credits=2000)
+    gang_type = create_gang_type("Venator Pilots", starting_credits=2000)
     profile = create_profile("Squat Hunt Leader", person_type, gang_type, price=50)
     gang = found_gang("The Pilot Yard", gang_type, owner=owner, budget=2000)
     fighter = hire(gang, profile, "Grombrindal", paid=50)
@@ -92,6 +90,7 @@ class TestFindingThePilot:
         assert any("grown a purpose" in problem for problem in pilot.problems)
         with pytest.raises(Refused):
             apply(pilot)
+        assert_reconciled(pilot_world[0])
 
     def test_a_second_gang_answering_is_refused(self, pilot_world, person_type, owner):
         _, _, _, hollow, slot = pilot_world
@@ -108,6 +107,41 @@ class TestFindingThePilot:
 
         assert not pilot.ok
         assert any("2 gangs" in problem for problem in pilot.problems)
+        assert_reconciled(other)
+
+    def test_content_authored_against_the_pilot_is_refused(self, pilot_world):
+        """A built-in naming the pilot's slot is somebody's content: the
+        deletion must refuse in words, never crash on the constraint."""
+        from n26.library.models import DefaultAssignment
+        from n26.tests.sandbox.actions import create_default_set
+
+        _, _, _, _, slot = pilot_world
+        group = create_default_set("Someone's kit", members=[])
+        DefaultAssignment.objects.create(default_set=group, slot=slot)
+
+        pilot = find()
+
+        assert not pilot.ok
+        assert any("authored against it" in problem for problem in pilot.problems)
+
+    def test_a_child_hanging_off_the_doomed_is_refused(self, pilot_world):
+        """A child assignment riding a doomed one via its parent would
+        cascade silently — beyond what the preview names — so the plan
+        refuses it instead."""
+        gang, fighter, _, _, slot = pilot_world
+        held = Assignment.objects.get(slot=slot, miniature=fighter)
+        from n26.tests.sandbox.actions import create_rule
+
+        Assignment.objects.create(
+            rule=create_rule("Hanger On"),
+            parent=held,
+            gang_root=gang,
+        )
+
+        pilot = find()
+
+        assert not pilot.ok
+        assert any("hangs off" in problem for problem in pilot.problems)
 
 
 class TestRetiring:

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -22,9 +22,17 @@ from n26.core.models import Assignment
 from n26.maintenance import (
     MAX_ATTEMPTS,
     Operation,
+    convert_gang_legacy_view,
     convert_skill_tree_view,
     convert_specialisation,
     convert_specialisation_view,
+    retire_gang_legacy_pilot_view,
+)
+from n26.tests.sandbox.test_conversion_gang_legacy import (
+    build_prod_shape as build_gang_legacy_shape,
+)
+from n26.tests.sandbox.test_conversion_gang_legacy import (
+    build_world as build_gang_legacy_world,
 )
 from n26.tests.sandbox.test_conversion_skill_tree import (
     build_prod_shape as build_skill_tree_shape,
@@ -183,6 +191,80 @@ class TestTheSkillTreeConversion:
             skill_tree__isnull=False, archived=False
         ).exclude(removes=True)
         assert left.count() == 1
+
+
+class TestTheGangLegacyPair:
+    """The pilot retirement and the Gang Legacy conversion, in the
+    order the console must run them: the conversion refuses while the
+    pilot stands, and converts once it is retired."""
+
+    @pytest.fixture
+    def legacy_world(self, person_type, owner, default_pack):
+        shape = build_gang_legacy_shape(person_type)
+        return build_gang_legacy_world(shape, owner)
+
+    def test_both_operations_are_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.CONVERT_GANG_LEGACY.value in registered
+        assert Operation.RETIRE_GANG_LEGACY_PILOT.value in registered
+        assert (
+            resolve_operation(Operation.CONVERT_GANG_LEGACY.value).view
+            is convert_gang_legacy_view
+        )
+        assert (
+            resolve_operation(Operation.RETIRE_GANG_LEGACY_PILOT.value).view
+            is retire_gang_legacy_pilot_view
+        )
+
+    def test_the_retirement_page_shows_the_plan_and_writes_nothing(
+        self, client, superuser, legacy_world
+    ):
+        from n26.tests.sandbox.actions import create_slot_type
+
+        create_slot_type("Gang Legacy")
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_retire_gang_legacy_pilot"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "hollow pickables" in page
+        assert not Backfill.objects.exists()
+
+    def test_the_conversion_refuses_while_the_pilot_stands(
+        self, client, superuser, legacy_world
+    ):
+        from n26.tests.sandbox.actions import create_slot_type
+
+        create_slot_type("Gang Legacy")
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_convert_gang_legacy"))
+
+        assert "retire the pilot first" in response.content.decode()
+
+    def test_retire_then_convert_in_the_console_order(
+        self, client, superuser, legacy_world
+    ):
+        from n26.tests.sandbox.actions import create_slot_type
+
+        create_slot_type("Gang Legacy")
+        client.force_login(superuser)
+
+        client.post(reverse("admin:maintenance_n26_retire_gang_legacy_pilot"))
+        retired = Backfill.objects.get(operation=Operation.RETIRE_GANG_LEGACY_PILOT)
+        assert retired.status == Backfill.Status.DONE
+
+        client.post(reverse("admin:maintenance_n26_convert_gang_legacy"))
+        converted = Backfill.objects.get(operation=Operation.CONVERT_GANG_LEGACY)
+        assert converted.status == Backfill.Status.DONE
+        assert any("applied" in line for line in converted.summary["report"])
+        left = Assignment.objects.filter(
+            archetype__isnull=False, archived=False
+        ).exclude(removes=True)
+        # The doubled click's spare and the other system's pick remain.
+        assert left.count() == 2
 
 
 class TestApplying:

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -44,6 +44,7 @@ from n26.tests.sandbox.test_conversion_specialisation import (
     build_prod_shape,
     build_world,
 )
+from n26.tests.sandbox.test_gang_legacy_pilot import build_pilot
 
 pytestmark = pytest.mark.django_db
 
@@ -67,11 +68,6 @@ def _lock_held_elsewhere(operation=None):
             cursor.execute("SELECT pg_advisory_unlock(%s)", [key])
     finally:
         other.close()
-
-
-@pytest.fixture
-def owner(db):
-    return User.objects.create_user("player")
 
 
 @pytest.fixture
@@ -233,11 +229,9 @@ class TestTheGangLegacyPair:
         assert not Backfill.objects.exists()
 
     def test_the_conversion_refuses_while_the_pilot_stands(
-        self, client, superuser, legacy_world
+        self, client, superuser, legacy_world, person_type, owner
     ):
-        from n26.tests.sandbox.actions import create_slot_type
-
-        create_slot_type("Gang Legacy")
+        build_pilot(person_type, owner)
         client.force_login(superuser)
 
         response = client.get(reverse("admin:maintenance_n26_convert_gang_legacy"))
@@ -245,16 +239,23 @@ class TestTheGangLegacyPair:
         assert "retire the pilot first" in response.content.decode()
 
     def test_retire_then_convert_in_the_console_order(
-        self, client, superuser, legacy_world
+        self, client, superuser, legacy_world, person_type, owner
     ):
-        from n26.tests.sandbox.actions import create_slot_type
+        """The full pilot shape rides through the console flow, so the
+        retirement's deletion paths — assignments, machinery, the
+        reconcile proof — are all exercised from the page."""
+        from n26.core.models import Assignment as CoreAssignment
+        from n26.library.models import SlotType
 
-        create_slot_type("Gang Legacy")
+        pilot_gang, _, _, _, pilot_slot = build_pilot(person_type, owner)
         client.force_login(superuser)
 
         client.post(reverse("admin:maintenance_n26_retire_gang_legacy_pilot"))
         retired = Backfill.objects.get(operation=Operation.RETIRE_GANG_LEGACY_PILOT)
         assert retired.status == Backfill.Status.DONE
+        assert not SlotType.objects.filter(name="Gang Legacy").exists()
+        assert not CoreAssignment.objects.filter(slot=pilot_slot.pk).exists()
+        assert CoreAssignment.objects.filter(gang_root=pilot_gang).exists()
 
         client.post(reverse("admin:maintenance_n26_convert_gang_legacy"))
         converted = Backfill.objects.get(operation=Operation.CONVERT_GANG_LEGACY)


### PR DESCRIPTION
The fourth slots-and-picks conversion, and the first paired with a deletion: the Venator "House Legacy" system moves onto the generic choice machinery, and the hand-built Gang Legacy slot experiment that squats on its names is retired first.

## Background

The `archetype` column holds two unrelated systems. The Venator half — twelve hunt profiles sharing one offer labelled "Gang Legacy" over a menu of six house tokens, each token carrying one modifier (that house's equipment list) — borrowed the Archetype kind before the concept had one. Separately, an early hand-built "Gang Legacy" slot type stands with **hollow pickables** (no payload, no linked category) and a handful of hand-placed assignments on one test gang: answers that grant nothing. Full analysis in `.claude/notes/archetype-today.md`.

## What changes

**"n26: the gang legacy slot pilot retires"** — the one operation that deletes, because no other route exists: the admin refuses the cascade (player rows are read-only there by design), the UI cannot delete a gang, and conversions delete nothing. It deletes exactly what its preview names — the pilot's assignments with their history events, then the hollow machinery — refuses if anything outside the pilot depends on those rows (a pickable grown a purpose, a second gang answering, an outsider hanging off the doomed rows), and proves the gang still reconciles.

**"n26: the Venator gang legacies become picks"** — the conversion, refusing while any pilot remnant stands so the console order is enforced, not remembered:

- The six menu houses become pickables carrying their equipment-list modifiers — moved, not copied.
- The twelve profiles' one shared offer becomes one shared grant of a per-fighter Gang Legacy slot (new engine step `SwapSharedCarrier`), preserving the factoring the authors chose.
- 81 stored choices re-said as picks on their same anchors. The Outcast archetypes sharing the column are not touched — told apart by their anchors, refused if a house pick ever anchors off the known profiles, and proven untouched by test and smoke run.
- History changes nothing: these picks stand as their own acts and never draw a kind word — pinned by a story test. Where a surface does ask a pick its sort, the answer becomes the card's word ("gang legacy").

## How it was proven

- 14 conversion tests + 6 retirement tests + 4 console tests covering the pair in order (refuse → retire → convert). Full n26 suite: 3703 passed.
- Smoke-rehearsed end to end on a fork of the content mirror at production's measured volume (43 reached gangs, 136 hunt fighters, 82 picks, the pilot's player state recreated, Outcast picks alongside): the conversion refused before retirement; the retirement left its gang reconciling; the conversion **applied in 6.2s**; and all 48 gangs — Outcasts included — verified unchanged from outside the run: pages, history stories, reconcile.

## Running it

After deploy, in order: maintenance console → "the gang legacy slot pilot retires" (preview names every row) → apply; then "the Venator gang legacies become picks" → apply. Content work afterwards, at leisure: re-offer Ironhead Squat legacies on the new picklist, and extend the slot grant to the three Squat Hunt profiles, which today carry no legacy question.

Refs #2181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8