### PR TITLE
feat: add n26 changelog pages

### DIFF
--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -28,8 +28,9 @@ Concretely:
 
 - **No app code in `n26/` imports `n23.*` or `gyrinx.*`.** n26 is a
   parallel edition, not a layer on the old one. Seven deliberate
-  exceptions: the dashboard reads `gyrinx.site.models.ChangelogEntry`,
-  deferred inside the view; the gangs view searches with
+  exceptions: `n26/core/views/changelog.py` reads
+  `gyrinx.site.models.ChangelogEntry`, deferred inside its shared
+  queryset helper; the gangs view searches with
   `gyrinx.querysets.search_queryset`; the artwork tag cleans SVG with
   `gyrinx.svg.sanitize_inline_svg`; `n26/library/artwork.py` stores and
   reads uploads through `gyrinx.artwork`; `n26/analytics.py` records

--- a/n26/core/templates/cotton/n26/changelog/entry.html
+++ b/n26/core/templates/cotton/n26/changelog/entry.html
@@ -1,30 +1,28 @@
 {% comment %}
 <c-n26.changelog.entry> — one update: a short title, two lines of rich text, a date.
 
-    <c-n26.changelog.entry title="Vehicles" date="6 Aug" href="/changelog/vehicles/">
-        Hire a Trazior and it brings its own card…
-    </c-n26.changelog.entry>
+    <c-n26.changelog.entry title="Vehicles" date="6 Aug"
+                           href="/changelog/vehicles/" :body="entry.body" />
 
-The whole row opens the entry: one real <a>, on the title, with .n26-row-link
-stretching its ::after over the row. Anything else clickable added here would
-need lifting above that ::after.
+The title opens the entry. Links in the rich-text summary remain independent
+destinations, so the row is not covered by a stretched link.
 
-The summary accepts rendered rich text. Its container is a div because editor
-output may contain paragraphs and lists, which cannot sit inside a paragraph.
-It is clamped to two small-text lines; the full text is one click away.
+The body is sanitised here rather than at each call site. It is clamped to two
+small-text lines; the full text is one click away.
 
   title — the short header.
   date — when. Stays beside the title at phone width.
   href — the entry.
+  body — stored rich text, sanitised before rendering.
 {% endcomment %}
-<c-vars title="" date="" href="" class="" />
+<c-vars title="" date="" href="" body="" class="" />
 
-<div class="relative px-1 py-3 hover:bg-ink-500/5 {{ class }}">
+<div class="px-1 py-3 {{ class }}">
     <div class="flex items-baseline justify-between gap-3">
         <h3 class="min-w-0 text-base font-semibold text-ink-900 dark:text-ink-100">
-            <a href="{{ href }}" class="n26-row-link rounded-control focus-ring">{{ title }}</a>
+            <c-n26.link href="{{ href }}" tone="current">{{ title }}</c-n26.link>
         </h3>
         {% if date %}<span class="shrink-0 text-sm tabular-nums text-muted">{{ date }}</span>{% endif %}
     </div>
-    <div class="rich-text n26-clamp-2 mt-0.5 text-sm text-muted">{{ slot }}</div>
+    <c-n26.rich-text :value="body" class="n26-clamp-2 mt-0.5 text-sm text-muted" />
 </div>

--- a/n26/core/templates/cotton/n26/changelog/entry.html
+++ b/n26/core/templates/cotton/n26/changelog/entry.html
@@ -1,5 +1,5 @@
 {% comment %}
-<c-n26.changelog.entry> — one update: a short title, two lines of it, a date.
+<c-n26.changelog.entry> — one update: a short title, two lines of rich text, a date.
 
     <c-n26.changelog.entry title="Vehicles" date="6 Aug" href="/changelog/vehicles/">
         Hire a Trazior and it brings its own card…
@@ -9,7 +9,9 @@ The whole row opens the entry: one real <a>, on the title, with .n26-row-link
 stretching its ::after over the row. Anything else clickable added here would
 need lifting above that ::after.
 
-The summary is clamped to two lines; the full text is one click away.
+The summary accepts rendered rich text. Its container is a div because editor
+output may contain paragraphs and lists, which cannot sit inside a paragraph.
+It is clamped to two small-text lines; the full text is one click away.
 
   title — the short header.
   date — when. Stays beside the title at phone width.
@@ -24,5 +26,5 @@ The summary is clamped to two lines; the full text is one click away.
         </h3>
         {% if date %}<span class="shrink-0 text-sm tabular-nums text-muted">{{ date }}</span>{% endif %}
     </div>
-    <p class="n26-clamp-2 mt-0.5 text-sm text-muted">{{ slot }}</p>
+    <div class="rich-text n26-clamp-2 mt-0.5 text-sm text-muted">{{ slot }}</div>
 </div>

--- a/n26/core/templates/cotton/n26/changelog/index.html
+++ b/n26/core/templates/cotton/n26/changelog/index.html
@@ -10,19 +10,25 @@ A list, not a feed: nothing loads more. Four or five entries on a dashboard, and
 a way through to the rest. The link to the full changelog sits in the heading,
 so every clickable line in the list itself opens an entry.
 
-  heading — what the section is called. "Updates" by default.
+  heading — what the section is called. "Updates" by default; pass an empty
+    string when the page already has a heading.
   href — the full changelog. Without one the heading is plain text.
   empty — what to say when there is nothing.
 {% endcomment %}
 <c-vars heading="Updates" href="" empty="" class="" />
 
 <section class="flex flex-col gap-2 {{ class }}">
-    <div class="flex items-baseline justify-between gap-2">
-        <h2 class="text-lg font-semibold text-ink-900 dark:text-ink-100">{{ heading }}</h2>
-        {% if href %}
-            <c-n26.link href="{{ href }}" tone="muted" class="text-sm">All updates</c-n26.link>
-        {% endif %}
-    </div>
+    {% if heading or href %}
+        <div class="flex items-baseline justify-between gap-2">
+            {% if heading %}<h2 class="text-lg font-semibold text-ink-900 dark:text-ink-100">{{ heading }}</h2>{% endif %}
+            {% if href %}
+                <c-n26.link href="{{ href }}" tone="muted" class="text-sm">
+                    <c-slot name="trailing"><span aria-hidden="true">&nbsp;→</span></c-slot>
+                    View all
+                </c-n26.link>
+            {% endif %}
+        </div>
+    {% endif %}
 
     {% if slot.strip %}
         <div class="divide-y divide-box-border border-y border-box-border">{{ slot }}</div>

--- a/n26/core/templates/cotton/n26/changelog/index.html
+++ b/n26/core/templates/cotton/n26/changelog/index.html
@@ -3,7 +3,7 @@
 
     <c-n26.changelog heading="Updates" href="/changelog/">
         <c-n26.changelog.entry title="Vehicles" date="6 Aug"
-                               href="/changelog/vehicles/">Hire a Trazior…</c-n26.changelog.entry>
+                               href="/changelog/vehicles/" :body="entry.body" />
     </c-n26.changelog>
 
 A list, not a feed: nothing loads more. Four or five entries on a dashboard, and

--- a/n26/core/templates/n26/_changelog_sidebar.html
+++ b/n26/core/templates/n26/_changelog_sidebar.html
@@ -1,0 +1,16 @@
+<aside class="hidden lg:block">
+    <c-ui.navlist variant="sidebar"
+                  aria-label="Changelog entries"
+                  :persist_scroll="True"
+                  scroll_key="n26-changelog"
+                  class="sticky top-24 max-h-[70vh] overflow-y-auto">
+        {% for item in sidebar %}
+            <c-ui.navlist.item href="{{ item.href }}" :current="item.current">
+                <span class="flex min-w-0 flex-col">
+                    <span>{{ item.title }}</span>
+                    <span class="text-xs text-muted">{{ item.date|date:"j M Y" }}</span>
+                </span>
+            </c-ui.navlist.item>
+        {% endfor %}
+    </c-ui.navlist>
+</aside>

--- a/n26/core/templates/n26/changelog.html
+++ b/n26/core/templates/n26/changelog.html
@@ -1,5 +1,4 @@
 {% extends "n26/layouts/base.html" %}
-{% load richtext %}
 {% block head_title %}Changelog{% endblock head_title %}
 {% block nav_heading %}Changelog{% endblock nav_heading %}
 {% block content %}
@@ -10,9 +9,8 @@
             {% for entry in entries %}
                 <c-n26.changelog.entry title="{{ entry.title }}"
                                        date="{{ entry.date|date:'j M Y' }}"
-                                       href="{% url 'n26-changelog-entry' entry.pk %}">
-                    {{ entry.body|safe_rich_text }}
-                </c-n26.changelog.entry>
+                                       href="{% url 'n26-changelog-entry' entry.pk %}"
+                                       :body="entry.body" />
             {% endfor %}
         </c-n26.changelog>
     </div>

--- a/n26/core/templates/n26/changelog.html
+++ b/n26/core/templates/n26/changelog.html
@@ -1,0 +1,19 @@
+{% extends "n26/layouts/base.html" %}
+{% load richtext %}
+{% block head_title %}Changelog{% endblock head_title %}
+{% block nav_heading %}Changelog{% endblock nav_heading %}
+{% block content %}
+    <div class="mx-auto flex w-full max-w-2xl flex-col gap-6">
+        <c-n26.page-header title="Changelog"
+                           lead="Everything that has changed in the N26 preview." />
+        <c-n26.changelog heading="" empty="Nothing yet.">
+            {% for entry in entries %}
+                <c-n26.changelog.entry title="{{ entry.title }}"
+                                       date="{{ entry.date|date:'j M Y' }}"
+                                       href="{% url 'n26-changelog-entry' entry.pk %}">
+                    {{ entry.body|safe_rich_text }}
+                </c-n26.changelog.entry>
+            {% endfor %}
+        </c-n26.changelog>
+    </div>
+{% endblock content %}

--- a/n26/core/templates/n26/changelog.html
+++ b/n26/core/templates/n26/changelog.html
@@ -2,16 +2,19 @@
 {% block head_title %}Changelog{% endblock head_title %}
 {% block nav_heading %}Changelog{% endblock nav_heading %}
 {% block content %}
-    <div class="mx-auto flex w-full max-w-2xl flex-col gap-6">
-        <c-n26.page-header title="Changelog"
-                           lead="Everything that has changed in the N26 preview." />
-        <c-n26.changelog heading="" empty="Nothing yet.">
-            {% for entry in entries %}
-                <c-n26.changelog.entry title="{{ entry.title }}"
-                                       date="{{ entry.date|date:'j M Y' }}"
-                                       href="{% url 'n26-changelog-entry' entry.pk %}"
-                                       :body="entry.body" />
-            {% endfor %}
-        </c-n26.changelog>
+    <div class="grid items-start gap-8 lg:grid-cols-[15rem_minmax(0,1fr)]">
+        {% include "n26/_changelog_sidebar.html" %}
+        <div class="min-w-0">
+            <c-n26.page-header title="Changelog"
+                               lead="Everything that has changed in the N26 preview." />
+            <c-n26.changelog heading="" empty="Nothing yet." class="mt-6">
+                {% for entry in entries %}
+                    <c-n26.changelog.entry title="{{ entry.title }}"
+                                           date="{{ entry.date|date:'j M Y' }}"
+                                           href="{% url 'n26-changelog-entry' entry.pk %}"
+                                           :body="entry.body" />
+                {% endfor %}
+            </c-n26.changelog>
+        </div>
     </div>
 {% endblock content %}

--- a/n26/core/templates/n26/changelog_entry.html
+++ b/n26/core/templates/n26/changelog_entry.html
@@ -1,0 +1,37 @@
+{% extends "n26/layouts/base.html" %}
+{% block head_title %}
+    {{ entry.title }}
+{% endblock head_title %}
+{% block nav_heading %}Changelog{% endblock nav_heading %}
+{% block content %}
+    <div class="grid items-start gap-8 lg:grid-cols-[15rem_minmax(0,1fr)]">
+        <aside class="hidden lg:block">
+            <c-ui.navlist variant="sidebar"
+                          aria-label="Changelog entries"
+                          class="sticky top-24 max-h-[70vh] overflow-y-auto">
+                {% for item in sidebar %}
+                    <c-ui.navlist.item href="{{ item.href }}" :current="item.current">
+                        <span class="block">{{ item.title }}</span>
+                        <span class="block text-xs text-muted">{{ item.date|date:"j M Y" }}</span>
+                    </c-ui.navlist.item>
+                {% endfor %}
+            </c-ui.navlist>
+        </aside>
+        <article class="min-w-0">
+            <c-n26.page-header title="{{ entry.title }}">
+                <c-slot name="breadcrumb">
+                    <c-ui.breadcrumbs>
+                        <c-ui.breadcrumbs.item href="{% url 'n26-changelog' %}">Changelog</c-ui.breadcrumbs.item>
+                        <c-ui.breadcrumbs.item :current="True">
+                            {{ entry.title }}
+                        </c-ui.breadcrumbs.item>
+                    </c-ui.breadcrumbs>
+                </c-slot>
+                <c-slot name="lead">
+                    <time datetime="{{ entry.date|date:'Y-m-d' }}">{{ entry.date|date:"j F Y" }}</time>
+                </c-slot>
+            </c-n26.page-header>
+            <c-n26.rich-text :value="entry.body" class="mt-6" />
+        </article>
+    </div>
+{% endblock content %}

--- a/n26/core/templates/n26/changelog_entry.html
+++ b/n26/core/templates/n26/changelog_entry.html
@@ -8,11 +8,15 @@
         <aside class="hidden lg:block">
             <c-ui.navlist variant="sidebar"
                           aria-label="Changelog entries"
+                          :persist_scroll="True"
+                          scroll_key="n26-changelog"
                           class="sticky top-24 max-h-[70vh] overflow-y-auto">
                 {% for item in sidebar %}
                     <c-ui.navlist.item href="{{ item.href }}" :current="item.current">
-                        <span class="block">{{ item.title }}</span>
-                        <span class="block text-xs text-muted">{{ item.date|date:"j M Y" }}</span>
+                        <span class="flex min-w-0 flex-col">
+                            <span>{{ item.title }}</span>
+                            <span class="text-xs text-muted">{{ item.date|date:"j M Y" }}</span>
+                        </span>
                     </c-ui.navlist.item>
                 {% endfor %}
             </c-ui.navlist>

--- a/n26/core/templates/n26/changelog_entry.html
+++ b/n26/core/templates/n26/changelog_entry.html
@@ -5,22 +5,7 @@
 {% block nav_heading %}Changelog{% endblock nav_heading %}
 {% block content %}
     <div class="grid items-start gap-8 lg:grid-cols-[15rem_minmax(0,1fr)]">
-        <aside class="hidden lg:block">
-            <c-ui.navlist variant="sidebar"
-                          aria-label="Changelog entries"
-                          :persist_scroll="True"
-                          scroll_key="n26-changelog"
-                          class="sticky top-24 max-h-[70vh] overflow-y-auto">
-                {% for item in sidebar %}
-                    <c-ui.navlist.item href="{{ item.href }}" :current="item.current">
-                        <span class="flex min-w-0 flex-col">
-                            <span>{{ item.title }}</span>
-                            <span class="text-xs text-muted">{{ item.date|date:"j M Y" }}</span>
-                        </span>
-                    </c-ui.navlist.item>
-                {% endfor %}
-            </c-ui.navlist>
-        </aside>
+        {% include "n26/_changelog_sidebar.html" %}
         <article class="min-w-0">
             <c-n26.page-header title="{{ entry.title }}">
                 <c-slot name="breadcrumb">

--- a/n26/core/templates/n26/dashboard.html
+++ b/n26/core/templates/n26/dashboard.html
@@ -1,6 +1,5 @@
 {% extends "n26/layouts/base.html" %}
 {% load navigation %}
-{% load richtext %}
 {% comment %}
 The edition's front page: the signed-in user's gangs and the site
 changelog, drawn entirely from the design system — the gallery's shell
@@ -64,9 +63,8 @@ places — the same pattern a gang's screens use for their siblings.
                 {% for entry in changelog %}
                     <c-n26.changelog.entry title="{{ entry.title }}"
                                            date="{{ entry.date|date:'j M' }}"
-                                           href="{% url 'n26-changelog-entry' entry.pk %}">
-                        {{ entry.body|safe_rich_text }}
-                    </c-n26.changelog.entry>
+                                           href="{% url 'n26-changelog-entry' entry.pk %}"
+                                           :body="entry.body" />
                 {% endfor %}
             </c-n26.changelog>
         </c-slot>

--- a/n26/core/templates/n26/dashboard.html
+++ b/n26/core/templates/n26/dashboard.html
@@ -60,9 +60,11 @@ places — the same pattern a gang's screens use for their siblings.
             </c-n26.gang-table>
         </c-slot>
         <c-slot name="changelog">
-            <c-n26.changelog empty="Nothing new yet.">
+            <c-n26.changelog href="{% url 'n26-changelog' %}" empty="Nothing new yet.">
                 {% for entry in changelog %}
-                    <c-n26.changelog.entry title="{{ entry.title }}" date="{{ entry.date|date:'j M' }}" href="#">
+                    <c-n26.changelog.entry title="{{ entry.title }}"
+                                           date="{{ entry.date|date:'j M' }}"
+                                           href="{% url 'n26-changelog-entry' entry.pk %}">
                         {{ entry.body|safe_rich_text }}
                     </c-n26.changelog.entry>
                 {% endfor %}

--- a/n26/core/views/__init__.py
+++ b/n26/core/views/__init__.py
@@ -13,6 +13,7 @@ what makes it a move rather than a change.
 """
 
 from n26.core.views.api import preview_view
+from n26.core.views.changelog import changelog, changelog_entry
 from n26.core.views.choose import choose
 from n26.core.views.edit import edit_fighter
 from n26.core.views.equip import equip, equip_gang
@@ -43,6 +44,8 @@ from n26.core.views.printing import print_gang, print_setup
 
 __all__ = [
     "accessorise_assignment",
+    "changelog",
+    "changelog_entry",
     "choose",
     "create_gang",
     "dashboard",

--- a/n26/core/views/changelog.py
+++ b/n26/core/views/changelog.py
@@ -8,7 +8,8 @@ an entry has the same meaning for every reader.
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
-#: The label that assigns a site-wide changelog entry to this edition.
+#: Both editions read one table, so an entry appears here only when its
+#: author says which edition it concerns. Untagged news belongs to neither.
 CHANGELOG_TAG = "N26"
 
 
@@ -20,10 +21,14 @@ def changelog_entries():
     """
     from gyrinx.site.models import ChangelogEntry
 
-    return ChangelogEntry.objects.filter(
-        archived=False,
-        tags__name__iexact=CHANGELOG_TAG,
-    ).distinct()
+    return (
+        ChangelogEntry.objects.filter(
+            archived=False,
+            tags__name__iexact=CHANGELOG_TAG,
+        )
+        .distinct()
+        .order_by("-date", "-created")
+    )
 
 
 def changelog(request):

--- a/n26/core/views/changelog.py
+++ b/n26/core/views/changelog.py
@@ -33,27 +33,33 @@ def changelog_entries():
 
 def changelog(request):
     """Every changelog entry about this edition."""
+    entries = list(changelog_entries())
     return render(
         request,
         "n26/changelog.html",
-        {"entries": changelog_entries()},
+        {"entries": entries, "sidebar": _sidebar(entries)},
     )
 
 
 def changelog_entry(request, pk):
     """One complete entry, with every edition entry beside it."""
     entry = get_object_or_404(changelog_entries(), pk=pk)
-    sidebar = [
-        {
-            "title": item.title,
-            "date": item.date,
-            "href": reverse("n26-changelog-entry", args=[item.pk]),
-            "current": item.pk == entry.pk,
-        }
-        for item in changelog_entries().only("id", "title", "date")
-    ]
+    sidebar = _sidebar(changelog_entries().only("id", "title", "date"), entry)
     return render(
         request,
         "n26/changelog_entry.html",
         {"entry": entry, "sidebar": sidebar},
     )
+
+
+def _sidebar(entries, current=None):
+    """Links shared by the index and every entry page."""
+    return [
+        {
+            "title": item.title,
+            "date": item.date,
+            "href": reverse("n26-changelog-entry", args=[item.pk]),
+            "current": current is not None and item.pk == current.pk,
+        }
+        for item in entries
+    ]

--- a/n26/core/views/changelog.py
+++ b/n26/core/views/changelog.py
@@ -1,0 +1,54 @@
+"""The site's changelog, narrowed to the entries about this edition.
+
+This is the one n26 module that reads the platform-owned changelog table.
+Both pages are deliberately public: release notes hold no player data, and
+an entry has the same meaning for every reader.
+"""
+
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+
+#: The label that assigns a site-wide changelog entry to this edition.
+CHANGELOG_TAG = "N26"
+
+
+def changelog_entries():
+    """Live entries tagged for this edition, newest first.
+
+    Tag names are unique case-sensitively, so matching both ``N26`` and
+    ``n26`` can join one entry twice when it carries both spellings.
+    """
+    from gyrinx.site.models import ChangelogEntry
+
+    return ChangelogEntry.objects.filter(
+        archived=False,
+        tags__name__iexact=CHANGELOG_TAG,
+    ).distinct()
+
+
+def changelog(request):
+    """Every changelog entry about this edition."""
+    return render(
+        request,
+        "n26/changelog.html",
+        {"entries": changelog_entries()},
+    )
+
+
+def changelog_entry(request, pk):
+    """One complete entry, with every edition entry beside it."""
+    entry = get_object_or_404(changelog_entries(), pk=pk)
+    sidebar = [
+        {
+            "title": item.title,
+            "date": item.date,
+            "href": reverse("n26-changelog-entry", args=[item.pk]),
+            "current": item.pk == entry.pk,
+        }
+        for item in changelog_entries().only("id", "title", "date")
+    ]
+    return render(
+        request,
+        "n26/changelog_entry.html",
+        {"entry": entry, "sidebar": sidebar},
+    )

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -6,6 +6,7 @@ from django.core.paginator import Paginator
 from django.shortcuts import redirect, render
 from django.urls import reverse
 
+from n26.core.views.changelog import changelog_entries
 from n26.core.views.permissions import _any_gang_or_404, _own_gang_or_404
 
 #: How many gangs a page of the list holds. A row carries a name, a
@@ -13,12 +14,6 @@ from n26.core.views.permissions import _any_gang_or_404, _own_gang_or_404
 #: and a half of scrolling — enough to read down, few enough that the
 #: page is not the whole table.
 GANGS_PER_PAGE = 25
-
-# The changelog belongs to the site and both editions read the same
-# table, so an entry reaches this dashboard only if someone tagged it for
-# this edition. An entry nobody tagged appears on neither dashboard: a
-# reader should not have to work out which edition a change was about.
-CHANGELOG_TAG = "N26"
 
 
 @login_required
@@ -36,22 +31,12 @@ def dashboard(request):
     The changelog is the site's, narrowed to the entries tagged for this
     edition.
     """
-    from gyrinx.site.models import ChangelogEntry
-
     return render(
         request,
         "n26/dashboard.html",
         {
             **_gang_table_context(request),
-            # Tag names are unique but case-sensitively so: "N26" and "n26"
-            # are two rows an admin can create, and an entry tagged with
-            # either is meant for this page. Matching both is also why the
-            # rows need deduplicating — an entry carrying both spellings
-            # matches the join twice and would otherwise be listed twice,
-            # taking two of the five places.
-            "changelog": ChangelogEntry.objects.filter(
-                archived=False, tags__name__iexact=CHANGELOG_TAG
-            ).distinct()[:5],
+            "changelog": changelog_entries()[:5],
         },
     )
 

--- a/n26/designsystem/assets/app.css
+++ b/n26/designsystem/assets/app.css
@@ -744,6 +744,9 @@
         -webkit-line-clamp: 2;
         overflow: hidden;
     }
+    .n26-clamp-2 :is(p, ul, ol, blockquote) {
+        margin-bottom: 0;
+    }
 
     /* One price column, so every row in a list puts its number — and therefore
      * its buttons — in the same place. A column of buttons that almost lines up

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1624,10 +1624,9 @@ GROUPS: list[Group] = [
                     "two lines, the full text being a click away. The way through "
                     "to everything is in the heading rather than a last row, which "
                     "would be the one row in the list that does not behave like "
-                    "the list. Rows are clickable by the same stretched-anchor "
-                    "means c-n26.gang-table uses. A summary accepts sanitised rich "
-                    "text; links inside it are covered by the row link and become "
-                    "clickable on the full entry page."
+                    "the list. The title opens the full entry; links in a rich-text "
+                    "summary keep their own destinations. The entry component "
+                    "sanitises its body rather than relying on each caller."
                 ),
             ),
             Component(

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1625,7 +1625,9 @@ GROUPS: list[Group] = [
                     "to everything is in the heading rather than a last row, which "
                     "would be the one row in the list that does not behave like "
                     "the list. Rows are clickable by the same stretched-anchor "
-                    "means c-n26.gang-table uses."
+                    "means c-n26.gang-table uses. A summary accepts sanitised rich "
+                    "text; links inside it are covered by the row link and become "
+                    "clickable on the full entry page."
                 ),
             ),
             Component(

--- a/n26/designsystem/templates/designsystem/demos/changelog/10-updates.html
+++ b/n26/designsystem/templates/designsystem/demos/changelog/10-updates.html
@@ -3,8 +3,9 @@
 {# layout: full #}
 <c-n26.changelog href="#">
     {% for entry in dashboard_changelog %}
-        <c-n26.changelog.entry title="{{ entry.title }}" date="{{ entry.date }}" href="#">
-            {{ entry.text }}
-        </c-n26.changelog.entry>
+        <c-n26.changelog.entry title="{{ entry.title }}"
+                               date="{{ entry.date }}"
+                               href="#"
+                               :body="entry.text" />
     {% endfor %}
 </c-n26.changelog>

--- a/n26/designsystem/templates/designsystem/demos/changelog/30-rich-summary.html
+++ b/n26/designsystem/templates/designsystem/demos/changelog/30-rich-summary.html
@@ -1,12 +1,8 @@
 {# title: Rich-text summary #}
 {# note: Paragraphs, emphasis and lists keep their rich-text styling while the whole summary remains a two-line preview. #}
 {# layout: full #}
+{% with rich_body="<p>Profiles now include <strong>their key changes</strong>.</p><ul><li>One concise point</li><li>Another concise point</li></ul>" %}
 <c-n26.changelog heading="Updates">
-    <c-n26.changelog.entry title="A richer update" date="19 Aug" href="#">
-        <p>Profiles now include <strong>their key changes</strong>.</p>
-        <ul>
-            <li>One concise point</li>
-            <li>Another concise point</li>
-        </ul>
-    </c-n26.changelog.entry>
+    <c-n26.changelog.entry title="A richer update" date="19 Aug" href="#" :body="rich_body" />
 </c-n26.changelog>
+{% endwith %}

--- a/n26/designsystem/templates/designsystem/demos/changelog/30-rich-summary.html
+++ b/n26/designsystem/templates/designsystem/demos/changelog/30-rich-summary.html
@@ -1,0 +1,12 @@
+{# title: Rich-text summary #}
+{# note: Paragraphs, emphasis and lists keep their rich-text styling while the whole summary remains a two-line preview. #}
+{# layout: full #}
+<c-n26.changelog heading="Updates">
+    <c-n26.changelog.entry title="A richer update" date="19 Aug" href="#">
+        <p>Profiles now include <strong>their key changes</strong>.</p>
+        <ul>
+            <li>One concise point</li>
+            <li>Another concise point</li>
+        </ul>
+    </c-n26.changelog.entry>
+</c-n26.changelog>

--- a/n26/designsystem/templates/designsystem/demos/view-dashboard/10-dashboard.html
+++ b/n26/designsystem/templates/designsystem/demos/view-dashboard/10-dashboard.html
@@ -23,9 +23,10 @@
     <c-slot name="changelog">
         <c-n26.changelog href="#">
             {% for entry in dashboard_changelog %}
-                <c-n26.changelog.entry title="{{ entry.title }}" date="{{ entry.date }}" href="#">
-                    {{ entry.text }}
-                </c-n26.changelog.entry>
+                <c-n26.changelog.entry title="{{ entry.title }}"
+                                       date="{{ entry.date }}"
+                                       href="#"
+                                       :body="entry.text" />
             {% endfor %}
         </c-n26.changelog>
     </c-slot>

--- a/n26/designsystem/templates/designsystem/shell/home.html
+++ b/n26/designsystem/templates/designsystem/shell/home.html
@@ -54,9 +54,10 @@ the bottom.
         <c-slot name="changelog">
             <c-n26.changelog href="#">
                 {% for entry in dashboard_changelog %}
-                    <c-n26.changelog.entry title="{{ entry.title }}" date="{{ entry.date }}" href="#">
-                        {{ entry.text }}
-                    </c-n26.changelog.entry>
+                    <c-n26.changelog.entry title="{{ entry.title }}"
+                                           date="{{ entry.date }}"
+                                           href="#"
+                                           :body="entry.text" />
                 {% endfor %}
             </c-n26.changelog>
         </c-slot>

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -244,7 +244,7 @@ class TestTheChangelogLinks:
 
         body = client.get("/n26/").content.decode()
 
-        assert '<div class="rich-text n26-clamp-2' in body
+        assert 'class="rich-text n26-clamp-2' in body
         assert "<ul><li>One point</li></ul>" in body
 
 

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -244,8 +244,7 @@ class TestTheChangelogLinks:
 
         body = client.get("/n26/").content.decode()
 
-        assert 'class="rich-text n26-clamp-2 mt-0.5 text-sm text-muted"' in body
-        assert '<p class="n26-clamp-2' not in body
+        assert '<div class="rich-text n26-clamp-2' in body
         assert "<ul><li>One point</li></ul>" in body
 
 

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -291,11 +291,31 @@ class TestTheChangelogIndex:
         changelog_entry("The older entry", CHANGELOG_TAG, date="2026-08-01")
 
         body = client.get("/n26/changelog/").content.decode()
+        sidebar = body[body.index("<aside") : body.index("</aside>")]
+        listing = body[body.index("<section", body.index("</aside>")) :]
 
-        assert body.count("The newest entry") == 1
-        assert in_order(body, "The newest entry", "The older entry") == sorted(
-            in_order(body, "The newest entry", "The older entry")
+        assert sidebar.count("The newest entry") == 1
+        assert listing.count("The newest entry") == 1
+        assert in_order(listing, "The newest entry", "The older entry") == sorted(
+            in_order(listing, "The newest entry", "The older entry")
         )
+
+    def test_the_sidebar_links_every_entry_in_the_same_order(
+        self, client, default_pack
+    ):
+        newest = changelog_entry("Newest in the menu", CHANGELOG_TAG, date="2026-08-19")
+        oldest = changelog_entry("Oldest in the menu", CHANGELOG_TAG, date="2026-08-01")
+        changelog_entry("Not in the menu", "N23", date="2026-08-20")
+
+        body = client.get("/n26/changelog/").content.decode()
+        sidebar = body[body.index("<aside") : body.index("</aside>")]
+
+        positions = in_order(sidebar, "Newest in the menu", "Oldest in the menu")
+        assert positions == sorted(positions)
+        assert f"/n26/changelog/{newest.pk}/" in sidebar
+        assert f"/n26/changelog/{oldest.pk}/" in sidebar
+        assert "Not in the menu" not in sidebar
+        assert 'aria-current="page"' not in sidebar
 
     def test_entries_are_rich_sanitised_previews_that_open_the_full_page(
         self, client, default_pack

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -19,7 +19,7 @@ The load-bearing ideas:
 import pytest
 from django.contrib.auth.models import User
 
-from n26.core.views.gangs import CHANGELOG_TAG
+from n26.core.views.changelog import CHANGELOG_TAG
 
 pytestmark = pytest.mark.django_db
 
@@ -213,6 +213,186 @@ class TestTheChangelogPanel:
             assert client.get("/n26/").status_code == 200
 
         assert len(with_ten.captured_queries) == len(with_two.captured_queries)
+
+
+class TestTheChangelogLinks:
+    """The dashboard previews rich entries and leads to their full pages."""
+
+    def test_each_entry_links_to_its_full_page(self, tester, client, default_pack):
+        entry = changelog_entry("Trading post", CHANGELOG_TAG)
+
+        body = client.get("/n26/").content.decode()
+
+        assert f"/n26/changelog/{entry.pk}/" in body
+
+    def test_the_heading_links_to_every_update(self, tester, client, default_pack):
+        body = client.get("/n26/").content.decode()
+
+        assert 'href="/n26/changelog/"' in body
+        assert "View all" in body
+
+    def test_rich_summaries_stay_inside_the_small_clamped_container(
+        self, tester, client, default_pack
+    ):
+        """A block body must not close its summary container early and
+        escape the smaller two-line preview."""
+        changelog_entry(
+            "Several details",
+            CHANGELOG_TAG,
+            body="<p>First paragraph.</p><ul><li>One point</li></ul>",
+        )
+
+        body = client.get("/n26/").content.decode()
+
+        assert 'class="rich-text n26-clamp-2 mt-0.5 text-sm text-muted"' in body
+        assert '<p class="n26-clamp-2' not in body
+        assert "<ul><li>One point</li></ul>" in body
+
+
+class TestTheChangelogIndex:
+    """The public index lists every live entry about this edition."""
+
+    def test_anybody_may_read_it_without_an_account(self, client, default_pack):
+        assert client.get("/n26/changelog/").status_code == 200
+
+    def test_it_lists_every_entry_not_just_the_dashboards_five(
+        self, client, default_pack
+    ):
+        for i in range(7):
+            changelog_entry(f"Entry number {i}", CHANGELOG_TAG)
+
+        body = client.get("/n26/changelog/").content.decode()
+
+        assert "Entry number 0" in body
+        assert "Entry number 6" in body
+
+    def test_it_keeps_only_live_news_for_this_edition(self, client, default_pack):
+        changelog_entry("The N26 entry", CHANGELOG_TAG)
+        changelog_entry("The old edition entry", "N23")
+        changelog_entry("The untagged entry")
+        archived = changelog_entry("The archived entry", CHANGELOG_TAG)
+        archived.archive()
+
+        body = client.get("/n26/changelog/").content.decode()
+
+        assert "The N26 entry" in body
+        assert "The old edition entry" not in body
+        assert "The untagged entry" not in body
+        assert "The archived entry" not in body
+
+    def test_it_deduplicates_two_spellings_and_orders_newest_first(
+        self, client, default_pack
+    ):
+        changelog_entry(
+            "The newest entry",
+            CHANGELOG_TAG,
+            CHANGELOG_TAG.lower(),
+            date="2026-08-19",
+        )
+        changelog_entry("The older entry", CHANGELOG_TAG, date="2026-08-01")
+
+        body = client.get("/n26/changelog/").content.decode()
+
+        assert body.count("The newest entry") == 1
+        assert in_order(body, "The newest entry", "The older entry") == sorted(
+            in_order(body, "The newest entry", "The older entry")
+        )
+
+    def test_entries_are_rich_sanitised_previews_that_open_the_full_page(
+        self, client, default_pack
+    ):
+        entry = changelog_entry(
+            "A careful preview",
+            CHANGELOG_TAG,
+            body='<script>alert("no")</script><ul><li><strong>Safe</strong></li></ul>',
+        )
+
+        body = client.get("/n26/changelog/").content.decode()
+
+        assert "alert" not in body
+        assert "<ul><li><strong>Safe</strong></li></ul>" in body
+        assert f"/n26/changelog/{entry.pk}/" in body
+
+
+class TestOneChangelogEntry:
+    """A public detail page shows the complete entry and an ordered menu."""
+
+    def test_anybody_may_read_the_full_rich_entry(self, client, default_pack):
+        entry = changelog_entry(
+            "Everything in this update",
+            CHANGELOG_TAG,
+            body=(
+                "<p>The opening.</p>"
+                "<ul><li><strong>First point</strong></li><li>Second point</li></ul>"
+            ),
+        )
+
+        response = client.get(f"/n26/changelog/{entry.pk}/")
+        body = response.content.decode()
+
+        assert response.status_code == 200
+        assert "<p>The opening.</p>" in body
+        assert "<ul><li><strong>First point</strong></li>" in body
+        assert "n26-clamp-2" not in body
+
+    def test_the_full_body_is_sanitised(self, client, default_pack):
+        entry = changelog_entry(
+            "A careful entry",
+            CHANGELOG_TAG,
+            body='<script>alert("no")</script><p><strong>Safe</strong></p>',
+        )
+
+        body = client.get(f"/n26/changelog/{entry.pk}/").content.decode()
+
+        assert "alert" not in body
+        assert "<strong>Safe</strong>" in body
+
+    @pytest.mark.parametrize("tags", [("N23",), ()])
+    def test_news_not_assigned_to_this_edition_is_not_reachable(
+        self, client, default_pack, tags
+    ):
+        entry = changelog_entry("Not for this edition", *tags)
+
+        assert client.get(f"/n26/changelog/{entry.pk}/").status_code == 404
+
+    def test_an_archived_entry_is_not_reachable(self, client, default_pack):
+        entry = changelog_entry("Archived news", CHANGELOG_TAG)
+        entry.archive()
+
+        assert client.get(f"/n26/changelog/{entry.pk}/").status_code == 404
+
+    def test_an_unknown_or_malformed_id_is_a_404(self, client, default_pack):
+        from uuid import uuid4
+
+        assert client.get(f"/n26/changelog/{uuid4()}/").status_code == 404
+        assert client.get("/n26/changelog/not-a-uuid/").status_code == 404
+
+    def test_the_sidebar_lists_every_entry_newest_first_and_marks_this_one(
+        self, client, default_pack
+    ):
+        import re
+
+        current = changelog_entry("The current entry", CHANGELOG_TAG, date="2026-08-10")
+        changelog_entry("The newest entry", CHANGELOG_TAG, date="2026-08-19")
+        changelog_entry("The oldest entry", CHANGELOG_TAG, date="2026-08-01")
+        changelog_entry("The other edition", "N23", date="2026-08-20")
+
+        body = client.get(f"/n26/changelog/{current.pk}/").content.decode()
+        sidebar = body[body.index("<aside") : body.index("</aside>")]
+
+        positions = in_order(
+            sidebar, "The newest entry", "The current entry", "The oldest entry"
+        )
+        assert positions == sorted(positions)
+        assert "The other edition" not in sidebar
+        current_url = f"/n26/changelog/{current.pk}/"
+        anchor = re.search(
+            rf'<a[^>]*href="{re.escape(current_url)}"[^>]*>',
+            sidebar,
+        )
+        assert anchor is not None
+        assert 'aria-current="page"' in anchor.group()
+        assert "is-current" in anchor.group()
 
 
 TELEPORT = '<template x-teleport="body">'

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -12,6 +12,12 @@ from n26.library import views as authoring_views
 
 urlpatterns = [
     path("", views.dashboard, name="n26-dashboard"),
+    path("changelog/", views.changelog, name="n26-changelog"),
+    path(
+        "changelog/<uuid:pk>/",
+        views.changelog_entry,
+        name="n26-changelog-entry",
+    ),
     path("gangs/", views.gangs, name="n26-gangs"),
     path("gangs/new/", views.create_gang, name="n26-create-gang"),
     # After gangs/new/, which would otherwise resolve "new" as an id.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a dedicated N26 changelog index and detail pages so release notes are navigable and rich text displays correctly.

- Lists all live entries tagged for N26 at `/n26/changelog/`
- Uses the same ordered, scroll-preserving changelog sidebar on both the index and detail pages
- Shows complete sanitised entries at `/n26/changelog/<id>/`
- Links dashboard update titles to their details and adds the compact `View all →` action
- Fixes dashboard rich-text previews so paragraphs and bullet lists stay inside the smaller two-line summary
- Centralises summary sanitisation in the changelog component while keeping links inside rich text independently usable
- Covers tag filtering, ordering, sanitisation, public access, navigation, and 404 behaviour

[n26_changelog_final_desktop.mp4](https://cursor.com/agents/bc-0a7d4af0-dbdb-4a12-81db-53113675eec1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fn26_changelog_final_desktop.mp4)

[n26_changelog_index_sidebar.mp4](https://cursor.com/agents/bc-0a7d4af0-dbdb-4a12-81db-53113675eec1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fn26_changelog_index_sidebar.mp4)

How to try it:
1. Add changelog entries tagged `N26` in the admin.
2. Open `/n26/`, then follow an update or `View all →`.
3. Open `/n26/changelog/` directly while signed out to verify the public view and sidebar.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a7d4af0-dbdb-4a12-81db-53113675eec1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a7d4af0-dbdb-4a12-81db-53113675eec1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

