### PR TITLE
feat: stash equip page with manage controls and orphan UI comparison

### DIFF
--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -1,47 +1,12 @@
-"""A collection as one fighter sees it: what is for sale, and what they hold.
+"""A browsed collection joined to possessions.
 
-:mod:`n26.core.browse` renders a collection knowing nothing about who is
-reading it — a taxonomy of priced lines, the same shape whether the
-collection was written out by hand or swept together by a selector.
-:mod:`n26.core.owned` reads the other half off the fighter's card: which
-copies of which content they are already carrying.
+A category contains either :class:`Listing` or :class:`OwnedRow` for a
+piece of content. An owned row keeps its listing when another copy can be
+bought; stash-only rows have no listing. Actions state their meaning and
+target while templates decide how to draw them.
 
-A catalogue is the two joined. It is what the equip screen draws, and
-it is a structure rather than a bag of dictionaries so that the join has
-one definition: a test can build one and ask what a row offers without
-going through a request, and a gallery can build one without a database.
-
-  --- owning something replaces its row ---
-
-A category holds :class:`Listing` or :class:`OwnedRow`, one or the
-other for a given piece of content, never both and never a flag on one type.
-Where the fighter holds one of the thing a row names, the row says so
-instead of offering another: the count stands where Buy would be and
-opens onto the copies themselves.
-
-The ordinary row is not lost when that happens — it is nested, as
-:attr:`OwnedRow.buy`, unconditionally. That is how a reader buys a
-second, and it is the same row they would have seen had they owned none,
-so there is one definition of what buying this thing looks like.
-
-  --- a row's actions say what they mean, never how to draw it ---
-
-Buy is a submit: the catalogue is one form, and a purchase names its
-line and clicks. Sell, Reassign and Delete are links, because each opens
-a confirmation that is a server-rendered state of the page it was
-clicked on. A template that had to know which of the four was which
-would decide that by name, and the first act added would be drawn wrong.
-
-Tones are the row's own vocabulary — what the control *means* — and a
-template maps them to whatever the button kit calls those colours. So
-nothing here knows that a sale is red.
-
-  --- what a row submits ---
-
-Each input's name is derived from the row's key and carried on the row.
-The server derives the same names when it reads the click back, and a
-name computed twice from two places is a name that eventually disagrees
-with itself.
+Input names live on the rows because the server must derive the same names
+when it validates a purchase.
 """
 
 from dataclasses import dataclass, field
@@ -490,7 +455,6 @@ def copy_row(copy, refunds=True):
 
 
 def owned_row(row, copies, refunds=True):
-    """The same row, for a fighter who is carrying some of these."""
     return OwnedRow(
         key=row.key,
         name=row.name,
@@ -501,7 +465,6 @@ def owned_row(row, copies, refunds=True):
 
 
 def owned_row_manage_only(key, copies, refunds=True):
-    """A row for gear held but not sold by the list being browsed."""
     return OwnedRow(
         key=key,
         name=copies[0].name,
@@ -511,8 +474,7 @@ def owned_row_manage_only(key, copies, refunds=True):
     )
 
 
-def build_stash_catalogue(owned, name="In stash", refunds=True):
-    """Every held copy on the stash tab — manage-only, no buy underneath."""
+def build_stash_catalogue(owned, name, refunds=True):
     catalogue = Catalogue(name=name)
     section = CatalogueSection(name=name)
     rows = [
@@ -529,7 +491,7 @@ def build_stash_catalogue(owned, name="In stash", refunds=True):
 def build_catalogue(view, owned, name=None, refunds=True):
     """A browsed collection joined to what one fighter already holds.
 
-    ``owned`` is the index :func:`n26.core.owned.owned_things` returns,
+    ``owned`` is the index :func:`n26.core.owned.possessions` returns,
     keyed the way rows are keyed — so the join is one dictionary read per
     row, however much the fighter is carrying and however long the list.
 

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -253,6 +253,7 @@ class OwnedRow:
     #: buy another. Absent on a manage-only row — gear held but not sold
     #: by the list being read.
     buy: Listing | None = None
+    expanded: bool = False
 
 
 @dataclass
@@ -454,31 +455,38 @@ def copy_row(copy, refunds=True):
     )
 
 
-def owned_row(row, copies, refunds=True):
+def owned_row(row, copies, refunds=True, expanded=False):
     return OwnedRow(
         key=row.key,
         name=row.name,
         count=len(copies),
         copies=tuple(copy_row(copy, refunds=refunds) for copy in copies),
         buy=row,
+        expanded=expanded,
     )
 
 
-def owned_row_manage_only(key, copies, refunds=True):
+def owned_row_manage_only(key, copies, refunds=True, expanded=False):
     return OwnedRow(
         key=key,
         name=copies[0].name,
         count=len(copies),
         copies=tuple(copy_row(copy, refunds=refunds) for copy in copies),
         buy=None,
+        expanded=expanded,
     )
 
 
-def build_stash_catalogue(owned, name, refunds=True):
+def build_stash_catalogue(owned, name, refunds=True, expanded_key=""):
     catalogue = Catalogue(name=name)
     section = CatalogueSection(name=name)
     rows = [
-        owned_row_manage_only(key, copies, refunds=refunds)
+        owned_row_manage_only(
+            key,
+            copies,
+            refunds=refunds,
+            expanded=key == expanded_key,
+        )
         for key, copies in sorted(
             owned.items(), key=lambda item: item[1][0].name.casefold()
         )
@@ -488,7 +496,7 @@ def build_stash_catalogue(owned, name, refunds=True):
     return catalogue
 
 
-def build_catalogue(view, owned, name=None, refunds=True):
+def build_catalogue(view, owned, name=None, refunds=True, expanded_key=""):
     """A browsed collection joined to what one fighter already holds.
 
     ``owned`` is the index :func:`n26.core.owned.possessions` returns,
@@ -511,7 +519,16 @@ def build_catalogue(view, owned, name=None, refunds=True):
             for line in category.lines:
                 row = listing_row(line)
                 copies = owned.get(row.key)
-                rows.append(owned_row(row, copies, refunds=refunds) if copies else row)
+                rows.append(
+                    owned_row(
+                        row,
+                        copies,
+                        refunds=refunds,
+                        expanded=row.key == expanded_key,
+                    )
+                    if copies
+                    else row
+                )
             drawn.categories.append(CatalogueCategory(name=category.name, rows=rows))
         catalogue.sections.append(drawn)
     return catalogue

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -511,16 +511,6 @@ def owned_row_manage_only(key, copies, refunds=True):
     )
 
 
-def stash_orphan_rows(catalogue, owned, refunds=True):
-    """Held copies whose content this catalogue does not sell."""
-    listed = {row.key for row in catalogue.all_rows()}
-    rows = []
-    for key, copies in owned.items():
-        if key not in listed:
-            rows.append(owned_row_manage_only(key, copies, refunds=refunds))
-    return sorted(rows, key=lambda row: row.name.casefold())
-
-
 def build_stash_catalogue(owned, name="In stash", refunds=True):
     """Every held copy on the stash tab — manage-only, no buy underneath."""
     catalogue = Catalogue(name=name)

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -285,9 +285,9 @@ class OwnedRow:
     count: int
     copies: tuple[OwnedCopyRow, ...]
     #: The row this would have been had they owned none, so a reader can
-    #: buy another. Always present: owning one of something has never
-    #: been a reason the equip page stops selling it.
-    buy: Listing
+    #: buy another. Absent on a manage-only row — gear held but not sold
+    #: by the list being read.
+    buy: Listing | None = None
 
 
 @dataclass
@@ -498,6 +498,42 @@ def owned_row(row, copies, refunds=True):
         copies=tuple(copy_row(copy, refunds=refunds) for copy in copies),
         buy=row,
     )
+
+
+def owned_row_manage_only(key, copies, refunds=True):
+    """A row for gear held but not sold by the list being browsed."""
+    return OwnedRow(
+        key=key,
+        name=copies[0].name,
+        count=len(copies),
+        copies=tuple(copy_row(copy, refunds=refunds) for copy in copies),
+        buy=None,
+    )
+
+
+def stash_orphan_rows(catalogue, owned, refunds=True):
+    """Held copies whose content this catalogue does not sell."""
+    listed = {row.key for row in catalogue.all_rows()}
+    rows = []
+    for key, copies in owned.items():
+        if key not in listed:
+            rows.append(owned_row_manage_only(key, copies, refunds=refunds))
+    return sorted(rows, key=lambda row: row.name.casefold())
+
+
+def build_stash_catalogue(owned, name="In stash", refunds=True):
+    """Every held copy on the stash tab — manage-only, no buy underneath."""
+    catalogue = Catalogue(name=name)
+    section = CatalogueSection(name=name)
+    rows = [
+        owned_row_manage_only(key, copies, refunds=refunds)
+        for key, copies in sorted(
+            owned.items(), key=lambda item: item[1][0].name.casefold()
+        )
+    ]
+    section.categories.append(CatalogueCategory(name="", rows=rows))
+    catalogue.sections.append(section)
+    return catalogue
 
 
 def build_catalogue(view, owned, name=None, refunds=True):

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -1,72 +1,32 @@
-"""What a model already holds, as a catalogue needs to see it.
+"""Possessions as catalogue rows, read from an already-built card.
 
-A catalogue asks two questions of a fighter's card. Does this fighter
-already own one of these? And if so, what exactly — which copy, worth
-what, with what hanging off it — so the reader can sell it, hand it to
-somebody else, undo the purchase, or take it off the card.
-
-Both answers come off the card the page has already built. Nothing here
-queries, which is the whole point: a catalogue is hundreds of rows, and an
-owned-count fetched per row would be hundreds of queries.
-
-What is owned is drawn as a *state of an equip row*: where the fighter holds
-one of the thing a row names, the row says so instead of offering another.
-Anything they own that the list on screen does not sell has nowhere to be
-drawn, which is a known gap and not one to be closed from here.
-
-A **thing** is a root assignment: the fighter owns it and may re-home it.
-A **part** is one of its children — a paid ammo type, a sight bolted to a
-gun. A part is sold and removed like anything else. Whether it can be
-re-homed on its own depends on what sort of part it is, and
-:func:`is_detachable` is where that is said.
-
-Neither is *anything* the gang holds. Selling, handing on and dropping
-are acts on **possessions**, and :func:`is_possession` is the one place
-that says what one is — read by the catalogue that draws the controls and
-by the routes behind them, so a screen can never offer what a route
-would refuse, nor the other way round.
-
-Where a control leads is settled here too, in the same pass that finds
-the copy. A confirmation is a query parameter on the page the reader is
-already on, so what a row needs is that page's address and nothing more;
-building the rows half-formed and walking them again to fill the links in
-would leave anyone who called this directly holding controls that lead
-nowhere.
+The index built here issues no queries. It keeps root gear separate from
+parts such as ammunition and accessories, and gives every allowed act a URL
+on the page that supplied the card.
 """
 
 from dataclasses import dataclass
-from enum import Enum
 from urllib.parse import urlencode
 
 from n26.library.models.assignable import Family
 
 
-class EquipAnchor(Enum):
-    """Which screen's possessions are being read — a fighter's card or the stash."""
-
-    FIGHTER = "fighter"
-    STASH = "stash"
-
-
 @dataclass(frozen=True)
 class EquipHost:
-    """Where an equip screen reads possessions from and sends the reader back.
-
-    One object carries the gang, the page address, the assignment roots to
-    walk, and which anchor this screen is — so the catalogue, the dialogs
-    and the POST redirects all agree without each guessing from the other.
-    """
+    """The assignment roots and return address behind an equip screen."""
 
     gang: object
     at: str
     roots: tuple
-    anchor: EquipAnchor
     miniature: object | None = None
 
     @property
+    def is_stash(self):
+        return self.miniature is None
+
+    @property
     def held_label(self):
-        """Words for how many copies the reader already holds."""
-        return "equipped" if self.anchor is EquipAnchor.FIGHTER else "in stash"
+        return "in stash" if self.is_stash else "equipped"
 
     @classmethod
     def fighter(cls, gang, card, miniature, at):
@@ -74,7 +34,6 @@ class EquipHost:
             gang=gang,
             at=at,
             roots=tuple(card.roots),
-            anchor=EquipAnchor.FIGHTER,
             miniature=miniature,
         )
 
@@ -84,23 +43,11 @@ class EquipHost:
             gang=gang,
             at=at,
             roots=tuple(gang_card.stash_roots),
-            anchor=EquipAnchor.STASH,
-            miniature=None,
         )
 
 
-#: The dialogs a screen can have open, each a query parameter naming one
-#: assignment on the card. Both sides read this tuple: the rows that draw
-#: the controls and the view that answers the URL behind them, so neither
-#: can invent a question the other does not know.
-#:
-#: Three of them confirm something about the assignment named. The last
-#: two ask a question instead — which accessory to bolt onto the weapon
-#: named, and which of its alternatives a thing is taken with — and they
-#: sit here because they are the same sort of state: one assignment on
-#: this card, open because the address says so, closed by going back to
-#: the address without it. A screen draws one at a time, so a URL naming
-#: two draws whichever comes first here.
+#: URL parameters that can open one assignment dialog. Their order is the
+#: precedence when an address names more than one.
 DIALOGS = ("sell", "reassign", "refund", "remove", "accessorise", "rechoose")
 
 
@@ -301,15 +248,10 @@ def possessions(host: EquipHost):
     for node in host.roots:
         if node.assignment is None:
             continue
-        if host.anchor is EquipAnchor.FIGHTER:
-            if node.broadcast:
-                continue
-            if node.suppressed:
-                # A modifier has taken this away, so the card says the fighter
-                # does not have it — and a screen must not offer to sell
-                # something the card denies. The assignment is untouched
-                # underneath: drop whatever cancelled it and the controls come back.
-                continue
+        if node.broadcast or node.suppressed:
+            # Suppressed assignments remain stored but are not possessions on
+            # this card; broadcast roots belong to the gang, not the fighter.
+            continue
         if not is_possession(node.assignable):
             continue
         key = thing_key(node.assignable)

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -35,9 +35,59 @@ nowhere.
 """
 
 from dataclasses import dataclass
+from enum import Enum
 from urllib.parse import urlencode
 
 from n26.library.models.assignable import Family
+
+
+class EquipAnchor(Enum):
+    """Which screen's possessions are being read — a fighter's card or the stash."""
+
+    FIGHTER = "fighter"
+    STASH = "stash"
+
+
+@dataclass(frozen=True)
+class EquipHost:
+    """Where an equip screen reads possessions from and sends the reader back.
+
+    One object carries the gang, the page address, the assignment roots to
+    walk, and which anchor this screen is — so the catalogue, the dialogs
+    and the POST redirects all agree without each guessing from the other.
+    """
+
+    gang: object
+    at: str
+    roots: tuple
+    anchor: EquipAnchor
+    miniature: object | None = None
+
+    @property
+    def held_label(self):
+        """Words for how many copies the reader already holds."""
+        return "equipped" if self.anchor is EquipAnchor.FIGHTER else "in stash"
+
+    @classmethod
+    def fighter(cls, gang, card, miniature, at):
+        return cls(
+            gang=gang,
+            at=at,
+            roots=tuple(card.roots),
+            anchor=EquipAnchor.FIGHTER,
+            miniature=miniature,
+        )
+
+    @classmethod
+    def stash(cls, gang, gang_card, at):
+        return cls(
+            gang=gang,
+            at=at,
+            roots=tuple(gang_card.stash_roots),
+            anchor=EquipAnchor.STASH,
+            miniature=None,
+        )
+
 
 #: The dialogs a screen can have open, each a query parameter naming one
 #: assignment on the card. Both sides read this tuple: the rows that draw
@@ -235,60 +285,36 @@ def _parts_of(node, at):
     return tuple(parts)
 
 
-def owned_things(card, at):
-    """Everything on this card, keyed the way a catalogue keys its rows.
+def possessions(host: EquipHost):
+    """Everything this host carries, keyed the way a catalogue keys its rows.
 
     Keyed by :func:`thing_key`, so a row looks its own key up and finds
-    the copies of itself the fighter is carrying — one dictionary read per
-    row, whatever the fighter owns.
+    the copies held — one dictionary read per row, however much is carried.
 
-    ``at`` is the page the reader is on, query string and all: the
+    ``host.at`` is the page the reader is on, query string and all: the
     confirmations open over it and Cancel returns to it, so the list they
     were reading is still the list underneath.
-
-    Two of the same weapon are two entries under one key, never one entry
-    counted twice: each is its own entry in the ledger, each may carry
-    different ammo, and each is sold, moved and dropped on its own.
-
-    Only what the model **owns** — see :func:`is_possession`. A card
-    carries a good deal more than kit, and none of the rest is something
-    to put a Sell button beside: the fighter's own profile is the
-    fighter, their skills are what they know, their equipment lists are
-    where they buy from.
-
-    The gang-hosted assignments are skipped for a second reason. They ride
-    every member's card so gang-wide rules reach them, but they are the gang's
-    property and not this fighter's to sell.
-
-    A **granted** weapon is skipped for a third: it is lent, not owned. A
-    modifier puts it on the card and nobody bought it, so there is
-    nothing to sell, nothing to hand to another fighter, and nothing for
-    an accessory to hang off. It is skipped twice over — this reads
-    ``card.roots``, which holds what the gang owns, while a grant lives
-    on ``card.granted``; and a granted line carries no assignment. The
-    consequence a reader should expect on the equipment screen: a row for
-    something the fighter owns replaces its Buy button, and a granted
-    weapon does not, so a fighter lent a pair of claws is still offered
-    claws. That is deliberate — the lent pair goes when its granter does,
-    and being unable to buy a pair of your own would be the worse
-    surprise.
     """
     from n26.library.models import Weapon
 
     index = {}
-    for node in card.roots:
-        if node.broadcast or node.assignment is None:
+    for node in host.roots:
+        if node.assignment is None:
             continue
-        if node.suppressed:
-            # A modifier has taken this away, so the card says the fighter
-            # does not have it — and a screen must not offer to sell
-            # something the card denies. The assignment is untouched
-            # underneath: drop whatever cancelled it and the controls come back.
-            continue
+        if host.anchor is EquipAnchor.FIGHTER:
+            if node.broadcast:
+                continue
+            if node.suppressed:
+                # A modifier has taken this away, so the card says the fighter
+                # does not have it — and a screen must not offer to sell
+                # something the card denies. The assignment is untouched
+                # underneath: drop whatever cancelled it and the controls come back.
+                continue
         if not is_possession(node.assignable):
             continue
         key = thing_key(node.assignable)
         pk = str(node.assignment.pk)
+        at = host.at
         index.setdefault(key, []).append(
             OwnedThing(
                 id=pk,
@@ -314,3 +340,8 @@ def owned_things(card, at):
             )
         )
     return index
+
+
+def owned_things(card, at):
+    """Everything on this fighter's card — see :func:`possessions`."""
+    return possessions(EquipHost.fighter(card.miniature.gang, card, card.miniature, at))

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -1569,13 +1569,13 @@ def stash_lines(gang_card):
     ]
 
 
-def render_gang(gang, with_effects=True):
+def render_gang(gang, with_effects=True, *, card=None):
     """A whole gang sheet. A fixed number of queries, whatever its size."""
     from n26.core.card import build_gang_card, build_modifier_index
     from n26.core.effects import compute, compute_gang, counter_readings
 
     models = roster(gang)
-    gang_card = build_gang_card(gang)
+    gang_card = card or build_gang_card(gang)
     cards = gang_card.members
 
     computed = {}

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -535,10 +535,8 @@ class StashLine:
     #: line names. Every stash line has one; the stash holds stored
     #: assignments and nothing computed.
     id: str = ""
-    #: Whether this is something that goes on a weapon rather than on a
-    #: model — an accessory. The label on its reassign act follows from
-    #: that; where the act leads is filled in by the screen drawing it.
-    can_refit: bool = False
+    #: An accessory moves onto a weapon rather than a model.
+    is_accessory: bool = False
     #: What can happen to this line, each a link to a dialog on the page
     #: that drew it — see ``n26.core.views.owned.link_stash_actions``.
     #: Empty is a name with nothing to click, which is what a print-out
@@ -1562,7 +1560,7 @@ def stash_lines(gang_card):
             kind=kind_of(node.assignable),
             provenance=stash_provenance(node),
             id=str(node.assignment.pk) if node.assignment is not None else "",
-            can_refit=isinstance(node.assignable, WeaponAccessory),
+            is_accessory=isinstance(node.assignable, WeaponAccessory),
         )
         for node in gang_card.stash_roots
         # No row of its own is the kind's whole contract — a chosen

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -536,13 +536,14 @@ class StashLine:
     #: assignments and nothing computed.
     id: str = ""
     #: Whether this is something that goes on a weapon rather than on a
-    #: model, which is to say an accessory. That there is a control to
-    #: draw follows from what the thing is; where it leads does not.
+    #: model — an accessory. The label on its reassign act follows from
+    #: that; where the act leads is filled in by the screen drawing it.
     can_refit: bool = False
-    #: Where that control goes, filled in by the screen drawing it (see
-    #: ``n26.core.views.owned.link_refits``). Empty is a line with
-    #: nothing to click, which is right for a print-out.
-    refit_href: str = ""
+    #: What can happen to this line, each a link to a dialog on the page
+    #: that drew it — see ``n26.core.views.owned.link_stash_actions``.
+    #: Empty is a name with nothing to click, which is what a print-out
+    #: and a reader who does not own the gang want.
+    menu: tuple = ()
 
 
 @dataclass

--- a/n26/core/templates/cotton/n26/collection_picker/item.html
+++ b/n26/core/templates/cotton/n26/collection_picker/item.html
@@ -23,6 +23,8 @@ everything else is shrink-0, so the actions stay put and stay hittable.
     name grows a disclosure button, and the content is built only once opened.
   :disclosure — draw that button. Off where the row's own actions set
     `expanded` instead, so there are not two controls saying one thing.
+  :open — render details open on the server. URL-driven rows use this so
+    their controls remain available without JavaScript.
   details_label — what the disclosure says it will show: "card", "details".
   rows — further rows under this one, always visible. For options a reader
     chooses between, which is not something to hide.
@@ -46,6 +48,7 @@ everything else is shrink-0, so the actions stay put and stay hittable.
     keywords=""
     details_label="card"
     :disclosure="True"
+    :open="False"
     :notes="[]"
     price_control=""
     state=""
@@ -60,7 +63,7 @@ everything else is shrink-0, so the actions stay put and stay hittable.
         search: {% if keywords %}{{ name|add:' '|add:keywords|lower|json_dumps }}{% else %}{{ name|lower|json_dumps }}{% endif %},
         section: '',
         category: ''
-     }, expanded: false{% if state %}, {{ state }}{% endif %} }"
+     }, expanded: {{ open|yesno:"true,false" }}{% if state %}, {{ state }}{% endif %} }"
      x-init="
         facets.section = sectionName;
         facets.category = categoryName || sectionName;
@@ -73,7 +76,6 @@ everything else is shrink-0, so the actions stay put and stay hittable.
             .filter(Boolean).join(' ').toLowerCase();
         register(facets)"
      x-show="matches(facets)"
-     x-cloak
      class="min-h-11 px-1 py-1 hover:bg-ink-500/5 {{ class }}">
     <div class="flex min-h-9 items-center gap-2">
 
@@ -141,18 +143,21 @@ everything else is shrink-0, so the actions stay put and stay hittable.
     {% endfor %}
 
     {% comment %}
-    x-if inside the x-show, so Alpine does not walk the details until they are
-    first opened: the markup is served either way, but forty unopened rows
-    would otherwise hold forty model cards' worth of bindings alive.
-
-    x-if needs a <template>, and a template cannot be a flex child, which is
-    why the details hang below the row rather than inside it.
+    Closed details stay in an x-if so Alpine does not bind every hidden row.
+    URL-open details are rendered directly so they remain available without
+    JavaScript.
     {% endcomment %}
     {% if details %}
-        <div x-show="expanded" x-collapse x-cloak>
-            <template x-if="expanded">
+        {% if open %}
+            <div x-show="expanded" x-collapse>
                 <div class="n26-cp-inset pb-2 pt-1">{{ details }}</div>
-            </template>
-        </div>
+            </div>
+        {% else %}
+            <div x-show="expanded" x-collapse x-cloak>
+                <template x-if="expanded">
+                    <div class="n26-cp-inset pb-2 pt-1">{{ details }}</div>
+                </template>
+            </div>
+        {% endif %}
     {% endif %}
 </div>

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -63,10 +63,7 @@ itself.
     </c-slot>
 
     {{ slot }}
-    {% comment %}
-    Which collection was being bought from and which section tab was open, so
-    the answer lands back where the question was asked.
-    {% endcomment %}
+    {# Preserve the page and picker state that opened the dialog. #}
     <input type="hidden" name="return" value="{{ dialog.cancel_url }}">
     {% if dialog.list %}<input type="hidden" name="list" value="{{ dialog.list }}">{% endif %}
     {% if dialog.section %}<input type="hidden" name="section" value="{{ dialog.section }}">{% endif %}

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -56,6 +56,10 @@ itself.
             gang, undoing the purchase.
         {% else %}
             It and anything attached to it are permanently removed from the gang.
+            No credits are returned.
+            {% if dialog.can_refund %}
+                Use Refund instead to recover the amount paid.
+            {% endif %}
         {% endif %}
     </c-slot>
 

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -70,7 +70,6 @@ itself.
     <input type="hidden" name="return" value="{{ dialog.cancel_url }}">
     {% if dialog.list %}<input type="hidden" name="list" value="{{ dialog.list }}">{% endif %}
     {% if dialog.section %}<input type="hidden" name="section" value="{{ dialog.section }}">{% endif %}
-    {% if dialog.orphan_ui %}<input type="hidden" name="orphan_ui" value="{{ dialog.orphan_ui }}">{% endif %}
 
     {% comment %}
     The listing's own include, so a set is asked about the same way wherever it

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -42,23 +42,20 @@ itself.
             {% endif %}
         {% elif dialog.kind == "sell" %}
             {% if dialog.keepable %}
-                {{ dialog.sum }} The gun leaves the card and stops counting
-                towards the gang's rating.
+                {{ dialog.sum }} The gun is removed from the gang.
             {% else %}
-                {{ dialog.sum }} It leaves the card with anything attached to it,
-                and stops counting towards the gang's rating.
+                {{ dialog.sum }} It and anything attached to it are removed from
+                the gang.
             {% endif %}
         {% elif dialog.kind == "rechoose" %}
             You will be charged or refunded the difference.
         {% elif dialog.kind == "reassign" %}
-            Where it lives changes; what it is worth does not — a move never
-            re-prices.
+            Moving it does not change its rating.
         {% elif dialog.kind == "refund" %}
-            {{ dialog.sum }} It leaves the card with anything attached to it,
-            and the purchase is undone rather than traded away.
+            {{ dialog.sum }} It and anything attached to it are removed from the
+            gang, undoing the purchase.
         {% else %}
-            It comes off the card, along with anything attached to it. What was
-            paid for it stays spent.
+            It and anything attached to it are permanently removed from the gang.
         {% endif %}
     </c-slot>
 

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -67,8 +67,10 @@ itself.
     Which collection was being bought from and which section tab was open, so
     the answer lands back where the question was asked.
     {% endcomment %}
+    <input type="hidden" name="return" value="{{ dialog.cancel_url }}">
     {% if dialog.list %}<input type="hidden" name="list" value="{{ dialog.list }}">{% endif %}
     {% if dialog.section %}<input type="hidden" name="section" value="{{ dialog.section }}">{% endif %}
+    {% if dialog.orphan_ui %}<input type="hidden" name="orphan_ui" value="{{ dialog.orphan_ui }}">{% endif %}
 
     {% comment %}
     The listing's own include, so a set is asked about the same way wherever it
@@ -123,7 +125,18 @@ itself.
     {% endif %}
 
     {% if dialog.kind == "reassign" %}
-        {% if dialog.models %}
+        {% if dialog.weapons %}
+            <input type="hidden" name="to" value="weapon">
+            <c-ui.field label="Weapon" for="reassign-weapon">
+                <c-ui.select.native name="weapon" id="reassign-weapon" placeholder="">
+                    {% for weapon in dialog.weapons %}
+                        <c-ui.select.option value="{{ weapon.pk }}">
+                            {{ weapon.label }}
+                        </c-ui.select.option>
+                    {% endfor %}
+                </c-ui.select.native>
+            </c-ui.field>
+        {% elif dialog.models %}
             {% comment %}
             No placeholder option: the first name on the roster is selected
             from the start, so Move always has an answer.
@@ -135,16 +148,18 @@ itself.
                     {% endfor %}
                 </c-ui.select.native>
             </c-ui.field>
-            <c-slot name="actions">
-                {% comment %}
-                The kit writes its own type="button" after {{ attrs }}, and
-                HTML keeps the first of a duplicate pair — which is the only
-                reason the type set here wins and this stays a submit.
-                {% endcomment %}
-                <c-ui.button type="submit" name="to" value="stash" size="md">
-                    To the stash
-                </c-ui.button>
-            </c-slot>
+            {% if not dialog.stash_host %}
+                <c-slot name="actions">
+                    {% comment %}
+                    The kit writes its own type="button" after {{ attrs }}, and
+                    HTML keeps the first of a duplicate pair — which is the only
+                    reason the type set here wins and this stays a submit.
+                    {% endcomment %}
+                    <c-ui.button type="submit" name="to" value="stash" size="md">
+                        To the stash
+                    </c-ui.button>
+                </c-slot>
+            {% endif %}
         {% else %}
             <input type="hidden" name="to" value="stash">
         {% endif %}

--- a/n26/core/templates/cotton/n26/stash/group.html
+++ b/n26/core/templates/cotton/n26/stash/group.html
@@ -3,18 +3,9 @@
 
     <c-n26.stash.group label="wargear" :lines="lines" />
 
-The kind as the label, the items beside it as a comma-separated run drawn by
-<c-n26.assignable-lines> — so the commas are that component's business, and
-something granted by a modifier carries the same mark it would on a fighter's
-card. Each item's rating sits against its own name rather than in a column;
-nothing is compared down a stash, so a column would spend the width the names
-want.
-
-A group whose lines have acts on them is stacked instead, one line each with a
-menu on the right: gear in the stash is waiting to be handed to someone, and a
-comma-separated run has nowhere to put a control. The choice is read off the
-first line, since a group is all one kind. Print-outs and readers who do not
-own the gang always take the compact form, having no menu at all.
+A read-only group is a compact comma-separated run. Actions require one row per
+item so each menu stays beside the assignment it changes; print and read-only
+sheets therefore remain compact.
 
   label — the kind. Capitalised here because kinds arrive from a model's
     verbose_name, written lower case to appear mid-sentence.

--- a/n26/core/templates/cotton/n26/stash/group.html
+++ b/n26/core/templates/cotton/n26/stash/group.html
@@ -10,11 +10,11 @@ card. Each item's rating sits against its own name rather than in a column;
 nothing is compared down a stash, so a column would spend the width the names
 want.
 
-A group whose lines have somewhere to go is stacked instead, one line each with
-its own link: an accessory in the stash is gear waiting for a weapon, and a
+A group whose lines have acts on them is stacked instead, one line each with a
+menu on the right: gear in the stash is waiting to be handed to someone, and a
 comma-separated run has nowhere to put a control. The choice is read off the
-first line, since a group is all one kind. Print-outs always take the compact
-form, having no links at all.
+first line, since a group is all one kind. Print-outs and readers who do not
+own the gang always take the compact form, having no menu at all.
 
   label — the kind. Capitalised here because kinds arrive from a model's
     verbose_name, written lower case to appear mid-sentence.
@@ -25,14 +25,33 @@ form, having no links at all.
 <div class="flex items-baseline gap-1.5 {{ class }}">
     <dt class="whitespace-nowrap text-xs text-muted">{{ label|capfirst }}</dt>
     <dd class="min-w-0 flex-1 text-xs text-ink-900 dark:text-ink-100">
-        {% if lines.0.refit_href %}
+        {% if lines.0.menu %}
             <ul class="flex flex-col gap-1">
                 {% for line in lines %}
-                    <li class="flex items-baseline gap-2">
+                    <li class="flex min-h-7 items-center gap-2">
                         <span class="min-w-0 flex-1">
                             {{ line.name }}{% if line.rating %} <span class="tabular-nums">{{ line.rating }}¢</span>{% endif %}
                         </span>
-                        <c-n26.link href="{{ line.refit_href }}" class="shrink-0">Fit to a weapon</c-n26.link>
+                        <c-ui.dropdown align="end" min_width="10rem">
+                            <c-slot name="trigger">
+                                <c-ui.button size="sm"
+                                             class="px-1.5!"
+                                             aria-label="Actions for {{ line.name }}"
+                                             title="Actions for {{ line.name }}"
+                                             aria-haspopup="menu"
+                                             ::aria-expanded="dropdownMenu">
+                                    <span class="n26-icon-only">
+                                        <c-n26.icon name="chevron-down"
+                                                    class="size-3 transition-transform"
+                                                    stroke_width="2.5"
+                                                    ::class="{ 'rotate-180': dropdownMenu }" />
+                                    </span>
+                                </c-ui.button>
+                            </c-slot>
+                            {% for action in line.menu %}
+                                <c-ui.dropdown.item href="{{ action.target }}">{{ action.label }}</c-ui.dropdown.item>
+                            {% endfor %}
+                        </c-ui.dropdown>
                     </li>
                 {% endfor %}
             </ul>

--- a/n26/core/templates/cotton/n26/stash/index.html
+++ b/n26/core/templates/cotton/n26/stash/index.html
@@ -20,7 +20,7 @@ contents shifts every fighter after it around the grid.
   :total — what the whole stash is pinned at, in credits. Drawn quietly: the
     wealth strip above is where that number lives.
   empty — what to say when there is nothing.
-  actions — controls beside the title, such as the way to the equip screen.
+  actions — links after the title in a middot run (e.g. Equip), not buttons.
 {% endcomment %}
 <c-vars :lines="None" :total="0" empty="" actions="" class="" />
 
@@ -28,11 +28,15 @@ contents shifts every fighter after it around the grid.
     <c-slot name="header">
         {# -mx-2 because the kit's header band hardcodes px-6 where the rows #}
         {# below are px-4, so the name would start further in than the contents. #}
-        <div class="-mx-2 flex items-start gap-3">
-            <div class="min-w-0 flex-1 font-semibold">Stash</div>
-            {% if actions.strip %}
-                <div class="shrink-0">{{ actions }}</div>
-            {% endif %}
+        <div class="-mx-2 flex items-baseline gap-3">
+            <div class="min-w-0 flex-1">
+                <c-n26.action-links class="text-sm">
+                    <span class="font-semibold text-ink-900 dark:text-ink-100">Stash</span>
+                    {% if actions.strip %}
+                        {{ actions }}
+                    {% endif %}
+                </c-n26.action-links>
+            </div>
             <span class="shrink-0 text-sm tabular-nums text-muted">{{ total }}¢</span>
         </div>
     </c-slot>

--- a/n26/core/templates/cotton/n26/stash/index.html
+++ b/n26/core/templates/cotton/n26/stash/index.html
@@ -20,8 +20,9 @@ contents shifts every fighter after it around the grid.
   :total — what the whole stash is pinned at, in credits. Drawn quietly: the
     wealth strip above is where that number lives.
   empty — what to say when there is nothing.
+  actions — controls beside the title, such as the way to the equip screen.
 {% endcomment %}
-<c-vars :lines="None" :total="0" empty="" class="" />
+<c-vars :lines="None" :total="0" empty="" actions="" class="" />
 
 <c-ui.card padding="none" class="{{ class }}">
     <c-slot name="header">
@@ -29,6 +30,9 @@ contents shifts every fighter after it around the grid.
         {# below are px-4, so the name would start further in than the contents. #}
         <div class="-mx-2 flex items-start gap-3">
             <div class="min-w-0 flex-1 font-semibold">Stash</div>
+            {% if actions.strip %}
+                <div class="shrink-0">{{ actions }}</div>
+            {% endif %}
             <span class="shrink-0 text-sm tabular-nums text-muted">{{ total }}¢</span>
         </div>
     </c-slot>

--- a/n26/core/templates/cotton/n26/view/gang_sheet.html
+++ b/n26/core/templates/cotton/n26/view/gang_sheet.html
@@ -18,6 +18,7 @@ is drawn as the first card of the grid, ahead of `members`.
   secondary_actions — Print, and a dropdown holding Delete. A run of its own,
     after the primary actions rather than sorted in among them.
   stash_empty — what to say when the stash is empty.
+  stash_actions — controls in the stash card header, such as Equip.
 {% endcomment %}
 {# The slots are declared: an undeclared slot name is not empty when nobody #}
 {# fills it — it resolves to the caller's own variable of that name. #}
@@ -36,6 +37,7 @@ is drawn as the first card of the grid, ahead of `members`.
     secondary_actions=""
     members=""
     stash_empty=""
+    stash_actions=""
     class=""
 />
 
@@ -125,6 +127,7 @@ is drawn as the first card of the grid, ahead of `members`.
     {% endcomment %}
     <div class="grid auto-rows-min grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         <c-n26.stash :lines="sheet.stash" :total="sheet.stash_rating">
+            {% if stash_actions %}<c-slot name="actions">{{ stash_actions }}</c-slot>{% endif %}
             {% if stash_empty %}<c-slot name="empty">{{ stash_empty }}</c-slot>{% endif %}
         </c-n26.stash>
         {{ members }}

--- a/n26/core/templates/cotton/n26/view/gang_sheet.html
+++ b/n26/core/templates/cotton/n26/view/gang_sheet.html
@@ -18,7 +18,7 @@ is drawn as the first card of the grid, ahead of `members`.
   secondary_actions — Print, and a dropdown holding Delete. A run of its own,
     after the primary actions rather than sorted in among them.
   stash_empty — what to say when the stash is empty.
-  stash_actions — controls in the stash card header, such as Equip.
+  stash_actions — a middot link after the Stash title (e.g. Equip).
 {% endcomment %}
 {# The slots are declared: an undeclared slot name is not empty when nobody #}
 {# fills it — it resolves to the caller's own variable of that name. #}

--- a/n26/core/templates/n26/gang_equip.html
+++ b/n26/core/templates/n26/gang_equip.html
@@ -1,29 +1,16 @@
 {% extends "n26/layouts/base.html" %}
 {% load navigation %}
 {% comment %}
-Buying equipment into the gang's stash — the fighter equip page's gang-anchored
-twin. The rows are the shared ones (n26/includes/equip_row.html), so a change to
-either page's chrome still wants a look at the other.
+Equipping the gang's stash — buy into it and manage what it holds. The rows are
+the shared ones (n26/includes/equip_row.html), so a change to either page's
+chrome still wants a look at the fighter's equip page.
 
-The shell is the hire page's rather than the fighter's: this screen is about the
-gang, so it wears a gang heading and the gang's figures, and there is no model
-header to carry a fighter's tabs.
-
-Which list is URL state (?list=<pk>, or ?list=all for the whole library), so a
-list is linkable and the back button walks the choices. The Buy buttons submit
-the line's identity and nothing else; every price is the server's own
-derivation.
-
-No use notes on the rows. A restriction is about a model, and a stash is not
-one — the row simply has nothing to draw there. Nor is there any count of what
-the stash already holds: what the gang owns is drawn on the gang page, with the
-controls that act on it.
+Which list is URL state (?list=<pk>, ?list=all, or ?list=stash), so a list is
+linkable and the back button walks the choices. Gear the current list does not
+sell is drawn either beside the catalogue (?orphan_ui=a) or on its own tab
+(?orphan_ui=b, the default). Append ?orphan_ui=a to compare the two.
 {% endcomment %}
-{% block head_title %}Buy Equipment{% endblock head_title %}
-{% comment %}
-The bar names the gang and opens on the reader's others, as the hire page's
-does. The heading below says what this screen is for.
-{% endcomment %}
+{% block head_title %}Equip{% endblock head_title %}
 {% block nav_switcher %}
     {% gang_switcher gang as gang_switcher_ %}
     <c-n26.quick-switcher.of :switcher="gang_switcher_" hotkey="f" />
@@ -32,18 +19,21 @@ does. The heading below says what this screen is for.
     {% include 'n26/_nav.html' with here='gangs' %}
 {% endblock %}
 {% block content %}
-    {% comment %}
-    The frame is the one every form screen shares, and it draws no footer: every
-    Buy button in the catalogue is this form's submit, so a button at the end
-    would be a second answer to a question already answered.
-
-    It posts to this page's own address, state and all — an action that dropped
-    ?list= would answer a purchase from the library tab by snapping the reader
-    back to the first list.
-    {% endcomment %}
+    {% if dialog %}
+        <c-n26.owned-dialog :dialog="dialog">
+            {% csrf_token %}
+        </c-n26.owned-dialog>
+    {% endif %}
+    {% for panel in accessorise %}
+        <c-n26.owned-dialog :dialog="panel"
+                            :open="panel.open"
+                            id="n26-accessorise-{{ panel.id }}">
+            {% csrf_token %}
+        </c-n26.owned-dialog>
+    {% endfor %}
     <c-n26.form-page action="{{ action }}"
-                     title="Buy Equipment"
-                     lead="Everything bought here goes into the gang's stash. Reassign it to a fighter from the gang page, or buy on a fighter's own page to arm them directly.">
+                     title="Equip"
+                     lead="Buy into the stash and manage what the gang already holds. Hand gear to a fighter from here, or buy on a fighter's own page to arm them directly.">
         <c-slot name="breadcrumb">
             <c-ui.breadcrumbs>
                 <c-ui.breadcrumbs.item>
@@ -51,39 +41,38 @@ does. The heading below says what this screen is for.
                 </c-ui.breadcrumbs.item>
                 <c-ui.breadcrumbs.item href="{% url 'n26-gang' gang.pk %}">{{ gang.name }}</c-ui.breadcrumbs.item>
                 <c-ui.breadcrumbs.item :current="True">
-                    Buy Equipment
+                    Equip
                 </c-ui.breadcrumbs.item>
             </c-ui.breadcrumbs>
         </c-slot>
+        <c-slot name="header_actions">
+            <c-n26.gang-figures :gang="gang" :summary="summary" />
+        </c-slot>
         {% csrf_token %}
-        {% comment %}
-        The numbers a purchase is decided against, above the list: the credits a
-        click will spend are on the same screen as the click, and the redirect
-        after a purchase brings the strip back already updated.
-        {% endcomment %}
-        <c-n26.gang-figures :gang="gang" :summary="summary" />
-        {% comment %}
-        Which list, as the page's top-level choice, down the left of the
-        catalogue: the gang's own lists, then the Trading Post, then the whole
-        library. A rail rather than a strip over the rows, because choosing the
-        list you are buying from is a larger decision than narrowing what it shows.
-        On a phone the rail takes the full width above the catalogue.
-
-        Always drawn, because the library tab is always there — and a gang with
-        no lists of its own would otherwise have no way to reach it.
-
-        Links, not client state: a list is a place you can be, so it goes in the
-        URL — linkable, back-button-friendly, and the server renders the one you
-        are on.
-        {% endcomment %}
+        <p class="text-xs text-muted">
+            Orphan UI:
+            {% if orphan_ui == "a" %}
+                <c-n26.link href="{{ orphan_toggle_a }}" underline="always">
+                    Section beside catalogue
+                </c-n26.link>
+            {% else %}
+                <c-n26.link href="{{ orphan_toggle_a }}">
+                    Section beside catalogue
+                </c-n26.link>
+            {% endif %}
+            ·
+            {% if orphan_ui == "b" %}
+                <c-n26.link href="{{ orphan_toggle_b }}" underline="always">
+                    In stash tab
+                </c-n26.link>
+            {% else %}
+                <c-n26.link href="{{ orphan_toggle_b }}">
+                    In stash tab
+                </c-n26.link>
+            {% endif %}
+        </p>
         <div class="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-[11rem_minmax(0,1fr)]">
             <c-ui.navlist variant="sidebar" aria-label="Which list" class="self-start text-sm">
-                {% comment %}
-                The full name where the tab shortened it, empty where nothing
-                was lost — decided in the view, because a template tag written
-                inside a component's attributes is not read as one and lands in
-                the page as text.
-                {% endcomment %}
                 {% for tab in collection_tabs %}
                     <c-ui.navlist.item href="{{ tab.href }}" :current="tab.current" title="{{ tab.title }}">
                         {{ tab.label }}
@@ -91,90 +80,27 @@ does. The heading below says what this screen is for.
                 {% endfor %}
             </c-ui.navlist>
             {% if catalogue %}
-                <c-n26.collection-picker :categories="categories"
-                                         :sections="sections"
-                                         price_floor="{{ price_floor }}"
-                                         price_ceiling="{{ price_ceiling }}"
-                                         tp_ceiling="{{ tp_ceiling }}"
-                                         noun="items">
-                    <c-slot name="filters">
-                        <c-n26.search-bar :live="True"
-                                          :nested="True"
-                                          model="query"
-                                          placeholder="Search {{ browsing }}" />
-                        {% if category_options or price_ceiling > price_floor or has_trade_points %}
-                            {% comment %}
-                            A size under the search field above them: these refine
-                            what the field returned rather than competing with it.
-                            {% endcomment %}
-                            <div class="flex flex-wrap items-center gap-2">
-                                {% if category_options %}
-                                    <c-n26.filter-menu label="Category"
-                                                       name="category"
-                                                       size="xs"
-                                                       :options="category_options" />
-                                {% endif %}
-                                {% if price_ceiling > price_floor %}
-                                    <c-n26.range-menu label="Price"
-                                                      model_min="minPrice"
-                                                      model_max="maxPrice"
-                                                      min="{{ price_floor }}"
-                                                      max="{{ price_ceiling }}"
-                                                      step="5"
-                                                      suffix="¢"
-                                                      size="xs"
-                                                      at_max_label="Any" />
-                                {% endif %}
-                                {% if has_trade_points %}
-                                    <c-n26.range-menu label="Trade points"
-                                                      model="maxTradePoints"
-                                                      min="0"
-                                                      max="{{ tp_ceiling }}"
-                                                      step="1"
-                                                      prefix="≤ "
-                                                      size="xs"
-                                                      at_min_label="Freely available"
-                                                      at_max_label="Any" />
-                                {% endif %}
+                {% if orphan_rows %}
+                    <div class="flex flex-col gap-4 md:col-start-2">
+                        <section class="rounded-lg border border-box-border p-3">
+                            <h3 class="mb-2 text-sm font-semibold text-ink-900 dark:text-ink-100">In stash — not on this list</h3>
+                            <div class="flex flex-col gap-1">
+                                {% for row in orphan_rows %}
+                                    {% include "n26/includes/equip_stash_row.html" with row=row %}
+                                {% endfor %}
                             </div>
-                        {% endif %}
-                    </c-slot>
-                    {% comment %}
-                    Names are bound, not written into the attribute. A name with
-                    an ampersand in it — "Armour & field armour" — comes back
-                    from an attribute HTML-escaped, and the picker keys its
-                    filter and its counts on the string the view put in
-                    `categories`. The two would not match, and the whole category
-                    would count zero and hide itself.
-                    {% endcomment %}
-                    {% for section in catalogue.sections %}
-                        <c-n26.collection-picker.section :name="section.name" :open="forloop.first">
-                            {% for category in section.categories %}
-                                {% if category.name %}
-                                    <c-n26.collection-picker.category :name="category.name">
-                                        {% for row in category.rows %}
-                                            {% include "n26/includes/equip_row.html" %}
-                                        {% endfor %}
-                                    </c-n26.collection-picker.category>
-                                {% else %}
-                                    {% comment %}
-                                    Unnamed home: rows sit straight inside the
-                                    section, the same convention as the fighter's
-                                    page and the hire page.
-                                    {% endcomment %}
-                                    {% for row in category.rows %}
-                                        {% include "n26/includes/equip_row.html" %}
-                                    {% endfor %}
-                                {% endif %}
-                            {% endfor %}
-                        </c-n26.collection-picker.section>
-                    {% endfor %}
-                </c-n26.collection-picker>
+                        </section>
+                        {% include "n26/includes/gang_equip_catalogue.html" %}
+                    </div>
+                {% else %}
+                    {% include "n26/includes/gang_equip_catalogue.html" %}
+                {% endif %}
             {% else %}
-                <p class="text-muted">
+                <p class="text-muted md:col-start-2">
                     No equipment lists yet — this gang has none of its own to browse.
                     Lists arrive with the gang's own content; everything the library
-                    holds is on the All equipment tab.
+                    holds is on the All equipment tab, and everything held is on
+                    the In stash tab.
                 </p>
             {% endif %}
         </div>

--- a/n26/core/templates/n26/gang_equip.html
+++ b/n26/core/templates/n26/gang_equip.html
@@ -7,8 +7,7 @@ chrome still wants a look at the fighter's equip page.
 
 Which list is URL state (?list=<pk>, ?list=all, or ?list=stash), so a list is
 linkable and the back button walks the choices. Gear the current list does not
-sell is drawn either beside the catalogue (?orphan_ui=a) or on its own tab
-(?orphan_ui=b, the default). Append ?orphan_ui=a to compare the two.
+sell is managed from the In stash tab.
 {% endcomment %}
 {% block head_title %}Equip{% endblock head_title %}
 {% block nav_switcher %}
@@ -49,28 +48,6 @@ sell is drawn either beside the catalogue (?orphan_ui=a) or on its own tab
             <c-n26.gang-figures :gang="gang" :summary="summary" />
         </c-slot>
         {% csrf_token %}
-        <p class="text-xs text-muted">
-            Orphan UI:
-            {% if orphan_ui == "a" %}
-                <c-n26.link href="{{ orphan_toggle_a }}" underline="always">
-                    Section beside catalogue
-                </c-n26.link>
-            {% else %}
-                <c-n26.link href="{{ orphan_toggle_a }}">
-                    Section beside catalogue
-                </c-n26.link>
-            {% endif %}
-            ·
-            {% if orphan_ui == "b" %}
-                <c-n26.link href="{{ orphan_toggle_b }}" underline="always">
-                    In stash tab
-                </c-n26.link>
-            {% else %}
-                <c-n26.link href="{{ orphan_toggle_b }}">
-                    In stash tab
-                </c-n26.link>
-            {% endif %}
-        </p>
         <div class="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-[11rem_minmax(0,1fr)]">
             <c-ui.navlist variant="sidebar" aria-label="Which list" class="self-start text-sm">
                 {% for tab in collection_tabs %}
@@ -80,21 +57,7 @@ sell is drawn either beside the catalogue (?orphan_ui=a) or on its own tab
                 {% endfor %}
             </c-ui.navlist>
             {% if catalogue %}
-                {% if orphan_rows %}
-                    <div class="flex flex-col gap-4 md:col-start-2">
-                        <section class="rounded-lg border border-box-border p-3">
-                            <h3 class="mb-2 text-sm font-semibold text-ink-900 dark:text-ink-100">In stash — not on this list</h3>
-                            <div class="flex flex-col gap-1">
-                                {% for row in orphan_rows %}
-                                    {% include "n26/includes/equip_stash_row.html" with row=row %}
-                                {% endfor %}
-                            </div>
-                        </section>
-                        {% include "n26/includes/gang_equip_catalogue.html" %}
-                    </div>
-                {% else %}
-                    {% include "n26/includes/gang_equip_catalogue.html" %}
-                {% endif %}
+                {% include "n26/includes/gang_equip_catalogue.html" %}
             {% else %}
                 <p class="text-muted md:col-start-2">
                     No equipment lists yet — this gang has none of its own to browse.

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -28,6 +28,11 @@ that said it twice would be spending the width the name needs.
     {% include 'n26/_nav.html' with here='gangs' %}
 {% endblock %}
 {% block content %}
+    {% if dialog %}
+        <c-n26.owned-dialog :dialog="dialog">
+            {% csrf_token %}
+        </c-n26.owned-dialog>
+    {% endif %}
     {% badge_for gang.owner as owner_badge %}
     <c-n26.view.gang-sheet :sheet="sheet"
                            owner="{{ gang.owner.username }}"
@@ -295,41 +300,6 @@ that said it twice would be spending the width the name needs.
                 {% endif %}
             </c-n26.dialog>
         {% endif %}
-    {% endif %}
-    {% comment %}
-    The stash's own question: a sight kept back from a sale is gear waiting for
-    a gun, and this is where it goes back on one. Every gun in the gang is
-    offered rather than only the ones it fits — fitting shortens a long list,
-    and a gang's guns are few enough that hiding one would be a refusal in
-    disguise. With no gun anywhere there is nothing to click, so no submit is
-    drawn.
-    {% endcomment %}
-    {% if refitting %}
-        <c-n26.dialog title="{{ refitting.title }}"
-                      action="{{ refitting.action }}"
-                      cancel_url="{{ refitting.cancel_url }}"
-                      submit_label="{{ refitting.submit_label }}">
-            <c-slot name="lead">
-                It keeps what it is worth — a move never re-prices — and its
-                effects land on whichever gun it ends up on.
-            </c-slot>
-            {% csrf_token %}
-            <input type="hidden" name="return" value="{{ refitting.cancel_url }}">
-            <input type="hidden" name="to" value="weapon">
-            {% if refitting.weapons %}
-                <c-ui.field label="Weapon" for="refit-weapon">
-                    <c-ui.select.native name="weapon" id="refit-weapon" placeholder="">
-                        {% for weapon in refitting.weapons %}
-                            <c-ui.select.option value="{{ weapon.pk }}">
-                                {{ weapon.label }}
-                            </c-ui.select.option>
-                        {% endfor %}
-                    </c-ui.select.native>
-                </c-ui.field>
-            {% else %}
-                <p class="text-muted">Nobody in the gang is carrying a weapon.</p>
-            {% endif %}
-        </c-n26.dialog>
     {% endif %}
     {% if renaming %}
         <c-n26.dialog title="Rename {{ renaming.name }}"

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -158,9 +158,7 @@ that said it twice would be spending the width the name needs.
         {% endif %}
         {% if yours %}
             <c-slot name="stash_actions">
-                <c-ui.button size="xs" variant="primary" href="{% url 'n26-equip-gang' gang.pk %}">
-                    Equip
-                </c-ui.button>
+                <c-n26.action-link href="{% url 'n26-equip-gang' gang.pk %}">Equip</c-n26.action-link>
             </c-slot>
         {% endif %}
         <c-slot name="stash_empty">

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -116,9 +116,6 @@ that said it twice would be spending the width the name needs.
                              href="{% url 'n26-hire-fighter' gang.pk %}">
                     Hire Fighters
                 </c-ui.button>
-                <c-ui.button size="sm" variant="primary" href="{% url 'n26-equip-gang' gang.pk %}">
-                    Buy Equipment
-                </c-ui.button>
             </c-slot>
             <c-slot name="secondary_actions">
                 <c-n26.button-group>
@@ -157,6 +154,13 @@ that said it twice would be spending the width the name needs.
                         </c-ui.dropdown.item>
                     </c-ui.dropdown>
                 </c-n26.button-group>
+            </c-slot>
+        {% endif %}
+        {% if yours %}
+            <c-slot name="stash_actions">
+                <c-ui.button size="xs" variant="primary" href="{% url 'n26-equip-gang' gang.pk %}">
+                    Equip
+                </c-ui.button>
             </c-slot>
         {% endif %}
         <c-slot name="stash_empty">
@@ -312,6 +316,7 @@ that said it twice would be spending the width the name needs.
                 effects land on whichever gun it ends up on.
             </c-slot>
             {% csrf_token %}
+            <input type="hidden" name="return" value="{{ refitting.cancel_url }}">
             <input type="hidden" name="to" value="weapon">
             {% if refitting.weapons %}
                 <c-ui.field label="Weapon" for="refit-weapon">

--- a/n26/core/templates/n26/includes/equip_owned_line.html
+++ b/n26/core/templates/n26/includes/equip_owned_line.html
@@ -5,6 +5,11 @@ and `held_label` from the page when the host is the stash.
 Owning something is a *state of its row*, not a list of its own: where a copy is
 held, the count stands where Buy would be and opens the row onto what they have.
 {% endcomment %}
+{% if row.expanded %}
+    {% querystring owned=None as owned_toggle_href %}
+{% else %}
+    {% querystring owned=row.key as owned_toggle_href %}
+{% endif %}
 {% if row.buy %}
     <c-n26.collection-picker.item name="{{ row.name }}"
                                   :price="row.buy.price"
@@ -12,21 +17,21 @@ held, the count stands where Buy would be and opens the row onto what they have.
                                   :exclusive="row.buy.is_exclusive"
                                   :notes="row.buy.notes"
                                   :disclosure="False"
+                                  :open="row.expanded"
                                   state="quoted: {{ row.buy.price }}, price: {{ row.buy.price }}">
         <c-slot name="price_control">
             <span aria-hidden="true"></span>
         </c-slot>
         <c-slot name="actions">
-            <c-ui.button size="sm"
+            <c-ui.button href="{{ owned_toggle_href }}"
+                         size="sm"
                          class="inline-flex items-center gap-1.5"
-                         @click="expanded = !expanded"
-                         ::aria-expanded="expanded">
+                         aria-expanded="{{ row.expanded|yesno:'true,false' }}">
                 <span><span class="tabular-nums">{{ row.count }}</span> {{ held_label|default:"equipped" }}</span>
                 <span class="n26-icon-only">
                     <c-n26.icon name="chevron-down"
-                                class="size-3 transition-transform"
-                                stroke_width="2.5"
-                                ::class="{ 'rotate-180': expanded }" />
+                                class="size-3 transition-transform{% if row.expanded %} rotate-180{% endif %}"
+                                stroke_width="2.5" />
                 </span>
             </c-ui.button>
         </c-slot>
@@ -55,21 +60,21 @@ held, the count stands where Buy would be and opens the row onto what they have.
     <c-n26.collection-picker.item name="{{ row.name }}"
                                   :price="0"
                                   :disclosure="False"
+                                  :open="row.expanded"
                                   state="quoted: 0, price: 0">
         <c-slot name="price_control">
             <span aria-hidden="true"></span>
         </c-slot>
         <c-slot name="actions">
-            <c-ui.button size="sm"
+            <c-ui.button href="{{ owned_toggle_href }}"
+                         size="sm"
                          class="inline-flex items-center gap-1.5"
-                         @click="expanded = !expanded"
-                         ::aria-expanded="expanded">
+                         aria-expanded="{{ row.expanded|yesno:'true,false' }}">
                 <span><span class="tabular-nums">{{ row.count }}</span> {{ held_label|default:"equipped" }}</span>
                 <span class="n26-icon-only">
                     <c-n26.icon name="chevron-down"
-                                class="size-3 transition-transform"
-                                stroke_width="2.5"
-                                ::class="{ 'rotate-180': expanded }" />
+                                class="size-3 transition-transform{% if row.expanded %} rotate-180{% endif %}"
+                                stroke_width="2.5" />
                 </span>
             </c-ui.button>
         </c-slot>

--- a/n26/core/templates/n26/includes/equip_owned_line.html
+++ b/n26/core/templates/n26/includes/equip_owned_line.html
@@ -1,89 +1,80 @@
 {% comment %}
-A row for something the fighter is already carrying. Expects `row` — an
-n26.core.listing.OwnedRow — and `price_cap` from the page.
+A row for something already held. Expects `row` — an n26.core.listing.OwnedRow —
+and `held_label` from the page when the host is the stash.
 
-Owning something is a *state of its row*, not a list of its own: where the
-fighter holds one of the thing a row names, the count stands where Buy would be
-and opens the row onto what they have. It takes the disclosure's place rather
-than sitting beside it — `expanded` is the row's own state and this sets it, so
-there is one control and not two doing the same thing under different words.
-
-The button says how many are equipped, in words: "2 equipped". A bare figure in
-brackets is a count of something the reader has to work out, and the one thing
-worth saying about a row they already own is what they own. Default rather than
-green — this row is not offering to sell anybody anything until they open it.
-
-No price beside it. What a price on a closed row would be quoting is the cost of
-*another* one, which is a question nobody is asking until they open the row and
-find the offer; and next to a count it reads as what the ones in hand are worth,
-which it is not. The column itself stays, empty, so the button lines up with the
-buttons on every row above.
-
-  --- and underneath, the ordinary row ---
-
-Opened, the row shows the copies and then the row it replaced, whole: the price
-box, the ammo boxes and the green Buy. Owning one of something has never been a
-reason the equip page stops selling it, and a second is bought exactly the way the
-first was, because it is literally the same row — which is where the price a
-reader might want belongs, with the click it feeds.
+Owning something is a *state of its row*, not a list of its own: where a copy is
+held, the count stands where Buy would be and opens the row onto what they have.
 {% endcomment %}
-<c-n26.collection-picker.item name="{{ row.name }}"
-                              :price="row.buy.price"
-                              :trade_points="row.buy.trade_points"
-                              :exclusive="row.buy.is_exclusive"
-                              :notes="row.buy.notes"
-                              :disclosure="False"
-                              state="quoted: {{ row.buy.price }}, price: {{ row.buy.price }}">
-    {% comment %}
-    An empty column rather than no column. `:price` is still what the price
-    slider filters this row by — a row is narrowed by what the list asks for
-    the thing, whether or not this reader is being shown the figure.
-    {% endcomment %}
-    <c-slot name="price_control">
-        <span aria-hidden="true"></span>
-    </c-slot>
-    <c-slot name="actions">
-        {% comment %}
-        The visible words are the button's name; an aria-label repeating them
-        would be read twice, and aria-expanded already says it opens.
-        {% endcomment %}
-        <c-ui.button size="sm"
-                     class="inline-flex items-center gap-1.5"
-                     @click="expanded = !expanded"
-                     ::aria-expanded="expanded">
-            <span><span class="tabular-nums">{{ row.count }}</span> equipped</span>
-            <span class="n26-icon-only">
-                <c-n26.icon name="chevron-down"
-                            class="size-3 transition-transform"
-                            stroke_width="2.5"
-                            ::class="{ 'rotate-180': expanded }" />
-            </span>
-        </c-ui.button>
-    </c-slot>
-    <c-slot name="details">
-        <c-n26.owned-lines :copies="row.copies" />
-        {% comment %}
-        A rule above the buy row, because the two halves answer different
-        questions: everything above is about the copies in hand, everything
-        below is a purchase. Without it the last copy and the offer of another
-        read as one list of four similar rows.
-        {% endcomment %}
-        <div class="mt-1 border-t border-box-border pt-1">
-            <div class="flex min-h-9 items-center gap-2">
-                <span class="min-w-0 flex-1 text-sm text-muted">Buy another</span>
-                <span class="n26-cp-price shrink-0 text-sm text-ink-900 dark:text-ink-100">
-                    {% include "n26/includes/equip_price.html" with field=row.buy.price_field quoted=row.buy.price label=row.buy.name %}
+{% if row.buy %}
+    <c-n26.collection-picker.item name="{{ row.name }}"
+                                  :price="row.buy.price"
+                                  :trade_points="row.buy.trade_points"
+                                  :exclusive="row.buy.is_exclusive"
+                                  :notes="row.buy.notes"
+                                  :disclosure="False"
+                                  state="quoted: {{ row.buy.price }}, price: {{ row.buy.price }}">
+        <c-slot name="price_control">
+            <span aria-hidden="true"></span>
+        </c-slot>
+        <c-slot name="actions">
+            <c-ui.button size="sm"
+                         class="inline-flex items-center gap-1.5"
+                         @click="expanded = !expanded"
+                         ::aria-expanded="expanded">
+                <span><span class="tabular-nums">{{ row.count }}</span> {{ held_label|default:"equipped" }}</span>
+                <span class="n26-icon-only">
+                    <c-n26.icon name="chevron-down"
+                                class="size-3 transition-transform"
+                                stroke_width="2.5"
+                                ::class="{ 'rotate-180': expanded }" />
                 </span>
-                <span class="flex shrink-0 items-center gap-1">
-                    {% include "n26/includes/row_action.html" with action=row.buy.buy %}
-                </span>
+            </c-ui.button>
+        </c-slot>
+        <c-slot name="details">
+            <c-n26.owned-lines :copies="row.copies" />
+            <div class="mt-1 border-t border-box-border pt-1">
+                <div class="flex min-h-9 items-center gap-2">
+                    <span class="min-w-0 flex-1 text-sm text-muted">Buy another</span>
+                    <span class="n26-cp-price shrink-0 text-sm text-ink-900 dark:text-ink-100">
+                        {% include "n26/includes/equip_price.html" with field=row.buy.price_field quoted=row.buy.price label=row.buy.name %}
+                    </span>
+                    <span class="flex shrink-0 items-center gap-1">
+                        {% include "n26/includes/row_action.html" with action=row.buy.buy %}
+                    </span>
+                </div>
+                {% if row.buy.choices %}
+                    {% include "n26/includes/equip_choices.html" with choices=row.buy.choices %}
+                {% endif %}
+                {% if row.buy.options %}
+                    {% include "n26/includes/equip_options.html" with row=row.buy %}
+                {% endif %}
             </div>
-            {% if row.buy.choices %}
-                {% include "n26/includes/equip_choices.html" with choices=row.buy.choices %}
-            {% endif %}
-            {% if row.buy.options %}
-                {% include "n26/includes/equip_options.html" with row=row.buy %}
-            {% endif %}
-        </div>
-    </c-slot>
-</c-n26.collection-picker.item>
+        </c-slot>
+    </c-n26.collection-picker.item>
+{% else %}
+    <c-n26.collection-picker.item name="{{ row.name }}"
+                                  :price="0"
+                                  :disclosure="False"
+                                  state="quoted: 0, price: 0">
+        <c-slot name="price_control">
+            <span aria-hidden="true"></span>
+        </c-slot>
+        <c-slot name="actions">
+            <c-ui.button size="sm"
+                         class="inline-flex items-center gap-1.5"
+                         @click="expanded = !expanded"
+                         ::aria-expanded="expanded">
+                <span><span class="tabular-nums">{{ row.count }}</span> {{ held_label|default:"equipped" }}</span>
+                <span class="n26-icon-only">
+                    <c-n26.icon name="chevron-down"
+                                class="size-3 transition-transform"
+                                stroke_width="2.5"
+                                ::class="{ 'rotate-180': expanded }" />
+                </span>
+            </c-ui.button>
+        </c-slot>
+        <c-slot name="details">
+            <c-n26.owned-lines :copies="row.copies" />
+        </c-slot>
+    </c-n26.collection-picker.item>
+{% endif %}

--- a/n26/core/templates/n26/includes/equip_stash_row.html
+++ b/n26/core/templates/n26/includes/equip_stash_row.html
@@ -1,7 +1,0 @@
-{% comment %}
-One manage-only stash row outside the browsed catalogue — expects `row`, an
-OwnedRow with no buy underneath, and `held_label` from the page.
-{% endcomment %}
-<div class="rounded-md border border-box-border px-3 py-2">
-    <c-n26.owned-lines :copies="row.copies" />
-</div>

--- a/n26/core/templates/n26/includes/equip_stash_row.html
+++ b/n26/core/templates/n26/includes/equip_stash_row.html
@@ -1,0 +1,7 @@
+{% comment %}
+One manage-only stash row outside the browsed catalogue — expects `row`, an
+OwnedRow with no buy underneath, and `held_label` from the page.
+{% endcomment %}
+<div class="rounded-md border border-box-border px-3 py-2">
+    <c-n26.owned-lines :copies="row.copies" />
+</div>

--- a/n26/core/templates/n26/includes/gang_equip_catalogue.html
+++ b/n26/core/templates/n26/includes/gang_equip_catalogue.html
@@ -49,6 +49,11 @@ The gang stash equip catalogue — expects `catalogue`, picker context, `action`
             {% endif %}
         {% endif %}
     </c-slot>
+    {% if stash_tab %}
+        <c-slot name="empty">
+            Nothing in the stash yet.
+        </c-slot>
+    {% endif %}
     {% for section in catalogue.sections %}
         <c-n26.collection-picker.section :name="section.name" :open="forloop.first">
             {% for category in section.categories %}

--- a/n26/core/templates/n26/includes/gang_equip_catalogue.html
+++ b/n26/core/templates/n26/includes/gang_equip_catalogue.html
@@ -47,8 +47,6 @@ The gang stash equip catalogue — expects `catalogue`, picker context, `action`
                     {% endif %}
                 </div>
             {% endif %}
-        {% else %}
-            <p class="text-sm text-muted">Everything the gang holds in its stash.</p>
         {% endif %}
     </c-slot>
     {% for section in catalogue.sections %}

--- a/n26/core/templates/n26/includes/gang_equip_catalogue.html
+++ b/n26/core/templates/n26/includes/gang_equip_catalogue.html
@@ -1,0 +1,71 @@
+{% comment %}
+The gang stash equip catalogue — expects `catalogue`, picker context, `action`,
+`browsing`, `held_label`, and `stash_tab`.
+{% endcomment %}
+<c-n26.collection-picker :categories="categories"
+                         :sections="sections"
+                         price_floor="{{ price_floor }}"
+                         price_ceiling="{{ price_ceiling }}"
+                         tp_ceiling="{{ tp_ceiling }}"
+                         noun="items"
+                         class="md:col-start-2">
+    <c-slot name="filters">
+        {% if not stash_tab %}
+            <c-n26.search-bar :live="True"
+                              :nested="True"
+                              model="query"
+                              placeholder="Search {{ browsing }}" />
+            {% if category_options or price_ceiling > price_floor or has_trade_points %}
+                <div class="flex flex-wrap items-center gap-2">
+                    {% if category_options %}
+                        <c-n26.filter-menu label="Category"
+                                           name="category"
+                                           size="xs"
+                                           :options="category_options" />
+                    {% endif %}
+                    {% if price_ceiling > price_floor %}
+                        <c-n26.range-menu label="Price"
+                                          model_min="minPrice"
+                                          model_max="maxPrice"
+                                          min="{{ price_floor }}"
+                                          max="{{ price_ceiling }}"
+                                          step="5"
+                                          suffix="¢"
+                                          size="xs"
+                                          at_max_label="Any" />
+                    {% endif %}
+                    {% if has_trade_points %}
+                        <c-n26.range-menu label="Trade points"
+                                          model="maxTradePoints"
+                                          min="0"
+                                          max="{{ tp_ceiling }}"
+                                          step="1"
+                                          prefix="≤ "
+                                          size="xs"
+                                          at_min_label="Freely available"
+                                          at_max_label="Any" />
+                    {% endif %}
+                </div>
+            {% endif %}
+        {% else %}
+            <p class="text-sm text-muted">Everything the gang holds in its stash.</p>
+        {% endif %}
+    </c-slot>
+    {% for section in catalogue.sections %}
+        <c-n26.collection-picker.section :name="section.name" :open="forloop.first">
+            {% for category in section.categories %}
+                {% if category.name %}
+                    <c-n26.collection-picker.category :name="category.name">
+                        {% for row in category.rows %}
+                            {% include "n26/includes/equip_row.html" %}
+                        {% endfor %}
+                    </c-n26.collection-picker.category>
+                {% else %}
+                    {% for row in category.rows %}
+                        {% include "n26/includes/equip_row.html" %}
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        </c-n26.collection-picker.section>
+    {% endfor %}
+</c-n26.collection-picker>

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1390,10 +1390,11 @@ def test_a_sale_confirmation_states_its_arithmetic(
     client.force_login(tester)
     response = client.get(f"{equip_url(fighter, house_list)}&sell={sword.pk}")
     body = response.content.decode()
+    copy = " ".join(body.split())
 
     assert response.context["dialog"]["proceeds"] == 18
-    assert "Half of its 35¢ rating, rounded up — 18¢." in body
-    assert "removed from the gang" in body
+    assert "Half of its 35¢ rating, rounded up — 18¢." in copy
+    assert "It and anything attached to it are removed from the gang." in copy
     assert "<dialog open" in body
     assert reverse("n26-sell", args=[sword.pk]) in body
 
@@ -1483,10 +1484,13 @@ def test_a_refund_names_what_was_paid_and_not_its_rating(
     body = client.get(
         f"{equip_url(fighter, house_list)}&refund={knife.pk}"
     ).content.decode()
+    copy = " ".join(body.split())
 
-    assert "5¢ comes back" in body
-    assert "the amount paid, not its rating" in body
-    assert "removed from the gang, undoing the purchase" in body
+    assert "5¢ comes back — the amount paid, not its rating." in copy
+    assert (
+        "It and anything attached to it are removed from the gang, undoing the purchase."
+        in copy
+    )
     assert reverse("n26-refund", args=[knife.pk]) in body
 
 

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1457,8 +1457,13 @@ def test_a_removal_says_it_is_permanent(client, tester, gang, fighter, house_lis
     body = client.get(
         f"{equip_url(fighter, house_list)}&remove={knife.pk}"
     ).content.decode()
+    copy = " ".join(body.split())
 
-    assert "permanently removed from the gang" in body
+    assert (
+        "It and anything attached to it are permanently removed from the gang. "
+        "No credits are returned. Use Refund instead to recover the amount paid."
+        in copy
+    )
     assert reverse("n26-remove", args=[knife.pk]) in body
 
 
@@ -1589,6 +1594,7 @@ def test_a_gang_with_no_budget_is_offered_no_refund(
     ).content.decode()
     assert "Delete" in asked
     assert "Refund" not in asked
+    assert "No credits are returned." in asked
 
 
 @pytest.fixture

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1392,7 +1392,8 @@ def test_a_sale_confirmation_states_its_arithmetic(
     body = response.content.decode()
 
     assert response.context["dialog"]["proceeds"] == 18
-    assert "Half of 35¢, rounded up — 18¢." in body
+    assert "Half of its 35¢ rating, rounded up — 18¢." in body
+    assert "removed from the gang" in body
     assert "<dialog open" in body
     assert reverse("n26-sell", args=[sword.pk]) in body
 
@@ -1408,7 +1409,7 @@ def test_a_sale_of_something_worth_almost_nothing_names_the_floor(
         f"{equip_url(fighter, house_list)}&sell={trinket.pk}"
     ).content.decode()
 
-    assert "5¢: half of 4¢ is less than the 5¢ a sale never goes under." in body
+    assert "5¢: half of its 4¢ rating is below the 5¢ minimum sale price." in body
 
 
 def test_a_move_offers_the_stash_and_the_roster(
@@ -1425,6 +1426,7 @@ def test_a_move_offers_the_stash_and_the_roster(
     body = response.content.decode()
 
     assert [model.name for model in response.context["dialog"]["models"]] == ["Nell"]
+    assert "Moving it does not change its rating." in body
     assert 'name="to" value="stash"' in body
     assert 'name="miniature"' in body
 
@@ -1446,9 +1448,7 @@ def test_a_move_with_nobody_else_on_the_roster_is_a_move_to_the_stash(
     assert 'name="miniature"' not in body
 
 
-def test_a_removal_says_the_money_stays_spent(
-    client, tester, gang, fighter, house_list
-):
+def test_a_removal_says_it_is_permanent(client, tester, gang, fighter, house_list):
     from n26.library.models import Wargear
 
     knife = buy_one(gang, fighter, tester, Wargear.objects.get(name="Knife"), paid=10)
@@ -1457,11 +1457,11 @@ def test_a_removal_says_the_money_stays_spent(
         f"{equip_url(fighter, house_list)}&remove={knife.pk}"
     ).content.decode()
 
-    assert "stays spent" in body
+    assert "permanently removed from the gang" in body
     assert reverse("n26-remove", args=[knife.pk]) in body
 
 
-def test_a_refund_names_what_was_paid_and_not_what_it_is_worth(
+def test_a_refund_names_what_was_paid_and_not_its_rating(
     client, tester, gang, fighter, house_list
 ):
     """Three acts take a thing away and the money is the whole difference
@@ -1485,7 +1485,8 @@ def test_a_refund_names_what_was_paid_and_not_what_it_is_worth(
     ).content.decode()
 
     assert "5¢ comes back" in body
-    assert "not what it is worth" in body
+    assert "the amount paid, not its rating" in body
+    assert "removed from the gang, undoing the purchase" in body
     assert reverse("n26-refund", args=[knife.pk]) in body
 
 

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -1,10 +1,8 @@
-"""Buying equipment for the gang: the stash's own end of the equip page.
+"""Buying and managing equipment in a gang's stash.
 
 ``browse``, ``Operation.buy`` and the fighter's equip page have their own
-tests — these are about what the gang anchor changes. A purchase lands in
-the stash rather than on anybody's card, the lists offered are the gang's
-own, one tab is the whole library, and no line is marked usable or not,
-because a restriction is about a model and the stash is not one.
+tests. These cover the gang-specific destination, lists, stash management,
+and the absence of fighter usability rules.
 """
 
 import pytest
@@ -96,12 +94,6 @@ class TestTheWayIn:
 
         assert "Equip" in body
         assert reverse("n26-equip-gang", args=[gang.pk]) in body
-        assert "Buy Equipment" not in body
-
-    def test_the_gang_header_does_not_offer_buy_equipment(self, client, tester, gang):
-        client.force_login(tester)
-        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
-
         assert "Buy Equipment" not in body
 
     def test_a_reader_who_does_not_own_it_is_offered_nothing(self, client, gang):
@@ -634,7 +626,7 @@ class TestStashManagement:
         client.force_login(tester)
         body = client.get(equip_url(gang, house_list)).content.decode()
 
-        assert "Equip" in body
+        assert ">Equip</h1>" in body
         assert "Buy Equipment" not in body
 
     def test_a_held_item_on_the_browsed_list_draws_in_stash(
@@ -672,7 +664,6 @@ class TestStashManagement:
         assert on_stash.context["stash_tab"] is True
         assert "Autogun" in body
         assert f"sell={bought.pk}" in body
-        assert "Everything the gang holds in its stash" not in body
 
     def test_selling_from_the_stash_tab_returns_to_it(
         self, client, tester, gang, house_list
@@ -686,11 +677,8 @@ class TestStashManagement:
         client.force_login(tester)
         response = client.post(
             reverse("n26-sell", args=[bought.pk]),
-            {
-                "list": "stash",
-                "return": equip_url(gang, scope="stash"),
-            },
+            {"return": equip_url(gang, scope="stash")},
         )
 
         assert response.status_code == 302
-        assert "list=stash" in response["Location"]
+        assert response["Location"] == equip_url(gang, scope="stash")

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -90,12 +90,19 @@ def choice_field(thing, group):
 class TestTheWayIn:
     """The gang page offers the act, and only to whoever owns the gang."""
 
-    def test_the_owner_is_offered_it_on_the_gang_page(self, client, tester, gang):
+    def test_the_owner_is_offered_equip_on_the_stash(self, client, tester, gang):
         client.force_login(tester)
         body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
 
-        assert "Buy Equipment" in body
+        assert "Equip" in body
         assert reverse("n26-equip-gang", args=[gang.pk]) in body
+        assert "Buy Equipment" not in body
+
+    def test_the_gang_header_does_not_offer_buy_equipment(self, client, tester, gang):
+        client.force_login(tester)
+        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+
+        assert "Buy Equipment" not in body
 
     def test_a_reader_who_does_not_own_it_is_offered_nothing(self, client, gang):
         """A roster anybody may read, with none of the acts on it: not a
@@ -121,11 +128,12 @@ class TestWhichListsAreOffered:
         tabs = client.get(equip_url(gang)).context["collection_tabs"]
 
         assert [tab["label"] for tab in tabs] == [
+            "In stash",
             "House List",
             "Trading Post",
             "All equipment",
         ]
-        assert tabs[0]["current"]
+        assert tabs[1]["current"]
         assert tabs[-1]["href"] == "?list=all"
 
     def test_a_list_of_skills_is_no_tab_however_the_gang_holds_it(
@@ -146,7 +154,11 @@ class TestWhichListsAreOffered:
         client.force_login(tester)
         tabs = client.get(equip_url(gang)).context["collection_tabs"]
 
-        assert [tab["label"] for tab in tabs] == ["House List", "All equipment"]
+        assert [tab["label"] for tab in tabs] == [
+            "In stash",
+            "House List",
+            "All equipment",
+        ]
 
     def test_a_shortened_tab_keeps_its_full_name_on_the_link(
         self, client, tester, gang
@@ -180,7 +192,8 @@ class TestWhichListsAreOffered:
 
         assert response.context["catalogue"] is None
         assert [tab["label"] for tab in response.context["collection_tabs"]] == [
-            "All equipment"
+            "In stash",
+            "All equipment",
         ]
         assert "No equipment lists yet" in response.content.decode()
 
@@ -612,3 +625,87 @@ class TestTheQueryBudget:
             create_wargear(f"Filler {index}", price=5)
             create_weapon(f"Filler gun {index}", price=5, profiles=[("", 0)])
         assert self.measure(client, url) == few
+
+
+class TestStashManagement:
+    """Held gear is manageable on the gang equip page, including orphans."""
+
+    def test_the_page_is_called_equip(self, client, tester, gang, house_list):
+        client.force_login(tester)
+        body = client.get(equip_url(gang, house_list)).content.decode()
+
+        assert "Equip" in body
+        assert "Buy Equipment" not in body
+
+    def test_a_held_item_on_the_browsed_list_draws_in_stash(
+        self, client, tester, gang, house_list
+    ):
+        from n26.library.models import Wargear
+
+        knife = Wargear.objects.get(name="Knife")
+        with operation(gang, actor=tester) as op:
+            bought = op.buy(gang.stash, thing=knife, paid=10)
+
+        client.force_login(tester)
+        body = client.get(equip_url(gang, house_list)).content.decode()
+
+        assert "in stash" in body
+        assert f"sell={bought.pk}" in body
+
+    def test_orphan_ui_a_draws_gear_the_list_does_not_sell(
+        self, client, tester, gang, house_list
+    ):
+        from n26.library.authoring import create_weapon
+
+        autogun = create_weapon("Autogun", price=20, profiles=[("", 0)])
+        with operation(gang, actor=tester) as op:
+            bought = op.buy(gang.stash, thing=autogun, paid=20)
+
+        client.force_login(tester)
+        url = f"{equip_url(gang, house_list)}&orphan_ui=a"
+        response = client.get(url)
+        body = response.content.decode()
+
+        assert response.context["orphan_rows"]
+        assert "In stash — not on this list" in body
+        assert f"sell={bought.pk}" in body
+
+    def test_orphan_ui_b_lists_everything_on_the_stash_tab(
+        self, client, tester, gang, house_list
+    ):
+        from n26.library.authoring import create_weapon
+
+        autogun = create_weapon("Autogun", price=20, profiles=[("", 0)])
+        with operation(gang, actor=tester) as op:
+            bought = op.buy(gang.stash, thing=autogun, paid=20)
+
+        client.force_login(tester)
+        url = equip_url(gang, scope="stash")
+        response = client.get(url)
+        body = response.content.decode()
+
+        assert response.context["stash_tab"] is True
+        assert "Autogun" in body
+        assert f"sell={bought.pk}" in body
+
+    def test_selling_from_the_stash_tab_returns_to_it(
+        self, client, tester, gang, house_list
+    ):
+        from n26.library.models import Wargear
+
+        knife = Wargear.objects.get(name="Knife")
+        with operation(gang, actor=tester) as op:
+            bought = op.buy(gang.stash, thing=knife, paid=10)
+
+        client.force_login(tester)
+        response = client.post(
+            reverse("n26-sell", args=[bought.pk]),
+            {
+                "list": "stash",
+                "orphan_ui": "b",
+                "return": equip_url(gang, scope="stash"),
+            },
+        )
+
+        assert response.status_code == 302
+        assert "list=stash" in response["Location"]

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -652,7 +652,7 @@ class TestStashManagement:
         assert "in stash" in body
         assert f"sell={bought.pk}" in body
 
-    def test_orphan_ui_a_draws_gear_the_list_does_not_sell(
+    def test_gear_the_list_does_not_sell_is_on_the_stash_tab(
         self, client, tester, gang, house_list
     ):
         from n26.library.authoring import create_weapon
@@ -662,31 +662,17 @@ class TestStashManagement:
             bought = op.buy(gang.stash, thing=autogun, paid=20)
 
         client.force_login(tester)
-        url = f"{equip_url(gang, house_list)}&orphan_ui=a"
-        response = client.get(url)
-        body = response.content.decode()
+        on_house = client.get(equip_url(gang, house_list))
+        on_stash = client.get(equip_url(gang, scope="stash"))
+        body = on_stash.content.decode()
 
-        assert response.context["orphan_rows"]
-        assert "In stash — not on this list" in body
-        assert f"sell={bought.pk}" in body
-
-    def test_orphan_ui_b_lists_everything_on_the_stash_tab(
-        self, client, tester, gang, house_list
-    ):
-        from n26.library.authoring import create_weapon
-
-        autogun = create_weapon("Autogun", price=20, profiles=[("", 0)])
-        with operation(gang, actor=tester) as op:
-            bought = op.buy(gang.stash, thing=autogun, paid=20)
-
-        client.force_login(tester)
-        url = equip_url(gang, scope="stash")
-        response = client.get(url)
-        body = response.content.decode()
-
-        assert response.context["stash_tab"] is True
+        assert "Autogun" not in {
+            row.name for row in on_house.context["catalogue"].all_rows()
+        }
+        assert on_stash.context["stash_tab"] is True
         assert "Autogun" in body
         assert f"sell={bought.pk}" in body
+        assert "Everything the gang holds in its stash" not in body
 
     def test_selling_from_the_stash_tab_returns_to_it(
         self, client, tester, gang, house_list
@@ -702,7 +688,6 @@ class TestStashManagement:
             reverse("n26-sell", args=[bought.pk]),
             {
                 "list": "stash",
-                "orphan_ui": "b",
                 "return": equip_url(gang, scope="stash"),
             },
         )

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -655,15 +655,23 @@ class TestStashManagement:
 
         client.force_login(tester)
         on_house = client.get(equip_url(gang, house_list))
-        on_stash = client.get(equip_url(gang, scope="stash"))
+        on_stash = client.get(
+            f"{equip_url(gang, scope='stash')}&owned={key_of(autogun)}"
+        )
         body = on_stash.content.decode()
 
         assert "Autogun" not in {
             row.name for row in on_house.context["catalogue"].all_rows()
         }
         assert on_stash.context["stash_tab"] is True
+        (row,) = on_stash.context["catalogue"].all_rows()
+        assert row.expanded is True
         assert "Autogun" in body
         assert f"sell={bought.pk}" in body
+        assert 'aria-expanded="true"' in body
+        assert '@click="expanded = !expanded"' not in body
+        sell = body.index(f"sell={bought.pk}")
+        assert body.rfind("<template", 0, sell) <= body.rfind("</template>", 0, sell)
 
     def test_selling_from_the_stash_tab_returns_to_it(
         self, client, tester, gang, house_list

--- a/n26/core/test_views_gang_sheet.py
+++ b/n26/core/test_views_gang_sheet.py
@@ -297,10 +297,8 @@ def test_a_named_profile_opens_with_a_dash_under_its_weapon(
     assert "aria-hidden" not in table[table.rindex("<td", 0, gun) : gun]
 
 
-class TestRefittingAStashedAccessory:
-    """A sight kept back from a sale is gear waiting for a gun, and the
-    sheet is where the gang's spare kit is read — so the way back onto a
-    gun is here."""
+class TestStashActions:
+    """Gear in the stash can be handed on from the gang sheet itself."""
 
     @pytest.fixture
     def kit(self, gang, tester, make_profile, make_statline):
@@ -321,7 +319,22 @@ class TestRefittingAStashedAccessory:
             op.move(bolted, stash)
         return gun, bolted
 
-    def test_the_stash_line_offers_a_way_back_onto_a_gun(
+    def test_a_stashed_wargear_line_offers_reassign(self, client, tester, gang, gang_type):
+        from n26.library.authoring import create_wargear
+
+        knife = create_wargear("Knife", price=10)
+        with operation(gang, actor=tester) as op:
+            op.found(gang_type)
+            bought = op.buy(gang.stash, thing=knife, paid=10)
+
+        client.force_login(tester)
+        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+
+        assert "Reassign" in body
+        assert f"reassign={bought.pk}" in body
+        assert "Actions for Knife" in body
+
+    def test_a_stashed_accessory_offers_fit_to_a_weapon_in_its_menu(
         self, client, tester, gang, kit
     ):
         _, bolted = kit
@@ -329,40 +342,41 @@ class TestRefittingAStashedAccessory:
         body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
 
         assert "Telescopic sight" in body
-        assert f"?refit={bolted.pk}" in body
+        assert f"reassign={bolted.pk}" in body
         assert "Fit to a weapon" in body
 
-    def test_the_address_opens_a_picker_over_the_gangs_guns(
+    def test_reassign_opens_a_picker_over_the_gangs_guns(
         self, client, tester, gang, kit
     ):
         gun, bolted = kit
         client.force_login(tester)
         response = client.get(
-            reverse("n26-gang", args=[gang.pk]) + f"?refit={bolted.pk}"
+            reverse("n26-gang", args=[gang.pk]) + f"?reassign={bolted.pk}"
         )
         body = response.content.decode()
+        dialog = response.context["dialog"]
 
-        assert response.context["refitting"]["weapons"] == [
-            {"pk": str(gun.pk), "label": "Autogun (Vex)"}
-        ]
+        assert dialog["weapons"] == [{"pk": str(gun.pk), "label": "Autogun (Vex)"}]
         assert "<dialog open" in body
-        # The picker posts the same move a fighter's row does, one level
-        # down the chain.
         assert reverse("n26-reassign", args=[bolted.pk]) in body
         assert 'name="to" value="weapon"' in body
 
-    def test_something_that_is_not_a_stashed_accessory_opens_nothing(
+    def test_something_that_is_not_in_the_stash_opens_nothing(
         self, client, tester, gang, kit
     ):
         gun, _ = kit
         client.force_login(tester)
-        response = client.get(reverse("n26-gang", args=[gang.pk]) + f"?refit={gun.pk}")
-        assert response.context["refitting"] is None
+        response = client.get(
+            reverse("n26-gang", args=[gang.pk]) + f"?reassign={gun.pk}"
+        )
+        assert response.context["dialog"] is None
 
     def test_a_pk_that_is_not_a_ulid_opens_nothing(self, client, tester, gang, kit):
         client.force_login(tester)
-        response = client.get(reverse("n26-gang", args=[gang.pk]) + "?refit=nonsense")
-        assert response.context["refitting"] is None
+        response = client.get(
+            reverse("n26-gang", args=[gang.pk]) + "?reassign=nonsense"
+        )
+        assert response.context["dialog"] is None
 
     def test_another_gangs_stash_is_not_reachable(
         self, client, tester, gang, kit, gang_type
@@ -385,6 +399,6 @@ class TestRefittingAStashedAccessory:
 
         client.force_login(tester)
         response = client.get(
-            reverse("n26-gang", args=[gang.pk]) + f"?refit={hidden.pk}"
+            reverse("n26-gang", args=[gang.pk]) + f"?reassign={hidden.pk}"
         )
-        assert response.context["refitting"] is None
+        assert response.context["dialog"] is None

--- a/n26/core/test_views_gang_sheet.py
+++ b/n26/core/test_views_gang_sheet.py
@@ -41,7 +41,8 @@ def test_draws_the_gang(client, tester, gang):
     assert str(gang.gang_type) in body
 
 
-def test_the_sheet_builds_the_gang_card_once(client, tester, gang, monkeypatch):
+@pytest.mark.parametrize("query", ["", "?sell=nonsense"])
+def test_the_sheet_builds_the_gang_card_once(client, tester, gang, monkeypatch, query):
     from n26.core import card
 
     built = []
@@ -54,7 +55,7 @@ def test_the_sheet_builds_the_gang_card_once(client, tester, gang, monkeypatch):
     monkeypatch.setattr(card, "build_gang_card", counted)
     client.force_login(tester)
 
-    assert client.get(reverse("n26-gang", args=[gang.pk])).status_code == 200
+    assert client.get(reverse("n26-gang", args=[gang.pk]) + query).status_code == 200
     assert len(built) == 1
 
 

--- a/n26/core/test_views_gang_sheet.py
+++ b/n26/core/test_views_gang_sheet.py
@@ -41,6 +41,23 @@ def test_draws_the_gang(client, tester, gang):
     assert str(gang.gang_type) in body
 
 
+def test_the_sheet_builds_the_gang_card_once(client, tester, gang, monkeypatch):
+    from n26.core import card
+
+    built = []
+    build_gang_card = card.build_gang_card
+
+    def counted(*args, **kwargs):
+        built.append(None)
+        return build_gang_card(*args, **kwargs)
+
+    monkeypatch.setattr(card, "build_gang_card", counted)
+    client.force_login(tester)
+
+    assert client.get(reverse("n26-gang", args=[gang.pk])).status_code == 200
+    assert len(built) == 1
+
+
 def test_the_way_to_the_gang_list_is_named_for_what_it_offers(client, tester, gang):
     """The screen it leads to holds a reader through several hires, so the
     control says so. Hiring a vehicle is its own control and stays
@@ -319,7 +336,9 @@ class TestStashActions:
             op.move(bolted, stash)
         return gun, bolted
 
-    def test_a_stashed_wargear_line_offers_reassign(self, client, tester, gang, gang_type):
+    def test_a_stashed_wargear_line_offers_reassign(
+        self, client, tester, gang, gang_type
+    ):
         from n26.library.authoring import create_wargear
 
         knife = create_wargear("Knife", price=10)

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -991,6 +991,28 @@ def test_the_gangs_own_rows_are_not_the_fighters_to_sell(gang, fighter, tester):
     assert thing_key(crate) not in owned_things(build_card(fighter), AT)
 
 
+def test_a_suppressed_possession_has_no_dialog(fighter, sword):
+    from django.test import RequestFactory
+
+    from n26.core.card import build_card
+    from n26.core.owned import EquipHost
+    from n26.core.views.owned import owned_dialog
+
+    card = build_card(fighter)
+    node = next(
+        node
+        for node in card.all_nodes()
+        if node.assignment is not None and node.assignment.pk == sword.pk
+    )
+    node.suppressed = True
+    request = RequestFactory().get(AT, {"sell": str(sword.pk)})
+
+    assert (
+        owned_dialog(request, EquipHost.fighter(fighter.gang, card, fighter, AT))
+        is None
+    )
+
+
 def test_an_unowned_row_is_counted_as_nothing(gang, fighter):
     from n26.core.card import build_card
     from n26.core.owned import owned_things, thing_key

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -781,14 +781,25 @@ class TestFittingOneBackOntoAGun:
         assert gang.credits == before
         assert_reconciled(gang)
 
-    def test_the_click_lands_on_the_sheet_it_was_made_from(
+    def test_the_click_lands_on_the_stash_equip_page_without_a_return_field(
         self, client, tester, gang, gun, stashed
     ):
         client.force_login(tester)
         response = client.post(
             url("n26-reassign", stashed), {"to": "weapon", "weapon": str(gun.pk)}
         )
-        assert response.url == reverse("n26-gang", args=[gang.pk])
+        assert response.url.startswith(reverse("n26-equip-gang", args=[gang.pk]))
+
+    def test_a_return_field_sends_the_reader_back_to_the_sheet(
+        self, client, tester, gang, gun, stashed
+    ):
+        client.force_login(tester)
+        sheet = reverse("n26-gang", args=[gang.pk])
+        response = client.post(
+            url("n26-reassign", stashed),
+            {"to": "weapon", "weapon": str(gun.pk), "return": sheet},
+        )
+        assert response.url == sheet
 
     def test_a_weapon_in_another_gang_is_nowhere_to_fit_it(
         self, client, tester, gang, stashed, gang_type, make_profile, make_statline
@@ -993,10 +1004,13 @@ class TestThePanelsAPageCarries:
         from django.test import RequestFactory
 
         from n26.core.card import build_card
+        from n26.core.owned import EquipHost
         from n26.core.views.owned import accessorise_dialogs
 
+        card = build_card(fighter)
         request = RequestFactory().get(AT, query)
-        return accessorise_dialogs(request, build_card(fighter), at=AT)
+        host = EquipHost.fighter(fighter.gang, card, fighter, AT)
+        return accessorise_dialogs(request, host)
 
     def test_every_gun_gets_one_and_nothing_else_does(self, fighter, gun, sight, sword):
         """A sword is a possession, and a gun is somewhere to bolt a sight

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -801,6 +801,21 @@ class TestFittingOneBackOntoAGun:
         )
         assert response.url == sheet
 
+    def test_an_external_return_field_is_ignored(
+        self, client, tester, gang, gun, stashed
+    ):
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", stashed),
+            {
+                "to": "weapon",
+                "weapon": str(gun.pk),
+                "return": "https://example.com/elsewhere",
+            },
+        )
+
+        assert response.url.startswith(reverse("n26-equip-gang", args=[gang.pk]))
+
     def test_a_weapon_in_another_gang_is_nowhere_to_fit_it(
         self, client, tester, gang, stashed, gang_type, make_profile, make_statline
     ):

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -607,52 +607,49 @@ ALL_SCOPE = "all"
 #: What that tab is called, on the tab and as the list being browsed.
 ALL_LABEL = "All equipment"
 
-#: The stash-holdings tab for orphan UI option B — not a collection.
+#: The stash-holdings tab — not a collection. Gear the current list does
+#: not sell is reached from here, rather than drawn beside the catalogue.
 STASH_SCOPE = "stash"
 
 #: What that tab is called.
 STASH_LABEL = "In stash"
 
 
-def gang_tabs(collections, chosen, everything, *, stash=False, orphan_ui="b"):
+def gang_tabs(collections, chosen, everything, *, stash=False):
     """The lists the gang can buy from, and the whole library after them.
 
     The library tab comes last because it is the fallback: what a gang
     buys from is its own lists, and everything else is there for the
     thing no list carries.
 
-    With ``orphan_ui=b``, an ``In stash`` tab lists everything held
-    regardless of which list sells it. With ``orphan_ui=a``, orphans are
-    drawn beside the catalogue instead, and this tab is omitted.
+    ``In stash`` comes first: everything held, regardless of which list
+    sells it, so gear bought elsewhere still has somewhere to be managed.
     """
     tabs = collection_tabs(collections, chosen)
     for tab, collection in zip(tabs, collections, strict=True):
-        tab["href"] = _gang_tab_href(collection.pk, orphan_ui=orphan_ui)
+        tab["href"] = _gang_tab_href(collection.pk)
     tabs.append(
         {
             "label": ALL_LABEL,
             "title": "",
-            "href": _gang_tab_href(ALL_SCOPE, orphan_ui=orphan_ui),
+            "href": _gang_tab_href(ALL_SCOPE),
             "current": everything,
         }
     )
-    if orphan_ui == "b":
-        tabs.insert(
-            0,
-            {
-                "label": STASH_LABEL,
-                "title": "Everything the gang holds in its stash",
-                "href": _gang_tab_href(STASH_SCOPE, orphan_ui=orphan_ui),
-                "current": stash,
-            },
-        )
+    tabs.insert(
+        0,
+        {
+            "label": STASH_LABEL,
+            "title": "",
+            "href": _gang_tab_href(STASH_SCOPE),
+            "current": stash,
+        },
+    )
     return tabs
 
 
-def _gang_tab_href(scope, *, orphan_ui="b", section=""):
+def _gang_tab_href(scope, *, section=""):
     params = [("list", scope)]
-    if orphan_ui and orphan_ui != "b":
-        params.append(("orphan_ui", orphan_ui))
     if section:
         params.append(("section", section))
     return f"?{urlencode(params)}"
@@ -680,19 +677,15 @@ def equip_gang(request, pk):
     carries. Built only when the address asks for it — it prices the
     library, which is not something to pay for on every visit.
 
-    ``?list=stash`` (orphan UI option B) is everything held, regardless
-    of which list sells it. Option A draws the same orphans beside the
-    catalogue instead; switch with ``?orphan_ui=a`` to compare.
+    ``?list=stash`` is everything held, regardless of which list sells
+    it — so gear bought from All equipment still has somewhere to be sold
+    or handed on when browsing a narrower list.
     """
     from n26.core.access import gang_collections
     from n26.core.browse import all_gear, browse
     from n26.core.card import build_gang_card, build_modifier_index
     from n26.core.effects import compute_gang
-    from n26.core.listing import (
-        build_catalogue,
-        build_stash_catalogue,
-        stash_orphan_rows,
-    )
+    from n26.core.listing import build_catalogue, build_stash_catalogue
     from n26.core.owned import EquipHost, possessions
     from n26.core.render import roster as gang_roster
     from n26.core.render import summarise_roster
@@ -710,10 +703,6 @@ def equip_gang(request, pk):
         access.collection
         for access in gang_collections(gang, card=card, computed=computed)
     )
-
-    orphan_ui = request.POST.get("orphan_ui", request.GET.get("orphan_ui", "b"))[:1]
-    if orphan_ui not in ("a", "b"):
-        orphan_ui = "b"
 
     # Read from the POST as well as the URL: the form posts to the address
     # it was drawn at, and a click must buy from the list it was clicked
@@ -744,8 +733,6 @@ def equip_gang(request, pk):
         params.append(("list", chosen.pk))
     if section:
         params.append(("section", section))
-    if orphan_ui != "b":
-        params.append(("orphan_ui", orphan_ui))
     here = f"{request.path}?{urlencode(params)}" if params else request.path
 
     view = None
@@ -781,18 +768,6 @@ def equip_gang(request, pk):
         catalogue = None
         browsing = ""
 
-    orphan_rows = []
-    if orphan_ui == "a" and not stash_tab and catalogue is not None:
-        orphan_rows = stash_orphan_rows(catalogue, owned, refunds=refunds)
-
-    toggle_scope = (
-        STASH_SCOPE
-        if stash_tab
-        else (ALL_SCOPE if everything else str(chosen.pk) if chosen else "")
-    )
-    orphan_toggle_a = _gang_tab_href(toggle_scope, orphan_ui="a", section=section)
-    orphan_toggle_b = _gang_tab_href(toggle_scope, orphan_ui="b", section=section)
-
     return render(
         request,
         "n26/gang_equip.html",
@@ -804,14 +779,9 @@ def equip_gang(request, pk):
                 chosen,
                 everything,
                 stash=stash_tab,
-                orphan_ui=orphan_ui,
             ),
             "browsing": browsing,
             "catalogue": catalogue,
-            "orphan_rows": orphan_rows,
-            "orphan_ui": orphan_ui,
-            "orphan_toggle_a": orphan_toggle_a,
-            "orphan_toggle_b": orphan_toggle_b,
             "stash_tab": stash_tab,
             "held_label": host.held_label,
             "dialog": owned_dialog(request, host),

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -611,28 +611,17 @@ ALL_LABEL = "All equipment"
 #: not sell is reached from here, rather than drawn beside the catalogue.
 STASH_SCOPE = "stash"
 
-#: What that tab is called.
 STASH_LABEL = "In stash"
 
 
 def gang_tabs(collections, chosen, everything, *, stash=False):
-    """The lists the gang can buy from, and the whole library after them.
-
-    The library tab comes last because it is the fallback: what a gang
-    buys from is its own lists, and everything else is there for the
-    thing no list carries.
-
-    ``In stash`` comes first: everything held, regardless of which list
-    sells it, so gear bought elsewhere still has somewhere to be managed.
-    """
+    """The stash, buyable collections, and library tabs."""
     tabs = collection_tabs(collections, chosen)
-    for tab, collection in zip(tabs, collections, strict=True):
-        tab["href"] = _gang_tab_href(collection.pk)
     tabs.append(
         {
             "label": ALL_LABEL,
             "title": "",
-            "href": _gang_tab_href(ALL_SCOPE),
+            "href": f"?list={ALL_SCOPE}",
             "current": everything,
         }
     )
@@ -641,45 +630,21 @@ def gang_tabs(collections, chosen, everything, *, stash=False):
         {
             "label": STASH_LABEL,
             "title": "",
-            "href": _gang_tab_href(STASH_SCOPE),
+            "href": f"?list={STASH_SCOPE}",
             "current": stash,
         },
     )
     return tabs
 
 
-def _gang_tab_href(scope, *, section=""):
-    params = [("list", scope)]
-    if section:
-        params.append(("section", section))
-    return f"?{urlencode(params)}"
-
-
 @login_required
 def equip_gang(request, pk):
-    """Equip the gang's stash — buy into it and manage what it holds.
+    """Buy into the stash and manage what it holds.
 
-    The gang's own end of the equip page. What is bought here belongs to
-    the gang rather than to anyone on the roster: it lands in the stash,
-    and this screen is where it is handed to a fighter. The division is
-    the anchor and nothing else — a fighter's page buys onto that
-    fighter, this one buys into the store.
-
-    Which list is URL state (``?list=``), and the lists are the gang's
-    own: the collections it carries or was granted, kept to the ones
-    holding gear, plus the standard Trading Post. There is no fighter
-    here, so no line is marked usable or not — a restriction is about a
-    model, and the stash is not one. The gang's card is built once and
-    answers which lists it holds.
-
-    ``?list=all`` is the whole library instead: every kind of gear a list
-    could sell, filed under its own categories, for the thing no list
-    carries. Built only when the address asks for it — it prices the
-    library, which is not something to pay for on every visit.
-
-    ``?list=stash`` is everything held, regardless of which list sells
-    it — so gear bought from All equipment still has somewhere to be sold
-    or handed on when browsing a narrower list.
+    The chosen collection is URL state. ``all`` browses the library and
+    ``stash`` lists every possession, including gear absent from narrower
+    lists. Usability notes are omitted because they apply to fighters, not
+    the stash.
     """
     from n26.core.access import gang_collections
     from n26.core.browse import all_gear, browse
@@ -693,8 +658,7 @@ def equip_gang(request, pk):
 
     gang = _own_gang_or_404(request, pk)
 
-    # One card build serves the page: which lists the gang carries is read
-    # off it, and building it twice is the easy mistake here.
+    # One card answers both collection access and possessions.
     card = build_gang_card(gang, with_statlines=False)
     index = build_modifier_index([node.assignable for node in card.all_nodes()])
     computed = compute_gang(card, index)
@@ -704,9 +668,7 @@ def equip_gang(request, pk):
         for access in gang_collections(gang, card=card, computed=computed)
     )
 
-    # Read from the POST as well as the URL: the form posts to the address
-    # it was drawn at, and a click must buy from the list it was clicked
-    # on whichever way the state arrived.
+    # The collection picker posts its URL state back with a purchase.
     wanted = request.POST.get("list", request.GET.get("list", ""))
     stash_tab = wanted == STASH_SCOPE
     everything = wanted == ALL_SCOPE
@@ -716,12 +678,10 @@ def equip_gang(request, pk):
             if str(collection.pk) == wanted:
                 chosen = collection
                 break
-        if chosen is None and collections and not stash_tab:
+        if chosen is None and collections:
             chosen = collections[0]
 
-    # Which of the picker's section tabs the reader was on — client state
-    # the picker posts along and reads back from the URL, as on a
-    # fighter's page.
+    # Preserve the collection picker's section across purchases.
     section = request.POST.get("section", request.GET.get("section", ""))[:100]
 
     params = []
@@ -736,14 +696,12 @@ def equip_gang(request, pk):
     here = f"{request.path}?{urlencode(params)}" if params else request.path
 
     view = None
-    if stash_tab:
-        pass
-    elif everything:
+    if everything:
         view = all_gear(ALL_LABEL)
     elif chosen is not None:
         view = browse(chosen)
 
-    if request.method == "POST" and view is not None and not stash_tab:
+    if request.method == "POST" and view is not None:
         return _buy_clicked(
             request,
             gang,
@@ -759,7 +717,7 @@ def equip_gang(request, pk):
     refunds = not gang.credits_unlimited
 
     if stash_tab:
-        catalogue = build_stash_catalogue(owned, refunds=refunds)
+        catalogue = build_stash_catalogue(owned, STASH_LABEL, refunds=refunds)
         browsing = STASH_LABEL
     elif view is not None:
         catalogue = build_catalogue(view, owned, refunds=refunds)

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -412,7 +412,7 @@ def equip(request, pk):
     from n26.core.card import build_card, build_modifier_index
     from n26.core.effects import compute
     from n26.core.listing import build_catalogue
-    from n26.core.owned import owned_things
+    from n26.core.owned import EquipHost, possessions
     from n26.core.views.owned import accessorise_dialogs, owned_dialog
 
     miniature = _own_miniature_or_404(request, pk)
@@ -476,7 +476,8 @@ def equip(request, pk):
     # over this page, on the list being read, and Cancel comes back to it,
     # so the page's own address is what the controls are built from.
     at = here(chosen)
-    owned = owned_things(card, at)
+    host = EquipHost.fighter(gang, card, miniature, at=at)
+    owned = possessions(host)
 
     # The whole screen, as one structure: the browsed list joined to what
     # the fighter holds. A row is a row for something on sale or a row for
@@ -524,15 +525,13 @@ def equip(request, pk):
             # remove one assignment on this fighter's card. A server state,
             # so it is a link, it survives a reload, and it is drawn rather than
             # revealed by a script.
-            "dialog": owned_dialog(
-                request, card, at=at, miniature=miniature, gang=gang
-            ),
+            "dialog": owned_dialog(request, host),
             # The accessory question for every gun the fighter is
             # carrying, drawn closed beside the rows. The one the address
             # names is drawn open, so the link works with no script; with
             # a script the click opens the panel that is already on the
             # page and never rebuilds the catalogue.
-            "accessorise": accessorise_dialogs(request, card, at=at),
+            "accessorise": accessorise_dialogs(request, host),
             **picker_context(catalogue, view),
         },
     )
@@ -608,33 +607,64 @@ ALL_SCOPE = "all"
 #: What that tab is called, on the tab and as the list being browsed.
 ALL_LABEL = "All equipment"
 
+#: The stash-holdings tab for orphan UI option B — not a collection.
+STASH_SCOPE = "stash"
 
-def gang_tabs(collections, chosen, everything):
+#: What that tab is called.
+STASH_LABEL = "In stash"
+
+
+def gang_tabs(collections, chosen, everything, *, stash=False, orphan_ui="b"):
     """The lists the gang can buy from, and the whole library after them.
 
     The library tab comes last because it is the fallback: what a gang
     buys from is its own lists, and everything else is there for the
     thing no list carries.
+
+    With ``orphan_ui=b``, an ``In stash`` tab lists everything held
+    regardless of which list sells it. With ``orphan_ui=a``, orphans are
+    drawn beside the catalogue instead, and this tab is omitted.
     """
-    tabs = collection_tabs(collections, None if everything else chosen)
+    tabs = collection_tabs(collections, chosen)
+    for tab, collection in zip(tabs, collections, strict=True):
+        tab["href"] = _gang_tab_href(collection.pk, orphan_ui=orphan_ui)
     tabs.append(
         {
             "label": ALL_LABEL,
             "title": "",
-            "href": f"?list={ALL_SCOPE}",
+            "href": _gang_tab_href(ALL_SCOPE, orphan_ui=orphan_ui),
             "current": everything,
         }
     )
+    if orphan_ui == "b":
+        tabs.insert(
+            0,
+            {
+                "label": STASH_LABEL,
+                "title": "Everything the gang holds in its stash",
+                "href": _gang_tab_href(STASH_SCOPE, orphan_ui=orphan_ui),
+                "current": stash,
+            },
+        )
     return tabs
+
+
+def _gang_tab_href(scope, *, orphan_ui="b", section=""):
+    params = [("list", scope)]
+    if orphan_ui and orphan_ui != "b":
+        params.append(("orphan_ui", orphan_ui))
+    if section:
+        params.append(("section", section))
+    return f"?{urlencode(params)}"
 
 
 @login_required
 def equip_gang(request, pk):
-    """Buy equipment into the gang's stash.
+    """Equip the gang's stash — buy into it and manage what it holds.
 
     The gang's own end of the equip page. What is bought here belongs to
     the gang rather than to anyone on the roster: it lands in the stash,
-    and the gang page is where it is handed to a fighter. The division is
+    and this screen is where it is handed to a fighter. The division is
     the anchor and nothing else — a fighter's page buys onto that
     fighter, this one buys into the store.
 
@@ -650,18 +680,23 @@ def equip_gang(request, pk):
     carries. Built only when the address asks for it — it prices the
     library, which is not something to pay for on every visit.
 
-    A row says what it sells and nothing about what the stash already
-    holds. What the gang owns is drawn on the gang page, with the
-    controls that act on it; a count here would need the same
-    confirmations again, on a screen whose one act is buying.
+    ``?list=stash`` (orphan UI option B) is everything held, regardless
+    of which list sells it. Option A draws the same orphans beside the
+    catalogue instead; switch with ``?orphan_ui=a`` to compare.
     """
     from n26.core.access import gang_collections
     from n26.core.browse import all_gear, browse
     from n26.core.card import build_gang_card, build_modifier_index
     from n26.core.effects import compute_gang
-    from n26.core.listing import build_catalogue
+    from n26.core.listing import (
+        build_catalogue,
+        build_stash_catalogue,
+        stash_orphan_rows,
+    )
+    from n26.core.owned import EquipHost, possessions
     from n26.core.render import roster as gang_roster
     from n26.core.render import summarise_roster
+    from n26.core.views.owned import accessorise_dialogs, owned_dialog
 
     gang = _own_gang_or_404(request, pk)
 
@@ -676,18 +711,23 @@ def equip_gang(request, pk):
         for access in gang_collections(gang, card=card, computed=computed)
     )
 
+    orphan_ui = request.POST.get("orphan_ui", request.GET.get("orphan_ui", "b"))[:1]
+    if orphan_ui not in ("a", "b"):
+        orphan_ui = "b"
+
     # Read from the POST as well as the URL: the form posts to the address
     # it was drawn at, and a click must buy from the list it was clicked
     # on whichever way the state arrived.
     wanted = request.POST.get("list", request.GET.get("list", ""))
+    stash_tab = wanted == STASH_SCOPE
     everything = wanted == ALL_SCOPE
     chosen = None
-    if not everything:
+    if not stash_tab and not everything:
         for collection in collections:
             if str(collection.pk) == wanted:
                 chosen = collection
                 break
-        if chosen is None and collections:
+        if chosen is None and collections and not stash_tab:
             chosen = collections[0]
 
     # Which of the picker's section tabs the reader was on — client state
@@ -695,23 +735,28 @@ def equip_gang(request, pk):
     # fighter's page.
     section = request.POST.get("section", request.GET.get("section", ""))[:100]
 
-    if everything:
-        params = [("list", ALL_SCOPE)]
+    params = []
+    if stash_tab:
+        params.append(("list", STASH_SCOPE))
+    elif everything:
+        params.append(("list", ALL_SCOPE))
     elif chosen is not None:
-        params = [("list", chosen.pk)]
-    else:
-        params = []
+        params.append(("list", chosen.pk))
     if section:
         params.append(("section", section))
+    if orphan_ui != "b":
+        params.append(("orphan_ui", orphan_ui))
     here = f"{request.path}?{urlencode(params)}" if params else request.path
 
     view = None
-    if everything:
+    if stash_tab:
+        pass
+    elif everything:
         view = all_gear(ALL_LABEL)
     elif chosen is not None:
         view = browse(chosen)
 
-    if request.method == "POST" and view is not None:
+    if request.method == "POST" and view is not None and not stash_tab:
         return _buy_clicked(
             request,
             gang,
@@ -722,10 +767,31 @@ def equip_gang(request, pk):
             collection=ALL_LABEL if everything else chosen.name,
         )
 
-    # Nothing joined in about what is already held: a row that said so
-    # would open onto the copies and their acts, and those confirmations
-    # live on the gang page, over the stash they are about.
-    catalogue = build_catalogue(view, {}) if view is not None else None
+    host = EquipHost.stash(gang, card, at=here)
+    owned = possessions(host)
+    refunds = not gang.credits_unlimited
+
+    if stash_tab:
+        catalogue = build_stash_catalogue(owned, refunds=refunds)
+        browsing = STASH_LABEL
+    elif view is not None:
+        catalogue = build_catalogue(view, owned, refunds=refunds)
+        browsing = ALL_LABEL if everything else str(chosen or "")
+    else:
+        catalogue = None
+        browsing = ""
+
+    orphan_rows = []
+    if orphan_ui == "a" and not stash_tab and catalogue is not None:
+        orphan_rows = stash_orphan_rows(catalogue, owned, refunds=refunds)
+
+    toggle_scope = (
+        STASH_SCOPE
+        if stash_tab
+        else (ALL_SCOPE if everything else str(chosen.pk) if chosen else "")
+    )
+    orphan_toggle_a = _gang_tab_href(toggle_scope, orphan_ui="a", section=section)
+    orphan_toggle_b = _gang_tab_href(toggle_scope, orphan_ui="b", section=section)
 
     return render(
         request,
@@ -733,17 +799,23 @@ def equip_gang(request, pk):
         {
             "gang": gang,
             "action": here,
-            "collection_tabs": gang_tabs(collections, chosen, everything),
-            # What is being browsed, as the search box says it. A name
-            # rather than the collection, because the library tab is no
-            # collection and the box asks the same question of both.
-            "browsing": ALL_LABEL if everything else str(chosen or ""),
+            "collection_tabs": gang_tabs(
+                collections,
+                chosen,
+                everything,
+                stash=stash_tab,
+                orphan_ui=orphan_ui,
+            ),
+            "browsing": browsing,
             "catalogue": catalogue,
-            # Who the gang fields, for the figures strip: a purchase into
-            # the store is decided against the roster it will arm, and the
-            # count opens onto the ranks it is made of. The gang card
-            # cannot answer it — its members are keyed by id and carry no
-            # model — so the roster is fetched, one query.
+            "orphan_rows": orphan_rows,
+            "orphan_ui": orphan_ui,
+            "orphan_toggle_a": orphan_toggle_a,
+            "orphan_toggle_b": orphan_toggle_b,
+            "stash_tab": stash_tab,
+            "held_label": host.held_label,
+            "dialog": owned_dialog(request, host),
+            "accessorise": accessorise_dialogs(request, host),
             "summary": summarise_roster(gang_roster(gang)),
             **picker_context(catalogue, view),
         },

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -447,11 +447,13 @@ def equip(request, pk):
     # lands the reader back on the third tab; an unknown name just leaves
     # the picker on its first.
     section = request.POST.get("section", request.GET.get("section", ""))[:100]
+    expanded_key = request.POST.get("owned", request.GET.get("owned", ""))[:200]
 
     def here(collection):
         params = [
             *([("list", collection.pk)] if collection is not None else []),
             *([("section", section)] if section else []),
+            *([("owned", expanded_key)] if expanded_key else []),
         ]
         return f"{request.path}?{urlencode(params)}" if params else request.path
 
@@ -484,7 +486,12 @@ def equip(request, pk):
     # something they are carrying, and which it is is the structure's
     # answer rather than a question the template asks of the card.
     catalogue = (
-        build_catalogue(view, owned, refunds=not gang.credits_unlimited)
+        build_catalogue(
+            view,
+            owned,
+            refunds=not gang.credits_unlimited,
+            expanded_key=expanded_key,
+        )
         if view is not None
         else None
     )
@@ -683,6 +690,7 @@ def equip_gang(request, pk):
 
     # Preserve the collection picker's section across purchases.
     section = request.POST.get("section", request.GET.get("section", ""))[:100]
+    expanded_key = request.POST.get("owned", request.GET.get("owned", ""))[:200]
 
     params = []
     if stash_tab:
@@ -693,6 +701,8 @@ def equip_gang(request, pk):
         params.append(("list", chosen.pk))
     if section:
         params.append(("section", section))
+    if expanded_key:
+        params.append(("owned", expanded_key))
     here = f"{request.path}?{urlencode(params)}" if params else request.path
 
     view = None
@@ -717,10 +727,20 @@ def equip_gang(request, pk):
     refunds = not gang.credits_unlimited
 
     if stash_tab:
-        catalogue = build_stash_catalogue(owned, STASH_LABEL, refunds=refunds)
+        catalogue = build_stash_catalogue(
+            owned,
+            STASH_LABEL,
+            refunds=refunds,
+            expanded_key=expanded_key,
+        )
         browsing = STASH_LABEL
     elif view is not None:
-        catalogue = build_catalogue(view, owned, refunds=refunds)
+        catalogue = build_catalogue(
+            view,
+            owned,
+            refunds=refunds,
+            expanded_key=expanded_key,
+        )
         browsing = ALL_LABEL if everything else str(chosen or "")
     else:
         catalogue = None

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -195,26 +195,29 @@ def gang_sheet(request, pk):
     its own grid reaches. A fighter with no grid gets no control, which
     is a content gap showing rather than a screen being withheld.
     """
+    from n26.core.card import build_gang_card
+    from n26.core.owned import EquipHost
     from n26.core.render import render_gang
     from n26.core.views.choose import link_slots
     from n26.core.views.learn import link_skills
-    from n26.core.views.owned import link_refits, refit_dialog
+    from n26.core.views.owned import link_stash_actions, owned_dialog
 
     gang = _any_gang_or_404(pk)
     yours = gang.owner_id == getattr(request.user, "id", None)
     at = reverse("n26-gang", args=[gang.pk])
     sheet = render_gang(gang)
+    dialog = None
     if yours:
         link_slots(gang, sheet, *sheet.models)
         link_skills(*sheet.models)
-        # A stashed accessory is somewhere to click: it is gear waiting
-        # for a gun, and the sheet is the screen where the gang's spare
-        # kit is read.
-        link_refits(sheet, at)
+        link_stash_actions(sheet, at, refunds=not gang.credits_unlimited)
     # One question at a time: a URL naming two dialogs draws the leaving
     # one, because two open modals is not a state the page can mean.
     leaving = _leaving(request, gang) if yours else None
     renaming = None if leaving or not yours else _renaming(request, gang)
+    if yours and not leaving and not renaming:
+        host = EquipHost.stash(gang, build_gang_card(gang), at=at)
+        dialog = owned_dialog(request, host)
     return render(
         request,
         "n26/gang_sheet.html",
@@ -228,11 +231,7 @@ def gang_sheet(request, pk):
             "card_mode": "gang" if yours else "view",
             "renaming": renaming,
             "leaving": leaving,
-            "refitting": (
-                None
-                if leaving or renaming or not yours
-                else refit_dialog(request, gang, at)
-            ),
+            "dialog": dialog,
             # A gang founded without a budget never spent credits, so
             # there is nothing a refund could give back: its cards offer
             # Delete alone.

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -205,7 +205,8 @@ def gang_sheet(request, pk):
     gang = _any_gang_or_404(pk)
     yours = gang.owner_id == getattr(request.user, "id", None)
     at = reverse("n26-gang", args=[gang.pk])
-    sheet = render_gang(gang)
+    card = build_gang_card(gang)
+    sheet = render_gang(gang, card=card)
     dialog = None
     if yours:
         link_slots(gang, sheet, *sheet.models)
@@ -221,7 +222,7 @@ def gang_sheet(request, pk):
         and not renaming
         and any(request.GET.get(kind) for kind in DIALOGS)
     ):
-        host = EquipHost.stash(gang, build_gang_card(gang), at=at)
+        host = EquipHost.stash(gang, card, at=at)
         dialog = owned_dialog(request, host)
     return render(
         request,

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -196,7 +196,7 @@ def gang_sheet(request, pk):
     is a content gap showing rather than a screen being withheld.
     """
     from n26.core.card import build_gang_card
-    from n26.core.owned import EquipHost
+    from n26.core.owned import DIALOGS, EquipHost
     from n26.core.render import render_gang
     from n26.core.views.choose import link_slots
     from n26.core.views.learn import link_skills
@@ -215,7 +215,12 @@ def gang_sheet(request, pk):
     # one, because two open modals is not a state the page can mean.
     leaving = _leaving(request, gang) if yours else None
     renaming = None if leaving or not yours else _renaming(request, gang)
-    if yours and not leaving and not renaming:
+    if (
+        yours
+        and not leaving
+        and not renaming
+        and any(request.GET.get(kind) for kind in DIALOGS)
+    ):
         host = EquipHost.stash(gang, build_gang_card(gang), at=at)
         dialog = owned_dialog(request, host)
     return render(

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -21,7 +21,7 @@ nothing is written, because the refusal unwinds the transaction.
 The acts are deliberately distinct, and the ledger says which happened:
 
 ``sell``
-    Half of what the thing is worth, rounded up, into the gang's credits.
+    Half of the thing's rating, rounded up, into the gang's credits.
     Not a refund: what was paid has nothing to do with it. A gun with
     something bolted to it asks one more question — whether the
     accessories are being sold with it or kept — because those are two
@@ -31,11 +31,11 @@ The acts are deliberately distinct, and the ledger says which happened:
     and no re-pricing. The last of the three is how a stashed accessory
     is fitted to a gun: the same act, one level down the chain.
 ``refund``
-    Undoing the purchase: every credit that was paid comes back. What was
-    paid and what the thing is worth part company at the first discount,
-    which is why this is not a sale.
+    Undoing the purchase: every credit that was paid comes back. The amount
+    paid and the rating part company at the first discount, which is why
+    this is not a sale.
 ``remove``
-    Off the card, money stays spent.
+    Permanently removed from the gang, with no credit change.
 ``accessorise``
     A purchase, hosted on the weapon rather than on the fighter. The only
     one that adds something.
@@ -337,10 +337,10 @@ def owned_dialog(request, host: EquipHost):
             "proceeds": proceeds,
             "rating": rating,
             "sum": (
-                f"Half of {rating}¢, rounded up — {proceeds}¢."
+                f"Half of its {rating}¢ rating, rounded up — {proceeds}¢."
                 if halved
-                else f"{proceeds}¢: half of {rating}¢ is less than the "
-                f"{MINIMUM_PROCEEDS}¢ a sale never goes under."
+                else f"{proceeds}¢: half of its {rating}¢ rating is below the "
+                f"{MINIMUM_PROCEEDS}¢ minimum sale price."
             ),
             "submit_label": "Sell",
             "submit_variant": "danger",
@@ -419,7 +419,7 @@ def owned_dialog(request, host: EquipHost):
             "title": f"Refund {name}?",
             "proceeds": paid,
             "sum": (
-                f"{paid}¢ comes back — what was paid for it, not what it is worth."
+                f"{paid}¢ comes back — the amount paid, not its rating."
                 if paid
                 else "Nothing was paid for this, so nothing comes back."
             ),
@@ -481,9 +481,9 @@ def _return_to(request, fallback):
 @login_required
 @require_POST
 def sell_assignment(request, pk):
-    """Sell something on: it archives, and half its worth comes back.
+    """Sell something on: it archives, and half its rating comes back.
 
-    Half of what it *is worth*, not of what was paid — see
+    Half of its rating, not of what was paid — see
     ``Operation.sell``. The confirmation names the figure because with
     the arithmetic done by the server there is nothing on the page for a
     reader to check it against.
@@ -782,7 +782,7 @@ def accessorise_assignment(request, pk):
 @login_required
 @require_POST
 def remove_assignment(request, pk):
-    """Take something off the card. The money stays spent.
+    """Remove something from the gang without changing credits.
 
     ``Operation.remove`` archives rather than deletes, so the ledger goes
     on saying the gang once owned this — it simply stops counting.
@@ -822,7 +822,7 @@ def remove_assignment(request, pk):
 def refund_assignment(request, pk):
     """Undo the purchase: it archives, and every credit paid comes back.
 
-    What was *paid*, not what it is worth — see ``Operation.refund``. The
+    What was *paid*, not its rating — see ``Operation.refund``. The
     figure is read before the write, because afterwards every entry in
     the subtree has been settled to zero and there is nothing left to add
     up.

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -441,94 +441,41 @@ def owned_dialog(request, host: EquipHost):
     }
 
 
-def link_refits(sheet, at):
-    """Point every stashed accessory at the dialog that fits it to a gun.
+def link_stash_actions(sheet, at, *, refunds=True):
+    """Every stashed possession as a menu of acts on the gang sheet.
 
-    Costs no queries: the line already knows its own assignment and whether it
-    is the sort of thing that goes on a weapon, and this only turns that
-    into a URL. A line without one draws as a name with nothing to click,
-    which is what a print-out wants.
+    Costs no queries: the line already knows its assignment and whether
+    it is the sort of thing that goes on a weapon, and this only turns
+    that into URLs. A line without a menu draws as a name alone, which
+    is what a print-out and a reader who does not own the gang want.
     """
+    from n26.core.listing import DANGER, LINK, SECONDARY, Action
+
     for line in sheet.stash:
-        if line.can_refit and line.id:
-            line.refit_href = with_query(at, refit=line.id)
-
-
-def refit_dialog(request, gang, at):
-    """The "fit this to which gun?" panel, when ``?refit=`` names something
-    in the stash.
-
-    The reverse of the equipment screen's accessory picker: there the
-    weapon is known and the accessory chosen, here the accessory is known
-    and the weapon chosen. Both end with one assignment hanging off
-    another.
-
-    Every gun the gang has is offered, not only the ones the accessory
-    fits — the same rule as everywhere else, said the other way round.
-    Fitting narrows a list of accessories because that list is long; a
-    gang's guns are few, and hiding the one a reader meant would be a
-    refusal wearing a shorter list as a disguise.
-
-    A name that is not a stashed accessory of this gang's draws nothing:
-    a stale link is a page without a dialog rather than an error worth a
-    screen.
-    """
-    from n26.core.models import Assignment
-
-    named = request.GET.get("refit")
-    if not named:
-        return None
-    stash = getattr(gang, "stash", None)
-    if stash is None:
-        return None
-    try:
-        accessory = (
-            Assignment.objects.filter(pk=named, stash=stash, archived=False)
-            .exclude(weapon_accessory=None)
-            .select_related("weapon_accessory")
-            .first()
-        )
-    except ValidationError:
-        return None
-    if accessory is None:
-        return None
-
-    # Every live weapon in the gang, wherever it is — a gun in the stash
-    # is somewhere to fit a sight as much as one on a fighter is.
-    weapons = list(
-        Assignment.objects.filter(gang_root=gang, archived=False)
-        .exclude(weapon=None)
-        .select_related("weapon", "miniature_root")
-        .order_by("miniature_root__name", "weapon__name")
-    )
-    name = str(accessory.assignable)
-    return {
-        "name": name,
-        "title": f"Fit {name} to a weapon",
-        "action": reverse("n26-reassign", args=[accessory.pk]),
-        "cancel_url": at,
-        "weapons": [
-            {
-                "pk": str(weapon.pk),
-                # Whose gun it is, because a gang can hold three autoguns
-                # and the answer to "which one" is the fighter carrying it.
-                "label": (
-                    f"{weapon.assignable} ({weapon.miniature_root.name})"
-                    if weapon.miniature_root is not None
-                    else f"{weapon.assignable} (stash)"
-                ),
-            }
-            for weapon in weapons
-        ],
-        "submit_label": "Fit" if weapons else "",
-    }
+        if not line.id:
+            continue
+        menu = [
+            Action(
+                "Fit to a weapon" if line.can_refit else "Reassign",
+                LINK,
+                with_query(at, reassign=line.id),
+                SECONDARY,
+            ),
+            Action("Sell", LINK, with_query(at, sell=line.id), DANGER),
+        ]
+        if refunds:
+            menu.append(
+                Action("Refund", LINK, with_query(at, refund=line.id), SECONDARY)
+            )
+        menu.append(Action("Delete", LINK, with_query(at, remove=line.id), SECONDARY))
+        line.menu = tuple(menu)
 
 
 def _back_to(request, assignment, gang):
     """Where a click lands: the screen it was clicked on.
 
     A hidden ``return`` field names the address exactly when the form
-    knows it — the gang sheet's refit dialog, or an equip screen with its
+    knows it — the gang sheet's stash menu, or an equip screen with its
     list state. Without one, the assignment's host before the act is read:
     stash-held gear lands on the gang equip page, carried gear on the
     fighter's.

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -48,13 +48,12 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.http import Http404
-from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
+from gyrinx.http import safe_redirect
 from n26.core.owned import (
     DIALOGS,
-    EquipAnchor,
     EquipHost,
     is_possession,
     thing_key,
@@ -102,7 +101,7 @@ def _held(host, pk):
     """
     for root in host.roots:
         for node in root.walk():
-            if host.anchor is EquipAnchor.FIGHTER and node.broadcast:
+            if node.broadcast:
                 continue
             if node.assignment is None:
                 continue
@@ -115,7 +114,6 @@ def _held(host, pk):
 
 
 def _roster(gang):
-    """Everyone live on the roster."""
     from n26.core.models import Miniature
 
     return list(
@@ -133,14 +131,13 @@ def _other_models(gang, miniature):
 
 
 def _gang_weapons(gang):
-    """Every live weapon in the gang, wherever it is."""
     from n26.core.models import Assignment
 
     return list(
         Assignment.objects.filter(gang_root=gang, archived=False)
         .exclude(weapon=None)
-        .select_related("weapon", "miniature", "stash")
-        .order_by("weapon__name")
+        .select_related("weapon", "miniature_root")
+        .order_by("miniature_root__name", "weapon__name")
     )
 
 
@@ -240,7 +237,7 @@ def accessorise_dialogs(request, host: EquipHost):
         for node in host.roots
         if node.assignment is not None
         and not node.suppressed
-        and (host.anchor is not EquipAnchor.FIGHTER or not node.broadcast)
+        and not node.broadcast
         and isinstance(node.assignable, Weapon)
     ]
     if not weapons:
@@ -313,7 +310,7 @@ def owned_dialog(request, host: EquipHost):
     # left afterwards is still the fighter's gun.
     is_part = assignment.parent_id is not None
     dialog = _panel(request, assignment, kind, host.at) | {
-        "stash_host": host.anchor is EquipAnchor.STASH,
+        "stash_host": host.is_stash,
     }
 
     if kind == "sell":
@@ -367,7 +364,7 @@ def owned_dialog(request, host: EquipHost):
         }
 
     if kind == "reassign":
-        if host.anchor is EquipAnchor.STASH and assignment.weapon_accessory_id:
+        if host.is_stash and assignment.weapon_accessory_id:
             weapons = _gang_weapons(gang)
             return dialog | {
                 "title": f"Fit {name} to a weapon",
@@ -389,11 +386,7 @@ def owned_dialog(request, host: EquipHost):
         return dialog | {
             "title": f"Move {name}",
             "models": models,
-            # With nobody on the roster a fighter's move is to the stash
-            # alone; on the stash screen there is nowhere else to offer.
-            "submit_label": (
-                "Move" if host.anchor is EquipAnchor.STASH or models else "To the stash"
-            ),
+            "submit_label": "Move" if host.is_stash or models else "To the stash",
             "submit_variant": "primary",
         }
 
@@ -442,13 +435,7 @@ def owned_dialog(request, host: EquipHost):
 
 
 def link_stash_actions(sheet, at, *, refunds=True):
-    """Every stashed possession as a menu of acts on the gang sheet.
-
-    Costs no queries: the line already knows its assignment and whether
-    it is the sort of thing that goes on a weapon, and this only turns
-    that into URLs. A line without a menu draws as a name alone, which
-    is what a print-out and a reader who does not own the gang want.
-    """
+    """Add dialog links without querying; print and read-only sheets stay plain."""
     from n26.core.listing import DANGER, LINK, SECONDARY, Action
 
     for line in sheet.stash:
@@ -456,7 +443,7 @@ def link_stash_actions(sheet, at, *, refunds=True):
             continue
         menu = [
             Action(
-                "Fit to a weapon" if line.can_refit else "Reassign",
+                "Fit to a weapon" if line.is_accessory else "Reassign",
                 LINK,
                 with_query(at, reassign=line.id),
                 SECONDARY,
@@ -472,16 +459,7 @@ def link_stash_actions(sheet, at, *, refunds=True):
 
 
 def _back_to(request, assignment, gang):
-    """Where a click lands: the screen it was clicked on.
-
-    A hidden ``return`` field names the address exactly when the form
-    knows it — the gang sheet's stash menu, or an equip screen with its
-    list state. Without one, the assignment's host before the act is read:
-    stash-held gear lands on the gang equip page, carried gear on the
-    fighter's.
-    """
-    if return_to := request.POST.get("return", ""):
-        return return_to
+    """Infer the source screen before an operation moves the assignment."""
     if assignment.stash_root_id or assignment.stash_id:
         base = reverse("n26-equip-gang", args=[gang.pk])
     elif assignment.miniature_root_id:
@@ -494,6 +472,10 @@ def _back_to(request, assignment, gang):
         if (value := request.POST.get(key, ""))
     }
     return with_query(base, **where) if where else base
+
+
+def _return_to(request, fallback):
+    return safe_redirect(request, request.POST.get("return"), fallback_url=fallback)
 
 
 @login_required
@@ -539,7 +521,7 @@ def sell_assignment(request, pk):
             proceeds = op.sell(assignment)
     except Refusal as refusal:
         messages.error(request, str(refusal))
-        return redirect(back)
+        return _return_to(request, back)
 
     record(
         request,
@@ -560,7 +542,7 @@ def sell_assignment(request, pk):
         )
     else:
         messages.success(request, f"Sold {name} for {proceeds}¢.")
-    return redirect(back)
+    return _return_to(request, back)
 
 
 @login_required
@@ -619,14 +601,14 @@ def reassign_assignment(request, pk):
             destination = None
     if destination is None:
         messages.error(request, f"There is nowhere to move {name} to.")
-        return redirect(back)
+        return _return_to(request, back)
 
     try:
         with operation(gang, actor=request.user) as op:
             op.move(assignment, destination)
     except Refusal as refusal:
         messages.error(request, str(refusal))
-        return redirect(back)
+        return _return_to(request, back)
 
     record(
         request,
@@ -645,7 +627,7 @@ def reassign_assignment(request, pk):
         messages.success(request, f"Fitted {name} to {destination.assignable}.")
     else:
         messages.success(request, f"Moved {name} to {destination.name}.")
-    return redirect(back)
+    return _return_to(request, back)
 
 
 @login_required
@@ -691,7 +673,7 @@ def rechoose_assignment(request, pk):
             op.rechoose(assignment, option=[option.default_set for option in picked])
     except Refusal as refusal:
         messages.error(request, str(refusal))
-        return redirect(back)
+        return _return_to(request, back)
     if entry is not None:
         entry.refresh_from_db()
     after = entry.paid if entry is not None else 0
@@ -714,7 +696,7 @@ def rechoose_assignment(request, pk):
     now = {row.default_set_id for row in assignment.chosen_options.all()}
     if now == taken:
         messages.success(request, f"{thing}'s options are unchanged.")
-        return redirect(back)
+        return _return_to(request, back)
     holds = ", ".join(option.name for option in thing.options_taken(now))
     settled = (
         f" — {after - before}¢ more."
@@ -724,7 +706,7 @@ def rechoose_assignment(request, pk):
         else "."
     )
     messages.success(request, f"{thing} now has {holds}{settled}")
-    return redirect(back)
+    return _return_to(request, back)
 
 
 @login_required
@@ -768,14 +750,14 @@ def accessorise_assignment(request, pk):
         # A stale dialog or a hand-made click. The screen it came from is
         # the answer, with the list on it as it now stands.
         messages.error(request, "That accessory is not one to fit.")
-        return redirect(back)
+        return _return_to(request, back)
 
     try:
         with operation(gang, actor=request.user) as op:
             bought = op.buy(assignment, thing=accessory)
     except Refusal as refusal:
         messages.error(request, str(refusal))
-        return redirect(back)
+        return _return_to(request, back)
 
     record(
         request,
@@ -794,7 +776,7 @@ def accessorise_assignment(request, pk):
         f"Fitted {accessory.name} to {assignment.assignable} — "
         f"{bought.ledger_entry.paid}¢.",
     )
-    return redirect(back)
+    return _return_to(request, back)
 
 
 @login_required
@@ -819,7 +801,7 @@ def remove_assignment(request, pk):
             op.remove(assignment)
     except Refusal as refusal:
         messages.error(request, str(refusal))
-        return redirect(back)
+        return _return_to(request, back)
 
     record(
         request,
@@ -832,7 +814,7 @@ def remove_assignment(request, pk):
         action="remove",
     )
     messages.success(request, f"Removed {name}.")
-    return redirect(back)
+    return _return_to(request, back)
 
 
 @login_required
@@ -864,7 +846,7 @@ def refund_assignment(request, pk):
             op.refund(assignment)
     except Refusal as refusal:
         messages.error(request, str(refusal))
-        return redirect(back)
+        return _return_to(request, back)
 
     record(
         request,
@@ -878,4 +860,4 @@ def refund_assignment(request, pk):
         refunded=paid,
     )
     messages.success(request, f"Refunded {name} — {paid}¢ back.")
-    return redirect(back)
+    return _return_to(request, back)

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -214,7 +214,6 @@ def _panel(request, assignment, kind, at):
         # listing's own form does this with a hidden field the picker
         # writes; a dialog is a form of its own and has to say it here.
         "section": request.GET.get("section", ""),
-        "orphan_ui": request.GET.get("orphan_ui", ""),
     }
 
 
@@ -544,7 +543,7 @@ def _back_to(request, assignment, gang):
         base = reverse("n26-gang", args=[gang.pk])
     where = {
         key: value
-        for key in ("list", "section", "orphan_ui")
+        for key in ("list", "section")
         if (value := request.POST.get(key, ""))
     }
     return with_query(base, **where) if where else base

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -51,7 +51,6 @@ from django.http import Http404
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
-from gyrinx.http import safe_redirect
 from n26.core.owned import (
     DIALOGS,
     EquipHost,
@@ -59,7 +58,7 @@ from n26.core.owned import (
     thing_key,
     with_query,
 )
-from n26.core.views.permissions import _own_assignment_or_404
+from n26.core.views.permissions import _own_assignment_or_404, _safe_redirect
 
 
 def _possession_or_404(request, pk):
@@ -101,7 +100,7 @@ def _held(host, pk):
     """
     for root in host.roots:
         for node in root.walk():
-            if node.broadcast:
+            if node.broadcast or node.suppressed:
                 continue
             if node.assignment is None:
                 continue
@@ -476,7 +475,7 @@ def _back_to(request, assignment, gang):
 
 
 def _return_to(request, fallback):
-    return safe_redirect(request, request.POST.get("return"), fallback_url=fallback)
+    return _safe_redirect(request, request.POST.get("return"), fallback_url=fallback)
 
 
 @login_required

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -52,7 +52,14 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
-from n26.core.owned import DIALOGS, is_possession, thing_key, with_query
+from n26.core.owned import (
+    DIALOGS,
+    EquipAnchor,
+    EquipHost,
+    is_possession,
+    thing_key,
+    with_query,
+)
 from n26.core.views.permissions import _own_assignment_or_404
 
 
@@ -80,40 +87,60 @@ def _possession_or_404(request, pk):
     return assignment
 
 
-def _held(card, pk):
-    """The stored possession ``pk`` names, if this card is carrying it.
+def _held(host, pk):
+    """The stored possession ``pk`` names, if this host is carrying it.
 
-    The card is the fighter's own, so finding an assignment on it is the
-    whole of the permission check for drawing a dialog about it — and it is
-    free, where fetching it again would be a query per click. The gang's
-    broadcast assignments are skipped: they ride the card so gang-wide rules
-    reach it, and they are not this fighter's to sell.
+    The host's roots are the whole of the permission check for drawing a
+    dialog about it — and it is free, where fetching it again would be a
+    query per click. Broadcast assignments are skipped on a fighter's card:
+    they ride it so gang-wide rules reach it, and they are not this
+    fighter's to sell.
 
     The same kind test the routes apply, so a URL naming the fighter's own
     profile draws no dialog rather than a confirmation whose click would
     404 — a screen must not ask a question its answer refuses.
     """
-    return next(
-        (
-            node.assignment
-            for node in card.all_nodes()
-            if not node.broadcast
-            and node.assignment is not None
-            and str(node.assignment.pk) == pk
-            and is_possession(node.assignable)
-        ),
-        None,
-    )
+    for root in host.roots:
+        for node in root.walk():
+            if host.anchor is EquipAnchor.FIGHTER and node.broadcast:
+                continue
+            if node.assignment is None:
+                continue
+            if str(node.assignment.pk) != pk:
+                continue
+            if not is_possession(node.assignable):
+                continue
+            return node.assignment
+    return None
 
 
-def _other_models(gang, miniature):
-    """Everyone else on the roster — where a thing could go instead."""
+def _roster(gang):
+    """Everyone live on the roster."""
     from n26.core.models import Miniature
 
     return list(
         Miniature.objects.filter(
             membership__gang=gang, membership__archived=False
-        ).exclude(pk=miniature.pk)
+        ).order_by("name")
+    )
+
+
+def _other_models(gang, miniature):
+    """Everyone else on the roster — where a thing could go instead."""
+    if miniature is None:
+        return _roster(gang)
+    return [model for model in _roster(gang) if model.pk != miniature.pk]
+
+
+def _gang_weapons(gang):
+    """Every live weapon in the gang, wherever it is."""
+    from n26.core.models import Assignment
+
+    return list(
+        Assignment.objects.filter(gang_root=gang, archived=False)
+        .exclude(weapon=None)
+        .select_related("weapon", "miniature", "stash")
+        .order_by("weapon__name")
     )
 
 
@@ -187,11 +214,12 @@ def _panel(request, assignment, kind, at):
         # listing's own form does this with a hidden field the picker
         # writes; a dialog is a form of its own and has to say it here.
         "section": request.GET.get("section", ""),
+        "orphan_ui": request.GET.get("orphan_ui", ""),
     }
 
 
-def accessorise_dialogs(request, card, *, at):
-    """The accessory question for every weapon on this card, all of them.
+def accessorise_dialogs(request, host: EquipHost):
+    """The accessory question for every weapon on this host, all of them.
 
     Not only the one the URL names. A page draws the lot — closed, and
     each one addressed by the id of the assignment it is about — so the click
@@ -201,19 +229,19 @@ def accessorise_dialogs(request, card, *, at):
     button is a link, and the one it names is the one drawn open here.
 
     Every weapon costs the same single read of the accessory table.
-    Fitting is then arithmetic on what the card already holds, so a
-    fighter carrying six guns asks the database exactly what a fighter
-    carrying one does — and a fighter carrying none asks nothing.
+    Fitting is then arithmetic on what the host already holds, so a screen
+    carrying six guns asks the database exactly what a screen carrying one
+    does — and a screen carrying none asks nothing.
     """
     from n26.library.models import Weapon
 
     kind, named = _asked(request)
     weapons = [
         node
-        for node in card.roots
-        if not node.broadcast
+        for node in host.roots
+        if node.assignment is not None
         and not node.suppressed
-        and node.assignment is not None
+        and (host.anchor is not EquipAnchor.FIGHTER or not node.broadcast)
         and isinstance(node.assignable, Weapon)
     ]
     if not weapons:
@@ -224,7 +252,7 @@ def accessorise_dialogs(request, card, *, at):
     for node in weapons:
         pk = str(node.assignment.pk)
         accessories = fitting_accessories(node.assignable, catalogue)
-        panel = _panel(request, node.assignment, "accessorise", at)
+        panel = _panel(request, node.assignment, "accessorise", host.at)
         dialogs.append(
             panel
             | {
@@ -245,16 +273,16 @@ def accessorise_dialogs(request, card, *, at):
     return dialogs
 
 
-def owned_dialog(request, card, *, at, miniature, gang):
+def owned_dialog(request, host: EquipHost):
     """The dialog the URL says is open, as a template's worth of facts.
 
     One of the query parameters in :data:`n26.core.owned.DIALOGS`, naming
-    an assignment on this card. A name that is not on the card draws nothing at
+    an assignment on this host. A name that is not on the host draws nothing at
     all: a stale link is a page without a dialog, not an error worth a
     screen.
 
     ``accessorise`` is not among them: that question is drawn for every
-    weapon on the card by :func:`accessorise_dialogs`, one of which the
+    weapon on the host by :func:`accessorise_dialogs`, one of which the
     address opens. Answering it here as well would draw the same panel
     twice.
     """
@@ -269,13 +297,14 @@ def owned_dialog(request, card, *, at, miniature, gang):
     if kind is None or kind == "accessorise":
         return None
 
+    gang = host.gang
     # A gang founded without a budget never paid credits, so there is
     # nothing a refund could give back: a refund address asks the remove
     # question instead, exactly as the fighter-level flow answers.
     if kind == "refund" and gang.credits_unlimited:
         kind = "remove"
 
-    assignment = _held(card, named)
+    assignment = _held(host, named)
     if assignment is None:
         return None
 
@@ -284,7 +313,9 @@ def owned_dialog(request, card, *, at, miniature, gang):
     # bolted to it. It is removed rather than deleted, because what is
     # left afterwards is still the fighter's gun.
     is_part = assignment.parent_id is not None
-    dialog = _panel(request, assignment, kind, at)
+    dialog = _panel(request, assignment, kind, host.at) | {
+        "stash_host": host.anchor is EquipAnchor.STASH,
+    }
 
     if kind == "sell":
         # Anything bolted on that the gang could keep instead of selling.
@@ -337,14 +368,33 @@ def owned_dialog(request, card, *, at, miniature, gang):
         }
 
     if kind == "reassign":
-        models = _other_models(gang, miniature)
+        if host.anchor is EquipAnchor.STASH and assignment.weapon_accessory_id:
+            weapons = _gang_weapons(gang)
+            return dialog | {
+                "title": f"Fit {name} to a weapon",
+                "weapons": [
+                    {
+                        "pk": str(weapon.pk),
+                        "label": (
+                            f"{weapon.assignable} ({weapon.miniature_root.name})"
+                            if weapon.miniature_root_id
+                            else f"{weapon.assignable} (stash)"
+                        ),
+                    }
+                    for weapon in weapons
+                ],
+                "submit_label": "Fit" if weapons else "",
+                "submit_variant": "primary",
+            }
+        models = _other_models(gang, host.miniature)
         return dialog | {
             "title": f"Move {name}",
             "models": models,
-            # With nobody else on the roster the stash is not one of two
-            # places it could go — it is the only one, so it stops being
-            # a second control and becomes the act.
-            "submit_label": "Move" if models else "To the stash",
+            # With nobody on the roster a fighter's move is to the stash
+            # alone; on the stash screen there is nowhere else to offer.
+            "submit_label": (
+                "Move" if host.anchor is EquipAnchor.STASH or models else "To the stash"
+            ),
             "submit_variant": "primary",
         }
 
@@ -475,24 +525,29 @@ def refit_dialog(request, gang, at):
     }
 
 
-def _back_to(request, miniature, gang):
+def _back_to(request, assignment, gang):
     """Where a click lands: the screen it was clicked on.
 
-    The fighter's own equip screen, on the list they were reading and
-    the section tab they had open — kitting a fighter out is a run of
-    clicks, and one that drops the reader back at the top of the first
-    list has undone their place in it. With no fighter to return to, the
-    gang's sheet.
+    A hidden ``return`` field names the address exactly when the form
+    knows it — the gang sheet's refit dialog, or an equip screen with its
+    list state. Without one, the assignment's host before the act is read:
+    stash-held gear lands on the gang equip page, carried gear on the
+    fighter's.
     """
-    if miniature is None:
-        return reverse("n26-gang", args=[gang.pk])
-    url = reverse("n26-equip", args=[miniature.pk])
+    if return_to := request.POST.get("return", ""):
+        return return_to
+    if assignment.stash_root_id or assignment.stash_id:
+        base = reverse("n26-equip-gang", args=[gang.pk])
+    elif assignment.miniature_root_id:
+        base = reverse("n26-equip", args=[assignment.miniature_root_id])
+    else:
+        base = reverse("n26-gang", args=[gang.pk])
     where = {
         key: value
-        for key in ("list", "section")
+        for key in ("list", "section", "orphan_ui")
         if (value := request.POST.get(key, ""))
     }
-    return with_query(url, **where) if where else url
+    return with_query(base, **where) if where else base
 
 
 @login_required
@@ -519,7 +574,7 @@ def sell_assignment(request, pk):
     gang = assignment.gang_root
     miniature = assignment.miniature_root
     name = str(assignment.assignable)
-    back = _back_to(request, miniature, gang)
+    back = _back_to(request, assignment, gang)
 
     stash = getattr(gang, "stash", None)
     keeping = (
@@ -588,7 +643,7 @@ def reassign_assignment(request, pk):
     # Read before the move, because afterwards it names the new home and
     # the reader wants the screen they clicked on.
     came_from = assignment.miniature_root
-    back = _back_to(request, came_from, gang)
+    back = _back_to(request, assignment, gang)
     name = str(assignment.assignable)
 
     wanted = request.POST.get("to")
@@ -679,7 +734,7 @@ def rechoose_assignment(request, pk):
         raise Http404("Nothing to choose")
     gang = assignment.gang_root
     miniature = assignment.miniature_root
-    back = _back_to(request, miniature, gang)
+    back = _back_to(request, assignment, gang)
 
     picked = _choices_picked(request.POST, thing_key(thing), offered_choices(thing))
     taken = {row.default_set_id for row in assignment.chosen_options.all()}
@@ -757,7 +812,7 @@ def accessorise_assignment(request, pk):
         raise Http404("Not a weapon")
     gang = assignment.gang_root
     miniature = assignment.miniature_root
-    back = _back_to(request, miniature, gang)
+    back = _back_to(request, assignment, gang)
 
     try:
         accessory = WeaponAccessory.objects.selectable().get(
@@ -811,7 +866,7 @@ def remove_assignment(request, pk):
     gang = assignment.gang_root
     miniature = assignment.miniature_root
     name = str(assignment.assignable)
-    back = _back_to(request, miniature, gang)
+    back = _back_to(request, assignment, gang)
 
     try:
         with operation(gang, actor=request.user) as op:
@@ -856,7 +911,7 @@ def refund_assignment(request, pk):
     miniature = assignment.miniature_root
     name = str(assignment.assignable)
     _, paid = refund_of(assignment)
-    back = _back_to(request, miniature, gang)
+    back = _back_to(request, assignment, gang)
 
     try:
         with operation(gang, actor=request.user) as op:

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -311,6 +311,7 @@ def owned_dialog(request, host: EquipHost):
     is_part = assignment.parent_id is not None
     dialog = _panel(request, assignment, kind, host.at) | {
         "stash_host": host.is_stash,
+        "can_refund": not gang.credits_unlimited,
     }
 
     if kind == "sell":

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -7,8 +7,20 @@ only ever a bad link and a 500 is the wrong answer to one.
 """
 
 from django.core.exceptions import ValidationError
-from django.http import Http404
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
+from django.utils.http import url_has_allowed_host_and_scheme
+
+
+def _safe_redirect(request, url, fallback_url="/"):
+    """Redirect only to this request's host."""
+    if url and url_has_allowed_host_and_scheme(
+        url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return HttpResponseRedirect(url)
+    return HttpResponseRedirect(fallback_url)
 
 
 def _own_gang_or_404(request, pk):

--- a/n26/designsystem/templates/designsystem/shell/gang.html
+++ b/n26/designsystem/templates/designsystem/shell/gang.html
@@ -87,11 +87,7 @@ a page and its chrome is not visible in either one alone.
             </c-n26.button-group>
         </c-slot>
         <c-slot name="stash_actions">
-            <c-ui.button size="xs"
-                         variant="primary"
-                         href="{% url 'designsystem:shell_shop' %}">
-                Equip
-            </c-ui.button>
+            <c-n26.action-link href="{% url 'designsystem:shell_shop' %}">Equip</c-n26.action-link>
         </c-slot>
         <c-slot name="stash_empty">
             Nothing in the stash yet.

--- a/n26/designsystem/templates/designsystem/shell/gang.html
+++ b/n26/designsystem/templates/designsystem/shell/gang.html
@@ -86,6 +86,13 @@ a page and its chrome is not visible in either one alone.
                 </c-ui.dropdown>
             </c-n26.button-group>
         </c-slot>
+        <c-slot name="stash_actions">
+            <c-ui.button size="xs"
+                         variant="primary"
+                         href="{% url 'designsystem:shell_shop' %}">
+                Equip
+            </c-ui.button>
+        </c-slot>
         <c-slot name="stash_empty">
             Nothing in the stash yet.
         </c-slot>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves gang equipment buying out of the gang header and into the stash card as **Equip**, wires the gang equip page for stash management, and adds **RHS action menus** on the gang sheet stash grid for reassigning gear to fighters (or fitting accessories to weapons), selling, refunding, and deleting.

Orphan gear lives on the **In stash** tab on the equip page.

## What changed

- **Stash card header:** `Stash · Equip` middot action-link
- **Gang sheet stash grid:** chevron menu on each line — Reassign (or Fit to a weapon for accessories), Sell, Refund, Delete — opening the shared `owned_dialog`
- **Gang equip page:** full owned-row machinery via `EquipHost` / `In stash` tab
- Owned-row expansion is URL-driven and server-rendered, so management controls remain available without JavaScript
- Dialog copy uses domain terms and Delete explicitly points to Refund when credits should be recovered
- Safe redirects remain within `n26`; suppressed assignments cannot be reached through hand-written dialog URLs
- Gang sheets reuse one hydrated card for rendering and stash dialogs

## How to try it

1. Open a gang you own
2. Stash card: use **Equip** or the chevron menu on a line → **Reassign** to hand gear to a fighter
3. Equip page: **In stash** tab for gear the current list does not sell

## Testing

- Focused stash/equip regression suite: 239 passed
- Full suite: 8,082 passed, 12 skipped, 1 expected failure
- CI required checks green; CodeRabbit and CodeQL analyses green
- Formatting and template lint pass

[Delete dialog explaining no credits return and pointing to Refund](https://cursor.com/agents/bc-01a01b0f-fe5f-7a1d-b4bd-b0ba7e7121f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdelete_no_refund_copy.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01b0f-fe5f-7a1d-b4bd-b0ba7e7121f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01b0f-fe5f-7a1d-b4bd-b0ba7e7121f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

