### PR TITLE
feat: the Outcast archetypes become picks

### DIFF
--- a/.claude/notes/archetype-conversion-plan.md
+++ b/.claude/notes/archetype-conversion-plan.md
@@ -1,0 +1,155 @@
+# The Archetype conversion — the plan
+
+The last system on the archetype column, and the last of the four
+conversions. Everything below is measured from production, 2026-08-19,
+read-only.
+
+## What is there
+
+| | count |
+|---|---|
+| Live picks | 102 |
+| — landing on the gang (a Leader's answer) | 40 |
+| — landing on a model (a Champion's own) | 62 |
+| Archived picks (stay put) | 73 |
+| Gangs reached (holding a carrier profile) | 65 |
+| Carrier fighters | 143 |
+| Archetypes on the menu | 5 |
+
+The menu ("Outcast Archetypes / Archetypes") lists exactly the five —
+Brawler, Gunslinger, Mastermind, Survivor, Wyrd — all live, each
+carrying its whole printed table as 10–11 modifiers. The six emptied
+house rows and Ironhead Squat are **not** on it and are no part of
+this.
+
+Five carried offers, all narrowed to that one menu, all labelled
+"Archetype":
+
+- four on the Leader profiles (`Leader 1`–`Leader 4`), each its own
+  copy, answers landing **on the gang**;
+- one on the Champion profile, answer landing **on the bearer**.
+
+Data is clean: no doubled answers, no pick without an anchor, no
+anchor that is not a live profile line, and every pick's host matches
+its anchor's kind (40 gang-hosted from Leader anchors, 62
+model-hosted from Champion anchors).
+
+## The behaviour that must survive
+
+1. **The gang's archetype reaches every fighter except Champions.**
+   The tables hang off the shared rank subtypes; Champions are simply
+   not named by them.
+2. **A Champion's own pick affects only that Champion.** Each token
+   carries bearer-only "(own pick)" rows — inert in the gang's
+   radiated copy, live on a Champion who picked personally.
+3. **The gang's archetype dies with the Leader.** The pick is caused
+   by the Leader's profile line; removing the Leader cascades it away.
+   "Chosen when a Leader is recruited" is data, not prose.
+4. **A Champion may pick what the gang already has.** Ten do today,
+   silently.
+
+All four are carried by the modifiers themselves, so moving them
+wholesale preserves them by construction — and each gets a test.
+
+## The shape
+
+```
+create slot type "Archetype", allowing repeats
+create pickable "Brawler"     (Archetype, qualifier "Archetype"), moving 10 modifiers
+create pickable "Gunslinger"  … moving 10
+create pickable "Mastermind"  … moving 10
+create pickable "Survivor"    … moving 10
+create pickable "Wyrd"        … moving 11
+create picklist "Archetypes" offering all five
+create slot "Archetype", pick landing on the gang        ← the Leaders' question
+create slot "Archetype (Champion)", pick landing on the bearer, label "Archetype"
+on the "Leader 1" profile: replace its offer with a grant of "Archetype"   ← ×4, one per profile
+on the "Champion" profile: replace its offer with a grant of "Archetype (Champion)"
+rewrite 102 picks
+prove 25 of 65 reached gangs read the same, or refuse
+```
+
+Nothing is deleted: the five archetype rows stay (emptied), the menu
+collection stays, the one detached fossil offer stays.
+
+### Three decisions inside that
+
+**Two slots, one slot type, repeats allowed.** The two questions are
+the same sort of question, so one type. Repeats must be *allowed*:
+ten Champions currently hold their gang's archetype and the page says
+nothing about it, because an offer never remarks on a repeat. Refusing
+repeats risks introducing a note where there is silence today — and
+the game permits it anyway. (In practice the note machinery would not
+fire either way, since the two questions are asked on different cards;
+allowing repeats is the setting that cannot surprise us.)
+
+**The pickables carry a qualifier — "Archetype".** Two of the five
+names are already taken: `Brawler` and `Gunslinger` exist as
+**Specialisation** pickables, and pickable names are unique per pack
+and qualifier. A qualifier is exactly the tool for this (it tells two
+same-named things apart in authoring screens and never reaches a
+player), so all five take one, uniformly, and the cards go on saying
+"Brawler". Without it the plan refuses — the preflight added in #2248
+catches the collision before anything is written.
+
+**The four Leader offers stay four.** Per your call: four grants of
+the same slot, one per profile, rather than one grant re-anchored onto
+the shared Leader subtype. No stored pick moves anchor, so the death
+cascade is untouched; the factoring stays as the authors left it.
+
+## What the history says
+
+Nothing changes. The slot type is named "Archetype", so a pick's kind
+word reads "archetype" after the conversion exactly as it reads
+"archetype" now — identical whether or not these picks draw the word
+at all. Pinned by a story test, as every conversion has been.
+
+## Engine work
+
+One addition: `CreatePickable` learns a `qualifier`. Everything else —
+`SwapCarrier` (used five times), `CreateSlot(assigned_to="gang")`,
+`RewritePick` — already exists and is proven.
+
+The gang-landing slot needs no new machinery: `_choose_for_slot`
+already documents the case ("the Leader is asked and the gang holds
+the answer") and routes a pick to the gang when the slot says so,
+mirroring the offer's `will_be_assigned_to="gang"` exactly.
+
+## The proof
+
+Sandbox tests, following the four suites already in the tree:
+
+- plan wording; deletes nothing; a standing "Archetype" slot type
+  refuses; a pickable name collision refuses (the qualifier is what
+  clears it); an off-menu pick anchored on a carrier profile refuses;
+  an archived menu entry refuses.
+- page parity across the shapes: a gang whose Leader answered, a
+  Champion who answered differently, a Champion who answered *the
+  same*, a gang with two Leaders (one exists), a gang that never
+  answered, and an archived re-choice left behind.
+- the four behaviours above, asserted per fighter before and after:
+  Champions untouched by the gang's archetype; a Champion's own pick
+  reaching only them; the Leader's death taking the gang's archetype
+  with it; the matching Champion drawing no note.
+- rechoosing on the new machinery, both slots.
+- story parity, and the kind word reading "archetype".
+
+Then the standing rule: a fork of the content mirror, a population
+built at the measured volume above (65 gangs, 143 carrier fighters,
+102 picks, including the two-Leader gang and the ten matching
+Champions), the real code path run and timed, and **every** reached
+gang diffed from outside the run — pages, history, reconcile.
+
+## Console
+
+One new operation, "n26: the Outcast archetypes become picks", on the
+same runner, lock, attempt cap and audit record as the other three.
+No retirement needed: the field is clear (no "Archetype" slot type,
+no "Archetypes" picklist, no slot of either name).
+
+## After it lands
+
+The `archetype` column holds nothing live. Retiring the column itself
+— and the emptied Archetype, SkillTree and Specialisation kinds with
+it — is a separate piece of work, and the one place where deleting is
+finally the point rather than a hazard.

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -33,6 +33,30 @@ from n26.library.standard_content import XP_COUNTER
 #: named in whatever they changed.
 DRAWS_NO_LINE = (Hidden, Slot, Pickable)
 
+
+def _speaks_for_itself(node, chosen_keys):
+    """A pick nothing on this card speaks for, which must draw its own
+    line rather than vanish.
+
+    A pick is normally drawn as its choice's answer, so it draws no line
+    of its own — but that assumes the choice is drawn *here*. It need
+    not be: a question asked of one holder may be answered onto another
+    (the Leader is asked the gang's archetype, and the gang holds it),
+    and then the card holding the answer shows no choice row to hang it
+    under. Left to the ordinary rule the thing the holder owns would
+    appear nowhere at all.
+
+    A pick with no choice behind it at all is a different case and keeps
+    drawing nothing: nobody was offered it, so it says nothing about its
+    holder (``effects.is_orphan_pick``).
+    """
+    return (
+        isinstance(node.assignable, Pickable)
+        and node.key not in chosen_keys
+        and node.chosen_for_key is not None
+    )
+
+
 #: The book's weapon slots on one card. Each weapon takes its own
 #: ``slots`` against this budget — asterisked weapons two, grenades none.
 #: Shown wherever a selection is being weighed; never enforced, because
@@ -1175,7 +1199,9 @@ def card_to_model_card(
             # has, and this is no longer part of it.
             continue
         thing = node.assignable
-        if isinstance(thing, DRAWS_NO_LINE):
+        if isinstance(thing, DRAWS_NO_LINE) and not _speaks_for_itself(
+            node, chosen_keys
+        ):
             # No row of its own. A hidden carrier's effects have already
             # landed (a shifted stat cell names it); a slot draws its
             # choice row instead; a pick appears as that row's answer, or
@@ -1370,7 +1396,8 @@ def _gang_rows(gang_card, gang_computed):
             # Taken away by a modifier — the assignment stays, the line goes.
             continue
         if isinstance(node.assignable, (*DRAWS_NO_LINE, Counter)):
-            continue
+            if not _speaks_for_itself(node, chosen_keys):
+                continue
         if isinstance(node.assignable, Rule):
             rules.append(AssignableLine(name=node.name, provenance=provenance_of(node)))
             continue

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -36,26 +36,32 @@ from n26.library.standard_content import XP_COUNTER
 DRAWS_NO_LINE = (Hidden, Slot, Pickable)
 
 
-def _speaks_for_itself(node, chosen_keys):
-    """A pick nothing on this card speaks for, which must draw its own
-    line rather than vanish.
+def _speaks_for_itself(node, asked_here):
+    """A pick whose question this card never asks, which must draw its
+    own line rather than appear nowhere at all.
 
     A pick is normally drawn as its choice's answer, so it draws no line
-    of its own — but that assumes the choice is drawn *here*. It need
+    of its own — but that assumes the question is asked *here*. It need
     not be: a question asked of one holder may be answered onto another
     (the Leader is asked the gang's archetype, and the gang holds it),
-    and then the card holding the answer shows no choice row to hang it
-    under. Left to the ordinary rule the thing the holder owns would
-    appear nowhere at all.
+    and then the card holding the answer has no choice row to hang it
+    under.
 
-    A pick with no choice behind it at all is a different case and keeps
+    The test is the question's own line, not whether a choice row was
+    drawn: a hidden choice asks nothing and still speaks for its answer,
+    which is the whole of what hidden means. So a pick is left to the
+    ordinary rule wherever the assignment it answers stands on this
+    card, drawn or silent, and draws its own line only where that
+    assignment is somewhere else entirely.
+
+    A pick with no choice behind it at all is a third case and keeps
     drawing nothing: nobody was offered it, so it says nothing about its
     holder (``effects.is_orphan_pick``).
     """
     return (
         isinstance(node.assignable, Pickable)
-        and node.key not in chosen_keys
         and node.chosen_for_key is not None
+        and node.chosen_for_key not in asked_here
     )
 
 
@@ -1103,6 +1109,10 @@ def card_to_model_card(
         if computed
         else set()
     )
+    #: Every assignment standing on this card, so a pick can tell a
+    #: question asked here — drawn or hidden — from one asked of
+    #: somebody else entirely (``_speaks_for_itself``).
+    asked_here = {node.key for node in card.all_nodes()}
 
     # A line's cause is almost always another line on the same card — the
     # membership, the anchor subtype, the weapon a profile hangs off — so
@@ -1202,7 +1212,7 @@ def card_to_model_card(
             continue
         thing = node.assignable
         if isinstance(thing, DRAWS_NO_LINE) and not _speaks_for_itself(
-            node, chosen_keys
+            node, asked_here
         ):
             # No row of its own. A hidden carrier's effects have already
             # landed (a shifted stat cell names it); a slot draws its
@@ -1388,6 +1398,7 @@ def _gang_rows(gang_card, gang_computed):
         if gang_computed
         else set()
     )
+    asked_here = {node.key for node in gang_card.all_nodes()}
     provenance_of = _provenance_within(gang_card)
     rows = []
     rules = []
@@ -1398,7 +1409,7 @@ def _gang_rows(gang_card, gang_computed):
             # Taken away by a modifier — the assignment stays, the line goes.
             continue
         if isinstance(node.assignable, (*DRAWS_NO_LINE, Counter)):
-            if not _speaks_for_itself(node, chosen_keys):
+            if not _speaks_for_itself(node, asked_here):
                 continue
         if isinstance(node.assignable, Rule):
             rules.append(AssignableLine(name=node.name, provenance=provenance_of(node)))

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -27,10 +27,12 @@ from n26.library.models import (
 )
 from n26.library.standard_content import XP_COUNTER
 
-#: The kinds that never draw a line of their own. A hidden carrier by
+#: The kinds that draw no line of their own. A hidden carrier by
 #: definition; a slot because its line *is* its choice row; a pick
-#: because it appears as that row's answer. Their effects still show,
-#: named in whatever they changed.
+#: because it appears as that row's answer — which holds only where
+#: that row is drawn on the same card, so ``_speaks_for_itself`` below
+#: reads the one case where it is not. Their effects still show, named
+#: in whatever they changed.
 DRAWS_NO_LINE = (Hidden, Slot, Pickable)
 
 

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -1109,16 +1109,16 @@ def card_to_model_card(
         if computed
         else set()
     )
-    #: Every assignment standing on this card, so a pick can tell a
-    #: question asked here — drawn or hidden — from one asked of
-    #: somebody else entirely (``_speaks_for_itself``).
-    asked_here = {node.key for node in card.all_nodes()}
-
     # A line's cause is almost always another line on the same card — the
     # membership, the anchor subtype, the weapon a profile hangs off — so
     # its name is resolved from what is already in memory, never by a
     # query. A cause off the card degrades to the reason alone.
     nodes_by_key = {node.key: node for node in card.all_nodes()}
+    #: Every assignment standing on this card, so a pick can tell a
+    #: question asked here — drawn or hidden — from one asked of
+    #: somebody else entirely (``_speaks_for_itself``). The same keys
+    #: the causes are resolved from, and a card is walked once.
+    asked_here = nodes_by_key.keys()
 
     def provenance_of(node):
         cause = nodes_by_key.get(node.caused_by_key)
@@ -1363,7 +1363,12 @@ def _weapon_changes(weapon_state):
 
 
 def _provenance_within(card):
-    """A ``provenance_of`` resolving causes among one card's own nodes."""
+    """A ``provenance_of`` resolving causes among one card's own nodes.
+
+    The keys it resolved from ride along as ``standing_here``: every
+    assignment on the card, which is also what tells a pick whether the
+    question it answers is asked here at all.
+    """
     nodes_by_key = {node.key: node for node in card.all_nodes()}
 
     def provenance_of(node):
@@ -1375,6 +1380,7 @@ def _provenance_within(card):
             computed=node.computed,
         )
 
+    provenance_of.standing_here = nodes_by_key.keys()
     return provenance_of
 
 
@@ -1398,8 +1404,8 @@ def _gang_rows(gang_card, gang_computed):
         if gang_computed
         else set()
     )
-    asked_here = {node.key for node in gang_card.all_nodes()}
     provenance_of = _provenance_within(gang_card)
+    asked_here = provenance_of.standing_here
     rows = []
     rules = []
     for node in gang_card.roots:

--- a/n26/library/conversion/__init__.py
+++ b/n26/library/conversion/__init__.py
@@ -8,6 +8,7 @@ one transaction and proves, before committing, that every affected
 gang's pages still say the same things. The preview is the contract.
 """
 
+from n26.library.conversion.archetype import plan_archetype
 from n26.library.conversion.base import ConversionRefused, Plan, apply
 from n26.library.conversion.gang_legacy import plan_gang_legacy
 from n26.library.conversion.paths import plan_paths
@@ -22,6 +23,7 @@ SYSTEMS = {
     "specialisation": plan_specialisation,
     "skill_tree": plan_skill_tree,
     "gang_legacy": plan_gang_legacy,
+    "archetype": plan_archetype,
 }
 
 __all__ = [
@@ -29,6 +31,7 @@ __all__ = [
     "Plan",
     "SYSTEMS",
     "apply",
+    "plan_archetype",
     "plan_gang_legacy",
     "plan_paths",
     "plan_skill_tree",

--- a/n26/library/conversion/archetype.py
+++ b/n26/library/conversion/archetype.py
@@ -73,6 +73,8 @@ PROVEN = 25
 
 
 def plan_archetype():
+    from django.db.models.functions import Lower
+
     from n26.core.models import Assignment
     from n26.library.models import (
         Modifier,
@@ -104,7 +106,11 @@ def plan_archetype():
     # Scoped to the default pack, where this builds: a custom pack's own
     # rows of these names are somebody's content, not a collision.
     pack = default_pack_id()
-    if SlotType.objects.filter(name=SLOT_TYPE, pack_id=pack).exists():
+    # Names are unique per pack under ``Lower``, so these look the same
+    # way the constraint does: an exact-match check calls a differently
+    # cased row free, and the collision then arrives as a database error
+    # where a sentence was promised.
+    if SlotType.objects.filter(name__iexact=SLOT_TYPE, pack_id=pack).exists():
         problems.append(f"a slot type named “{SLOT_TYPE}” already stands")
 
     # Each offer must name a profile, and all of them the same menu:
@@ -164,20 +170,23 @@ def plan_archetype():
     # The names the steps would create must be free in the default pack,
     # under the qualifier they will wear — a collision would turn a
     # valid-looking plan into a mid-apply integrity error.
-    taken = Pickable.objects.filter(
-        pack_id=pack,
-        qualifier=QUALIFIER,
-        name__in=[row.name for row in old_rows],
-    ).values_list("name", flat=True)
+    wanted = {row.name.lower() for row in old_rows}
+    taken = [
+        name
+        for name in Pickable.objects.filter(pack_id=pack)
+        .annotate(folded=Lower("name"), folded_qualifier=Lower("qualifier"))
+        .filter(folded__in=wanted, folded_qualifier=QUALIFIER.lower())
+        .values_list("name", flat=True)
+    ]
     if taken:
         problems.append(
             "pickables already wear these names and qualifier: "
             + ", ".join(sorted(taken))
         )
-    if Picklist.objects.filter(pack_id=pack, name=PICKLIST).exists():
+    if Picklist.objects.filter(pack_id=pack, name__iexact=PICKLIST).exists():
         problems.append(f"a picklist named “{PICKLIST}” already stands")
     for name in (GANG_SLOT, OWN_SLOT):
-        if Slot.objects.filter(pack_id=pack, name=name).exists():
+        if Slot.objects.filter(pack_id=pack, name__iexact=name).exists():
             problems.append(f"a slot named “{name}” already stands")
 
     # Only live answers move. An archived pick is history nothing draws,
@@ -196,6 +205,15 @@ def plan_archetype():
     # the same profile that carries the offer it answered.
     gang_profiles = {row.pk for _, held in to_gang for _, row in held}
     own_profiles = {row.pk for _, held in to_bearer for _, row in held}
+    # One profile carrying both a gang-landing offer and a bearer-landing
+    # one asks two questions this plan cannot tell apart by anchor, and
+    # its picks would settle on whichever slot the check reached first.
+    both = gang_profiles & own_profiles
+    if both:
+        problems.append(
+            f"{len(both)} profile(s) carry both a gang-landing offer and a "
+            "bearer-landing one, so their picks cannot be told apart"
+        )
     pick_slots = {}
     for pick in answers:
         if pick.caused_by_id is None:

--- a/n26/library/conversion/archetype.py
+++ b/n26/library/conversion/archetype.py
@@ -1,0 +1,352 @@
+"""The Archetype conversion — the Outcast system, and the last of them.
+
+Today: the Outcast Leader profiles each carry their own offer of the
+archetype kind, narrowed to the Outcast menu, whose answer lands **on
+the gang**; the Champion profile carries the same offer landing on the
+**bearer**. Each archetype on that menu carries its whole printed table
+as ordinary modifiers — the rank placements, a granted subtype, a
+powers family — including the bearer-only rows that say what a Champion
+gets from picking it personally.
+
+After: an "Archetype" slot type; the menu's archetypes as pickables
+carrying those same modifiers, moved not copied; two slots — the gang's,
+which every Leader profile grants, and the Champion's own — and every
+stored choice re-said as a pick on its same anchor.
+
+Four behaviours ride the modifiers rather than this conversion, and so
+survive it by construction:
+
+* the gang's archetype reaches every fighter except Champions, the
+  tables naming the ranks it applies to;
+* a Champion's own pick reaches that Champion alone, through the
+  bearer-only rows, inert in the gang's radiated copy;
+* the gang's archetype dies with the Leader, the pick hanging from the
+  Leader's own line by a ``caused_by`` this conversion never moves;
+* a Champion may pick what the gang already holds, silently — which is
+  why the slot type allows repeats, where the Skill Tree one refuses
+  them. An offer never remarks on a repeat, and this must not start.
+
+**Nothing is deleted.** The emptied archetype rows, the menu
+collection, and any detached fossil offer stay where they are.
+
+The pickables take a qualifier. Two of these names already belong to
+pickables of another slot type, and a name is unique per pack and
+qualifier — so all of them take one, uniformly, and the cards go on
+saying what they say. A qualifier is author-facing only and never
+reaches a player.
+
+Production converts from the maintenance console, once, after the code
+deploys — see :mod:`n26.maintenance`. Elsewhere the command does it
+(``manage n26_convert archetype``).
+"""
+
+from n26.library.conversion.base import (
+    CreatePickable,
+    CreatePicklist,
+    CreateSlot,
+    CreateSlotType,
+    Plan,
+    RewritePick,
+    SwapCarrier,
+    carriers_of,
+    duplicate_names,
+    one_answer_per_question,
+    spread,
+)
+
+SLOT_TYPE = "Archetype"
+PLURAL = "Archetypes"
+PICKLIST = "Archetypes"
+GANG_SLOT = "Archetype"
+OWN_SLOT = "Archetype (Champion)"
+OFFER_LABEL = "Archetype"
+#: Told apart from the pickables of other slot types wearing these
+#: names. Author-facing only.
+QUALIFIER = "Archetype"
+
+#: How many gangs the apply proves unchanged before committing — the
+#: same reasoning as every conversion: a spread wide enough to hold
+#: every shape the system comes in, proven with the lock held for
+#: seconds, where proving everyone would hold rows players are using
+#: for minutes.
+PROVEN = 25
+
+
+def plan_archetype():
+    from n26.core.models import Assignment
+    from n26.library.models import (
+        Modifier,
+        OffersChoice,
+        Pickable,
+        Picklist,
+        Slot,
+        SlotType,
+    )
+    from n26.library.models.pack import default_pack_id
+
+    problems = []
+
+    # Every carried archetype offer wearing this system's label. A
+    # detached one is a fossil: carried by nothing, it does nothing on
+    # any page, and it is left where it lies.
+    carried = [
+        (m, carriers_of(m))
+        for m in Modifier.objects.filter(
+            offers_choice__isnull=False,
+            offers_choice__of_kind__model="archetype",
+        ).select_related("offers_choice", "offers_choice__from_section")
+        if m.offers_choice.label == OFFER_LABEL
+    ]
+    live_offers = [(m, held) for m, held in carried if held]
+    if not live_offers:
+        return Plan(system="archetype", nothing_here=True)
+
+    # Scoped to the default pack, where this builds: a custom pack's own
+    # rows of these names are somebody's content, not a collision.
+    pack = default_pack_id()
+    if SlotType.objects.filter(name=SLOT_TYPE, pack_id=pack).exists():
+        problems.append(f"a slot type named “{SLOT_TYPE}” already stands")
+
+    # Each offer must name a profile, and all of them the same menu:
+    # two menus would be two systems, and this plan converts one.
+    to_gang, to_bearer, sections = [], [], set()
+    for offer, held in live_offers:
+        strangers = sorted({kind for kind, _ in held if kind != "Profile"})
+        if strangers:
+            problems.append(
+                f"“{offer.name}” is carried by things that are not "
+                "profiles: " + ", ".join(strangers)
+            )
+        if len(held) != 1:
+            # Every offer here is one profile's own. A shared one would
+            # need the shared swap, and nothing in this system uses it.
+            problems.append(
+                f"“{offer.name}” is carried by {len(held)} things — "
+                "expected one profile"
+            )
+        sections.add(offer.offers_choice.from_section_id)
+        lands = offer.offers_choice.will_be_assigned_to
+        if lands == OffersChoice.WillBeAssignedTo.GANG:
+            to_gang.append((offer, held))
+        else:
+            to_bearer.append((offer, held))
+
+    if len(sections) > 1:
+        problems.append(
+            f"the offers name {len(sections)} different menus — expected one"
+        )
+    section = live_offers[0][0].offers_choice.from_section
+    if section is None:
+        problems.append("the offer names no menu — expected the archetype list")
+        old_rows = []
+    else:
+        # Live entries of live archetypes only: an archived row on the
+        # menu is content somebody retired, and a conversion must not
+        # resurrect it as a pickable.
+        old_rows = sorted(
+            (
+                entry.archetype
+                for entry in section.collection.entries.filter(
+                    archetype__isnull=False,
+                    archetype__archived=False,
+                    archived=False,
+                ).select_related("archetype")
+            ),
+            key=lambda row: row.name,
+        )
+        if not old_rows:
+            problems.append("the menu offers no archetypes to convert")
+
+    twice = duplicate_names(old_rows)
+    if twice:
+        problems.append("more than one live archetype is called: " + ", ".join(twice))
+
+    # The names the steps would create must be free in the default pack,
+    # under the qualifier they will wear — a collision would turn a
+    # valid-looking plan into a mid-apply integrity error.
+    taken = Pickable.objects.filter(
+        pack_id=pack,
+        qualifier=QUALIFIER,
+        name__in=[row.name for row in old_rows],
+    ).values_list("name", flat=True)
+    if taken:
+        problems.append(
+            "pickables already wear these names and qualifier: "
+            + ", ".join(sorted(taken))
+        )
+    if Picklist.objects.filter(pack_id=pack, name=PICKLIST).exists():
+        problems.append(f"a picklist named “{PICKLIST}” already stands")
+    for name in (GANG_SLOT, OWN_SLOT):
+        if Slot.objects.filter(pack_id=pack, name=name).exists():
+            problems.append(f"a slot named “{name}” already stands")
+
+    # Only live answers move. An archived pick is history nothing draws,
+    # and with no old row being deleted there is nothing to make it
+    # follow.
+    becoming = {row.pk: row.name for row in old_rows}
+    picks = list(
+        Assignment.objects.filter(archetype__in=list(becoming), archived=False)
+        .exclude(removes=True)
+        .select_related("archetype", "gang_root", "caused_by")
+        .order_by("created")
+    )
+    answers, spares = one_answer_per_question(picks)
+
+    # Which slot each pick settles, by the profile its anchor names —
+    # the same profile that carries the offer it answered.
+    gang_profiles = {row.pk for _, held in to_gang for _, row in held}
+    own_profiles = {row.pk for _, held in to_bearer for _, row in held}
+    pick_slots = {}
+    for pick in answers:
+        if pick.caused_by_id is None:
+            problems.append(f"pick {pick.pk} has no caused_by to settle against")
+        elif pick.caused_by.profile_id in gang_profiles:
+            pick_slots[pick.pk] = GANG_SLOT
+        elif pick.caused_by.profile_id in own_profiles:
+            pick_slots[pick.pk] = OWN_SLOT
+        else:
+            problems.append(
+                f"pick {pick.pk} is anchored on “{pick.caused_by}”, which "
+                "carries none of these offers"
+            )
+
+    # A live pick of an archetype the menu does not offer, anchored on a
+    # carrying profile, would keep its line and lose its question when
+    # the offer is swapped. Refuse rather than strand it.
+    all_profiles = gang_profiles | own_profiles
+    strays = (
+        Assignment.objects.filter(
+            archetype__isnull=False,
+            archived=False,
+            caused_by__profile__in=all_profiles,
+        )
+        .exclude(removes=True)
+        .exclude(archetype__in=list(becoming))
+        .select_related("archetype")
+    )
+    for stray in strays:
+        problems.append(
+            f"pick {stray.pk} names “{stray.archetype.name}”, which the menu "
+            "does not offer — it would lose its question unanswered"
+        )
+
+    if problems:
+        return Plan(system="archetype", problems=tuple(problems))
+
+    steps = [
+        # Repeats allowed: a Champion may pick what the gang holds, and
+        # ten do. An offer never remarks on a repeat, and converting
+        # must not start.
+        CreateSlotType(name=SLOT_TYPE, plural_name=PLURAL, allows_repeats=True),
+        *[
+            CreatePickable(
+                name=row.name,
+                slot_type=SLOT_TYPE,
+                moved_modifier_ids=tuple(m.pk for m in row.modifiers.all()),
+                moved_from=("library.Archetype", row.pk),
+                qualifier=QUALIFIER,
+            )
+            for row in old_rows
+        ],
+        CreatePicklist(
+            name=PICKLIST,
+            slot_type=SLOT_TYPE,
+            members=tuple(row.name for row in old_rows),
+        ),
+        # The gang's question: asked on the Leader's card, answered on
+        # the gang, and dying with the Leader through the anchor.
+        CreateSlot(
+            name=GANG_SLOT,
+            slot_type=SLOT_TYPE,
+            picklist=PICKLIST,
+            assigned_to="gang",
+            min_picks=0,
+        ),
+        # The Champion's own, which the cards call the same thing.
+        CreateSlot(
+            name=OWN_SLOT,
+            slot_type=SLOT_TYPE,
+            picklist=PICKLIST,
+            label=OFFER_LABEL,
+            assigned_to="bearer",
+            min_picks=0,
+        ),
+    ]
+    for offer, held in sorted(live_offers, key=lambda pair: pair[0].name):
+        profile = held[0][1]
+        slot = GANG_SLOT if profile.pk in gang_profiles else OWN_SLOT
+        steps.append(
+            SwapCarrier(
+                carrier=("library.Profile", profile.pk),
+                carrier_name=f"the “{profile.name}” profile",
+                drop_modifier_id=offer.pk,
+                drop_modifier_name=offer.name,
+                grant_name=(
+                    f"{profile.name}: "
+                    + (
+                        "the gang is asked its Archetype"
+                        if slot == GANG_SLOT
+                        else "the model is asked its Archetype"
+                    )
+                ),
+                slot=slot,
+                reach="model",
+            )
+        )
+    steps += [
+        RewritePick(
+            assignment_id=pick.pk,
+            old_column="archetype",
+            pickable=becoming[pick.archetype_id],
+            slot=pick_slots[pick.pk],
+            gang=str(pick.gang_root),
+        )
+        for pick in answers
+    ]
+
+    # Every gang the change reaches: one holding a fighter of any
+    # carrying profile, answered or not.
+    holders = set(
+        Assignment.objects.filter(archived=False, profile__in=all_profiles)
+        .exclude(removes=True)
+        .values_list("gang_root_id", flat=True)
+        .distinct()
+    )
+    answered = {pick.gang_root_id for pick in answers}
+    holders |= answered
+
+    # The shapes worth proving: a gang asked twice over (two Leaders), a
+    # Champion holding what the gang holds, a gang that never answered,
+    # and ordinary ones.
+    asked_twice, matching = [], []
+    gang_choice = {}
+    for pick in answers:
+        if pick_slots[pick.pk] == GANG_SLOT:
+            if pick.gang_root_id in gang_choice:
+                asked_twice.append(pick.gang_root_id)
+            gang_choice[pick.gang_root_id] = pick.archetype_id
+    for pick in answers:
+        if (
+            pick_slots[pick.pk] == OWN_SLOT
+            and gang_choice.get(pick.gang_root_id) == pick.archetype_id
+        ):
+            matching.append(pick.gang_root_id)
+
+    proven = spread(
+        holders,
+        [
+            [pick.gang_root_id for pick in spares],
+            sorted(asked_twice, key=str),
+            sorted(matching, key=str),
+            sorted(holders - answered, key=str),
+            sorted(answered, key=str),
+        ],
+        PROVEN,
+    )
+    return Plan(
+        system="archetype",
+        steps=tuple(steps),
+        gang_ids=tuple(proven),
+        reaches=len(holders),
+        left_alone=len(spares),
+    )

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -202,12 +202,19 @@ class CreatePickable:
     #: whose whole payload is the link itself: a chosen-mode placement
     #: reads the chosen thing's ``category`` and nothing else.
     linked: tuple = ()
+    #: What tells this one apart from another pickable of the same name
+    #: — author-facing only, and never drawn for a player. A name is
+    #: unique per pack and qualifier, so a system whose names are
+    #: already spoken for by another slot type's pickables converts by
+    #: qualifying its own.
+    qualifier: str = ""
 
     def say(self):
         n = len(self.moved_modifier_ids)
         moved = f", moving {n} modifier{'' if n == 1 else 's'}" if n else ""
         linked = f", linked to category “{self.linked[1]}”" if self.linked else ""
-        return f"create pickable “{self.name}” ({self.slot_type}){moved}{linked}"
+        told = f", told apart as “{self.qualifier}”" if self.qualifier else ""
+        return f"create pickable “{self.name}” ({self.slot_type}){moved}{linked}{told}"
 
     def perform(self, made):
         from django.apps import apps
@@ -217,7 +224,10 @@ class CreatePickable:
 
         linking = {"category_id": self.linked[0]} if self.linked else {}
         pickable = create_pickable(
-            self.name, made.slot_types[self.slot_type], **linking
+            self.name,
+            made.slot_types[self.slot_type],
+            qualifier=self.qualifier,
+            **linking,
         )
         if self.moved_modifier_ids:
             app_label, model_name = self.moved_from[0].split(".")

--- a/n26/library/conversion/gang_legacy.py
+++ b/n26/library/conversion/gang_legacy.py
@@ -99,7 +99,9 @@ def plan_gang_legacy():
     # Scoped to the default pack, where this builds: a custom pack's
     # own slot type of the same name is somebody's content, not a
     # collision.
-    if SlotType.objects.filter(name=SLOT_TYPE, pack_id=default_pack_id()).exists():
+    if SlotType.objects.filter(
+        name__iexact=SLOT_TYPE, pack_id=default_pack_id()
+    ).exists():
         problems.append(
             f"a slot type named “{SLOT_TYPE}” already stands — retire the "
             "pilot first (the console offers it)"
@@ -144,18 +146,27 @@ def plan_gang_legacy():
     # The names the steps would create must be free in the default pack
     # — a survivor of the pilot, or anything else wearing one, would
     # turn a valid-looking plan into a mid-apply integrity error.
+    from django.db.models.functions import Lower
+
     from n26.library.models import Pickable, Picklist, Slot
 
-    taken = Pickable.objects.filter(
-        pack_id=default_pack_id(), name__in=[row.name for row in old_rows]
-    ).values_list("name", flat=True)
+    wanted = {row.name.lower() for row in old_rows}
+    taken = [
+        name
+        for name in Pickable.objects.filter(pack_id=default_pack_id())
+        .annotate(folded=Lower("name"))
+        .filter(folded__in=wanted)
+        .values_list("name", flat=True)
+    ]
     if taken:
         problems.append(
             "pickables already wear these names: " + ", ".join(sorted(taken))
         )
-    if Picklist.objects.filter(pack_id=default_pack_id(), name=PICKLIST).exists():
+    if Picklist.objects.filter(
+        pack_id=default_pack_id(), name__iexact=PICKLIST
+    ).exists():
         problems.append(f"a picklist named “{PICKLIST}” already stands")
-    if Slot.objects.filter(pack_id=default_pack_id(), name=SLOT).exists():
+    if Slot.objects.filter(pack_id=default_pack_id(), name__iexact=SLOT).exists():
         problems.append(f"a slot named “{SLOT}” already stands")
 
     # No granted-carrier check here: a profile is never granted by a

--- a/n26/library/conversion/paths.py
+++ b/n26/library/conversion/paths.py
@@ -102,7 +102,7 @@ def plan_paths():
     # PROTECT the retirement. The same rewrite keeps the history coherent.
     picks = list(
         Assignment.objects.filter(affiliation__in=old_paths)
-        .select_related("affiliation", "gang_root")
+        .select_related("affiliation", "gang_root", "caused_by")
         .order_by("created")
     )
     unanchored = [str(pick.pk) for pick in picks if pick.caused_by_id is None]

--- a/n26/library/conversion/paths.py
+++ b/n26/library/conversion/paths.py
@@ -110,6 +110,19 @@ def plan_paths():
         problems.append(
             "picks with no caused_by to settle against: " + ", ".join(unanchored)
         )
+    # A pick hanging from anything but the carrier answers a question
+    # this slot does not ask: rewritten, it would name the slot while
+    # nothing drew it as that slot's answer. Refuse it by name — the
+    # plan knows, and saying so beats leaving it to the page proof.
+    strays = [
+        str(pick.pk)
+        for pick in picks
+        if pick.caused_by_id is not None and pick.caused_by.hidden_id != carrier.pk
+    ]
+    if strays:
+        problems.append(
+            "picks anchored on something other than the carrier: " + ", ".join(strays)
+        )
 
     if problems:
         return Plan(system="paths", problems=tuple(problems))

--- a/n26/library/gang_legacy_pilot.py
+++ b/n26/library/gang_legacy_pilot.py
@@ -83,7 +83,7 @@ def find():
     # custom pack's own slot type of this name is somebody's content,
     # never the pilot.
     slot_type = SlotType.objects.filter(
-        name=SLOT_TYPE, pack_id=default_pack_id()
+        name__iexact=SLOT_TYPE, pack_id=default_pack_id()
     ).first()
     if slot_type is None:
         return Pilot(nothing_here=True)

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "Operation",
+    "convert_archetype",
     "convert_gang_legacy",
     "convert_skill_tree",
     "convert_specialisation",
@@ -98,6 +99,10 @@ class Operation(models.TextChoices):
         "n26_retire_gang_legacy_pilot",
         "n26: the gang legacy slot pilot retires",
     )
+    CONVERT_ARCHETYPE = (
+        "n26_convert_archetype",
+        "n26: the Outcast archetypes become picks",
+    )
     MERGE_WARGEAR_INTO_WEAPON = (
         "n26_merge_wargear_into_weapon",
         "n26: duplicated wargear becomes its weapon",
@@ -110,6 +115,7 @@ LOCK_KEYS = {
     Operation.CONVERT_SKILL_TREE: 826_020_602,
     Operation.CONVERT_GANG_LEGACY: 826_020_603,
     Operation.RETIRE_GANG_LEGACY_PILOT: 826_020_604,
+    Operation.CONVERT_ARCHETYPE: 826_020_605,
 }
 
 
@@ -321,6 +327,17 @@ def convert_gang_legacy(backfill_id, **said_by_whoever_enqueued_it):
 
 
 @task
+def convert_archetype(backfill_id, **said_by_whoever_enqueued_it):
+    """The Archetype conversion, as a task — see ``_run_conversion``."""
+    _run_conversion(
+        backfill_id,
+        Operation.CONVERT_ARCHETYPE,
+        "archetype",
+        **said_by_whoever_enqueued_it,
+    )
+
+
+@task
 def retire_gang_legacy_pilot(backfill_id, **said_by_whoever_enqueued_it):
     """Retire the Gang Legacy slot pilot, once, and write down the outcome.
 
@@ -428,6 +445,15 @@ def convert_gang_legacy_view(request):
         Operation.CONVERT_GANG_LEGACY,
         "gang_legacy",
         convert_gang_legacy,
+    )
+
+
+def convert_archetype_view(request):
+    return _conversion_view(
+        request,
+        Operation.CONVERT_ARCHETYPE,
+        "archetype",
+        convert_archetype,
     )
 
 
@@ -542,6 +568,23 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.CONVERT_ARCHETYPE.value,
+        name=Operation.CONVERT_ARCHETYPE.label,
+        description=(
+            "Move the Outcast archetypes onto slots and picks: each Leader "
+            "profile grants the gang's Archetype slot and the Champion "
+            "profile grants its own, instead of offering a choice, and "
+            "every stored choice is re-said as a pick. What an archetype "
+            "does travels with it untouched. Proves every affected gang's "
+            "pages read the same, or writes nothing."
+        ),
+        view=convert_archetype_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a conversion holds one
 #: transaction for as long as proving its spread of gangs takes. It is also
@@ -555,6 +598,7 @@ task_routes = [
     TaskRoute(convert_skill_tree, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_gang_legacy, ack_deadline=600, min_retry_delay=60),
     TaskRoute(retire_gang_legacy_pilot, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(convert_archetype, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/tests/sandbox/test_conversion_archetype.py
+++ b/n26/tests/sandbox/test_conversion_archetype.py
@@ -492,6 +492,28 @@ class TestTheRefusals:
         assert not plan.ok
         assert any("already wear these names" in p for p in plan.problems)
 
+    def test_a_differently_cased_collision_is_refused_in_words(self, world):
+        """The name constraint folds case, so the check must too: an
+        exact-match look would call “brawler” free and let the collision
+        arrive as a database error where a sentence was promised."""
+        from n26.tests.sandbox.actions import create_pickable
+
+        other = create_slot_type("Something Else")
+        create_pickable("brawler", other, qualifier="archetype")
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("already wear these names" in p for p in plan.problems)
+
+    def test_a_differently_cased_slot_type_is_refused(self, world):
+        create_slot_type("ARCHETYPE")
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("already stands" in problem for problem in plan.problems)
+
     def test_a_shared_offer_is_refused(self, world, prod_shape):
         """Every offer here is one profile's own; a shared one is a
         different shape and needs a different step."""
@@ -509,6 +531,26 @@ class TestTheRefusals:
 
         assert not plan.ok
         assert any("expected one profile" in p for p in plan.problems)
+
+    def test_a_profile_asking_both_questions_is_refused(self, world, prod_shape):
+        """A profile carrying both offers asks two questions no anchor
+        tells apart, so its picks could settle on either slot."""
+        from n26.library.authoring import attach_modifiers_to
+
+        _, _, leaders, champion, _, _ = prod_shape
+        champion_offer = next(
+            m
+            for m in champion.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(leaders[0], [champion_offer])
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("cannot be told apart" in p for p in plan.problems) or any(
+            "expected one profile" in p for p in plan.problems
+        )
 
     def test_an_off_menu_pick_is_refused(self, world, prod_shape):
         _, _, leaders, _, _, _ = prod_shape

--- a/n26/tests/sandbox/test_conversion_archetype.py
+++ b/n26/tests/sandbox/test_conversion_archetype.py
@@ -1,0 +1,565 @@
+"""The Archetype conversion, proven on a prod-shaped world.
+
+The Outcast shape, and the last system on the column: four Leader
+profiles each offering the gang's archetype, a Champion profile
+offering its own, and archetype tokens carrying their whole printed
+tables — rank placements for everyone the gang's pick reaches, and
+bearer-only rows for a Champion who picked personally.
+
+What this suite is really for is the four behaviours the tables carry.
+They ride the modifiers, so moving those wholesale should preserve
+them — "should" being the word a test exists to remove:
+
+* the gang's archetype reaches Leaders and Hive Scum, never Champions;
+* a Champion's own pick reaches that Champion alone;
+* the gang's archetype dies with the Leader who was asked;
+* a Champion may hold what the gang holds, and nothing remarks on it.
+"""
+
+import pytest
+
+from n26.core.browse import placements_for
+from n26.core.capture import differences, gang_state
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.conversion import apply, plan_archetype
+from n26.library.models import Archetype, Pickable, Slot
+from n26.tests.sandbox.actions import (
+    choose,
+    create_archetype,
+    create_category,
+    create_collection,
+    create_default_set,
+    create_gang_type,
+    create_profile,
+    create_skill,
+    create_slot_type,
+    create_subtype,
+    found_gang,
+    has_subtypes,
+    hire,
+    modifier,
+    offers_choice,
+    places,
+    remove,
+    section_of,
+    targets_every_model,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+#: Who each archetype's rank rows reach, and what they place. The
+#: Champion row is the bearer-only one: what a Champion gets from
+#: picking this personally, inert in the gang's radiated copy.
+TABLES = {
+    "Brawler": {"leader": "Combat", "scum": "Brawn", "own": "Combat"},
+    "Mastermind": {"leader": "Cunning", "scum": "Savant", "own": "Cunning"},
+    "Wyrd": {"leader": "Savant", "scum": "Cunning", "own": "Savant"},
+}
+
+
+@pytest.fixture
+def prod_shape(default_pack, person_type):
+    return build_prod_shape(person_type)
+
+
+@pytest.fixture
+def world(prod_shape, owner):
+    return build_world(prod_shape, owner)
+
+
+def build_prod_shape(person_type):
+    """The system as production holds it: four Leader profiles each
+    with their own gang-landing offer, a Champion profile with its own
+    bearer-landing one, and the archetype tables as modifiers."""
+    sets = {
+        name: create_category("Skills", name, position)
+        for position, name in enumerate(["Brawn", "Combat", "Cunning", "Savant"])
+    }
+    for name, category in sets.items():
+        create_skill(f"{name} Trick", category=category)
+    collection = create_collection("Skills & Powers")
+    tiers = {
+        "primary": section_of(collection, "Primary", 0),
+        "other": section_of(collection, "Other", 1, is_default=True),
+    }
+    subtypes = {
+        "leader": create_subtype("Outcast Leader"),
+        "champion": create_subtype("Outcast Champion"),
+        "scum": create_subtype("Hive Scum"),
+    }
+
+    tokens = {}
+    for name, table in TABLES.items():
+        token = create_archetype(name)
+        modifier(
+            f"{name}: Leader models — {table['leader']} is Primary",
+            targets_every_model(has_subtypes(subtypes["leader"])),
+            places(sets[table["leader"]], tiers["primary"]),
+            carried_by=token,
+        )
+        modifier(
+            f"{name}: Hive Scum — {table['scum']} is Primary",
+            targets_every_model(has_subtypes(subtypes["scum"])),
+            places(sets[table["scum"]], tiers["primary"]),
+            carried_by=token,
+        )
+        # The bearer-only row: what a Champion gets by picking this
+        # themselves. Never reached through the gang's radiated copy.
+        modifier(
+            f"{name}: Champion (own pick) — {table['own']} is Primary",
+            targets_model(),
+            places(sets[table["own"]], tiers["primary"]),
+            carried_by=token,
+        )
+        tokens[name] = token
+
+    menu = create_collection("Outcast Archetypes", entries=list(tokens.values()))
+    section = section_of(menu, "Archetypes", 0, is_default=True)
+
+    gang_type = create_gang_type("Outcast", starting_credits=2000)
+    leaders = []
+    for n in (1, 2):
+        profile = create_profile(f"Leader {n}", person_type, gang_type, price=135)
+        profile.built_ins = create_default_set(
+            f"Leader {n} kit", members=[subtypes["leader"]]
+        )
+        profile.save()
+        modifier(
+            f"Leader {n}: chooses the gang's Archetype",
+            targets_model(),
+            offers_choice(
+                Archetype,
+                from_section=section,
+                label="Archetype",
+                will_be_assigned_to="gang",
+            ),
+            carried_by=profile,
+        )
+        leaders.append(profile)
+
+    champion = create_profile("Champion", person_type, gang_type, price=95)
+    champion.built_ins = create_default_set(
+        "Champion kit", members=[subtypes["champion"]]
+    )
+    champion.save()
+    modifier(
+        "Champion: chooses an Archetype",
+        targets_model(),
+        offers_choice(Archetype, from_section=section, label="Archetype"),
+        carried_by=champion,
+    )
+
+    scum = create_profile("Hive Scum", person_type, gang_type, price=40)
+    scum.built_ins = create_default_set("Scum kit", members=[subtypes["scum"]])
+    scum.save()
+
+    return gang_type, tokens, leaders, champion, scum, (collection, tiers, sets)
+
+
+def build_world(prod_shape, owner):
+    """Four gangs: one answered throughout with a Champion who chose
+    differently, one whose Champion matches the gang, one asked twice
+    over (two Leaders), and one that never answered."""
+    gang_type, tokens, leaders, champion, scum, _ = prod_shape
+
+    gangs = {
+        "answered": found_gang("The Cast Out", gang_type, owner=owner, budget=2000),
+        "matching": found_gang("The Echoes", gang_type, owner=owner, budget=2000),
+        "twice": found_gang("The Two Crowns", gang_type, owner=owner, budget=2000),
+        "quiet": found_gang("The Unspoken", gang_type, owner=owner, budget=2000),
+    }
+    fighters = {
+        "leader": hire(gangs["answered"], leaders[0], "Grim", paid=135),
+        "champion": hire(gangs["answered"], champion, "Vex", paid=95),
+        "scum": hire(gangs["answered"], scum, "Nub", paid=40),
+        "match_leader": hire(gangs["matching"], leaders[0], "Karn", paid=135),
+        "match_champion": hire(gangs["matching"], champion, "Sable", paid=95),
+        "first_leader": hire(gangs["twice"], leaders[0], "Ash", paid=135),
+        "second_leader": hire(gangs["twice"], leaders[1], "Bram", paid=135),
+        "quiet_leader": hire(gangs["quiet"], leaders[0], "Mute", paid=135),
+    }
+
+    def line(fighter, profile):
+        return Assignment.objects.get(profile=profile, miniature_root=fighter)
+
+    # The answered gang: a re-choice leaving an archived answer behind,
+    # and a Champion who chose differently from the gang.
+    choose(line(fighters["leader"], leaders[0]), tokens["Brawler"])
+    remove(
+        Assignment.objects.get(
+            archetype=tokens["Brawler"], gang=gangs["answered"], archived=False
+        )
+    )
+    choose(line(fighters["leader"], leaders[0]), tokens["Mastermind"])
+    choose(line(fighters["champion"], champion), tokens["Wyrd"])
+
+    # The matching gang: the Champion holds what the gang holds.
+    choose(line(fighters["match_leader"], leaders[0]), tokens["Brawler"])
+    choose(line(fighters["match_champion"], champion), tokens["Brawler"])
+
+    # Two Leaders, two questions, two answers on one gang.
+    choose(line(fighters["first_leader"], leaders[0]), tokens["Brawler"])
+    choose(line(fighters["second_leader"], leaders[1]), tokens["Wyrd"])
+
+    return gangs, fighters
+
+
+class TestThePlan:
+    def test_it_says_everything_it_would_do(self, world):
+        plan = plan_archetype()
+
+        assert plan.ok and not plan.nothing_here
+        said = "\n".join(plan.preview())
+        assert "create slot type “Archetype”" in said
+        assert "refusing repeats" not in said  # a Champion may match the gang
+        assert said.count("create pickable") == 3
+        assert "told apart as “Archetype”" in said
+        assert "create slot “Archetype” drawing on “Archetypes”" in said
+        assert "pick landing on the gang" in said
+        assert "create slot “Archetype (Champion)”" in said
+        assert said.count("replace “Leader") == 2
+        assert "replace “Champion: chooses an Archetype”" in said
+        # Six live answers; the archived re-choice stays where it is.
+        assert said.count("rewrite pick") == 6
+        assert "prove 4 of 4 reached gangs read the same, or refuse" in said
+
+    def test_it_deletes_nothing(self, world):
+        assert "retire" not in "\n".join(plan_archetype().preview())
+
+
+class TestTheApply:
+    def test_every_page_reads_the_same(self, world):
+        gangs, _ = world
+        before = {key: gang_state(g) for key, g in gangs.items()}
+
+        apply(plan_archetype())
+
+        for key, gang in gangs.items():
+            assert differences(before[key], gang_state(gang)) == []
+            assert_reconciled(gang)
+
+    def test_the_gang_pick_still_lands_on_the_gang(self, world):
+        gangs, _ = world
+
+        apply(plan_archetype())
+
+        pick = Assignment.objects.get(
+            gang=gangs["answered"], pickable__isnull=False, archived=False
+        )
+        assert pick.pickable.name == "Mastermind"
+        assert pick.archetype_id is None
+        assert pick.chosen_for_slot == Slot.objects.get(name="Archetype")
+        assert pick.miniature_id is None
+
+    def test_the_champion_pick_still_lands_on_the_champion(self, world):
+        _, fighters = world
+
+        apply(plan_archetype())
+
+        pick = Assignment.objects.get(
+            miniature=fighters["champion"], pickable__isnull=False, archived=False
+        )
+        assert pick.pickable.name == "Wyrd"
+        assert pick.chosen_for_slot == Slot.objects.get(name="Archetype (Champion)")
+
+    def test_the_archived_answer_stays_as_it_was(self, world):
+        gangs, _ = world
+
+        apply(plan_archetype())
+
+        archived = Assignment.objects.get(
+            gang=gangs["answered"], archived=True, archetype__isnull=False
+        )
+        assert archived.archetype.name == "Brawler"
+        assert archived.pickable_id is None
+
+
+class TestTheBehaviourThatMustSurvive:
+    """The four things the printed tables do, asserted per fighter
+    before and after. These ride the modifiers rather than the
+    conversion, which is the claim being tested."""
+
+    def test_the_gangs_archetype_reaches_everyone_except_champions(
+        self, world, prod_shape
+    ):
+        _, _, _, _, _, (collection, _, _) = prod_shape
+        _, fighters = world
+        before = {
+            who: _tiers(fighters[who], collection)
+            for who in ("leader", "champion", "scum")
+        }
+        # The gang chose Mastermind: its Leader row places Cunning, its
+        # Hive Scum row places Savant, and no row of it names Champions
+        # — the Champion's Savant comes from their own Wyrd pick.
+        assert before["leader"] == {"Cunning": "Primary"}
+        assert before["scum"] == {"Savant": "Primary"}
+
+        apply(plan_archetype())
+
+        for who, was in before.items():
+            assert _tiers(fighters[who], collection) == was
+
+    def test_a_champions_own_pick_reaches_that_champion_alone(self, world, prod_shape):
+        """Wyrd's bearer-only row places Savant for the Champion who
+        picked it; nobody else in the gang reads it."""
+        _, _, _, _, _, (collection, _, _) = prod_shape
+        _, fighters = world
+        before = _tiers(fighters["champion"], collection)
+        assert before == {"Savant": "Primary"}
+
+        apply(plan_archetype())
+
+        assert _tiers(fighters["champion"], collection) == before
+        # The gang's own pick is Mastermind; the Champion's Wyrd reaches
+        # nobody else, so the Hive Scum still reads the gang's table.
+        assert _tiers(fighters["scum"], collection) == {"Savant": "Primary"}
+        assert _tiers(fighters["leader"], collection) == {"Cunning": "Primary"}
+
+    def test_the_gangs_archetype_dies_with_the_leader(self, world, prod_shape):
+        """The pick hangs from the Leader's own line, so removing the
+        Leader takes the gang's archetype with it — the whole reason
+        the answer is anchored where it is."""
+        gang_type, tokens, leaders, _, _, _ = prod_shape
+        gangs, fighters = world
+        apply(plan_archetype())
+        assert Assignment.objects.filter(
+            gang=gangs["answered"], pickable__isnull=False, archived=False
+        ).exists()
+
+        remove(
+            Assignment.objects.get(
+                profile=leaders[0], miniature_root=fighters["leader"]
+            )
+        )
+
+        assert not Assignment.objects.filter(
+            gang=gangs["answered"], pickable__isnull=False, archived=False
+        ).exists()
+        gangs["answered"].refresh_from_db()
+        assert_reconciled(gangs["answered"])
+
+    def test_a_champion_may_hold_what_the_gang_holds_silently(self, world):
+        """Ten do in production. An offer never remarks on a repeat, and
+        the slot type allowing them is what keeps that silence."""
+        gangs, _ = world
+        before = gang_state(gangs["matching"])
+        assert before["notes"] == []
+
+        apply(plan_archetype())
+
+        after = gang_state(gangs["matching"])
+        assert differences(before, after) == []
+        assert after["notes"] == []
+
+    def test_a_gang_asked_twice_keeps_both_answers(self, world):
+        gangs, _ = world
+        before = gang_state(gangs["twice"])
+
+        apply(plan_archetype())
+
+        assert differences(before, gang_state(gangs["twice"])) == []
+        held = Assignment.objects.filter(
+            gang=gangs["twice"], pickable__isnull=False, archived=False
+        )
+        assert sorted(p.pickable.name for p in held) == ["Brawler", "Wyrd"]
+
+
+class TestTheGangSheetShowsWhatTheGangHolds:
+    """A pick answering a question asked of somebody else would
+    otherwise appear on no card at all: drawn as its choice's answer,
+    on a card that draws no such choice. The gang's archetype is the
+    first system with that shape, and the sheet must still list it."""
+
+    def test_the_gang_sheet_lists_the_archetype_before_and_after(self, world):
+        gangs, _ = world
+        before = gang_state(gangs["answered"])
+        assert "Mastermind" in before["rows"]
+
+        apply(plan_archetype())
+
+        assert "Mastermind" in gang_state(gangs["answered"])["rows"]
+
+    def test_a_pick_its_own_card_asks_about_draws_no_line_of_its_own(
+        self, world, prod_shape
+    ):
+        """The ordinary shape is untouched: where the question is asked
+        on the same card as the answer, the pick is still drawn under
+        the choice row and nowhere else."""
+        _, fighters = world
+
+        apply(plan_archetype())
+
+        card = gang_state(fighters["champion"].gang)["models"][
+            str(fighters["champion"].pk)
+        ]
+        assert ("Archetype", "Wyrd") in card["choices"]
+        # Drawn as the choice's answer and nowhere else: not among the
+        # kit, the rules, or anything else the card lists.
+        assert not any(
+            "Wyrd" in str(value)
+            for key, value in card.items()
+            if key not in {"choices", "remarks"}
+        )
+
+
+class TestTheStory:
+    def test_the_words_already_written_do_not_move(self, world):
+        from n26.core import history
+        from n26.core.history import _kindword
+
+        gangs, _ = world
+        said = _story(history.build(gangs["answered"]))
+
+        apply(plan_archetype())
+
+        assert _story(history.build(gangs["answered"])) == said
+        pick = Assignment.objects.filter(
+            gang=gangs["answered"], pickable__isnull=False
+        ).first()
+        # The slot type wears the kind's own name, so the word a pick
+        # answers to is the word it always had.
+        assert _kindword(pick) == "archetype"
+
+
+class TestRechoosing:
+    def test_both_slots_answer_again_on_the_new_machinery(self, world, prod_shape):
+        gang_type, tokens, leaders, champion, _, _ = prod_shape
+        gangs, fighters = world
+        apply(plan_archetype())
+
+        remove(
+            Assignment.objects.get(gang=gangs["answered"], pickable__name="Mastermind")
+        )
+        choose(
+            Assignment.objects.get(
+                profile=leaders[0], miniature_root=fighters["leader"]
+            ),
+            Pickable.objects.get(name="Wyrd"),
+            slot=Slot.objects.get(name="Archetype"),
+        )
+        remove(
+            Assignment.objects.get(
+                miniature=fighters["champion"], pickable__name="Wyrd"
+            )
+        )
+        choose(
+            Assignment.objects.get(
+                profile=champion, miniature_root=fighters["champion"]
+            ),
+            Pickable.objects.get(name="Brawler"),
+            slot=Slot.objects.get(name="Archetype (Champion)"),
+        )
+
+        state = gang_state(gangs["answered"])
+        # The gang holds the answer, so its sheet lists it; the question
+        # itself is asked on the Leader's card, where the offer used to
+        # be, and that card shows the choice row.
+        assert "Wyrd" in state["rows"]
+        leader_card = state["models"][str(fighters["leader"].pk)]
+        assert ("Archetype", "Wyrd") in leader_card["choices"]
+        card = state["models"][str(fighters["champion"].pk)]
+        assert ("Archetype", "Brawler") in card["choices"]
+        gangs["answered"].refresh_from_db()
+        assert_reconciled(gangs["answered"])
+
+    def test_a_second_run_is_a_clean_no_op(self, world):
+        apply(plan_archetype())
+
+        assert plan_archetype().nothing_here
+
+
+class TestTheRefusals:
+    def test_a_standing_slot_type_is_refused(self, world):
+        create_slot_type("Archetype")
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("already stands" in problem for problem in plan.problems)
+
+    def test_a_colliding_pickable_is_refused(self, world):
+        """The qualifier is what clears the way; one wearing it too is
+        a collision the plan must name rather than crash on."""
+        from n26.tests.sandbox.actions import create_pickable
+
+        other = create_slot_type("Something Else")
+        create_pickable("Brawler", other, qualifier="Archetype")
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("already wear these names" in p for p in plan.problems)
+
+    def test_a_shared_offer_is_refused(self, world, prod_shape):
+        """Every offer here is one profile's own; a shared one is a
+        different shape and needs a different step."""
+        from n26.library.authoring import attach_modifiers_to
+
+        _, _, leaders, _, scum, _ = prod_shape
+        offer = next(
+            m
+            for m in leaders[0].modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(scum, [offer])
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("expected one profile" in p for p in plan.problems)
+
+    def test_an_off_menu_pick_is_refused(self, world, prod_shape):
+        _, _, leaders, _, _, _ = prod_shape
+        gangs, fighters = world
+        offmenu = create_archetype("Something Else Entirely")
+        line = Assignment.objects.get(
+            profile=leaders[0], miniature_root=fighters["quiet_leader"]
+        )
+        Assignment.objects.create(
+            archetype=offmenu,
+            gang=gangs["quiet"],
+            caused_by=line,
+            chosen_for=line,
+            gang_root=gangs["quiet"],
+        )
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("the menu does not offer" in p for p in plan.problems)
+
+    def test_an_archived_archetype_is_not_resurrected(self, world, prod_shape):
+        _, tokens, _, _, _, _ = prod_shape
+        tokens["Wyrd"].archived = True
+        tokens["Wyrd"].save()
+
+        plan = plan_archetype()
+
+        assert not plan.ok
+        assert any("Wyrd" in problem for problem in plan.problems)
+
+
+def _tiers(miniature, collection):
+    """``{category name: tier}`` as this fighter's sections sit."""
+    from n26.core.card import build_card, build_modifier_index
+    from n26.core.effects import compute
+
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    placed = placements_for(compute(card, index), collection)
+    return {
+        category.name: where.section.name
+        for category, where in placed.items()
+        if where.section.name != "Other"
+    }
+
+
+def _story(acts):
+    """Every word a gang's history page puts on the screen."""
+    told = []
+    for act in acts:
+        told.append("".join(span.text for span in act.spans))
+        told.extend(f"{sub.name}|{sub.kind}|{sub.note}" for sub in act.subs)
+    return told

--- a/n26/tests/sandbox/test_conversion_paths.py
+++ b/n26/tests/sandbox/test_conversion_paths.py
@@ -204,12 +204,12 @@ class TestTheRefusals:
             apply(plan)
         assert not SlotType.objects.filter(name="Path").exists()
 
-    def test_a_pick_anchored_on_the_wrong_row_refuses_and_unwinds(
+    def test_a_pick_anchored_on_the_wrong_row_is_refused(
         self, gangs, prod_shape, owner
     ):
-        """The safety net proves itself: a hand-made pick whose cause is
-        not the offer's carrier would stop reading as chosen after the
-        rewrite — the apply sees the page change and unwinds everything."""
+        """A hand-made pick whose cause is not the offer's carrier
+        answers a question this slot does not ask. The plan names it and
+        refuses; nothing is written."""
         from n26.tests.sandbox.actions import assign
 
         gang_type, carrier, paths = prod_shape
@@ -220,9 +220,12 @@ class TestTheRefusals:
         )
         stray.save()
 
-        with pytest.raises(ConversionRefused, match="pages would change"):
-            apply(plan_paths())
+        plan = plan_paths()
 
+        assert not plan.ok
+        assert any("other than the carrier" in problem for problem in plan.problems)
+        with pytest.raises(ConversionRefused):
+            apply(plan)
         assert not SlotType.objects.filter(name="Path").exists()
         stray.refresh_from_db()
         assert stray.affiliation == paths["Path of the Fanatic"]

--- a/n26/tests/sandbox/test_conversion_paths.py
+++ b/n26/tests/sandbox/test_conversion_paths.py
@@ -230,6 +230,42 @@ class TestTheRefusals:
         stray.refresh_from_db()
         assert stray.affiliation == paths["Path of the Fanatic"]
 
+    def test_a_page_that_would_change_unwinds_the_whole_run(
+        self, gangs, prod_shape, monkeypatch
+    ):
+        """The last safety net, and the one every conversion leans on:
+        whatever the plan believed, a page that reads differently after
+        the steps have run ends the whole thing. Proven by making a step
+        do something the plan never said — the only way to reach a net
+        that exists for what nobody predicted."""
+        from n26.library.conversion import base
+
+        gang_type, carrier, paths = prod_shape
+        settled, _ = gangs
+        real_perform = base.RewritePick.perform
+
+        def and_something_else(self, made):
+            real_perform(self, made)
+            # A rule the gang never had: nothing in the plan says this,
+            # so the pages part company and the run must unwind.
+            from n26.tests.sandbox.actions import assign, create_rule
+
+            if not getattr(and_something_else, "done", False):
+                and_something_else.done = True
+                assign(create_rule("Uninvited"), gang=settled)
+
+        monkeypatch.setattr(base.RewritePick, "perform", and_something_else)
+
+        with pytest.raises(ConversionRefused, match="pages would change"):
+            apply(plan_paths())
+
+        # Unwound whole: no slot type, no stray rule, every pick as it was.
+        assert not SlotType.objects.filter(name="Path").exists()
+        assert not Assignment.objects.filter(rule__name="Uninvited").exists()
+        assert Assignment.objects.filter(
+            affiliation__name="Path of the Pious", gang=settled
+        ).exists()
+
     def test_a_shared_offer_is_a_problem_not_a_silent_detach(
         self, gangs, prod_shape, default_pack
     ):

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -555,6 +555,40 @@ class TestAHiddenChoice:
 
         assert drawn.remarks == []
 
+    def test_a_hand_made_pick_draws_no_line_either(
+        self, gang, bundled, houses, legacy, legacies
+    ):
+        """Answered outright rather than by a starting pick, which is
+        the other way into a hidden choice. Hidden means the card says
+        nothing, however the answer arrived — so the pick draws no line
+        of its own, and its holder shows only what it gives."""
+        from n26.core.models import Assignment
+        from n26.library.models import Slot
+
+        kaustos = hire(gang, bundled, "Kaustos", paid=100)
+        slot = Slot.objects.get(name="Hidden legacy")
+        standing = Assignment.objects.get(
+            miniature_root=kaustos, pickable__isnull=False, archived=False
+        )
+        remove(standing)
+        choose(
+            Assignment.objects.get(profile=bundled, miniature_root=kaustos),
+            houses["Escher"],
+            slot=slot,
+            miniature=kaustos,
+        )
+
+        drawn = drawn_card(kaustos)
+        assert drawn.choices == []
+        assert not any(
+            "Escher" in str(getattr(drawn, field))
+            for field in ("equipment", "rules", "skills", "subtypes")
+        )
+        _, computed = card_of(kaustos)
+        assert [line.name for line in computed.collections] == [
+            "House Escher Equipment List"
+        ]
+
 
 class TestAChoiceTheGangIsAsked:
     """A slot the gang holds is asked once, on the gang's own card. It

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -22,11 +22,18 @@ from n26.core.models import Assignment
 from n26.maintenance import (
     MAX_ATTEMPTS,
     Operation,
+    convert_archetype_view,
     convert_gang_legacy_view,
     convert_skill_tree_view,
     convert_specialisation,
     convert_specialisation_view,
     retire_gang_legacy_pilot_view,
+)
+from n26.tests.sandbox.test_conversion_archetype import (
+    build_prod_shape as build_archetype_shape,
+)
+from n26.tests.sandbox.test_conversion_archetype import (
+    build_world as build_archetype_world,
 )
 from n26.tests.sandbox.test_conversion_gang_legacy import (
     build_prod_shape as build_gang_legacy_shape,
@@ -266,6 +273,51 @@ class TestTheGangLegacyPair:
         ).exclude(removes=True)
         # The doubled click's spare and the other system's pick remain.
         assert left.count() == 2
+
+
+class TestTheArchetypeConversion:
+    """The last conversion the console offers, and the first whose
+    answers live on a different holder from the question."""
+
+    @pytest.fixture
+    def archetype_world(self, person_type, owner, default_pack):
+        shape = build_archetype_shape(person_type)
+        return build_archetype_world(shape, owner)
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.CONVERT_ARCHETYPE.value in registered
+        found = resolve_operation(Operation.CONVERT_ARCHETYPE.value)
+        assert found.name == Operation.CONVERT_ARCHETYPE.label
+        assert found.view is convert_archetype_view
+
+    def test_its_page_shows_the_plan_and_writes_nothing(
+        self, client, superuser, archetype_world
+    ):
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_convert_archetype"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "create slot type “Archetype”" in page
+        assert "pick landing on the gang" in page
+        assert not Backfill.objects.exists()
+
+    def test_applying_records_what_it_did(self, client, superuser, archetype_world):
+        client.force_login(superuser)
+
+        response = client.post(reverse("admin:maintenance_n26_convert_archetype"))
+
+        assert response.status_code == 302
+        run = Backfill.objects.get(operation=Operation.CONVERT_ARCHETYPE)
+        assert run.status == Backfill.Status.DONE
+        assert any("applied" in line for line in run.summary["report"])
+        left = Assignment.objects.filter(
+            archetype__isnull=False, archived=False
+        ).exclude(removes=True)
+        assert left.count() == 0
 
 
 class TestApplying:


### PR DESCRIPTION
The last of the four slots-and-picks conversions, and the last system on the `archetype` column. After this, that column holds nothing live.

## What changes

- **`n26/library/conversion/archetype.py`** — an "Archetype" slot type; the menu's five archetypes as pickables carrying their whole printed tables (moved, not copied); **two slots** — the gang's, which every Leader profile grants and whose answer lands on the gang, and the Champion's own — and every stored choice re-said as a pick on its same anchor. Nothing is deleted.
- **The four behaviours the printed tables carry** ride the modifiers rather than the conversion, and each is now pinned by a test asserting per-fighter placements before and after: the gang's archetype reaches every fighter *except* Champions; a Champion's own pick reaches that Champion alone (the bearer-only rows); the gang's archetype **dies with the Leader** who was asked, through a `caused_by` the conversion never moves; and a Champion may hold what the gang holds silently.
- **Repeats are allowed** here, where the Skill Tree slot type refuses them: ten Champions in production hold their gang's own archetype and the page says nothing about it. An offer never remarks on a repeat, and converting must not start.
- **The pickables wear a qualifier.** `Brawler` and `Gunslinger` already belong to pickables of another slot type, and a name is unique per pack and qualifier — so all five take one, uniformly. A qualifier is author-facing and never reaches a player; the cards go on saying "Brawler". `CreatePickable` learns to set it.
- **The Paths plan gains an anchor check** its two younger siblings already have: a pick hanging from something other than the carrier is refused by name, rather than caught downstream as an incidental page difference.

## The rendering gap this uncovered

A pick is drawn as its choice's answer, and so draws no line of its own — which quietly assumes the choice is drawn on the *same card*. This is the first system where a question asked of one holder is answered onto another (the Leader is asked; the gang holds it), and the gang's own sheet draws no choice row to hang that answer under. Converting would have made each gang's archetype vanish from its sheet — caught by the parity proof, not by inspection.

`n26/core/render.py` now draws a pick that nothing on its card speaks for; a pick with no choice behind it at all still draws nothing (an orphan says nothing about its holder). **On today's data the change is inert** — every pick shipped so far answers a question asked where it lives — and it is pinned both ways by tests.

## How it was proven

- 21 conversion tests + 3 console tests. Full n26 suite: 3771 passed.
- Smoke-rehearsed on a fork of the content mirror at production's measured volume (65 reached gangs, 143 carrier fighters, 103 picks — 41 landing on gangs, 62 on Champions — including a gang asked twice over, ten Champions matching their gang, and an archived re-choice): **applied in 6.5s**, and all 65 gangs verified unchanged from outside the run — pages, every fighter card, history stories, reconcile. Hosts preserved exactly (41 gang-hosted, 62 model-hosted). The Leader-death cascade was then proven on the converted data: removing the Leader took the gang's archetype and left both Champions' own picks standing.

## Running it

After deploy: maintenance console → "n26: the Outcast archetypes become picks" → the page shows the full plan → Apply.

## After it lands

The `archetype` column holds nothing live, and neither do `skill_tree` or `specialisation`. Retiring those columns and their emptied kinds is separate work — and the one place where deleting is the point rather than a hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8