### PR TITLE
chore: the conversion engine drops what no conversion asks for

### DIFF
--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -419,59 +419,6 @@ class SwapSharedCarrier:
 
 
 @dataclass(frozen=True)
-class DropModifier:
-    """A modifier retired outright — for behaviour that is ending, not
-    moving. The plan must have proven the modifier does nothing on any
-    page: either nothing holds its carrier, or the modifier itself is
-    inert wherever the carrier appears."""
-
-    carrier: tuple  # (model label, pk)
-    carrier_name: str
-    modifier_id: object
-    modifier_name: str
-
-    def say(self):
-        return f"on {self.carrier_name}: retire “{self.modifier_name}”"
-
-    def perform(self, made):
-        from django.apps import apps
-
-        from n26.library.models import Modifier
-
-        app_label, model_name = self.carrier[0].split(".")
-        carrier = apps.get_model(app_label, model_name).objects.get(pk=self.carrier[1])
-        dropped = Modifier.objects.get(pk=self.modifier_id)
-        scope_row, effect_row = dropped.scope, dropped.effect
-        carrier.modifiers.remove(dropped)
-        dropped.delete()
-        scope_row.delete()
-        effect_row.delete()
-
-
-@dataclass(frozen=True)
-class RetireModifier:
-    """A modifier nothing carries, deleted with its scope and effect
-    rows. A detached modifier does nothing on any page, but its effect
-    row still names whatever it granted or removed — and protects that
-    thing from retiring."""
-
-    modifier_id: object
-    modifier_name: str
-
-    def say(self):
-        return f"retire the carrierless modifier “{self.modifier_name}”"
-
-    def perform(self, made):
-        from n26.library.models import Modifier
-
-        dropped = Modifier.objects.get(pk=self.modifier_id)
-        scope_row, effect_row = dropped.scope, dropped.effect
-        dropped.delete()
-        scope_row.delete()
-        effect_row.delete()
-
-
-@dataclass(frozen=True)
 class RewritePick:
     """One stored choice, re-said as a pick: the old kind's column moves
     to ``pickable``, the anchor it already hangs from (``caused_by``)

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -267,23 +267,6 @@ def _run_conversion(backfill_id, operation, system, **said_by_whoever_enqueued_i
     """
     from n26.library.conversion import ConversionRefused, apply
 
-    # A message from a version that could be told not to keep its work.
-    # Ignoring the instruction would turn the careful thing somebody asked
-    # for into the committing one, which is the opposite of what they
-    # wanted; there is no rehearsing any more, so the honest answer is to
-    # decline it.
-    if said_by_whoever_enqueued_it.get("keep") is False:
-        _write(
-            backfill_id,
-            status=Backfill.Status.FAILED,
-            error=(
-                "This asked to be rehearsed and then thrown away, which this "
-                "version cannot do. Nothing was run. Ask for it again from "
-                "the page."
-            ),
-        )
-        return
-
     _run_recorded(
         backfill_id,
         operation,
@@ -378,15 +361,6 @@ def _conversion_view(request, operation, system, task_fn):
             # the screen of whoever asked for it.
             messages.error(
                 request, "The conversion refuses: " + "; ".join(plan.problems)
-            )
-            return HttpResponseRedirect(address)
-        if request.POST.get("keep") == "no":
-            # A page open since before the rehearsal was taken away. Its
-            # gentler button would land here and convert for real.
-            messages.warning(
-                request,
-                "That page offered a rehearsal, which no longer exists. "
-                "Nothing has been run — reload and apply if you mean to.",
             )
             return HttpResponseRedirect(address)
         backfill = Backfill.objects.create(

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -483,32 +483,6 @@ class TestTheRunsOwnGuards:
         backfill.refresh_from_db()
         assert backfill.status == Backfill.Status.DONE
 
-    def test_a_message_asking_not_to_keep_its_work_does_not_keep_it(self, world):
-        """A version ago this could be told to do the whole thing and
-        throw it away. Ignoring that instruction would commit what
-        somebody asked to be careful about."""
-        backfill = Backfill.objects.create(
-            operation=Operation.CONVERT_SPECIALISATION,
-            status=Backfill.Status.RUNNING,
-        )
-
-        convert_specialisation.enqueue(backfill_id=str(backfill.id), keep=False)
-
-        backfill.refresh_from_db()
-        assert backfill.status == Backfill.Status.FAILED
-        assert "cannot do" in backfill.error
-        assert Assignment.objects.filter(specialisation__isnull=False).exists()
-
-    def test_the_gentler_button_of_an_old_page_converts_nothing(
-        self, client, superuser, world
-    ):
-        client.force_login(superuser)
-
-        client.post(reverse(URL_NAME), {"keep": "no"}, follow=True)
-
-        assert not Backfill.objects.exists()
-        assert Assignment.objects.filter(specialisation__isnull=False).exists()
-
     def test_a_cancelled_run_stays_cancelled(self, world):
         backfill = Backfill.objects.create(
             operation=Operation.CONVERT_SPECIALISATION,


### PR DESCRIPTION
Tidy-up after the four slots-and-picks conversions all ran in production. Three deletions, no behaviour change, 105 lines gone and none added.

## What goes

- **`DropModifier` and `RetireModifier`** (`n26/library/conversion/base.py`) — steps that retired a modifier outright, built while a conversion still tried to clear away the rows it replaced. "Delete nothing" settled that question, and no conversion has named either since. A step nothing performs is a shape for the next author to copy by mistake.
- **The two rehearsal guards** (`n26/maintenance.py`) — a task declining a message that asked to be rehearsed and thrown away, and a view catching the gentler button of a page that offered one. Their tests go with them.

## Why the guards can go

The rehearsal itself lived for one day: added in the morning, taken out the same evening, and the guards written the next morning to cover the tab and the message it might have left behind. Both are now unreachable, for different reasons:

- **The message.** A conversion task carries a 600-second ack deadline and a bounded retry; a message enqueued during that day cannot still be in flight.
- **The page.** A tab left open on it can still post, so this one is worth stating plainly rather than waving away. Without the guard, that post takes the ordinary path: the running-guard, then the plan. Every conversion has run in production, so the plan reads `nothing_here` and the page says there is nothing to convert. On a database that has *not* converted — a local one, forked from the mirror — the same post would convert for real, which is what the guard used to prevent. That is judged acceptable: the tab would be the developer's own, on their own database, and the conversion it would run is the one they would have run anyway.

What the guards cost is legibility: they describe a feature that existed for a day, which a reader now has to reconstruct before the code makes sense.

## What deliberately stays

- **Every conversion module and console operation.** All five have run in production, but the content mirror is still unconverted — it holds the old offers and only the pre-existing slot types — and every local database forks from it. Deleting the conversions now would strand them with no route across. The sequence is: re-sync the mirror from production, then retire the operations the way the wargear merge was retired (slug registered, `view=None`, code deleted) so the audit records still read as names.
- `SwapSharedCarrier`, `Retire`, and the `linked` / `qualifier` options on `CreatePickable` — each used by a conversion that ran, and each part of the record of how it ran.
- `test_it_survives_a_message_from_another_version`, which still proves the task ignores arguments it does not know — the general case the `keep` guard was one instance of.

## Test plan

- [x] `pytest n26` — 3806 passed
- [x] No reference anywhere to the deleted steps or guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8