### PR TITLE
fix: a superuser may remove player data through the admin

### DIFF
--- a/.claude/notes/conversion-cleanup-order.md
+++ b/.claude/notes/conversion-cleanup-order.md
@@ -1,0 +1,107 @@
+# Finishing the conversions — what is left, and in what order
+
+Measured against production, 2026-08-20, read-only. The four conversions
+have all run; this is everything they left behind and the order it can
+be cleared in.
+
+## What is actually left
+
+| | count |
+|---|---|
+| Emptied kind rows (Archetype 12, SkillTree 6, Specialisation 8) | 26 |
+| — of those, still carrying anything | 1 (Ironhead Squat) |
+| Archived assignments naming an old kind | 399 |
+| Live assignments naming an old kind | 4 (doubled-click spares) |
+| Menu collections left standing | 3 |
+| Detached fossil offers | 1 |
+| Unreachable offer (general hidden, never held by anything) | 1 |
+
+**The columns are closed.** No live route creates a new row of any old
+kind: the archetype fossil is carried by nothing, the general
+Specialisation hidden has never been held by any assignment and its
+granter is detached, and every other offer became a slot grant. The
+four live rows are spares from a click that landed twice, anchored on
+a subtype whose question is now a slot.
+
+## The order
+
+Four things can start at once. Everything else is one chain behind
+them.
+
+### Wave 1 — start together, no ordering between them
+
+1. **The double-submit fix.** The only item still *making* mess: a
+   click landing twice writes a second identical answer. Nothing else
+   waits on it, and every day it stays costs another spare.
+2. **The archived-pick sweep.** A console operation rewriting the 399
+   archived assignments onto their pickables, as the Paths conversion
+   did for its own. **This is the gate**: the kinds cannot be retired
+   while anything names them, so start it early even though it lands
+   last. Needs the conversion machinery, so it must precede wave 4.
+3. **The timeout revert.** The Cloud Run request timeout and the task
+   ack deadline move together or not at all — a run outliving its
+   deadline is redelivered while the first copy works. Conversions now
+   finish in single-digit seconds.
+4. **Squat legacies** (content, in the admin). Re-offer Ironhead Squat
+   as a Gang Legacy pickable and grant the slot to the three Squat Hunt
+   profiles, which carry no legacy question. This also empties the last
+   archetype row still carrying anything, which wave 2 wants.
+
+### Wave 2 — after the sweep has run in production
+
+5. **The library cleanup.** One more one-shot operation, the pilot
+   retirement's shape: delete the 26 emptied kind rows, the three menu
+   collections, the detached fossil offer, the general hidden and its
+   detached granter. Refuses if anything still names them, which is
+   why the sweep comes first.
+
+   The four spares belong to this decision. They are a duplicate line
+   on four gangs' pages; archiving them removes it. That is a page
+   change on four gangs, and it is a fix rather than a regression —
+   but it is a change, and it should be named rather than slipped in.
+
+### Wave 3
+
+6. **Re-sync the content mirror from production.** After 4 and 5, so
+   the mirror inherits the tidy library rather than the old one.
+
+### Wave 4
+
+7. **Retire the conversion modules and their console operations.**
+   Slug registered with `view=None`, code deleted, the way the wargear
+   merge went. Waits on the mirror: until then every local database
+   forks unconverted and needs the conversions as its route across.
+
+### Wave 5 — the big one, planned separately
+
+8. **Drop the three kinds and their columns.** This is not a tidy-up;
+   it is a change across 21 files and every parallel registry the
+   library keeps: `ASSIGNABLE_FIELDS` and the Assignment columns,
+   `OFFERABLE_KINDS`, the ingest sheets and their four tables, the
+   specs and authoring pages, collection entries, the selector
+   algebra, card building, history, sample data — plus a migration
+   dropping three columns and three tables. Startup checks enforce the
+   registries agreeing, so a half-done version does not boot.
+
+   Worth doing, but worth its own plan and its own smoke test on a
+   fork, and it must be last: it needs the sweep (no data), the
+   library cleanup (no rows) and the retirement (no code) all done.
+
+## The critical path
+
+    archived sweep → library cleanup → mirror re-sync → retire the
+    conversions → drop the kinds
+
+The double-submit fix, the timeout revert and the Squat content hang
+off nothing and can land in any order alongside it.
+
+## One judgement worth making early
+
+Retiring the kinds means rewriting 399 archived assignments — history
+rows the later conversions deliberately left alone. The precedent
+exists (Paths rewrote its archived picks so the retirement could
+land), and the alternative is keeping three dead kinds in the
+authoring menus, the ingest sheets and the card code for ever. The
+recommendation is to do it, but to decide it deliberately before wave
+1 starts, because the sweep is only worth building if the kinds are
+going.

--- a/n26/core/admin.py
+++ b/n26/core/admin.py
@@ -8,6 +8,11 @@ are registered read-only: the admin is for finding and inspecting, not
 for writing what only an operation may write. The pinned caches on Gang
 and Miniature are read-only fields for the same reason.
 
+Removing is the exception, and a superuser's alone. A gang that has to
+go takes everything it owns with it, and refusing that left no way to
+delete one at all — Django asks for the permission on every model the
+cascade would reach.
+
 Display-only state (AssignmentSet, PrintConfig, StatOverride) is
 editable — it moves no money, changes no rating and touches no ledger —
 though their selection M2Ms are managed in the app, where the choices
@@ -31,7 +36,21 @@ from n26.core.models.assignment import ASSIGNABLE_FIELDS
 
 
 class ReadOnlyAdmin(admin.ModelAdmin):
-    """Look, don't touch — see the module docstring."""
+    """Look, don't write — but a superuser may still remove.
+
+    Writing is what the guard is for: a row created or edited here skips
+    the ledger entry, the event and the repin, and nothing notices until
+    reconcile runs. Removing is a different act, and one somebody needs
+    when a test gang has to go: everything a gang owns is deleted with
+    it, so nothing is left half-referring to what went.
+
+    It is not free of edges. Deleting *part* of a gang — one assignment
+    out of a live chain — leaves that gang's pinned totals standing for
+    rows that are gone, which reconcile then reports as a discrepancy;
+    the repair is to recompute, or to delete the gang whole. Given to
+    superusers only, who are also the ones the maintenance console
+    opens for.
+    """
 
     def has_add_permission(self, request):
         return False
@@ -40,7 +59,7 @@ class ReadOnlyAdmin(admin.ModelAdmin):
         return False
 
     def has_delete_permission(self, request, obj=None):
-        return False
+        return request.user.is_superuser
 
 
 @admin.register(Gang)

--- a/n26/core/admin.py
+++ b/n26/core/admin.py
@@ -8,10 +8,11 @@ are registered read-only: the admin is for finding and inspecting, not
 for writing what only an operation may write. The pinned caches on Gang
 and Miniature are read-only fields for the same reason.
 
-Removing is the exception, and a superuser's alone. A gang that has to
-go takes everything it owns with it, and refusing that left no way to
-delete one at all — Django asks for the permission on every model the
-cascade would reach.
+Removing is the exception, and a superuser's alone. Django asks for
+the delete permission on every model a cascade reaches, so a gang is
+deletable only where the models its deletion touches allow it. It is
+taken one at a time, on the page that says what goes: the changelists
+offer no batch delete.
 
 Display-only state (AssignmentSet, PrintConfig, StatOverride) is
 editable — it moves no money, changes no rating and touches no ledger —
@@ -35,21 +36,36 @@ from n26.core.models import (
 from n26.core.models.assignment import ASSIGNABLE_FIELDS
 
 
-class ReadOnlyAdmin(admin.ModelAdmin):
+class OneAtATime:
+    """No batch delete from a list.
+
+    Deleting player data is a deliberate act, taken on the page that
+    says what goes with it. The changelist's batch offers the same
+    power a checkbox at a time, over things whose consequences differ
+    one from the next, and with no such page in between.
+    """
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop("delete_selected", None)
+        return actions
+
+
+class ReadOnlyAdmin(OneAtATime, admin.ModelAdmin):
     """Look, don't write — but a superuser may still remove.
 
-    Writing is what the guard is for: a row created or edited here skips
-    the ledger entry, the event and the repin, and nothing notices until
-    reconcile runs. Removing is a different act, and one somebody needs
-    when a test gang has to go: everything a gang owns is deleted with
-    it, so nothing is left half-referring to what went.
+    Writing is what the guard is for: an assignment created or edited
+    here skips the ledger entry, the event and the repin, and nothing
+    notices until reconcile runs. Removing is a different act, and a
+    superuser's: a gang that has to go takes its assignments, its
+    ledger and its stash with it. Its models stay — belonging to a gang
+    is an assignment, and a model outlives the one that placed it.
 
-    It is not free of edges. Deleting *part* of a gang — one assignment
-    out of a live chain — leaves that gang's pinned totals standing for
-    rows that are gone, which reconcile then reports as a discrepancy;
-    the repair is to recompute, or to delete the gang whole. Given to
-    superusers only, who are also the ones the maintenance console
-    opens for.
+    Deleting *part* of a gang is possible and is the sharp edge: one
+    assignment out of a live chain leaves that gang's pinned totals
+    standing for what has gone, which reconcile reports as a
+    discrepancy, and a lone ledger event is the audit trail losing a
+    line. The repair is to recompute, or to delete the gang whole.
     """
 
     def has_add_permission(self, request):
@@ -63,7 +79,7 @@ class ReadOnlyAdmin(admin.ModelAdmin):
 
 
 @admin.register(Gang)
-class GangAdmin(admin.ModelAdmin):
+class GangAdmin(OneAtATime, admin.ModelAdmin):
     list_display = [
         "name",
         "gang_type",

--- a/n26/core/test_admin.py
+++ b/n26/core/test_admin.py
@@ -13,7 +13,14 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 
 from n26.core import admin as core_admin
-from n26.core.models import Assignment, Gang, LedgerEntry, LedgerEvent, Stash
+from n26.core.models import (
+    Assignment,
+    Gang,
+    LedgerEntry,
+    LedgerEvent,
+    Miniature,
+    Stash,
+)
 from n26.core.operations import operation
 
 pytestmark = pytest.mark.django_db
@@ -127,16 +134,34 @@ class TestWhatTheGuardStillRefuses:
         assert guard.has_delete_permission(self._asked(staff)) is True
         assert guard.has_delete_permission(self._asked(clerk)) is False
 
+    def test_no_changelist_offers_a_batch_delete(self, staff):
+        """Deletion is deliberate, one at a time, on the page that says
+        what goes with it — including the gang's own changelist."""
+        for model in (Assignment, LedgerEntry, LedgerEvent, Stash, Gang):
+            guard = django_admin.site._registry[model]
+            assert "delete_selected" not in guard.get_actions(self._asked(staff))
+
+    def test_a_single_row_may_still_be_removed(self, staff):
+        """The escape hatch the guard exists to keep open: one thing,
+        deliberately, from its own page."""
+        guard = django_admin.site._registry[LedgerEvent]
+
+        assert guard.has_delete_permission(self._asked(staff)) is True
+
 
 @pytest.mark.django_db
 def test_a_superuser_can_delete_a_gang_and_everything_it_owns(client, staff, gang):
-    """The whole reason removing is allowed: Django asks for the
-    permission on every model the cascade reaches, so refusing it on
-    the ledger-adjacent ones left no way to delete a gang at all."""
+    """A gang deleted through the admin takes its assignments, its
+    ledger and its events. Its models stay, gangless, as they do
+    whenever a membership ends."""
     assert Assignment.objects.filter(gang_root=gang).exists()
     # An entry hangs off its assignment rather than the gang, so it goes
     # the same way: down the cascade, one step further along.
     assert LedgerEntry.objects.filter(assignment__gang_root=gang).exists()
+    hired = list(
+        Miniature.objects.filter(membership__gang=gang).values_list("pk", flat=True)
+    )
+    assert hired
     client.force_login(staff)
 
     response = client.post(
@@ -148,3 +173,23 @@ def test_a_superuser_can_delete_a_gang_and_everything_it_owns(client, staff, gan
     assert not Assignment.objects.filter(gang_root=gang.pk).exists()
     assert not LedgerEntry.objects.filter(assignment__gang_root=gang.pk).exists()
     assert not LedgerEvent.objects.filter(gang=gang.pk).exists()
+    # The models stay, and stay gangless: a membership is an assignment
+    # like any other, and a model is not deleted by the ending of one
+    # (test_miniature.py pins the same rule from the other side).
+    left = Miniature.objects.filter(pk__in=hired)
+    assert left.count() == len(hired)
+    assert all(model.gang is None for model in left)
+
+
+@pytest.mark.django_db
+def test_a_staffer_is_refused_the_same_deletion(client, clerk, gang):
+    """The other half of the gate, asked through the door rather than
+    of the permission method."""
+    client.force_login(clerk)
+
+    response = client.post(
+        reverse("admin:n26_gang_delete", args=[gang.pk]), {"post": "yes"}
+    )
+
+    assert response.status_code in (302, 403)
+    assert Gang.objects.filter(pk=gang.pk).exists()

--- a/n26/core/test_admin.py
+++ b/n26/core/test_admin.py
@@ -25,6 +25,12 @@ def staff(db):
 
 
 @pytest.fixture
+def clerk(db):
+    """Staff, but not a superuser — the admin's ordinary reader."""
+    return User.objects.create_user("clerk", "", "password", is_staff=True)
+
+
+@pytest.fixture
 def gang(gang_type, staff, make_profile):
     gang = Gang.objects.create(name="The Ashen Choir", owner=staff, gang_type=gang_type)
     with operation(gang, actor=staff) as op:
@@ -95,3 +101,50 @@ def test_readonly_admin_is_what_the_registry_uses():
     permission overrides."""
     for model in (Assignment, LedgerEntry, LedgerEvent, Stash):
         assert isinstance(django_admin.site._registry[model], core_admin.ReadOnlyAdmin)
+
+
+class TestWhatTheGuardStillRefuses:
+    """Writing is refused of everyone; removing is a superuser's."""
+
+    def _asked(self, user):
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/")
+        request.user = user
+        return request
+
+    def test_nobody_may_write_through_it(self, staff, clerk):
+        guard = django_admin.site._registry[Assignment]
+
+        for user in (staff, clerk):
+            asked = self._asked(user)
+            assert guard.has_add_permission(asked) is False
+            assert guard.has_change_permission(asked) is False
+
+    def test_a_superuser_may_remove_and_a_staffer_may_not(self, staff, clerk):
+        guard = django_admin.site._registry[Assignment]
+
+        assert guard.has_delete_permission(self._asked(staff)) is True
+        assert guard.has_delete_permission(self._asked(clerk)) is False
+
+
+@pytest.mark.django_db
+def test_a_superuser_can_delete_a_gang_and_everything_it_owns(client, staff, gang):
+    """The whole reason removing is allowed: Django asks for the
+    permission on every model the cascade reaches, so refusing it on
+    the ledger-adjacent ones left no way to delete a gang at all."""
+    assert Assignment.objects.filter(gang_root=gang).exists()
+    # An entry hangs off its assignment rather than the gang, so it goes
+    # the same way: down the cascade, one step further along.
+    assert LedgerEntry.objects.filter(assignment__gang_root=gang).exists()
+    client.force_login(staff)
+
+    response = client.post(
+        reverse("admin:n26_gang_delete", args=[gang.pk]), {"post": "yes"}
+    )
+
+    assert response.status_code == 302
+    assert not Gang.objects.filter(pk=gang.pk).exists()
+    assert not Assignment.objects.filter(gang_root=gang.pk).exists()
+    assert not LedgerEntry.objects.filter(assignment__gang_root=gang.pk).exists()
+    assert not LedgerEvent.objects.filter(gang=gang.pk).exists()


### PR DESCRIPTION
First of the conversion cleanups, and a blocker in its own right: a gang cannot currently be deleted through the admin by anyone.

## The problem

The ledger-adjacent models — Assignment, LedgerEntry, LedgerEvent, Stash — are registered read-only, because a row written through the admin skips the ledger entry, the event and the repin, and nothing notices until reconcile runs. That guard refused deletion too.

Django asks for the delete permission on **every model a cascade would reach**, so refusing it on those four made deleting a gang impossible, with an error naming all four:

> Deleting the gang would result in deleting related objects, but your account doesn't have permission to delete the following types of objects: ledger entry, assignment, ledger event, stash

## The change

Writing stays refused of everyone — that is what the guard is for. Removing becomes a superuser's, the same people the maintenance console opens for.

The sharp edge is stated in the docstring, where whoever uses it will read it: deleting *part* of a gang leaves that gang's pinned totals standing for rows that are gone, which reconcile then reports as a discrepancy. The whole gang is the safe unit, and it takes everything it owns with it.

## Also here

`.claude/notes/conversion-cleanup-order.md` — the order the remaining conversion cleanups can be done in, measured against production: what is left (26 emptied kind rows, 399 archived assignments naming an old kind, 4 live spares, 3 menus, 1 fossil offer), which four things can start at once, and the single chain the rest hangs off. Notably the old columns are already closed — no live route creates a row of any retired kind.

## Test plan

- [x] `pytest n26` — 3809 passed
- [x] The two new tests fail without the change: the permission check returns False, and the gang-delete POST 403s instead of redirecting
- [x] End-to-end: a superuser posting to the gang delete view removes the gang, its assignments, its ledger entries and its events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8