### PR TITLE
fix: a question keeps one answer, however fast the second arrives

### DIFF
--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -1432,10 +1432,30 @@ def _sold_separately(line, entry, weapon):
     return frozenset()
 
 
+def _hold(gang):
+    """Take the gang's own line, before this operation touches anything.
+
+    Every operation ends by rewriting the gang's pinned numbers, so each
+    one takes this line before it commits whatever else it did. Taking it
+    first instead gives every writer the same order: one gang's work
+    settles an act at a time, each act reads what the act before it
+    wrote, and no two ever wait on each other's rows in opposite orders.
+
+    Held for the length of the transaction, and only against others
+    taking it — one gang at a time, while every other gang goes on
+    untouched.
+    """
+    from n26.core.models import Gang
+
+    Gang.objects.select_for_update().filter(pk=gang.pk).first()
+
+
 @contextmanager
 def operation(gang, actor=None):
     """One transaction; pinned numbers rewritten when it closes."""
     op = Operation(gang, actor=actor)
     with transaction.atomic():
+        if gang is not None and gang.pk is not None:
+            _hold(gang)
         yield op
         op.settle()

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -1435,11 +1435,11 @@ def _sold_separately(line, entry, weapon):
 def _hold(gang):
     """Take the gang's own line, before this operation touches anything.
 
-    Every operation ends by rewriting the gang's pinned numbers, so each
-    one takes this line before it commits whatever else it did. Taking it
-    first instead gives every writer the same order: one gang's work
-    settles an act at a time, each act reads what the act before it
-    wrote, and no two ever wait on each other's rows in opposite orders.
+    Every operation ends by rewriting the gang's pinned numbers, so all
+    of them take this line either way. Taking it first gives every writer
+    one order: one gang's work settles an act at a time, each act reads
+    what the act before it wrote, and no two wait on each other's rows in
+    opposite orders.
 
     Held for the length of the transaction, and only against others
     taking it — one gang at a time, while every other gang goes on

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -115,44 +115,27 @@ def _find_slot(gang, key):
     raise Http404("No such choice")
 
 
-def _one_at_a_time(gang):
-    """Hold the gang while this answer is written.
+def _settled(found):
+    """The picks that answer this question, as the card reads them.
 
-    A question with one answer is settled by replacing what stands, and
-    two answers arriving together would each look first and find nothing
-    standing — a double click on Choose is exactly that, and it leaves
-    the question answered twice. Taking the gang's own line first makes
-    the second wait for the first, so it reads what the first wrote.
-
-    Held for the length of the operation's transaction, and only against
-    others taking it: one gang's answers are settled one at a time,
-    while everything else goes on as before.
+    The card is the one authority on what answers what: it scopes a
+    question broadcast onto many cards to the one whose card was
+    clicked, and it adopts an answer that names no question — or names
+    one this card no longer asks — rather than leaving it stranded. A
+    query written here would have to repeat all of that and would drift
+    from it, so the card is asked instead.
     """
-    from n26.core.models import Gang
-
-    Gang.objects.select_for_update().filter(pk=gang.pk).first()
+    return [pick for pick in found.slot.picks if pick.assignment is not None]
 
 
-def _standing_answers(found):
-    """Whatever already answers this question, read afresh.
+def _pick_of(found, wanted):
+    """The pick behind one option on the list, or None if it is not there."""
+    from n26.core.render import option_key
 
-    The page named the picks it drew, but it was built before this
-    answer — and before any other in flight. What settles the question
-    is what the database says now: the live assignments hanging from
-    this anchor that name this choice.
-    """
-    from n26.core.models import Assignment
-
-    standing = Assignment.objects.filter(
-        caused_by=found.anchor, archived=False
-    ).exclude(removes=True)
-    slot = found.slot.slot
-    if slot is not None:
-        return list(standing.filter(chosen_for_slot=slot))
-    offer = found.slot.offer
-    if offer is not None:
-        return list(standing.filter(chosen_for_offer=offer))
-    return []
+    return next(
+        (pick for pick in _settled(found) if option_key(pick.assignable) == wanted),
+        None,
+    )
 
 
 def _host(found):
@@ -198,7 +181,7 @@ def choose(request, pk, slot):
     """
     from n26.analytics import EventVerb, N26Noun, record
     from n26.core.operations import Refusal, operation
-    from n26.core.render import NONE_KEY, build_choice_offer, option_key
+    from n26.core.render import NONE_KEY, build_choice_offer
 
     gang = _own_gang_or_404(request, pk)
     found = _find_slot(gang, slot)
@@ -223,11 +206,8 @@ def choose(request, pk, slot):
                     request, "That is not one of the things available to pick."
                 )
                 return redirect(request.path)
-            standing = [
-                pick for pick in found.slot.picks if pick.assignment is not None
-            ]
             with operation(gang, actor=request.user) as op:
-                for pick in standing:
+                for pick in _settled(_find_slot(gang, slot)):
                     op.remove(pick.assignment)
             record(
                 request,
@@ -248,15 +228,7 @@ def choose(request, pk, slot):
             ),
             None,
         )
-        held = next(
-            (
-                pick
-                for pick in found.slot.picks
-                if option_key(pick.assignable) == wanted and pick.assignment is not None
-            ),
-            None,
-        )
-        if picked is None or (dropped and held is None):
+        if picked is None or (dropped and _pick_of(found, wanted) is None):
             # Nothing on the list, or nothing behind the option a click
             # asked to take back — a stale page either way, and the list
             # itself is the reply.
@@ -266,23 +238,42 @@ def choose(request, pk, slot):
         landing = request.path if offer.takes_several else back
         try:
             with operation(gang, actor=request.user) as op:
-                _one_at_a_time(gang)
+                # The page named the picks it drew, but it was drawn
+                # before this answer and before any other in flight. The
+                # card is computed again with the gang held, so what
+                # settles the question is what stands at the moment of
+                # writing — and a question that has since gone stops
+                # resolving here rather than growing an answer nobody
+                # asked for.
+                fresh = _find_slot(gang, slot)
                 if dropped:
-                    op.remove(held.assignment)
+                    taken = _pick_of(fresh, wanted)
+                    if taken is not None:
+                        op.remove(taken.assignment)
+                elif offer.takes_several and _pick_of(fresh, wanted) is not None:
+                    # A worked-at choice, and this pick is already among
+                    # them: the click has landed once already, and once is
+                    # what it asked for.
+                    pass
                 else:
                     if not offer.takes_several:
-                        # One pick, already made: the new pick replaces
-                        # it. Read from the database rather than from the
-                        # page, which was built before this answer — and
-                        # possibly before another one landed.
-                        for standing in _standing_answers(found):
-                            op.remove(standing)
+                        # One pick, already made: the new pick replaces it.
+                        for standing in _settled(fresh):
+                            op.remove(standing.assignment)
+                    elif fresh.slot.is_full:
+                        # Filled while this page stood open. The way to
+                        # something else is to take a pick back, never to
+                        # have one pushed out unasked.
+                        raise Refusal(
+                            f"{offer.label} holds all the picks it will "
+                            "take. Take one back to make room."
+                        )
                     op.choose(
-                        found.anchor,
+                        fresh.anchor,
                         picked.thing,
-                        slot=found.slot.slot,
-                        offer=found.slot.offer,
-                        **_host(found),
+                        slot=fresh.slot.slot,
+                        offer=fresh.slot.offer,
+                        **_host(fresh),
                     )
         except Refusal as refusal:
             messages.error(request, str(refusal))

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -115,6 +115,46 @@ def _find_slot(gang, key):
     raise Http404("No such choice")
 
 
+def _one_at_a_time(gang):
+    """Hold the gang while this answer is written.
+
+    A question with one answer is settled by replacing what stands, and
+    two answers arriving together would each look first and find nothing
+    standing — a double click on Choose is exactly that, and it leaves
+    the question answered twice. Taking the gang's own line first makes
+    the second wait for the first, so it reads what the first wrote.
+
+    Held for the length of the operation's transaction, and only against
+    others taking it: one gang's answers are settled one at a time,
+    while everything else goes on as before.
+    """
+    from n26.core.models import Gang
+
+    Gang.objects.select_for_update().filter(pk=gang.pk).first()
+
+
+def _standing_answers(found):
+    """Whatever already answers this question, read afresh.
+
+    The page named the picks it drew, but it was built before this
+    answer — and before any other in flight. What settles the question
+    is what the database says now: the live assignments hanging from
+    this anchor that name this choice.
+    """
+    from n26.core.models import Assignment
+
+    standing = Assignment.objects.filter(
+        caused_by=found.anchor, archived=False
+    ).exclude(removes=True)
+    slot = found.slot.slot
+    if slot is not None:
+        return list(standing.filter(chosen_for_slot=slot))
+    offer = found.slot.offer
+    if offer is not None:
+        return list(standing.filter(chosen_for_offer=offer))
+    return []
+
+
 def _host(found):
     """Whose choice this is, when the carrier cannot say.
 
@@ -226,18 +266,17 @@ def choose(request, pk, slot):
         landing = request.path if offer.takes_several else back
         try:
             with operation(gang, actor=request.user) as op:
+                _one_at_a_time(gang)
                 if dropped:
                     op.remove(held.assignment)
                 else:
-                    if (
-                        not offer.takes_several
-                        and found.slot.is_full
-                        and found.slot.picks
-                    ):
-                        # One pick, already made: the new pick replaces it.
-                        standing = found.slot.picks[0]
-                        if standing.assignment is not None:
-                            op.remove(standing.assignment)
+                    if not offer.takes_several:
+                        # One pick, already made: the new pick replaces
+                        # it. Read from the database rather than from the
+                        # page, which was built before this answer — and
+                        # possibly before another one landed.
+                        for standing in _standing_answers(found):
+                            op.remove(standing)
                     op.choose(
                         found.anchor,
                         picked.thing,

--- a/n26/tests/sandbox/test_choosing.py
+++ b/n26/tests/sandbox/test_choosing.py
@@ -283,6 +283,31 @@ def names_on(offer):
     return {option.name for group in offer.groups for option in group.options}
 
 
+def _slot_href(gang, miniature, kind_label):
+    """A question's address even once it has been answered.
+
+    A card files an answered skill question into the Skills row rather
+    than drawing it again, so the sheet stops listing it — but the
+    question is still asked and still has an address, which is what a
+    stale page or a second click posts to.
+    """
+    computed = fighter_computed(miniature)
+    slot = next(
+        line
+        for line in computed.choices
+        if line.kind_label == kind_label
+        and getattr(line.anchor, "assignment", None) is not None
+        and line.identity is not None
+    )
+    key = f"{miniature.pk}:{slot.anchor.assignment.pk}:{slot.identity.pk}"
+    return reverse("n26-choose", args=[gang.pk, key])
+
+
+def _skills_of(gang, name):
+    card = next(c for c in render_gang(gang).models if c.name == name)
+    return sorted(line.name for line in card.skills)
+
+
 def gang_computed(gang):
     card = build_gang_card(gang)
     index = build_modifier_index([node.assignable for node in card.all_nodes()])
@@ -550,6 +575,41 @@ class TestMakingOneChoice:
         assert "Sorrow: Primary skill" not in slots
         assert not slots["Ash: Primary skill"].is_resolved
         assert second.name == "Ash"
+        assert_reconciled(gang)
+
+    def test_answering_again_leaves_the_other_fighters_answer_alone(
+        self, client, owner, gang, crew, profiles, archetypes, skills
+    ):
+        """One question broadcast onto two cards is two questions.
+
+        The skill offer rides the gang type and reaches every Leader, so
+        both Leaders' answers hang off the one line that asked and name
+        the one offer. Only the fighter whose card was clicked tells them
+        apart — so changing one Leader's mind leaves the other Leader's
+        skill exactly where it is.
+        """
+        # The Primary tier is empty until an archetype opens a set into it.
+        choose(gang_anchor(gang, "Outcast Leader", crew), archetypes["Brawler"])
+        ash = hire_with_option(gang, profiles["leader"], "Ash")
+        client.force_login(owner)
+        self.post(
+            client, sheet_slots(gang)["Sorrow: Primary skill"].href, skills["Berserker"]
+        )
+        self.post(
+            client, sheet_slots(gang)["Ash: Primary skill"].href, skills["Berserker"]
+        )
+        assert _skills_of(gang, "Sorrow") == ["Berserker"]
+        assert _skills_of(gang, "Ash") == ["Berserker"]
+
+        self.post(
+            client,
+            _slot_href(gang, crew["leader"], "Primary skill"),
+            skills["Parry"],
+        )
+
+        assert _skills_of(gang, "Sorrow") == ["Parry"]
+        assert _skills_of(gang, "Ash") == ["Berserker"]
+        assert ash.name == "Ash"
         assert_reconciled(gang)
 
     def test_what_was_chosen_dies_with_its_carrier(

--- a/n26/tests/sandbox/test_outcast_affiliation_flow.py
+++ b/n26/tests/sandbox/test_outcast_affiliation_flow.py
@@ -207,16 +207,14 @@ def top_level_rows(gang):
 
 
 class TestAnAnswerArrivingTwice:
-    """A question with one answer keeps one answer, however the second
+    """A question taking one answer holds one answer, however the second
     arrives.
 
-    Answering replaces what stands, and the picker used to decide what
-    stood from the page it had drawn. Two answers sent at once are each
-    drawn from a page where the question is open, so each found nothing
-    to replace and both landed — a double click on Choose, and the
-    question answered twice ever after. What stands is read from the
-    database now, inside the operation, with the gang held while it is
-    written.
+    Answering replaces what stands, so the two acts — take back, write —
+    have to be one act. The gang is held for the length of it and the
+    card is computed inside that hold, so a second answer waits for the
+    first and then reads what the first wrote. Two clicks land one row,
+    whether they arrive one after the other or together.
     """
 
     def test_a_second_answer_replaces_the_first(
@@ -234,10 +232,19 @@ class TestAnAnswerArrivingTwice:
         ]
 
     @pytest.mark.django_db(transaction=True)
-    def test_two_answers_at_once_still_leave_one(self, owner, gang, affiliations):
-        """The double click, as it happens: two posts in flight together,
-        neither able to see what the other is writing."""
+    def test_two_answers_at_once_still_leave_one(
+        self, monkeypatch, owner, gang, affiliations
+    ):
+        """The double click, as it happens.
+
+        Both requests are made to read the open question before either is
+        allowed to write, which is the ordering that used to produce two
+        rows: each looked, each saw nothing standing, and each wrote. The
+        reading is synchronised rather than merely the posting, so the
+        race is forced rather than hoped for.
+        """
         import threading
+        from importlib import import_module
 
         from django.db import connections
         from django.test import Client
@@ -245,17 +252,35 @@ class TestAnAnswerArrivingTwice:
         top, _ = affiliations
         url = picker_url(gang, "Affiliation")
         payload = {"thing": thing_key(top["Clanless"])}
-        together = threading.Barrier(2, timeout=10)
+        both_have_read = threading.Barrier(2, timeout=30)
+        guard = threading.Lock()
+        has_read = set()
+        picker = import_module("n26.core.views.choose")
+        read_slot = picker._find_slot
         went_wrong = []
+        landed = []
+
+        def read_then_wait(gang, key):
+            """Hold each request at its first look, so neither writes
+            until both have seen the question open."""
+            found = read_slot(gang, key)
+            with guard:
+                first_look = threading.current_thread().ident not in has_read
+                has_read.add(threading.current_thread().ident)
+            if first_look:
+                both_have_read.wait()
+            return found
+
+        monkeypatch.setattr(picker, "_find_slot", read_then_wait)
 
         def answer():
             try:
                 each = Client()
                 each.force_login(owner)
-                together.wait()
-                each.post(url, payload)
+                landed.append(each.post(url, payload))
             except Exception as bad:  # noqa: BLE001 — reported, not raised
                 went_wrong.append(repr(bad))
+                both_have_read.abort()
             finally:
                 connections.close_all()
 
@@ -263,9 +288,20 @@ class TestAnAnswerArrivingTwice:
         for click in clicks:
             click.start()
         for click in clicks:
-            click.join(timeout=30)
+            click.join(timeout=60)
 
+        # A thread still running is a request that never came back —
+        # a deadlock or a stall, which a row count alone would not show.
+        assert [click.is_alive() for click in clicks] == [False, False]
         assert went_wrong == []
+        # Both clicks were taken. One row because the second replaced the
+        # first, not because a click was turned away — a refusal comes
+        # back to the picker rather than to the gang.
+        gang_page = reverse("n26-gang", args=[gang.pk])
+        assert [(r.status_code, r["Location"]) for r in landed] == [
+            (302, gang_page),
+            (302, gang_page),
+        ]
         assert len(top_level_rows(gang)) == 1
 
 

--- a/n26/tests/sandbox/test_outcast_affiliation_flow.py
+++ b/n26/tests/sandbox/test_outcast_affiliation_flow.py
@@ -206,6 +206,69 @@ def top_level_rows(gang):
     ]
 
 
+class TestAnAnswerArrivingTwice:
+    """A question with one answer keeps one answer, however the second
+    arrives.
+
+    Answering replaces what stands, and the picker used to decide what
+    stood from the page it had drawn. Two answers sent at once are each
+    drawn from a page where the question is open, so each found nothing
+    to replace and both landed — a double click on Choose, and the
+    question answered twice ever after. What stands is read from the
+    database now, inside the operation, with the gang held while it is
+    written.
+    """
+
+    def test_a_second_answer_replaces_the_first(
+        self, client, owner, gang, affiliations
+    ):
+        top, _ = affiliations
+        client.force_login(owner)
+        url = picker_url(gang, "Affiliation")
+
+        client.post(url, {"thing": thing_key(top["Clanless"])})
+        client.post(url, {"thing": thing_key(top["Mutant"])})
+
+        assert [str(row.assignable) for row in top_level_rows(gang)] == [
+            "Mutant Outcast"
+        ]
+
+    @pytest.mark.django_db(transaction=True)
+    def test_two_answers_at_once_still_leave_one(self, owner, gang, affiliations):
+        """The double click, as it happens: two posts in flight together,
+        neither able to see what the other is writing."""
+        import threading
+
+        from django.db import connections
+        from django.test import Client
+
+        top, _ = affiliations
+        url = picker_url(gang, "Affiliation")
+        payload = {"thing": thing_key(top["Clanless"])}
+        together = threading.Barrier(2, timeout=10)
+        went_wrong = []
+
+        def answer():
+            try:
+                each = Client()
+                each.force_login(owner)
+                together.wait()
+                each.post(url, payload)
+            except Exception as bad:  # noqa: BLE001 — reported, not raised
+                went_wrong.append(repr(bad))
+            finally:
+                connections.close_all()
+
+        clicks = [threading.Thread(target=answer) for _ in range(2)]
+        for click in clicks:
+            click.start()
+        for click in clicks:
+            click.join(timeout=30)
+
+        assert went_wrong == []
+        assert len(top_level_rows(gang)) == 1
+
+
 class TestTheAffiliationPicker:
     """The first question: four things on offer, and only those."""
 

--- a/n26/tests/sandbox/test_outcast_affiliation_flow.py
+++ b/n26/tests/sandbox/test_outcast_affiliation_flow.py
@@ -24,6 +24,7 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 
 from n26.core.owned import thing_key
+from n26.core.reconcile import assert_reconciled
 from n26.core.render import render_gang
 from n26.library.models import Affiliation
 from n26.tests.sandbox.actions import (
@@ -217,20 +218,6 @@ class TestAnAnswerArrivingTwice:
     whether they arrive one after the other or together.
     """
 
-    def test_a_second_answer_replaces_the_first(
-        self, client, owner, gang, affiliations
-    ):
-        top, _ = affiliations
-        client.force_login(owner)
-        url = picker_url(gang, "Affiliation")
-
-        client.post(url, {"thing": thing_key(top["Clanless"])})
-        client.post(url, {"thing": thing_key(top["Mutant"])})
-
-        assert [str(row.assignable) for row in top_level_rows(gang)] == [
-            "Mutant Outcast"
-        ]
-
     @pytest.mark.django_db(transaction=True)
     def test_two_answers_at_once_still_leave_one(
         self, monkeypatch, owner, gang, affiliations
@@ -303,6 +290,7 @@ class TestAnAnswerArrivingTwice:
             (302, gang_page),
         ]
         assert len(top_level_rows(gang)) == 1
+        assert_reconciled(gang)
 
 
 class TestTheAffiliationPicker:


### PR DESCRIPTION
Clicking Choose twice, fast, answered the question twice: the card showed one answer and the spare sat in the gear list beneath it. It is a genuine race rather than a missing branch, and fixing it properly turned out to mean changing where the answer is read from as much as adding a lock.

## What was happening

A question taking one answer is settled by *replacing* what stands — take the old answer back, write the new one. Those are two acts, and nothing made them one. The picker also decided what stood from the page it had drawn, so two answers sent at once were each drawn from a page where the question was still open. Neither saw anything to replace, both wrote, and the question stayed answered twice from then on.

## What changed

**The card decides what stands.** The first cut of this fix read the standing answer with a query written in the view. That query was not the card's own rule for what answers what, and it got two things wrong that review caught:

- It was not scoped to the fighter. A question broadcast onto many cards — every Leader picks a Primary skill — puts both Leaders' answers on the one line that asked, naming the one offer. Answering for one Leader archived the other Leader's skill.
- It matched only answers that name the offer, while the card also adopts an answer naming no question, or naming one the card no longer asks. After any re-authoring of the content, the card showed an answer the view could not see — and the doubling this change exists to stop came straight back.

So the card is computed again inside the operation and asked directly. One authority on what answers what, and it is the one consulted. A question that has since gone stops resolving there, rather than growing an answer nobody asked for.

**The hold moved out of the picker.** Every operation already ends by rewriting the gang's pinned numbers, so each one took the gang's line *last*, after its assignment rows — while the picker took it *first*. Two writes on one gang could end up waiting on each other's rows in opposite orders and deadlock, and the loser would get a 500 rather than a refusal. The hold now lives in `operation()`, so every writer takes it first. The order is uniform, no row is contended that was not contended before, and every other writer — "Chose None" among them — now reads what the act before it wrote.

**A worked-at choice guards its own writes.** A choice taking several picks had the same stale-page problem: a click that had already landed wrote a second row, and one arriving at a full slot pushed the count past what the slot takes. Now the first adds nothing and the second is refused.

## How it was proven

The concurrency test forces the interleaving rather than hoping for it: both requests are held at their first look at the question until each has seen it open, which is the ordering that produced two rows. It also checks that both clicks were actually taken and that neither worker is still running — so a refusal, or a stall, cannot read as a pass.

- On the unfixed code it fails in about five seconds (`assert 2 == 1`).
- A second test covers two fighters answering one broadcast question: changing one fighter's mind leaves the other's answer alone. That one fails on the first cut of this fix, which is what caught the scoping bug.

Worth recording why the bug survived this long: the *sequential* version of the same test — post twice in a row — passes even on the unfixed code, because the second request sees the first's committed row. Only real concurrency shows it.

## What this does and does not clean

Production has no doubled answers on the slot machinery today. The few known spares predate this machinery and carry no recorded offer identity; they are untouched here and get cleared in the library cleanup.

## Test plan

- [x] `pytest n26` — 3809 passed, 1 xfailed
- [x] The concurrency test fails on the pre-fix code and passes on this one
- [x] The broadcast test fails on the first cut of this fix and passes on this one
- [x] The existing choosing and affiliation-flow suites pass unchanged

## How to try it

Open a gang with an unanswered choice, click into the picker, and double-click Choose. One answer, and the gear list beneath the card stays clean. Then answer the same broadcast question for two Leaders and change one of them — the other keeps its skill.
