### PR TITLE
fix: the create-gang page no longer offers a nameless gang type

### DIFF
--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -35,12 +35,13 @@ class CreateGangForm(forms.Form):
     # type. Only this screen narrows: a gang founded before a type was turned
     # off still names it everywhere it is drawn.
     gang_type = forms.ModelChoiceField(
-        # Nameless is excluded as well as unfoundable: a type with no name
-        # draws as an empty card that sorts before everything, and there is
-        # no answer a player could give it. Belt and braces — nothing may
-        # author one (n26.library.authoring.create_gang_type) — but one
-        # already in a pack must not be offered.
-        queryset=GangType.objects.filter(foundable=True).exclude(name=""),
+        # Nameless is narrowed away as well as unfoundable. A type whose
+        # name is empty — or only whitespace, which draws the same — is an
+        # empty card sorting before every real one, and no answer a player
+        # could give. The verb refuses to author one
+        # (n26.library.authoring.create_gang_type); a row already in a pack
+        # is what this excludes.
+        queryset=GangType.objects.filter(foundable=True).exclude(name__regex=r"^\s*$"),
         label="Gang type",
         help_text=(
             "What the gang is, which fixes who you can hire and what they may carry."

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -35,7 +35,12 @@ class CreateGangForm(forms.Form):
     # type. Only this screen narrows: a gang founded before a type was turned
     # off still names it everywhere it is drawn.
     gang_type = forms.ModelChoiceField(
-        queryset=GangType.objects.filter(foundable=True),
+        # Nameless is excluded as well as unfoundable: a type with no name
+        # draws as an empty card that sorts before everything, and there is
+        # no answer a player could give it. Belt and braces — nothing may
+        # author one (n26.library.authoring.create_gang_type) — but one
+        # already in a pack must not be offered.
+        queryset=GangType.objects.filter(foundable=True).exclude(name=""),
         label="Gang type",
         help_text=(
             "What the gang is, which fixes who you can hire and what they may carry."

--- a/n26/core/templates/admin/maintenance/n26/_delete_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_delete_detail.html
@@ -1,0 +1,26 @@
+{% comment %}
+    The summary of one deletion run, on the Backfill detail page: what it
+    was going to delete, and — once it has finished — what it did. A
+    conversion's caption cannot stand in here: it promises that nothing is
+    written until every affected gang is proven, which is a promise a
+    deletion does not make.
+{% endcomment %}
+{% if backfill.summary.report %}
+    <h2>What it did</h2>
+    <ul>
+        {% for line in backfill.summary.report %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% elif backfill.summary.preview %}
+    <h2>What it is doing</h2>
+    <p>
+        These are the rows it planned to delete. The deletion is one transaction,
+        so a run still working has deleted nothing yet, and a run that fails or is
+        interrupted leaves every row standing.
+    </p>
+    <ul>
+        {% for line in backfill.summary.preview %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+{% if backfill.summary.attempts %}
+    <p>Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }}.</p>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/delete.html
+++ b/n26/core/templates/admin/maintenance/n26/delete.html
@@ -1,9 +1,11 @@
 {% extends "admin/base_site.html" %}
 {% comment %}
-The pilot retirement's console page: what stands, what deleting it
-means, an apply button, and the recent runs. Context from
-retire_gang_legacy_pilot_view (n26/maintenance.py): title, pilot,
-preview, apply_url, recent.
+A deletion's console page: what stands, what deleting it means, an apply
+button, and the recent runs. Shared by every operation that deletes —
+the shape is the same for all of them and only the wording differs, so
+the words arrive in context rather than being written here twice.
+Context from _deletion_view (n26/maintenance.py): title, plan, preview,
+words, apply_url, recent.
 {% endcomment %}
 {% block title %}
     {{ title }} | {{ site_title|default:_("Django site admin") }}
@@ -22,20 +24,14 @@ preview, apply_url, recent.
         <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
     </p>
     <h1>{{ title }}</h1>
-    <p>
-        This deletes — the one operation that does. The pilot was a hand-built
-        experiment whose pickables carry nothing, and its rows squat on the
-        names the real Gang Legacy conversion needs. Every row it would
-        delete is listed below; it refuses if anything outside the pilot has
-        come to depend on them.
-    </p>
-    {% if pilot.nothing_here %}
-        <h2>Nothing to retire</h2>
-        <p>No slot type of the pilot's name stands. It has been retired already, or was never here.</p>
-    {% elif not pilot.ok %}
-        <h2 class="mt-problems">The retirement refuses</h2>
+    <p>{{ words.intro }}</p>
+    {% if plan.nothing_here %}
+        <h2>{{ words.nothing_heading }}</h2>
+        <p>{{ words.nothing_words }}</p>
+    {% elif not plan.ok %}
+        <h2 class="mt-problems">{{ words.refuses_heading }}</h2>
         <ul class="mt-problems">
-            {% for problem in pilot.problems %}<li>{{ problem }}</li>{% endfor %}
+            {% for problem in plan.problems %}<li>{{ problem }}</li>{% endfor %}
         </ul>
         <p>Nothing can be applied while any of these stands.</p>
     {% else %}
@@ -45,9 +41,9 @@ preview, apply_url, recent.
         </ul>
         <form method="post"
               class="mt-form"
-              onsubmit="return confirm('Delete the pilot? This cannot be undone.')">
+              onsubmit="return confirm('{{ words.confirm|escapejs }}')">
             {% csrf_token %}
-            <button type="submit" class="button default">Retire the pilot</button>
+            <button type="submit" class="button default">{{ words.button }}</button>
         </form>
     {% endif %}
     {% if recent %}

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -59,6 +59,11 @@ def create_gang_type(
     library_author_help="",
     **kwargs,
 ):
+    """A kind of gang. The name is the whole of what a player sees when
+    the create-gang page offers it, so a blank one is refused here rather
+    than drawn as an empty card — whatever path asked for it."""
+    if not (name or "").strip():
+        raise ValidationError("A gang type needs a name.")
     return GangType.objects.create(
         name=name,
         starting_credits=starting_credits,

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -61,8 +61,11 @@ def create_gang_type(
 ):
     """A kind of gang. The name is the whole of what a player sees when
     the create-gang page offers it, so a blank one is refused here rather
-    than drawn as an empty card — whatever path asked for it."""
-    if not (name or "").strip():
+    than drawn as an empty card — whatever path asked for it. Stored
+    stripped, since a padded name draws with the padding.
+    """
+    name = (name or "").strip()
+    if not name:
         raise ValidationError("A gang type needs a name.")
     return GangType.objects.create(
         name=name,

--- a/n26/library/ingest.py
+++ b/n26/library/ingest.py
@@ -1042,9 +1042,9 @@ def _plan_profiles(plan, rows):
 
         gang_name = _clean(row.get("Gang", ""))
         if not gang_name:
-            # Planned anyway, a blank cell founds a gang type with no
-            # name, which draws as an empty card on the create-gang page
-            # — and lands first, nothing sorting before nothing.
+            # Every entry is hired off a gang list, and a gang type with
+            # no name draws as an empty card on the create-gang page,
+            # landing before every real one — nothing sorts before nothing.
             plan.problem(
                 source,
                 f"{name!r} names no Gang — every entry is hired off a gang "

--- a/n26/library/ingest.py
+++ b/n26/library/ingest.py
@@ -1041,6 +1041,16 @@ def _plan_profiles(plan, rows):
             continue
 
         gang_name = _clean(row.get("Gang", ""))
+        if not gang_name:
+            # Planned anyway, a blank cell founds a gang type with no
+            # name, which draws as an empty card on the create-gang page
+            # — and lands first, nothing sorting before nothing.
+            plan.problem(
+                source,
+                f"{name!r} names no Gang — every entry is hired off a gang "
+                f"list, and the sheet has not said which",
+            )
+            continue
         gang_key = f"GangType:{_norm(gang_name)}"
         if not plan.get(gang_key):
             plan.add("GangType", gang_name, {}, source, key=gang_key)

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -218,6 +218,12 @@ def apply(nameless):
                 or set(now.gang_ids) != set(nameless.gang_ids)
                 or set(now.gang_type_ids) != set(nameless.gang_type_ids)
                 or set(now.assignment_ids) != set(nameless.assignment_ids)
+                # The counts too, not only the rows named: the preview
+                # promises everything that dies, and a history event or a
+                # saved layout written since it was read would die
+                # unannounced.
+                or now.events != nameless.events
+                or now.print_configs != nameless.print_configs
             ):
                 raise Refused(
                     "not deleted: what stands has changed since the plan was "

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -2,10 +2,10 @@
 
 An ingest of a profiles sheet planned a gang type from a blank ``Gang``
 cell, so a ``GangType`` was founded whose name is the empty string. Being
-foundable by default, it drew as an empty card on the create-gang page,
-sorting before every real gang type because nothing sorts before nothing
-— and one player founded a gang on it, which is a gang of nothing: no
-house list to hire from, no built-ins, no name to print.
+foundable by default, it draws as an empty card on the create-gang page,
+sorting before every real gang type because nothing sorts before nothing.
+A gang founded on it is a gang of nothing: no house list to hire from, no
+built-ins, no name to print.
 
 A blank Gang cell is a problem the sheet must fix
 (``n26.library.ingest``), the verb refuses a blank name
@@ -29,6 +29,9 @@ from dataclasses import dataclass
 
 from django.db import transaction
 
+#: A name that draws as nothing: empty, or only whitespace.
+BLANK = r"^\s*$"
+
 
 class Refused(Exception):
     """The repair found more than the accident it was written for."""
@@ -42,6 +45,7 @@ class Nameless:
     gang_ids: tuple = ()
     assignment_ids: tuple = ()
     events: int = 0
+    print_configs: int = 0
     problems: tuple = ()
     nothing_here: bool = False
 
@@ -56,14 +60,21 @@ class Nameless:
         gangs = len(self.gang_ids)
         lines = []
         if gangs:
+            rides = [
+                f"{len(self.assignment_ids)} founding "
+                f"assignment{'' if len(self.assignment_ids) == 1 else 's'}",
+                f"{self.events} history event{'' if self.events == 1 else 's'}",
+                "an empty stash",
+            ]
+            if self.print_configs:
+                rides.append(
+                    f"{self.print_configs} saved print "
+                    f"layout{'' if self.print_configs == 1 else 's'}"
+                )
             lines.append(
                 f"delete {gangs} gang{'' if gangs == 1 else 's'} founded on a "
                 f"nameless type — each untouched since founding — and with "
-                f"{'it' if gangs == 1 else 'them'} "
-                f"{len(self.assignment_ids)} founding "
-                f"assignment{'' if len(self.assignment_ids) == 1 else 's'}, "
-                f"{self.events} history event"
-                f"{'' if self.events == 1 else 's'}, and an empty stash"
+                f"{'it' if gangs == 1 else 'them'} " + ", ".join(rides)
             )
         else:
             lines.append("no gang was founded on it, so nothing of a player's dies")
@@ -75,7 +86,13 @@ class Nameless:
 
 def find():
     """Read the nameless types as they stand. Never writes."""
-    from n26.core.models import Assignment, Gang, LedgerEvent, Miniature
+    from n26.core.models import (
+        Assignment,
+        Gang,
+        LedgerEvent,
+        Miniature,
+        PrintConfig,
+    )
     from n26.library.models import GangType, Profile
     from n26.library.models.pack import default_pack_id
 
@@ -83,7 +100,13 @@ def find():
     # content and not this accident, and the create page no longer offers
     # a nameless one from anywhere.
     doomed_types = list(
-        GangType.objects.filter(name="", pack_id=default_pack_id()).order_by("created")
+        GangType.objects.filter(
+            # Whitespace draws the same empty card as nothing at all, and
+            # the verb stores a stripped name, so a padded one can only be
+            # a row that predates the guard.
+            name__regex=BLANK,
+            pack_id=default_pack_id(),
+        ).order_by("created")
     )
     if not doomed_types:
         return Nameless(nothing_here=True)
@@ -96,10 +119,10 @@ def find():
                 "modifiers — something has been authored onto it, so it is "
                 "not the empty row this deletes"
             )
-        hired = Profile.objects.filter(gang_type=gang_type)
-        if hired.exists():
+        hired = Profile.objects.filter(gang_type=gang_type).count()
+        if hired:
             problems.append(
-                f"{hired.count()} fighter entries are hired off the nameless "
+                f"{hired} fighter entries are hired off the nameless "
                 f"type {gang_type.pk} — it is being used as a gang list, so "
                 "it wants a name rather than deleting"
             )
@@ -122,6 +145,9 @@ def find():
                 "beyond its founding — it has been played, so it is not this "
                 "repair's to delete"
             )
+        # Not covered by the strays count above, and not belt and braces:
+        # ``Miniature.membership`` is SET_NULL, so deleting a gang with
+        # models on it would leave the models behind, belonging to nothing.
         models_in = Miniature.objects.filter(membership__gang=gang).count()
         if models_in:
             problems.append(
@@ -144,11 +170,16 @@ def find():
         )
 
     events = LedgerEvent.objects.filter(gang_id__in=doomed_gang_ids).count()
+    # Saved print layouts cascade with the gang. They are not a reason to
+    # refuse — a layout is a view of a gang, not something played — but
+    # the preview enumerates everything that dies, so it says these too.
+    layouts = PrintConfig.objects.filter(gang_id__in=doomed_gang_ids).count()
     return Nameless(
         gang_type_ids=tuple(sorted((t.pk for t in doomed_types), key=str)),
         gang_ids=tuple(sorted(doomed_gang_ids, key=str)),
-        assignment_ids=tuple(sorted((f for f in foundings), key=str)),
+        assignment_ids=tuple(sorted(foundings, key=str)),
         events=events,
+        print_configs=layouts,
         problems=tuple(problems),
     )
 
@@ -168,6 +199,30 @@ def apply(nameless):
     report = list(nameless.preview())
     try:
         with transaction.atomic():
+            # The plan was read before this transaction opened, and a
+            # gang's assignments cascade rather than protect — so a gang
+            # played in between would ride the delete down instead of
+            # refusing. Two things close that window. The doomed gangs
+            # are locked first: assigning anything to a gang takes a
+            # key-share lock on its row, which this conflicts with, so
+            # no hire can land from here on. Then the plan is read
+            # again, and anything that moved before the lock refuses.
+            list(
+                Gang.objects.select_for_update()
+                .filter(pk__in=nameless.gang_ids)
+                .order_by("pk")
+            )
+            now = find()
+            if (
+                now.problems
+                or set(now.gang_ids) != set(nameless.gang_ids)
+                or set(now.gang_type_ids) != set(nameless.gang_type_ids)
+                or set(now.assignment_ids) != set(nameless.assignment_ids)
+            ):
+                raise Refused(
+                    "not deleted: what stands has changed since the plan was "
+                    "read — read it again"
+                )
             # The gangs first: ``Gang.gang_type`` is PROTECT, and their
             # assignments, stash and history events ride them down.
             Gang.objects.filter(pk__in=nameless.gang_ids).delete()
@@ -180,5 +235,14 @@ def apply(nameless):
             "refused — something still names what would be deleted: "
             f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}"
         ) from protected
+    report.append(
+        "deleted gang types "
+        + ", ".join(str(pk) for pk in nameless.gang_type_ids)
+        + (
+            "; deleted gangs " + ", ".join(str(pk) for pk in nameless.gang_ids)
+            if nameless.gang_ids
+            else "; no gangs stood on them"
+        )
+    )
     report.append("deleted; every gang type in the pack has a name")
     return report

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -1,0 +1,184 @@
+"""Deleting a gang type with no name — a one-shot repair.
+
+An ingest of a profiles sheet planned a gang type from a blank ``Gang``
+cell, so a ``GangType`` was founded whose name is the empty string. Being
+foundable by default, it drew as an empty card on the create-gang page,
+sorting before every real gang type because nothing sorts before nothing
+— and one player founded a gang on it, which is a gang of nothing: no
+house list to hire from, no built-ins, no name to print.
+
+A blank Gang cell is a problem the sheet must fix
+(``n26.library.ingest``), the verb refuses a blank name
+(``n26.library.authoring.create_gang_type``) and the create page offers
+no nameless type (``n26.core.forms``). This deletes the row that stands
+in spite of all three, and the gang founded on it.
+
+Deletion is why this is its own operation: conversions delete nothing,
+and ``Gang.gang_type`` is ``PROTECT``, so the gang must go first. What
+stands between this and deleting somebody's real gang is the check that
+each doomed gang is **untouched** — its founding assignment and nothing
+else. A gang anyone has hired into is a gang somebody meant to keep,
+whatever its type is called, and this refuses in words rather than
+delete it.
+
+The plan/apply split is the conversion discipline's: :func:`find` reads
+and describes, :func:`apply` performs exactly that.
+"""
+
+from dataclasses import dataclass
+
+from django.db import transaction
+
+
+class Refused(Exception):
+    """The repair found more than the accident it was written for."""
+
+
+@dataclass(frozen=True)
+class Nameless:
+    """What stands, and what deleting it would take with it."""
+
+    gang_type_ids: tuple = ()
+    gang_ids: tuple = ()
+    assignment_ids: tuple = ()
+    events: int = 0
+    problems: tuple = ()
+    nothing_here: bool = False
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    def preview(self):
+        if self.nothing_here:
+            return ["nothing to delete — every gang type in the pack has a name"]
+        types = len(self.gang_type_ids)
+        gangs = len(self.gang_ids)
+        lines = []
+        if gangs:
+            lines.append(
+                f"delete {gangs} gang{'' if gangs == 1 else 's'} founded on a "
+                f"nameless type — each untouched since founding — and with "
+                f"{'it' if gangs == 1 else 'them'} "
+                f"{len(self.assignment_ids)} founding "
+                f"assignment{'' if len(self.assignment_ids) == 1 else 's'}, "
+                f"{self.events} history event"
+                f"{'' if self.events == 1 else 's'}, and an empty stash"
+            )
+        else:
+            lines.append("no gang was founded on it, so nothing of a player's dies")
+        lines.append(
+            f"delete {types} gang type{'' if types == 1 else 's'} with no name"
+        )
+        return lines
+
+
+def find():
+    """Read the nameless types as they stand. Never writes."""
+    from n26.core.models import Assignment, Gang, LedgerEvent, Miniature
+    from n26.library.models import GangType, Profile
+    from n26.library.models.pack import default_pack_id
+
+    # Scoped to the default pack: a custom pack's own rows are somebody's
+    # content and not this accident, and the create page no longer offers
+    # a nameless one from anywhere.
+    doomed_types = list(
+        GangType.objects.filter(name="", pack_id=default_pack_id()).order_by("created")
+    )
+    if not doomed_types:
+        return Nameless(nothing_here=True)
+
+    problems = []
+    for gang_type in doomed_types:
+        if gang_type.built_ins_id is not None or gang_type.modifiers.exists():
+            problems.append(
+                f"the nameless type {gang_type.pk} carries built-ins or "
+                "modifiers — something has been authored onto it, so it is "
+                "not the empty row this deletes"
+            )
+        hired = Profile.objects.filter(gang_type=gang_type)
+        if hired.exists():
+            problems.append(
+                f"{hired.count()} fighter entries are hired off the nameless "
+                f"type {gang_type.pk} — it is being used as a gang list, so "
+                "it wants a name rather than deleting"
+            )
+
+    gangs = list(Gang.objects.filter(gang_type__in=doomed_types))
+    doomed_gang_ids = {gang.pk for gang in gangs}
+    foundings = {gang.founding_id for gang in gangs if gang.founding_id}
+
+    for gang in gangs:
+        # Untouched means: the founding assignment and nothing else. Both
+        # the hosted and the denormalised root are read, and archived rows
+        # count — a sold weapon is still a gang somebody played.
+        theirs = Assignment.objects.filter(gang=gang) | Assignment.objects.filter(
+            gang_root=gang
+        )
+        strays = theirs.exclude(pk=gang.founding_id).distinct().count()
+        if strays:
+            problems.append(
+                f"a gang founded on a nameless type has {strays} assignments "
+                "beyond its founding — it has been played, so it is not this "
+                "repair's to delete"
+            )
+        models_in = Miniature.objects.filter(membership__gang=gang).count()
+        if models_in:
+            problems.append(
+                f"a gang founded on a nameless type holds {models_in} models "
+                "— it has been hired into, so it is not this repair's to delete"
+            )
+
+    # An assignment naming a nameless type that is not one of these gangs'
+    # foundings is something this has not accounted for; ``PROTECT`` would
+    # stop the delete anyway, and a refusal in words beats a crash.
+    strangers = (
+        Assignment.objects.filter(gang_type__in=doomed_types)
+        .exclude(pk__in=foundings)
+        .count()
+    )
+    if strangers:
+        problems.append(
+            f"{strangers} assignments name a nameless gang type but are not "
+            "one of these gangs' foundings"
+        )
+
+    events = LedgerEvent.objects.filter(gang_id__in=doomed_gang_ids).count()
+    return Nameless(
+        gang_type_ids=tuple(sorted((t.pk for t in doomed_types), key=str)),
+        gang_ids=tuple(sorted(doomed_gang_ids, key=str)),
+        assignment_ids=tuple(sorted((f for f in foundings), key=str)),
+        events=events,
+        problems=tuple(problems),
+    )
+
+
+def apply(nameless):
+    """Delete exactly what the plan names — the gangs, then the types."""
+    from django.db.models import ProtectedError
+
+    from n26.core.models import Gang
+    from n26.library.models import GangType
+
+    if nameless.problems:
+        raise Refused("not deleted: " + "; ".join(nameless.problems))
+    if nameless.nothing_here:
+        return list(nameless.preview())
+
+    report = list(nameless.preview())
+    try:
+        with transaction.atomic():
+            # The gangs first: ``Gang.gang_type`` is PROTECT, and their
+            # assignments, stash and history events ride them down.
+            Gang.objects.filter(pk__in=nameless.gang_ids).delete()
+            GangType.objects.filter(pk__in=nameless.gang_type_ids).delete()
+    except ProtectedError as protected:
+        # The backstop behind find()'s enumerated checks: whatever this
+        # names is a referent nobody listed, and the answer is the same
+        # refusal in words, never a crash.
+        raise Refused(
+            "refused — something still names what would be deleted: "
+            f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}"
+        ) from protected
+    report.append("deleted; every gang type in the pack has a name")
+    return report

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -57,6 +57,7 @@ __all__ = [
     "convert_gang_legacy",
     "convert_skill_tree",
     "convert_specialisation",
+    "delete_nameless_gang_type",
     "retire_gang_legacy_pilot",
     "task_routes",
 ]
@@ -103,6 +104,10 @@ class Operation(models.TextChoices):
         "n26_convert_archetype",
         "n26: the Outcast archetypes become picks",
     )
+    DELETE_NAMELESS_GANG_TYPE = (
+        "n26_delete_nameless_gang_type",
+        "n26: the gang type with no name is deleted",
+    )
     MERGE_WARGEAR_INTO_WEAPON = (
         "n26_merge_wargear_into_weapon",
         "n26: duplicated wargear becomes its weapon",
@@ -116,6 +121,7 @@ LOCK_KEYS = {
     Operation.CONVERT_GANG_LEGACY: 826_020_603,
     Operation.RETIRE_GANG_LEGACY_PILOT: 826_020_604,
     Operation.CONVERT_ARCHETYPE: 826_020_605,
+    Operation.DELETE_NAMELESS_GANG_TYPE: 826_020_606,
 }
 
 
@@ -339,6 +345,25 @@ def retire_gang_legacy_pilot(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def delete_nameless_gang_type(backfill_id, **said_by_whoever_enqueued_it):
+    """Delete the nameless gang type and the gang founded on it, once.
+
+    The same runner discipline as a conversion — the lock, the claim,
+    every ending recorded — around work that deletes, which is why the
+    module it calls proves the gang untouched before it does.
+    """
+    from n26.library.nameless_gang_type import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.DELETE_NAMELESS_GANG_TYPE,
+        "Nameless gang type deletion",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
 def _conversion_view(request, operation, system, task_fn):
     """Preview a conversion (GET), or record a run and enqueue it (POST)."""
     address = reverse(f"admin:maintenance_{operation.value}")
@@ -431,52 +456,121 @@ def convert_archetype_view(request):
     )
 
 
-def retire_gang_legacy_pilot_view(request):
-    """Preview the pilot retirement (GET), or record a run and enqueue it."""
-    from n26.library.gang_legacy_pilot import find
+#: The words one deletion page says for itself. Everything else about
+#: the page — the plan, the refusals, the apply button, the recent runs —
+#: is the same for every deletion, so only these differ.
+PILOT_WORDS = {
+    "noun": "retirement",
+    "intro": (
+        "This deletes — one of the two operations that do. The pilot was a "
+        "hand-built experiment whose pickables carry nothing, and its rows "
+        "squat on the names the real Gang Legacy conversion needs. Every row "
+        "it would delete is listed below; it refuses if anything outside the "
+        "pilot has come to depend on them."
+    ),
+    "nothing_heading": "Nothing to retire",
+    "nothing_words": (
+        "No slot type of the pilot's name stands. It has been retired "
+        "already, or was never here."
+    ),
+    "refuses_heading": "The retirement refuses",
+    "button": "Retire the pilot",
+    "confirm": "Delete the pilot? This cannot be undone.",
+}
 
-    operation = Operation.RETIRE_GANG_LEGACY_PILOT
+NAMELESS_WORDS = {
+    "noun": "deletion",
+    "intro": (
+        "This deletes — one of the two operations that do. An ingest planned "
+        "a gang type from a blank Gang cell, so a type with no name was "
+        "founded and drew as an empty card on the create-gang page. This "
+        "deletes that row, and any gang founded on it — a gang of nothing, "
+        "with no list to hire from. It refuses for any such gang that has "
+        "been played: anything beyond its founding assignment, and it stays."
+    ),
+    "nothing_heading": "Nothing to delete",
+    "nothing_words": "Every gang type in the pack has a name.",
+    "refuses_heading": "The deletion refuses",
+    "button": "Delete the nameless gang type",
+    "confirm": "Delete the nameless gang type and the gang founded on it? This cannot be undone.",
+}
+
+
+def _deletion_view(request, operation, find_fn, task_fn, words):
+    """Preview a deletion (GET), or record a run and enqueue it.
+
+    Shared by every operation that deletes. The discipline is the
+    conversion view's — a running guard, nothing recorded for a run with
+    nothing to do, a refusal shown to whoever asked for it rather than
+    filed as a failure — and only ``words`` differs between pages.
+    """
     address = reverse(f"admin:maintenance_{operation.value}")
     if request.method == "POST":
         running = running_guard(operation)
         if running is not None:
-            messages.warning(request, "That retirement is already running.")
+            messages.warning(request, f"That {words['noun']} is already running.")
             return HttpResponseRedirect(
                 reverse("admin:maintenance_backfill_detail", args=[running.id])
             )
-        pilot = find()
-        if pilot.nothing_here:
-            messages.info(request, "There is nothing to retire.")
+        plan = find_fn()
+        if plan.nothing_here:
+            messages.info(request, words["nothing_words"])
             return HttpResponseRedirect(address)
-        if not pilot.ok:
+        if not plan.ok:
             messages.error(
-                request, "The retirement refuses: " + "; ".join(pilot.problems)
+                request,
+                f"The {words['noun']} refuses: " + "; ".join(plan.problems),
             )
             return HttpResponseRedirect(address)
         backfill = Backfill.objects.create(
             operation=operation,
             triggered_by=request.user,
             status=Backfill.Status.RUNNING,
-            summary={"preview": list(pilot.preview()), "attempts": 0},
+            summary={"preview": list(plan.preview()), "attempts": 0},
         )
-        retire_gang_legacy_pilot.enqueue(backfill_id=str(backfill.id))
+        task_fn.enqueue(backfill_id=str(backfill.id))
         messages.success(
-            request, "The retirement is running. This page shows what it did."
+            request, f"The {words['noun']} is running. This page shows what it did."
         )
         return HttpResponseRedirect(
             reverse("admin:maintenance_backfill_detail", args=[backfill.id])
         )
 
-    pilot = find()
+    plan = find_fn()
     context = page_context(
         request,
         operation.label,
-        pilot=pilot,
-        preview=list(pilot.preview()),
+        plan=plan,
+        preview=list(plan.preview()),
+        words=words,
         apply_url=address,
         recent=Backfill.objects.filter(operation=operation)[:10],
     )
-    return render(request, "admin/maintenance/n26/retire_pilot.html", context)
+    return render(request, "admin/maintenance/n26/delete.html", context)
+
+
+def retire_gang_legacy_pilot_view(request):
+    from n26.library.gang_legacy_pilot import find
+
+    return _deletion_view(
+        request,
+        Operation.RETIRE_GANG_LEGACY_PILOT,
+        find,
+        retire_gang_legacy_pilot,
+        PILOT_WORDS,
+    )
+
+
+def delete_nameless_gang_type_view(request):
+    from n26.library.nameless_gang_type import find
+
+    return _deletion_view(
+        request,
+        Operation.DELETE_NAMELESS_GANG_TYPE,
+        find,
+        delete_nameless_gang_type,
+        NAMELESS_WORDS,
+    )
 
 
 register_operation(
@@ -559,6 +653,22 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.DELETE_NAMELESS_GANG_TYPE.value,
+        name=Operation.DELETE_NAMELESS_GANG_TYPE.label,
+        description=(
+            "Delete the gang type an ingest founded from a blank Gang cell — "
+            "the nameless one that drew as an empty card on the create-gang "
+            "page — and any gang founded on it, which has no list to hire "
+            "from. Refuses for a gang that has been played, or a type "
+            "anything has been authored onto."
+        ),
+        view=delete_nameless_gang_type_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a conversion holds one
 #: transaction for as long as proving its spread of gangs takes. It is also
@@ -573,6 +683,7 @@ task_routes = [
     TaskRoute(convert_gang_legacy, ack_deadline=600, min_retry_delay=60),
     TaskRoute(retire_gang_legacy_pilot, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_archetype, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -462,13 +462,14 @@ def convert_archetype_view(request):
 PILOT_WORDS = {
     "noun": "retirement",
     "intro": (
-        "This deletes — one of the two operations that do. The pilot was a "
-        "hand-built experiment whose pickables carry nothing, and its rows "
+        "This deletes library rows and the assignments answering them. The "
+        "pilot was a hand-built experiment whose pickables carry nothing, and its rows "
         "squat on the names the real Gang Legacy conversion needs. Every row "
         "it would delete is listed below; it refuses if anything outside the "
         "pilot has come to depend on them."
     ),
     "nothing_heading": "Nothing to retire",
+    "nothing_flash": "There was nothing to retire.",
     "nothing_words": (
         "No slot type of the pilot's name stands. It has been retired "
         "already, or was never here."
@@ -481,7 +482,7 @@ PILOT_WORDS = {
 NAMELESS_WORDS = {
     "noun": "deletion",
     "intro": (
-        "This deletes — one of the two operations that do. An ingest planned "
+        "This deletes a library row and a player's gang. An ingest planned "
         "a gang type from a blank Gang cell, so a type with no name was "
         "founded and drew as an empty card on the create-gang page. This "
         "deletes that row, and any gang founded on it — a gang of nothing, "
@@ -489,6 +490,7 @@ NAMELESS_WORDS = {
         "been played: anything beyond its founding assignment, and it stays."
     ),
     "nothing_heading": "Nothing to delete",
+    "nothing_flash": "There was nothing to delete — every gang type has a name.",
     "nothing_words": "Every gang type in the pack has a name.",
     "refuses_heading": "The deletion refuses",
     "button": "Delete the nameless gang type",
@@ -514,7 +516,7 @@ def _deletion_view(request, operation, find_fn, task_fn, words):
             )
         plan = find_fn()
         if plan.nothing_here:
-            messages.info(request, words["nothing_words"])
+            messages.info(request, words["nothing_flash"])
             return HttpResponseRedirect(address)
         if not plan.ok:
             messages.error(
@@ -550,6 +552,7 @@ def _deletion_view(request, operation, find_fn, task_fn, words):
 
 
 def retire_gang_legacy_pilot_view(request):
+    """Preview the pilot retirement (GET), or record a run and enqueue it."""
     from n26.library.gang_legacy_pilot import find
 
     return _deletion_view(
@@ -562,6 +565,7 @@ def retire_gang_legacy_pilot_view(request):
 
 
 def delete_nameless_gang_type_view(request):
+    """Preview the deletion (GET), or record a run and enqueue it."""
     from n26.library.nameless_gang_type import find
 
     return _deletion_view(
@@ -615,7 +619,7 @@ register_operation(
             "anything outside the pilot has come to depend on it."
         ),
         view=retire_gang_legacy_pilot_view,
-        detail_template="admin/maintenance/n26/_convert_detail.html",
+        detail_template="admin/maintenance/n26/_delete_detail.html",
     )
 )
 
@@ -665,7 +669,7 @@ register_operation(
             "anything has been authored onto."
         ),
         view=delete_nameless_gang_type_view,
-        detail_template="admin/maintenance/n26/_convert_detail.html",
+        detail_template="admin/maintenance/n26/_delete_detail.html",
     )
 )
 

--- a/n26/tests/sandbox/test_ingest.py
+++ b/n26/tests/sandbox/test_ingest.py
@@ -710,6 +710,25 @@ Chaos Helot Cult,2-5,,4+,,4,5,2,3,2,5+,,,,,,,,,,,,,
         assert not plan.ok
         assert "another sheet" in plan.problems[0].message
 
+    def test_a_row_with_no_gang_is_sent_back_rather_than_founding_a_nameless_type(
+        self, foundation
+    ):
+        """A gang type planned from a blank Gang cell has no name, and
+        draws on the create-gang page as an empty card that sorts before
+        every real type — with no answer a player could give it."""
+        plan = plan_ingest(
+            profiles=read_csv(
+                """
+Gang,Section,Category,Name,M,WS,BS,S,T,W,I,A,Sv,Ld,Cl,Wil,Int,Type,Subtype(s),Starting XP,Rating,Special Rules,Default skills,Default assignment,Primary Skill Sets,Secondary Skill Sets
+,Dramatis Personae,Hired Gun,Nameless Blade,5",3+,3+,3,3,2,4,2,5+,7,7,7,7,Fighter,Ganger,,80,,,,,
+"""
+            )
+        )
+        assert not plan.ok
+        assert any("names no Gang" in problem.message for problem in plan.problems)
+        assert not [row for row in plan.planned if row.kind == "GangType"]
+        assert plan.get("Profile:nameless blade") is None
+
 
 # --- Stage 3: plan → rows ------------------------------------------------------
 

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -1,0 +1,156 @@
+"""The nameless gang type, and the repair that deletes it.
+
+An ingest planned a gang type from a blank Gang cell, so a ``GangType``
+with no name stood in the pack — foundable by default, drawn as an empty
+card sorting before every real type, and founded on by one player. Three
+things are proven here: nothing may author such a row any more, the
+create page would not offer one that already stands, and the repair
+deletes exactly the accident — refusing the moment a gang founded on it
+turns out to have been played.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from n26.core.forms import CreateGangForm
+from n26.core.models import Assignment, Gang
+from n26.library import authoring
+from n26.library.models import GangType
+from n26.library.nameless_gang_type import Refused, apply, find
+from n26.tests.sandbox.actions import (
+    create_gang_type,
+    create_profile,
+    found_gang,
+    hire,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def nameless(db, default_pack):
+    """The row as production holds it: no name, no badge, foundable."""
+    return GangType.objects.create(name="")
+
+
+@pytest.fixture
+def founded_on_it(nameless, owner):
+    """A gang of nothing — founded on the empty card and untouched since."""
+    return found_gang("A Gang Of Nothing", nameless, owner=owner)
+
+
+class TestNothingMayAuthorOne:
+    def test_the_verb_refuses_a_blank_name(self, db, default_pack):
+        with pytest.raises(ValidationError, match="needs a name"):
+            authoring.create_gang_type("")
+        with pytest.raises(ValidationError, match="needs a name"):
+            authoring.create_gang_type("   ")
+        assert not GangType.objects.exists()
+
+
+class TestTheCreatePageDoesNotOfferOne:
+    def test_a_nameless_type_is_not_a_card(self, nameless):
+        real = create_gang_type("Escher", starting_credits=1000)
+
+        offered = CreateGangForm().gang_type_choices()
+
+        assert [card["value"] for card in offered] == [str(real.pk)]
+
+    def test_it_is_not_an_answer_either(self, nameless):
+        create_gang_type("Escher", starting_credits=1000)
+
+        form = CreateGangForm(data={"name": "The Nothings", "gang_type": nameless.pk})
+
+        assert not form.is_valid()
+        assert "gang_type" in form.errors
+
+
+class TestFindingIt:
+    def test_it_names_the_type_and_the_gang_founded_on_it(self, founded_on_it):
+        found = find()
+
+        assert found.ok and not found.nothing_here
+        assert len(found.gang_type_ids) == 1
+        assert found.gang_ids == (founded_on_it.pk,)
+        assert found.assignment_ids == (founded_on_it.founding_id,)
+        said = "\n".join(found.preview())
+        assert "delete 1 gang founded on a nameless type" in said
+        assert "delete 1 gang type with no name" in said
+
+    def test_a_type_with_no_gang_on_it_still_goes(self, nameless):
+        found = find()
+
+        assert found.ok and found.gang_ids == ()
+        assert "nothing of a player's dies" in "\n".join(found.preview())
+
+    def test_a_pack_of_named_types_has_nothing_to_delete(self, db, default_pack):
+        create_gang_type("Escher", starting_credits=1000)
+
+        found = find()
+
+        assert found.nothing_here
+        assert apply(found) == found.preview()
+
+
+class TestRefusing:
+    def test_a_gang_that_has_been_hired_into_is_left_alone(
+        self, founded_on_it, person_type
+    ):
+        profile = create_profile(
+            "Somebody", person_type, founded_on_it.gang_type, price=50
+        )
+        hire(founded_on_it, profile, "Somebody At All")
+
+        found = find()
+
+        assert not found.ok
+        assert any("has been played" in problem for problem in found.problems)
+        with pytest.raises(Refused, match="not deleted"):
+            apply(found)
+        assert Gang.objects.filter(pk=founded_on_it.pk).exists()
+
+    def test_a_type_something_is_hired_off_wants_a_name_instead(
+        self, nameless, person_type
+    ):
+        create_profile("Somebody", person_type, nameless, price=50)
+
+        found = find()
+
+        assert not found.ok
+        assert any(
+            "hired off the nameless type" in problem for problem in found.problems
+        )
+
+    def test_a_type_authored_onto_is_not_the_empty_row(self, nameless, person_type):
+        nameless.built_ins = authoring.create_default_set("Something")
+        nameless.save()
+
+        found = find()
+
+        assert not found.ok
+        assert any("authored onto it" in problem for problem in found.problems)
+
+
+class TestApplying:
+    def test_it_deletes_the_gang_and_then_the_type(self, founded_on_it):
+        named = create_gang_type("Escher", starting_credits=1000)
+        kept = found_gang("The Real Thing", named, owner=founded_on_it.owner)
+
+        report = apply(find())
+
+        assert not GangType.objects.filter(name="").exists()
+        assert not Gang.objects.filter(pk=founded_on_it.pk).exists()
+        # The founding assignment rode the gang down; the real gang beside
+        # it is untouched.
+        assert not Assignment.objects.filter(gang_root=founded_on_it).exists()
+        assert Gang.objects.filter(pk=kept.pk).exists()
+        assert GangType.objects.filter(pk=named.pk).exists()
+        assert "deleted; every gang type in the pack has a name" in report
+
+    def test_running_it_twice_finds_nothing_the_second_time(self, founded_on_it):
+        apply(find())
+
+        again = find()
+
+        assert again.nothing_here
+        assert apply(again) == again.preview()

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -244,6 +244,20 @@ class TestApplying:
 
         assert Gang.objects.filter(pk=founded_on_it.pk).exists()
         assert GangType.objects.filter(name="").exists()
+        assert_reconciled(founded_on_it)
+
+    def test_a_layout_saved_since_the_plan_was_read_refuses_too(self, founded_on_it):
+        """The preview promises everything that dies by count, and a
+        print layout cascades with its gang."""
+        from n26.core.models import PrintConfig
+
+        stale = find()
+        PrintConfig.objects.create(gang=founded_on_it, name="For the table")
+
+        with pytest.raises(Refused, match="changed since the plan was read"):
+            apply(stale)
+
+        assert Gang.objects.filter(pk=founded_on_it.pk).exists()
 
     def test_running_it_twice_finds_nothing_the_second_time(self, founded_on_it):
         apply(find())

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -2,9 +2,9 @@
 
 An ingest planned a gang type from a blank Gang cell, so a ``GangType``
 with no name stood in the pack — foundable by default, drawn as an empty
-card sorting before every real type, and founded on by one player. Three
-things are proven here: nothing may author such a row any more, the
-create page would not offer one that already stands, and the repair
+card sorting before every real type, and foundable into a gang of
+nothing. Three things are proven here: nothing may author such a row,
+the create page does not offer one that already stands, and the repair
 deletes exactly the accident — refusing the moment a gang founded on it
 turns out to have been played.
 """
@@ -14,14 +14,19 @@ from django.core.exceptions import ValidationError
 
 from n26.core.forms import CreateGangForm
 from n26.core.models import Assignment, Gang
+from n26.core.reconcile import assert_reconciled
 from n26.library import authoring
 from n26.library.models import GangType
 from n26.library.nameless_gang_type import Refused, apply, find
 from n26.tests.sandbox.actions import (
     create_gang_type,
     create_profile,
+    create_rule,
+    ef_adds,
     found_gang,
     hire,
+    modifier,
+    targets_model,
 )
 
 pytestmark = pytest.mark.django_db
@@ -65,6 +70,38 @@ class TestTheCreatePageDoesNotOfferOne:
         assert "gang_type" in form.errors
 
 
+class TestWhitespaceIsNoNameEither:
+    """A name of nothing but spaces draws the identical empty card, so
+    every guard treats it as the blank it looks like."""
+
+    @pytest.fixture
+    def padded(self, db, default_pack):
+        return GangType.objects.create(name="   ")
+
+    def test_the_verb_refuses_it_and_strips_what_it_stores(self, db, default_pack):
+        with pytest.raises(ValidationError, match="needs a name"):
+            authoring.create_gang_type("   ")
+
+        assert authoring.create_gang_type("  Escher  ").name == "Escher"
+
+    def test_the_create_page_does_not_offer_it(self, padded):
+        real = create_gang_type("Escher", starting_credits=1000)
+
+        offered = CreateGangForm().gang_type_choices()
+
+        assert [card["value"] for card in offered] == [str(real.pk)]
+
+    def test_the_repair_finds_it(self, padded):
+        found = find()
+
+        assert found.ok and not found.nothing_here
+        assert found.gang_type_ids == (padded.pk,)
+
+        apply(found)
+
+        assert not GangType.objects.filter(pk=padded.pk).exists()
+
+
 class TestFindingIt:
     def test_it_names_the_type_and_the_gang_founded_on_it(self, founded_on_it):
         found = find()
@@ -99,7 +136,8 @@ class TestRefusing:
         profile = create_profile(
             "Somebody", person_type, founded_on_it.gang_type, price=50
         )
-        hire(founded_on_it, profile, "Somebody At All")
+        hire(founded_on_it, profile, "Somebody At All", paid=50)
+        assert_reconciled(founded_on_it)
 
         found = find()
 
@@ -121,7 +159,7 @@ class TestRefusing:
             "hired off the nameless type" in problem for problem in found.problems
         )
 
-    def test_a_type_authored_onto_is_not_the_empty_row(self, nameless, person_type):
+    def test_a_type_carrying_built_ins_is_not_the_empty_row(self, nameless):
         nameless.built_ins = authoring.create_default_set("Something")
         nameless.save()
 
@@ -129,6 +167,46 @@ class TestRefusing:
 
         assert not found.ok
         assert any("authored onto it" in problem for problem in found.problems)
+
+    def test_a_type_carrying_modifiers_is_not_the_empty_row(self, nameless):
+        nameless.modifiers.add(
+            modifier("Something", targets_model(), ef_adds(create_rule("Tough")))
+        )
+
+        found = find()
+
+        assert not found.ok
+        assert any("authored onto it" in problem for problem in found.problems)
+
+    def test_an_assignment_naming_it_that_is_not_a_founding_is_refused(
+        self, founded_on_it
+    ):
+        """``Assignment.gang_type`` is PROTECT, so the delete would fail
+        anyway — refusing in words beats a crash, and says which rows."""
+        stranger = Assignment.objects.create(
+            gang_type=founded_on_it.gang_type, gang=founded_on_it
+        )
+
+        found = find()
+
+        assert not found.ok
+        assert any(
+            "one of these gangs' foundings" in problem for problem in found.problems
+        )
+        assert stranger.pk not in found.assignment_ids
+        with pytest.raises(Refused, match="not deleted"):
+            apply(found)
+
+    def test_a_nameless_type_in_another_pack_is_left_alone(self, db, default_pack):
+        """Names are unique per pack, and another pack's rows are
+        somebody's content rather than this accident."""
+        theirs = authoring.create_pack("Someone Else's")
+        GangType.objects.create(name="", pack=theirs)
+
+        found = find()
+
+        assert found.nothing_here
+        assert GangType.objects.filter(pack=theirs, name="").exists()
 
 
 class TestApplying:
@@ -146,6 +224,26 @@ class TestApplying:
         assert Gang.objects.filter(pk=kept.pk).exists()
         assert GangType.objects.filter(pk=named.pk).exists()
         assert "deleted; every gang type in the pack has a name" in report
+
+    def test_a_plan_read_before_the_world_moved_is_refused(
+        self, founded_on_it, person_type
+    ):
+        """A gang's assignments cascade rather than protect, so a gang
+        hired into between reading the plan and deleting would ride the
+        delete down. The plan is read again inside the transaction, and
+        anything that has moved refuses."""
+        stale = find()
+        assert stale.ok
+        profile = create_profile(
+            "Somebody", person_type, founded_on_it.gang_type, price=50
+        )
+        hire(founded_on_it, profile, "Somebody At All", paid=50)
+
+        with pytest.raises(Refused, match="changed since the plan was read"):
+            apply(stale)
+
+        assert Gang.objects.filter(pk=founded_on_it.pk).exists()
+        assert GangType.objects.filter(name="").exists()
 
     def test_running_it_twice_finds_nothing_the_second_time(self, founded_on_it):
         apply(find())

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -27,6 +27,7 @@ from n26.maintenance import (
     convert_skill_tree_view,
     convert_specialisation,
     convert_specialisation_view,
+    delete_nameless_gang_type_view,
     retire_gang_legacy_pilot_view,
 )
 from n26.tests.sandbox.test_conversion_archetype import (
@@ -493,3 +494,80 @@ class TestTheRunsOwnGuards:
 
         backfill.refresh_from_db()
         assert backfill.status == Backfill.Status.CANCELLED
+
+
+class TestTheNamelessGangTypeDeletion:
+    """The second operation that deletes: an empty-named gang type an
+    ingest founded from a blank Gang cell, and the gang of nothing
+    founded on it."""
+
+    @pytest.fixture
+    def nameless_world(self, owner, default_pack):
+        from n26.library.models import GangType
+        from n26.tests.sandbox.actions import create_gang_type, found_gang
+
+        nameless = GangType.objects.create(name="")
+        create_gang_type("Escher", starting_credits=1000)
+        return found_gang("A Gang Of Nothing", nameless, owner=owner)
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.DELETE_NAMELESS_GANG_TYPE.value in registered
+        found = resolve_operation(Operation.DELETE_NAMELESS_GANG_TYPE.value)
+        assert found.name == Operation.DELETE_NAMELESS_GANG_TYPE.label
+        assert found.view is delete_nameless_gang_type_view
+
+    def test_its_page_shows_the_plan_and_writes_nothing(
+        self, client, superuser, nameless_world
+    ):
+        from n26.library.models import GangType
+
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_delete_nameless_gang_type")
+        )
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "delete 1 gang founded on a nameless type" in page
+        assert not Backfill.objects.exists()
+        assert GangType.objects.filter(name="").exists()
+
+    def test_applying_records_what_it_deleted(self, client, superuser, nameless_world):
+        from n26.core.models import Gang
+        from n26.library.models import GangType
+
+        client.force_login(superuser)
+
+        response = client.post(
+            reverse("admin:maintenance_n26_delete_nameless_gang_type")
+        )
+
+        assert response.status_code == 302
+        run = Backfill.objects.get(operation=Operation.DELETE_NAMELESS_GANG_TYPE)
+        assert run.status == Backfill.Status.DONE
+        assert any("deleted" in line for line in run.summary["report"])
+        assert not GangType.objects.filter(name="").exists()
+        assert not Gang.objects.filter(pk=nameless_world.pk).exists()
+        assert GangType.objects.filter(name="Escher").exists()
+
+    def test_a_gang_that_has_been_played_stops_the_run_before_it_records(
+        self, client, superuser, nameless_world, person_type
+    ):
+        """The refusal belongs on the screen of whoever asked for it,
+        not filed as a failed run."""
+        from n26.core.models import Gang
+        from n26.tests.sandbox.actions import create_profile, hire
+
+        profile = create_profile(
+            "Somebody", person_type, nameless_world.gang_type, price=50
+        )
+        hire(nameless_world, profile, "Somebody At All")
+        client.force_login(superuser)
+
+        client.post(reverse("admin:maintenance_n26_delete_nameless_gang_type"))
+
+        assert not Backfill.objects.exists()
+        assert Gang.objects.filter(pk=nameless_world.pk).exists()


### PR DESCRIPTION
The create-gang page was drawing a blank option — an empty radio card, no name, no badge, sitting ahead of every real gang type. Picking it founded a gang of nothing: no house list to hire from, no built-ins, no name to print.

The card was a `GangType` row whose name is the empty string. It was created by an ingest of a profiles sheet on which one row's **Gang** cell was blank: the planner turns that cell into a gang type unconditionally, and `foundable` defaults to true, so the nameless type was offered for founding. It sorted first because nothing sorts before nothing.

## Summary

- **Three guards, root cause outwards.** `_plan_profiles` now makes a blank Gang cell a plan problem, alongside the guards it already has for a row naming no profile and no Type — so the sheet is corrected rather than the library inventing a type. `authoring.create_gang_type` refuses a blank name whatever path asks for one, and `CreateGangForm` excludes nameless types as well as unfoundable ones, so a row already sitting in a pack can never be drawn as a card.
- **A repair for the row that already exists.** `n26/library/nameless_gang_type.py` finds nameless gang types in the default pack together with any gang founded on one, and deletes both — gangs first, since `Gang.gang_type` is `PROTECT`. It refuses rather than deletes if a doomed gang holds anything beyond its founding assignment or any models, if fighter entries are hired off the type, or if built-ins or modifiers have been authored onto it. It is registered on the maintenance console and runs on the tasks framework under the same lock, attempt-cap and record-every-ending discipline as the conversions.
- **One deletion page instead of two.** The gang legacy pilot retirement and this repair share `_deletion_view` and `n26/core/templates/admin/maintenance/n26/delete.html`, with each operation's own wording passed in as context.

## Test plan

- [x] `pytest -n auto` — 8146 passed, 12 skipped, 1 xfailed
- [x] New sandbox suite `n26/tests/sandbox/test_nameless_gang_type.py`: the verb refuses a blank name; the create form neither offers a nameless type nor accepts one as an answer; `find()` names the type and the gang founded on it; the repair refuses for a gang that has been hired into, for a type with entries hired off it, and for one with built-ins authored onto it; applying deletes both and leaves a named type and its gang untouched; running it twice finds nothing the second time
- [x] New ingest case: a profiles row with a blank Gang cell is a plan problem, plans no gang type, and plans no profile
- [x] New console cases in `n26/tests/test_maintenance_console.py`: the operation is registered and named, its page shows the plan and writes nothing, applying records what it deleted, and a gang that has been played stops the run before any record is written
- [x] Run against a fork of the content mirror: the console page renders the plan, POST enqueues, the task deletes exactly the two rows and records its report, and every other gang type, profile and gang compares equal before and after. Re-running finds nothing to do.

## Trying it

- `/n26/gangs/new/` — the card grid, with no empty card at the front.
- `/admin/maintenance/` → "n26: the gang type with no name is deleted" — the preview lists what it would delete, and refuses in words if the gang has been played.

## Next steps

The repair needs triggering from the maintenance console once this deploys; until then the row is still in the pack, merely no longer offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)