### PR TITLE
feat: plan built-in assignment reconciliation

### DIFF
--- a/n26/core/built_ins.py
+++ b/n26/core/built_ins.py
@@ -1,0 +1,250 @@
+"""Read-only plans for bringing built-ins up to date.
+
+The plan is the shared answer for three later writers: the authoring preview,
+near-real-time propagation, and the historical backfill.  It reads current
+player data and says what one default member would mean for every existing use;
+it never creates or changes an assignment.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from django.db import models
+
+from n26.core.models import Assignment, ChosenProfileOption, ProfileRole, Reason
+from n26.core.models.assignment import ASSIGNABLE_FIELDS
+from n26.library.models import Collection, Counter, Rule, Subtype, WeaponProfile
+
+
+class BuiltInAction(StrEnum):
+    """What reconciling one use would do."""
+
+    CREATE = "create"
+    MATERIALISED = "materialised"
+    SATISFIED = "satisfied"
+    PARTED_WITH = "parted-with"
+    OUT_OF_SCOPE = "out-of-scope"
+
+
+@dataclass(frozen=True)
+class PlannedBuiltInUse:
+    """One existing acquisition and the answer for one built-in member."""
+
+    carrier: Assignment
+    action: BuiltInAction
+    existing: Assignment | None = None
+    removal: Assignment | None = None
+
+    @property
+    def writes(self):
+        return self.action == BuiltInAction.CREATE
+
+    @property
+    def changes_card(self):
+        return self.writes and self.removal is None
+
+
+@dataclass(frozen=True)
+class BuiltInPlan:
+    """The impact of one actual or hypothetical member of a default set."""
+
+    default_set: object | None
+    thing: object
+    member: object | None
+    uses: tuple[PlannedBuiltInUse, ...]
+
+    def count(self, action):
+        return sum(use.action == action for use in self.uses)
+
+    @property
+    def writes(self):
+        return sum(use.writes for use in self.uses)
+
+    @property
+    def visible_changes(self):
+        return sum(use.changes_card for use in self.uses)
+
+
+def plan_built_in_add(carrier, thing):
+    """Plan adding ``thing`` to ``carrier`` without writing either side.
+
+    A carrier whose set is shared reaches every holder of that set, exactly as
+    the real add would.  Before its first built-in it has no set yet, so only
+    existing assignments of that carrier are in scope.
+    """
+
+    default_set = getattr(carrier, "built_ins", None)
+    carriers = (
+        _carriers_of(default_set)
+        if default_set is not None
+        else _assignments_of(carrier)
+    )
+    return _plan(default_set, thing, member=None, carriers=carriers)
+
+
+def plan_default_member(member):
+    """Plan reconciling one stored ``DefaultAssignment`` member."""
+
+    return _plan(
+        member.default_set,
+        member.assignable,
+        member=member,
+        carriers=_carriers_of(member.default_set),
+    )
+
+
+def _plan(default_set, thing, *, member, carriers):
+    uses = tuple(
+        _plan_use(carrier, thing, member)
+        for carrier in sorted(carriers, key=lambda row: str(row.pk))
+    )
+    return BuiltInPlan(
+        default_set=default_set,
+        thing=thing,
+        member=member,
+        uses=uses,
+    )
+
+
+def _assignments_of(carrier):
+    field = Assignment.field_for(carrier)
+    rows = Assignment.objects.filter(
+        archived=False,
+        **{field: carrier},
+    ).select_related("profile_role")
+    return _hydrate(rows)
+
+
+def _carriers_of(default_set):
+    """Every live acquisition that took ``default_set``.
+
+    A set can be the built-ins of several kinds and the payload of an option.
+    The assignment union has one column per kind, so narrow per kind rather
+    than making Postgres plan one join across the whole union.
+    """
+
+    ids = set()
+    for field in ASSIGNABLE_FIELDS:
+        model = Assignment._meta.get_field(field).related_model
+        if not hasattr(model, "built_ins"):
+            continue
+        ids.update(
+            Assignment.objects.filter(
+                archived=False,
+                **{f"{field}__built_ins": default_set},
+            ).values_list("pk", flat=True)
+        )
+    ids.update(
+        ChosenProfileOption.objects.filter(
+            assignment__archived=False,
+            default_set=default_set,
+        ).values_list("assignment_id", flat=True)
+    )
+    rows = Assignment.objects.filter(pk__in=ids).select_related("profile_role")
+    return _hydrate(rows)
+
+
+def _hydrate(rows):
+    """Resolve each carrier's assignable without a query per result."""
+
+    return list(Assignment.with_assignables(rows))
+
+
+def _plan_use(carrier, thing, member):
+    if not _applies_to(carrier, thing):
+        return PlannedBuiltInUse(carrier, BuiltInAction.OUT_OF_SCOPE)
+
+    source = _source_match(carrier, thing, member, archived=False)
+    if source is not None:
+        return PlannedBuiltInUse(carrier, BuiltInAction.MATERIALISED, source)
+
+    departed = _source_match(carrier, thing, member, archived=True)
+    if departed is not None:
+        return PlannedBuiltInUse(carrier, BuiltInAction.PARTED_WITH, departed)
+
+    positive = _hosted_match(carrier, thing, removes=False, archived=False)
+    removal = _hosted_match(carrier, thing, removes=True, archived=False)
+    if isinstance(thing, (Rule, Subtype, Counter)) and positive is not None:
+        return PlannedBuiltInUse(
+            carrier,
+            BuiltInAction.SATISFIED,
+            existing=positive,
+            removal=removal,
+        )
+    return PlannedBuiltInUse(
+        carrier,
+        BuiltInAction.CREATE,
+        removal=removal,
+    )
+
+
+def _applies_to(carrier, thing):
+    role = getattr(carrier, "profile_role", None)
+    return (
+        role is None
+        or role.role != ProfileRole.Role.LEGACY
+        or isinstance(thing, Collection)
+    )
+
+
+def _source_match(carrier, thing, member, *, archived):
+    """The assignment this exact member made, including legacy rows.
+
+    Before provenance columns existed, the cause and ``Reason.DEFAULT`` were
+    the only evidence.  That fallback applies only to a stored member: a
+    hypothetical add cannot already have materialised.
+    """
+
+    if member is None:
+        return None
+    exact = Assignment.objects.filter(
+        materialised_from=member,
+        materialised_for=carrier,
+        archived=archived,
+    ).first()
+    if exact is not None:
+        return exact
+
+    field = Assignment.field_for(thing)
+    roots = {
+        "gang_root_id": carrier.gang_root_id,
+        "miniature_root_id": carrier.miniature_root_id,
+        "stash_root_id": carrier.stash_root_id,
+    }
+    legacy = Assignment.objects.filter(
+        archived=archived,
+        ledger_entry__reason=Reason.DEFAULT,
+        **roots,
+        **{field: thing},
+    )
+    if isinstance(thing, WeaponProfile):
+        legacy = legacy.filter(
+            parent__weapon=thing.weapon,
+            parent__caused_by=carrier,
+            caused_by=models.F("parent"),
+        )
+    else:
+        legacy = legacy.filter(caused_by=carrier, **_host(carrier))
+    return legacy.first()
+
+
+def _hosted_match(carrier, thing, *, removes, archived):
+    field = Assignment.field_for(thing)
+    return Assignment.objects.filter(
+        archived=archived,
+        removes=removes,
+        **_host(carrier),
+        **{field: thing},
+    ).first()
+
+
+def _host(carrier):
+    """Where this carrier's defaults land, mirroring ``Operation``."""
+
+    if carrier.miniature_root_id is not None:
+        return {"miniature_id": carrier.miniature_root_id}
+    if carrier.gang_id is not None:
+        return {"gang_id": carrier.gang_id}
+    if carrier.stash_root_id is not None:
+        return {"stash_id": carrier.stash_root_id}
+    raise ValueError(f"{carrier} has nowhere for built-ins to materialise.")

--- a/n26/core/migrations/0018_built_ins_remember_their_source.py
+++ b/n26/core/migrations/0018_built_ins_remember_their_source.py
@@ -1,0 +1,34 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0064_sheets_are_held_between_upload_and_import"),
+        ("n26", "0017_the_budget_is_part_of_the_story"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="assignment",
+            name="materialised_for",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="materialised_defaults",
+                to="n26.assignment",
+            ),
+        ),
+        migrations.AddField(
+            model_name="assignment",
+            name="materialised_from",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="materialisations",
+                to="library.defaultassignment",
+            ),
+        ),
+    ]

--- a/n26/core/models/assignment.py
+++ b/n26/core/models/assignment.py
@@ -246,6 +246,26 @@ class Assignment(NamesAnAssignable, Base, Archived):
         "self", on_delete=models.CASCADE, null=True, blank=True, related_name="caused"
     )
 
+    # The built-in member and acquisition whose materialisation this is.
+    # ``caused_by`` usually names the acquisition too, but bundled ammunition
+    # is caused by its weapon; keeping both facts makes reconciliation exact.
+    # Null is meaningful for every assignment that did not come from a
+    # built-in, and for historical defaults until the backfill identifies them.
+    materialised_from = models.ForeignKey(
+        "library.DefaultAssignment",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="materialisations",
+    )
+    materialised_for = models.ForeignKey(
+        "self",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="materialised_defaults",
+    )
+
     # An assignment that takes its assignable away rather than holding
     # it: the owner's own removal of a subtype or rule. Never a line on
     # a card — it is compiled at read time to an unconditional removal,

--- a/n26/core/test_assignable_wiring.py
+++ b/n26/core/test_assignable_wiring.py
@@ -189,6 +189,24 @@ class TestSettlingAChoice:
         assert named.null is True
 
 
+class TestBuiltInProvenance:
+    """A materialised default remembers both pieces of its origin."""
+
+    def test_the_member_is_protected_and_optional(self):
+        from django.db.models.deletion import PROTECT
+
+        source = Assignment._meta.get_field("materialised_from")
+        assert source.remote_field.on_delete is PROTECT
+        assert source.null is True
+
+    def test_the_acquisition_cascades_and_is_optional(self):
+        from django.db.models.deletion import CASCADE
+
+        carrier = Assignment._meta.get_field("materialised_for")
+        assert carrier.remote_field.on_delete is CASCADE
+        assert carrier.null is True
+
+
 class TestTheStartupCheck:
     def test_it_passes_as_things_stand(self):
         assert every_assignable_has_a_column(None) == []

--- a/n26/tests/sandbox/test_built_in_planning.py
+++ b/n26/tests/sandbox/test_built_in_planning.py
@@ -1,0 +1,150 @@
+"""Planning a built-in change reads every existing use and writes nothing."""
+
+import pytest
+
+from n26.core.built_ins import (
+    BuiltInAction,
+    plan_built_in_add,
+    plan_default_member,
+)
+from n26.core.models import Assignment, CounterValue, LedgerEvent
+from n26.core.operations import operation
+from n26.library.authoring import add_default_member
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    assign,
+    create_counter,
+    create_default_set,
+    create_rule,
+    create_subtype,
+    found_gang,
+    hire,
+    offer_option,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def gang(owner, gang_type):
+    return found_gang("The Bad Girls", gang_type, owner=owner, budget=1000)
+
+
+@pytest.fixture
+def ganger(make_profile):
+    return make_profile("Escher Ganger", price=50)
+
+
+@pytest.fixture
+def yolanda(gang, ganger):
+    return hire(gang, ganger, "Yolanda", paid=50)
+
+
+class TestAReadOnlyPlan:
+    def test_a_missing_member_would_reach_an_existing_hire(self, ganger, yolanda):
+        rule = create_rule("Hot-headed")
+        assignments = Assignment.objects.count()
+        events = LedgerEvent.objects.count()
+
+        plan = plan_built_in_add(ganger, rule)
+
+        assert len(plan.uses) == 1
+        assert plan.uses[0].carrier == yolanda.membership
+        assert plan.uses[0].action == BuiltInAction.CREATE
+        assert plan.writes == 1
+        assert plan.visible_changes == 1
+        assert Assignment.objects.count() == assignments
+        assert LedgerEvent.objects.count() == events
+
+    @pytest.mark.parametrize(
+        "make_thing",
+        [create_rule, create_subtype, create_counter],
+        ids=["rule", "subtype", "counter"],
+    )
+    def test_an_independent_fact_already_on_the_model_satisfies_it(
+        self, make_thing, ganger, yolanda
+    ):
+        thing = make_thing(f"Standing {make_thing.__name__}")
+        standing = assign(thing, miniature=yolanda)
+
+        plan = plan_built_in_add(ganger, thing)
+
+        assert plan.uses[0].action == BuiltInAction.SATISFIED
+        assert plan.uses[0].existing == standing
+        assert plan.writes == 0
+        assert plan.visible_changes == 0
+
+    def test_a_matching_counter_keeps_its_running_value(self, ganger, yolanda):
+        xp = create_counter("XP")
+        standing = assign(xp, miniature=yolanda)
+        with operation(yolanda.gang, actor=yolanda.gang.owner) as op:
+            op.tally(standing, 7)
+
+        plan = plan_built_in_add(ganger, xp)
+
+        assert plan.uses[0].action == BuiltInAction.SATISFIED
+        assert CounterValue.objects.get(assignment=standing).value == 7
+
+    def test_an_owner_removal_keeps_a_new_default_hidden(self, ganger, yolanda):
+        rule = create_rule("Hot-headed")
+        with operation(yolanda.gang, actor=yolanda.gang.owner) as op:
+            removal = op.take_away(yolanda, rule)
+
+        plan = plan_built_in_add(ganger, rule)
+
+        assert plan.uses[0].action == BuiltInAction.CREATE
+        assert plan.uses[0].removal == removal
+        assert plan.writes == 1
+        assert plan.visible_changes == 0
+
+
+class TestStoredMembers:
+    def test_a_member_materialised_before_provenance_fields_is_recognised(
+        self, ganger, gang
+    ):
+        rule = create_rule("Hot-headed")
+
+        member = add_built_in(ganger, rule)
+        yolanda = hire(gang, ganger, "Yolanda", paid=50)
+        standing = Assignment.objects.get(
+            caused_by=yolanda.membership,
+            rule=rule,
+            archived=False,
+        )
+        assert standing.materialised_from_id is None
+
+        plan = plan_default_member(member)
+
+        assert plan.uses[0].action == BuiltInAction.MATERIALISED
+        assert plan.uses[0].existing == standing
+        assert plan.writes == 0
+
+    def test_a_shared_set_reaches_every_carrier_that_uses_it(self, make_profile, gang):
+        shared = create_default_set("Shared vows")
+        first = make_profile("First", built_ins=shared)
+        second = make_profile("Second", built_ins=shared)
+        hire(gang, first, "One")
+        hire(gang, second, "Two")
+
+        plan = plan_built_in_add(first, create_rule("Sworn"))
+
+        assert len(plan.uses) == 2
+        assert {use.carrier.profile for use in plan.uses} == {first, second}
+        assert plan.writes == 2
+
+    def test_an_option_member_reaches_only_acquisitions_that_took_that_set(
+        self, make_profile, gang
+    ):
+        profile = make_profile("Khimerix")
+        plain = create_default_set("Plain")
+        altered = create_default_set("Altered")
+        offer_option(profile, "Plain", default_set=plain, position=0)
+        offer_option(profile, "Altered", default_set=altered, position=1)
+        hire(gang, profile, "Plain one", option=plain)
+        changed = hire(gang, profile, "Changed one", option=altered)
+        member = add_default_member(altered, create_rule("Unstable"))
+
+        plan = plan_default_member(member)
+
+        assert [use.carrier for use in plan.uses] == [changed.membership]
+        assert plan.uses[0].action == BuiltInAction.CREATE

--- a/n26/tests/sandbox/test_built_in_planning.py
+++ b/n26/tests/sandbox/test_built_in_planning.py
@@ -99,6 +99,30 @@ class TestAReadOnlyPlan:
 
 
 class TestStoredMembers:
+    def test_explicit_provenance_identifies_the_member_and_its_acquisition(
+        self, ganger, gang
+    ):
+        rule = create_rule("Hot-headed")
+        member = add_built_in(ganger, rule)
+        yolanda = hire(gang, ganger, "Yolanda", paid=50)
+        standing = Assignment.objects.get(
+            caused_by=yolanda.membership,
+            rule=rule,
+            archived=False,
+        )
+        standing.materialised_from = member
+        standing.materialised_for = yolanda.membership
+        standing.save(
+            update_fields=["materialised_from", "materialised_for", "modified"]
+        )
+
+        plan = plan_default_member(member)
+
+        assert plan.uses[0].action == BuiltInAction.MATERIALISED
+        assert plan.uses[0].existing == standing
+        assert list(member.materialisations.all()) == [standing]
+        assert list(yolanda.membership.materialised_defaults.all()) == [standing]
+
     def test_a_member_materialised_before_provenance_fields_is_recognised(
         self, ganger, gang
     ):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the read-only foundation for making newly-authored built-ins reach existing acquisitions.

- records nullable provenance from materialised assignments to their default member and carrier
- plans the impact of actual or hypothetical built-in members without writing player data
- treats independent matching rules, subtypes, and counters as already satisfied
- accounts for owner removals, shared default sets, selected option sets, and legacy profile scope

This chunk intentionally does not propagate or backfill anything yet, so current authoring behaviour remains unchanged.

Testing is pending on this pre-test revision.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a020f3-b6c4-7511-96dc-d196005b694c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a020f3-b6c4-7511-96dc-d196005b694c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

