### PR TITLE
feat: a gang played on the nameless gang type is repointed, not refused

### DIFF
--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -670,19 +670,27 @@ class Operation:
         with the assignment — and write a new one in whatever name did
         the founding.
 
-        What the old type materialised goes, and the new type's built-ins
-        arrive in its place. A gang with no founding at all is simply
-        founded.
+        The new type's built-ins arrive caused by that same founding. A
+        gang with no founding at all is simply founded.
+
+        Refused where the founding already granted something. Taking the
+        old type's kit away means unwinding purchases that hang off it
+        and saying in the ledger that they went, which is a refund's job
+        — deleting the rows here would take their entries and events
+        with them and say nothing, and the ledger is written to once and
+        never altered.
         """
         from n26.core.models import Stash
 
         founding = self.gang.founding
         if founding is None:
             return self.found(gang_type)
-        founding.caused.all().delete()
-        # Any option recorded against the founding was an option of the
-        # type it used to name, and the new one does not offer it.
-        founding.chosen_options.all().delete()
+        if founding.caused.exists() or founding.chosen_options.exists():
+            raise Refusal(
+                f"{self.gang} was founded on a type that gave it things, and "
+                "those would have to be given back before it can be said to "
+                "be a different type."
+            )
         founding.gang_type = gang_type
         founding.save()
         Stash.objects.get_or_create(gang=self.gang)

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -680,6 +680,9 @@ class Operation:
         if founding is None:
             return self.found(gang_type)
         founding.caused.all().delete()
+        # Any option recorded against the founding was an option of the
+        # type it used to name, and the new one does not offer it.
+        founding.chosen_options.all().delete()
         founding.gang_type = gang_type
         founding.save()
         Stash.objects.get_or_create(gang=self.gang)

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -682,20 +682,26 @@ class Operation:
         """
         from n26.core.models import Stash
 
-        # The gang says what it is as well as its founding, and the two
-        # disagreeing is a gang whose pages and whose history describe
-        # different types.
-        self.gang.gang_type = gang_type
-        self.gang.save(update_fields=["gang_type", "modified"])
+        # Refused before anything is written, in memory as much as in the
+        # database: a caller that catches this and carries on would
+        # otherwise hold a gang saying it is something the database says
+        # it is not.
         founding = self.gang.founding
-        if founding is None:
-            return self.found(gang_type)
-        if founding.caused.exists() or founding.chosen_options.exists():
+        if founding is not None and (
+            founding.caused.exists() or founding.chosen_options.exists()
+        ):
             raise Refusal(
                 f"{self.gang} was founded on a type that gave it things, and "
                 "those would have to be given back before it can be said to "
                 "be a different type."
             )
+        # The gang says what it is as well as its founding, and the two
+        # disagreeing is a gang whose pages and whose history describe
+        # different types.
+        self.gang.gang_type = gang_type
+        self.gang.save(update_fields=["gang_type", "modified"])
+        if founding is None:
+            return self.found(gang_type)
         founding.gang_type = gang_type
         founding.save()
         Stash.objects.get_or_create(gang=self.gang)

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -658,6 +658,34 @@ class Operation:
         self._materialise_defaults(founding, list(taken), gang=self.gang)
         return founding
 
+    def refound(self, gang_type):
+        """Say the gang is a different type, keeping the act that founded it.
+
+        Founding is something the owner did, and the founding assignment
+        carries the ledger entry and the history event that say so.
+        Repointing that assignment keeps both: the gang's history still
+        opens with its own creation, on its own date and in its owner's
+        name, and now names the type the gang really is. Founding again
+        instead would delete that act — the entry and the event cascade
+        with the assignment — and write a new one in whatever name did
+        the founding.
+
+        What the old type materialised goes, and the new type's built-ins
+        arrive in its place. A gang with no founding at all is simply
+        founded.
+        """
+        from n26.core.models import Stash
+
+        founding = self.gang.founding
+        if founding is None:
+            return self.found(gang_type)
+        founding.caused.all().delete()
+        founding.gang_type = gang_type
+        founding.save()
+        Stash.objects.get_or_create(gang=self.gang)
+        self._materialise_defaults(founding, [], gang=self.gang)
+        return founding
+
     def rechoose(self, carrier, option=None, note=""):
         """Change which of its options an assignment's thing is taken with.
 

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -682,6 +682,11 @@ class Operation:
         """
         from n26.core.models import Stash
 
+        # The gang says what it is as well as its founding, and the two
+        # disagreeing is a gang whose pages and whose history describe
+        # different types.
+        self.gang.gang_type = gang_type
+        self.gang.save(update_fields=["gang_type", "modified"])
         founding = self.gang.founding
         if founding is None:
             return self.found(gang_type)

--- a/n26/core/templates/admin/maintenance/n26/_delete_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_delete_detail.html
@@ -1,9 +1,9 @@
 {% comment %}
     The summary of one deletion run, on the Backfill detail page: what it
     was going to delete, and — once it has finished — what it did. A
-    conversion's caption cannot stand in here: it promises that nothing is
-    written until every affected gang is proven, which is a promise a
-    deletion does not make.
+    deletion promises only that it is one transaction; the promise that
+    nothing is written until every affected gang reads the same is a
+    conversion's, and belongs on a conversion's record alone.
 {% endcomment %}
 {% if backfill.summary.report %}
     <h2>What it did</h2>

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -75,9 +75,10 @@ class Nameless:
     assignment_ids: tuple = ()
     events: int = 0
     print_configs: int = 0
-    #: What a nameless type granted the gangs being repointed. A type
-    #: that granted anything is refused: giving it back is a refund's
-    #: work rather than this repair's.
+    #: What a nameless type granted the gangs being repointed —
+    #: assignments and options alike, since the verb refuses for either.
+    #: A type that granted anything is refused: giving it back is a
+    #: refund's work rather than this repair's.
     replaced: int = 0
     #: Gangs left alone, each with the reason in words. Not a refusal —
     #: the rest of the plan still runs.
@@ -178,7 +179,14 @@ def _played_as(gang, doomed_type_ids):
 
 def find():
     """Read the nameless types as they stand. Never writes."""
-    from n26.core.models import Assignment, Gang, LedgerEvent, Miniature, PrintConfig
+    from n26.core.models import (
+        Assignment,
+        ChosenProfileOption,
+        Gang,
+        LedgerEvent,
+        Miniature,
+        PrintConfig,
+    )
     from n26.library.models import GangType, Profile
     from n26.library.models.pack import default_pack_id
 
@@ -254,13 +262,18 @@ def find():
         # all, the question becomes "caused by nothing", which every
         # assignment a gang was ever given answers.
         if gang.founding_id:
-            replaced += Assignment.objects.filter(caused_by_id=gang.founding_id).count()
+            replaced += (
+                Assignment.objects.filter(caused_by_id=gang.founding_id).count()
+                + ChosenProfileOption.objects.filter(
+                    assignment_id=gang.founding_id
+                ).count()
+            )
 
     if replaced:
         problems.append(
-            f"a founding being repointed granted its gang {replaced} "
-            "assignments — giving those back is a refund's work, not this "
-            "repair's, so it is left alone"
+            f"a founding being repointed granted its gang {replaced} things — "
+            "giving those back is a refund's work, not this repair's, so it "
+            "is left alone"
         )
 
     doomed_gang_ids = {gang.pk for gang in doomed_gangs}
@@ -328,8 +341,6 @@ def _repoint(gang, target, actor=None):
     """
     from n26.core.operations import operation
 
-    gang.gang_type = target
-    gang.save(update_fields=["gang_type", "modified"])
     with operation(gang, actor=actor) as op:
         op.refound(target)
 

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -1,4 +1,4 @@
-"""Deleting a gang type with no name — a one-shot repair.
+"""Retiring a gang type with no name — a one-shot repair.
 
 An ingest of a profiles sheet planned a gang type from a blank ``Gang``
 cell, so a ``GangType`` was founded whose name is the empty string. Being
@@ -10,22 +10,39 @@ built-ins, no name to print.
 A blank Gang cell is a problem the sheet must fix
 (``n26.library.ingest``), the verb refuses a blank name
 (``n26.library.authoring.create_gang_type``) and the create page offers
-no nameless type (``n26.core.forms``). This deletes the row that stands
-in spite of all three, and the gang founded on it.
+no nameless type (``n26.core.forms``). This retires the row that stands
+in spite of all three, and settles whatever was founded on it.
 
-Deletion is why this is its own operation: conversions delete nothing,
-and ``Gang.gang_type`` is ``PROTECT``, so the gang must go first. What
-stands between this and deleting somebody's real gang is the check that
-each doomed gang is **untouched** — its founding assignment and nothing
-else. A gang anyone has hired into is a gang somebody meant to keep,
-whatever its type is called, and this refuses in words rather than
-delete it.
+Two endings, per gang, because the gangs are not alike:
+
+* **Untouched** — its founding assignment and nothing else. Nobody has
+  played it, so it goes with the type.
+* **Played** — models hired, gear bought. Deleting one of these would
+  destroy somebody's gang, so instead it is **repointed** to the type it
+  has really been played as: the one every model it holds was hired
+  from. A gang whose models all come from the Outcast list is an Outcast
+  gang naming the wrong type, and saying so takes nothing away.
+
+Repointing is not a change of column. What a gang type brings — its
+built-ins and its gang-wide modifiers — arrives *caused by the founding
+assignment*, so a repoint retires the old founding and founds again
+through ``operation.found``, which is what materialises the new type's
+built-ins and gives its modifiers a carrier every member's card can
+find. The operation rewrites the pinned numbers as it closes.
+
+A gang that cannot be read this way — models from several lists, or from
+none — is left exactly as it stands, and the type it names is left with
+it. Half a repair on somebody's gang is worse than none, and a type
+nothing stands on can be retired whenever it is.
+
+``Gang.gang_type`` is ``PROTECT``, which fixes the order: every gang
+settles before the type it names can go.
 
 The plan/apply split is the conversion discipline's: :func:`find` reads
 and describes, :func:`apply` performs exactly that.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from django.db import transaction
 
@@ -39,15 +56,27 @@ class Refused(Exception):
 
 @dataclass(frozen=True)
 class Nameless:
-    """What stands, and what deleting it would take with it."""
+    """What stands, and what retiring it does to each part."""
 
+    #: Types nothing stands on once the plan has run — these go.
     gang_type_ids: tuple = ()
-    gang_ids: tuple = ()
+    #: Types left standing, because a gang nobody can read names them.
+    kept_type_ids: tuple = ()
+    #: Untouched gangs, deleted with the type.
+    doomed_gang_ids: tuple = ()
+    #: ``(gang id, target type id)`` for each gang played as something.
+    repoint: tuple = ()
+    #: The foundings of the doomed gangs, which ride them down.
     assignment_ids: tuple = ()
     events: int = 0
     print_configs: int = 0
+    #: Gangs left alone, each with the reason in words. Not a refusal —
+    #: the rest of the plan still runs.
+    stranded: tuple = ()
     problems: tuple = ()
     nothing_here: bool = False
+    #: What a target type is called, by id, so the preview reads in names.
+    said: dict = field(default_factory=dict, compare=False)
 
     @property
     def ok(self):
@@ -55,11 +84,17 @@ class Nameless:
 
     def preview(self):
         if self.nothing_here:
-            return ["nothing to delete — every gang type in the pack has a name"]
-        types = len(self.gang_type_ids)
-        gangs = len(self.gang_ids)
+            return ["nothing to retire — every gang type in the pack has a name"]
         lines = []
-        if gangs:
+        for _, target_id in self.repoint:
+            lines.append(
+                f"repoint a played gang onto {self.said.get(target_id, target_id)}, "
+                "the list its models were hired from — its founding is reissued, "
+                "so that type's built-ins and gang-wide rules arrive as they "
+                "would at founding, and nothing the gang owns is touched"
+            )
+        if self.doomed_gang_ids:
+            gangs = len(self.doomed_gang_ids)
             rides = [
                 f"{len(self.assignment_ids)} founding "
                 f"assignment{'' if len(self.assignment_ids) == 1 else 's'}",
@@ -72,27 +107,50 @@ class Nameless:
                     f"layout{'' if self.print_configs == 1 else 's'}"
                 )
             lines.append(
-                f"delete {gangs} gang{'' if gangs == 1 else 's'} founded on a "
-                f"nameless type — each untouched since founding — and with "
+                f"delete {gangs} untouched gang{'' if gangs == 1 else 's'} "
+                f"founded on a nameless type, and with "
                 f"{'it' if gangs == 1 else 'them'} " + ", ".join(rides)
             )
-        else:
-            lines.append("no gang was founded on it, so nothing of a player's dies")
-        lines.append(
-            f"delete {types} gang type{'' if types == 1 else 's'} with no name"
-        )
+        for reason in self.stranded:
+            lines.append(f"leave standing: {reason}")
+        if self.gang_type_ids:
+            types = len(self.gang_type_ids)
+            lines.append(
+                f"delete {types} gang type{'' if types == 1 else 's'} with no "
+                f"name, once nothing stands on {'it' if types == 1 else 'them'}"
+            )
+        if self.kept_type_ids:
+            kept = len(self.kept_type_ids)
+            lines.append(
+                f"keep {kept} nameless gang type{'' if kept == 1 else 's'}, still "
+                f"named by a gang nobody can read"
+            )
         return lines
+
+
+def _played_as(gang, doomed_type_ids):
+    """The gang type this gang's models were really hired from.
+
+    One answer or none: a gang whose living models all come from one
+    list is that list's gang under another name, and one whose models
+    come from several is a gang nobody can read on its owner's behalf.
+    Archived rows are left out — a model long since dead says less about
+    what the gang is than the ones standing in it now.
+    """
+    from n26.core.models import Assignment
+
+    hired = Assignment.objects.filter(
+        gang_root=gang, profile__isnull=False, archived=False
+    ).select_related("profile")
+    types = {
+        row.profile.gang_type_id for row in hired if row.profile.gang_type_id
+    } - set(doomed_type_ids)
+    return next(iter(types)) if len(types) == 1 else None
 
 
 def find():
     """Read the nameless types as they stand. Never writes."""
-    from n26.core.models import (
-        Assignment,
-        Gang,
-        LedgerEvent,
-        Miniature,
-        PrintConfig,
-    )
+    from n26.core.models import Assignment, Gang, LedgerEvent, Miniature, PrintConfig
     from n26.library.models import GangType, Profile
     from n26.library.models.pack import default_pack_id
 
@@ -111,25 +169,26 @@ def find():
     if not doomed_types:
         return Nameless(nothing_here=True)
 
+    doomed_type_ids = [row.pk for row in doomed_types]
     problems = []
     for gang_type in doomed_types:
         if gang_type.built_ins_id is not None or gang_type.modifiers.exists():
             problems.append(
                 f"the nameless type {gang_type.pk} carries built-ins or "
                 "modifiers — something has been authored onto it, so it is "
-                "not the empty row this deletes"
+                "not the empty row this retires"
             )
         hired = Profile.objects.filter(gang_type=gang_type).count()
         if hired:
             problems.append(
                 f"{hired} fighter entries are hired off the nameless "
                 f"type {gang_type.pk} — it is being used as a gang list, so "
-                "it wants a name rather than deleting"
+                "it wants a name rather than retiring"
             )
 
     gangs = list(Gang.objects.filter(gang_type__in=doomed_types))
-    doomed_gang_ids = {gang.pk for gang in gangs}
-    foundings = {gang.founding_id for gang in gangs if gang.founding_id}
+    doomed_gangs, repoint, stranded, said = [], [], [], {}
+    standing_on = set()
 
     for gang in gangs:
         # Untouched means: the founding assignment and nothing else. Both
@@ -139,34 +198,43 @@ def find():
             gang_root=gang
         )
         strays = theirs.exclude(pk=gang.founding_id).distinct().count()
-        if strays:
-            problems.append(
-                f"a gang founded on a nameless type has {strays} assignments "
-                "beyond its founding — it has been played, so it is not this "
-                "repair's to delete"
-            )
-        # Not covered by the strays count above, and not belt and braces:
+        # Not covered by the strays count, and not belt and braces:
         # ``Miniature.membership`` is SET_NULL, so deleting a gang with
         # models on it would leave the models behind, belonging to nothing.
         models_in = Miniature.objects.filter(membership__gang=gang).count()
-        if models_in:
-            problems.append(
-                f"a gang founded on a nameless type holds {models_in} models "
-                "— it has been hired into, so it is not this repair's to delete"
-            )
 
-    # An assignment naming a nameless type that is not one of these gangs'
-    # foundings is something this has not accounted for; ``PROTECT`` would
-    # stop the delete anyway, and a refusal in words beats a crash.
+        if not strays and not models_in:
+            doomed_gangs.append(gang)
+            continue
+
+        target = _played_as(gang, doomed_type_ids)
+        if target is None:
+            stranded.append(
+                f"a gang holding {models_in} models and {strays} assignments "
+                "beyond its founding, whose models come from no one gang list "
+                "— nobody can say what it was played as, so it keeps the type "
+                "it has"
+            )
+            standing_on.add(gang.gang_type_id)
+            continue
+        repoint.append((gang.pk, target))
+        said[target] = str(GangType.objects.get(pk=target))
+
+    doomed_gang_ids = {gang.pk for gang in doomed_gangs}
+    foundings = {gang.founding_id for gang in doomed_gangs if gang.founding_id}
+
+    # An assignment naming a nameless type on no gang founded on one is
+    # something this has not accounted for; ``PROTECT`` would stop the
+    # delete anyway, and a refusal in words beats a crash.
     strangers = (
         Assignment.objects.filter(gang_type__in=doomed_types)
-        .exclude(pk__in=foundings)
+        .exclude(gang_root__in=[gang.pk for gang in gangs])
         .count()
     )
     if strangers:
         problems.append(
-            f"{strangers} assignments name a nameless gang type but are not "
-            "one of these gangs' foundings"
+            f"{strangers} assignments name a nameless gang type but belong to "
+            "no gang founded on one"
         )
 
     events = LedgerEvent.objects.filter(gang_id__in=doomed_gang_ids).count()
@@ -175,47 +243,80 @@ def find():
     # the preview enumerates everything that dies, so it says these too.
     layouts = PrintConfig.objects.filter(gang_id__in=doomed_gang_ids).count()
     return Nameless(
-        gang_type_ids=tuple(sorted((t.pk for t in doomed_types), key=str)),
-        gang_ids=tuple(sorted(doomed_gang_ids, key=str)),
+        gang_type_ids=tuple(
+            sorted((pk for pk in doomed_type_ids if pk not in standing_on), key=str)
+        ),
+        kept_type_ids=tuple(sorted(standing_on, key=str)),
+        doomed_gang_ids=tuple(sorted(doomed_gang_ids, key=str)),
+        repoint=tuple(sorted(repoint, key=lambda pair: str(pair[0]))),
         assignment_ids=tuple(sorted(foundings, key=str)),
         events=events,
         print_configs=layouts,
+        stranded=tuple(stranded),
         problems=tuple(problems),
+        said=said,
     )
 
 
-def apply(nameless):
-    """Delete exactly what the plan names — the gangs, then the types."""
+def _repoint(gang, target, actor=None):
+    """Say what a gang really is, and give it what that brings.
+
+    The founding assignment is the carrier for everything a gang type
+    hands its gang, so the old one is retired and the gang founded
+    again. Nothing the gang owns hangs off that assignment — models are
+    hired, not caused — so what it holds is untouched. What changes is
+    the type it names, the built-ins that arrive with the new one, and
+    the pinned numbers the operation rewrites as it closes.
+    """
+    from n26.core.models import Assignment
+    from n26.core.operations import operation
+
+    was_id = gang.founding_id
+    if was_id is not None:
+        # Anything the old type caused goes with it: the gang stops
+        # carrying what a type it was never really of had given it.
+        Assignment.objects.filter(pk=was_id).delete()
+    gang.gang_type = target
+    gang.save(update_fields=["gang_type", "modified"])
+    with operation(gang, actor=actor) as op:
+        op.found(target)
+
+
+def apply(nameless, actor=None):
+    """Perform exactly what the plan names, and prove the gangs whole."""
     from django.db.models import ProtectedError
 
     from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
     from n26.library.models import GangType
 
     if nameless.problems:
-        raise Refused("not deleted: " + "; ".join(nameless.problems))
+        raise Refused("not retired: " + "; ".join(nameless.problems))
     if nameless.nothing_here:
         return list(nameless.preview())
 
     report = list(nameless.preview())
+    repointed = [pk for pk, _ in nameless.repoint]
     try:
         with transaction.atomic():
             # The plan was read before this transaction opened, and a
             # gang's assignments cascade rather than protect — so a gang
-            # played in between would ride the delete down instead of
-            # refusing. Two things close that window. The doomed gangs
-            # are locked first: assigning anything to a gang takes a
+            # played in between would ride a delete down instead of
+            # refusing. Two things close that window. The gangs are
+            # locked first: assigning anything to a gang takes a
             # key-share lock on its row, which this conflicts with, so
             # no hire can land from here on. Then the plan is read
             # again, and anything that moved before the lock refuses.
             list(
                 Gang.objects.select_for_update()
-                .filter(pk__in=nameless.gang_ids)
+                .filter(pk__in=[*nameless.doomed_gang_ids, *repointed])
                 .order_by("pk")
             )
             now = find()
             if (
                 now.problems
-                or set(now.gang_ids) != set(nameless.gang_ids)
+                or set(now.doomed_gang_ids) != set(nameless.doomed_gang_ids)
+                or set(now.repoint) != set(nameless.repoint)
                 or set(now.gang_type_ids) != set(nameless.gang_type_ids)
                 or set(now.assignment_ids) != set(nameless.assignment_ids)
                 # The counts too, not only the rows named: the preview
@@ -226,29 +327,61 @@ def apply(nameless):
                 or now.print_configs != nameless.print_configs
             ):
                 raise Refused(
-                    "not deleted: what stands has changed since the plan was "
+                    "not retired: what stands has changed since the plan was "
                     "read — read it again"
                 )
-            # The gangs first: ``Gang.gang_type`` is PROTECT, and their
-            # assignments, stash and history events ride them down.
-            Gang.objects.filter(pk__in=nameless.gang_ids).delete()
+
+            # Played gangs first: each stops naming a nameless type, which
+            # is what lets the type go at the end.
+            for gang_id, target_id in nameless.repoint:
+                _repoint(
+                    Gang.objects.get(pk=gang_id),
+                    GangType.objects.get(pk=target_id),
+                    actor=actor,
+                )
+
+            Gang.objects.filter(pk__in=nameless.doomed_gang_ids).delete()
             GangType.objects.filter(pk__in=nameless.gang_type_ids).delete()
+
+            # A repoint moves what a gang is worth — the new type's
+            # built-ins are things it now owns — so the pinned numbers
+            # must still describe the ledger they came from.
+            for gang_id in repointed:
+                gang = Gang.objects.get(pk=gang_id)
+                try:
+                    assert_reconciled(gang)
+                except Exception as failed:
+                    raise Refused(
+                        f"refused — a repointed gang no longer reconciles: {failed}"
+                    ) from failed
     except ProtectedError as protected:
         # The backstop behind find()'s enumerated checks: whatever this
         # names is a referent nobody listed, and the answer is the same
         # refusal in words, never a crash.
         raise Refused(
-            "refused — something still names what would be deleted: "
+            "refused — something still names what would be retired: "
             f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}"
         ) from protected
-    report.append(
-        "deleted gang types "
-        + ", ".join(str(pk) for pk in nameless.gang_type_ids)
-        + (
-            "; deleted gangs " + ", ".join(str(pk) for pk in nameless.gang_ids)
-            if nameless.gang_ids
-            else "; no gangs stood on them"
+
+    if nameless.repoint:
+        report.append(
+            "repointed gangs "
+            + ", ".join(f"{pk} → {target}" for pk, target in nameless.repoint)
         )
+    if nameless.gang_type_ids:
+        deleted_gangs = (
+            "; deleted gangs " + ", ".join(str(pk) for pk in nameless.doomed_gang_ids)
+            if nameless.doomed_gang_ids
+            else "; no untouched gangs stood on them"
+        )
+        report.append(
+            "deleted gang types "
+            + ", ".join(str(pk) for pk in nameless.gang_type_ids)
+            + deleted_gangs
+        )
+    report.append(
+        "done; a nameless type stands where a gang could not be read"
+        if nameless.kept_type_ids
+        else "retired; every gang type in the pack has a name"
     )
-    report.append("deleted; every gang type in the pack has a name")
     return report

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -270,8 +270,12 @@ def find():
         # built-ins arrive. A nameless type carrying built-ins is refused
         # above, so this is normally nothing — counted rather than
         # assumed, because the preview promises the gang keeps what it
-        # owns and that promise should be checked.
-        replaced += Assignment.objects.filter(caused_by_id=gang.founding_id).count()
+        # owns and that promise should be checked. Only where there is a
+        # founding to have caused anything: asked about no founding at
+        # all, the question becomes "caused by nothing", which every
+        # assignment a gang was ever given answers.
+        if gang.founding_id:
+            replaced += Assignment.objects.filter(caused_by_id=gang.founding_id).count()
 
     doomed_gang_ids = {gang.pk for gang in doomed_gangs}
     foundings = {gang.founding_id for gang in doomed_gangs if gang.founding_id}

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -23,12 +23,17 @@ Two endings, per gang, because the gangs are not alike:
   from. A gang whose models all come from the Outcast list is an Outcast
   gang naming the wrong type, and saying so takes nothing away.
 
-Repointing is not a change of column. What a gang type brings — its
-built-ins and its gang-wide modifiers — arrives *caused by the founding
-assignment*, so a repoint retires the old founding and founds again
-through ``operation.found``, which is what materialises the new type's
-built-ins and gives its modifiers a carrier every member's card can
-find. The operation rewrites the pinned numbers as it closes.
+Repointing is not a change of column, and it is not a second founding
+either. What a gang type brings — its built-ins and its gang-wide
+modifiers — arrives *caused by the founding assignment*, so the repoint
+goes through ``operation.refound``: the founding the owner made is kept
+and made to name the new type, and that type's built-ins arrive caused
+by it. Keeping it is the point. The founding carries the gang's opening
+ledger entry and the history event that says its owner created it, and
+both cascade with the assignment — a gang founded afresh would open its
+history with a stranger creating it, dated the day of the repair. The
+operation rewrites the pinned numbers as it closes; built-ins arrive
+free, so the gang's rating cannot move.
 
 A gang that cannot be read this way — models from several lists, or from
 none — is left exactly as it stands, and the type it names is left with
@@ -70,6 +75,9 @@ class Nameless:
     assignment_ids: tuple = ()
     events: int = 0
     print_configs: int = 0
+    #: What the nameless type materialised onto the gangs being
+    #: repointed, which the new type's built-ins replace.
+    replaced: int = 0
     #: Gangs left alone, each with the reason in words. Not a refusal —
     #: the rest of the plan still runs.
     stranded: tuple = ()
@@ -89,9 +97,17 @@ class Nameless:
         for _, target_id in self.repoint:
             lines.append(
                 f"repoint a played gang onto {self.said.get(target_id, target_id)}, "
-                "the list its models were hired from — its founding is reissued, "
-                "so that type's built-ins and gang-wide rules arrive as they "
-                "would at founding, and nothing the gang owns is touched"
+                "the list its models were hired from — the act that founded it "
+                "is kept and made to name that type, so its history still opens "
+                "with its owner creating it, and that type's built-ins and "
+                "gang-wide rules arrive. Its models, its gear and its budget "
+                "are untouched"
+            )
+        if self.replaced:
+            lines.append(
+                f"remove {self.replaced} assignment"
+                f"{'' if self.replaced == 1 else 's'} the nameless type gave "
+                "those gangs, replaced by what the new type gives"
             )
         if self.doomed_gang_ids:
             gangs = len(self.doomed_gang_ids)
@@ -136,16 +152,48 @@ def _played_as(gang, doomed_type_ids):
     come from several is a gang nobody can read on its owner's behalf.
     Archived rows are left out — a model long since dead says less about
     what the gang is than the ones standing in it now.
+
+    The one answer must also be a list a player could found a gang on,
+    or the repair would move somebody's gang somewhere they could never
+    have put it themselves.
     """
     from n26.core.models import Assignment
+    from n26.library.models import GangType
 
     hired = Assignment.objects.filter(
         gang_root=gang, profile__isnull=False, archived=False
-    ).select_related("profile")
-    types = {
-        row.profile.gang_type_id for row in hired if row.profile.gang_type_id
-    } - set(doomed_type_ids)
-    return next(iter(types)) if len(types) == 1 else None
+    ).values_list("profile__gang_type_id", flat=True)
+    types = set(hired) - {None} - set(doomed_type_ids)
+    # Only onto a type somebody could have founded. A pet or a hired gun
+    # carries a profile off a list nobody plays as — Dramatis Personae,
+    # Allies — and a gang moved onto one of those would be a gang no
+    # player could have made.
+    foundable = set(
+        GangType.objects.filter(pk__in=types, foundable=True).values_list(
+            "pk", flat=True
+        )
+    )
+    return next(iter(foundable)) if len(foundable) == 1 and len(types) == 1 else None
+
+
+def _why_unreadable(gang, doomed_type_ids):
+    """Which of the two shapes a gang nobody can read is in."""
+    from n26.core.models import Assignment
+
+    found = (
+        set(
+            Assignment.objects.filter(
+                gang_root=gang, profile__isnull=False, archived=False
+            ).values_list("profile__gang_type_id", flat=True)
+        )
+        - {None}
+        - set(doomed_type_ids)
+    )
+    if not found:
+        return "no gang list at all"
+    if len(found) > 1:
+        return f"{len(found)} different gang lists"
+    return "a list nobody can found a gang on"
 
 
 def find():
@@ -155,13 +203,11 @@ def find():
     from n26.library.models.pack import default_pack_id
 
     # Scoped to the default pack: a custom pack's own rows are somebody's
-    # content and not this accident, and the create page no longer offers
-    # a nameless one from anywhere.
+    # content and not this accident, and the create page offers no
+    # nameless type from any pack.
     doomed_types = list(
         GangType.objects.filter(
-            # Whitespace draws the same empty card as nothing at all, and
-            # the verb stores a stripped name, so a padded one can only be
-            # a row that predates the guard.
+            # Whitespace draws the same empty card as nothing at all.
             name__regex=BLANK,
             pack_id=default_pack_id(),
         ).order_by("created")
@@ -189,6 +235,7 @@ def find():
     gangs = list(Gang.objects.filter(gang_type__in=doomed_types))
     doomed_gangs, repoint, stranded, said = [], [], [], {}
     standing_on = set()
+    replaced = 0
 
     for gang in gangs:
         # Untouched means: the founding assignment and nothing else. Both
@@ -211,30 +258,48 @@ def find():
         if target is None:
             stranded.append(
                 f"a gang holding {models_in} models and {strays} assignments "
-                "beyond its founding, whose models come from no one gang list "
-                "— nobody can say what it was played as, so it keeps the type "
-                "it has"
+                f"beyond its founding, whose models come from "
+                f"{_why_unreadable(gang, doomed_type_ids)} — nobody can say "
+                "what it was played as, so it keeps the type it has"
             )
             standing_on.add(gang.gang_type_id)
             continue
         repoint.append((gang.pk, target))
         said[target] = str(GangType.objects.get(pk=target))
+        # What the old type gave the gang goes when the new type's
+        # built-ins arrive. A nameless type carrying built-ins is refused
+        # above, so this is normally nothing — counted rather than
+        # assumed, because the preview promises the gang keeps what it
+        # owns and that promise should be checked.
+        replaced += Assignment.objects.filter(caused_by_id=gang.founding_id).count()
 
     doomed_gang_ids = {gang.pk for gang in doomed_gangs}
     foundings = {gang.founding_id for gang in doomed_gangs if gang.founding_id}
+    repointing = {pk for pk, _ in repoint}
 
-    # An assignment naming a nameless type on no gang founded on one is
-    # something this has not accounted for; ``PROTECT`` would stop the
-    # delete anyway, and a refusal in words beats a crash.
+    # Only the types actually going are at issue: a gang left standing
+    # goes on naming the type it names, which is why that type stays.
+    # Every assignment naming a type that *is* going has to be one this
+    # plan takes away — the founding of a gang being deleted, or of one
+    # being repointed, whose founding is reissued. Anything else still
+    # names the type when the delete comes, and ``PROTECT`` would fail
+    # the run whole: a refusal in words beats a rollback nobody can read.
+    going = [row for row in doomed_types if row.pk not in standing_on]
+    settled = {
+        *foundings,
+        *(
+            gang.founding_id
+            for gang in gangs
+            if gang.pk in repointing and gang.founding_id
+        ),
+    }
     strangers = (
-        Assignment.objects.filter(gang_type__in=doomed_types)
-        .exclude(gang_root__in=[gang.pk for gang in gangs])
-        .count()
+        Assignment.objects.filter(gang_type__in=going).exclude(pk__in=settled).count()
     )
     if strangers:
         problems.append(
-            f"{strangers} assignments name a nameless gang type but belong to "
-            "no gang founded on one"
+            f"{strangers} assignments name a nameless gang type that would be "
+            "deleted and are not a founding this takes away"
         )
 
     events = LedgerEvent.objects.filter(gang_id__in=doomed_gang_ids).count()
@@ -252,6 +317,7 @@ def find():
         assignment_ids=tuple(sorted(foundings, key=str)),
         events=events,
         print_configs=layouts,
+        replaced=replaced,
         stranded=tuple(stranded),
         problems=tuple(problems),
         said=said,
@@ -261,25 +327,21 @@ def find():
 def _repoint(gang, target, actor=None):
     """Say what a gang really is, and give it what that brings.
 
-    The founding assignment is the carrier for everything a gang type
-    hands its gang, so the old one is retired and the gang founded
-    again. Nothing the gang owns hangs off that assignment — models are
-    hired, not caused — so what it holds is untouched. What changes is
-    the type it names, the built-ins that arrive with the new one, and
-    the pinned numbers the operation rewrites as it closes.
+    The founding assignment is repointed rather than replaced, because
+    it carries the gang's opening ledger entry and the history event
+    that says its owner created it. Deleting it would take that act out
+    of the gang's history — entry and event cascade with the assignment
+    — and write a new one, dated today, in the name of whoever ran the
+    repair. What changes is the type the gang names, the built-ins that
+    arrive with it, and the pinned numbers the operation rewrites as it
+    closes.
     """
-    from n26.core.models import Assignment
     from n26.core.operations import operation
 
-    was_id = gang.founding_id
-    if was_id is not None:
-        # Anything the old type caused goes with it: the gang stops
-        # carrying what a type it was never really of had given it.
-        Assignment.objects.filter(pk=was_id).delete()
     gang.gang_type = target
     gang.save(update_fields=["gang_type", "modified"])
     with operation(gang, actor=actor) as op:
-        op.found(target)
+        op.refound(target)
 
 
 def apply(nameless, actor=None):
@@ -287,7 +349,8 @@ def apply(nameless, actor=None):
     from django.db.models import ProtectedError
 
     from n26.core.models import Gang
-    from n26.core.reconcile import assert_reconciled
+    from n26.core.operations import Refusal
+    from n26.core.reconcile import Discrepancy, assert_reconciled
     from n26.library.models import GangType
 
     if nameless.problems:
@@ -312,6 +375,14 @@ def apply(nameless, actor=None):
                 .filter(pk__in=[*nameless.doomed_gang_ids, *repointed])
                 .order_by("pk")
             )
+            # The types as well as the gangs: a gang founded on one after
+            # the re-read would fail the delete as a database error
+            # rather than as a refusal anybody can read.
+            list(
+                GangType.objects.select_for_update()
+                .filter(pk__in=nameless.gang_type_ids)
+                .order_by("pk")
+            )
             now = find()
             if (
                 now.problems
@@ -334,23 +405,32 @@ def apply(nameless, actor=None):
             # Played gangs first: each stops naming a nameless type, which
             # is what lets the type go at the end.
             for gang_id, target_id in nameless.repoint:
-                _repoint(
-                    Gang.objects.get(pk=gang_id),
-                    GangType.objects.get(pk=target_id),
-                    actor=actor,
-                )
+                try:
+                    _repoint(
+                        Gang.objects.get(pk=gang_id),
+                        GangType.objects.get(pk=target_id),
+                        actor=actor,
+                    )
+                except Refusal as refused:
+                    # An operation that turns something away says why in
+                    # words; that is an ending the record can carry,
+                    # never a traceback.
+                    raise Refused(
+                        f"refused — a repoint was turned away: {refused}"
+                    ) from refused
 
             Gang.objects.filter(pk__in=nameless.doomed_gang_ids).delete()
             GangType.objects.filter(pk__in=nameless.gang_type_ids).delete()
 
-            # A repoint moves what a gang is worth — the new type's
-            # built-ins are things it now owns — so the pinned numbers
-            # must still describe the ledger they came from.
+            # A repoint must leave the books exactly as it found them:
+            # built-ins arrive free, so the rating cannot move, and the
+            # pinned numbers must still describe the ledger they came
+            # from.
             for gang_id in repointed:
                 gang = Gang.objects.get(pk=gang_id)
                 try:
                     assert_reconciled(gang)
-                except Exception as failed:
+                except Discrepancy as failed:
                     raise Refused(
                         f"refused — a repointed gang no longer reconciles: {failed}"
                     ) from failed
@@ -368,16 +448,16 @@ def apply(nameless, actor=None):
             "repointed gangs "
             + ", ".join(f"{pk} → {target}" for pk, target in nameless.repoint)
         )
-    if nameless.gang_type_ids:
-        deleted_gangs = (
-            "; deleted gangs " + ", ".join(str(pk) for pk in nameless.doomed_gang_ids)
-            if nameless.doomed_gang_ids
-            else "; no untouched gangs stood on them"
-        )
+    # A gang can be deleted while the type it stood on stays, and a
+    # destructive outcome the record does not name is a deletion nobody
+    # can trace.
+    if nameless.doomed_gang_ids:
         report.append(
-            "deleted gang types "
-            + ", ".join(str(pk) for pk in nameless.gang_type_ids)
-            + deleted_gangs
+            "deleted gangs " + ", ".join(str(pk) for pk in nameless.doomed_gang_ids)
+        )
+    if nameless.gang_type_ids:
+        report.append(
+            "deleted gang types " + ", ".join(str(pk) for pk in nameless.gang_type_ids)
         )
     report.append(
         "done; a nameless type stands where a gang could not be read"

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -252,7 +252,8 @@ def find():
             standing_on.add(gang.gang_type_id)
             continue
         repoint.append((gang.pk, target))
-        said[target] = str(GangType.objects.get(pk=target))
+        if target not in said:
+            said[target] = str(GangType.objects.get(pk=target))
         # What the old type gave the gang goes when the new type's
         # built-ins arrive. A nameless type carrying built-ins is refused
         # above, so this is normally nothing — counted rather than

--- a/n26/library/nameless_gang_type.py
+++ b/n26/library/nameless_gang_type.py
@@ -75,8 +75,9 @@ class Nameless:
     assignment_ids: tuple = ()
     events: int = 0
     print_configs: int = 0
-    #: What the nameless type materialised onto the gangs being
-    #: repointed, which the new type's built-ins replace.
+    #: What a nameless type granted the gangs being repointed. A type
+    #: that granted anything is refused: giving it back is a refund's
+    #: work rather than this repair's.
     replaced: int = 0
     #: Gangs left alone, each with the reason in words. Not a refusal —
     #: the rest of the plan still runs.
@@ -103,12 +104,7 @@ class Nameless:
                 "gang-wide rules arrive. Its models, its gear and its budget "
                 "are untouched"
             )
-        if self.replaced:
-            lines.append(
-                f"remove {self.replaced} assignment"
-                f"{'' if self.replaced == 1 else 's'} the nameless type gave "
-                "those gangs, replaced by what the new type gives"
-            )
+
         if self.doomed_gang_ids:
             gangs = len(self.doomed_gang_ids)
             rides = [
@@ -145,13 +141,15 @@ class Nameless:
 
 
 def _played_as(gang, doomed_type_ids):
-    """The gang type this gang's models were really hired from.
+    """What this gang's models were really hired from, or why nobody
+    can say.
 
-    One answer or none: a gang whose living models all come from one
-    list is that list's gang under another name, and one whose models
-    come from several is a gang nobody can read on its owner's behalf.
-    Archived rows are left out — a model long since dead says less about
-    what the gang is than the ones standing in it now.
+    Returns ``(target, reason)`` — one of them, never both. One answer
+    or none: a gang whose living models all come from one list is that
+    list's gang under another name, and one whose models come from
+    several is a gang nobody can read on its owner's behalf. Archived
+    rows are left out — a model long since dead says less about what the
+    gang is than the ones standing in it now.
 
     The one answer must also be a list a player could found a gang on,
     or the repair would move somebody's gang somewhere they could never
@@ -164,36 +162,18 @@ def _played_as(gang, doomed_type_ids):
         gang_root=gang, profile__isnull=False, archived=False
     ).values_list("profile__gang_type_id", flat=True)
     types = set(hired) - {None} - set(doomed_type_ids)
-    # Only onto a type somebody could have founded. A pet or a hired gun
-    # carries a profile off a list nobody plays as — Dramatis Personae,
-    # Allies — and a gang moved onto one of those would be a gang no
-    # player could have made.
+    if not types:
+        return None, "no gang list at all"
+    if len(types) > 1:
+        return None, f"{len(types)} different gang lists"
     foundable = set(
         GangType.objects.filter(pk__in=types, foundable=True).values_list(
             "pk", flat=True
         )
     )
-    return next(iter(foundable)) if len(foundable) == 1 and len(types) == 1 else None
-
-
-def _why_unreadable(gang, doomed_type_ids):
-    """Which of the two shapes a gang nobody can read is in."""
-    from n26.core.models import Assignment
-
-    found = (
-        set(
-            Assignment.objects.filter(
-                gang_root=gang, profile__isnull=False, archived=False
-            ).values_list("profile__gang_type_id", flat=True)
-        )
-        - {None}
-        - set(doomed_type_ids)
-    )
-    if not found:
-        return "no gang list at all"
-    if len(found) > 1:
-        return f"{len(found)} different gang lists"
-    return "a list nobody can found a gang on"
+    if not foundable:
+        return None, "a list nobody can found a gang on"
+    return next(iter(foundable)), ""
 
 
 def find():
@@ -254,13 +234,12 @@ def find():
             doomed_gangs.append(gang)
             continue
 
-        target = _played_as(gang, doomed_type_ids)
+        target, why = _played_as(gang, doomed_type_ids)
         if target is None:
             stranded.append(
                 f"a gang holding {models_in} models and {strays} assignments "
-                f"beyond its founding, whose models come from "
-                f"{_why_unreadable(gang, doomed_type_ids)} — nobody can say "
-                "what it was played as, so it keeps the type it has"
+                f"beyond its founding, whose models come from {why} — nobody "
+                "can say what it was played as, so it keeps the type it has"
             )
             standing_on.add(gang.gang_type_id)
             continue
@@ -276,6 +255,13 @@ def find():
         # assignment a gang was ever given answers.
         if gang.founding_id:
             replaced += Assignment.objects.filter(caused_by_id=gang.founding_id).count()
+
+    if replaced:
+        problems.append(
+            f"a founding being repointed granted its gang {replaced} "
+            "assignments — giving those back is a refund's work, not this "
+            "repair's, so it is left alone"
+        )
 
     doomed_gang_ids = {gang.pk for gang in doomed_gangs}
     foundings = {gang.founding_id for gang in doomed_gangs if gang.founding_id}
@@ -400,6 +386,7 @@ def apply(nameless, actor=None):
                 # unannounced.
                 or now.events != nameless.events
                 or now.print_configs != nameless.print_configs
+                or now.replaced != nameless.replaced
             ):
                 raise Refused(
                     "not retired: what stands has changed since the plan was "

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -348,9 +348,10 @@ def retire_gang_legacy_pilot(backfill_id, **said_by_whoever_enqueued_it):
 def _who_asked(backfill_id):
     """The operator a run acts as, for the history it writes.
 
-    A repoint founds a gang again, and a founding is something somebody
-    did — filed against nobody it reads as the gang having done it to
-    itself.
+    A repair that hands a gang something writes that down, and an act
+    filed against nobody reads as the gang having done it to itself.
+    The gang's own acts keep their own actor: what a repair may not do
+    is put its name on those.
     """
     backfill = Backfill.objects.filter(pk=backfill_id).first()
     return backfill.triggered_by if backfill else None
@@ -499,11 +500,12 @@ NAMELESS_WORDS = {
         "with no name was founded and drew as an empty card on the "
         "create-gang page. A gang founded on it and never played is "
         "deleted with it. A gang somebody has played is not: it is "
-        "repointed to the list its models were actually hired from, which "
-        "reissues its founding so that type's built-ins and gang-wide "
-        "rules arrive — nothing it owns is touched. A gang whose models "
-        "come from no one list is left exactly as it stands, and so is "
-        "the type it names."
+        "repointed to the list its models were actually hired from. The "
+        "act that founded it is kept and made to name that type, so its "
+        "history still opens with its owner creating it, and that type's "
+        "built-ins and gang-wide rules arrive — its models, its gear and "
+        "its budget are untouched. A gang whose models come from no one "
+        "list is left exactly as it stands, and so is the type it names."
     ),
     "nothing_heading": "Nothing to retire",
     "nothing_flash": "There was nothing to retire — every gang type has a name.",
@@ -682,8 +684,9 @@ register_operation(
             "the nameless one that drew as an empty card on the create-gang "
             "page. An untouched gang founded on it goes with it; a played "
             "one is repointed to the list its models were hired from, "
-            "founding again so that type's built-ins arrive. A gang that "
-            "cannot be read, and the type it names, are left standing."
+            "keeping the act that founded it so its history is not "
+            "rewritten. A gang that cannot be read, and the type it "
+            "names, are left standing."
         ),
         view=delete_nameless_gang_type_view,
         detail_template="admin/maintenance/n26/_delete_detail.html",

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -106,7 +106,7 @@ class Operation(models.TextChoices):
     )
     DELETE_NAMELESS_GANG_TYPE = (
         "n26_delete_nameless_gang_type",
-        "n26: the gang type with no name is deleted",
+        "n26: the gang type with no name is retired",
     )
     MERGE_WARGEAR_INTO_WEAPON = (
         "n26_merge_wargear_into_weapon",
@@ -345,21 +345,33 @@ def retire_gang_legacy_pilot(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+def _who_asked(backfill_id):
+    """The operator a run acts as, for the history it writes.
+
+    A repoint founds a gang again, and a founding is something somebody
+    did — filed against nobody it reads as the gang having done it to
+    itself.
+    """
+    backfill = Backfill.objects.filter(pk=backfill_id).first()
+    return backfill.triggered_by if backfill else None
+
+
 @task
 def delete_nameless_gang_type(backfill_id, **said_by_whoever_enqueued_it):
-    """Delete the nameless gang type and the gang founded on it, once.
+    """Retire the nameless gang type and settle what stood on it, once.
 
     The same runner discipline as a conversion — the lock, the claim,
-    every ending recorded — around work that deletes, which is why the
-    module it calls proves the gang untouched before it does.
+    every ending recorded — around work that deletes and rewrites a
+    player's gang, which is why the module it calls reads every gang
+    before it touches one.
     """
     from n26.library.nameless_gang_type import Refused, apply, find
 
     _run_recorded(
         backfill_id,
         Operation.DELETE_NAMELESS_GANG_TYPE,
-        "Nameless gang type deletion",
-        lambda: apply(find()),
+        "Nameless gang type retirement",
+        lambda: apply(find(), actor=_who_asked(backfill_id)),
         Refused,
     )
 
@@ -480,21 +492,25 @@ PILOT_WORDS = {
 }
 
 NAMELESS_WORDS = {
-    "noun": "deletion",
+    "noun": "retirement",
     "intro": (
-        "This deletes a library row and a player's gang. An ingest planned "
-        "a gang type from a blank Gang cell, so a type with no name was "
-        "founded and drew as an empty card on the create-gang page. This "
-        "deletes that row, and any gang founded on it — a gang of nothing, "
-        "with no list to hire from. It refuses for any such gang that has "
-        "been played: anything beyond its founding assignment, and it stays."
+        "This deletes a library row, and rewrites what a player's gang is. "
+        "An ingest planned a gang type from a blank Gang cell, so a type "
+        "with no name was founded and drew as an empty card on the "
+        "create-gang page. A gang founded on it and never played is "
+        "deleted with it. A gang somebody has played is not: it is "
+        "repointed to the list its models were actually hired from, which "
+        "reissues its founding so that type's built-ins and gang-wide "
+        "rules arrive — nothing it owns is touched. A gang whose models "
+        "come from no one list is left exactly as it stands, and so is "
+        "the type it names."
     ),
-    "nothing_heading": "Nothing to delete",
-    "nothing_flash": "There was nothing to delete — every gang type has a name.",
+    "nothing_heading": "Nothing to retire",
+    "nothing_flash": "There was nothing to retire — every gang type has a name.",
     "nothing_words": "Every gang type in the pack has a name.",
-    "refuses_heading": "The deletion refuses",
-    "button": "Delete the nameless gang type",
-    "confirm": "Delete the nameless gang type and the gang founded on it? This cannot be undone.",
+    "refuses_heading": "The retirement refuses",
+    "button": "Retire the nameless gang type",
+    "confirm": "Retire the nameless gang type? Untouched gangs on it are deleted and played ones are repointed. This cannot be undone.",
 }
 
 
@@ -662,11 +678,12 @@ register_operation(
         operation=Operation.DELETE_NAMELESS_GANG_TYPE.value,
         name=Operation.DELETE_NAMELESS_GANG_TYPE.label,
         description=(
-            "Delete the gang type an ingest founded from a blank Gang cell — "
+            "Retire the gang type an ingest founded from a blank Gang cell — "
             "the nameless one that drew as an empty card on the create-gang "
-            "page — and any gang founded on it, which has no list to hire "
-            "from. Refuses for a gang that has been played, or a type "
-            "anything has been authored onto."
+            "page. An untouched gang founded on it goes with it; a played "
+            "one is repointed to the list its models were hired from, "
+            "founding again so that type's built-ins arrive. A gang that "
+            "cannot be read, and the type it names, are left standing."
         ),
         view=delete_nameless_gang_type_view,
         detail_template="admin/maintenance/n26/_delete_detail.html",

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -230,6 +230,20 @@ class TestRepointing:
         assert "Escher" in told
         assert opening_act.actor
 
+    def test_a_gang_with_no_founding_counts_nothing_of_anybody_elses(
+        self, played_on_it, escher
+    ):
+        """Asked what a founding caused when there is no founding, the
+        question becomes "caused by nothing" — which every assignment
+        anybody was ever given answers."""
+        played_on_it.founding = None
+        played_on_it.save(update_fields=["founding", "modified"])
+
+        found = find()
+
+        assert found.replaced == 0
+        assert found.repoint == ((played_on_it.pk, escher.pk),)
+
     def test_the_nameless_type_goes_once_nothing_stands_on_it(
         self, played_on_it, founded_on_it, escher
     ):

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -143,7 +143,9 @@ class TestReadingWhatStandsOnIt:
         assert found.repoint == ((played_on_it.pk, escher.pk),)
         said = "\n".join(found.preview())
         assert "repoint a played gang onto Escher" in said
-        assert "nothing the gang owns is touched" in said
+        assert "its history still opens with its owner creating it" in said
+        assert "Its models, its gear and its budget are untouched" in said
+        assert_reconciled(played_on_it)
 
     def test_a_type_with_no_gang_on_it_still_goes(self, nameless):
         found = find()
@@ -196,6 +198,38 @@ class TestRepointing:
         assert [str(row.assignable) for row in arrived] == ["Wise"]
         assert_reconciled(played_on_it)
 
+    def test_the_gang_keeps_its_own_founding_act(self, played_on_it, escher, owner):
+        """Founding is something the owner did, and the history says so.
+
+        A repoint that deleted the founding assignment would take that
+        act with it — entry and event cascade — and write a new one,
+        dated today, in the name of whoever ran the repair. The owner
+        would open their history and find their hires first and a
+        stranger creating their gang last.
+        """
+        from n26.core.history import build
+
+        founding_id = played_on_it.founding_id
+        opening = played_on_it.ledger_events.order_by("created", "id").first()
+        was = (opening.pk, opening.created, opening.actor_id)
+
+        apply(find())
+
+        played_on_it.refresh_from_db()
+        assert played_on_it.founding_id == founding_id
+        still = played_on_it.ledger_events.order_by("created", "id").first()
+        assert (still.pk, still.created, still.actor_id) == was
+        assert still.actor_id == owner.pk
+
+        # And it now says what the gang really is, because the history
+        # reads the assignment as it stands rather than any stored wording.
+        acts = build(played_on_it, viewer=owner)
+        opening_act = acts[0]
+        told = "".join(span.text for span in opening_act.spans)
+        assert "created the gang" in told
+        assert "Escher" in told
+        assert opening_act.actor
+
     def test_the_nameless_type_goes_once_nothing_stands_on_it(
         self, played_on_it, founded_on_it, escher
     ):
@@ -207,6 +241,8 @@ class TestRepointing:
         assert Gang.objects.filter(pk=played_on_it.pk).exists()
         assert not GangType.objects.filter(name="").exists()
         assert any("repointed gangs" in line for line in report)
+        assert any("deleted gangs" in line for line in report)
+        assert_reconciled(Gang.objects.get(pk=played_on_it.pk))
 
     def test_a_gang_read_from_no_one_list_is_left_standing(
         self, played_on_it, nameless, person_type
@@ -227,13 +263,35 @@ class TestRepointing:
         assert found.repoint == ()
         assert found.gang_type_ids == ()
         assert found.kept_type_ids == (nameless.pk,)
-        assert any("no one gang list" in reason for reason in found.stranded)
+        assert any("2 different gang lists" in reason for reason in found.stranded)
 
         apply(found)
 
         played_on_it.refresh_from_db()
         assert played_on_it.gang_type_id == nameless.pk
         assert GangType.objects.filter(pk=nameless.pk).exists()
+        assert_reconciled(played_on_it)
+
+    def test_a_list_nobody_can_found_is_not_a_target(
+        self, nameless, owner, person_type
+    ):
+        """Hired guns and pets carry profiles off lists nobody plays as.
+        A gang moved onto one of those would be a gang no player could
+        have made, so it is left standing instead."""
+        hangers_on = create_gang_type("Dramatis Personae", foundable=False)
+        gang = found_gang("Odd One", nameless, owner=owner)
+        hire(
+            gang,
+            create_profile("Hired Gun", person_type, hangers_on, price=50),
+            "For Hire",
+            paid=50,
+        )
+
+        found = find()
+
+        assert found.repoint == ()
+        assert found.kept_type_ids == (nameless.pk,)
+        assert_reconciled(gang)
 
     def test_an_untouched_gang_still_goes_beside_one_left_standing(
         self, played_on_it, founded_on_it, nameless, person_type
@@ -248,11 +306,15 @@ class TestRepointing:
             paid=50,
         )
 
-        apply(find())
+        report = apply(find())
 
         assert not Gang.objects.filter(pk=founded_on_it.pk).exists()
         assert Gang.objects.filter(pk=played_on_it.pk).exists()
         assert GangType.objects.filter(pk=nameless.pk).exists()
+        # The record must still name the gang it destroyed, even though
+        # the type it stood on outlived it.
+        assert any("deleted gangs" in line for line in report)
+        assert_reconciled(played_on_it)
 
 
 class TestRefusing:
@@ -299,10 +361,28 @@ class TestRefusing:
 
         assert not found.ok
         assert any(
-            "belong to no gang founded on one" in problem for problem in found.problems
+            "not a founding this takes away" in problem for problem in found.problems
         )
         with pytest.raises(Refused, match="not retired"):
             apply(found)
+
+    def test_a_row_naming_the_type_on_a_repointed_gang_is_refused(
+        self, played_on_it, nameless
+    ):
+        """A repointed gang keeps its own assignments, so one of those
+        naming the nameless type would still name it when the delete
+        came — and PROTECT would fail the whole run."""
+        Assignment.objects.create(gang_type=nameless, gang=played_on_it)
+
+        found = find()
+
+        assert not found.ok
+        assert any(
+            "not a founding this takes away" in problem for problem in found.problems
+        )
+        with pytest.raises(Refused, match="not retired"):
+            apply(found)
+        assert GangType.objects.filter(pk=nameless.pk).exists()
 
     def test_a_nameless_type_in_another_pack_is_left_alone(self, db, default_pack):
         """Names are unique per pack, and another pack's rows are
@@ -372,3 +452,4 @@ class TestApplying:
 
         assert again.nothing_here
         assert apply(again) == again.preview()
+        assert_reconciled(Gang.objects.get(pk=played_on_it.pk))

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -175,7 +175,9 @@ class TestRepointing:
         assert {
             m.pk for m in Miniature.objects.filter(membership__gang=played_on_it)
         } == models
-        assert played_on_it.rating >= was_rating
+        # Not "no less than": built-ins arrive free, so a repoint cannot
+        # move the rating at all, and anything that does is a regression.
+        assert played_on_it.rating == was_rating
         assert_reconciled(played_on_it)
 
     def test_the_new_type_brings_its_built_ins(self, played_on_it, escher):

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -511,6 +511,10 @@ class TestRefoundTheVerb:
             with operation(played_on_it, actor=owner) as op:
                 op.refound(escher)
 
+        # In memory as well as in the database: a caller that catches the
+        # refusal and carries on must not hold a gang saying it is
+        # something the database says it is not.
+        assert played_on_it.gang_type_id != escher.pk
         played_on_it.refresh_from_db()
         assert played_on_it.gang_type_id != escher.pk
 

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -398,6 +398,29 @@ class TestRefusing:
             apply(found)
         assert GangType.objects.filter(pk=nameless.pk).exists()
 
+    def test_a_founding_that_granted_something_is_left_alone(
+        self, played_on_it, escher
+    ):
+        """Taking back what a type gave means unwinding purchases that
+        hang off it and saying in the ledger that they went, which is a
+        refund's work. This repair repoints a founding that granted
+        nothing, and says so rather than deleting quietly."""
+        Assignment.objects.create(
+            rule=create_rule("A Gift"),
+            gang=played_on_it,
+            caused_by=played_on_it.founding,
+        )
+
+        found = find()
+
+        assert not found.ok
+        assert found.replaced == 1
+        assert any("refund's work" in problem for problem in found.problems)
+        with pytest.raises(Refused, match="not retired"):
+            apply(found)
+        played_on_it.refresh_from_db()
+        assert played_on_it.gang_type_id != escher.pk
+
     def test_a_nameless_type_in_another_pack_is_left_alone(self, db, default_pack):
         """Names are unique per pack, and another pack's rows are
         somebody's content rather than this accident."""
@@ -467,3 +490,42 @@ class TestApplying:
         assert again.nothing_here
         assert apply(again) == again.preview()
         assert_reconciled(Gang.objects.get(pk=played_on_it.pk))
+
+
+class TestRefoundTheVerb:
+    """``operation.refound`` is a verb of its own, and a second caller
+    would not have this repair's proof that the old type gave nothing."""
+
+    def test_it_refuses_a_founding_that_granted_something(
+        self, played_on_it, escher, owner
+    ):
+        from n26.core.operations import Refusal, operation
+
+        Assignment.objects.create(
+            rule=create_rule("A Gift"),
+            gang=played_on_it,
+            caused_by=played_on_it.founding,
+        )
+
+        with pytest.raises(Refusal, match="given back"):
+            with operation(played_on_it, actor=owner) as op:
+                op.refound(escher)
+
+        played_on_it.refresh_from_db()
+        assert played_on_it.gang_type_id != escher.pk
+
+    def test_a_gang_with_no_founding_is_simply_founded(
+        self, played_on_it, escher, owner
+    ):
+        from n26.core.operations import operation
+
+        played_on_it.founding = None
+        played_on_it.save(update_fields=["founding", "modified"])
+
+        with operation(played_on_it, actor=owner) as op:
+            op.refound(escher)
+
+        played_on_it.refresh_from_db()
+        assert played_on_it.founding is not None
+        assert played_on_it.founding.assignable == escher
+        assert_reconciled(played_on_it)

--- a/n26/tests/sandbox/test_nameless_gang_type.py
+++ b/n26/tests/sandbox/test_nameless_gang_type.py
@@ -1,19 +1,21 @@
-"""The nameless gang type, and the repair that deletes it.
+"""The nameless gang type, and the repair that retires it.
 
 An ingest planned a gang type from a blank Gang cell, so a ``GangType``
 with no name stood in the pack — foundable by default, drawn as an empty
 card sorting before every real type, and foundable into a gang of
-nothing. Three things are proven here: nothing may author such a row,
-the create page does not offer one that already stands, and the repair
-deletes exactly the accident — refusing the moment a gang founded on it
-turns out to have been played.
+nothing. Nothing may author such a row and the create page does not
+offer one that already stands; what is left is what to do with the gangs
+already founded on it, and they are not alike. One nobody played is
+deleted. One somebody played is repointed to the list its models were
+really hired from, which is what it has been all along. One nobody can
+read is left exactly as it stands.
 """
 
 import pytest
 from django.core.exceptions import ValidationError
 
 from n26.core.forms import CreateGangForm
-from n26.core.models import Assignment, Gang
+from n26.core.models import Assignment, Gang, Miniature
 from n26.core.reconcile import assert_reconciled
 from n26.library import authoring
 from n26.library.models import GangType
@@ -39,9 +41,34 @@ def nameless(db, default_pack):
 
 
 @pytest.fixture
+def escher(db, default_pack):
+    """A real gang list, with something to hire off it."""
+    return create_gang_type("Escher", starting_credits=1000)
+
+
+@pytest.fixture
+def escher_ganger(escher, person_type):
+    return create_profile("Ganger", person_type, escher, price=50)
+
+
+@pytest.fixture
 def founded_on_it(nameless, owner):
     """A gang of nothing — founded on the empty card and untouched since."""
     return found_gang("A Gang Of Nothing", nameless, owner=owner)
+
+
+@pytest.fixture
+def played_on_it(nameless, owner, escher_ganger):
+    """The same founding, then played: models hired off a real list.
+
+    Nothing stops a gang hiring from a list its own type does not name,
+    so a gang founded on nothing gets filled from somewhere real — which
+    is what tells the repair what it has been all along.
+    """
+    gang = found_gang("Played As Escher", nameless, owner=owner)
+    hire(gang, escher_ganger, "One", paid=50)
+    hire(gang, escher_ganger, "Two", paid=50)
+    return gang
 
 
 class TestNothingMayAuthorOne:
@@ -54,16 +81,12 @@ class TestNothingMayAuthorOne:
 
 
 class TestTheCreatePageDoesNotOfferOne:
-    def test_a_nameless_type_is_not_a_card(self, nameless):
-        real = create_gang_type("Escher", starting_credits=1000)
-
+    def test_a_nameless_type_is_not_a_card(self, nameless, escher):
         offered = CreateGangForm().gang_type_choices()
 
-        assert [card["value"] for card in offered] == [str(real.pk)]
+        assert [card["value"] for card in offered] == [str(escher.pk)]
 
-    def test_it_is_not_an_answer_either(self, nameless):
-        create_gang_type("Escher", starting_credits=1000)
-
+    def test_it_is_not_an_answer_either(self, nameless, escher):
         form = CreateGangForm(data={"name": "The Nothings", "gang_type": nameless.pk})
 
         assert not form.is_valid()
@@ -84,12 +107,10 @@ class TestWhitespaceIsNoNameEither:
 
         assert authoring.create_gang_type("  Escher  ").name == "Escher"
 
-    def test_the_create_page_does_not_offer_it(self, padded):
-        real = create_gang_type("Escher", starting_credits=1000)
-
+    def test_the_create_page_does_not_offer_it(self, padded, escher):
         offered = CreateGangForm().gang_type_choices()
 
-        assert [card["value"] for card in offered] == [str(real.pk)]
+        assert [card["value"] for card in offered] == [str(escher.pk)]
 
     def test_the_repair_finds_it(self, padded):
         found = find()
@@ -102,51 +123,139 @@ class TestWhitespaceIsNoNameEither:
         assert not GangType.objects.filter(pk=padded.pk).exists()
 
 
-class TestFindingIt:
-    def test_it_names_the_type_and_the_gang_founded_on_it(self, founded_on_it):
+class TestReadingWhatStandsOnIt:
+    def test_an_untouched_gang_is_named_for_deleting(self, founded_on_it):
         found = find()
 
         assert found.ok and not found.nothing_here
-        assert len(found.gang_type_ids) == 1
-        assert found.gang_ids == (founded_on_it.pk,)
+        assert found.doomed_gang_ids == (founded_on_it.pk,)
+        assert found.repoint == ()
         assert found.assignment_ids == (founded_on_it.founding_id,)
         said = "\n".join(found.preview())
-        assert "delete 1 gang founded on a nameless type" in said
+        assert "delete 1 untouched gang founded on a nameless type" in said
         assert "delete 1 gang type with no name" in said
+
+    def test_a_played_gang_is_named_for_repointing(self, played_on_it, escher):
+        found = find()
+
+        assert found.ok
+        assert found.doomed_gang_ids == ()
+        assert found.repoint == ((played_on_it.pk, escher.pk),)
+        said = "\n".join(found.preview())
+        assert "repoint a played gang onto Escher" in said
+        assert "nothing the gang owns is touched" in said
 
     def test_a_type_with_no_gang_on_it_still_goes(self, nameless):
         found = find()
 
-        assert found.ok and found.gang_ids == ()
-        assert "nothing of a player's dies" in "\n".join(found.preview())
+        assert found.ok and found.doomed_gang_ids == () and found.repoint == ()
+        assert "delete 1 gang type with no name" in "\n".join(found.preview())
 
-    def test_a_pack_of_named_types_has_nothing_to_delete(self, db, default_pack):
-        create_gang_type("Escher", starting_credits=1000)
-
+    def test_a_pack_of_named_types_has_nothing_to_retire(self, db, escher):
         found = find()
 
         assert found.nothing_here
         assert apply(found) == found.preview()
 
 
-class TestRefusing:
-    def test_a_gang_that_has_been_hired_into_is_left_alone(
-        self, founded_on_it, person_type
-    ):
-        profile = create_profile(
-            "Somebody", person_type, founded_on_it.gang_type, price=50
+class TestRepointing:
+    """A played gang is what its models say it is. Saying so must take
+    nothing away and must leave the gang's books straight."""
+
+    def test_it_keeps_everything_the_gang_owns(self, played_on_it, escher):
+        was_rating = played_on_it.rating
+        models = {m.pk for m in Miniature.objects.filter(membership__gang=played_on_it)}
+
+        apply(find())
+
+        played_on_it.refresh_from_db()
+        assert played_on_it.gang_type_id == escher.pk
+        assert {
+            m.pk for m in Miniature.objects.filter(membership__gang=played_on_it)
+        } == models
+        assert played_on_it.rating >= was_rating
+        assert_reconciled(played_on_it)
+
+    def test_the_new_type_brings_its_built_ins(self, played_on_it, escher):
+        """A gang type hands its gang things through the founding
+        assignment, so a repoint that did not found again would leave the
+        gang without what its type gives."""
+        escher.built_ins = authoring.create_default_set(
+            "Escher built-ins", members=[create_rule("Wise")]
         )
-        hire(founded_on_it, profile, "Somebody At All", paid=50)
-        assert_reconciled(founded_on_it)
+        escher.save()
+
+        apply(find())
+
+        played_on_it.refresh_from_db()
+        assert played_on_it.founding is not None
+        assert played_on_it.founding.assignable == escher
+        arrived = Assignment.objects.filter(
+            gang_root=played_on_it, caused_by=played_on_it.founding
+        )
+        assert [str(row.assignable) for row in arrived] == ["Wise"]
+        assert_reconciled(played_on_it)
+
+    def test_the_nameless_type_goes_once_nothing_stands_on_it(
+        self, played_on_it, founded_on_it, escher
+    ):
+        """One gang of each kind on the same type: the untouched one is
+        deleted, the played one repointed, and only then may the type go."""
+        report = apply(find())
+
+        assert not Gang.objects.filter(pk=founded_on_it.pk).exists()
+        assert Gang.objects.filter(pk=played_on_it.pk).exists()
+        assert not GangType.objects.filter(name="").exists()
+        assert any("repointed gangs" in line for line in report)
+
+    def test_a_gang_read_from_no_one_list_is_left_standing(
+        self, played_on_it, nameless, person_type
+    ):
+        """Models from two lists, and nobody can say which the gang is.
+        It keeps what it has, and so does the type it names."""
+        other = create_gang_type("Goliath", starting_credits=1000)
+        hire(
+            played_on_it,
+            create_profile("Bruiser", person_type, other, price=50),
+            "Three",
+            paid=50,
+        )
 
         found = find()
 
-        assert not found.ok
-        assert any("has been played" in problem for problem in found.problems)
-        with pytest.raises(Refused, match="not deleted"):
-            apply(found)
-        assert Gang.objects.filter(pk=founded_on_it.pk).exists()
+        assert found.ok
+        assert found.repoint == ()
+        assert found.gang_type_ids == ()
+        assert found.kept_type_ids == (nameless.pk,)
+        assert any("no one gang list" in reason for reason in found.stranded)
 
+        apply(found)
+
+        played_on_it.refresh_from_db()
+        assert played_on_it.gang_type_id == nameless.pk
+        assert GangType.objects.filter(pk=nameless.pk).exists()
+
+    def test_an_untouched_gang_still_goes_beside_one_left_standing(
+        self, played_on_it, founded_on_it, nameless, person_type
+    ):
+        """Per gang, not all or nothing: the unreadable one holding up
+        the type must not hold up the empty one's deletion."""
+        other = create_gang_type("Goliath", starting_credits=1000)
+        hire(
+            played_on_it,
+            create_profile("Bruiser", person_type, other, price=50),
+            "Three",
+            paid=50,
+        )
+
+        apply(find())
+
+        assert not Gang.objects.filter(pk=founded_on_it.pk).exists()
+        assert Gang.objects.filter(pk=played_on_it.pk).exists()
+        assert GangType.objects.filter(pk=nameless.pk).exists()
+
+
+class TestRefusing:
     def test_a_type_something_is_hired_off_wants_a_name_instead(
         self, nameless, person_type
     ):
@@ -178,23 +287,21 @@ class TestRefusing:
         assert not found.ok
         assert any("authored onto it" in problem for problem in found.problems)
 
-    def test_an_assignment_naming_it_that_is_not_a_founding_is_refused(
-        self, founded_on_it
+    def test_an_assignment_naming_it_on_no_such_gang_is_refused(
+        self, nameless, escher, owner
     ):
         """``Assignment.gang_type`` is PROTECT, so the delete would fail
-        anyway — refusing in words beats a crash, and says which rows."""
-        stranger = Assignment.objects.create(
-            gang_type=founded_on_it.gang_type, gang=founded_on_it
-        )
+        anyway — refusing in words beats a crash, and says how many."""
+        elsewhere = found_gang("Somewhere Else", escher, owner=owner)
+        Assignment.objects.create(gang_type=nameless, gang=elsewhere)
 
         found = find()
 
         assert not found.ok
         assert any(
-            "one of these gangs' foundings" in problem for problem in found.problems
+            "belong to no gang founded on one" in problem for problem in found.problems
         )
-        assert stranger.pk not in found.assignment_ids
-        with pytest.raises(Refused, match="not deleted"):
+        with pytest.raises(Refused, match="not retired"):
             apply(found)
 
     def test_a_nameless_type_in_another_pack_is_left_alone(self, db, default_pack):
@@ -210,8 +317,8 @@ class TestRefusing:
 
 
 class TestApplying:
-    def test_it_deletes_the_gang_and_then_the_type(self, founded_on_it):
-        named = create_gang_type("Escher", starting_credits=1000)
+    def test_it_deletes_the_untouched_gang_and_then_the_type(self, founded_on_it):
+        named = create_gang_type("Cawdor", starting_credits=1000)
         kept = found_gang("The Real Thing", named, owner=founded_on_it.owner)
 
         report = apply(find())
@@ -223,10 +330,10 @@ class TestApplying:
         assert not Assignment.objects.filter(gang_root=founded_on_it).exists()
         assert Gang.objects.filter(pk=kept.pk).exists()
         assert GangType.objects.filter(pk=named.pk).exists()
-        assert "deleted; every gang type in the pack has a name" in report
+        assert "retired; every gang type in the pack has a name" in report
 
     def test_a_plan_read_before_the_world_moved_is_refused(
-        self, founded_on_it, person_type
+        self, founded_on_it, escher_ganger
     ):
         """A gang's assignments cascade rather than protect, so a gang
         hired into between reading the plan and deleting would ride the
@@ -234,10 +341,7 @@ class TestApplying:
         anything that has moved refuses."""
         stale = find()
         assert stale.ok
-        profile = create_profile(
-            "Somebody", person_type, founded_on_it.gang_type, price=50
-        )
-        hire(founded_on_it, profile, "Somebody At All", paid=50)
+        hire(founded_on_it, escher_ganger, "Somebody At All", paid=50)
 
         with pytest.raises(Refused, match="changed since the plan was read"):
             apply(stale)
@@ -259,7 +363,9 @@ class TestApplying:
 
         assert Gang.objects.filter(pk=founded_on_it.pk).exists()
 
-    def test_running_it_twice_finds_nothing_the_second_time(self, founded_on_it):
+    def test_running_it_twice_finds_nothing_the_second_time(
+        self, played_on_it, founded_on_it
+    ):
         apply(find())
 
         again = find()

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -496,10 +496,10 @@ class TestTheRunsOwnGuards:
         assert backfill.status == Backfill.Status.CANCELLED
 
 
-class TestTheNamelessGangTypeDeletion:
+class TestTheNamelessGangTypeRetirement:
     """The second operation that deletes: an empty-named gang type an
-    ingest founded from a blank Gang cell, and the gang of nothing
-    founded on it."""
+    ingest founded from a blank Gang cell, the gang of nothing founded
+    on it, and — where somebody played one — a repoint instead."""
 
     @pytest.fixture
     def nameless_world(self, owner, default_pack):
@@ -531,11 +531,11 @@ class TestTheNamelessGangTypeDeletion:
 
         page = response.content.decode()
         assert response.status_code == 200
-        assert "delete 1 gang founded on a nameless type" in page
+        assert "delete 1 untouched gang founded on a nameless type" in page
         assert not Backfill.objects.exists()
         assert GangType.objects.filter(name="").exists()
 
-    def test_applying_records_what_it_deleted(self, client, superuser, nameless_world):
+    def test_applying_records_what_it_retired(self, client, superuser, nameless_world):
         from n26.core.models import Gang
         from n26.library.models import GangType
 
@@ -553,21 +553,51 @@ class TestTheNamelessGangTypeDeletion:
         assert not Gang.objects.filter(pk=nameless_world.pk).exists()
         assert GangType.objects.filter(name="Escher").exists()
 
-    def test_a_gang_that_has_been_played_stops_the_run_before_it_records(
+    def test_a_played_gang_is_repointed_rather_than_deleted(
         self, client, superuser, nameless_world, person_type
     ):
-        """The refusal belongs on the screen of whoever asked for it,
-        not filed as a failed run."""
+        """The whole point of the operation running at all: a gang
+        somebody has played keeps everything, and stops naming nothing."""
         from n26.core.models import Gang
+        from n26.library.models import GangType
         from n26.tests.sandbox.actions import create_profile, hire
 
-        profile = create_profile(
-            "Somebody", person_type, nameless_world.gang_type, price=50
-        )
-        hire(nameless_world, profile, "Somebody At All")
+        escher = GangType.objects.get(name="Escher")
+        profile = create_profile("Ganger", person_type, escher, price=50)
+        hire(nameless_world, profile, "Somebody At All", paid=50)
         client.force_login(superuser)
 
         client.post(reverse("admin:maintenance_n26_delete_nameless_gang_type"))
 
-        assert not Backfill.objects.exists()
-        assert Gang.objects.filter(pk=nameless_world.pk).exists()
+        run = Backfill.objects.get(operation=Operation.DELETE_NAMELESS_GANG_TYPE)
+        assert run.status == Backfill.Status.DONE
+        assert Gang.objects.get(pk=nameless_world.pk).gang_type_id == escher.pk
+        assert not GangType.objects.filter(name="").exists()
+
+    def test_a_gang_nobody_can_read_stops_the_type_going(
+        self, client, superuser, nameless_world, person_type
+    ):
+        """Two lists in one gang and nobody can say what it is, so the
+        gang and the type it names are both left standing."""
+        from n26.core.models import Gang
+        from n26.library.models import GangType
+        from n26.tests.sandbox.actions import create_gang_type, create_profile, hire
+
+        for house in ("Escher", "Goliath"):
+            gang_type = GangType.objects.filter(name=house).first() or create_gang_type(
+                house, starting_credits=1000
+            )
+            hire(
+                nameless_world,
+                create_profile(f"{house} Ganger", person_type, gang_type, price=50),
+                f"From {house}",
+                paid=50,
+            )
+        client.force_login(superuser)
+
+        client.post(reverse("admin:maintenance_n26_delete_nameless_gang_type"))
+
+        run = Backfill.objects.get(operation=Operation.DELETE_NAMELESS_GANG_TYPE)
+        assert run.status == Backfill.Status.DONE
+        assert GangType.objects.filter(name="").exists()
+        assert Gang.objects.get(pk=nameless_world.pk).gang_type.name == ""

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import operations, resolve_operation
 from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
 from n26.maintenance import (
     MAX_ATTEMPTS,
     Operation,
@@ -573,6 +574,7 @@ class TestTheNamelessGangTypeRetirement:
         assert run.status == Backfill.Status.DONE
         assert Gang.objects.get(pk=nameless_world.pk).gang_type_id == escher.pk
         assert not GangType.objects.filter(name="").exists()
+        assert_reconciled(Gang.objects.get(pk=nameless_world.pk))
 
     def test_a_gang_nobody_can_read_stops_the_type_going(
         self, client, superuser, nameless_world, person_type
@@ -601,3 +603,4 @@ class TestTheNamelessGangTypeRetirement:
         assert run.status == Backfill.Status.DONE
         assert GangType.objects.filter(name="").exists()
         assert Gang.objects.get(pk=nameless_world.pk).gang_type.name == ""
+        assert_reconciled(Gang.objects.get(pk=nameless_world.pk))


### PR DESCRIPTION
The nameless-gang-type retirement refused when it was run: one of the gangs founded on the blank card had actually been played — seven models hired, gear bought — and a played gang is not a repair's to delete. That refusal was correct, but it was also all-or-nothing, so the untouched gang standing beside it could not be cleared either, and the nameless type stayed.

## Summary

- **The gangs are settled one at a time, because they are not alike.** An untouched gang goes with the type. A played one is **repointed** to the gang type its living models were all hired from — a gang whose models come only off the Outcast list is an Outcast gang naming the wrong type, and saying so takes nothing away. A gang whose models come from several lists, from none, or only from a list nobody can found is left exactly as it stands, and so is the type it names.
- **A repoint keeps the act that founded the gang.** `Operation.refound` repoints the founding assignment rather than replacing it. That assignment carries the gang's opening ledger entry and the history event saying its owner created it, and both cascade with it — founding afresh would delete the gang's own creation and write a new one, dated the day of the repair, in the name of whoever ran it. Keeping it means the history still opens with its owner, at its own date; and since the history reads through the assignment, that opening act now names the type the gang really is. The old type's built-ins go, the new type's arrive caused by the same founding, and because built-ins are free the rating cannot move.
- **Every destructive outcome is named in the record**, including a gang deleted while the type it stood on stays. Every assignment naming a type that is going must be a founding the plan takes away, or the run refuses in words rather than failing on `PROTECT`.

## Test plan

- [x] `pytest -n auto` — 8163 passed, 12 skipped, 1 xfailed
- [x] The gang keeps its own founding act: same assignment, same opening ledger event, same date, same actor — and its history reads "created the gang, a Escher gang" afterwards
- [x] Repointing keeps every model, brings the new type's built-ins as assignments caused by the kept founding, and reconciles
- [x] Per-gang rather than all-or-nothing: an untouched gang is still deleted beside one left standing, and the record names it
- [x] Unreadable gangs: models from two lists, or from a list nobody can found, leave both the gang and its type alone, with the reason in the preview
- [x] The refusals still hold — entries hired off the type, built-ins or modifiers authored onto it, an assignment naming a doomed type that no founding takes away, another pack's rows, and a plan read before the world moved
- [x] Console: a played gang is repointed through the real page and recorded; a gang nobody can read leaves the type standing
- [x] Smoke-tested on a fork of the content mirror at production's shape — an untouched gang plus a seven-model gang hired off one list. Founding act kept, history opening "You created the gang, a Outcast gang", every model kept, rating unmoved, books reconciling, and every other gang and gang type compared unchanged.

## Trying it

`/admin/maintenance/` → "n26: the gang type with no name is retired". The preview says, per gang, which will be repointed, which deleted, and which left alone.