### PR TITLE
chore: the authoring menu stops offering the kinds slots replaced

### DIFF
--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -75,6 +75,14 @@ LEAF_KINDS = {
 }
 
 
+#: Kinds a menu no longer offers. What they said is said by slots and
+#: picks now, and the rows that remain are history: pointed at by
+#: answers a gang took back, and by nothing a reader can still choose.
+#: They keep their pages, so those rows stay reachable and editable —
+#: it is the invitation to make another one that goes.
+RETIRED_KINDS = frozenset({"archetype", "skill-tree", "specialisation"})
+
+
 #: Kinds whose page is a place you come back to: the thing, and the
 #: parts you add to it over time. ``kind -> the verb that adds a part``.
 def _describe_weapon_profile(profile):
@@ -927,6 +935,8 @@ def index(request):
     qualities, the kit, the gang-scale picks."""
     grouped = {family: [] for family in Family}
     for kind, verb_name in LEAF_KINDS.items():
+        if kind in RETIRED_KINDS:
+            continue
         model = _model_for(specs()[verb_name])
         grouped[model.family].append(
             {
@@ -3221,7 +3231,8 @@ def foundations(request):
                     "count": _model_for(specs()[verb]).objects.count(),
                 }
                 for kind, verb in LEAF_KINDS.items()
-                if _model_for(specs()[verb]).family == Family.FOUNDATION
+                if kind not in RETIRED_KINDS
+                and _model_for(specs()[verb]).family == Family.FOUNDATION
             ],
         },
     )

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -900,7 +900,7 @@ class TestFamilies:
         assert positions == sorted(positions)
         # A kind sits under its family.
         assert positions[2] < body.index("wargear")
-        assert positions[3] < body.index("archetype")
+        assert positions[3] < body.index("affiliation")
 
     def test_the_family_table(self):
         """The grouping as agreed, pinned so it changes deliberately."""
@@ -1136,6 +1136,33 @@ class TestASlotTypeReadsAsAKind:
 
     def page(self, client, slot_type):
         return client.get(f"/n26/authoring/slot-type/{slot_type.pk}/").content.decode()
+
+    def test_the_index_offers_none_of_the_retired_kinds(
+        self, author, client, default_pack
+    ):
+        """What an archetype, a skill tree and a specialisation said is
+        said by slots and picks. The menu stops inviting another one."""
+        from n26.library.views import RETIRED_KINDS
+
+        body = client.get("/n26/authoring/").content.decode()
+
+        for kind in RETIRED_KINDS:
+            assert f"/n26/authoring/{kind}/new/" not in body, kind
+
+    def test_a_retired_kinds_page_still_opens(self, author, client, default_pack):
+        """The rows are still there — answers a gang took back point at
+        them — so they stay reachable and editable. Only the invitation
+        to make another one goes."""
+        from n26.tests.sandbox.actions import create_specialisation
+
+        held = create_specialisation("Sniper")
+
+        listing = client.get("/n26/authoring/specialisation/")
+        page = client.get(f"/n26/authoring/specialisation/{held.pk}/")
+
+        assert listing.status_code == 200
+        assert page.status_code == 200
+        assert "Sniper" in page.content.decode()
 
     def test_the_index_groups_the_choice_kinds_together(
         self, author, client, default_pack


### PR DESCRIPTION
A small guard while the old kinds are being retired: stop inviting authors to make more of them.

## What changes

Archetype, Skill Tree and Specialisation no longer appear on the authoring front page or in the foundation menu. What they said is said by slots and picks now, and every route that could create a *live* one is already gone — so a new row of these kinds can only be a mistake, and the columns behind them are meant to be closing.

## What deliberately stays

The pages. Rows still exist — answers a gang took back point at them — so those rows stay reachable, listable and editable, and every link that finds a thing by its kind goes on working. `LEAF_KINDS` is untouched for exactly that reason: it is also the reverse map from a model to its page, and thinning it would break links to rows that are still there. A `RETIRED_KINDS` set filters the two menus and nothing else.

## A test worth noting

`test_the_index_groups_by_family` used "archetype" as its example of a Gang-family kind — the exemplar is now "affiliation", which the menu still offers. Two new tests pin both halves of this change: the menu offers none of the retired kinds, and a retired kind's page still opens and shows its rows.

## Test plan

- [x] `pytest n26` — 3814 passed
- [x] The authoring suite alone — 572 passed
- [x] The front page still renders every remaining family group in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8