### PR TITLE
chore: a cloud agent reaches the production database read-only, without holding a key

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -154,7 +154,9 @@ else
     CSP_TMP=$(mktemp)
     curl -sfLo "$CSP_TMP" \
       "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${CSP_VERSION}/cloud-sql-proxy.linux.${CSP_ARCH}"
-    echo "${CSP_SHA}  ${CSP_TMP}" | sha256sum -c --status -
+    # Reported rather than silenced: a mismatch here means the download did not
+    # produce the pinned binary, which is the one failure worth a message.
+    echo "${CSP_SHA}  ${CSP_TMP}" | sha256sum -c -
     sudo install -m 0755 "$CSP_TMP" "$CSP_BIN"
     rm -f "$CSP_TMP"
   fi

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -102,4 +102,53 @@ npm install
 npm run build
 manage collectstatic --noinput
 
+# ---------------------------------------------------------------------------
+# 7. Read-only production database access.
+#
+#    A cloud agent authenticates to Google Cloud with a five-minute token that
+#    scripts/cursor/mint-gcp-token.sh obtains from the local Cursor socket. The
+#    token is federated into a service account that can only SELECT, so there is
+#    no service account key anywhere on the machine.
+#
+#    Only the TOOLS are installed here. The credential config itself is written
+#    on every boot by .cursor/start.sh, because it arrives in an environment
+#    variable and a build snapshot must not capture it.
+# ---------------------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  log "Installing jq"
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq jq
+fi
+
+# Version and checksums are pinned rather than resolved at build time: the
+# GitHub releases API is rate limited for unauthenticated callers, so resolving
+# "latest" here would make builds fail unpredictably. Google publishes no
+# checksum sidecar, so these were computed from the pinned release.
+CSP_VERSION="v2.25.3"
+CSP_BIN="/usr/local/bin/cloud-sql-proxy"
+if ! "$CSP_BIN" --version 2>/dev/null | grep -q "${CSP_VERSION#v}"; then
+  case "$(uname -m)" in
+    x86_64)
+      CSP_ARCH="amd64"
+      CSP_SHA="f0584d79e877a8a46300fe2513840972c44e704c15dc3da6a49d5408f7d6f233"
+      ;;
+    aarch64)
+      CSP_ARCH="arm64"
+      CSP_SHA="9ffbf512ee24dbeca527eb12fc43d7a322724afccf369d7c172995fca35444d9"
+      ;;
+    *)
+      echo "Unsupported architecture $(uname -m) for cloud-sql-proxy" >&2
+      exit 1
+      ;;
+  esac
+  log "Installing cloud-sql-proxy ${CSP_VERSION} (${CSP_ARCH})"
+  CSP_TMP=$(mktemp)
+  curl -sfLo "$CSP_TMP" \
+    "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${CSP_VERSION}/cloud-sql-proxy.linux.${CSP_ARCH}"
+  echo "${CSP_SHA}  ${CSP_TMP}" | sha256sum -c - >/dev/null
+  sudo install -m 0755 "$CSP_TMP" "$CSP_BIN"
+  rm -f "$CSP_TMP"
+fi
+log "$("$CSP_BIN" --version 2>/dev/null | head -1)"
+
 log "Install complete"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -126,26 +126,30 @@ fi
 # checksum sidecar, so these were computed from the pinned release.
 CSP_VERSION="v2.25.3"
 CSP_BIN="/usr/local/bin/cloud-sql-proxy"
-if ! "$CSP_BIN" --version 2>/dev/null | grep -q "${CSP_VERSION#v}"; then
-  case "$(uname -m)" in
-    x86_64)
-      CSP_ARCH="amd64"
-      CSP_SHA="f0584d79e877a8a46300fe2513840972c44e704c15dc3da6a49d5408f7d6f233"
-      ;;
-    aarch64)
-      CSP_ARCH="arm64"
-      CSP_SHA="9ffbf512ee24dbeca527eb12fc43d7a322724afccf369d7c172995fca35444d9"
-      ;;
-    *)
-      echo "Unsupported architecture $(uname -m) for cloud-sql-proxy" >&2
-      exit 1
-      ;;
-  esac
+case "$(uname -m)" in
+  x86_64)
+    CSP_ARCH="amd64"
+    CSP_SHA="f0584d79e877a8a46300fe2513840972c44e704c15dc3da6a49d5408f7d6f233"
+    ;;
+  aarch64)
+    CSP_ARCH="arm64"
+    CSP_SHA="9ffbf512ee24dbeca527eb12fc43d7a322724afccf369d7c172995fca35444d9"
+    ;;
+  *)
+    echo "Unsupported architecture $(uname -m) for cloud-sql-proxy" >&2
+    exit 1
+    ;;
+esac
+
+# Whether the right binary is already present is decided by its digest rather
+# than by matching its reported version, which would treat 2.25.30 as 2.25.3 and
+# says nothing about whether the file has been altered since it was installed.
+if ! echo "${CSP_SHA}  ${CSP_BIN}" | sha256sum -c --status - 2>/dev/null; then
   log "Installing cloud-sql-proxy ${CSP_VERSION} (${CSP_ARCH})"
   CSP_TMP=$(mktemp)
   curl -sfLo "$CSP_TMP" \
     "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${CSP_VERSION}/cloud-sql-proxy.linux.${CSP_ARCH}"
-  echo "${CSP_SHA}  ${CSP_TMP}" | sha256sum -c - >/dev/null
+  echo "${CSP_SHA}  ${CSP_TMP}" | sha256sum -c --status -
   sudo install -m 0755 "$CSP_TMP" "$CSP_BIN"
   rm -f "$CSP_TMP"
 fi

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -120,12 +120,15 @@ if ! command -v jq >/dev/null 2>&1; then
   sudo apt-get install -y -qq jq
 fi
 
-# Version and checksums are pinned rather than resolved at build time: the
-# GitHub releases API is rate limited for unauthenticated callers, so resolving
-# "latest" here would make builds fail unpredictably. Google publishes no
-# checksum sidecar, so these were computed from the pinned release.
+# The version and its digests are pinned rather than resolved at build time:
+# the GitHub releases API is rate limited for unauthenticated callers, so
+# resolving "latest" here would make builds fail unpredictably. Google publishes
+# no checksum sidecar, so compute these from the release artefacts when bumping
+# the version.
 CSP_VERSION="v2.25.3"
 CSP_BIN="/usr/local/bin/cloud-sql-proxy"
+CSP_ARCH=""
+CSP_SHA=""
 case "$(uname -m)" in
   x86_64)
     CSP_ARCH="amd64"
@@ -135,24 +138,27 @@ case "$(uname -m)" in
     CSP_ARCH="arm64"
     CSP_SHA="9ffbf512ee24dbeca527eb12fc43d7a322724afccf369d7c172995fca35444d9"
     ;;
-  *)
-    echo "Unsupported architecture $(uname -m) for cloud-sql-proxy" >&2
-    exit 1
-    ;;
 esac
 
-# Whether the right binary is already present is decided by its digest rather
-# than by matching its reported version, which would treat 2.25.30 as 2.25.3 and
-# says nothing about whether the file has been altered since it was installed.
-if ! echo "${CSP_SHA}  ${CSP_BIN}" | sha256sum -c --status - 2>/dev/null; then
-  log "Installing cloud-sql-proxy ${CSP_VERSION} (${CSP_ARCH})"
-  CSP_TMP=$(mktemp)
-  curl -sfLo "$CSP_TMP" \
-    "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${CSP_VERSION}/cloud-sql-proxy.linux.${CSP_ARCH}"
-  echo "${CSP_SHA}  ${CSP_TMP}" | sha256sum -c --status -
-  sudo install -m 0755 "$CSP_TMP" "$CSP_BIN"
-  rm -f "$CSP_TMP"
+if [ -z "$CSP_ARCH" ]; then
+  # Production database access is an optional extra. An architecture with no
+  # published build must not discard the interpreter, the database, the
+  # migrations and the assets that everything else depends on.
+  log "No cloud-sql-proxy build for $(uname -m); skipping it. Production database access will be unavailable."
+else
+  # Whether the right binary is already present is decided by its digest rather
+  # than by matching its reported version, which would treat 2.25.30 as 2.25.3
+  # and says nothing about whether the file has been altered since installation.
+  if ! echo "${CSP_SHA}  ${CSP_BIN}" | sha256sum -c --status - 2>/dev/null; then
+    log "Installing cloud-sql-proxy ${CSP_VERSION} (${CSP_ARCH})"
+    CSP_TMP=$(mktemp)
+    curl -sfLo "$CSP_TMP" \
+      "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${CSP_VERSION}/cloud-sql-proxy.linux.${CSP_ARCH}"
+    echo "${CSP_SHA}  ${CSP_TMP}" | sha256sum -c --status -
+    sudo install -m 0755 "$CSP_TMP" "$CSP_BIN"
+    rm -f "$CSP_TMP"
+  fi
+  log "$("$CSP_BIN" --version 2>/dev/null | head -1)"
 fi
-log "$("$CSP_BIN" --version 2>/dev/null | head -1)"
 
 log "Install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -34,16 +34,22 @@ set -euo pipefail
 # agent's own shell.
 #
 # An unset variable is the normal case: agents that do not need production
-# access simply skip this.
+# access simply skip this. Whatever the outcome, what is on disk ends up
+# reflecting the variable, so withdrawing the variable withdraws the access
+# rather than leaving an earlier boot's config in place.
 # ---------------------------------------------------------------------------
 WIF_CONFIG_DIR="/etc/gyrinx"
 WIF_CONFIG_PATH="${WIF_CONFIG_DIR}/cursor-wif.json"
 
-if [ -n "${GCP_WIF_CONFIG:-}" ]; then
+if [ -z "${GCP_WIF_CONFIG:-}" ]; then
+  rm -f "$WIF_CONFIG_PATH"
+else
   if ! printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
     # Warn rather than exit: a malformed variable should not stop the dev
-    # server from coming up.
+    # server from coming up. The old config goes anyway, so a typo fails closed
+    # instead of quietly leaving the previous credentials usable.
     echo "GCP_WIF_CONFIG is set but is not a JSON object; skipping." >&2
+    rm -f "$WIF_CONFIG_PATH"
   elif ! sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$WIF_CONFIG_DIR" 2>/dev/null; then
     echo "Could not create ${WIF_CONFIG_DIR}; skipping credential config." >&2
   else

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -9,6 +9,38 @@
 
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Read-only production database credentials.
+#
+# GCP_WIF_CONFIG holds the external_account configuration as JSON. It is
+# supplied as a Cursor environment variable rather than committed, because this
+# repository is public and the config names the Google Cloud project. Writing it
+# here rather than in install.sh keeps it out of the build snapshot.
+#
+# The file lands outside the workspace so it never appears in git status.
+# GOOGLE_APPLICATION_CREDENTIALS must point at this same path, and
+# GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES must be 1; both are set as Cursor
+# environment variables, because exports from this script do not reach the
+# agent's own shell.
+#
+# An unset variable is the normal case: agents that do not need production
+# access simply skip this.
+# ---------------------------------------------------------------------------
+WIF_CONFIG_PATH="${HOME}/.gcp/cursor-wif.json"
+if [ -n "${GCP_WIF_CONFIG:-}" ]; then
+  if printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    mkdir -p "$(dirname "$WIF_CONFIG_PATH")"
+    # Subshell so the restrictive umask applies to the file at creation rather
+    # than leaving it briefly world-readable before a chmod.
+    ( umask 077; printf '%s' "$GCP_WIF_CONFIG" > "$WIF_CONFIG_PATH" )
+    echo "Wrote Google credential config to ${WIF_CONFIG_PATH}."
+  else
+    # Warn rather than exit: a malformed variable should not stop the dev
+    # server from coming up.
+    echo "GCP_WIF_CONFIG is set but is not a JSON object; skipping." >&2
+  fi
+fi
+
 sudo pg_ctlcluster 16 main start 2>/dev/null \
   || sudo service postgresql start 2>/dev/null \
   || true

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -47,23 +47,31 @@ set -euo pipefail
 WIF_CONFIG_DIR="/etc/gyrinx"
 WIF_CONFIG_PATH="${WIF_CONFIG_DIR}/cursor-wif.json"
 
+# Every path that does not write a fresh config discards the old one, so what is
+# on disk always reflects the variable: rotating it to a different project, or
+# withdrawing it, cannot leave an earlier boot's credentials in use. rm -f
+# forgives a missing file but not a permission error, which would otherwise end
+# the boot before PostgreSQL had started.
+discard_config() { rm -f "$WIF_CONFIG_PATH" 2>/dev/null || true; }
+
 if [ -z "${GCP_WIF_CONFIG:-}" ]; then
-  # rm -f forgives a missing file but not a permission error, which would
-  # otherwise end the boot before PostgreSQL had started.
-  rm -f "$WIF_CONFIG_PATH" 2>/dev/null || true
+  discard_config
 elif ! command -v jq >/dev/null 2>&1; then
   # Distinguished from a malformed variable so the reader is sent after the
   # right thing: jq arrives late in install.sh, so a partial build lands here.
   echo "jq is not installed; skipping credential config." >&2
+  discard_config
 elif ! printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
-  # The old config goes anyway, so a typo fails closed instead of quietly
-  # leaving the previous credentials usable.
+  # A typo fails closed rather than quietly leaving the previous credentials
+  # usable.
   echo "GCP_WIF_CONFIG is set but is not a JSON object; skipping." >&2
-  rm -f "$WIF_CONFIG_PATH" 2>/dev/null || true
+  discard_config
 elif ! sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$WIF_CONFIG_DIR" 2>/dev/null; then
   echo "Could not create ${WIF_CONFIG_DIR}; skipping credential config." >&2
+  discard_config
 elif ! WIF_TMP=$(mktemp "${WIF_CONFIG_DIR}/.cursor-wif.XXXXXX" 2>/dev/null); then
   echo "Could not create a temporary file in ${WIF_CONFIG_DIR}; skipping credential config." >&2
+  discard_config
 else
   # Written to a fresh file inside the private directory and renamed into place.
   # rename(2) replaces a symlink at the destination rather than following it, so
@@ -76,6 +84,7 @@ else
   else
     rm -f "$WIF_TMP" 2>/dev/null || true
     echo "Could not write ${WIF_CONFIG_PATH}; skipping credential config." >&2
+    discard_config
   fi
 fi
 

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -17,12 +17,16 @@ set -euo pipefail
 # repository is public and the config names the Google Cloud project. Writing it
 # here rather than in install.sh keeps it out of the build snapshot.
 #
-# The path is a fixed absolute location rather than anything under $HOME. It has
-# to be stated identically in the GOOGLE_APPLICATION_CREDENTIALS environment
-# variable, and a path that depends on which user the agent runs as is a silent
-# mismatch waiting to happen. It also sits outside the workspace, so it never
-# appears in git status and cannot be committed to a public repository by
-# accident.
+# The path is fixed and absolute rather than derived from $HOME. It has to be
+# repeated verbatim in GOOGLE_APPLICATION_CREDENTIALS, and a path that depends
+# on which user the agent runs as is a silent mismatch waiting to happen.
+#
+# It is NOT in /tmp. A shared, world-writable directory lets any other process
+# on the machine pre-place a symlink at the destination, in which case the write
+# lands wherever that link points -- an arbitrary file overwrite running as this
+# user. A private directory removes the exposure entirely; the directory is
+# re-created with restrictive ownership on every boot, so tampering between runs
+# is repaired rather than inherited.
 #
 # GOOGLE_APPLICATION_CREDENTIALS must name this same path and
 # GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES must be 1; both are set as Cursor
@@ -32,18 +36,26 @@ set -euo pipefail
 # An unset variable is the normal case: agents that do not need production
 # access simply skip this.
 # ---------------------------------------------------------------------------
-WIF_CONFIG_PATH="/tmp/cursor-wif.json"
+WIF_CONFIG_DIR="/etc/gyrinx"
+WIF_CONFIG_PATH="${WIF_CONFIG_DIR}/cursor-wif.json"
+
 if [ -n "${GCP_WIF_CONFIG:-}" ]; then
-  if printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
-    mkdir -p "$(dirname "$WIF_CONFIG_PATH")"
-    # Subshell so the restrictive umask applies to the file at creation rather
-    # than leaving it briefly world-readable before a chmod.
-    ( umask 077; printf '%s' "$GCP_WIF_CONFIG" > "$WIF_CONFIG_PATH" )
-    echo "Wrote Google credential config to ${WIF_CONFIG_PATH}."
-  else
+  if ! printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
     # Warn rather than exit: a malformed variable should not stop the dev
     # server from coming up.
     echo "GCP_WIF_CONFIG is set but is not a JSON object; skipping." >&2
+  elif ! sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$WIF_CONFIG_DIR" 2>/dev/null; then
+    echo "Could not create ${WIF_CONFIG_DIR}; skipping credential config." >&2
+  else
+    # Written to a fresh file inside the private directory and renamed into
+    # place. rename(2) replaces a symlink at the destination rather than
+    # following it, so there is no window in which the final path can be
+    # redirected. mktemp creates at mode 600 to begin with.
+    WIF_TMP=$(mktemp "${WIF_CONFIG_DIR}/.cursor-wif.XXXXXX")
+    printf '%s' "$GCP_WIF_CONFIG" > "$WIF_TMP"
+    chmod 600 "$WIF_TMP"
+    mv -f "$WIF_TMP" "$WIF_CONFIG_PATH"
+    echo "Wrote Google credential config to ${WIF_CONFIG_PATH}."
   fi
 fi
 

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -17,8 +17,14 @@ set -euo pipefail
 # repository is public and the config names the Google Cloud project. Writing it
 # here rather than in install.sh keeps it out of the build snapshot.
 #
-# The file lands outside the workspace so it never appears in git status.
-# GOOGLE_APPLICATION_CREDENTIALS must point at this same path, and
+# The path is a fixed absolute location rather than anything under $HOME. It has
+# to be stated identically in the GOOGLE_APPLICATION_CREDENTIALS environment
+# variable, and a path that depends on which user the agent runs as is a silent
+# mismatch waiting to happen. It also sits outside the workspace, so it never
+# appears in git status and cannot be committed to a public repository by
+# accident.
+#
+# GOOGLE_APPLICATION_CREDENTIALS must name this same path and
 # GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES must be 1; both are set as Cursor
 # environment variables, because exports from this script do not reach the
 # agent's own shell.
@@ -26,7 +32,7 @@ set -euo pipefail
 # An unset variable is the normal case: agents that do not need production
 # access simply skip this.
 # ---------------------------------------------------------------------------
-WIF_CONFIG_PATH="${HOME}/.gcp/cursor-wif.json"
+WIF_CONFIG_PATH="/tmp/cursor-wif.json"
 if [ -n "${GCP_WIF_CONFIG:-}" ]; then
   if printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
     mkdir -p "$(dirname "$WIF_CONFIG_PATH")"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -6,6 +6,10 @@
 # build snapshot, so the migrated schema is already present) and returns once
 # the server is accepting connections. The Django dev server itself runs as the
 # "dev-server" terminal (see environment.json), so its logs stay visible.
+#
+# Anything added to this file belongs ABOVE the PostgreSQL readiness loop at the
+# foot of it. That loop exits 0 as soon as the server answers, so work appended
+# after it never runs.
 
 set -euo pipefail
 
@@ -21,12 +25,11 @@ set -euo pipefail
 # repeated verbatim in GOOGLE_APPLICATION_CREDENTIALS, and a path that depends
 # on which user the agent runs as is a silent mismatch waiting to happen.
 #
-# It is NOT in /tmp. A shared, world-writable directory lets any other process
-# on the machine pre-place a symlink at the destination, in which case the write
-# lands wherever that link points -- an arbitrary file overwrite running as this
-# user. A private directory removes the exposure entirely; the directory is
-# re-created with restrictive ownership on every boot, so tampering between runs
-# is repaired rather than inherited.
+# The directory holding it must not be world-writable: in a shared directory
+# another process can pre-place a symlink at the destination and the write
+# follows it, which is an arbitrary file overwrite running as this user. A
+# private directory removes the exposure, and re-creating it with restrictive
+# ownership on every boot repairs tampering rather than inheriting it.
 #
 # GOOGLE_APPLICATION_CREDENTIALS must name this same path and
 # GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES must be 1; both are set as Cursor
@@ -37,31 +40,42 @@ set -euo pipefail
 # access simply skip this. Whatever the outcome, what is on disk ends up
 # reflecting the variable, so withdrawing the variable withdraws the access
 # rather than leaving an earlier boot's config in place.
+#
+# Nothing in this section may abort the script. Production access is an optional
+# extra, and failing to configure it must not cost the environment its database.
 # ---------------------------------------------------------------------------
 WIF_CONFIG_DIR="/etc/gyrinx"
 WIF_CONFIG_PATH="${WIF_CONFIG_DIR}/cursor-wif.json"
 
 if [ -z "${GCP_WIF_CONFIG:-}" ]; then
-  rm -f "$WIF_CONFIG_PATH"
+  # rm -f forgives a missing file but not a permission error, which would
+  # otherwise end the boot before PostgreSQL had started.
+  rm -f "$WIF_CONFIG_PATH" 2>/dev/null || true
+elif ! command -v jq >/dev/null 2>&1; then
+  # Distinguished from a malformed variable so the reader is sent after the
+  # right thing: jq arrives late in install.sh, so a partial build lands here.
+  echo "jq is not installed; skipping credential config." >&2
+elif ! printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  # The old config goes anyway, so a typo fails closed instead of quietly
+  # leaving the previous credentials usable.
+  echo "GCP_WIF_CONFIG is set but is not a JSON object; skipping." >&2
+  rm -f "$WIF_CONFIG_PATH" 2>/dev/null || true
+elif ! sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$WIF_CONFIG_DIR" 2>/dev/null; then
+  echo "Could not create ${WIF_CONFIG_DIR}; skipping credential config." >&2
+elif ! WIF_TMP=$(mktemp "${WIF_CONFIG_DIR}/.cursor-wif.XXXXXX" 2>/dev/null); then
+  echo "Could not create a temporary file in ${WIF_CONFIG_DIR}; skipping credential config." >&2
 else
-  if ! printf '%s' "$GCP_WIF_CONFIG" | jq -e 'type == "object"' >/dev/null 2>&1; then
-    # Warn rather than exit: a malformed variable should not stop the dev
-    # server from coming up. The old config goes anyway, so a typo fails closed
-    # instead of quietly leaving the previous credentials usable.
-    echo "GCP_WIF_CONFIG is set but is not a JSON object; skipping." >&2
-    rm -f "$WIF_CONFIG_PATH"
-  elif ! sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$WIF_CONFIG_DIR" 2>/dev/null; then
-    echo "Could not create ${WIF_CONFIG_DIR}; skipping credential config." >&2
-  else
-    # Written to a fresh file inside the private directory and renamed into
-    # place. rename(2) replaces a symlink at the destination rather than
-    # following it, so there is no window in which the final path can be
-    # redirected. mktemp creates at mode 600 to begin with.
-    WIF_TMP=$(mktemp "${WIF_CONFIG_DIR}/.cursor-wif.XXXXXX")
-    printf '%s' "$GCP_WIF_CONFIG" > "$WIF_TMP"
-    chmod 600 "$WIF_TMP"
-    mv -f "$WIF_TMP" "$WIF_CONFIG_PATH"
+  # Written to a fresh file inside the private directory and renamed into place.
+  # rename(2) replaces a symlink at the destination rather than following it, so
+  # there is no window in which the final path can be redirected, and mktemp
+  # creates at mode 600 to begin with.
+  if { printf '%s' "$GCP_WIF_CONFIG" > "$WIF_TMP" 2>/dev/null \
+    && chmod 600 "$WIF_TMP" 2>/dev/null \
+    && mv -f "$WIF_TMP" "$WIF_CONFIG_PATH" 2>/dev/null; }; then
     echo "Wrote Google credential config to ${WIF_CONFIG_PATH}."
+  else
+    rm -f "$WIF_TMP" 2>/dev/null || true
+    echo "Could not write ${WIF_CONFIG_PATH}; skipping credential config." >&2
   fi
 fi
 

--- a/scripts/cursor/mint-gcp-token.sh
+++ b/scripts/cursor/mint-gcp-token.sh
@@ -108,6 +108,10 @@ expiry=$(printf '%s' "$payload" | jq -r '.expires_at // empty' 2>/dev/null) \
 # the quotes.
 case "$expiry" in
   '' | *[!0-9]*) emit_failure "mint response carried no usable expiry" ;;
+  # Twelve digits or more is no time in seconds anyone will see, and a value too
+  # large for shell arithmetic makes the bounds below fail rather than compare --
+  # which, with errexit off, would pass it through untested.
+  ????????????*) emit_failure "mint response expiry is implausibly large; expected epoch seconds" ;;
 esac
 
 # Google wants an absolute time in seconds. A relative lifetime would read as a

--- a/scripts/cursor/mint-gcp-token.sh
+++ b/scripts/cursor/mint-gcp-token.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Google external_account executable-sourced credential for Cursor Cloud Agents.
-# Mints a 5-minute OIDC JWT from the local Cursor agent socket and prints the
+# Mints a five-minute OIDC JWT from the local Cursor agent socket and prints the
 # JSON contract Google's auth libraries expect on stdout.
 #
 # Contract sources:
@@ -8,31 +8,43 @@
 #   Google: https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-other-providers
 #
 # Requires: curl, jq. Set GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1 in the env.
-
-set -euo pipefail
+#
+# errexit is deliberately NOT enabled. The contract is to exit 0 having printed
+# a JSON document in every circumstance, so a stray non-zero status from any
+# command must not terminate the script; each step is checked explicitly instead.
+set -uo pipefail
 
 SOCKET="${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}"
 AUD="${GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE:-}"
 OUT="${GOOGLE_EXTERNAL_ACCOUNT_OUTPUT_FILE:-}"
 
-# Google reads our stdout as JSON, so failures must be reported as a success:false
-# document with exit 0. A non-zero exit produces a far less useful error.
-fail() {
-  jq -nc --arg m "$1" '{version:1, success:false, code:"401", message:$m}'
+# The auth library reads stdout as JSON, so a failure is reported as a document
+# rather than an exit status; a non-zero exit yields a far less useful error.
+# The code is carried through so that it matches the condition being described.
+emit_failure() {
+  local message="$1" code="${2:-401}"
+  if command -v jq >/dev/null 2>&1; then
+    jq -nc --arg m "$message" --arg c "$code" \
+      '{version:1, success:false, code:$c, message:$m}'
+  else
+    printf '{"version":1,"success":false,"code":"401","message":"jq is not installed"}\n'
+  fi
   exit 0
 }
 
-command -v jq >/dev/null 2>&1 || { echo '{"version":1,"success":false,"code":"401","message":"jq not installed"}'; exit 0; }
-[[ -n "$AUD" ]] || fail "GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE is not set"
+command -v jq >/dev/null 2>&1 || emit_failure "jq is not installed"
+command -v curl >/dev/null 2>&1 || emit_failure "curl is not installed"
+[ -n "$AUD" ] || emit_failure "GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE is not set"
 
-body=$(jq -nc --arg aud "$AUD" '{aud: $aud}')
+body=$(jq -nc --arg aud "$AUD" '{aud: $aud}') \
+  || emit_failure "could not build the mint request body"
 
 code=""
 payload=""
 delay=1
 for attempt in 1 2 3 4 5; do
-  # The socket can be missing briefly right after VM boot, so a connection
-  # failure is retried rather than treated as fatal.
+  # The socket can be absent briefly after boot, so a connection failure is
+  # retried rather than treated as fatal.
   if resp=$(curl -sS --max-time 10 -w $'\n%{http_code}' \
       --unix-socket "$SOCKET" \
       -H 'Content-Type: application/json' \
@@ -42,36 +54,62 @@ for attempt in 1 2 3 4 5; do
     payload=$(printf '%s' "$resp" | sed '$d')
   else
     code="000"
-    payload="could not connect to $SOCKET"
+    payload="could not connect to ${SOCKET}"
   fi
 
   case "$code" in
     200) break ;;
-    # Cursor documents 403 as fatal: this agent is not allowed to mint at all.
-    403) fail "cursor refused the mint (403): $payload" ;;
-    000|429|500|502|503|504)
-      if [[ "$attempt" == "5" ]]; then fail "cursor mint failed after 5 attempts (last: $code $payload)"; fi
-      sleep "$delay"; delay=$((delay * 2)); continue ;;
-    *) fail "cursor mint failed (HTTP $code): $payload" ;;
+    # Cursor documents 403 as fatal: this run is not allowed to mint at all.
+    403) emit_failure "cursor refused the mint: ${payload}" "403" ;;
+    000 | 429 | 500 | 502 | 503 | 504)
+      if [ "$attempt" = "5" ]; then
+        emit_failure "cursor mint failed after 5 attempts (last: ${code} ${payload})" "$code"
+      fi
+      sleep "$delay"
+      delay=$((delay * 2))
+      ;;
+    *) emit_failure "cursor mint failed: ${payload}" "$code" ;;
   esac
 done
 
-[[ "$code" == "200" ]] || fail "cursor mint did not succeed (last: $code)"
+[ "$code" = "200" ] || emit_failure "cursor mint did not succeed (last: ${code})" "$code"
 
-token=$(printf '%s' "$payload" | jq -r '.token // empty')
-exp=$(printf '%s' "$payload" | jq -r '.expires_at // empty')
-[[ -n "$token" && -n "$exp" ]] || fail "unexpected mint response shape: $payload"
+token=$(printf '%s' "$payload" | jq -r '.token // empty' 2>/dev/null) \
+  || emit_failure "mint response was not valid JSON"
+expiry=$(printf '%s' "$payload" | jq -r '.expires_at // empty' 2>/dev/null) \
+  || emit_failure "mint response was not valid JSON"
 
-result=$(jq -nc --arg t "$token" --argjson e "$exp" \
-  '{version:1, success:true, token_type:"urn:ietf:params:oauth:token-type:id_token", id_token:$t, expiration_time:$e}')
+[ -n "$token" ] || emit_failure "mint response carried no token"
+# Guards --argjson below, which rejects anything that is not a JSON number, and
+# accepts an expiry delivered as a string because jq -r has already unquoted it.
+case "$expiry" in
+  '' | *[!0-9]*) emit_failure "mint response carried no usable expiry" ;;
+esac
 
-# Cache for the SDK. Cursor allows 30 mints/minute per VM and tokens last only
-# 5 minutes, so letting the library reuse a live token matters.
-if [[ -n "$OUT" ]]; then
-  tmp="${OUT}.tmp.$$"
-  printf '%s' "$result" > "$tmp"
-  chmod 600 "$tmp"
-  mv -f "$tmp" "$OUT"
+result=$(jq -nc --arg t "$token" --argjson e "$expiry" \
+  '{version:1, success:true, token_type:"urn:ietf:params:oauth:token-type:id_token", id_token:$t, expiration_time:$e}') \
+  || emit_failure "could not build the credential document"
+
+# Cache for the library. Cursor allows 30 mints a minute per machine and tokens
+# last five minutes, so letting it reuse a live token matters.
+#
+# Best effort throughout: a token in hand must still reach stdout even if it
+# cannot be cached. The file is created by mktemp alongside its destination and
+# renamed into place, because the nominated path can sit in a shared directory
+# where another process may have pre-placed a symlink. rename(2) replaces such a
+# link rather than writing through it, and mktemp opens at mode 600 to begin with.
+if [ -n "$OUT" ]; then
+  if cache_tmp=$(mktemp "$(dirname "$OUT")/.cursor-gcp-token.XXXXXX" 2>/dev/null); then
+    if ! { printf '%s' "$result" > "$cache_tmp" 2>/dev/null \
+      && chmod 600 "$cache_tmp" 2>/dev/null \
+      && mv -f "$cache_tmp" "$OUT" 2>/dev/null; }; then
+      rm -f "$cache_tmp" 2>/dev/null
+      echo "warning: could not cache the token at ${OUT}" >&2
+    fi
+  else
+    echo "warning: could not create a cache file beside ${OUT}" >&2
+  fi
 fi
 
 printf '%s\n' "$result"
+exit 0

--- a/scripts/cursor/mint-gcp-token.sh
+++ b/scripts/cursor/mint-gcp-token.sh
@@ -18,9 +18,20 @@ SOCKET="${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}"
 AUD="${GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE:-}"
 OUT="${GOOGLE_EXTERNAL_ACCOUNT_OUTPUT_FILE:-}"
 
+# The retry budget must finish inside the executable timeout the credential
+# config allows, or the process is killed part-way through and the failure
+# document never reaches stdout -- the very outcome exiting 0 exists to avoid.
+# Worst case is ATTEMPTS x MAX_TIME plus the waits between them: eleven seconds,
+# against a timeout the config sets at fifteen. Raise the two together, and keep
+# the margin: the worst case only arrives when the socket hangs rather than
+# refusing, which is exactly when the failure document matters most.
+ATTEMPTS=3
+MAX_TIME=3
+RETRY_WAIT=1
+
 # The auth library reads stdout as JSON, so a failure is reported as a document
 # rather than an exit status; a non-zero exit yields a far less useful error.
-# The code is carried through so that it matches the condition being described.
+# The code field mirrors the HTTP status where there is one.
 emit_failure() {
   local message="$1" code="${2:-401}"
   if command -v jq >/dev/null 2>&1; then
@@ -32,6 +43,16 @@ emit_failure() {
   exit 0
 }
 
+# A response body is quoted back only for statuses that cannot be carrying a
+# token, so an unexpected success never puts a JWT into an error message, an
+# exception, or a log.
+describe_body() {
+  case "$1" in
+    000 | 4?? | 5??) printf '%.200s' "$2" ;;
+    *) printf '(body withheld: a %s response may carry a token)' "$1" ;;
+  esac
+}
+
 command -v jq >/dev/null 2>&1 || emit_failure "jq is not installed"
 command -v curl >/dev/null 2>&1 || emit_failure "curl is not installed"
 [ -n "$AUD" ] || emit_failure "GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE is not set"
@@ -41,15 +62,17 @@ body=$(jq -nc --arg aud "$AUD" '{aud: $aud}') \
 
 code=""
 payload=""
-delay=1
-for attempt in 1 2 3 4 5; do
+attempt=0
+while [ "$attempt" -lt "$ATTEMPTS" ]; do
+  attempt=$((attempt + 1))
+
   # The socket can be absent briefly after boot, so a connection failure is
   # retried rather than treated as fatal.
-  if resp=$(curl -sS --max-time 10 -w $'\n%{http_code}' \
-      --unix-socket "$SOCKET" \
-      -H 'Content-Type: application/json' \
-      -d "$body" \
-      http://cursor-agent/v1/tokens/oidc 2>/dev/null); then
+  if resp=$(curl -sS --max-time "$MAX_TIME" -w $'\n%{http_code}' \
+    --unix-socket "$SOCKET" \
+    -H 'Content-Type: application/json' \
+    -d "$body" \
+    http://cursor-agent/v1/tokens/oidc 2>/dev/null); then
     code=$(printf '%s' "$resp" | tail -n1)
     payload=$(printf '%s' "$resp" | sed '$d')
   else
@@ -60,31 +83,43 @@ for attempt in 1 2 3 4 5; do
   case "$code" in
     200) break ;;
     # Cursor documents 403 as fatal: this run is not allowed to mint at all.
-    403) emit_failure "cursor refused the mint: ${payload}" "403" ;;
+    403) emit_failure "cursor refused the mint: $(describe_body "$code" "$payload")" "403" ;;
     000 | 429 | 500 | 502 | 503 | 504)
-      if [ "$attempt" = "5" ]; then
-        emit_failure "cursor mint failed after 5 attempts (last: ${code} ${payload})" "$code"
+      if [ "$attempt" -ge "$ATTEMPTS" ]; then
+        emit_failure "cursor mint failed after ${ATTEMPTS} attempts (last: ${code} $(describe_body "$code" "$payload"))" "$code"
       fi
-      sleep "$delay"
-      delay=$((delay * 2))
+      sleep "$RETRY_WAIT"
       ;;
-    *) emit_failure "cursor mint failed: ${payload}" "$code" ;;
+    *) emit_failure "cursor mint failed: $(describe_body "$code" "$payload")" "$code" ;;
   esac
 done
 
 [ "$code" = "200" ] || emit_failure "cursor mint did not succeed (last: ${code})" "$code"
 
 token=$(printf '%s' "$payload" | jq -r '.token // empty' 2>/dev/null) \
-  || emit_failure "mint response was not valid JSON"
+  || emit_failure "mint response could not be read as a JSON object"
 expiry=$(printf '%s' "$payload" | jq -r '.expires_at // empty' 2>/dev/null) \
-  || emit_failure "mint response was not valid JSON"
+  || emit_failure "mint response could not be read as a JSON object"
 
 [ -n "$token" ] || emit_failure "mint response carried no token"
-# Guards --argjson below, which rejects anything that is not a JSON number, and
-# accepts an expiry delivered as a string because jq -r has already unquoted it.
+
+# Guards --argjson below, which rejects anything that is not a JSON number. It
+# also accepts an expiry delivered as a string, since jq -r has already removed
+# the quotes.
 case "$expiry" in
   '' | *[!0-9]*) emit_failure "mint response carried no usable expiry" ;;
 esac
+
+# Google wants an absolute time in seconds. A relative lifetime would read as a
+# 1970 expiry and a value in milliseconds would cache a token long past its
+# death, and neither announces itself -- so both are rejected here rather than
+# left to surface as an inexplicable authentication failure later.
+now=$(date +%s)
+if [ "$expiry" -le "$now" ]; then
+  emit_failure "mint response expiry is not in the future; expected epoch seconds"
+elif [ "$expiry" -gt $((now + 86400)) ]; then
+  emit_failure "mint response expiry is implausibly distant; expected epoch seconds"
+fi
 
 result=$(jq -nc --arg t "$token" --argjson e "$expiry" \
   '{version:1, success:true, token_type:"urn:ietf:params:oauth:token-type:id_token", id_token:$t, expiration_time:$e}') \
@@ -93,11 +128,22 @@ result=$(jq -nc --arg t "$token" --argjson e "$expiry" \
 # Cache for the library. Cursor allows 30 mints a minute per machine and tokens
 # last five minutes, so letting it reuse a live token matters.
 #
-# Best effort throughout: a token in hand must still reach stdout even if it
-# cannot be cached. The file is created by mktemp alongside its destination and
-# renamed into place, because the nominated path can sit in a shared directory
-# where another process may have pre-placed a symlink. rename(2) replaces such a
-# link rather than writing through it, and mktemp opens at mode 600 to begin with.
+# Best effort throughout: a token in hand must reach stdout even if it cannot be
+# stored. The file is created by mktemp beside its destination and renamed into
+# place, because the nominated path can sit in a shared directory where another
+# process may have pre-placed a symlink; rename(2) replaces such a link rather
+# than writing through it, and mktemp opens at mode 600 to begin with.
+case "$OUT" in
+  '') ;;
+  /*) ;;
+  # A relative path would land in whatever directory the library happened to
+  # invoke this from, which is nobody's intent.
+  *)
+    echo "warning: ignoring a relative cache path: ${OUT}" >&2
+    OUT=""
+    ;;
+esac
+
 if [ -n "$OUT" ]; then
   if cache_tmp=$(mktemp "$(dirname "$OUT")/.cursor-gcp-token.XXXXXX" 2>/dev/null); then
     if ! { printf '%s' "$result" > "$cache_tmp" 2>/dev/null \

--- a/scripts/cursor/mint-gcp-token.sh
+++ b/scripts/cursor/mint-gcp-token.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Google external_account executable-sourced credential for Cursor Cloud Agents.
+# Mints a 5-minute OIDC JWT from the local Cursor agent socket and prints the
+# JSON contract Google's auth libraries expect on stdout.
+#
+# Contract sources:
+#   Cursor: https://cursor.com/docs/cloud-agent/identity
+#   Google: https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-other-providers
+#
+# Requires: curl, jq. Set GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1 in the env.
+
+set -euo pipefail
+
+SOCKET="${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}"
+AUD="${GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE:-}"
+OUT="${GOOGLE_EXTERNAL_ACCOUNT_OUTPUT_FILE:-}"
+
+# Google reads our stdout as JSON, so failures must be reported as a success:false
+# document with exit 0. A non-zero exit produces a far less useful error.
+fail() {
+  jq -nc --arg m "$1" '{version:1, success:false, code:"401", message:$m}'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || { echo '{"version":1,"success":false,"code":"401","message":"jq not installed"}'; exit 0; }
+[[ -n "$AUD" ]] || fail "GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE is not set"
+
+body=$(jq -nc --arg aud "$AUD" '{aud: $aud}')
+
+code=""
+payload=""
+delay=1
+for attempt in 1 2 3 4 5; do
+  # The socket can be missing briefly right after VM boot, so a connection
+  # failure is retried rather than treated as fatal.
+  if resp=$(curl -sS --max-time 10 -w $'\n%{http_code}' \
+      --unix-socket "$SOCKET" \
+      -H 'Content-Type: application/json' \
+      -d "$body" \
+      http://cursor-agent/v1/tokens/oidc 2>/dev/null); then
+    code=$(printf '%s' "$resp" | tail -n1)
+    payload=$(printf '%s' "$resp" | sed '$d')
+  else
+    code="000"
+    payload="could not connect to $SOCKET"
+  fi
+
+  case "$code" in
+    200) break ;;
+    # Cursor documents 403 as fatal: this agent is not allowed to mint at all.
+    403) fail "cursor refused the mint (403): $payload" ;;
+    000|429|500|502|503|504)
+      if [[ "$attempt" == "5" ]]; then fail "cursor mint failed after 5 attempts (last: $code $payload)"; fi
+      sleep "$delay"; delay=$((delay * 2)); continue ;;
+    *) fail "cursor mint failed (HTTP $code): $payload" ;;
+  esac
+done
+
+[[ "$code" == "200" ]] || fail "cursor mint did not succeed (last: $code)"
+
+token=$(printf '%s' "$payload" | jq -r '.token // empty')
+exp=$(printf '%s' "$payload" | jq -r '.expires_at // empty')
+[[ -n "$token" && -n "$exp" ]] || fail "unexpected mint response shape: $payload"
+
+result=$(jq -nc --arg t "$token" --argjson e "$exp" \
+  '{version:1, success:true, token_type:"urn:ietf:params:oauth:token-type:id_token", id_token:$t, expiration_time:$e}')
+
+# Cache for the SDK. Cursor allows 30 mints/minute per VM and tokens last only
+# 5 minutes, so letting the library reuse a live token matters.
+if [[ -n "$OUT" ]]; then
+  tmp="${OUT}.tmp.$$"
+  printf '%s' "$result" > "$tmp"
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$OUT"
+fi
+
+printf '%s\n' "$result"


### PR DESCRIPTION
Lets a Cursor cloud agent read the production database, using a credential that
expires in five minutes instead of a service account key that never does.

The agent asks its local Cursor socket for a short-lived identity token, Google
checks that token against a federation rule, and hands back permission to act as
a service account whose database role can only `SELECT`. Nothing downloadable
exists at any point, and a compromised agent VM leaves no lasting credential
behind.

## What's here

- `scripts/cursor/mint-gcp-token.sh` — the executable Google's auth libraries
  call to get a token. It talks to the Cursor socket and prints the JSON the
  `external_account` credential type expects.
- `.cursor/install.sh` — installs `jq` and `cloud-sql-proxy` into the build
  snapshot.
- `.cursor/start.sh` — writes the credential config on every boot.

## Why the split

Tools belong in the snapshot: identical for every agent, wasteful to fetch
repeatedly. The credential config does not — it arrives in an environment
variable, and baking a project-specific configuration into a shared snapshot is
the wrong lifecycle for it.

Nothing identifying is committed. The mint script takes its audience from
`GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE`, and the config that names the Google Cloud
project is supplied as a Cursor environment variable, because this repository is
public.

## Details worth knowing when it breaks

- The credential config is written to a private directory created mode 700,
  not to `/tmp`. A shared directory lets another process pre-place a symlink at
  the destination, and a shell redirection follows it — an arbitrary file
  overwrite as the agent user. The file is created by `mktemp` and renamed into
  place, because `rename(2)` replaces a symlink rather than writing through it.
- The credential block sits near the top of `start.sh` deliberately. The
  PostgreSQL readiness loop below it exits 0 on success, so anything appended to
  the end of that file would never run.
- The mint script reports failure as a `success:false` JSON document with exit
  code 0. The auth library parses stdout; a non-zero exit produces a far less
  useful error.
- Connection failures and 429/5xx are retried with backoff, since the socket can
  be missing briefly after boot. A 403 is fatal — the run is not permitted to
  mint at all.
- `cloud-sql-proxy` is pinned by version and SHA-256. Resolving "latest" at build
  time would depend on the unauthenticated GitHub releases API, which is rate
  limited and would fail builds unpredictably. Google publishes no checksum
  sidecar, so the digests were computed from the pinned release.
- An unset `GCP_WIF_CONFIG` is the normal case and is skipped silently. A
  malformed one warns and carries on, so a bad variable cannot stop the dev
  server coming up.

## Required environment variables

Set as Cursor environment variables, not in these scripts — exports from a start
script do not reach the agent's own shell.

- `GCP_WIF_CONFIG` — the credential config JSON
- `GOOGLE_APPLICATION_CREDENTIALS` — `/etc/gyrinx/cursor-wif.json`
- `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` — `1`

## Testing

The helper only runs inside a cloud agent, where the socket exists, so it is not
reachable from the test suite. It was instead exercised against a stand-in
socket: thirty-three assertions covering the successful path, an expiry given as
a string, as a relative duration, in milliseconds and beyond the range of shell
arithmetic, a response that is not JSON, a response carrying no token, a
refusal, an unwritable cache, a relative cache path and a planted symlink at the
cache destination. The worst-case retry budget was measured rather than
reasoned about.

The per-boot script has twelve assertions: the variable unset, malformed, and
valid; a re-run; a symlink planted at the destination; a config that cannot be
removed; and a boot with jq absent.

Both scripts were also run in their previous form to confirm the defects were
real rather than theoretical -- an earlier revision exited 5 with empty stdout
on a malformed response, and another exited 1 where it would have left
PostgreSQL unstarted.
