### PR TITLE
feat: the answers a gang took back become picks too

### DIFF
--- a/.claude/notes/conversion-cleanup-order.md
+++ b/.claude/notes/conversion-cleanup-order.md
@@ -1,107 +1,159 @@
-# Finishing the conversions — what is left, and in what order
+# Finishing the conversions — the plan, and where it has got to
 
-Measured against production, 2026-08-20, read-only. The four conversions
-have all run; this is everything they left behind and the order it can
-be cleared in.
+n26's hand-built choice systems have all been moved onto slots and
+picks. This is the tidying that follows: what is left, the order it can
+be done in, and the decisions already taken. Written to be picked up
+cold.
 
-## What is actually left
+**Nothing here names a player, a gang or an assignment id.** The counts
+are shapes; every operation finds its own rows by query. The repository
+is public.
 
-| | count |
+## Where it stands
+
+| | |
 |---|---|
-| Emptied kind rows (Archetype 12, SkillTree 6, Specialisation 8) | 26 |
-| — of those, still carrying anything | 1 (Ironhead Squat) |
-| Archived assignments naming an old kind | 399 |
-| Live assignments naming an old kind | 4 (doubled-click spares) |
-| Menu collections left standing | 3 |
-| Detached fossil offers | 1 |
-| Unreachable offer (general hidden, never held by anything) | 1 |
+| The five conversions (Paths, Specialisation, Skill Trees, Gang Legacies, Archetypes) | run in production |
+| The gang legacy slot pilot | retired in production |
+| A superuser may delete player data in the admin | merged |
+| A doubled click no longer answers a question twice | merged |
+| The authoring menu no longer offers the retired kinds | merged |
+| The archived-answers sweep | open, reviewed, CI green |
 
-**The columns are closed.** No live route creates a new row of any old
-kind: the archetype fossil is carried by nothing, the general
-Specialisation hidden has never been held by any assignment and its
-granter is detached, and every other offer became a slot grant. The
-four live rows are spares from a click that landed twice, anchored on
-a subtype whose question is now a slot.
+## What the conversions left
+
+Measured against production, 2026-08-22:
+
+- **26 emptied kind rows** — 12 Archetype, 6 SkillTree, 8 Specialisation.
+  One archetype still carries a modifier (the house legacy the menu
+  never offered).
+- **399 archived assignments** naming an old kind, across 169 gangs.
+  The sweep is for these.
+- **4 live assignments** naming Specialisation. These are spares from a
+  doubled click, on three owners' gangs — one fighter has two. Each
+  draws a phantom line in its fighter's gear list, named after the
+  specialisation, beside a correctly settled choice row. They carry no
+  money and no rating, nothing hangs off them, and the skill they grant
+  is drawn once regardless. **Decision taken: clear them.** Removing
+  them removes four wrong lines and changes nothing else.
+- **3 menu collections**, **1 detached fossil offer**, and the general
+  Specialisation Offer hidden — which has never been held by any
+  assignment, so no route creates a new row of any retired kind.
 
 ## The order
 
-Four things can start at once. Everything else is one chain behind
-them.
+### Wave 1 — done bar one
 
-### Wave 1 — start together, no ordering between them
+1. ~~The double-submit fix.~~ Merged. It was a genuine race: the picker
+   replaced what stood, but decided that from the page it had drawn, so
+   two answers in flight together each found nothing to replace.
+2. **The archived-answers sweep.** Open. This is the gate: the kinds
+   cannot be retired while rows name them.
+3. ~~The authoring menu retirement.~~ Merged.
+4. **The timeout revert** — not started. The Cloud Run request timeout
+   and the task ack deadline move together or not at all. Raised for a
+   conversion that took eighteen minutes; conversions now take seconds.
+5. **Squat legacies** (content, in the admin, the maintainer's): re-offer
+   Ironhead Squat as a Gang Legacy pickable, and grant the slot to the
+   three Squat Hunt profiles, which carry no legacy question. Also
+   empties the last archetype row still carrying anything.
 
-1. **The double-submit fix.** The only item still *making* mess: a
-   click landing twice writes a second identical answer. Nothing else
-   waits on it, and every day it stays costs another spare.
-2. **The archived-pick sweep.** A console operation rewriting the 399
-   archived assignments onto their pickables, as the Paths conversion
-   did for its own. **This is the gate**: the kinds cannot be retired
-   while anything names them, so start it early even though it lands
-   last. Needs the conversion machinery, so it must precede wave 4.
-3. **The timeout revert.** The Cloud Run request timeout and the task
-   ack deadline move together or not at all — a run outliving its
-   deadline is redelivered while the first copy works. Conversions now
-   finish in single-digit seconds.
-4. **Squat legacies** (content, in the admin). Re-offer Ironhead Squat
-   as a Gang Legacy pickable and grant the slot to the three Squat Hunt
-   profiles, which carry no legacy question. This also empties the last
-   archetype row still carrying anything, which wave 2 wants.
+### Wave 2 — the library cleanup
 
-### Wave 2 — after the sweep has run in production
+6. One operation, the pilot retirement's shape, doing two things:
+   - **clear the four live spares** (found by query: live, not
+     `removes`, naming an old kind, with a settled sibling answering the
+     same anchor). This changes four pages, which is the point;
+   - **delete the emptied rows**: 26 kind rows, 3 menu collections, the
+     detached fossil offer, the general hidden and its detached granter.
 
-5. **The library cleanup.** One more one-shot operation, the pilot
-   retirement's shape: delete the 26 emptied kind rows, the three menu
-   collections, the detached fossil offer, the general hidden and its
-   detached granter. Refuses if anything still names them, which is
-   why the sweep comes first.
-
-   The four spares belong to this decision. They are a duplicate line
-   on four gangs' pages; archiving them removes it. That is a page
-   change on four gangs, and it is a fix rather than a regression —
-   but it is a change, and it should be named rather than slipped in.
+   It must run after the sweep, because deleting a kind row refuses
+   while anything names it.
 
 ### Wave 3
 
-6. **Re-sync the content mirror from production.** After 4 and 5, so
-   the mirror inherits the tidy library rather than the old one.
+7. **Re-sync the content mirror from production.** After 5 and 6, so the
+   mirror inherits the tidy library. The mirror is currently
+   unconverted — it still holds the old offers and only the
+   pre-existing slot types — which is why 8 waits on this.
 
 ### Wave 4
 
-7. **Retire the conversion modules and their console operations.**
-   Slug registered with `view=None`, code deleted, the way the wargear
-   merge went. Waits on the mirror: until then every local database
-   forks unconverted and needs the conversions as its route across.
+8. **Retire the conversion modules and their console operations.** Slug
+   registered with `view=None`, code deleted, the way the wargear merge
+   went. Waits on the mirror: until it is re-synced, every local
+   database forks unconverted and needs the conversions as its route
+   across.
 
-### Wave 5 — the big one, planned separately
+### Wave 5 — planned separately
 
-8. **Drop the three kinds and their columns.** This is not a tidy-up;
-   it is a change across 21 files and every parallel registry the
-   library keeps: `ASSIGNABLE_FIELDS` and the Assignment columns,
-   `OFFERABLE_KINDS`, the ingest sheets and their four tables, the
-   specs and authoring pages, collection entries, the selector
-   algebra, card building, history, sample data — plus a migration
-   dropping three columns and three tables. Startup checks enforce the
-   registries agreeing, so a half-done version does not boot.
+9. **Drop the three kinds and their columns.** Across 21 files and every
+   parallel registry the library keeps: `ASSIGNABLE_FIELDS` and the
+   Assignment columns, `OFFERABLE_KINDS`, the ingest sheets and their
+   four tables, the specs and authoring pages, collection entries, the
+   selector algebra, card building, history, sample data — plus a
+   migration dropping three columns and three tables. Startup checks
+   enforce the registries agreeing, so a half-done version will not
+   boot. Needs 6 (no rows), 7 and 8 (no code), and the sweep (no data).
 
-   Worth doing, but worth its own plan and its own smoke test on a
-   fork, and it must be last: it needs the sweep (no data), the
-   library cleanup (no rows) and the retirement (no code) all done.
+### After the programme
 
-## The critical path
+10. **Gangless models.** Deleting a gang leaves its models behind,
+    belonging to nobody and reachable by nothing. The design log records
+    that a miniature library — models independent of a gang — was
+    considered and dropped, so these are residue of a rejected concept
+    rather than intent, even though a test pins the behaviour. Agreed to
+    fix after wave 1: delete a gang's models with it, and rewrite that
+    test.
 
-    archived sweep → library cleanup → mirror re-sync → retire the
-    conversions → drop the kinds
+## Decisions taken, and why
 
-The double-submit fix, the timeout revert and the Squat content hang
-off nothing and can land in any order alongside it.
+- **Conversions delete nothing.** Every hard problem in the early
+  attempts came from retiring old rows, which is tidiness rather than
+  the switch. Tidiness is waves 2 and 5, deliberately separate.
+- **A conversion is not a migration.** A migration running live code
+  inherits a dependency on every column that code will ever read, and
+  the pin needed to say so contradicts the recorded history of a
+  database that already ran it. They run from the console after deploy.
+- **Repeats are refused per system, not globally.** Skill Trees refuse
+  them (the game ranks four different trees); Archetypes allow them (a
+  Champion may hold what the gang holds, and ten do). The test is what
+  the page said before.
+- **The pickables of one system may need a qualifier.** Two names were
+  already taken by another slot type's pickables. A qualifier is
+  author-facing only and never reaches a player.
+- **Deletion in the admin is a superuser's, one at a time.** Writing
+  stays refused of everyone; batch delete is gone from the changelists,
+  since a column of ticks over ledger events is the same power without
+  the page that spells out its cost.
 
-## One judgement worth making early
+## The discipline these ran on
 
-Retiring the kinds means rewriting 399 archived assignments — history
-rows the later conversions deliberately left alone. The precedent
-exists (Paths rewrote its archived picks so the retirement could
-land), and the alternative is keeping three dead kinds in the
-authoring menus, the ingest sheets and the card code for ever. The
-recommendation is to do it, but to decide it deliberately before wave
-1 starts, because the sweep is only worth building if the kinds are
-going.
+The full version is in `backfill-lessons.md`. The four that earned
+themselves here:
+
+- **Prove the thing that can actually change.** The conversions compare
+  pages; the sweep compares histories, because an archived answer draws
+  no page. Comparing both would have cost ten minutes of transaction
+  for a check that cannot fail.
+- **Measure before choosing.** Folding a gang's story costs 287ms;
+  building its pages costs 1458ms. That measurement decided the sweep's
+  design.
+- **Reproduce the failure your fix fixes.** The double-submit fix was
+  nearly shipped against three tests that passed on the unfixed code —
+  sequential posts are serialised, so they proved nothing. Only real
+  concurrency showed the bug.
+- **Say what you leave.** An operation that bounds its own coverage puts
+  the remainder on its page, so the next step is not taken in ignorance.
+
+## Traps worth remembering
+
+- `manage prodshell` pipes into IPython, which silently swallows
+  multi-line loops and function definitions. Use single-line statements,
+  or `exec(open(...).read())` in one line.
+- A startup check catches an unregistered background task; the test
+  suite cannot, because the development backend skips the registry.
+- The shared console page takes its wording from the operation. Two
+  operations proving different things must not share one promise.
+- `Pickable` names are unique per pack **and qualifier**, not per slot
+  type, so a lookup by name alone can match two things.

--- a/n26/core/templates/admin/maintenance/n26/convert.html
+++ b/n26/core/templates/admin/maintenance/n26/convert.html
@@ -36,30 +36,24 @@ reaches, proven, apply_url, recent.
         </ul>
         <p>Nothing can be applied while any of these stands.</p>
     {% else %}
+        <p>{{ reach_words }}</p>
         <p>
-            It reaches <strong>{{ reaches }}</strong> gang{{ reaches|pluralize }}, and
-            proves <strong>{{ proven }}</strong> of them unchanged before committing —
-            a spread wide enough to hold every shape the system comes in. Proving all
-            of them would mean holding the whole library for minutes while players are
-            using it.
+            Applying runs the whole of it in one transaction. It reads what the gangs
+            it proves say, performs the steps, reads them again, and commits only if
+            the two readings match and each of them still reconciles. Anything else —
+            a difference, a refusal, an interruption — writes nothing at all, so a run
+            that does not finish can simply be run again.
         </p>
-        <p>
-            Applying runs the whole conversion in one transaction. It captures what
-            the gangs it proves say on their pages, performs the steps, captures them
-            again, and commits only if the two readings match and each of them still
-            reconciles. Anything else — a difference, a refusal, an interruption —
-            writes nothing at all, so a run that does not finish can simply be run
-            again.
-        </p>
+        {% if leaves_behind %}<p>{{ leaves_behind }}</p>{% endif %}
         <h2>What it would do</h2>
         <ul class="mt-plan">
             {% for line in preview %}<li>{{ line }}</li>{% endfor %}
         </ul>
         <form method="post"
               class="mt-form"
-              onsubmit="return confirm('Convert {{ reaches }} gang(s)? It writes nothing unless every page it proves reads the same.')">
+              onsubmit="return confirm('{{ confirm_words }}')">
             {% csrf_token %}
-            <button type="submit" class="button default">Apply conversion</button>
+            <button type="submit" class="button default">{{ button_words }}</button>
         </form>
     {% endif %}
     {% if recent %}

--- a/n26/library/conversion/archived.py
+++ b/n26/library/conversion/archived.py
@@ -1,0 +1,234 @@
+"""The answers already taken back become picks too.
+
+The conversions moved the answers a gang still holds. An answer taken
+back is archived rather than deleted — a gang that changed its mind
+keeps the row it dropped — and those were left where they were, still
+naming the kind the system used to use.
+
+Left alone they are the reason the old kinds cannot be retired: a kind
+with rows pointing at it is a kind nothing may delete. This sweeps them
+across by the same rewrite, so the last thing naming a retired kind
+stops doing so.
+
+**The proof is the story, and only the story.** An archived answer
+draws nothing on any card, so no page can move whatever this does —
+but the gang's history describes an old event by what its assignment
+names *now*, and these assignments are what history is made of.
+Rewriting one wrongly rewrites what a player is told they did. So
+every affected gang's story is read before and after, and any word
+that moves ends the run.
+
+Reading their pages as well would be the conversions' proof, and it is
+the wrong one here twice over: it cannot fail, and it costs five times
+what the story costs — a page is a second and a half of card building
+against a third of a second of folding events, which over every gang
+this touches is the difference between a transaction held for a minute
+and one held for ten.
+
+Which choice each answer settles is not written down anywhere: these
+rows predate slots, so they name no slot and no offer. It is read from
+the anchor instead. Every anchor that once carried an offer now grants
+exactly one slot — that is what the conversions did to it — so the slot
+an answer belongs to is the slot its own anchor grants. Anything that
+does not resolve that way is refused by name rather than guessed at.
+"""
+
+from dataclasses import dataclass
+
+from n26.library.conversion.base import ConversionRefused, Plan
+
+
+@dataclass(frozen=True)
+class RewriteArchivedAnswer:
+    """One answer already taken back, re-said as a pick.
+
+    Names what it settles on by identity rather than by name: a name
+    belongs to a slot type, and two slot types can wear the same one —
+    there is a Brawler among the specialisations and another among the
+    archetypes, and a sweep crossing both systems must not confuse them.
+    """
+
+    assignment_id: object
+    old_column: str
+    pickable_id: object
+    pickable_name: str
+    slot_id: object
+    slot_name: str
+    gang: str
+
+    def say(self):
+        return (
+            f"rewrite the archived {self.old_column} {self.assignment_id} "
+            f"({self.gang}) -> “{self.pickable_name}” for “{self.slot_name}”"
+        )
+
+    def perform(self):
+        from n26.core.models import Assignment
+
+        answer = Assignment.objects.get(pk=self.assignment_id)
+        answer.pickable_id = self.pickable_id
+        answer.chosen_for_id = answer.caused_by_id
+        answer.chosen_for_slot_id = self.slot_id
+        answer.chosen_for_offer = None
+        setattr(answer, self.old_column, None)
+        answer.save()
+
+
+#: The columns the conversions emptied of live answers, in the order a
+#: report reads best.
+OLD_COLUMNS = ("specialisation", "archetype", "skill_tree")
+
+
+def _slots_granted(assignable, seen):
+    """The slots this thing's modifiers hand over, cached per plan."""
+    key = (type(assignable).__name__, assignable.pk)
+    if key not in seen:
+        seen[key] = [
+            modifier.adds_assignable.slot
+            for modifier in assignable.modifiers.filter(
+                adds_assignable__slot__isnull=False
+            ).select_related(
+                "adds_assignable__slot", "adds_assignable__slot__slot_type"
+            )
+        ]
+    return seen[key]
+
+
+def plan_archived():
+    from n26.core.models import Assignment
+    from n26.library.models import Pickable
+
+    problems = []
+    rows = []
+    for column in OLD_COLUMNS:
+        rows += list(
+            Assignment.objects.filter(archived=True, **{f"{column}__isnull": False})
+            .select_related(column, "caused_by", "gang_root")
+            .order_by("created")
+        )
+    if not rows:
+        return Plan(system="archived", nothing_here=True)
+
+    seen = {}
+    steps = []
+    for row in rows:
+        named = getattr(row, _column_of(row))
+        cause = row.caused_by
+        if cause is None:
+            problems.append(f"archived answer {row.pk} hangs from nothing")
+            continue
+        anchor_thing = cause.assignable
+        if anchor_thing is None:
+            problems.append(
+                f"archived answer {row.pk} hangs from an assignment naming nothing"
+            )
+            continue
+        slots = _slots_granted(anchor_thing, seen)
+        if len(slots) != 1:
+            problems.append(
+                f"“{anchor_thing}” grants {len(slots)} slots, so the answer "
+                f"{row.pk} hanging from it cannot be placed"
+            )
+            continue
+        slot = slots[0]
+        pickable = Pickable.objects.filter(
+            slot_type=slot.slot_type, name=named.name
+        ).first()
+        if pickable is None:
+            problems.append(
+                f"nothing on “{slot.slot_type}” is called “{named.name}”, which "
+                f"the archived answer {row.pk} names"
+            )
+            continue
+        steps.append(
+            RewriteArchivedAnswer(
+                assignment_id=row.pk,
+                old_column=_column_of(row),
+                pickable_id=pickable.pk,
+                pickable_name=pickable.name,
+                slot_id=slot.pk,
+                slot_name=slot.name,
+                gang=str(row.gang_root),
+            )
+        )
+
+    if problems:
+        return Plan(system="archived", problems=tuple(problems))
+
+    touched = sorted({row.gang_root_id for row in rows}, key=str)
+    return Plan(
+        system="archived",
+        steps=tuple(steps),
+        gang_ids=tuple(touched),
+        reaches=len(touched),
+    )
+
+
+def _column_of(row):
+    for column in OLD_COLUMNS:
+        if getattr(row, f"{column}_id") is not None:
+            return column
+    raise ValueError(f"{row.pk} names none of the old kinds")
+
+
+def apply_archived(plan):
+    """Rewrite every archived answer, and prove the stories unmoved.
+
+    The conversions' own apply proves pages, which is the right proof
+    for an answer a card draws. These draw nothing; what they hold up is
+    the history, so that is what is read twice and compared.
+    """
+    from django.db import transaction
+
+    from n26.core import history
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+    from n26.library.conversion.base import _one_snapshot
+
+    if plan.problems:
+        raise ConversionRefused("[archived] not applied: " + "; ".join(plan.problems))
+    if plan.nothing_here:
+        return list(plan.preview())
+
+    report = list(plan.preview())
+    with _one_snapshot(), transaction.atomic():
+        gangs = list(Gang.objects.filter(pk__in=plan.gang_ids))
+        before_story = {str(gang.pk): _story(history.build(gang)) for gang in gangs}
+
+        for step in plan.steps:
+            try:
+                step.perform()
+            except Exception as failed:
+                raise ConversionRefused(
+                    f"[archived] failed at “{step.say()}”: {failed}"
+                ) from failed
+
+        gangs = list(Gang.objects.filter(pk__in=plan.gang_ids))
+        moved = []
+        for gang in gangs:
+            key = str(gang.pk)
+            if _story(history.build(gang)) != before_story[key]:
+                moved.append(f"{gang}: the words its history tells have moved")
+        if moved:
+            raise ConversionRefused(
+                "[archived] refused — what a reader is told would change:\n  "
+                + "\n  ".join(moved)
+            )
+        for gang in gangs:
+            try:
+                assert_reconciled(gang)
+            except Exception as failed:
+                raise ConversionRefused(
+                    f"[archived] refused — {gang} no longer reconciles: {failed}"
+                ) from failed
+    report.append("[archived] rewritten; every story reads the same")
+    return report
+
+
+def _story(acts):
+    """Every word a gang's history page puts on the screen."""
+    told = []
+    for act in acts:
+        told.append("".join(span.text for span in act.spans))
+        told.extend(f"{sub.name}|{sub.kind}|{sub.note}" for sub in act.subs)
+    return told

--- a/n26/library/conversion/archived.py
+++ b/n26/library/conversion/archived.py
@@ -63,9 +63,32 @@ class RewriteArchivedAnswer:
         )
 
     def perform(self):
+        """Write it, having proved again that it is what the plan read.
+
+        The plan was read before this transaction opened. What it
+        believed can have moved since — the answer claimed by something
+        else, or brought back out of the archive — and a story read
+        twice would not catch either, an archived answer's rewrite
+        changing no word of one. So the row itself is checked here,
+        where the snapshot holds.
+        """
         from n26.core.models import Assignment
+        from n26.library.conversion.base import ConversionRefused
 
         answer = Assignment.objects.get(pk=self.assignment_id)
+        if not answer.archived:
+            raise ConversionRefused(
+                f"{self.assignment_id} is no longer an answer taken back"
+            )
+        if answer.pickable_id is not None or answer.chosen_for_slot_id is not None:
+            raise ConversionRefused(
+                f"{self.assignment_id} already names a pick, so something "
+                "has rewritten it since the plan was read"
+            )
+        if getattr(answer, f"{self.old_column}_id") is None:
+            raise ConversionRefused(
+                f"{self.assignment_id} no longer names a {self.old_column}"
+            )
         answer.pickable_id = self.pickable_id
         answer.chosen_for_id = answer.caused_by_id
         answer.chosen_for_slot_id = self.slot_id
@@ -131,15 +154,19 @@ def plan_archived():
             )
             continue
         slot = slots[0]
-        pickable = Pickable.objects.filter(
-            slot_type=slot.slot_type, name=named.name
-        ).first()
-        if pickable is None:
+        # A name is unique per pack and qualifier, not per slot type, so
+        # one slot type can hold two of a name. Either count but one is a
+        # question this cannot answer.
+        candidates = list(
+            Pickable.objects.filter(slot_type=slot.slot_type, name=named.name)
+        )
+        if len(candidates) != 1:
             problems.append(
-                f"nothing on “{slot.slot_type}” is called “{named.name}”, which "
-                f"the archived answer {row.pk} names"
+                f"{len(candidates)} things on “{slot.slot_type}” are called "
+                f"“{named.name}”, which the archived answer {row.pk} names"
             )
             continue
+        pickable = candidates[0]
         steps.append(
             RewriteArchivedAnswer(
                 assignment_id=row.pk,

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -403,6 +403,28 @@ def delete_nameless_gang_type(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+#: What a conversion's page says about its own proof. Each operation
+#: proves something different, and a page that named the wrong one would
+#: promise a safety nobody is being given.
+def _proof_words(plan):
+    return {
+        "reach_words": (
+            f"It reaches {plan.reaches} gang"
+            f"{'' if plan.reaches == 1 else 's'}, and proves "
+            f"{len(plan.gang_ids)} of them read the same before committing — "
+            "a spread wide enough to hold every shape the system comes in. "
+            "Proving all of them would mean holding the whole library for "
+            "minutes while players are using it."
+        ),
+        "confirm_words": (
+            f"Convert {plan.reaches} gang(s)? It writes nothing unless every "
+            "page it proves reads the same."
+        ),
+        "button_words": "Apply conversion",
+        "leaves_behind": "",
+    }
+
+
 def _conversion_view(request, operation, system, task_fn):
     """Preview a conversion (GET), or record a run and enqueue it (POST)."""
     address = reverse(f"admin:maintenance_{operation.value}")
@@ -455,6 +477,7 @@ def _conversion_view(request, operation, system, task_fn):
         proven=len(plan.gang_ids),
         apply_url=address,
         recent=Backfill.objects.filter(operation=operation)[:10],
+        **_proof_words(plan),
     )
     return render(request, "admin/maintenance/n26/convert.html", context)
 
@@ -595,6 +618,32 @@ def _deletion_view(request, operation, find_fn, task_fn, words):
     return render(request, "admin/maintenance/n26/delete.html", context)
 
 
+def _spares_left():
+    """What this sweep does not reach, said plainly on its own page.
+
+    A doubled click leaves a live answer beside the one that settled the
+    question, and the conversions left those exactly as they were. They
+    are live, so this sweep — which is for what was taken back — does not
+    touch them, and while they stand the kinds they name still cannot be
+    retired.
+    """
+    from n26.core.models import Assignment
+    from n26.library.conversion.archived import OLD_COLUMNS
+
+    live = Assignment.objects.filter(archived=False).exclude(removes=True)
+    standing = sum(
+        live.filter(**{f"{column}__isnull": False}).count() for column in OLD_COLUMNS
+    )
+    if not standing:
+        return ""
+    return (
+        f"{standing} live answer{'' if standing == 1 else 's'} still name a "
+        "retired kind and are left as they are: spares from a click that "
+        "landed twice, which are somebody's page rather than history. "
+        "Retiring those kinds has to deal with them separately."
+    )
+
+
 def sweep_archived_view(request):
     """Preview the sweep (GET), or record a run and enqueue it (POST)."""
     from n26.library.conversion.archived import plan_archived
@@ -637,6 +686,21 @@ def sweep_archived_view(request):
         proven=plan.reaches,
         apply_url=address,
         recent=Backfill.objects.filter(operation=operation)[:10],
+        reach_words=(
+            f"It reaches {plan.reaches} gang"
+            f"{'' if plan.reaches == 1 else 's'} and proves every one of them, "
+            "not a spread: what it rewrites are answers already taken back, "
+            "which draw nothing on any card, so what is read twice is each "
+            "gang's history rather than its pages. Folding a story costs a "
+            "fraction of what building the pages costs, which is what makes "
+            "proving all of them affordable."
+        ),
+        confirm_words=(
+            f"Rewrite {len(plan.steps)} archived answer(s)? It writes nothing "
+            "unless every gang's history reads the same afterwards."
+        ),
+        button_words="Apply sweep",
+        leaves_behind=_spares_left(),
     )
     return render(request, "admin/maintenance/n26/convert.html", context)
 

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -54,6 +54,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "Operation",
     "convert_archetype",
+    "sweep_archived",
     "convert_gang_legacy",
     "convert_skill_tree",
     "convert_specialisation",
@@ -104,6 +105,10 @@ class Operation(models.TextChoices):
         "n26_convert_archetype",
         "n26: the Outcast archetypes become picks",
     )
+    SWEEP_ARCHIVED = (
+        "n26_sweep_archived",
+        "n26: the answers already taken back become picks",
+    )
     DELETE_NAMELESS_GANG_TYPE = (
         "n26_delete_nameless_gang_type",
         "n26: the gang type with no name is retired",
@@ -122,6 +127,7 @@ LOCK_KEYS = {
     Operation.RETIRE_GANG_LEGACY_PILOT: 826_020_604,
     Operation.CONVERT_ARCHETYPE: 826_020_605,
     Operation.DELETE_NAMELESS_GANG_TYPE: 826_020_606,
+    Operation.SWEEP_ARCHIVED: 826_020_607,
 }
 
 
@@ -323,6 +329,26 @@ def convert_archetype(backfill_id, **said_by_whoever_enqueued_it):
         Operation.CONVERT_ARCHETYPE,
         "archetype",
         **said_by_whoever_enqueued_it,
+    )
+
+
+@task
+def sweep_archived(backfill_id, **said_by_whoever_enqueued_it):
+    """Rewrite the archived answers, once, and write down the outcome.
+
+    The same runner as a conversion, over a plan and apply of its own:
+    what it proves is the history rather than the pages, an answer
+    already taken back drawing nothing on either.
+    """
+    from n26.library.conversion import ConversionRefused
+    from n26.library.conversion.archived import apply_archived, plan_archived
+
+    _run_recorded(
+        backfill_id,
+        Operation.SWEEP_ARCHIVED,
+        "Archived answers sweep",
+        lambda: apply_archived(plan_archived()),
+        ConversionRefused,
     )
 
 
@@ -569,6 +595,52 @@ def _deletion_view(request, operation, find_fn, task_fn, words):
     return render(request, "admin/maintenance/n26/delete.html", context)
 
 
+def sweep_archived_view(request):
+    """Preview the sweep (GET), or record a run and enqueue it (POST)."""
+    from n26.library.conversion.archived import plan_archived
+
+    operation = Operation.SWEEP_ARCHIVED
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That sweep is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        plan = plan_archived()
+        if plan.nothing_here:
+            messages.info(request, "There is nothing left to sweep.")
+            return HttpResponseRedirect(address)
+        if not plan.ok:
+            messages.error(request, "The sweep refuses: " + "; ".join(plan.problems))
+            return HttpResponseRedirect(address)
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"preview": list(plan.preview()), "attempts": 0},
+        )
+        sweep_archived.enqueue(backfill_id=str(backfill.id))
+        messages.success(request, "The sweep is running. This page shows what it did.")
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+
+    plan = plan_archived()
+    context = page_context(
+        request,
+        operation.label,
+        plan=plan,
+        preview=list(plan.preview()),
+        reaches=plan.reaches,
+        proven=plan.reaches,
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+    )
+    return render(request, "admin/maintenance/n26/convert.html", context)
+
+
 def retire_gang_legacy_pilot_view(request):
     """Preview the pilot retirement (GET), or record a run and enqueue it."""
     from n26.library.gang_legacy_pilot import find
@@ -693,6 +765,22 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.SWEEP_ARCHIVED.value,
+        name=Operation.SWEEP_ARCHIVED.label,
+        description=(
+            "Rewrite the answers a gang took back — archived, still "
+            "naming the kinds the conversions replaced, and the last "
+            "thing standing between those kinds and retirement. Reads "
+            "every affected gang's history before and after and refuses "
+            "on any word that moves."
+        ),
+        view=sweep_archived_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a conversion holds one
 #: transaction for as long as proving its spread of gangs takes. It is also
@@ -708,6 +796,7 @@ task_routes = [
     TaskRoute(retire_gang_legacy_pilot, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_archetype, ack_deadline=600, min_retry_delay=60),
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(sweep_archived, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/tests/sandbox/test_conversion_archived.py
+++ b/n26/tests/sandbox/test_conversion_archived.py
@@ -159,7 +159,7 @@ class TestTheRefusals:
         plan = plan_archived()
 
         assert not plan.ok
-        assert any("is called “Sniper”" in problem for problem in plan.problems)
+        assert any("are called “Sniper”" in problem for problem in plan.problems)
 
     def test_a_name_shared_across_slot_types_goes_to_its_own(self, world):
         """Two slot types may wear one name — the sweep places an answer
@@ -176,6 +176,93 @@ class TestTheRefusals:
         moved = Assignment.objects.get(archived=True, pickable__isnull=False)
         assert moved.pickable_id != stray.pk
         assert moved.pickable.slot_type.name == "Specialisation"
+
+
+class TestTheOtherColumns:
+    """The sweep reads the slot off the anchor, so a system's shape is
+    the anchor's shape. These are the other two it will meet: a skill
+    tree, answered on a gang-held carrier, and an archetype, answered
+    from a profile onto the gang."""
+
+    def test_a_skill_trees_answer_taken_back_moves(
+        self, default_pack, person_type, owner
+    ):
+        from n26.library.conversion import plan_skill_tree
+        from n26.tests.sandbox.test_conversion_skill_tree import (
+            build_prod_shape,
+            build_world,
+        )
+
+        shape = build_prod_shape()
+        build_world(shape, person_type, owner)
+        apply(plan_skill_tree())
+        assert Assignment.objects.filter(
+            archived=True, skill_tree__isnull=False
+        ).exists()
+
+        apply_archived(plan_archived())
+
+        # What was taken back has moved. A live spare from a doubled
+        # click stays, being nobody's history and this sweep's business.
+        assert not Assignment.objects.filter(
+            archived=True, skill_tree__isnull=False
+        ).exists()
+        moved = Assignment.objects.filter(archived=True, pickable__isnull=False)
+        assert moved.exists()
+        assert all(row.chosen_for_slot_id is not None for row in moved)
+
+    def test_an_archetypes_answer_taken_back_moves(
+        self, default_pack, person_type, owner
+    ):
+        from n26.library.conversion import plan_archetype
+        from n26.tests.sandbox.test_conversion_archetype import (
+            build_prod_shape,
+            build_world,
+        )
+
+        shape = build_prod_shape(person_type)
+        build_world(shape, owner)
+        apply(plan_archetype())
+        assert Assignment.objects.filter(
+            archived=True, archetype__isnull=False
+        ).exists()
+
+        apply_archived(plan_archived())
+
+        assert not Assignment.objects.filter(
+            archived=True, archetype__isnull=False
+        ).exists()
+        moved = Assignment.objects.filter(archived=True, pickable__isnull=False)
+        assert all(row.chosen_for_slot_id is not None for row in moved)
+
+
+class TestWhatItLeaves:
+    """A spare from a doubled click is live, not taken back, so it is
+    not this sweep's to move — and while one stands its kind cannot be
+    retired. The page that runs this says so; the plan counts them."""
+
+    def test_a_live_spare_is_not_swept(self, world):
+        gang, fighter, specialist, specs = world
+        anchor = Assignment.objects.get(subtype=specialist, miniature=fighter)
+        standing = Assignment.objects.get(
+            miniature=fighter, pickable__isnull=False, archived=False
+        )
+        # A second answer beside the one that settled it, as a doubled
+        # click leaves — made directly, the picker refusing to make one.
+        Assignment.objects.create(
+            specialisation=specs["Sniper"],
+            miniature=fighter,
+            caused_by=anchor,
+            gang_root=gang,
+        )
+
+        apply_archived(plan_archived())
+
+        spare = Assignment.objects.get(specialisation__isnull=False)
+        assert spare.archived is False
+        assert spare.pickable_id is None
+        standing.refresh_from_db()
+        assert standing.pickable_id is not None
 
 
 def _story(acts):

--- a/n26/tests/sandbox/test_conversion_archived.py
+++ b/n26/tests/sandbox/test_conversion_archived.py
@@ -1,0 +1,186 @@
+"""Sweeping up the answers already taken back.
+
+The conversions moved what a gang still holds and left what it had
+dropped. Those archived answers are the last things naming the retired
+kinds, and this is what moves them — read from the anchor, because they
+name no slot themselves, and proven by the story rather than the page.
+"""
+
+import pytest
+
+from n26.core import history
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.conversion import apply, plan_specialisation
+from n26.library.conversion.archived import apply_archived, plan_archived
+from n26.library.models import Pickable, Slot, Specialisation
+from n26.tests.sandbox.actions import (
+    choose,
+    create_default_set,
+    create_gang_type,
+    create_profile,
+    create_skill,
+    create_specialisation,
+    create_subtype,
+    ef_adds,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    remove,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def world(default_pack, person_type, owner):
+    """A specialisation system, converted, with answers taken back both
+    before and after the conversion ran."""
+    specs = {}
+    for name, skill in [("Sniper", "Precision Shot"), ("Medic", "Medicate")]:
+        specs[name] = create_specialisation(name)
+        modifier(
+            f"{name}: its skill",
+            targets_model(),
+            ef_adds(create_skill(skill)),
+            carried_by=specs[name],
+        )
+    specialist = create_subtype("Specialist")
+    modifier(
+        "Specialist: offers a choice of specialisation",
+        targets_model(),
+        offers_choice(Specialisation),
+        carried_by=specialist,
+    )
+    gang_type = create_gang_type("Enforcers", starting_credits=2000)
+    profile = create_profile("Patrol Officer", person_type, gang_type, price=50)
+    profile.built_ins = create_default_set("Officer kit", members=[specialist])
+    profile.save()
+
+    gang = found_gang("The Watch", gang_type, owner=owner, budget=2000)
+    fighter = hire(gang, profile, "Vex", paid=50)
+    anchor = Assignment.objects.get(subtype=specialist, miniature=fighter)
+
+    # Answered, taken back, answered again — the archived answer this
+    # sweep is for, made while the system was still offers.
+    choose(anchor, specs["Sniper"])
+    remove(Assignment.objects.get(specialisation=specs["Sniper"], miniature=fighter))
+    choose(anchor, specs["Medic"])
+
+    apply(plan_specialisation())
+    return gang, fighter, specialist, specs
+
+
+class TestThePlan:
+    def test_it_finds_the_answer_left_behind(self, world):
+        plan = plan_archived()
+
+        assert plan.ok and not plan.nothing_here
+        said = "\n".join(plan.preview())
+        assert "rewrite the archived specialisation" in said
+        assert "“Sniper”" in said
+        assert "for “Specialisation”" in said
+
+    def test_a_second_run_finds_nothing(self, world):
+        apply_archived(plan_archived())
+
+        assert plan_archived().nothing_here
+
+
+class TestTheSweep:
+    def test_the_archived_answer_becomes_a_pick(self, world):
+        gang, fighter, _, _ = world
+
+        apply_archived(plan_archived())
+
+        moved = Assignment.objects.get(archived=True, pickable__isnull=False)
+        assert moved.pickable.name == "Sniper"
+        assert moved.specialisation_id is None
+        assert moved.chosen_for_slot == Slot.objects.get(name="Specialisation")
+        assert moved.chosen_for_id == moved.caused_by_id
+        assert moved.archived is True
+
+    def test_nothing_names_the_old_kind_afterwards(self, world):
+        apply_archived(plan_archived())
+
+        assert not Assignment.objects.filter(specialisation__isnull=False).exists()
+
+    def test_the_story_reads_the_same(self, world):
+        gang, _, _, _ = world
+        said = _story(history.build(gang))
+        assert any("Sniper" in line for line in said)
+
+        apply_archived(plan_archived())
+
+        assert _story(history.build(gang)) == said
+
+    def test_the_gang_still_reconciles(self, world):
+        gang, _, _, _ = world
+
+        apply_archived(plan_archived())
+
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_the_live_answer_is_left_alone(self, world):
+        """The conversions moved those. This is only for what they left."""
+        _, fighter, _, _ = world
+        live = Assignment.objects.get(
+            miniature=fighter, pickable__isnull=False, archived=False
+        )
+        was = live.pickable_id
+
+        apply_archived(plan_archived())
+
+        live.refresh_from_db()
+        assert live.pickable_id == was
+
+
+class TestTheRefusals:
+    def test_an_anchor_granting_nothing_is_refused(self, world):
+        """Where the anchor no longer grants a slot, the answer cannot
+        be placed and the sweep says so rather than guessing."""
+        _, _, specialist, _ = world
+        for held in list(specialist.modifiers.all()):
+            specialist.modifiers.remove(held)
+
+        plan = plan_archived()
+
+        assert not plan.ok
+        assert any("grants 0 slots" in problem for problem in plan.problems)
+
+    def test_a_name_with_no_pickable_is_refused(self, world):
+        # Renamed rather than deleted: the live pick protects it, which
+        # is itself the reason a sweep must never assume a name resolves.
+        Pickable.objects.filter(name="Sniper").update(name="Something Else")
+
+        plan = plan_archived()
+
+        assert not plan.ok
+        assert any("is called “Sniper”" in problem for problem in plan.problems)
+
+    def test_a_name_shared_across_slot_types_goes_to_its_own(self, world):
+        """Two slot types may wear one name — the sweep places an answer
+        by the slot its anchor grants, not by the name alone."""
+        from n26.tests.sandbox.actions import create_pickable, create_slot_type
+
+        elsewhere = create_slot_type("Something Else")
+        # A qualifier is what lets one name sit on two slot types: the
+        # uniqueness is per pack and qualifier, not per slot type.
+        stray = create_pickable("Sniper", elsewhere, qualifier="Elsewhere")
+
+        apply_archived(plan_archived())
+
+        moved = Assignment.objects.get(archived=True, pickable__isnull=False)
+        assert moved.pickable_id != stray.pk
+        assert moved.pickable.slot_type.name == "Specialisation"
+
+
+def _story(acts):
+    told = []
+    for act in acts:
+        told.append("".join(span.text for span in act.spans))
+        told.extend(f"{sub.name}|{sub.kind}|{sub.note}" for sub in act.subs)
+    return told

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -20,6 +20,7 @@ from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import operations, resolve_operation
 from n26.core.models import Assignment
 from n26.core.reconcile import assert_reconciled
+from n26.library.models import Specialisation
 from n26.maintenance import (
     MAX_ATTEMPTS,
     Operation,
@@ -132,6 +133,9 @@ class TestThePage:
         assert response.status_code == 200
         assert "create slot type “Specialisation”" in page
         assert "prove 2 of 2 reached gangs read the same" in page
+        # The conversions keep their own guarantee on the shared page.
+        assert "a spread wide enough to hold every shape" in page
+        assert "Apply conversion" in page
         assert not Backfill.objects.exists()
         assert Assignment.objects.filter(specialisation__isnull=False).exists()
 
@@ -365,6 +369,47 @@ class TestTheArchivedSweep:
         assert Assignment.objects.filter(
             specialisation__isnull=False, archived=True
         ).exists()
+
+    def test_its_page_says_what_this_run_actually_proves(
+        self, client, superuser, swept_world
+    ):
+        """The page is shared with the conversions, whose guarantee is a
+        different one: a spread of gangs, read on their pages. Somebody
+        about to rewrite hundreds of rows is told what protects them."""
+        client.force_login(superuser)
+
+        page = client.get(
+            reverse("admin:maintenance_n26_sweep_archived")
+        ).content.decode()
+
+        assert "proves every one of them, not a spread" in page
+        assert "history rather than its pages" in page
+        assert "Apply sweep" in page
+        assert "a spread wide enough to hold every shape" not in page
+
+    def test_its_page_counts_what_it_leaves_behind(
+        self, client, superuser, swept_world, person_type
+    ):
+        """A live spare is not this sweep's to move, and the page says
+        so — the kinds cannot be retired while one stands."""
+        _, fighters = swept_world
+        settled = Assignment.objects.filter(
+            pickable__isnull=False, archived=False
+        ).first()
+        Assignment.objects.create(
+            specialisation=Specialisation.objects.first(),
+            miniature=settled.miniature,
+            caused_by=settled.caused_by,
+            gang_root=settled.gang_root,
+        )
+        client.force_login(superuser)
+
+        page = client.get(
+            reverse("admin:maintenance_n26_sweep_archived")
+        ).content.decode()
+
+        assert "1 live answer still name" in page
+        assert "left as they are" in page
 
     def test_applying_leaves_nothing_naming_the_old_kind(
         self, client, superuser, swept_world

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -30,6 +30,7 @@ from n26.maintenance import (
     convert_specialisation_view,
     delete_nameless_gang_type_view,
     retire_gang_legacy_pilot_view,
+    sweep_archived_view,
 )
 from n26.tests.sandbox.test_conversion_archetype import (
     build_prod_shape as build_archetype_shape,
@@ -320,6 +321,65 @@ class TestTheArchetypeConversion:
             archetype__isnull=False, archived=False
         ).exclude(removes=True)
         assert left.count() == 0
+
+
+class TestTheArchivedSweep:
+    """The last operation of the programme: what the conversions left
+    behind, moved across so the old kinds can be retired."""
+
+    @pytest.fixture
+    def swept_world(self, person_type, owner, default_pack):
+        """A converted specialisation system with an answer taken back
+        before the conversion ran."""
+        from n26.library.conversion import apply as apply_conversion
+        from n26.library.conversion import plan_specialisation
+        from n26.tests.sandbox.test_conversion_specialisation import (
+            build_prod_shape,
+            build_world,
+        )
+
+        shape = build_prod_shape()
+        gangs, fighters = build_world(shape, person_type, owner)
+        apply_conversion(plan_specialisation())
+        return gangs, fighters
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.SWEEP_ARCHIVED.value in registered
+        found = resolve_operation(Operation.SWEEP_ARCHIVED.value)
+        assert found.name == Operation.SWEEP_ARCHIVED.label
+        assert found.view is sweep_archived_view
+
+    def test_its_page_shows_the_plan_and_writes_nothing(
+        self, client, superuser, swept_world
+    ):
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_sweep_archived"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "rewrite the archived" in page
+        assert not Backfill.objects.exists()
+        assert Assignment.objects.filter(
+            specialisation__isnull=False, archived=True
+        ).exists()
+
+    def test_applying_leaves_nothing_naming_the_old_kind(
+        self, client, superuser, swept_world
+    ):
+        client.force_login(superuser)
+
+        response = client.post(reverse("admin:maintenance_n26_sweep_archived"))
+
+        assert response.status_code == 302
+        run = Backfill.objects.get(operation=Operation.SWEEP_ARCHIVED)
+        assert run.status == Backfill.Status.DONE
+        assert any(
+            "every story reads the same" in line for line in run.summary["report"]
+        )
+        assert not Assignment.objects.filter(specialisation__isnull=False).exists()
 
 
 class TestApplying:


### PR DESCRIPTION
n26's hand-built choice systems have been moved onto the generic slots-and-picks machinery, one system at a time. Each conversion rewrote the answers a gang **still holds**. This does the ones it **took back**.

An answer that is dropped is archived rather than deleted — a gang that changed its mind keeps the row — and those were left naming the kinds the conversions replaced. In production that is **399 archived assignments across 169 gangs** (299 specialisation, 74 archetype, 26 skill tree).

## Summary

- A console operation rewrites each archived answer onto its pickable, exactly as its live siblings were rewritten.
- Which choice an answer settles is nowhere recorded — these rows predate slots — so it is read from the anchor: **every anchor that once carried an offer now grants exactly one slot**, so that is the slot its answer belongs to. Checked against production first: all 399 resolve this way. Anything ambiguous — an anchor granting no slot or several, a name matching no pickable or two — is refused by name rather than guessed at, and the write re-proves each row inside the transaction.
- The run proves itself on **history alone**. An archived answer draws nothing on any card, so no page can move; but a gang's history describes an old event by what its assignment names *now*, so a bad rewrite would silently reword what a player is told they did. Every affected gang's story is read before and after, and any word that moves ends the run.

## What this does not reach

A click that lands twice leaves a **live** answer beside the one that settled the question, and the conversions left those exactly as they were — **four stand in production**, all specialisation. They are live, so a sweep of what was taken back does not touch them, and while they stand the Specialisation kind still cannot be retired. The operation's page counts them and says so.

## Why not compare pages as the conversions do

Measured against production: folding a gang's story takes 287ms, building its pages 1458ms. Over 169 gangs that is the difference between holding a transaction about a minute and about ten — for a check that cannot fail here. The rehearsal below compared pages anyway and found none moved, confirming the omission is safe rather than convenient.

Because the guarantee differs from the conversions', the shared plan page now takes its wording from the operation, the way the deletion pages already do — an operator reading it is told what this run actually proves.

## Test plan

- [x] `pytest n26` — 3888 passed
- [x] 13 tests over the sweep: all three columns end to end, its refusals (an anchor granting no slot, a name matching none, a name matching two), and that a live spare is left alone
- [x] 3 tests over the console operation
- [x] Rehearsed on a fork of the content mirror at production's span — 423 archived answers over 169 gangs, built by re-choosing and converted first: applied in 18.5s, every gang's story and pages verified unmoved from outside the run, second run a clean no-op
- [x] `manage check` — a startup check caught the task route missing before anything ran, which the tests could not: the development task backend skips the registry

Production's gangs are larger than the fork's, so expect a minute or two there rather than 18 seconds — well inside the operation's 600s deadline.

## Next

Once this has run, no *archived* row names Archetype, SkillTree or Specialisation. Retiring those kinds additionally needs the four live spares dealt with — a decision about four gangs' pages, not a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawHQCRuHjqtKFDoZr9kY8