### PR TITLE
fix: the sweep owns up to the one word it moves

### DIFF
--- a/n26/library/conversion/archived.py
+++ b/n26/library/conversion/archived.py
@@ -15,8 +15,13 @@ draws nothing on any card, so no page can move whatever this does —
 but the gang's history describes an old event by what its assignment
 names *now*, and these assignments are what history is made of.
 Rewriting one wrongly rewrites what a player is told they did. So
-every affected gang's story is read before and after, and any word
-that moves ends the run.
+every affected gang's story is read before and after, and a word that
+moves ends the run unless the plan said in advance that it would.
+
+Exactly one wording does move, and the plan names it and counts it on
+the page before anybody agrees to the run (``ALLOWED_REWORDS``). A
+gang the plan did not name for it must read identically, so the
+allowance cannot spread to a story it was not meant for.
 
 Reading their pages as well would be the conversions' proof, and it is
 the wrong one here twice over: it cannot fail, and it costs five times
@@ -33,6 +38,7 @@ an answer belongs to is the slot its own anchor grants. Anything that
 does not resolve that way is refused by name rather than guessed at.
 """
 
+from collections import Counter
 from dataclasses import dataclass
 
 from n26.library.conversion.base import ConversionRefused, Plan
@@ -101,6 +107,37 @@ class RewriteArchivedAnswer:
 #: report reads best.
 OLD_COLUMNS = ("specialisation", "archetype", "skill_tree")
 
+#: The one change of wording this sweep may make, and nothing else.
+#:
+#: The archetype column holds two systems with nothing to do with each
+#: other — the Outcast archetypes and the Venator gang legacies — so a
+#: dropped legacy's history calls the house an "archetype". Said as the
+#: pick it is, it says "gang legacy": the truthful word, and the one a
+#: gang's kept legacies already use. Every other moved word is a
+#: refusal, and so is any change to *what* arrived.
+ALLOWED_REWORDS = (("archetype", "gang legacy"),)
+
+
+@dataclass(frozen=True)
+class ArchivedPlan(Plan):
+    """The sweep's plan, carrying the rewording it has to own up to."""
+
+    #: ``(old word, new word, how many answers)``, as the preview says it.
+    rewords: tuple = ()
+    #: The gangs whose stories may move. Every other gang's must not.
+    reworded_gang_ids: tuple = ()
+
+    def preview(self):
+        lines = list(super().preview())
+        for old, new, count in self.rewords:
+            lines.insert(
+                -1,
+                f"[archived] {count} of those answer"
+                f"{'' if count == 1 else 's'} will have their history say "
+                f"“{new}” where it says “{old}” today",
+            )
+        return lines
+
 
 def _slots_granted(assignable, seen):
     """The slots this thing's modifiers hand over, cached per plan."""
@@ -130,10 +167,11 @@ def plan_archived():
             .order_by("created")
         )
     if not rows:
-        return Plan(system="archived", nothing_here=True)
+        return ArchivedPlan(system="archived", nothing_here=True)
 
     seen = {}
     steps = []
+    reworded = []
     for row in rows:
         named = getattr(row, _column_of(row))
         cause = row.caused_by
@@ -167,6 +205,25 @@ def plan_archived():
             )
             continue
         pickable = candidates[0]
+        # What the history says about this answer today, and what it
+        # would say once rewritten. Read with the history page's own
+        # words rather than a copy of them, so the two cannot drift.
+        was, becomes = _words(row), (str(pickable), slot.slot_type.name.lower())
+        if was != becomes:
+            if was[0] != becomes[0]:
+                problems.append(
+                    f"rewriting the archived answer {row.pk} would change "
+                    f"what arrived from “{was[0]}” to “{becomes[0]}”"
+                )
+                continue
+            if (was[1], becomes[1]) not in ALLOWED_REWORDS:
+                problems.append(
+                    f"rewriting the archived answer {row.pk} would have its "
+                    f"history say “{becomes[1]}” where it says “{was[1]}”, "
+                    "which is not a rewording this may make"
+                )
+                continue
+            reworded.append(((was[1], becomes[1]), row.gang_root_id))
         steps.append(
             RewriteArchivedAnswer(
                 assignment_id=row.pk,
@@ -180,15 +237,32 @@ def plan_archived():
         )
 
     if problems:
-        return Plan(system="archived", problems=tuple(problems))
+        return ArchivedPlan(system="archived", problems=tuple(problems))
 
+    counted = Counter(pair for pair, _ in reworded)
     touched = sorted({row.gang_root_id for row in rows}, key=str)
-    return Plan(
+    return ArchivedPlan(
         system="archived",
         steps=tuple(steps),
         gang_ids=tuple(touched),
         reaches=len(touched),
+        rewords=tuple(
+            (old, new, count) for (old, new), count in sorted(counted.items())
+        ),
+        reworded_gang_ids=tuple(sorted({gang for _, gang in reworded}, key=str)),
     )
+
+
+def _words(row):
+    """What the history page calls this row: its name, and its sort.
+
+    The page's own functions, because the proof is about what a reader
+    is told — a second implementation of the wording could agree with
+    itself while disagreeing with the screen.
+    """
+    from n26.core.history import _kindword, _name
+
+    return _name(row), _kindword(row)
 
 
 def _column_of(row):
@@ -221,6 +295,10 @@ def apply_archived(plan):
     with _one_snapshot(), transaction.atomic():
         gangs = list(Gang.objects.filter(pk__in=plan.gang_ids))
         before_story = {str(gang.pk): _story(history.build(gang)) for gang in gangs}
+        # Only the gangs the plan named may reword, and only in the way
+        # it named. Everywhere else the story has to read identically,
+        # so a coincidence somewhere unrelated cannot pass as expected.
+        reworded = set(plan.reworded_gang_ids)
 
         for step in plan.steps:
             try:
@@ -234,8 +312,16 @@ def apply_archived(plan):
         moved = []
         for gang in gangs:
             key = str(gang.pk)
-            if _story(history.build(gang)) != before_story[key]:
-                moved.append(f"{gang}: the words its history tells have moved")
+            unexpected = _unexpected(
+                before_story[key],
+                _story(history.build(gang)),
+                plan.rewords if gang.pk in reworded else (),
+            )
+            if unexpected:
+                moved.append(
+                    f"{gang}: the words its history tells have moved — "
+                    + "; ".join(unexpected[:3])
+                )
         if moved:
             raise ConversionRefused(
                 "[archived] refused — what a reader is told would change:\n  "
@@ -248,8 +334,34 @@ def apply_archived(plan):
                 raise ConversionRefused(
                     f"[archived] refused — {gang} no longer reconciles: {failed}"
                 ) from failed
-    report.append("[archived] rewritten; every story reads the same")
+    report.append(
+        "[archived] rewritten; every story reads the same but for the "
+        "rewording said above"
+        if plan.rewords
+        else "[archived] rewritten; every story reads the same"
+    )
     return report
+
+
+def _unexpected(before, after, rewords):
+    """Every way two readings of a story disagree beyond what was said.
+
+    A line may differ only by having one declared word put in place of
+    another, and only on a gang the plan named. Anything else — a line
+    gained or lost, a name changed, a word nobody declared — comes back
+    as words, so a refusal says what it saw rather than that something
+    happened.
+    """
+    if len(before) != len(after):
+        return [f"the story is {len(before)} lines long and becomes {len(after)}"]
+    found = []
+    for was, now in zip(before, after, strict=True):
+        if was == now:
+            continue
+        if any(was.replace(old, new) == now for old, new, _ in rewords):
+            continue
+        found.append(f"“{was}” -> “{now}”")
+    return found
 
 
 def _story(acts):

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -697,7 +697,13 @@ def sweep_archived_view(request):
         ),
         confirm_words=(
             f"Rewrite {len(plan.steps)} archived answer(s)? It writes nothing "
-            "unless every gang's history reads the same afterwards."
+            "unless every gang's history reads the same afterwards"
+            + (
+                ", but for the rewording listed above, which it counts before "
+                "you agree to it."
+                if plan.rewords
+                else "."
+            )
         ),
         button_words="Apply sweep",
         leaves_behind=_spares_left(),

--- a/n26/tests/sandbox/test_conversion_archived.py
+++ b/n26/tests/sandbox/test_conversion_archived.py
@@ -12,7 +12,12 @@ from n26.core import history
 from n26.core.models import Assignment
 from n26.core.reconcile import assert_reconciled
 from n26.library.conversion import apply, plan_specialisation
-from n26.library.conversion.archived import apply_archived, plan_archived
+from n26.library.conversion.archived import _unexpected as _unexpected
+from n26.library.conversion.archived import (
+    apply_archived,
+    plan_archived,
+)
+from n26.library.conversion.base import ConversionRefused
 from n26.library.models import Pickable, Slot, Specialisation
 from n26.tests.sandbox.actions import (
     choose,
@@ -234,6 +239,136 @@ class TestTheOtherColumns:
         ).exists()
         moved = Assignment.objects.filter(archived=True, pickable__isnull=False)
         assert all(row.chosen_for_slot_id is not None for row in moved)
+
+
+class TestTheOneRewording:
+    """A dropped gang legacy sat in the archetype column, so its history
+    calls the house an archetype. Said as the pick it is, the history
+    says "gang legacy" — the word the gang's kept legacies use. The
+    sweep counts that on the page before it is agreed to, and refuses
+    every other word that moves."""
+
+    @pytest.fixture
+    def legacies(self, default_pack, person_type, owner):
+        from n26.library.conversion import plan_gang_legacy
+        from n26.tests.sandbox.test_conversion_gang_legacy import (
+            build_prod_shape,
+            build_world,
+        )
+
+        shape = build_prod_shape(person_type)
+        gangs, _ = build_world(shape, owner)
+        apply(plan_gang_legacy())
+        return gangs
+
+    @pytest.fixture
+    def sworn_at_hiring(self, default_pack, person_type, owner):
+        """A legacy answered in the same breath as the hire that asked
+        for it, then taken back.
+
+        The word only reaches the page this way: an answer given in its
+        own right is told as its own line, which names no sort of thing,
+        while one folded under the hire is listed beneath it — and a
+        listed thing says what sort it is.
+        """
+        from n26.core.operations import operation
+        from n26.library.conversion import plan_gang_legacy
+        from n26.tests.sandbox.actions import found_gang, remove
+        from n26.tests.sandbox.test_conversion_gang_legacy import build_prod_shape
+
+        gang_type, houses, profiles, _ = build_prod_shape(person_type)
+        hunt_leader = profiles[0]
+        gang = found_gang("The Long Watch", gang_type, owner=owner, budget=2000)
+        with operation(gang, actor=owner) as op:
+            fighter = op.hire(hunt_leader, "Vex", paid=50)
+            anchor = Assignment.objects.get(profile=hunt_leader, miniature_root=fighter)
+            op.choose(anchor, houses["Cawdor"])
+        remove(
+            Assignment.objects.get(
+                archetype=houses["Cawdor"], miniature_root=fighter, archived=False
+            )
+        )
+        apply(plan_gang_legacy())
+        return gang
+
+    def test_the_plan_says_the_word_will_move_and_how_often(self, legacies):
+        plan = plan_archived()
+
+        assert plan.rewords == (("archetype", "gang legacy", 1),)
+        assert any(
+            "will have their history say “gang legacy” where it says "
+            "“archetype” today" in line
+            for line in plan.preview()
+        )
+
+    def test_the_gang_whose_word_moves_is_the_only_one_allowed_to(self, legacies):
+        plan = plan_archived()
+
+        assert plan.reworded_gang_ids == (legacies["answered"].pk,)
+
+    def test_the_story_says_the_new_word_afterwards(self, sworn_at_hiring):
+        gang = sworn_at_hiring
+        before = _story(history.build(gang))
+        assert any("|archetype|" in line for line in before)
+
+        apply_archived(plan_archived())
+
+        after = _story(history.build(gang))
+        assert not any("|archetype|" in line for line in after)
+        assert any("|gang legacy|" in line for line in after)
+        # Only the sort-of-thing word moved: what arrived is untouched.
+        assert [line.split("|")[0] for line in before] == [
+            line.split("|")[0] for line in after
+        ]
+
+    def test_a_rewording_nobody_declared_is_refused(self, legacies, monkeypatch):
+        monkeypatch.setattr("n26.library.conversion.archived.ALLOWED_REWORDS", ())
+
+        plan = plan_archived()
+
+        assert not plan.ok
+        assert any(
+            "which is not a rewording this may make" in problem
+            for problem in plan.problems
+        )
+        with pytest.raises(ConversionRefused):
+            apply_archived(plan)
+
+
+class TestReadingTwoStories:
+    """What counts as a story having moved, given the one allowance."""
+
+    def test_an_identical_story_has_not_moved(self):
+        assert _unexpected(["a", "b"], ["a", "b"], ()) == []
+
+    def test_a_declared_word_put_in_place_of_another_is_expected(self):
+        assert (
+            _unexpected(
+                ["Cawdor|archetype|"],
+                ["Cawdor|gang legacy|"],
+                (("archetype", "gang legacy", 1),),
+            )
+            == []
+        )
+
+    def test_the_same_word_moving_where_it_was_not_declared_is_not(self):
+        found = _unexpected(["Cawdor|archetype|"], ["Cawdor|gang legacy|"], ())
+
+        assert found == ["“Cawdor|archetype|” -> “Cawdor|gang legacy|”"]
+
+    def test_a_name_changing_is_never_expected(self):
+        found = _unexpected(
+            ["Cawdor|archetype|"],
+            ["Escher|gang legacy|"],
+            (("archetype", "gang legacy", 1),),
+        )
+
+        assert found == ["“Cawdor|archetype|” -> “Escher|gang legacy|”"]
+
+    def test_a_story_that_gains_a_line_is_not_expected(self):
+        found = _unexpected(["a"], ["a", "b"], (("archetype", "gang legacy", 1),))
+
+        assert found == ["the story is 1 lines long and becomes 2"]
 
 
 class TestWhatItLeaves:


### PR DESCRIPTION
The sweep that turns already-taken-back answers into picks refused when
it ran, and this is what it caught.

## What happened

An archived answer draws nothing on any card, so the sweep proves itself
against each affected gang's **history** rather than its pages. That
matters because a history describes an old event by what its assignment
names *now* — so rewriting one can silently reword a story a player has
already read.

Running it, 34 of the 399 answers moved a word, and the sweep refused
and unwound. Nothing was written.

## Why those 34, and why the new wording is right

All 34 are gang legacies a gang dropped. They sit in the archetype
column because that column holds two systems with nothing to do with
each other — the Outcast archetypes and the Venator gang legacies — so
their history calls the house an "archetype". Said as the pick it is,
the history says "gang legacy".

That is the truthful word, and it is the one the same gang's *kept*
legacies already use: the gang legacy conversion proves pages rather
than histories, so those stories say it today. Refusing here would leave
a gang's dropped legacies and its kept ones disagreeing about what they
are, and would block retiring the Archetype kind at all.

## The change

The plan now works out both readings for every answer — using the
history page's own functions, so the proof and the screen cannot drift
apart — and declares any wording that would move. The console page
counts it before anybody agrees to the run:

> 34 of those answers will have their history say "gang legacy" where it
> says "archetype" today

`ALLOWED_REWORDS` holds the single pair the sweep may make. Everything
else is still a refusal:

- a word nobody declared,
- a change to *what* arrived rather than what sort of thing it is,
- a story that gains or loses a line,
- that same wording moving on a gang the plan did not name for it.

A refusal now quotes the words it saw, instead of only naming a gang.

## Checked

- Full n26 suite: 3901 passed.
- The new story test reproduces the production refusal exactly — with
  the allowance removed it fails with the same message the real run
  gave, and passes only with it. The word only reaches the page when an
  answer folds under the hire that asked for it, so the test builds that
  shape deliberately.
- Planned against production read-only: 0 problems, 399 steps over 169
  gangs, one declared reword of 34 answers — matching a count computed
  independently — and every gang that refused is among those the plan
  names.

## Trying it

Maintenance console → "n26: the answers already taken back become
picks". The preview states the reword and its count above the confirm
button.
