### PR TITLE
feat: prodshell reaches production from a cloud agent

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -207,8 +207,8 @@ then
   fi
   log "Google credential environment written to ${GCP_ENV_FILE}"
 else
-  # Consistent with the rest of this step: production access is an optional
-  # extra and must not cost the environment everything built above it.
+  # Production access is an optional extra and must not cost the environment
+  # everything built above it.
   echo "Could not write ${GCP_ENV_FILE}; production database access will be unavailable." >&2
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,8 +355,20 @@ echo 'print(List.objects.filter(archived=False).count())' | manage prodshell
   single expression per query (e.g. `print([...comprehension...])`) and read results off
   the `In [N]:` lines.
 
-**Important:** Read-only mode is enforced — all write operations raise `RuntimeError`. Requires `gcloud` CLI,
-`cloud-sql-proxy`, and valid GCP authentication (both `gcloud auth login` and `gcloud auth application-default login`).
+**Important:** Read-only mode is enforced — all write operations raise `RuntimeError`.
+
+There are two ways in, and `prodshell` picks between them automatically:
+
+- **On a workstation** (`--auth=gcloud`): signs in as you and reads the application's own database
+  credentials. Requires the `gcloud` CLI, `cloud-sql-proxy`, and both `gcloud auth login` and
+  `gcloud auth application-default login`.
+- **On a cloud agent** (`--auth=iam`): uses the agent's federated credentials to connect as
+  `cursor-prodshell-ro`, a role the database grants `SELECT` and nothing else. No `gcloud`, no
+  password, and no key on disk — the agent mints a five-minute token and exchanges it. Chosen
+  automatically when `GOOGLE_APPLICATION_CREDENTIALS` names an `external_account` config.
+
+Under `iam` the read-only guarantee is the database's, not just this command's, so it holds for
+anything else that connects as that role too.
 
 - **One-off production data repairs run as a Backfill, not a management command.** The app runs on
   Cloud Run, so `manage` can't be pointed at production and `prodshell` is read-only — a repair

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ There are two ways in, and `prodshell` picks between them automatically:
   credentials. Requires the `gcloud` CLI, `cloud-sql-proxy`, and both `gcloud auth login` and
   `gcloud auth application-default login`.
 - **On a cloud agent** (`--auth=iam`): uses the agent's federated credentials to connect as
-  `cursor-prodshell-ro`, a role the database grants `SELECT` and nothing else. No `gcloud`, no
+  a dedicated role the database grants `SELECT` and nothing else. No `gcloud`, no
   password, and no key on disk — the agent mints a five-minute token and exchanges it. Chosen
   automatically when `GOOGLE_APPLICATION_CREDENTIALS` names an `external_account` config.
 

--- a/n23/core/management/commands/prodshell.py
+++ b/n23/core/management/commands/prodshell.py
@@ -228,7 +228,7 @@ class Command(BaseCommand):
             "user": db_user,
             # The proxy authenticates the connection, so there is no password to
             # hold, fetch, or leak.
-            "password": "",
+            "password": "",  # nosec B105 - the absence of a credential, not one
         }
 
     # -- Credential fetching --

--- a/n23/core/management/commands/prodshell.py
+++ b/n23/core/management/commands/prodshell.py
@@ -191,10 +191,14 @@ class Command(BaseCommand):
             # perfectly good reason to take the other path.
             return config if config.get("type") == "external_account" else None
 
-        config = cls._load_config(AGENT_CREDENTIAL_PATH, required=False)
-        if config is not None and config.get("type") == "external_account":
-            return config
-        return None
+        # Nobody named this one, so its absence is an absence. Its being present
+        # and unreadable is not: that is the ownership mismatch this whole path
+        # exists to avoid, and swallowing it would fall back to the workstation
+        # path and report a missing gcloud instead.
+        if not Path(AGENT_CREDENTIAL_PATH).exists():
+            return None
+        config = cls._load_config(AGENT_CREDENTIAL_PATH, required=True)
+        return config if config.get("type") == "external_account" else None
 
     def _use_iam_auth(self, mode):
         if mode == "iam":
@@ -464,6 +468,17 @@ class Command(BaseCommand):
 """
         self.stdout.write(self.style.ERROR(banner))
 
+    @staticmethod
+    def _settings_path():
+        """Where the generated settings module goes.
+
+        Inside the installed package, because the shell subprocess has to be
+        able to import it by name.
+        """
+        import gyrinx
+
+        return Path(gyrinx.__file__).parent / "_prodshell_settings.py"
+
     def _launch_shell(self, db_config, port):
         """Launch shell_plus as a subprocess with production database settings.
 
@@ -491,21 +506,26 @@ DATABASE_ROUTERS = [
 ]
 """
 
-        # Write settings to a temp file inside the project package so it's importable
-        import gyrinx
-
-        settings_path = Path(gyrinx.__file__).parent / "_prodshell_settings.py"
+        settings_path = self._settings_path()
 
         try:
             # The mode passed to open applies only when the file is created, so
             # one left behind by a run that was killed would keep whatever
             # permissions it had while a production password is written into it.
             settings_path.unlink(missing_ok=True)
-            fd = os.open(
-                str(settings_path),
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                0o600,
-            )
+            try:
+                fd = os.open(
+                    str(settings_path),
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+            except FileExistsError as e:
+                # Two sessions at once. Better to say so than to overwrite the
+                # settings the other one is about to read.
+                raise CommandError(
+                    f"{settings_path} was created by another prodshell session. "
+                    "Only one can run at a time; wait for the other to finish."
+                ) from e
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(settings_content)
 

--- a/n23/core/management/commands/prodshell.py
+++ b/n23/core/management/commands/prodshell.py
@@ -5,8 +5,10 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
+from urllib.parse import unquote
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -17,8 +19,15 @@ CLOUD_RUN_SERVICE = "gyrinx"
 PROXY_PORT = 5433
 PROXY_STARTUP_TIMEOUT = 15  # seconds
 
-# The database the federated role is granted SELECT on.
+# The database the federated role is granted SELECT on. The other path reads the
+# name off the running service; this one cannot, so it is stated here.
 IAM_DB_NAME = "app"
+
+# Where a cloud agent's credential configuration is written on every boot. Only a
+# login or interactive shell picks up the environment variable naming it, so a
+# command run through `bash -c` would otherwise see nothing and fall back to the
+# path meant for a workstation.
+AGENT_CREDENTIAL_PATH = Path("/etc/gyrinx/cursor-wif.json")
 
 # Scopes must be requested explicitly. Without them the impersonation call sends
 # an empty scope list and Google rejects the whole request as malformed, which
@@ -92,11 +101,7 @@ class Command(BaseCommand):
         finally:
             if proxy_process:
                 self.stdout.write("Stopping Cloud SQL Auth Proxy...")
-                proxy_process.terminate()
-                try:
-                    proxy_process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    proxy_process.kill()
+                self._stop_proxy(proxy_process)
                 self.stdout.write("Cloud SQL Auth Proxy stopped.")
 
     # -- Pre-flight checks --
@@ -147,24 +152,49 @@ class Command(BaseCommand):
     # -- Federated credentials --
 
     @staticmethod
-    def _credential_config():
-        """The external_account config ADC is pointed at, if that is what it is.
+    def _load_config(path, required):
+        """Read a credential configuration, or nothing if there is not one there.
+
+        A file that was named and then could not be read is an error rather than
+        an absence. Treating it as an absence would quietly fall back to the
+        workstation path, which connects with the application's own full
+        privileges -- the opposite of what someone configuring a restricted
+        identity was asking for.
+        """
+        try:
+            config = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            if required:
+                raise CommandError(f"{path} could not be read: {e}") from e
+            return None
+        if not isinstance(config, dict):
+            if required:
+                raise CommandError(
+                    f"{path} could not be read as a credential configuration."
+                )
+            return None
+        return config
+
+    @classmethod
+    def _credential_config(cls):
+        """The federated configuration in play, if there is one.
 
         A cloud agent authenticates by exchanging a short-lived token for
         permission to act as a service account, and the file describing that
         exchange is what distinguishes it from a developer signed in with
         gcloud.
         """
-        path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        if not path:
-            return None
-        try:
-            config = json.loads(Path(path).read_text(encoding="utf-8"))
-        except OSError, json.JSONDecodeError:
-            return None
-        if not isinstance(config, dict) or config.get("type") != "external_account":
-            return None
-        return config
+        named = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if named:
+            config = cls._load_config(named, required=True)
+            # A service account key is a credential configuration too, and a
+            # perfectly good reason to take the other path.
+            return config if config.get("type") == "external_account" else None
+
+        config = cls._load_config(AGENT_CREDENTIAL_PATH, required=False)
+        if config is not None and config.get("type") == "external_account":
+            return config
+        return None
 
     def _use_iam_auth(self, mode):
         if mode == "iam":
@@ -178,7 +208,9 @@ class Command(BaseCommand):
         """The account the federated credentials act as, from the config."""
         url = config.get("service_account_impersonation_url", "")
         match = re.search(r"/serviceAccounts/([^:/]+):", url)
-        return match.group(1) if match else None
+        # A hand-written configuration can escape the @, which would otherwise
+        # survive into the database role name and fail to match anything.
+        return unquote(match.group(1)) if match else None
 
     def _iam_db_config(self, db_name):
         """Work out who to connect as, and prove we can become them first.
@@ -202,10 +234,17 @@ class Command(BaseCommand):
                 "account, so there is no database role to connect as."
             )
 
+        # The proxy is a separate process and reads these from the environment,
+        # as does the credential lookup below. Set when the configuration was
+        # found at its known location rather than named by the environment.
+        if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(AGENT_CREDENTIAL_PATH)
+            os.environ.setdefault("GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES", "1")
+
         try:
             import google.auth
             import google.auth.transport.requests
-        except ImportError as e:  # pragma: no cover - google-auth is installed
+        except ImportError as e:  # pragma: no cover - a hard dependency
             raise CommandError(f"google-auth is not available: {e}") from e
 
         try:
@@ -219,6 +258,11 @@ class Command(BaseCommand):
                 "condition."
             ) from e
 
+        # The credentials know who they ended up as. Where that disagrees with a
+        # second reading of the configuration file, they are the authority.
+        service_account = (
+            getattr(credentials, "service_account_email", None) or service_account
+        )
         self.stdout.write(f"Authenticated as {service_account}.")
 
         # Cloud SQL drops the trailing domain from a service account's name.
@@ -228,7 +272,7 @@ class Command(BaseCommand):
             "user": db_user,
             # The proxy authenticates the connection, so there is no password to
             # hold, fetch, or leak.
-            "password": "",  # nosec B105 - the absence of a credential, not one
+            "password": "",  # nosec B105
         }
 
     # -- Credential fetching --
@@ -331,7 +375,7 @@ class Command(BaseCommand):
 
     # -- Cloud SQL Auth Proxy --
 
-    def _start_proxy(self, project, port, use_iam=False):
+    def _start_proxy(self, project, port, use_iam):
         """Start Cloud SQL Auth Proxy and wait for it to be ready."""
         instance_connection = f"{project}:{GCP_REGION}:{CLOUD_SQL_INSTANCE}"
         command = ["cloud-sql-proxy", instance_connection, f"--port={port}"]
@@ -339,33 +383,54 @@ class Command(BaseCommand):
             # Hands the connection an access token for the impersonated account
             # instead of a password.
             command.append("--auto-iam-authn")
+
+        # Diagnostics go to a file rather than a pipe. The proxy outlives this
+        # function and keeps logging -- a line per connection, and more again
+        # when it refreshes tokens -- and nothing reads a pipe once startup is
+        # over, so it would eventually fill and the proxy would block on writing
+        # to it, stalling every query with no indication why.
+        stderr_file = tempfile.TemporaryFile()
         proxy_process = subprocess.Popen(
             command,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            stderr=stderr_file,
         )
+
+        def proxy_output():
+            stderr_file.seek(0)
+            return stderr_file.read().decode(errors="replace")
 
         # Wait for the proxy to be ready by polling the port
         start = time.monotonic()
         while time.monotonic() - start < PROXY_STARTUP_TIMEOUT:
             # Check if process died
             if proxy_process.poll() is not None:
-                stderr = (
-                    proxy_process.stderr.read().decode() if proxy_process.stderr else ""
-                )
                 raise CommandError(
-                    f"Cloud SQL Auth Proxy exited unexpectedly:\n{stderr}"
+                    f"Cloud SQL Auth Proxy exited unexpectedly:\n{proxy_output()}"
                 )
             if self._port_is_open(port):
                 self.stdout.write(f"Cloud SQL Auth Proxy ready on port {port}.")
                 return proxy_process
             time.sleep(0.5)
 
-        proxy_process.terminate()
+        self._stop_proxy(proxy_process)
         raise CommandError(
-            f"Cloud SQL Auth Proxy did not start within {PROXY_STARTUP_TIMEOUT}s. "
-            "Check your gcloud credentials and network."
+            f"Cloud SQL Auth Proxy did not start within {PROXY_STARTUP_TIMEOUT}s:\n"
+            f"{proxy_output()}"
         )
+
+    @staticmethod
+    def _stop_proxy(proxy_process):
+        """Stop the proxy, and insist if it declines to go.
+
+        A proxy that survives keeps port 5433, so the next run fails to bind
+        with no hint as to what is holding it.
+        """
+        proxy_process.terminate()
+        try:
+            proxy_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proxy_process.kill()
 
     @staticmethod
     def _port_is_open(port):
@@ -375,16 +440,17 @@ class Command(BaseCommand):
 
     # -- Shell --
 
-    def _print_banner(self, port, use_iam=False, db_config=None):
+    def _print_banner(self, port, use_iam, db_config):
+        # Under gcloud the restriction is this command's own doing and reaches
+        # only what goes through the ORM: raw SQL on a cursor consults no router,
+        # and the connection holds the application's full privileges. Under iam
+        # the database refuses this role a write however it is asked.
         if use_iam:
-            # Worth distinguishing: under gcloud the read-only rule is this
-            # command's own doing and holds only inside it, whereas the database
-            # itself refuses to let this role write.
-            enforcement = "READ-ONLY (granted SELECT only; also enforced here)"
+            enforcement = "READ-ONLY (granted SELECT only; ORM writes also blocked)"
         else:
-            enforcement = "READ-ONLY (enforced by this command)"
-        connected_as = (db_config or {}).get("user", "unknown")
-        database = (db_config or {}).get("name", "unknown")
+            enforcement = "READ-ONLY (ORM writes blocked; raw SQL is not)"
+        connected_as = db_config["user"]
+        database = db_config["name"]
         banner = f"""
 {"=" * 54}
   WARNING: CONNECTED TO PRODUCTION DATABASE
@@ -393,7 +459,7 @@ class Command(BaseCommand):
   Connected as: {connected_as}
   Proxy port: {port}
   Mode: {enforcement}
-  All write operations will raise RuntimeError
+  Writes through the ORM raise RuntimeError
 {"=" * 54}
 """
         self.stdout.write(self.style.ERROR(banner))
@@ -431,8 +497,14 @@ DATABASE_ROUTERS = [
         settings_path = Path(gyrinx.__file__).parent / "_prodshell_settings.py"
 
         try:
+            # The mode passed to open applies only when the file is created, so
+            # one left behind by a run that was killed would keep whatever
+            # permissions it had while a production password is written into it.
+            settings_path.unlink(missing_ok=True)
             fd = os.open(
-                str(settings_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+                str(settings_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
             )
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(settings_content)

--- a/n23/core/management/commands/prodshell.py
+++ b/n23/core/management/commands/prodshell.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -15,6 +16,14 @@ CLOUD_SQL_INSTANCE = "gyrinx-app-bootstrap-db"
 CLOUD_RUN_SERVICE = "gyrinx"
 PROXY_PORT = 5433
 PROXY_STARTUP_TIMEOUT = 15  # seconds
+
+# The database the federated role is granted SELECT on.
+IAM_DB_NAME = "app"
+
+# Scopes must be requested explicitly. Without them the impersonation call sends
+# an empty scope list and Google rejects the whole request as malformed, which
+# reads like a broken configuration rather than a missing argument.
+IAM_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 
 
 class Command(BaseCommand):
@@ -35,25 +44,48 @@ class Command(BaseCommand):
             default=PROXY_PORT,
             help=f"Local port for Cloud SQL Auth Proxy (default: {PROXY_PORT})",
         )
+        parser.add_argument(
+            "--auth",
+            choices=["auto", "iam", "gcloud"],
+            default="auto",
+            help=(
+                "How to authenticate. 'gcloud' signs in as you and reads the "
+                "application's own database credentials. 'iam' uses federated "
+                "credentials to connect as a role that can only read, which is "
+                "how a cloud agent reaches production. 'auto' picks iam when "
+                "federated credentials are configured (default: auto)"
+            ),
+        )
+        parser.add_argument(
+            "--db-name",
+            default=None,
+            help=f"Database to connect to (iam default: {IAM_DB_NAME})",
+        )
 
     def handle(self, *args, **options):
         project = options["project"]
         port = options["port"]
         proxy_process = None
+        use_iam = self._use_iam_auth(options["auth"])
 
         try:
-            self._check_gcloud()
-            self._check_gcloud_auth()
             self._check_cloud_sql_proxy()
-            self._check_adc()
 
-            self.stdout.write("Fetching production database credentials...")
-            db_config = self._fetch_db_credentials(project)
+            if use_iam:
+                db_config = self._iam_db_config(options["db_name"])
+            else:
+                self._check_gcloud()
+                self._check_gcloud_auth()
+                self._check_adc()
+                self.stdout.write("Fetching production database credentials...")
+                db_config = self._fetch_db_credentials(project)
+                if options["db_name"]:
+                    db_config["name"] = options["db_name"]
 
             self.stdout.write(f"Starting Cloud SQL Auth Proxy on port {port}...")
-            proxy_process = self._start_proxy(project, port)
+            proxy_process = self._start_proxy(project, port, use_iam)
 
-            self._print_banner(port)
+            self._print_banner(port, use_iam, db_config)
             self._launch_shell(db_config, port)
         except KeyboardInterrupt:
             self.stdout.write("\nInterrupted.")
@@ -111,6 +143,93 @@ class Command(BaseCommand):
                 "  gcloud auth application-default login"
             )
         self.stdout.write("Checking Application Default Credentials... OK")
+
+    # -- Federated credentials --
+
+    @staticmethod
+    def _credential_config():
+        """The external_account config ADC is pointed at, if that is what it is.
+
+        A cloud agent authenticates by exchanging a short-lived token for
+        permission to act as a service account, and the file describing that
+        exchange is what distinguishes it from a developer signed in with
+        gcloud.
+        """
+        path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if not path:
+            return None
+        try:
+            config = json.loads(Path(path).read_text(encoding="utf-8"))
+        except OSError, json.JSONDecodeError:
+            return None
+        if not isinstance(config, dict) or config.get("type") != "external_account":
+            return None
+        return config
+
+    def _use_iam_auth(self, mode):
+        if mode == "iam":
+            return True
+        if mode == "gcloud":
+            return False
+        return self._credential_config() is not None
+
+    @staticmethod
+    def _impersonated_service_account(config):
+        """The account the federated credentials act as, from the config."""
+        url = config.get("service_account_impersonation_url", "")
+        match = re.search(r"/serviceAccounts/([^:/]+):", url)
+        return match.group(1) if match else None
+
+    def _iam_db_config(self, db_name):
+        """Work out who to connect as, and prove we can become them first.
+
+        Checking here rather than letting the connection fail means a rejected
+        token is reported as a rejected token, instead of surfacing much later
+        as an unexplained inability to reach the database.
+        """
+        config = self._credential_config()
+        if config is None:
+            raise CommandError(
+                "No federated credentials found. GOOGLE_APPLICATION_CREDENTIALS "
+                "must point at an external_account configuration file. This mode "
+                "is meant for a cloud agent; on a workstation use --auth=gcloud."
+            )
+
+        service_account = self._impersonated_service_account(config)
+        if not service_account:
+            raise CommandError(
+                "The credential configuration does not impersonate a service "
+                "account, so there is no database role to connect as."
+            )
+
+        try:
+            import google.auth
+            import google.auth.transport.requests
+        except ImportError as e:  # pragma: no cover - google-auth is installed
+            raise CommandError(f"google-auth is not available: {e}") from e
+
+        try:
+            credentials, _ = google.auth.default(scopes=IAM_SCOPES)
+            credentials.refresh(google.auth.transport.requests.Request())
+        except Exception as e:
+            raise CommandError(
+                f"Could not obtain credentials for {service_account}:\n{e}\n\n"
+                "The token is minted locally but exchanging it needs to reach "
+                "Google, and the identity must satisfy the provider's attribute "
+                "condition."
+            ) from e
+
+        self.stdout.write(f"Authenticated as {service_account}.")
+
+        # Cloud SQL drops the trailing domain from a service account's name.
+        db_user = re.sub(r"\.gserviceaccount\.com$", "", service_account)
+        return {
+            "name": db_name or IAM_DB_NAME,
+            "user": db_user,
+            # The proxy authenticates the connection, so there is no password to
+            # hold, fetch, or leak.
+            "password": "",
+        }
 
     # -- Credential fetching --
 
@@ -212,15 +331,16 @@ class Command(BaseCommand):
 
     # -- Cloud SQL Auth Proxy --
 
-    def _start_proxy(self, project, port):
+    def _start_proxy(self, project, port, use_iam=False):
         """Start Cloud SQL Auth Proxy and wait for it to be ready."""
         instance_connection = f"{project}:{GCP_REGION}:{CLOUD_SQL_INSTANCE}"
+        command = ["cloud-sql-proxy", instance_connection, f"--port={port}"]
+        if use_iam:
+            # Hands the connection an access token for the impersonated account
+            # instead of a password.
+            command.append("--auto-iam-authn")
         proxy_process = subprocess.Popen(
-            [
-                "cloud-sql-proxy",
-                instance_connection,
-                f"--port={port}",
-            ],
+            command,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
         )
@@ -255,13 +375,24 @@ class Command(BaseCommand):
 
     # -- Shell --
 
-    def _print_banner(self, port):
+    def _print_banner(self, port, use_iam=False, db_config=None):
+        if use_iam:
+            # Worth distinguishing: under gcloud the read-only rule is this
+            # command's own doing and holds only inside it, whereas the database
+            # itself refuses to let this role write.
+            enforcement = "READ-ONLY (granted SELECT only; also enforced here)"
+        else:
+            enforcement = "READ-ONLY (enforced by this command)"
+        connected_as = (db_config or {}).get("user", "unknown")
+        database = (db_config or {}).get("name", "unknown")
         banner = f"""
 {"=" * 54}
   WARNING: CONNECTED TO PRODUCTION DATABASE
   Instance: {CLOUD_SQL_INSTANCE}
+  Database: {database}
+  Connected as: {connected_as}
   Proxy port: {port}
-  Mode: READ-ONLY
+  Mode: {enforcement}
   All write operations will raise RuntimeError
 {"=" * 54}
 """

--- a/n23/core/tests/test_prodshell.py
+++ b/n23/core/tests/test_prodshell.py
@@ -1,249 +1,163 @@
+"""How prodshell decides who it is connecting to production as.
+
+The command has two ways in: a developer signed in with gcloud, reading the
+application's own database credentials, and a cloud agent holding federated
+credentials that can only read. Choosing the wrong one fails a long way from the
+cause, so the choice is worth pinning down.
+"""
+
 import json
-from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management.base import CommandError
 
-from n23.core.management.commands.prodshell import Command, ReadOnlyRouter
+from n23.core.management.commands.prodshell import Command
+
+SERVICE_ACCOUNT = "reader@example-project.iam.gserviceaccount.com"
+
+EXTERNAL_ACCOUNT = {
+    "type": "external_account",
+    "audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/q",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+    "token_url": "https://sts.googleapis.com/v1/token",
+    "credential_source": {"executable": {"command": "/somewhere/mint.sh"}},
+    "service_account_impersonation_url": (
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
+        f"{SERVICE_ACCOUNT}:generateAccessToken"
+    ),
+}
 
 
-@pytest.fixture
-def cmd():
-    return Command()
+def write_config(tmp_path, payload, name="creds.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
 
 
-class TestReadOnlyRouter:
-    def test_db_for_read_returns_default(self):
-        router = ReadOnlyRouter()
-        assert router.db_for_read(None) == "default"
-
-    def test_db_for_write_raises(self):
-        router = ReadOnlyRouter()
-        with pytest.raises(RuntimeError, match="Write operations are disabled"):
-            router.db_for_write(None)
-
-    def test_allow_relation_returns_true(self):
-        router = ReadOnlyRouter()
-        assert router.allow_relation(None, None) is True
-
-    def test_allow_migrate_returns_false(self):
-        router = ReadOnlyRouter()
-        assert router.allow_migrate("default", "core") is False
+def test_no_credentials_variable_is_not_federated(monkeypatch):
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    assert Command._credential_config() is None
 
 
-class TestPreflightChecks:
-    @patch("shutil.which", return_value=None)
-    def test_check_gcloud_missing(self, mock_which, cmd):
-        with pytest.raises(CommandError, match="gcloud CLI not found"):
-            cmd._check_gcloud()
+def test_a_missing_file_is_not_federated(monkeypatch, tmp_path):
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "absent.json"))
+    assert Command._credential_config() is None
 
-    @patch("shutil.which", return_value="/usr/bin/gcloud")
-    def test_check_gcloud_found(self, mock_which, cmd):
-        cmd._check_gcloud()
 
-    @patch(
-        "subprocess.run",
-        return_value=MagicMock(returncode=1, stderr="not authenticated"),
+def test_unreadable_json_is_not_federated(monkeypatch, tmp_path):
+    path = tmp_path / "broken.json"
+    path.write_text("not json at all", encoding="utf-8")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(path))
+    assert Command._credential_config() is None
+
+
+def test_a_service_account_key_is_not_federated(monkeypatch, tmp_path):
+    """The distinguishing mark is the type, not merely that a file is present."""
+    path = write_config(tmp_path, {"type": "service_account", "project_id": "x"})
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+    assert Command._credential_config() is None
+
+
+def test_an_external_account_config_is_federated(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
     )
-    def test_check_gcloud_auth_not_authenticated(self, mock_run, cmd):
-        with pytest.raises(CommandError, match="Not authenticated"):
-            cmd._check_gcloud_auth()
+    assert Command._credential_config() == EXTERNAL_ACCOUNT
 
-    @patch(
-        "subprocess.run",
-        return_value=MagicMock(returncode=0, stdout="token"),
+
+def test_auto_picks_federated_when_configured(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
     )
-    def test_check_gcloud_auth_ok(self, mock_run, cmd):
-        cmd._check_gcloud_auth()
+    assert Command()._use_iam_auth("auto") is True
 
-    @patch("shutil.which", return_value=None)
-    def test_check_cloud_sql_proxy_missing(self, mock_which, cmd):
-        with pytest.raises(CommandError, match="cloud-sql-proxy not found"):
-            cmd._check_cloud_sql_proxy()
 
-    @patch("shutil.which", return_value="/usr/bin/cloud-sql-proxy")
-    def test_check_cloud_sql_proxy_found(self, mock_which, cmd):
-        cmd._check_cloud_sql_proxy()
+def test_auto_falls_back_to_gcloud_on_a_workstation(monkeypatch):
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    assert Command()._use_iam_auth("auto") is False
 
-    @patch(
-        "subprocess.run",
-        return_value=MagicMock(returncode=1, stderr="not set"),
+
+def test_explicit_choices_override_what_is_configured(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
     )
-    def test_check_adc_not_authenticated(self, mock_run, cmd):
-        with pytest.raises(CommandError, match="Application Default Credentials"):
-            cmd._check_adc()
+    assert Command()._use_iam_auth("gcloud") is False
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    assert Command()._use_iam_auth("iam") is True
 
-    @patch(
-        "subprocess.run",
-        return_value=MagicMock(returncode=0, stdout="token"),
+
+def test_the_impersonated_account_is_read_from_the_config():
+    assert Command._impersonated_service_account(EXTERNAL_ACCOUNT) == SERVICE_ACCOUNT
+
+
+def test_a_config_that_impersonates_nobody_yields_nobody():
+    assert Command._impersonated_service_account({"type": "external_account"}) is None
+
+
+def test_the_database_role_drops_the_trailing_domain(monkeypatch, tmp_path):
+    """Cloud SQL names a service account without its domain suffix."""
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
     )
-    def test_check_adc_ok(self, mock_run, cmd):
-        cmd._check_adc()
-
-
-class TestFetchDbCredentials:
-    def _make_cloud_run_response(self, env_vars):
-        """Build a mock Cloud Run service describe JSON response."""
-        service = {
-            "spec": {
-                "template": {
-                    "spec": {
-                        "containers": [
-                            {
-                                "env": [
-                                    {"name": k, "value": v} for k, v in env_vars.items()
-                                ]
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-        return json.dumps(service)
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_success(self, mock_run, cmd):
-        env_vars = {
-            "DB_CONFIG": json.dumps({"user": "prod_user", "password": "prod_pass"}),
-            "DB_NAME": "prod_db",
-        }
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=self._make_cloud_run_response(env_vars),
-        )
-        result = cmd._fetch_db_credentials("test-project")
-        assert result["name"] == "prod_db"
-        assert result["user"] == "prod_user"
-        assert result["password"] == "prod_pass"
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_defaults_db_name(self, mock_run, cmd):
-        env_vars = {
-            "DB_CONFIG": json.dumps({"user": "u", "password": "p"}),
-        }
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=self._make_cloud_run_response(env_vars),
-        )
-        result = cmd._fetch_db_credentials("test-project")
-        assert result["name"] == "gyrinx"
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_gcloud_failure(self, mock_run, cmd):
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stderr="permission denied",
-        )
-        with pytest.raises(CommandError, match="Failed to fetch"):
-            cmd._fetch_db_credentials("test-project")
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_missing_user(self, mock_run, cmd):
-        env_vars = {
-            "DB_CONFIG": json.dumps({"password": "p"}),
-        }
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=self._make_cloud_run_response(env_vars),
-        )
-        with pytest.raises(CommandError, match="Could not extract"):
-            cmd._fetch_db_credentials("test-project")
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_missing_password(self, mock_run, cmd):
-        env_vars = {
-            "DB_CONFIG": json.dumps({"user": "u"}),
-        }
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=self._make_cloud_run_response(env_vars),
-        )
-        with pytest.raises(CommandError, match="Could not extract"):
-            cmd._fetch_db_credentials("test-project")
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_malformed_db_config(self, mock_run, cmd):
-        env_vars = {
-            "DB_CONFIG": "not-json",
-        }
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=self._make_cloud_run_response(env_vars),
-        )
-        with pytest.raises(CommandError, match="Failed to parse DB_CONFIG"):
-            cmd._fetch_db_credentials("test-project")
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_malformed_json(self, mock_run, cmd):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="not-json",
-        )
-        with pytest.raises(
-            CommandError, match="Failed to parse Cloud Run service config"
-        ):
-            cmd._fetch_db_credentials("test-project")
-
-    @patch("subprocess.run")
-    def test_fetch_credentials_no_containers(self, mock_run, cmd):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps({"spec": {"template": {"spec": {"containers": []}}}}),
-        )
-        with pytest.raises(CommandError, match="No containers found"):
-            cmd._fetch_db_credentials("test-project")
-
-
-class TestPortCheck:
-    @patch("socket.socket")
-    def test_port_not_open(self, mock_socket):
-        mock_sock_instance = mock_socket.return_value.__enter__.return_value
-        mock_sock_instance.connect_ex.return_value = 1
-        assert Command._port_is_open(19999) is False
-
-
-class TestProxyStartup:
-    @patch("subprocess.Popen")
-    def test_proxy_exits_unexpectedly(self, mock_popen, cmd):
-        mock_proc = MagicMock()
-        mock_proc.poll.return_value = 1  # process exited
-        mock_proc.stderr.read.return_value = b"bind error"
-        mock_popen.return_value = mock_proc
-
-        with pytest.raises(CommandError, match="exited unexpectedly"):
-            cmd._start_proxy("test-project", 5433)
-
-    @patch(
-        "n23.core.management.commands.prodshell.Command._port_is_open",
-        return_value=True,
+    monkeypatch.setattr(
+        "google.auth.default", lambda **kwargs: (_StubCredentials(), None)
     )
-    @patch("subprocess.Popen")
-    def test_proxy_starts_successfully(self, mock_popen, mock_port_is_open, cmd):
-        mock_proc = MagicMock()
-        mock_proc.poll.return_value = None  # still running
-        mock_popen.return_value = mock_proc
 
-        result = cmd._start_proxy("test-project", 5433)
-        assert result is mock_proc
+    config = Command()._iam_db_config(None)
 
-    @patch("n23.core.management.commands.prodshell.time.monotonic")
-    @patch(
-        "n23.core.management.commands.prodshell.Command._port_is_open",
-        return_value=False,
+    assert config["user"] == "reader@example-project.iam"
+    assert config["name"] == "app"
+    assert config["password"] == ""
+
+
+def test_the_database_can_be_overridden(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
     )
-    @patch("n23.core.management.commands.prodshell.time.sleep")
-    @patch("subprocess.Popen")
-    def test_proxy_startup_timeout(
-        self, mock_popen, mock_sleep, mock_port_is_open, mock_monotonic, cmd
-    ):
-        mock_proc = MagicMock()
-        mock_proc.poll.return_value = None  # still running
-        mock_popen.return_value = mock_proc
+    monkeypatch.setattr(
+        "google.auth.default", lambda **kwargs: (_StubCredentials(), None)
+    )
+    assert Command()._iam_db_config("somewhere_else")["name"] == "somewhere_else"
 
-        # Simulate time exceeding PROXY_STARTUP_TIMEOUT
-        mock_monotonic.side_effect = [0.0, 0.0, 20.0]
 
-        with pytest.raises(CommandError, match="did not start within"):
-            cmd._start_proxy("test-project", 5433)
+def test_scopes_are_requested(monkeypatch, tmp_path):
+    """Unscoped, the impersonation call is rejected as a malformed request."""
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+    )
+    seen = {}
 
-        mock_proc.terminate.assert_called_once()
+    def capture(**kwargs):
+        seen.update(kwargs)
+        return _StubCredentials(), None
+
+    monkeypatch.setattr("google.auth.default", capture)
+    Command()._iam_db_config(None)
+
+    assert seen["scopes"] == ["https://www.googleapis.com/auth/cloud-platform"]
+
+
+def test_federated_mode_without_credentials_says_so(monkeypatch):
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    with pytest.raises(CommandError, match="No federated credentials"):
+        Command()._iam_db_config(None)
+
+
+def test_a_rejected_token_is_reported_where_it_happens(monkeypatch, tmp_path):
+    """Rather than surfacing later as an unexplained connection failure."""
+    monkeypatch.setenv(
+        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+    )
+
+    def refuse(**kwargs):
+        raise RuntimeError("rejected by the attribute condition")
+
+    monkeypatch.setattr("google.auth.default", refuse)
+
+    with pytest.raises(CommandError, match="rejected by the attribute condition"):
+        Command()._iam_db_config(None)
+
+
+class _StubCredentials:
+    def refresh(self, request):
+        return None

--- a/n23/core/tests/test_prodshell.py
+++ b/n23/core/tests/test_prodshell.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -276,12 +277,6 @@ def write_config(tmp_path, payload, name="creds.json"):
     return str(path)
 
 
-def settings_file_path():
-    import gyrinx
-
-    return Path(gyrinx.__file__).parent / "_prodshell_settings.py"
-
-
 class StubCredentials:
     """Stands in for credentials that refresh without reaching Google."""
 
@@ -370,17 +365,23 @@ class TestWhichAuthPath:
         )
         assert Command._credential_config() == EXTERNAL_ACCOUNT
 
-    def test_a_junk_file_at_the_agent_location_is_not_fatal(
+    def test_an_unreadable_file_at_the_agent_location_is_refused(
         self, monkeypatch, tmp_path
     ):
-        """Nobody named it, so it is an absence rather than a broken setup."""
+        """Absence is an absence; present-but-unreadable is a broken setup.
+
+        A config that is there and cannot be read is the ownership mismatch this
+        path exists to avoid. Swallowing it would take the workstation path and
+        complain about a missing gcloud instead.
+        """
         monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
         path = tmp_path / "cursor-wif.json"
         path.write_text("rubbish", encoding="utf-8")
         monkeypatch.setattr(
             "n23.core.management.commands.prodshell.AGENT_CREDENTIAL_PATH", path
         )
-        assert Command._credential_config() is None
+        with pytest.raises(CommandError, match="could not be read"):
+            Command._credential_config()
 
     def test_auto_picks_federated_when_configured(self, monkeypatch, tmp_path):
         monkeypatch.setenv(
@@ -498,6 +499,45 @@ class TestFederatedDatabaseRole:
         with pytest.raises(CommandError, match="No federated credentials"):
             Command()._iam_db_config(None)
 
+    def test_the_environment_is_completed_for_the_proxy(self, monkeypatch, tmp_path):
+        """The proxy is a separate process and reads these from the environment.
+
+        This is the branch that makes the case work where nothing was inherited
+        — a command run through `bash -c` — so it has to set what it found.
+        """
+        path = tmp_path / "cursor-wif.json"
+        path.write_text(json.dumps(EXTERNAL_ACCOUNT), encoding="utf-8")
+        monkeypatch.setattr(
+            "n23.core.management.commands.prodshell.AGENT_CREDENTIAL_PATH", path
+        )
+        # Recorded before deleting so that both are restored afterwards rather
+        # than leaking into every later test on this worker.
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "recorded")
+        monkeypatch.setenv("GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES", "recorded")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS")
+        monkeypatch.delenv("GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES")
+        monkeypatch.setattr(
+            "google.auth.default", lambda **kwargs: (StubCredentials(), None)
+        )
+
+        Command()._iam_db_config(None)
+
+        assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == str(path)
+        assert os.environ["GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES"] == "1"
+
+    def test_an_inherited_environment_is_left_alone(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+        monkeypatch.setenv("GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES", "0")
+        monkeypatch.setattr(
+            "google.auth.default", lambda **kwargs: (StubCredentials(), None)
+        )
+
+        Command()._iam_db_config(None)
+
+        assert os.environ["GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES"] == "0"
+
     def test_a_refused_token_is_reported_where_it_happens(self, monkeypatch, tmp_path):
         """The exchange itself failing, rather than the lookup that precedes it.
 
@@ -539,28 +579,45 @@ class TestProxyArguments:
 
     def test_the_proxy_is_not_given_a_pipe_to_fill(self, cmd):
         """It outlives startup and keeps logging with nobody reading, so a pipe
-        would eventually fill and stall every query."""
+        would eventually fill and stall every query.
+
+        A real file is required rather than merely "not a pipe": inheriting the
+        terminal would scatter proxy logs through the shell session.
+        """
         with (
             patch("subprocess.Popen") as popen,
             patch.object(Command, "_port_is_open", return_value=True),
         ):
             popen.return_value = MagicMock(poll=MagicMock(return_value=None))
             cmd._start_proxy("test-project", 5433, use_iam=False)
-        assert popen.call_args.kwargs["stderr"] is not subprocess.PIPE
+
+        stderr = popen.call_args.kwargs["stderr"]
+        assert stderr is not subprocess.PIPE
+        assert stderr.fileno() >= 0
 
 
 class TestGeneratedSettings:
-    """What the shell subprocess is handed, and what is left behind afterwards."""
+    """What the shell subprocess is handed, and what is left behind afterwards.
 
-    def test_the_read_only_router_is_installed(self, cmd):
+    Each test is given its own path. Sharing the real one makes these race
+    against each other under parallel test execution, which is how the suite is
+    normally run.
+    """
+
+    @pytest.fixture
+    def settings_path(self, monkeypatch, tmp_path):
+        path = tmp_path / "_prodshell_settings.py"
+        monkeypatch.setattr(Command, "_settings_path", staticmethod(lambda: path))
+        return path
+
+    def test_the_read_only_router_is_installed(self, cmd, settings_path):
         """The layer that does not depend on database privileges, so it has to
         be present even on the path that already lacks them."""
         seen = {}
 
         def capture(argv, env=None, **kwargs):
-            path = settings_file_path()
-            seen["content"] = path.read_text(encoding="utf-8")
-            seen["mode"] = path.stat().st_mode & 0o777
+            seen["content"] = settings_path.read_text(encoding="utf-8")
+            seen["mode"] = settings_path.stat().st_mode & 0o777
             return MagicMock(returncode=0)
 
         with patch("subprocess.run", side_effect=capture):
@@ -572,36 +629,43 @@ class TestGeneratedSettings:
         assert "DATABASE_ROUTERS" in seen["content"]
         assert seen["mode"] == 0o600
 
-    def test_the_settings_file_does_not_outlive_the_shell(self, cmd):
+    def test_the_settings_file_does_not_outlive_the_shell(self, cmd, settings_path):
         with patch("subprocess.run", return_value=MagicMock(returncode=0)):
             cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
-        assert not settings_file_path().exists()
+        assert not settings_path.exists()
 
-    def test_the_settings_file_is_removed_even_when_the_shell_fails(self, cmd):
+    def test_the_settings_file_is_removed_even_when_the_shell_fails(
+        self, cmd, settings_path
+    ):
         with patch("subprocess.run", side_effect=RuntimeError("boom")):
             with pytest.raises(RuntimeError):
                 cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
-        assert not settings_file_path().exists()
+        assert not settings_path.exists()
 
-    def test_a_file_left_behind_cannot_keep_a_looser_mode(self, cmd):
+    def test_a_file_left_behind_cannot_keep_a_looser_mode(self, cmd, settings_path):
         """Truncating an existing file leaves its permissions alone, and a
         production password is about to be written into it."""
-        path = settings_file_path()
-        path.write_text("left over", encoding="utf-8")
-        path.chmod(0o644)
+        settings_path.write_text("left over", encoding="utf-8")
+        settings_path.chmod(0o644)
         seen = {}
 
         def capture(argv, env=None, **kwargs):
-            seen["mode"] = path.stat().st_mode & 0o777
+            seen["mode"] = settings_path.stat().st_mode & 0o777
             return MagicMock(returncode=0)
 
-        try:
-            with patch("subprocess.run", side_effect=capture):
-                cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
-        finally:
-            path.unlink(missing_ok=True)
+        with patch("subprocess.run", side_effect=capture):
+            cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
 
         assert seen["mode"] == 0o600
+
+    def test_a_second_session_is_told_rather_than_overwritten(self, cmd, settings_path):
+        """Overwriting would pull the settings out from under a shell that is
+        about to import them."""
+        settings_path.write_text("another session", encoding="utf-8")
+
+        with patch.object(Path, "unlink"):  # the other session still holds it
+            with pytest.raises(CommandError, match="another prodshell session"):
+                cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
 
 
 class TestBanner:

--- a/n23/core/tests/test_prodshell.py
+++ b/n23/core/tests/test_prodshell.py
@@ -1,23 +1,265 @@
-"""How prodshell decides who it is connecting to production as.
-
-The command has two ways in: a developer signed in with gcloud, reading the
-application's own database credentials, and a cloud agent holding federated
-credentials that can only read. Choosing the wrong one fails a long way from the
-cause, so the choice is worth pinning down.
-"""
-
+import io
 import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
-from django.core.management.base import CommandError
+from django.core.management.base import CommandError, OutputWrapper
 
-from n23.core.management.commands.prodshell import Command
+from n23.core.management.commands.prodshell import Command, ReadOnlyRouter
+
+
+@pytest.fixture
+def cmd():
+    return Command()
+
+
+class TestReadOnlyRouter:
+    def test_db_for_read_returns_default(self):
+        router = ReadOnlyRouter()
+        assert router.db_for_read(None) == "default"
+
+    def test_db_for_write_raises(self):
+        router = ReadOnlyRouter()
+        with pytest.raises(RuntimeError, match="Write operations are disabled"):
+            router.db_for_write(None)
+
+    def test_allow_relation_returns_true(self):
+        router = ReadOnlyRouter()
+        assert router.allow_relation(None, None) is True
+
+    def test_allow_migrate_returns_false(self):
+        router = ReadOnlyRouter()
+        assert router.allow_migrate("default", "core") is False
+
+
+class TestPreflightChecks:
+    @patch("shutil.which", return_value=None)
+    def test_check_gcloud_missing(self, mock_which, cmd):
+        with pytest.raises(CommandError, match="gcloud CLI not found"):
+            cmd._check_gcloud()
+
+    @patch("shutil.which", return_value="/usr/bin/gcloud")
+    def test_check_gcloud_found(self, mock_which, cmd):
+        cmd._check_gcloud()
+
+    @patch(
+        "subprocess.run",
+        return_value=MagicMock(returncode=1, stderr="not authenticated"),
+    )
+    def test_check_gcloud_auth_not_authenticated(self, mock_run, cmd):
+        with pytest.raises(CommandError, match="Not authenticated"):
+            cmd._check_gcloud_auth()
+
+    @patch(
+        "subprocess.run",
+        return_value=MagicMock(returncode=0, stdout="token"),
+    )
+    def test_check_gcloud_auth_ok(self, mock_run, cmd):
+        cmd._check_gcloud_auth()
+
+    @patch("shutil.which", return_value=None)
+    def test_check_cloud_sql_proxy_missing(self, mock_which, cmd):
+        with pytest.raises(CommandError, match="cloud-sql-proxy not found"):
+            cmd._check_cloud_sql_proxy()
+
+    @patch("shutil.which", return_value="/usr/bin/cloud-sql-proxy")
+    def test_check_cloud_sql_proxy_found(self, mock_which, cmd):
+        cmd._check_cloud_sql_proxy()
+
+    @patch(
+        "subprocess.run",
+        return_value=MagicMock(returncode=1, stderr="not set"),
+    )
+    def test_check_adc_not_authenticated(self, mock_run, cmd):
+        with pytest.raises(CommandError, match="Application Default Credentials"):
+            cmd._check_adc()
+
+    @patch(
+        "subprocess.run",
+        return_value=MagicMock(returncode=0, stdout="token"),
+    )
+    def test_check_adc_ok(self, mock_run, cmd):
+        cmd._check_adc()
+
+
+class TestFetchDbCredentials:
+    def _make_cloud_run_response(self, env_vars):
+        """Build a mock Cloud Run service describe JSON response."""
+        service = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {"name": k, "value": v} for k, v in env_vars.items()
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        return json.dumps(service)
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_success(self, mock_run, cmd):
+        env_vars = {
+            "DB_CONFIG": json.dumps({"user": "prod_user", "password": "prod_pass"}),
+            "DB_NAME": "prod_db",
+        }
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_cloud_run_response(env_vars),
+        )
+        result = cmd._fetch_db_credentials("test-project")
+        assert result["name"] == "prod_db"
+        assert result["user"] == "prod_user"
+        assert result["password"] == "prod_pass"
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_defaults_db_name(self, mock_run, cmd):
+        env_vars = {
+            "DB_CONFIG": json.dumps({"user": "u", "password": "p"}),
+        }
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_cloud_run_response(env_vars),
+        )
+        result = cmd._fetch_db_credentials("test-project")
+        assert result["name"] == "gyrinx"
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_gcloud_failure(self, mock_run, cmd):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="permission denied",
+        )
+        with pytest.raises(CommandError, match="Failed to fetch"):
+            cmd._fetch_db_credentials("test-project")
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_missing_user(self, mock_run, cmd):
+        env_vars = {
+            "DB_CONFIG": json.dumps({"password": "p"}),
+        }
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_cloud_run_response(env_vars),
+        )
+        with pytest.raises(CommandError, match="Could not extract"):
+            cmd._fetch_db_credentials("test-project")
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_missing_password(self, mock_run, cmd):
+        env_vars = {
+            "DB_CONFIG": json.dumps({"user": "u"}),
+        }
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_cloud_run_response(env_vars),
+        )
+        with pytest.raises(CommandError, match="Could not extract"):
+            cmd._fetch_db_credentials("test-project")
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_malformed_db_config(self, mock_run, cmd):
+        env_vars = {
+            "DB_CONFIG": "not-json",
+        }
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=self._make_cloud_run_response(env_vars),
+        )
+        with pytest.raises(CommandError, match="Failed to parse DB_CONFIG"):
+            cmd._fetch_db_credentials("test-project")
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_malformed_json(self, mock_run, cmd):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="not-json",
+        )
+        with pytest.raises(
+            CommandError, match="Failed to parse Cloud Run service config"
+        ):
+            cmd._fetch_db_credentials("test-project")
+
+    @patch("subprocess.run")
+    def test_fetch_credentials_no_containers(self, mock_run, cmd):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"spec": {"template": {"spec": {"containers": []}}}}),
+        )
+        with pytest.raises(CommandError, match="No containers found"):
+            cmd._fetch_db_credentials("test-project")
+
+
+class TestPortCheck:
+    @patch("socket.socket")
+    def test_port_not_open(self, mock_socket):
+        mock_sock_instance = mock_socket.return_value.__enter__.return_value
+        mock_sock_instance.connect_ex.return_value = 1
+        assert Command._port_is_open(19999) is False
+
+
+class TestProxyStartup:
+    @patch("subprocess.Popen")
+    def test_proxy_exits_unexpectedly(self, mock_popen, cmd):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1  # process exited
+        mock_proc.stderr.read.return_value = b"bind error"
+        mock_popen.return_value = mock_proc
+
+        with pytest.raises(CommandError, match="exited unexpectedly"):
+            cmd._start_proxy("test-project", 5433, use_iam=False)
+
+    @patch(
+        "n23.core.management.commands.prodshell.Command._port_is_open",
+        return_value=True,
+    )
+    @patch("subprocess.Popen")
+    def test_proxy_starts_successfully(self, mock_popen, mock_port_is_open, cmd):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # still running
+        mock_popen.return_value = mock_proc
+
+        result = cmd._start_proxy("test-project", 5433, use_iam=False)
+        assert result is mock_proc
+
+    @patch("n23.core.management.commands.prodshell.time.monotonic")
+    @patch(
+        "n23.core.management.commands.prodshell.Command._port_is_open",
+        return_value=False,
+    )
+    @patch("n23.core.management.commands.prodshell.time.sleep")
+    @patch("subprocess.Popen")
+    def test_proxy_startup_timeout(
+        self, mock_popen, mock_sleep, mock_port_is_open, mock_monotonic, cmd
+    ):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # still running
+        mock_popen.return_value = mock_proc
+
+        # Simulate time exceeding PROXY_STARTUP_TIMEOUT
+        mock_monotonic.side_effect = [0.0, 0.0, 20.0]
+
+        with pytest.raises(CommandError, match="did not start within"):
+            cmd._start_proxy("test-project", 5433, use_iam=False)
+
+        mock_proc.terminate.assert_called_once()
+
 
 SERVICE_ACCOUNT = "reader@example-project.iam.gserviceaccount.com"
 
 EXTERNAL_ACCOUNT = {
     "type": "external_account",
-    "audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/q",
+    "audience": (
+        "//iam.googleapis.com/projects/1/locations/global"
+        "/workloadIdentityPools/p/providers/q"
+    ),
     "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
     "token_url": "https://sts.googleapis.com/v1/token",
     "credential_source": {"executable": {"command": "/somewhere/mint.sh"}},
@@ -34,130 +276,358 @@ def write_config(tmp_path, payload, name="creds.json"):
     return str(path)
 
 
-def test_no_credentials_variable_is_not_federated(monkeypatch):
-    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
-    assert Command._credential_config() is None
+def settings_file_path():
+    import gyrinx
+
+    return Path(gyrinx.__file__).parent / "_prodshell_settings.py"
 
 
-def test_a_missing_file_is_not_federated(monkeypatch, tmp_path):
-    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "absent.json"))
-    assert Command._credential_config() is None
+class StubCredentials:
+    """Stands in for credentials that refresh without reaching Google."""
 
+    service_account_email = SERVICE_ACCOUNT
 
-def test_unreadable_json_is_not_federated(monkeypatch, tmp_path):
-    path = tmp_path / "broken.json"
-    path.write_text("not json at all", encoding="utf-8")
-    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(path))
-    assert Command._credential_config() is None
-
-
-def test_a_service_account_key_is_not_federated(monkeypatch, tmp_path):
-    """The distinguishing mark is the type, not merely that a file is present."""
-    path = write_config(tmp_path, {"type": "service_account", "project_id": "x"})
-    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
-    assert Command._credential_config() is None
-
-
-def test_an_external_account_config_is_federated(monkeypatch, tmp_path):
-    monkeypatch.setenv(
-        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
-    )
-    assert Command._credential_config() == EXTERNAL_ACCOUNT
-
-
-def test_auto_picks_federated_when_configured(monkeypatch, tmp_path):
-    monkeypatch.setenv(
-        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
-    )
-    assert Command()._use_iam_auth("auto") is True
-
-
-def test_auto_falls_back_to_gcloud_on_a_workstation(monkeypatch):
-    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
-    assert Command()._use_iam_auth("auto") is False
-
-
-def test_explicit_choices_override_what_is_configured(monkeypatch, tmp_path):
-    monkeypatch.setenv(
-        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
-    )
-    assert Command()._use_iam_auth("gcloud") is False
-    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
-    assert Command()._use_iam_auth("iam") is True
-
-
-def test_the_impersonated_account_is_read_from_the_config():
-    assert Command._impersonated_service_account(EXTERNAL_ACCOUNT) == SERVICE_ACCOUNT
-
-
-def test_a_config_that_impersonates_nobody_yields_nobody():
-    assert Command._impersonated_service_account({"type": "external_account"}) is None
-
-
-def test_the_database_role_drops_the_trailing_domain(monkeypatch, tmp_path):
-    """Cloud SQL names a service account without its domain suffix."""
-    monkeypatch.setenv(
-        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
-    )
-    monkeypatch.setattr(
-        "google.auth.default", lambda **kwargs: (_StubCredentials(), None)
-    )
-
-    config = Command()._iam_db_config(None)
-
-    assert config["user"] == "reader@example-project.iam"
-    assert config["name"] == "app"
-    assert config["password"] == ""
-
-
-def test_the_database_can_be_overridden(monkeypatch, tmp_path):
-    monkeypatch.setenv(
-        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
-    )
-    monkeypatch.setattr(
-        "google.auth.default", lambda **kwargs: (_StubCredentials(), None)
-    )
-    assert Command()._iam_db_config("somewhere_else")["name"] == "somewhere_else"
-
-
-def test_scopes_are_requested(monkeypatch, tmp_path):
-    """Unscoped, the impersonation call is rejected as a malformed request."""
-    monkeypatch.setenv(
-        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
-    )
-    seen = {}
-
-    def capture(**kwargs):
-        seen.update(kwargs)
-        return _StubCredentials(), None
-
-    monkeypatch.setattr("google.auth.default", capture)
-    Command()._iam_db_config(None)
-
-    assert seen["scopes"] == ["https://www.googleapis.com/auth/cloud-platform"]
-
-
-def test_federated_mode_without_credentials_says_so(monkeypatch):
-    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
-    with pytest.raises(CommandError, match="No federated credentials"):
-        Command()._iam_db_config(None)
-
-
-def test_a_rejected_token_is_reported_where_it_happens(monkeypatch, tmp_path):
-    """Rather than surfacing later as an unexplained connection failure."""
-    monkeypatch.setenv(
-        "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
-    )
-
-    def refuse(**kwargs):
-        raise RuntimeError("rejected by the attribute condition")
-
-    monkeypatch.setattr("google.auth.default", refuse)
-
-    with pytest.raises(CommandError, match="rejected by the attribute condition"):
-        Command()._iam_db_config(None)
-
-
-class _StubCredentials:
     def refresh(self, request):
         return None
+
+
+class TestWhichAuthPath:
+    """Which identity the command connects as, and how loudly it decides.
+
+    The two paths hold different privileges, so choosing between them silently
+    is the thing to avoid.
+    """
+
+    def test_no_credentials_anywhere_is_not_federated(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.setattr(
+            "n23.core.management.commands.prodshell.AGENT_CREDENTIAL_PATH",
+            tmp_path / "absent.json",
+        )
+        assert Command._credential_config() is None
+
+    def test_a_service_account_key_is_not_federated(self, monkeypatch, tmp_path):
+        """The discriminator is the type, not merely that a file is present."""
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            write_config(tmp_path, {"type": "service_account", "project_id": "x"}),
+        )
+        assert Command._credential_config() is None
+
+    def test_an_external_account_config_is_federated(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+        assert Command._credential_config() == EXTERNAL_ACCOUNT
+
+    def test_a_named_but_unparseable_config_is_refused(self, monkeypatch, tmp_path):
+        """Rather than quietly falling back to the fuller-privilege path.
+
+        Naming a credential file and then failing to read it is a broken setup.
+        Treating it as an absence would connect with the application's own
+        account instead, without saying so.
+        """
+        path = tmp_path / "broken.json"
+        path.write_text("not json at all", encoding="utf-8")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(path))
+        with pytest.raises(CommandError, match="could not be read"):
+            Command._credential_config()
+
+    def test_a_named_config_that_is_not_utf8_is_refused(self, monkeypatch, tmp_path):
+        path = tmp_path / "binary.json"
+        path.write_bytes(b"\xff\xfe\x00nonsense")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(path))
+        with pytest.raises(CommandError, match="could not be read"):
+            Command._credential_config()
+
+    def test_a_named_config_that_is_absent_is_refused(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "absent.json")
+        )
+        with pytest.raises(CommandError, match="could not be read"):
+            Command._credential_config()
+
+    def test_a_named_config_that_is_not_an_object_is_refused(
+        self, monkeypatch, tmp_path
+    ):
+        path = tmp_path / "list.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(path))
+        with pytest.raises(CommandError, match="credential configuration"):
+            Command._credential_config()
+
+    def test_an_agent_is_recognised_without_the_variable(self, monkeypatch, tmp_path):
+        """A shell that inherits no environment still finds the agent's config.
+
+        Only a login or interactive shell picks the variable up, so a command
+        run through `bash -c` would otherwise take the workstation path.
+        """
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        path = tmp_path / "cursor-wif.json"
+        path.write_text(json.dumps(EXTERNAL_ACCOUNT), encoding="utf-8")
+        monkeypatch.setattr(
+            "n23.core.management.commands.prodshell.AGENT_CREDENTIAL_PATH", path
+        )
+        assert Command._credential_config() == EXTERNAL_ACCOUNT
+
+    def test_a_junk_file_at_the_agent_location_is_not_fatal(
+        self, monkeypatch, tmp_path
+    ):
+        """Nobody named it, so it is an absence rather than a broken setup."""
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        path = tmp_path / "cursor-wif.json"
+        path.write_text("rubbish", encoding="utf-8")
+        monkeypatch.setattr(
+            "n23.core.management.commands.prodshell.AGENT_CREDENTIAL_PATH", path
+        )
+        assert Command._credential_config() is None
+
+    def test_auto_picks_federated_when_configured(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+        assert Command()._use_iam_auth("auto") is True
+
+    def test_auto_falls_back_to_gcloud_on_a_workstation(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.setattr(
+            "n23.core.management.commands.prodshell.AGENT_CREDENTIAL_PATH",
+            tmp_path / "absent.json",
+        )
+        assert Command()._use_iam_auth("auto") is False
+
+    def test_asking_for_gcloud_reads_no_configuration_at_all(
+        self, monkeypatch, tmp_path
+    ):
+        """A broken credential file must not stop someone choosing the other path."""
+        path = tmp_path / "broken.json"
+        path.write_text("not json", encoding="utf-8")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(path))
+        assert Command()._use_iam_auth("gcloud") is False
+
+    def test_asking_for_federated_is_honoured(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        assert Command()._use_iam_auth("iam") is True
+
+
+class TestFederatedDatabaseRole:
+    def test_the_impersonated_account_is_read_from_the_config(self):
+        assert (
+            Command._impersonated_service_account(EXTERNAL_ACCOUNT) == SERVICE_ACCOUNT
+        )
+
+    def test_a_config_that_impersonates_nobody_yields_nobody(self):
+        assert (
+            Command._impersonated_service_account({"type": "external_account"}) is None
+        )
+
+    def test_a_percent_encoded_account_is_decoded(self):
+        """An escaped @ would otherwise survive into the database role name."""
+        config = {
+            "service_account_impersonation_url": (
+                "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
+                "reader%40example-project.iam.gserviceaccount.com:generateAccessToken"
+            )
+        }
+        assert Command._impersonated_service_account(config) == SERVICE_ACCOUNT
+
+    def test_the_database_role_drops_the_trailing_domain(self, monkeypatch, tmp_path):
+        """Cloud SQL names a service account without its domain suffix."""
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+        monkeypatch.setattr(
+            "google.auth.default", lambda **kwargs: (StubCredentials(), None)
+        )
+
+        config = Command()._iam_db_config(None)
+
+        assert config["user"] == "reader@example-project.iam"
+        assert config["name"] == "app"
+        assert config["password"] == ""
+
+    def test_the_database_can_be_overridden(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+        monkeypatch.setattr(
+            "google.auth.default", lambda **kwargs: (StubCredentials(), None)
+        )
+        assert Command()._iam_db_config("somewhere_else")["name"] == "somewhere_else"
+
+    def test_the_role_comes_from_the_identity_actually_obtained(
+        self, monkeypatch, tmp_path
+    ):
+        """Not from a second parse of the configuration file.
+
+        Where the two disagree, the credentials are the authority on who this
+        connection is.
+        """
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+
+        class Elsewhere(StubCredentials):
+            service_account_email = "elsewhere@other.iam.gserviceaccount.com"
+
+        monkeypatch.setattr("google.auth.default", lambda **kwargs: (Elsewhere(), None))
+        assert Command()._iam_db_config(None)["user"] == "elsewhere@other.iam"
+
+    def test_scopes_are_requested(self, monkeypatch, tmp_path):
+        """Unscoped, the impersonation call is rejected as a malformed request."""
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+        seen = {}
+
+        def capture(**kwargs):
+            seen.update(kwargs)
+            return StubCredentials(), None
+
+        monkeypatch.setattr("google.auth.default", capture)
+        Command()._iam_db_config(None)
+
+        assert seen["scopes"] == ["https://www.googleapis.com/auth/cloud-platform"]
+
+    def test_federated_mode_without_credentials_says_so(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.setattr(
+            "n23.core.management.commands.prodshell.AGENT_CREDENTIAL_PATH",
+            tmp_path / "absent.json",
+        )
+        with pytest.raises(CommandError, match="No federated credentials"):
+            Command()._iam_db_config(None)
+
+    def test_a_refused_token_is_reported_where_it_happens(self, monkeypatch, tmp_path):
+        """The exchange itself failing, rather than the lookup that precedes it.
+
+        This is the likelier failure in practice: the credentials resolve, and
+        Google then declines to issue for them.
+        """
+        monkeypatch.setenv(
+            "GOOGLE_APPLICATION_CREDENTIALS", write_config(tmp_path, EXTERNAL_ACCOUNT)
+        )
+
+        class Refused(StubCredentials):
+            def refresh(self, request):
+                raise RuntimeError("rejected by the attribute condition")
+
+        monkeypatch.setattr("google.auth.default", lambda **kwargs: (Refused(), None))
+
+        with pytest.raises(CommandError, match="rejected by the attribute condition"):
+            Command()._iam_db_config(None)
+
+
+class TestProxyArguments:
+    def test_federated_mode_asks_the_proxy_to_authenticate(self, cmd):
+        with (
+            patch("subprocess.Popen") as popen,
+            patch.object(Command, "_port_is_open", return_value=True),
+        ):
+            popen.return_value = MagicMock(poll=MagicMock(return_value=None))
+            cmd._start_proxy("test-project", 5433, use_iam=True)
+        assert "--auto-iam-authn" in popen.call_args[0][0]
+
+    def test_the_workstation_path_does_not(self, cmd):
+        with (
+            patch("subprocess.Popen") as popen,
+            patch.object(Command, "_port_is_open", return_value=True),
+        ):
+            popen.return_value = MagicMock(poll=MagicMock(return_value=None))
+            cmd._start_proxy("test-project", 5433, use_iam=False)
+        assert "--auto-iam-authn" not in popen.call_args[0][0]
+
+    def test_the_proxy_is_not_given_a_pipe_to_fill(self, cmd):
+        """It outlives startup and keeps logging with nobody reading, so a pipe
+        would eventually fill and stall every query."""
+        with (
+            patch("subprocess.Popen") as popen,
+            patch.object(Command, "_port_is_open", return_value=True),
+        ):
+            popen.return_value = MagicMock(poll=MagicMock(return_value=None))
+            cmd._start_proxy("test-project", 5433, use_iam=False)
+        assert popen.call_args.kwargs["stderr"] is not subprocess.PIPE
+
+
+class TestGeneratedSettings:
+    """What the shell subprocess is handed, and what is left behind afterwards."""
+
+    def test_the_read_only_router_is_installed(self, cmd):
+        """The layer that does not depend on database privileges, so it has to
+        be present even on the path that already lacks them."""
+        seen = {}
+
+        def capture(argv, env=None, **kwargs):
+            path = settings_file_path()
+            seen["content"] = path.read_text(encoding="utf-8")
+            seen["mode"] = path.stat().st_mode & 0o777
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=capture):
+            cmd._launch_shell(
+                {"name": "app", "user": "someone", "password": "hunter2"}, 5433
+            )
+
+        assert "ReadOnlyRouter" in seen["content"]
+        assert "DATABASE_ROUTERS" in seen["content"]
+        assert seen["mode"] == 0o600
+
+    def test_the_settings_file_does_not_outlive_the_shell(self, cmd):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
+        assert not settings_file_path().exists()
+
+    def test_the_settings_file_is_removed_even_when_the_shell_fails(self, cmd):
+        with patch("subprocess.run", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
+        assert not settings_file_path().exists()
+
+    def test_a_file_left_behind_cannot_keep_a_looser_mode(self, cmd):
+        """Truncating an existing file leaves its permissions alone, and a
+        production password is about to be written into it."""
+        path = settings_file_path()
+        path.write_text("left over", encoding="utf-8")
+        path.chmod(0o644)
+        seen = {}
+
+        def capture(argv, env=None, **kwargs):
+            seen["mode"] = path.stat().st_mode & 0o777
+            return MagicMock(returncode=0)
+
+        try:
+            with patch("subprocess.run", side_effect=capture):
+                cmd._launch_shell({"name": "app", "user": "u", "password": "p"}, 5433)
+        finally:
+            path.unlink(missing_ok=True)
+
+        assert seen["mode"] == 0o600
+
+
+class TestBanner:
+    """The banner is the only statement of what is and is not being prevented."""
+
+    @staticmethod
+    def banner_for(use_iam, db_config):
+        buffer = io.StringIO()
+        command = Command()
+        command.stdout = OutputWrapper(buffer)
+        command._print_banner(5433, use_iam, db_config)
+        return buffer.getvalue()
+
+    def test_the_workstation_path_does_not_claim_to_stop_raw_sql(self):
+        """A router intercepts the ORM and nothing else, and that connection
+        holds the application's own privileges."""
+        printed = self.banner_for(False, {"name": "app", "user": "app-user"})
+        assert "raw SQL is not" in printed
+
+    def test_the_federated_path_says_the_grant_is_doing_the_work(self):
+        printed = self.banner_for(True, {"name": "app", "user": "reader@x.iam"})
+        assert "SELECT only" in printed
+
+    def test_the_banner_names_who_and_what_is_connected(self):
+        """The two paths connect as different users with different privileges,
+        so which one is in play has to be visible."""
+        printed = self.banner_for(True, {"name": "somedb", "user": "reader@x.iam"})
+        assert "reader@x.iam" in printed
+        assert "somedb" in printed


### PR DESCRIPTION
A cloud agent can now open a production shell and ask questions through the ORM,
rather than writing SQL by hand against the proxy. That was the point of giving
it database access at all.

It could not do this before. `prodshell` needs the `gcloud` CLI, a signed-in
user, and permission to read the application's own database password out of
Secret Manager. An agent has none of those, and the read-only role deliberately
cannot reach the secret.

## Two ways in, chosen automatically

- **Workstation** — unchanged. Sign in with `gcloud`, read the application's
  credentials, connect as the application.
- **Cloud agent** — use the federated credentials already present to connect as
  the role the database grants `SELECT` and nothing else. No `gcloud`, no
  password to fetch, no key anywhere.

The choice comes from what `GOOGLE_APPLICATION_CREDENTIALS` names: an
`external_account` configuration means a federated identity, and nothing else
does. `--auth=iam` / `--auth=gcloud` forces it either way.

## Two details worth knowing

Scopes are requested explicitly. Without them the impersonation call carries an
empty scope list and Google rejects the request as malformed — which reads like a
broken configuration rather than a missing argument, and is not a mistake you
make twice cheaply.

The credentials are exercised before the proxy starts, so an identity the
provider refuses is reported as a refusal at the point it happens, instead of
surfacing later as an unexplained inability to reach the database.

## Banner

It now names the database and the role, because the two ways in connect as
different users with different privileges, and says which of them is enforcing
read-only. Under `gcloud` that is this command; under `iam` it is the database,
so the guarantee holds for anything else connecting as that role too.

## Testing

Regression-checked against production through the workstation path — the ORM
answered, and the banner reports the expected user and database. Fifteen tests
cover the choice between the two paths, the derivation of the database role from
the configuration, that scopes are requested, and both failure paths.

The agent path itself cannot be exercised from a workstation, since it needs the
agent's socket. It needs one run on an agent to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)