### PR TITLE
feat: the answers a doubled click left behind can be cleared

### DIFF
--- a/n26/library/spare_answers.py
+++ b/n26/library/spare_answers.py
@@ -1,0 +1,276 @@
+"""The answers a doubled click left behind.
+
+A question answered twice in the same moment left two rows where one
+belongs: the picker settled the question from the page it had drawn, so
+two answers in flight together each found nothing to replace. The second
+row settles nothing — the question already reads as answered by its
+sibling — but it is still an assignment naming a thing, so the model's
+gear list draws a line for it.
+
+That line is the whole of what a player sees, and it is wrong: it names
+a sort of question, not a thing anybody owns. Nothing follows from the
+row otherwise. What it grants arrives once regardless, because the
+sibling grants it too; it was never paid for and adds nothing to what
+the gang is worth.
+
+Clearing one deletes it. It is not history — an answer taken back is
+archived and kept, and these were never taken back — so there is nothing
+to preserve, and leaving them archived instead would only hand the same
+rows to a sweep that would faithfully make two picks out of them.
+
+**The proof is the page, minus exactly the lines named.** Every other
+deletion in this programme proves that nothing a reader sees moves;
+this one is meant to move something, so it says which lines beforehand
+and holds itself to removing those and nothing else. A gang whose page
+changes in any other way ends the run.
+"""
+
+from dataclasses import dataclass
+
+from django.db import transaction
+
+
+class Refused(Exception):
+    """The world is not the one the clearing read."""
+
+
+@dataclass(frozen=True)
+class Spare:
+    """One row too many, and the line it draws."""
+
+    assignment_id: object
+    gang_id: object
+    model_id: str
+    model_said: str
+    gang_said: str
+    line_name: str
+    line_rating: object
+
+    def say(self):
+        return (
+            f"clear the spare “{self.line_name}” from {self.model_said} "
+            f"({self.gang_said})"
+        )
+
+
+@dataclass(frozen=True)
+class Spares:
+    """What stands, and what clearing it would take off the page."""
+
+    found: tuple = ()
+    problems: tuple = ()
+    nothing_here: bool = False
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    @property
+    def gang_ids(self):
+        return tuple(sorted({spare.gang_id for spare in self.found}, key=str))
+
+    def preview(self):
+        if self.nothing_here:
+            return ["nothing to clear — no question is answered twice over"]
+        lines = [spare.say() for spare in self.found]
+        lines.append(
+            f"prove {len(self.gang_ids)} gang"
+            f"{'' if len(self.gang_ids) == 1 else 's'} read the same but for "
+            f"those {len(self.found)} line"
+            f"{'' if len(self.found) == 1 else 's'}, or refuse"
+        )
+        return lines
+
+
+def find():
+    """Read the spares as they stand. Never writes."""
+    from n26.core.capture import gang_state
+    from n26.core.models import Assignment, Gang
+    from n26.library.conversion.archived import OLD_COLUMNS
+
+    live = Assignment.objects.filter(archived=False).exclude(removes=True)
+    rows = []
+    for column in OLD_COLUMNS:
+        rows += list(
+            live.filter(**{f"{column}__isnull": False})
+            .select_related(column, "caused_by", "gang_root", "miniature_root")
+            .order_by("created")
+        )
+    if not rows:
+        return Spares(nothing_here=True)
+
+    problems = []
+    found = []
+    pages = {}
+    candidates = {}
+    for row in rows:
+        named = row.assignable
+        if named is None:
+            problems.append(f"the spare {row.pk} names nothing")
+            continue
+        if row.caused_by_id is None:
+            problems.append(f"the spare {row.pk} hangs from nothing")
+            continue
+        # A spare is only spare because the question it answers is
+        # already settled. Without a sibling standing it is the answer,
+        # and clearing it would take a player's choice away.
+        settled = live.filter(
+            caused_by_id=row.caused_by_id, chosen_for_slot__isnull=False
+        )
+        if not settled.exists():
+            problems.append(
+                f"nothing else answers what the spare {row.pk} answers, so "
+                "it is the answer rather than a spare"
+            )
+            continue
+        hanging = (
+            Assignment.objects.filter(caused_by=row)
+            | Assignment.objects.filter(chosen_for=row)
+            | Assignment.objects.filter(parent=row)
+        )
+        if hanging.exists():
+            problems.append(f"something hangs off the spare {row.pk}")
+            continue
+        carried = _what_it_carries(row)
+        if carried:
+            problems.append(f"the spare {row.pk} carries {carried}")
+            continue
+        if row.miniature_root_id is None:
+            problems.append(f"the spare {row.pk} sits on no model")
+            continue
+
+        gang = row.gang_root
+        if gang.pk not in pages:
+            pages[gang.pk] = gang_state(Gang.objects.get(pk=gang.pk))
+        if str(row.miniature_root_id) not in pages[gang.pk]["models"]:
+            problems.append(f"the spare {row.pk} sits on no model the sheet draws")
+            continue
+        candidates.setdefault(
+            (gang.pk, str(row.miniature_root_id), str(named)), []
+        ).append(row)
+
+    # Which lines go is settled per model and name rather than per row,
+    # because a click that landed three times leaves three rows drawing
+    # three identical lines. The rule is that the page draws exactly as
+    # many as there are spares to account for them: one more and
+    # something a player owns shares the name, which is not this to
+    # delete.
+    for (gang_id, model_id, name), rows_here in sorted(
+        candidates.items(), key=lambda pair: str(pair[0])
+    ):
+        drawn = pages[gang_id]["models"][model_id]
+        matching = [line for line in drawn["equipment"] if line[0] == name]
+        first = rows_here[0]
+        if len(matching) != len(rows_here):
+            problems.append(
+                f"{len(matching)} lines on {first.miniature_root} are called "
+                f"“{name}” and {len(rows_here)} spares name it, so which "
+                "lines would go is not settled"
+            )
+            continue
+        for row, (line_name, line_rating) in zip(rows_here, matching, strict=True):
+            found.append(
+                Spare(
+                    assignment_id=row.pk,
+                    gang_id=gang_id,
+                    model_id=model_id,
+                    model_said=str(row.miniature_root),
+                    gang_said=str(row.gang_root),
+                    line_name=line_name,
+                    line_rating=line_rating,
+                )
+            )
+
+    if problems:
+        return Spares(problems=tuple(problems))
+    return Spares(found=tuple(found))
+
+
+def _what_it_carries(row):
+    """Money or worth hanging on this row, in words — empty if none.
+
+    A spare that was paid for or that counts towards what the gang is
+    worth is not a spare: clearing it would move a number a player
+    reads, and the money is somebody's to decide about, not this.
+    """
+    from n26.core.models import LedgerEntry
+
+    entry = LedgerEntry.objects.filter(assignment=row).first()
+    if entry is None:
+        return ""
+    said = []
+    if entry.paid:
+        said.append(f"{entry.paid} credits paid")
+    if entry.rating_contribution:
+        said.append(f"{entry.rating_contribution} of the gang's worth")
+    return " and ".join(said)
+
+
+def apply(spares):
+    """Clear exactly the spares named, and prove the pages otherwise whole."""
+    from n26.core.capture import differences, gang_state
+    from n26.core.models import Assignment, Gang
+    from n26.core.reconcile import assert_reconciled
+    from n26.library.conversion.base import _one_snapshot
+
+    if spares.problems:
+        raise Refused("not cleared: " + "; ".join(spares.problems))
+    if spares.nothing_here:
+        return list(spares.preview())
+
+    report = list(spares.preview())
+    with _one_snapshot(), transaction.atomic():
+        gangs = list(Gang.objects.filter(pk__in=spares.gang_ids))
+        before = {str(gang.pk): gang_state(gang) for gang in gangs}
+        want = _without_those_lines(before, spares)
+
+        # The history events describing these rows ride the deletion:
+        # ``LedgerEvent.assignment`` cascades. There is no story to keep
+        # — a click that landed twice is not something a player did
+        # twice.
+        deleted, _ = Assignment.objects.filter(
+            pk__in=[spare.assignment_id for spare in spares.found]
+        ).delete()
+        if not deleted:
+            raise Refused("refused — nothing was there to clear")
+
+        gangs = list(Gang.objects.filter(pk__in=spares.gang_ids))
+        after = {str(gang.pk): gang_state(gang) for gang in gangs}
+        changed = differences(want, after)
+        if changed:
+            raise Refused(
+                "refused — the pages changed in ways this did not say they "
+                "would:\n  " + "\n  ".join(changed[:10])
+            )
+        for gang in gangs:
+            try:
+                assert_reconciled(gang)
+            except Exception as failed:
+                raise Refused(
+                    f"refused — {gang} no longer reconciles: {failed}"
+                ) from failed
+    report.append("cleared; every page reads the same but for those lines")
+    return report
+
+
+def _without_those_lines(before, spares):
+    """The pages as they should read once the spares are gone.
+
+    Built from what was captured rather than from what is found
+    afterwards, so the run is held to the lines it named: anything else
+    that moves shows up as a difference instead of being absorbed.
+    """
+    import copy
+
+    want = copy.deepcopy(before)
+    for spare in spares.found:
+        gang = want[str(spare.gang_id)]
+        lines = gang["models"][spare.model_id]["equipment"]
+        line = (spare.line_name, spare.line_rating)
+        if line not in lines:
+            raise Refused(
+                f"refused — the line “{spare.line_name}” the plan named is "
+                f"no longer on {spare.model_said}"
+            )
+        lines.remove(line)
+    return want

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "Operation",
+    "clear_spare_answers",
     "convert_archetype",
     "sweep_archived",
     "convert_gang_legacy",
@@ -113,6 +114,10 @@ class Operation(models.TextChoices):
         "n26_delete_nameless_gang_type",
         "n26: the gang type with no name is retired",
     )
+    CLEAR_SPARE_ANSWERS = (
+        "n26_clear_spare_answers",
+        "n26: the answers a doubled click left behind are cleared",
+    )
     MERGE_WARGEAR_INTO_WEAPON = (
         "n26_merge_wargear_into_weapon",
         "n26: duplicated wargear becomes its weapon",
@@ -128,6 +133,7 @@ LOCK_KEYS = {
     Operation.CONVERT_ARCHETYPE: 826_020_605,
     Operation.DELETE_NAMELESS_GANG_TYPE: 826_020_606,
     Operation.SWEEP_ARCHIVED: 826_020_607,
+    Operation.CLEAR_SPARE_ANSWERS: 826_020_608,
 }
 
 
@@ -371,6 +377,25 @@ def retire_gang_legacy_pilot(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def clear_spare_answers(backfill_id, **said_by_whoever_enqueued_it):
+    """Clear the answers a doubled click left behind, and record it.
+
+    The runner discipline of a conversion around work that deletes a
+    player's rows and means to change their pages — so what it proves is
+    that the pages changed in exactly the way it said and no other.
+    """
+    from n26.library.spare_answers import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.CLEAR_SPARE_ANSWERS,
+        "Spare answers clearing",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
 def _who_asked(backfill_id):
     """The operator a run acts as, for the history it writes.
 
@@ -539,6 +564,26 @@ PILOT_WORDS = {
     "refuses_heading": "The retirement refuses",
     "button": "Retire the pilot",
     "confirm": "Delete the pilot? This cannot be undone.",
+}
+
+SPARE_WORDS = {
+    "noun": "clearing",
+    "intro": (
+        "This deletes player rows, and it means to change what those "
+        "players see: each spare draws a line on a model's gear list named "
+        "after a sort of question rather than a thing anybody owns. Every "
+        "line it would take away is named below, and it refuses unless the "
+        "pages afterwards read exactly as they do now but for those. A row "
+        "that was paid for, that counts towards what a gang is worth, that "
+        "has anything hanging off it, or whose question nothing else "
+        "answers, is not a spare and is left alone."
+    ),
+    "nothing_heading": "Nothing to clear",
+    "nothing_flash": "There was nothing to clear.",
+    "nothing_words": "No question is answered twice over.",
+    "refuses_heading": "The clearing refuses",
+    "button": "Clear the spares",
+    "confirm": "Delete these spare answers? This cannot be undone.",
 }
 
 NAMELESS_WORDS = {
@@ -724,6 +769,19 @@ def retire_gang_legacy_pilot_view(request):
     )
 
 
+def clear_spare_answers_view(request):
+    """Preview the clearing (GET), or record a run and enqueue it."""
+    from n26.library.spare_answers import find
+
+    return _deletion_view(
+        request,
+        Operation.CLEAR_SPARE_ANSWERS,
+        find,
+        clear_spare_answers,
+        SPARE_WORDS,
+    )
+
+
 def delete_nameless_gang_type_view(request):
     """Preview the deletion (GET), or record a run and enqueue it."""
     from n26.library.nameless_gang_type import find
@@ -851,6 +909,22 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.CLEAR_SPARE_ANSWERS.value,
+        name=Operation.CLEAR_SPARE_ANSWERS.label,
+        description=(
+            "Delete the second answer a doubled click left standing beside "
+            "the one that settled the question. Each draws a line on a "
+            "model's gear list named after the question rather than a thing, "
+            "and clearing it takes that line away and changes nothing else — "
+            "which is what it proves before committing. Must run before the "
+            "kinds those answers name can be retired."
+        ),
+        view=clear_spare_answers_view,
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a conversion holds one
 #: transaction for as long as proving its spread of gangs takes. It is also
@@ -867,6 +941,7 @@ task_routes = [
     TaskRoute(convert_archetype, ack_deadline=600, min_retry_delay=60),
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
     TaskRoute(sweep_archived, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(clear_spare_answers, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/tests/sandbox/test_spare_answers.py
+++ b/n26/tests/sandbox/test_spare_answers.py
@@ -1,0 +1,303 @@
+"""Clearing the answers a doubled click left behind.
+
+A question answered twice in one moment left two rows where one belongs.
+The second settles nothing — its sibling already did — but it still
+draws a line on the model's gear list, named after the question rather
+than after anything a player owns. This is what takes that line away,
+and it holds itself to taking away exactly that.
+"""
+
+import pytest
+
+from n26.core.capture import gang_state
+from n26.core.models import Assignment, LedgerEntry
+from n26.core.reconcile import assert_reconciled
+from n26.library.conversion import apply as apply_conversion
+from n26.library.conversion import plan_specialisation
+from n26.library.models import Specialisation
+from n26.library.spare_answers import Refused, apply, find
+from n26.tests.sandbox.actions import (
+    buy,
+    choose,
+    create_default_set,
+    create_gang_type,
+    create_profile,
+    create_skill,
+    create_specialisation,
+    create_subtype,
+    create_wargear,
+    ef_adds,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def settled(default_pack, person_type, owner):
+    """A specialisation system, converted, with one question settled."""
+    specs = {}
+    for name, skill in [("Sniper", "Precision Shot"), ("Medic", "Medicate")]:
+        specs[name] = create_specialisation(name)
+        modifier(
+            f"{name}: its skill",
+            targets_model(),
+            ef_adds(create_skill(skill)),
+            carried_by=specs[name],
+        )
+    specialist = create_subtype("Specialist")
+    modifier(
+        "Specialist: offers a choice of specialisation",
+        targets_model(),
+        offers_choice(Specialisation),
+        carried_by=specialist,
+    )
+    gang_type = create_gang_type("Enforcers", starting_credits=2000)
+    profile = create_profile("Patrol Officer", person_type, gang_type, price=50)
+    profile.built_ins = create_default_set("Officer kit", members=[specialist])
+    profile.save()
+
+    gang = found_gang("The Watch", gang_type, owner=owner, budget=2000)
+    fighter = hire(gang, profile, "Vex", paid=50)
+    anchor = Assignment.objects.get(subtype=specialist, miniature=fighter)
+    choose(anchor, specs["Medic"])
+    apply_conversion(plan_specialisation())
+    return gang, fighter, anchor, specs
+
+
+@pytest.fixture
+def doubled(settled):
+    """The same, with the second row a doubled click leaves.
+
+    Made directly: the picker refuses to make one, which is the whole
+    reason these are a handful of rows rather than an ongoing supply.
+    """
+    gang, fighter, anchor, specs = settled
+    spare = Assignment.objects.create(
+        specialisation=specs["Sniper"],
+        miniature=fighter,
+        caused_by=anchor,
+        gang_root=gang,
+    )
+    return gang, fighter, anchor, specs, spare
+
+
+class TestFindingThem:
+    def test_a_clean_world_has_nothing_to_clear(self, settled):
+        assert find().nothing_here
+
+    def test_it_names_the_line_it_would_take_away(self, doubled):
+        gang, fighter, _, _, spare = doubled
+
+        found = find()
+
+        assert found.ok and not found.nothing_here
+        assert len(found.found) == 1
+        only = found.found[0]
+        assert only.assignment_id == spare.pk
+        assert only.line_name == "Sniper"
+        assert only.model_id == str(fighter.pk)
+        assert f"clear the spare “Sniper” from {fighter}" in "\n".join(found.preview())
+
+    def test_the_line_it_names_is_really_on_the_page(self, doubled):
+        gang, fighter, _, _, _ = doubled
+
+        drawn = gang_state(gang)["models"][str(fighter.pk)]["equipment"]
+
+        assert ("Sniper", find().found[0].line_rating) in drawn
+
+
+class TestClearingThem:
+    def test_the_row_goes(self, doubled):
+        _, _, _, _, spare = doubled
+
+        apply(find())
+
+        assert not Assignment.objects.filter(pk=spare.pk).exists()
+
+    def test_the_line_goes_and_nothing_else_moves(self, doubled):
+        gang, fighter, _, _, _ = doubled
+        before = gang_state(gang)
+
+        apply(find())
+
+        after = gang_state(gang)
+        gone = [
+            line
+            for line in before["models"][str(fighter.pk)]["equipment"]
+            if line not in after["models"][str(fighter.pk)]["equipment"]
+        ]
+        assert [name for name, _ in gone] == ["Sniper"]
+        before["models"][str(fighter.pk)]["equipment"].remove(gone[0])
+        assert before == after
+
+    def test_the_settled_answer_is_untouched(self, doubled):
+        _, fighter, _, _, _ = doubled
+        settled_row = Assignment.objects.get(
+            miniature=fighter, pickable__isnull=False, archived=False
+        )
+
+        apply(find())
+
+        settled_row.refresh_from_db()
+        assert settled_row.pickable.name == "Medic"
+
+    def test_what_the_sibling_grants_still_arrives(self, doubled):
+        """The skill was never doubled and must not now be halved."""
+        gang, fighter, _, _, _ = doubled
+
+        apply(find())
+
+        assert "Medicate" in gang_state(gang)["models"][str(fighter.pk)]["skills"]
+
+    def test_the_gang_still_reconciles(self, doubled):
+        gang, _, _, _, _ = doubled
+
+        apply(find())
+
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_second_run_finds_nothing(self, doubled):
+        apply(find())
+
+        assert find().nothing_here
+
+
+class TestAClickThatLandedMoreThanTwice:
+    """Two spares of one name on one model draw two identical lines.
+    Which line belongs to which row is not a question worth asking —
+    both go, and the page is held to losing exactly two."""
+
+    @pytest.fixture
+    def twice_over(self, doubled):
+        gang, fighter, anchor, specs, spare = doubled
+        second = Assignment.objects.create(
+            specialisation=specs["Sniper"],
+            miniature=fighter,
+            caused_by=anchor,
+            gang_root=gang,
+        )
+        return gang, fighter, specs, [spare, second]
+
+    def test_both_are_found(self, twice_over):
+        _, _, _, spares = twice_over
+
+        found = find()
+
+        assert found.ok
+        assert {spare.assignment_id for spare in found.found} == {
+            row.pk for row in spares
+        }
+
+    def test_both_lines_go_and_nothing_else_moves(self, twice_over):
+        gang, fighter, _, _ = twice_over
+        before = gang_state(gang)
+        drawn = before["models"][str(fighter.pk)]["equipment"]
+        assert len([line for line in drawn if line[0] == "Sniper"]) == 2
+
+        apply(find())
+
+        after = gang_state(gang)
+        assert not [
+            line
+            for line in after["models"][str(fighter.pk)]["equipment"]
+            if line[0] == "Sniper"
+        ]
+        for line in [line for line in drawn if line[0] == "Sniper"]:
+            drawn.remove(line)
+        assert before == after
+
+
+class TestWhatItRefuses:
+    def test_a_thing_owned_under_the_same_name_is_not_touched(self, doubled):
+        """One spare and two lines of its name means something a player
+        owns shares it, and which line would go is not settled."""
+        gang, fighter, _, _, _ = doubled
+        drawn = gang_state(gang)["models"][str(fighter.pk)]["equipment"]
+        assert len([line for line in drawn if line[0] == "Sniper"]) == 1
+        # A real piece of kit that happens to wear the same name.
+        buy(fighter, thing=create_wargear("Sniper", price=10), paid=10)
+
+        found = find()
+
+        assert not found.ok
+        assert any("is not settled" in p for p in found.problems)
+
+    def test_the_only_answer_is_not_a_spare(self, settled):
+        """Without a sibling standing, the row *is* the answer, and
+        clearing it would take a player's choice away."""
+        gang, fighter, anchor, specs = settled
+        Assignment.objects.filter(
+            miniature=fighter, pickable__isnull=False, archived=False
+        ).delete()
+        Assignment.objects.create(
+            specialisation=specs["Sniper"],
+            miniature=fighter,
+            caused_by=anchor,
+            gang_root=gang,
+        )
+
+        found = find()
+
+        assert not found.ok
+        assert any("is the answer rather than a spare" in p for p in found.problems)
+        with pytest.raises(Refused):
+            apply(found)
+
+    def test_a_row_with_something_hanging_off_it_is_refused(self, doubled):
+        gang, fighter, _, specs, spare = doubled
+        Assignment.objects.create(
+            specialisation=specs["Medic"],
+            miniature=fighter,
+            caused_by=spare,
+            gang_root=gang,
+        )
+
+        found = find()
+
+        assert not found.ok
+        assert any("hangs off the spare" in p for p in found.problems)
+
+    def test_a_row_that_was_paid_for_is_refused(self, doubled):
+        gang, _, _, _, spare = doubled
+        LedgerEntry.objects.create(assignment=spare, list_price=25, paid=25)
+
+        found = find()
+
+        assert not found.ok
+        assert any("25 credits paid" in p for p in found.problems)
+
+    def test_a_row_counting_towards_what_the_gang_is_worth_is_refused(self, doubled):
+        _, _, _, _, spare = doubled
+        LedgerEntry.objects.create(assignment=spare, rating_contribution=25)
+
+        found = find()
+
+        assert not found.ok
+        assert any("of the gang's worth" in p for p in found.problems)
+
+    def test_a_page_that_moves_further_than_promised_ends_the_run(self, doubled):
+        """The proof is the page minus the named lines. A spare is only
+        safe to delete because the conversion left the kind it names
+        carrying nothing; one that has been given something back takes
+        that away with it, and the run unwinds rather than commit it."""
+        gang, fighter, _, specs, spare = doubled
+        modifier(
+            "Sniper: its skill again",
+            targets_model(),
+            ef_adds(create_skill("Overwatch")),
+            carried_by=specs["Sniper"],
+        )
+        found = find()
+        assert "Overwatch" in gang_state(gang)["models"][str(fighter.pk)]["skills"]
+
+        with pytest.raises(Refused) as refused:
+            apply(found)
+
+        assert "Overwatch" in str(refused.value)
+        assert Assignment.objects.filter(pk=spare.pk).exists()


### PR DESCRIPTION
The first half of tidying up after the conversions: clearing the handful
of answers a doubled click left standing.

Stacked on #2273 — review that one first; this PR's diff is its own last
commit.

## What a spare is

A question answered twice in the same moment left two rows where one
belongs. The picker settled the question from the page it had drawn, so
two answers in flight together each found nothing to replace. (That race
is fixed; these are the rows it left behind before it was.)

The second row settles nothing — the question already reads as answered
by its sibling — but it is still an assignment naming a thing, so the
model's gear list draws a line for it. That line is the whole of what a
player sees, and it is wrong: it is named after a sort of question
rather than after anything anybody owns. What the row would grant
arrives once regardless, because the sibling grants it too. It was never
paid for and adds nothing to what the gang is worth.

Four such rows stand, on three gangs, and while any of them does, the
kinds they name cannot be retired.

## Clearing means deleting

They are not history. An answer a player took back is archived and kept;
these were never taken back. Archiving them instead would only hand the
same rows to the sweep, which would faithfully turn each into a second
pick.

## The proof, which is different from the others here

Every other deletion in this programme proves that nothing a reader sees
moves. This one *means* to move something. So the reading names each
line it would take away, up front, and the run holds itself to removing
exactly those: the pages afterwards must equal the pages beforehand
minus those lines, or it unwinds.

Which lines go is settled per model and name rather than per row,
because a click that landed three times draws three identical lines. If
a page draws more lines of that name than there are spares to account
for, something a player owns shares the name and the run refuses rather
than guess which to remove.

A row is only touched if it is plainly spare. It is left alone when:

- nothing else answers its question — then it *is* the answer, and
  clearing it would take a player's choice away;
- it was paid for, or counts towards what the gang is worth;
- anything hangs off it.

## Checked

- Full n26 suite: 3918 passed. 17 new tests covering the finding, the
  clearing, the doubled-twice case, and each refusal.
- Read against production, read-only: 0 problems, exactly 4 spares
  across 3 gangs, each drawing a line worth nothing — including one
  model carrying two of them, which is the case that made the
  per-model-and-name rule necessary. An earlier one-line-per-row rule
  refused on it.

## Trying it

Maintenance console → "n26: the answers a doubled click left behind are
cleared". It lists every line it would take away before you confirm.

## What comes next

Deleting the emptied kind rows, the fossil menus and offers — which can
only run once these four are gone, since a kind cannot be deleted while
anything names it.
