### PR TITLE
feat: what the conversions left standing can be deleted

### DIFF
--- a/.claude/notes/conversion-cleanup-order.md
+++ b/.claude/notes/conversion-cleanup-order.md
@@ -36,9 +36,12 @@ Measured against production, 2026-08-22:
   money and no rating, nothing hangs off them, and the skill they grant
   is drawn once regardless. **Decision taken: clear them.** Removing
   them removes four wrong lines and changes nothing else.
-- **3 menu collections**, **1 detached fossil offer**, and the general
-  Specialisation Offer hidden — which has never been held by any
-  assignment, so no route creates a new row of any retired kind.
+- **4 menu collections** holding 22 entries, **1 detached fossil
+  offer**, and the general Specialisation Offer hidden — never held by
+  any assignment, so no route creates a new row of any retired kind.
+  Note the two markers whose names differ only in case: one of them
+  *is* held. Two placements aim at a menu from markers that profiles are
+  built with; only the placements are dead.
 
 ## The order
 
@@ -47,8 +50,18 @@ Measured against production, 2026-08-22:
 1. ~~The double-submit fix.~~ Merged. It was a genuine race: the picker
    replaced what stood, but decided that from the page it had drawn, so
    two answers in flight together each found nothing to replace.
-2. **The archived-answers sweep.** Open. This is the gate: the kinds
-   cannot be retired while rows name them.
+2. ~~The archived-answers sweep.~~ Merged, and merged again with the
+   rewording it has to own up to. This is the gate: the kinds cannot be
+   retired while rows name them.
+
+   Its first run **refused**, which is the proof working. 34 of the 399
+   answers move a word: dropped gang legacies, which sit in the
+   archetype column because that column holds two unrelated systems, so
+   their history calls the house an "archetype" where the pick says
+   "gang legacy". That is the truthful word and the one the same gang's
+   *kept* legacies already use, so the sweep now declares the rewording
+   and counts it on the page before anybody agrees to the run, and
+   refuses every other word that moves.
 3. ~~The authoring menu retirement.~~ Merged.
 4. **The timeout revert** — not started. The Cloud Run request timeout
    and the task ack deadline move together or not at all. Raised for a
@@ -60,26 +73,48 @@ Measured against production, 2026-08-22:
 
 ### Wave 2 — the library cleanup
 
-6. One operation, the pilot retirement's shape, doing two things:
-   - **clear the four live spares** (found by query: live, not
-     `removes`, naming an old kind, with a settled sibling answering the
-     same anchor). This changes four pages, which is the point;
-   - **delete the emptied rows**: 26 kind rows, 3 menu collections, the
-     detached fossil offer, the general hidden and its detached granter.
+Two operations rather than one, because they carry different risks and
+the second cannot run until the first has.
 
-   It must run after the sweep, because deleting a kind row refuses
+6. **Clear the spares.** Four live answers a doubled click left beside
+   the one that settled the question, on three gangs. Each draws a line
+   on a model's gear list named after the question rather than after
+   anything owned. Found by query: live, not `removes`, naming an old
+   kind, with a settled sibling on the same anchor, carrying no money
+   and no worth, nothing hanging off it.
+
+   Alone among these operations it *means* to change a page, so it names
+   each line beforehand and proves the pages afterwards equal the pages
+   before minus exactly those. Which lines go is settled per model and
+   name, not per row: one model carries two spares of one name and so
+   draws two identical lines, and a page drawing more of a name than
+   there are spares to account for means something owned shares it.
+
+7. **Delete what is left.** Library only, so the proof is that no page
+   moves at all. Measured on a fork of the mirror: 25 kind rows, 22 menu
+   entries, 4 menus, 6 modifiers, 1 marker.
+
+   What it leaves, and why — each said on its own page:
+   - the one archetype still carrying a modifier (see 5);
+   - the two markers profiles are **built with**. Nobody holding a
+     marker is not the same as nothing naming it; only what hands a
+     marker over or takes it away goes with it;
+   - an offer whose carrier somebody holds, being a question drawn on
+     their card, and any menu it still asks from.
+
+   Both must run after the sweep, because deleting a kind row refuses
    while anything names it.
 
 ### Wave 3
 
-7. **Re-sync the content mirror from production.** After 5 and 6, so the
+8. **Re-sync the content mirror from production.** After 5, 6 and 7, so the
    mirror inherits the tidy library. The mirror is currently
    unconverted — it still holds the old offers and only the
    pre-existing slot types — which is why 8 waits on this.
 
 ### Wave 4
 
-8. **Retire the conversion modules and their console operations.** Slug
+9. **Retire the conversion modules and their console operations.** Slug
    registered with `view=None`, code deleted, the way the wargear merge
    went. Waits on the mirror: until it is re-synced, every local
    database forks unconverted and needs the conversions as its route
@@ -87,18 +122,18 @@ Measured against production, 2026-08-22:
 
 ### Wave 5 — planned separately
 
-9. **Drop the three kinds and their columns.** Across 21 files and every
+10. **Drop the three kinds and their columns.** Across 21 files and every
    parallel registry the library keeps: `ASSIGNABLE_FIELDS` and the
    Assignment columns, `OFFERABLE_KINDS`, the ingest sheets and their
    four tables, the specs and authoring pages, collection entries, the
    selector algebra, card building, history, sample data — plus a
    migration dropping three columns and three tables. Startup checks
    enforce the registries agreeing, so a half-done version will not
-   boot. Needs 6 (no rows), 7 and 8 (no code), and the sweep (no data).
+   boot. Needs 6 and 7 (no rows), 8 and 9 (no code), and the sweep (no data).
 
 ### After the programme
 
-10. **Gangless models.** Deleting a gang leaves its models behind,
+11. **Gangless models.** Deleting a gang leaves its models behind,
     belonging to nobody and reachable by nothing. The design log records
     that a miniature library — models independent of a gang — was
     considered and dropped, so these are residue of a rejected concept
@@ -139,6 +174,17 @@ themselves here:
 - **Measure before choosing.** Folding a gang's story costs 287ms;
   building its pages costs 1458ms. That measurement decided the sweep's
   design.
+- **Rehearse at the library's real shape.** Running the whole chain on a
+  fork of the mirror caught two things no test had: a crash from
+  assuming a model names its profile directly, and a marker rule that
+  would have deleted markers profiles are built with — stopped only by
+  the database's own protection. Both were invisible in a sandbox built
+  by hand, because a hand-built world has only what the test remembered
+  to put in it.
+- **Ask every field, not the ones you remember.** A reverse-relation
+  scan misses everything declared `related_name="+"`, which this library
+  uses throughout; the first survey read as "nothing references these"
+  and was wrong. Scan forward from every model instead.
 - **Reproduce the failure your fix fixes.** The double-submit fix was
   nearly shipped against three tests that passed on the unfixed code —
   sequential posts are serialised, so they proved nothing. Only real

--- a/n26/library/retired_kinds.py
+++ b/n26/library/retired_kinds.py
@@ -1,0 +1,508 @@
+"""What the conversions left standing, and deleting it.
+
+Moving the hand-built choice systems onto slots and picks left their old
+machinery behind on purpose: a conversion proves that nothing a reader
+sees moves, and deleting rows is a different job with a different risk.
+This is that job.
+
+What stands is a library of things nothing uses. The kind rows the
+conversions emptied — their modifiers moved onto pickables, so each is a
+name and nothing else. The menus those kinds were chosen from, which no
+question now offers. The offers themselves, detached from every carrier
+or carried by a marker nothing holds. Read from the authoring pages it
+looks like content; read from a player's page it is not there at all.
+
+**Nothing here may change a page.** That is the whole test, and it is
+what makes deleting safe to do in bulk: if these rows really are unused,
+removing them is invisible, and if any of them is doing something the
+proof says so and the run unwinds.
+
+Three rules keep the reading honest:
+
+* A kind row that still carries a modifier is doing something, whatever
+  its column says. It is left where it is and named on the page, rather
+  than deleted or made into a refusal — the run should not fail over
+  content somebody is in the middle of moving.
+* A kind row anything still names cannot be deleted at all. Those are
+  the answers the sweep and the clearing deal with, so this refuses and
+  says which, rather than running before its turn.
+* A menu is deleted only when everything in it names a retired kind and
+  nothing outside what is going asks for it. A menu holding one live
+  entry keeps its shape and loses only the entries.
+
+An effect and its modifier travel together. A modifier here is one
+scope and one effect, so removing the effect would leave a scope
+addressing nobody about nothing; the carrier it hangs on is kept unless
+it too exists solely for what is going.
+"""
+
+from dataclasses import dataclass, field
+
+from django.db import transaction
+
+
+class Refused(Exception):
+    """The world is not the one the reading found."""
+
+
+@dataclass(frozen=True)
+class Fossils:
+    """Everything that would go, by kind of row."""
+
+    kind_rows: tuple = ()
+    entries: tuple = ()
+    collections: tuple = ()
+    sections: tuple = ()
+    modifiers: tuple = ()
+    hiddens: tuple = ()
+    said: tuple = ()
+    left_alone: tuple = ()
+    gang_ids: tuple = ()
+    problems: tuple = ()
+    nothing_here: bool = False
+    counts: dict = field(default_factory=dict)
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    def preview(self):
+        if self.nothing_here:
+            return ["nothing to delete — the retired kinds have gone already"]
+        lines = list(self.said)
+        for note in self.left_alone:
+            lines.append(f"leave {note}")
+        lines.append(
+            f"prove {len(self.gang_ids)} gang"
+            f"{'' if len(self.gang_ids) == 1 else 's'} read exactly the same, "
+            "or refuse"
+        )
+        return lines
+
+
+def _kinds():
+    """The retired kinds, each with the column an assignment names it by.
+
+    Read from the assignment's own registry rather than guessed from the
+    class name: a skill tree is ``skill_tree`` there, and a rule that
+    lowercased class names would quietly find nothing.
+    """
+    from django.apps import apps
+
+    from n26.core.models.assignment import ASSIGNABLE_FIELDS
+    from n26.library.conversion.archived import OLD_COLUMNS
+
+    return [
+        (column, apps.get_model(ASSIGNABLE_FIELDS[column])) for column in OLD_COLUMNS
+    ]
+
+
+def _named_by(model, rows):
+    """The menu entries naming these, where a menu can name them at all.
+
+    Found by what a field points at rather than by what it is called:
+    a menu holds only some of the kinds, so asking for a column it does
+    not have would be an error rather than an empty answer.
+    """
+    from n26.library.models import CollectionEntry
+
+    for entry_field in CollectionEntry._meta.get_fields():
+        if not getattr(entry_field, "concrete", False):
+            continue
+        if getattr(entry_field, "related_model", None) is model:
+            return CollectionEntry.objects.filter(**{f"{entry_field.name}__in": rows})
+    return CollectionEntry.objects.none()
+
+
+def _held_carriers(effect):
+    """What carries this effect and is itself held by somebody, in words.
+
+    An effect reaches a page through its carrier, so a carrier nobody
+    holds means the effect is drawn nowhere. Empty when nothing carries
+    it, or when what does is held by no one.
+    """
+    from n26.core.models import Assignment
+    from n26.library.conversion.base import carriers_of
+    from n26.library.models import Modifier
+
+    modifier = Modifier.objects.filter(**{f"{_part_name(effect)}": effect}).first()
+    if modifier is None:
+        return ""
+    said = []
+    for _, carrier in carriers_of(modifier):
+        column = _column_for(type(carrier))
+        if column and Assignment.objects.filter(**{column: carrier}).exists():
+            said.append(str(carrier))
+    return ", ".join(sorted(said))
+
+
+def _part_name(effect):
+    """The field a modifier holds this sort of effect in."""
+    from n26.library.models import Modifier
+
+    for one_to_one in Modifier._meta.get_fields():
+        if not getattr(one_to_one, "concrete", False):
+            continue
+        if getattr(one_to_one, "related_model", None) is type(effect):
+            return one_to_one.name
+    raise ValueError(f"no modifier holds a {type(effect).__name__}")
+
+
+def _anything_naming(row, doomed):
+    """What still names this row once everything going has gone.
+
+    Asked of every model and every field that points here rather than of
+    a list somebody remembered to write: a marker is named by the
+    assignments holding it, by the grants that hand it over, and by the
+    built-in kit of every profile it comes with, and only the first of
+    those is obvious. What is itself being deleted does not count.
+    """
+    from django.apps import apps
+
+    found = []
+    for model in apps.get_models():
+        if model._meta.auto_created:
+            continue
+        for pointing in model._meta.get_fields():
+            if not getattr(pointing, "is_relation", False):
+                continue
+            if not (
+                getattr(pointing, "concrete", False)
+                or getattr(pointing, "many_to_many", False)
+            ):
+                continue
+            if getattr(pointing, "related_model", None) is not type(row):
+                continue
+            here = model.objects.filter(**{pointing.name: row})
+            spared = doomed.get(model, set())
+            if spared:
+                here = here.exclude(pk__in=spared)
+            count = here.count()
+            if count:
+                found.append(f"{count} {model._meta.verbose_name_plural}")
+    return ", ".join(sorted(found))
+
+
+def _column_for(model):
+    """The assignment column naming this kind of thing, if there is one."""
+    from django.apps import apps
+
+    from n26.core.models.assignment import ASSIGNABLE_FIELDS
+
+    for column, label in ASSIGNABLE_FIELDS.items():
+        if apps.get_model(label) is model:
+            return column
+    return ""
+
+
+def find():
+    """Read what is left of the retired kinds. Never writes."""
+    from django.contrib.contenttypes.models import ContentType
+
+    from n26.core.models import Assignment
+    from n26.library.models import (
+        AddsAssignable,
+        Collection,
+        CollectionEntry,
+        CollectionSection,
+        Hidden,
+        Modifier,
+        OffersChoice,
+        PlacesCategory,
+        RemovesAssignable,
+    )
+
+    problems = []
+    left_alone = []
+    said = []
+
+    doomed_kinds = []
+    for column, model in _kinds():
+        for row in model.objects.all().order_by("name"):
+            held = Assignment.objects.filter(**{column: row}).count()
+            if held:
+                problems.append(
+                    f"{held} assignment{'' if held == 1 else 's'} still name "
+                    f"“{row}”, so it cannot be deleted yet"
+                )
+                continue
+            carried = row.modifiers.count()
+            if carried:
+                left_alone.append(
+                    f"“{row}” where it is: it still carries "
+                    f"{carried} modifier{'' if carried == 1 else 's'}, so it "
+                    "is doing something whatever its column says"
+                )
+                continue
+            doomed_kinds.append(row)
+
+    if problems:
+        return Fossils(problems=tuple(problems))
+
+    # The entries of a menu that name one of those, and the menus that
+    # are nothing but such entries.
+    entries = []
+    for _, model in _kinds():
+        here = [row for row in doomed_kinds if isinstance(row, model)]
+        if here:
+            entries += list(_named_by(model, here).select_related("collection"))
+    doomed_entries = {entry.pk for entry in entries}
+
+    # An offer of a retired kind that somebody is carrying is still a
+    # question on their card, unanswerable but drawn. Deleting it would
+    # take a line off a page, which is not this to do.
+    kinds = ContentType.objects.filter(
+        app_label="library",
+        model__in=[model._meta.model_name for _, model in _kinds()],
+    )
+    offers = []
+    standing = []
+    for offer in OffersChoice.objects.filter(of_kind__in=kinds).select_related(
+        "from_section"
+    ):
+        carried_by = _held_carriers(offer)
+        if carried_by:
+            standing.append(offer)
+            left_alone.append(
+                f"the offer on “{carried_by}”: somebody holds it, so it is a "
+                "question on a card rather than a fossil"
+            )
+            continue
+        offers.append(offer)
+
+    kept_sections = {
+        offer.from_section_id for offer in standing if offer.from_section_id
+    }
+    collections = []
+    for collection in Collection.objects.filter(
+        pk__in={entry.collection_id for entry in entries}
+    ).order_by("name"):
+        held = set(
+            CollectionEntry.objects.filter(collection=collection).values_list(
+                "pk", flat=True
+            )
+        )
+        if held - doomed_entries:
+            left_alone.append(
+                f"the menu “{collection}”: not everything in it names a "
+                "retired kind, so it loses those entries and keeps its shape"
+            )
+            continue
+        asked_of = set(
+            CollectionSection.objects.filter(collection=collection).values_list(
+                "pk", flat=True
+            )
+        )
+        if asked_of & kept_sections:
+            left_alone.append(
+                f"the menu “{collection}”: an offer somebody holds still asks "
+                "from it, so it keeps its shape"
+            )
+            continue
+        collections.append(collection)
+    sections = list(CollectionSection.objects.filter(collection__in=collections))
+
+    for offer in OffersChoice.objects.filter(from_section__in=sections):
+        if offer not in offers:
+            problems.append(
+                f"“{offer.modifier}” asks for a menu that would go but is "
+                "not an offer of a retired kind, so the menu is not dead"
+            )
+    places = list(PlacesCategory.objects.filter(section__in=sections))
+
+    if problems:
+        return Fossils(problems=tuple(problems))
+
+    modifiers = {
+        row.pk: row
+        for row in Modifier.objects.filter(offers_choice__in=offers)
+        | Modifier.objects.filter(places_category__in=places)
+    }
+
+    # A marker carrying nothing but what is going, and held by nobody, is
+    # part of what is going. Whatever grants or takes it away then names
+    # something that will not exist, so those go with it.
+    hiddens = []
+    for hidden in Hidden.objects.filter(modifiers__in=modifiers.values()).distinct():
+        others = hidden.modifiers.exclude(pk__in=modifiers).count()
+        if others:
+            left_alone.append(
+                f"the marker “{hidden}”: it carries {others} other "
+                f"modifier{'' if others == 1 else 's'}"
+            )
+            continue
+        # Whatever hands this marker over or takes it away exists for it
+        # alone and goes with it, so neither counts as a reason to keep
+        # it. Everything else naming it does, and the one that matters
+        # most is the built-in kit of a profile it comes with.
+        handers = {
+            naming: set(
+                naming.objects.filter(hidden=hidden).values_list("pk", flat=True)
+            )
+            for naming in (AddsAssignable, RemovesAssignable)
+        }
+        named_by = _anything_naming(hidden, {**handers, Modifier: set(modifiers)})
+        if named_by:
+            left_alone.append(f"the marker “{hidden}”: {named_by} still name it")
+            continue
+        hiddens.append(hidden)
+
+    for row in Modifier.objects.filter(
+        adds_assignable__in=AddsAssignable.objects.filter(hidden__in=hiddens)
+    ) | Modifier.objects.filter(
+        removes_assignable__in=RemovesAssignable.objects.filter(hidden__in=hiddens)
+    ):
+        modifiers[row.pk] = row
+
+    # Every gang that could possibly notice: one holding a marker whose
+    # modifier is going, or a model of a profile carrying one.
+    gang_ids = _gangs_touched(modifiers.values())
+
+    for row in doomed_kinds:
+        said.append(f"delete the emptied {type(row).__name__.lower()} “{row}”")
+    if entries:
+        said.append(
+            f"delete {len(entries)} menu entr{'y' if len(entries) == 1 else 'ies'} "
+            "naming them"
+        )
+    for collection in collections:
+        said.append(f"delete the menu “{collection}” and its sections")
+    for modifier in sorted(modifiers.values(), key=str):
+        said.append(f"delete the modifier “{modifier}”, which nothing needs")
+    for hidden in hiddens:
+        said.append(f"delete the marker “{hidden}”, which nothing holds")
+
+    if not (doomed_kinds or entries or collections or modifiers or hiddens):
+        return Fossils(nothing_here=True, left_alone=tuple(left_alone))
+
+    return Fossils(
+        kind_rows=tuple((type(row), row.pk) for row in doomed_kinds),
+        entries=tuple(entry.pk for entry in entries),
+        collections=tuple(collection.pk for collection in collections),
+        sections=tuple(section.pk for section in sections),
+        modifiers=tuple(modifiers),
+        hiddens=tuple(hidden.pk for hidden in hiddens),
+        said=tuple(said),
+        left_alone=tuple(left_alone),
+        gang_ids=tuple(gang_ids),
+        counts={
+            "kind rows": len(doomed_kinds),
+            "menu entries": len(entries),
+            "menus": len(collections),
+            "modifiers": len(modifiers),
+            "markers": len(hiddens),
+        },
+    )
+
+
+def _gangs_touched(modifiers):
+    """Every gang a modifier being deleted could reach.
+
+    A modifier hangs on a carrier and reaches a page through whoever
+    holds that carrier — a marker, a subtype, a profile alike, since
+    being hired as one is holding it. Asked of every kind of carrier
+    rather than a chosen few: a carrier nobody thought of is a gang the
+    proof would not have looked at.
+    """
+    from n26.core.models import Assignment
+    from n26.library.conversion.base import carriers_of
+
+    gangs = set()
+    for modifier in modifiers:
+        for _, carrier in carriers_of(modifier):
+            column = _column_for(type(carrier))
+            if not column:
+                continue
+            gangs |= set(
+                Assignment.objects.filter(**{column: carrier})
+                .values_list("gang_root_id", flat=True)
+                .distinct()
+            )
+    gangs.discard(None)
+    return sorted(gangs, key=str)
+
+
+def _delete_parts_of(modifiers):
+    """Delete each modifier's scope and effect, taking it with them."""
+    from n26.library.models import Modifier
+
+    parts = [
+        one_to_one.name
+        for one_to_one in Modifier._meta.get_fields()
+        if getattr(one_to_one, "one_to_one", False)
+        and getattr(one_to_one, "concrete", False)
+    ]
+    for modifier in list(modifiers):
+        for part in parts:
+            held = getattr(modifier, part, None)
+            if held is not None:
+                held.delete()
+
+
+def apply(fossils):
+    """Delete exactly what was read, and prove every page unmoved."""
+    from django.db.models import ProtectedError
+
+    from n26.core.capture import differences, gang_state
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+    from n26.library.conversion.base import _one_snapshot
+    from n26.library.models import (
+        Collection,
+        CollectionEntry,
+        CollectionSection,
+        Hidden,
+        Modifier,
+    )
+
+    if fossils.problems:
+        raise Refused("not deleted: " + "; ".join(fossils.problems))
+    if fossils.nothing_here:
+        return list(fossils.preview())
+
+    report = list(fossils.preview())
+    try:
+        with _one_snapshot(), transaction.atomic():
+            gangs = list(Gang.objects.filter(pk__in=fossils.gang_ids))
+            before = {str(gang.pk): gang_state(gang) for gang in gangs}
+
+            # The order is what protects what. An offer names the menu
+            # section it asks from, and a grant names the marker it
+            # hands over, so both have to go before the things they
+            # name — and a modifier owns its scope and its effect, each
+            # of which takes the modifier with it, so what is deleted is
+            # the parts rather than the modifier that would leave them
+            # behind.
+            _delete_parts_of(Modifier.objects.filter(pk__in=fossils.modifiers))
+            CollectionEntry.objects.filter(pk__in=fossils.entries).delete()
+            CollectionSection.objects.filter(pk__in=fossils.sections).delete()
+            Collection.objects.filter(pk__in=fossils.collections).delete()
+            Hidden.objects.filter(pk__in=fossils.hiddens).delete()
+            for model, pk in fossils.kind_rows:
+                model.objects.filter(pk=pk).delete()
+
+            gangs = list(Gang.objects.filter(pk__in=fossils.gang_ids))
+            after = {str(gang.pk): gang_state(gang) for gang in gangs}
+            changed = differences(before, after)
+            if changed:
+                raise Refused(
+                    "refused — what a reader is told would change:\n  "
+                    + "\n  ".join(changed[:10])
+                )
+            for gang in gangs:
+                try:
+                    assert_reconciled(gang)
+                except Exception as failed:
+                    raise Refused(
+                        f"refused — {gang} no longer reconciles: {failed}"
+                    ) from failed
+    except ProtectedError as protected:
+        # The backstop behind the enumerated checks: whatever this names
+        # is a referent nobody listed, and the answer is a refusal in
+        # words rather than a traceback.
+        raise Refused(
+            "refused — something still names what would be deleted: "
+            f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}"
+        ) from protected
+    report.append("deleted; every page reads the same")
+    return report

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -60,6 +60,7 @@ __all__ = [
     "convert_skill_tree",
     "convert_specialisation",
     "delete_nameless_gang_type",
+    "delete_retired_kinds",
     "retire_gang_legacy_pilot",
     "task_routes",
 ]
@@ -118,6 +119,10 @@ class Operation(models.TextChoices):
         "n26_clear_spare_answers",
         "n26: the answers a doubled click left behind are cleared",
     )
+    DELETE_RETIRED_KINDS = (
+        "n26_delete_retired_kinds",
+        "n26: what the conversions left standing is deleted",
+    )
     MERGE_WARGEAR_INTO_WEAPON = (
         "n26_merge_wargear_into_weapon",
         "n26: duplicated wargear becomes its weapon",
@@ -134,6 +139,7 @@ LOCK_KEYS = {
     Operation.DELETE_NAMELESS_GANG_TYPE: 826_020_606,
     Operation.SWEEP_ARCHIVED: 826_020_607,
     Operation.CLEAR_SPARE_ANSWERS: 826_020_608,
+    Operation.DELETE_RETIRED_KINDS: 826_020_609,
 }
 
 
@@ -396,6 +402,25 @@ def clear_spare_answers(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def delete_retired_kinds(backfill_id, **said_by_whoever_enqueued_it):
+    """Delete what the conversions left standing, and record it.
+
+    The runner discipline of a conversion around work that deletes
+    library rows only. Nothing a player holds is touched, which is why
+    what it proves is that no page moves at all.
+    """
+    from n26.library.retired_kinds import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.DELETE_RETIRED_KINDS,
+        "Retired kinds deletion",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
 def _who_asked(backfill_id):
     """The operator a run acts as, for the history it writes.
 
@@ -584,6 +609,25 @@ SPARE_WORDS = {
     "refuses_heading": "The clearing refuses",
     "button": "Clear the spares",
     "confirm": "Delete these spare answers? This cannot be undone.",
+}
+
+RETIRED_KIND_WORDS = {
+    "noun": "deletion",
+    "intro": (
+        "This deletes library rows and nothing a player holds: the kind rows "
+        "the conversions emptied, the menus those kinds were chosen from, and "
+        "the offers nothing carries. Every row it would delete is listed "
+        "below, along with anything it leaves alone and why. Because none of "
+        "it is in use, no page should move at all — and that is what it "
+        "proves before committing. It refuses while any answer still names a "
+        "retired kind, which the sweep and the clearing deal with first."
+    ),
+    "nothing_heading": "Nothing to delete",
+    "nothing_flash": "There was nothing to delete.",
+    "nothing_words": "The retired kinds have gone already.",
+    "refuses_heading": "The deletion refuses",
+    "button": "Delete what is left",
+    "confirm": "Delete these library rows? This cannot be undone.",
 }
 
 NAMELESS_WORDS = {
@@ -782,6 +826,19 @@ def clear_spare_answers_view(request):
     )
 
 
+def delete_retired_kinds_view(request):
+    """Preview the deletion (GET), or record a run and enqueue it."""
+    from n26.library.retired_kinds import find
+
+    return _deletion_view(
+        request,
+        Operation.DELETE_RETIRED_KINDS,
+        find,
+        delete_retired_kinds,
+        RETIRED_KIND_WORDS,
+    )
+
+
 def delete_nameless_gang_type_view(request):
     """Preview the deletion (GET), or record a run and enqueue it."""
     from n26.library.nameless_gang_type import find
@@ -925,6 +982,21 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.DELETE_RETIRED_KINDS.value,
+        name=Operation.DELETE_RETIRED_KINDS.label,
+        description=(
+            "Delete what the conversions left behind: the emptied kind rows, "
+            "the menus nothing offers from, and the detached offers. All "
+            "library, none of it in use, so it proves that no page moves at "
+            "all. Runs after the sweep and the clearing, which take the last "
+            "answers off those kinds."
+        ),
+        view=delete_retired_kinds_view,
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a conversion holds one
 #: transaction for as long as proving its spread of gangs takes. It is also
@@ -942,6 +1014,7 @@ task_routes = [
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
     TaskRoute(sweep_archived, ack_deadline=600, min_retry_delay=60),
     TaskRoute(clear_spare_answers, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(delete_retired_kinds, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/tests/sandbox/test_retired_kinds.py
+++ b/n26/tests/sandbox/test_retired_kinds.py
@@ -1,0 +1,275 @@
+"""Deleting what the conversions left standing.
+
+A conversion moves a system onto slots and picks and deletes nothing, so
+its old machinery is still there afterwards: kind rows with their
+modifiers moved away, the menu they were chosen from, the offer that
+asked the question. None of it reaches a page any more, which is both
+why it can go and how the going is proved — nothing a reader is told may
+move.
+"""
+
+import pytest
+
+from n26.core.capture import gang_state
+from n26.core.models import Assignment
+from n26.library.authoring import add_section
+from n26.library.conversion import apply as apply_conversion
+from n26.library.conversion import plan_specialisation
+from n26.library.conversion.archived import apply_archived, plan_archived
+from n26.library.models import (
+    Collection,
+    CollectionEntry,
+    Hidden,
+    Modifier,
+    Profile,
+    Specialisation,
+)
+from n26.library.retired_kinds import Refused, apply, find
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    add_entry,
+    choose,
+    create_collection,
+    create_default_set,
+    create_gang_type,
+    create_hidden,
+    create_profile,
+    create_skill,
+    create_specialisation,
+    create_subtype,
+    ef_adds,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    remove,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def converted(default_pack, person_type, owner):
+    """A specialisation system with a menu, converted, and the answer a
+    gang took back swept across — the state this deletion runs in."""
+    specs = {}
+    for name, skill in [("Sniper", "Precision Shot"), ("Medic", "Medicate")]:
+        specs[name] = create_specialisation(name)
+        modifier(
+            f"{name}: its skill",
+            targets_model(),
+            ef_adds(create_skill(skill)),
+            carried_by=specs[name],
+        )
+    menu = create_collection("Specialisations")
+    section = add_section(menu, "Specialisation")
+    for spec in specs.values():
+        add_entry(menu, spec)
+
+    specialist = create_subtype("Specialist")
+    modifier(
+        "Specialist: offers a choice of specialisation",
+        targets_model(),
+        offers_choice(Specialisation),
+        carried_by=specialist,
+    )
+    # The general offer, narrowed to the menu and hung on a marker
+    # nobody holds. A conversion will not touch an offer that names a
+    # section, so this is what it leaves behind for the deletion.
+    marker = create_hidden("Specialisation Offer")
+    modifier(
+        "Specialisation Offer: offers a choice of specialisation",
+        targets_model(),
+        offers_choice(Specialisation, from_section=section),
+        carried_by=marker,
+    )
+    gang_type = create_gang_type("Enforcers", starting_credits=2000)
+    profile = create_profile("Patrol Officer", person_type, gang_type, price=50)
+    profile.built_ins = create_default_set("Officer kit", members=[specialist])
+    profile.save()
+
+    gang = found_gang("The Watch", gang_type, owner=owner, budget=2000)
+    fighter = hire(gang, profile, "Vex", paid=50)
+    anchor = Assignment.objects.get(subtype=specialist, miniature=fighter)
+    choose(anchor, specs["Sniper"])
+    remove(Assignment.objects.get(specialisation=specs["Sniper"], miniature=fighter))
+    choose(anchor, specs["Medic"])
+
+    apply_conversion(plan_specialisation())
+    apply_archived(plan_archived())
+    return gang, fighter, specs, menu
+
+
+class TestWhatItWouldDelete:
+    def test_it_names_the_emptied_kinds_the_menu_and_the_offer(self, converted):
+        _, _, specs, menu = converted
+
+        fossils = find()
+
+        assert fossils.ok and not fossils.nothing_here
+        said = "\n".join(fossils.preview())
+        assert "delete the emptied specialisation “Sniper”" in said
+        assert "delete the emptied specialisation “Medic”" in said
+        assert f"delete the menu “{menu}” and its sections" in said
+        assert "Specialisation Offer: offers a choice of specialisation" in said
+        assert "delete the marker “Specialisation Offer”" in said
+        assert fossils.counts["kind rows"] == 2
+        assert fossils.counts["menu entries"] == 2
+        assert fossils.counts["menus"] == 1
+
+    def test_a_kind_still_carrying_something_is_left_where_it_is(self, converted):
+        _, _, specs, _ = converted
+        modifier(
+            "Sniper: something new",
+            targets_model(),
+            ef_adds(create_skill("Overwatch")),
+            carried_by=specs["Sniper"],
+        )
+
+        fossils = find()
+
+        assert fossils.ok
+        assert any(
+            "“Sniper” where it is: it still carries 1 modifier" in note
+            for note in fossils.left_alone
+        )
+        assert "delete the emptied specialisation “Sniper”" not in "\n".join(
+            fossils.preview()
+        )
+
+
+class TestDeletingIt:
+    def test_the_rows_go(self, converted):
+        _, _, _, menu = converted
+
+        apply(find())
+
+        assert not Specialisation.objects.exists()
+        assert not CollectionEntry.objects.filter(collection=menu).exists()
+        assert not Collection.objects.filter(pk=menu.pk).exists()
+        assert not Modifier.objects.filter(
+            name="Specialisation Offer: offers a choice of specialisation"
+        ).exists()
+        assert not Hidden.objects.filter(name="Specialisation Offer").exists()
+
+    def test_no_page_moves(self, converted):
+        gang, _, _, _ = converted
+        before = gang_state(gang)
+
+        apply(find())
+
+        assert gang_state(gang) == before
+
+    def test_the_pick_that_replaced_the_choice_still_stands(self, converted):
+        gang, fighter, _, _ = converted
+
+        apply(find())
+
+        drawn = gang_state(gang)["models"][str(fighter.pk)]
+        assert ("Specialisation", "Medic") in drawn["choices"]
+        assert "Medicate" in drawn["skills"]
+
+    def test_the_answer_the_sweep_moved_is_untouched(self, converted):
+        """It is a pick now, so nothing here names it."""
+        apply(find())
+
+        taken_back = Assignment.objects.get(archived=True, pickable__isnull=False)
+        assert taken_back.pickable.name == "Sniper"
+
+    def test_a_second_run_finds_nothing(self, converted):
+        apply(find())
+
+        assert find().nothing_here
+
+
+class TestWhatItRefuses:
+    def test_it_will_not_run_before_the_sweep(self, default_pack, person_type, owner):
+        """An answer still naming a kind means the sweep has not run, and
+        the kind cannot go while anything names it."""
+        spec = create_specialisation("Sniper")
+        specialist = create_subtype("Specialist")
+        modifier(
+            "Specialist: offers a choice of specialisation",
+            targets_model(),
+            offers_choice(Specialisation),
+            carried_by=specialist,
+        )
+        gang_type = create_gang_type("Enforcers", starting_credits=2000)
+        profile = create_profile("Patrol Officer", person_type, gang_type, price=50)
+        profile.built_ins = create_default_set("Officer kit", members=[specialist])
+        profile.save()
+        gang = found_gang("The Watch", gang_type, owner=owner, budget=2000)
+        fighter = hire(gang, profile, "Vex", paid=50)
+        choose(Assignment.objects.get(subtype=specialist, miniature=fighter), spec)
+
+        fossils = find()
+
+        assert not fossils.ok
+        assert any(
+            "1 assignment still name “Sniper”" in problem
+            for problem in fossils.problems
+        )
+        with pytest.raises(Refused):
+            apply(fossils)
+
+    def test_a_menu_holding_something_live_keeps_its_shape(self, converted):
+        _, _, _, menu = converted
+        add_entry(menu, create_skill("Nerves"))
+
+        fossils = find()
+
+        assert fossils.ok
+        assert any(
+            f"the menu “{menu}”: not everything in it names a retired kind" in note
+            for note in fossils.left_alone
+        )
+
+        apply(fossils)
+
+        assert Collection.objects.filter(pk=menu.pk).exists()
+        assert CollectionEntry.objects.filter(collection=menu).count() == 1
+
+    def test_a_marker_a_profile_comes_with_is_left_alone(self, converted):
+        """Nobody holding a marker is not the same as nothing naming it:
+        it can be part of what a profile arrives with, and deleting it
+        would take that away from every future hire."""
+        marker = Hidden.objects.get(name="Specialisation Offer")
+        add_built_in(Profile.objects.get(name="Patrol Officer"), marker)
+
+        fossils = find()
+
+        assert fossils.ok
+        assert any(
+            "the marker “Specialisation Offer”: 1 default assignments still name it"
+            in note
+            for note in fossils.left_alone
+        )
+
+        apply(fossils)
+
+        assert Hidden.objects.filter(pk=marker.pk).exists()
+
+    def test_an_offer_somebody_holds_is_left_alone(self, converted):
+        """An offer reaches a card through its carrier. Held by a player
+        it is a question drawn on their page — unanswerable now, but
+        theirs — and taking it away would take a line off that page."""
+        _, fighter, _, _ = converted
+        marker = Hidden.objects.get(name="Specialisation Offer")
+        Assignment.objects.create(
+            hidden=marker, miniature=fighter, gang_root=fighter.gang
+        )
+
+        fossils = find()
+
+        assert any(
+            "the offer on “Specialisation Offer”: somebody holds it" in note
+            for note in fossils.left_alone
+        )
+
+        apply(fossils)
+
+        assert Hidden.objects.filter(pk=marker.pk).exists()
+        assert Modifier.objects.filter(
+            name="Specialisation Offer: offers a choice of specialisation"
+        ).exists()


### PR DESCRIPTION
The last of the tidying: deleting the machinery the conversions left
behind.

Stacked on #2275 — review that first; this PR's diff is its own last
commit.

## What is left, and why it is still there

A conversion moves a system onto slots and picks and deliberately
deletes nothing: its job is to prove that nothing a reader sees moves,
and removing rows is a different job with a different risk. So the old
machinery is all still in place — kind rows whose modifiers moved onto
pickables, the menus those kinds were chosen from, the offers that asked
the question. From the authoring pages it reads as content. From a
player's page it is not there at all.

## Nothing here may change a page

That is the whole test, and it is what makes deleting in bulk safe: if
these rows really are unused, removing them is invisible, and if any one
of them is doing something the proof says which words moved and the run
unwinds.

## What it leaves, and why

The reading is deliberately cautious, and says out loud what it does not
touch:

- **A kind row anything still names** cannot go, so the run refuses and
  names it. Those answers belong to the sweep and the clearing, which
  run first.
- **A kind row still carrying a modifier** is doing something whatever
  its column says. It is left where it is and reported, rather than
  deleted or turned into a refusal — a run should not fail over content
  somebody is midway through moving.
- **An offer whose carrier somebody holds** is a question drawn on their
  card, unanswerable but theirs. It stays, and so does any menu it still
  asks from.
- **A marker anything still names** stays. Nobody *holding* a marker is
  not the same as nothing naming it: it can be part of the built-in kit
  a profile arrives with, and deleting it would strip that from every
  future hire. What hands a marker over or takes it away is the one
  exception — that exists for the marker alone and goes with it.
- **A menu** goes only when everything in it names a retired kind and
  nothing kept still asks from it; otherwise it loses those entries and
  keeps its shape.

## Two things the ORM shape makes easy to get wrong

A modifier *owns* its scope and its effect, and each of those takes the
modifier with it when deleted — so what gets deleted is the parts. A
modifier deleted on its own would leave both behind with nothing
pointing at them.

The order of deletion is the order of protection: an offer names the
menu section it asks from, and a grant names the marker it hands over,
so those go before the things they name.

## Checked

- Full n26 suite: 3929 passed, 11 new tests.
- **Rehearsed end to end on a fork of the content mirror**, at the real
  library's shape: the pilot retirement, all four conversions, the
  sweep, the clearing and then this, in order. It deletes 25 kind rows,
  22 menu entries, 4 menus, 6 modifiers and 1 marker; leaves the one
  archetype still carrying a modifier and the two markers that profiles
  come with, each with its reason; and a second reading finds nothing
  left.
- That rehearsal earned its keep twice. It caught a crash from assuming
  a model row names its profile directly (it does not — the profile
  arrives as an assignment), and it caught the marker rule being wrong:
  the first version would have deleted markers that profiles are built
  with, and only the database's own protection stopped it.
- Read against production, read-only, now that the sweep and the clearing
  have run there: 0 problems, and it names 25 kind rows, 22 menu entries,
  4 menus, 6 modifiers and 1 marker — leaving the one archetype that still
  carries a modifier, and the two markers held by players and built into
  48 and 3 profiles.

## How long it takes

It proves 99 gangs, being every gang that holds a carrier of a modifier
being deleted. Measured against production, a page reads in 0.8s, so
reading them before and after is about 160 seconds — well inside the
run's deadline, and that measurement is over a proxy from a laptop, so
in-cluster it is faster. Proving all of them rather than a spread is
affordable here, so it does.

## Trying it

Maintenance console → "n26: what the conversions left standing is
deleted". It lists every row it would delete and everything it leaves,
with reasons, before you confirm. It must run after the sweep and the
clearing.
