### PR TITLE
feat: the maintenance index leads with the newest repair, and says how often each has run

### DIFF
--- a/gyrinx/maintenance/registry.py
+++ b/gyrinx/maintenance/registry.py
@@ -21,6 +21,7 @@ maintenance route. Import from this module and ``gyrinx.maintenance.views``
 instead — neither touches the admin site.
 """
 
+import datetime
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -54,6 +55,12 @@ class MaintenanceOperation:
     slug: str | None = None
     #: Template rendering this operation's ``summary`` on the detail page.
     detail_template: str | None = None
+    #: The day this repair was offered, which the index sorts newest first.
+    #: One-off repairs accumulate and are nearly always run soon after being
+    #: written, so the newest is the one somebody has come to the page for.
+    #: Stated rather than derived: a repair has a date before it has ever run,
+    #: and that is exactly when it needs to be easy to find.
+    added: datetime.date | None = None
 
     @property
     def url_slug(self) -> str:

--- a/gyrinx/maintenance/templates/admin/maintenance/index.html
+++ b/gyrinx/maintenance/templates/admin/maintenance/index.html
@@ -7,6 +7,7 @@
     <style>
     .mt-page-intro { margin-bottom: 1.5rem; }
     .mt-table { width: 100%; margin-bottom: 2rem; }
+    .mt-nowrap { white-space: nowrap; }
     </style>
 {% endblock extrahead %}
 {% block content %}
@@ -16,21 +17,32 @@
         on these pages are gated to superusers and write an audit trail.
     </p>
     <h2>Available data repairs</h2>
+    <p class="mt-page-intro">Newest first.</p>
     <table class="table mt-table">
         <thead>
             <tr>
+                <th>Added</th>
                 <th>Operation</th>
                 <th>Description</th>
+                <th>Runs</th>
                 <th></th>
             </tr>
         </thead>
         <tbody>
             {% for op in operations %}
                 <tr>
+                    <td class="mt-nowrap">{{ op.added|date:"Y-m-d"|default:"—" }}</td>
                     <td>
                         <strong>{{ op.name }}</strong>
                     </td>
                     <td>{{ op.description }}</td>
+                    <td class="mt-nowrap">
+                        {% if op.runs %}
+                            {{ op.runs }}
+                        {% else %}
+                            never run
+                        {% endif %}
+                    </td>
                     <td>
                         <a class="button" href="{{ op.url }}">Open</a>
                     </td>

--- a/gyrinx/maintenance/tests/test_admin_views.py
+++ b/gyrinx/maintenance/tests/test_admin_views.py
@@ -344,3 +344,90 @@ def _fighter_statline_type():
             },
         )
     return statline_type
+
+
+# ------------------------------------------------- the index's own ordering
+
+
+def _next_suffix():
+    global _SCENARIO_SEQ
+    _SCENARIO_SEQ += 1
+    return _SCENARIO_SEQ
+
+
+def _index_body(make_user):
+    su = make_user(f"su-index-{_next_suffix()}", "pw")
+    su.is_staff = True
+    su.is_superuser = True
+    su.save()
+    c = Client()
+    c.force_login(su)
+    return c.get(reverse("admin:maintenance_index")).content.decode()
+
+
+@pytest.mark.django_db
+def test_the_repairs_are_listed_newest_first():
+    """These accumulate and are nearly always run soon after being written,
+    so the one somebody came for is the one written most recently."""
+    from gyrinx.maintenance.views import _operations_listing
+
+    dated = [op["added"] for op in _operations_listing() if op["added"]]
+
+    assert dated == sorted(dated, reverse=True)
+    assert len(dated) > 1
+
+
+@pytest.mark.django_db
+def test_a_repair_with_no_date_given_sorts_last(monkeypatch):
+    """Undated means nobody said, which is not a claim to be recent."""
+    import datetime
+
+    from gyrinx.maintenance import views as maintenance_views
+    from gyrinx.maintenance.registry import MaintenanceOperation
+
+    def _fake():
+        return (
+            MaintenanceOperation(
+                operation="undated", name="Undated", view=lambda r: None
+            ),
+            MaintenanceOperation(
+                operation="dated",
+                name="Dated",
+                view=lambda r: None,
+                added=datetime.date(2020, 1, 1),
+            ),
+        )
+
+    monkeypatch.setattr(maintenance_views, "operations", _fake)
+    monkeypatch.setattr(maintenance_views, "reverse", lambda name: "/nowhere/")
+
+    listing = maintenance_views._operations_listing()
+
+    assert [op["key"] for op in listing] == ["dated", "undated"]
+
+
+@pytest.mark.django_db
+def test_each_repair_says_how_often_it_has_run():
+    from gyrinx.maintenance.views import _operations_listing
+
+    Backfill.objects.create(operation=Operation.RECONCILE_LISTS.value)
+    Backfill.objects.create(operation=Operation.RECONCILE_LISTS.value)
+    Backfill.objects.create(operation=Operation.BACKFILL_PINS.value)
+
+    runs = {op["key"]: op["runs"] for op in _operations_listing()}
+
+    assert runs[Operation.RECONCILE_LISTS.value] == 2
+    assert runs[Operation.BACKFILL_PINS.value] == 1
+    assert runs[Operation.MIGRATE_PERSISTENT_STASH.value] == 0
+
+
+@pytest.mark.django_db
+def test_the_page_shows_the_date_and_the_count(make_user):
+    Backfill.objects.create(operation=Operation.RECONCILE_LISTS.value)
+
+    body = _index_body(make_user)
+
+    assert "<th>Added</th>" in body
+    assert "<th>Runs</th>" in body
+    assert "2026-07-04" in body
+    assert "never run" in body

--- a/gyrinx/maintenance/views.py
+++ b/gyrinx/maintenance/views.py
@@ -13,6 +13,7 @@ is ``admin.py``'s job, so no view can be published without the gate.
 import uuid as uuid_module
 
 from django.contrib import admin, messages
+from django.db.models import Count
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -89,18 +90,60 @@ def maintenance_index_view(request):
     ctx = page_context(
         request,
         "Maintenance",
-        operations=[
-            {
-                "key": op.operation,
-                "name": op.name,
-                "url": reverse(f"admin:{op.url_name}"),
-                "description": op.description,
-            }
-            for op in operations()
-        ],
+        operations=_operations_listing(),
         recent_backfills=Backfill.objects.order_by("-created")[:25],
     )
     return render(request, "admin/maintenance/index.html", ctx)
+
+
+def _operations_listing():
+    """The repairs on offer, newest first, each with how often it has run.
+
+    Newest first because these are one-off repairs rather than a standing
+    menu: the list only grows, and whoever opens the page has almost always
+    come for something written this week. Registration order buried that at
+    the bottom.
+
+    An operation with no date given sorts last rather than first — undated
+    means nobody said, which is not a claim to be recent.
+    """
+    ran = _runs_by_operation()
+    listing = [
+        {
+            "key": op.operation,
+            "name": op.name,
+            "url": reverse(f"admin:{op.url_name}"),
+            "description": op.description,
+            "added": op.added,
+            "runs": ran.get(op.operation, 0),
+        }
+        for op in operations()
+    ]
+    # Sorted on a key rather than by ``added`` directly, since a date and
+    # None do not compare. Stable, so registration order still separates
+    # two repairs written on one day.
+    listing.sort(key=lambda op: (op["added"] is None, _reverse_date(op["added"])))
+    return listing
+
+
+def _reverse_date(added):
+    """A sort key putting later dates first."""
+    return -added.toordinal() if added else 0
+
+
+def _runs_by_operation():
+    """How many records each operation has, in one query.
+
+    ``order_by()`` clears the model's own ordering, which would otherwise
+    join the created column into the grouping and count every row on its
+    own.
+    """
+    return dict(
+        Backfill.objects.values_list("operation")
+        .order_by()
+        .annotate(runs=Count("id"))
+        .values_list("operation", "runs")
+    )
 
 
 def backfill_detail_view(request, pk):

--- a/n23/core/admin/maintenance.py
+++ b/n23/core/admin/maintenance.py
@@ -18,6 +18,7 @@ Imported by ``n23.core.admin``; drop that import and the console goes empty.
 
 import logging
 import traceback
+from datetime import date
 
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -226,6 +227,7 @@ register_operation(
         # The published URL predates the slug, so keep them apart.
         slug="persistent_stash",
         name=Operation.MIGRATE_PERSISTENT_STASH.label,
+        added=date(2026, 6, 6),
         description=(
             "Move persistent-category gear off stash fighters back "
             "to the dying Fighter where provenance is provable from "
@@ -240,6 +242,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.RECONCILE_LISTS.value,
         name=Operation.RECONCILE_LISTS.label,
+        added=date(2026, 7, 4),
         description=(
             "True up every list's cached costs from live resolution, "
             "recording movement as RECONCILE ledger actions. Runs on "
@@ -254,6 +257,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.BACKFILL_PINS.value,
         name=Operation.BACKFILL_PINS.label,
+        added=date(2026, 7, 4),
         description=(
             "Write acquisition receipts onto every legacy assignment "
             "via the pinning choke point. Idempotent, resumable, "

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -36,6 +36,7 @@ attempt may be started before the record gives up and says so.
 import logging
 import traceback
 from contextlib import contextmanager
+from datetime import date
 
 from django.contrib import messages
 from django.db import connection, models, transaction
@@ -741,6 +742,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.CONVERT_SPECIALISATION.value,
         name=Operation.CONVERT_SPECIALISATION.label,
+        added=date(2026, 8, 17),
         description=(
             "Move the specialisations onto slots and picks: the Specialist "
             "subtype grants a slot instead of offering a choice, and every "
@@ -756,6 +758,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.CONVERT_SKILL_TREE.value,
         name=Operation.CONVERT_SKILL_TREE.label,
+        added=date(2026, 8, 18),
         description=(
             "Move the Venator ranked skill trees onto slots and picks: each "
             "rank carrier grants a slot instead of offering a choice, and "
@@ -771,6 +774,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.RETIRE_GANG_LEGACY_PILOT.value,
         name=Operation.RETIRE_GANG_LEGACY_PILOT.label,
+        added=date(2026, 8, 18),
         description=(
             "Delete the hand-built Gang Legacy slot experiment: its hollow "
             "pickables, its slot machinery, and the one test gang's "
@@ -787,6 +791,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.CONVERT_GANG_LEGACY.value,
         name=Operation.CONVERT_GANG_LEGACY.label,
+        added=date(2026, 8, 18),
         description=(
             "Move the Venator house legacies onto slots and picks: the "
             "hunt profiles grant a Gang Legacy slot instead of offering "
@@ -804,6 +809,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.CONVERT_ARCHETYPE.value,
         name=Operation.CONVERT_ARCHETYPE.label,
+        added=date(2026, 8, 20),
         description=(
             "Move the Outcast archetypes onto slots and picks: each Leader "
             "profile grants the gang's Archetype slot and the Champion "
@@ -821,6 +827,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.DELETE_NAMELESS_GANG_TYPE.value,
         name=Operation.DELETE_NAMELESS_GANG_TYPE.label,
+        added=date(2026, 8, 21),
         description=(
             "Retire the gang type an ingest founded from a blank Gang cell — "
             "the nameless one that drew as an empty card on the create-gang "
@@ -839,6 +846,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.SWEEP_ARCHIVED.value,
         name=Operation.SWEEP_ARCHIVED.label,
+        added=date(2026, 8, 22),
         description=(
             "Rewrite the answers a gang took back — archived, still "
             "naming the kinds the conversions replaced, and the last "
@@ -877,5 +885,6 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.MERGE_WARGEAR_INTO_WEAPON.value,
         name=Operation.MERGE_WARGEAR_INTO_WEAPON.label,
+        added=date(2026, 8, 18),
     )
 )


### PR DESCRIPTION
The maintenance console's list of repairs was in registration order, so
the newest sat at the bottom of a list that only ever grows — and it gave
no way to tell whether a repair had already been run.

## What changed

Each repair now states the day it was offered, and the index sorts on
that, newest first. Each row also says how many times it has run, or
"never run".

```
Added        Operation                                          Runs
2026-08-22   n26: the answers already taken back become picks    1
2026-08-21   n26: the gang type with no name is retired          1
2026-08-20   n26: the Outcast archetypes become picks            1
…
2026-06-06   Migrate persistent stash items (#1825)              1
```

## Two small decisions

**The date is stated, not derived from the first run.** A repair has a
date before it has ever run, and that is exactly when it most needs to
be easy to find.

**A repair with no date sorts last, not first.** Nobody having said is
not a claim to be recent. The field is optional so existing registrations
keep working.

The dates filled in for the repairs already registered are each one's
first appearance in the repository's history, rather than the day this
was written.

## Checked

- `gyrinx/maintenance` and the n26 console tests: 52 passed, 4 new.
- The new tests cover the ordering, undated sorting last, the run counts,
  and the rendered page carrying both columns.
- Rendered the real listing locally to read the order back.
