### PR TITLE
chore: the newest repairs carry their date, and the plan records the cleanup as run

### DIFF
--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -978,6 +978,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.CLEAR_SPARE_ANSWERS.value,
         name=Operation.CLEAR_SPARE_ANSWERS.label,
+        added=date(2026, 8, 22),
         description=(
             "Delete the second answer a doubled click left standing beside "
             "the one that settled the question. Each draws a line on a "
@@ -994,6 +995,7 @@ register_operation(
     MaintenanceOperation(
         operation=Operation.DELETE_RETIRED_KINDS.value,
         name=Operation.DELETE_RETIRED_KINDS.label,
+        added=date(2026, 8, 22),
         description=(
             "Delete what the conversions left behind: the emptied kind rows, "
             "the menus nothing offers from, and the detached offers. All "


### PR DESCRIPTION
The spares clearing and the retired-kinds deletion were written alongside the index change that began sorting repairs by the day they were added, so neither carries a date — which put them last on the list, below repairs from two months earlier.

Both are dated now. With them in place the three repairs added today sort in the order they must actually be run: sweep, then clearing, then deletion.

## Checked

- `gyrinx/maintenance` and the n26 console tests: 52 passed.
- Rendered the listing locally to read the order back.