### PR TITLE
refactor: the model and gang picture paths share one write, one form, one box

### DIFF
--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -180,21 +180,27 @@ class FighterNotesForm(forms.Form):
     notes = forms.CharField(required=False, widget=RichText())
 
 
-class FighterPictureForm(forms.Form):
-    """The edit page's picture box, an act of its own.
+class PictureForm(forms.Form):
+    """An edit page's picture box, an act of its own.
 
     ``image`` replaces what is stored, ``remove_image`` alone clears
-    it, and a submit carrying neither changes nothing.
+    it, and a submit carrying neither changes nothing. The ratio is the
+    caller's — a model's picture is portrait, a gang's landscape — and
+    the upload is brought to it on the way in.
     """
 
     image = forms.ImageField(required=False)
     remove_image = forms.BooleanField(required=False)
 
+    def __init__(self, ratio, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ratio = ratio
+
     def clean_image(self):
-        from n26.core.images import PORTRAIT, to_shape
+        from n26.core.images import to_shape
 
         upload = self.cleaned_data["image"]
-        return to_shape(upload, PORTRAIT) if upload else upload
+        return to_shape(upload, self.ratio) if upload else upload
 
 
 class GangStoryForm(forms.Form):
@@ -216,19 +222,6 @@ class GangStoryForm(forms.Form):
         label="Lore",
         help_text="The gang's story. Shown on the lore page, never printed.",
     )
-
-
-class GangPictureForm(forms.Form):
-    """The gang's picture box, the fighter's shape at the gang's ratio."""
-
-    image = forms.ImageField(required=False)
-    remove_image = forms.BooleanField(required=False)
-
-    def clean_image(self):
-        from n26.core.images import LANDSCAPE, to_shape
-
-        upload = self.cleaned_data["image"]
-        return to_shape(upload, LANDSCAPE) if upload else upload
 
 
 class FighterLoreForm(forms.Form):

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -192,7 +192,7 @@ class PictureForm(forms.Form):
     image = forms.ImageField(required=False)
     remove_image = forms.BooleanField(required=False)
 
-    def __init__(self, ratio, *args, **kwargs):
+    def __init__(self, *args, ratio, **kwargs):
         super().__init__(*args, **kwargs)
         self.ratio = ratio
 

--- a/n26/core/images.py
+++ b/n26/core/images.py
@@ -16,15 +16,33 @@ where the full decode happens.
 """
 
 from io import BytesIO
+from typing import NamedTuple
 
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from PIL import Image, ImageOps
 
+
+class Ratio(NamedTuple):
+    """A picture's shape, width to height, spelt ``4:5`` where drawn.
+
+    One constant serves every layer: the crop here works on the pair,
+    and a template stamps ``str(ratio)`` onto the browser's crop dialog
+    — so the window the dialog offers and the shape the server enforces
+    cannot come apart.
+    """
+
+    across: int
+    down: int
+
+    def __str__(self):
+        return f"{self.across}:{self.down}"
+
+
 #: A model's picture: portrait, four wide to five tall.
-PORTRAIT = (4, 5)
+PORTRAIT = Ratio(4, 5)
 #: A gang's picture: landscape, sixteen wide to nine tall.
-LANDSCAPE = (16, 9)
+LANDSCAPE = Ratio(16, 9)
 
 #: The long side of a stored picture. Phone photographs arrive at many
 #: times this; a card, a print sheet and a lore page never draw one

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -404,12 +404,7 @@ class Operation:
         say: the words are the owner's, and the journal is a list of
         acts, not a copy of the prose.
         """
-        if miniature.notes == notes:
-            return miniature
-        miniature.notes = notes
-        miniature.save(update_fields=["notes", "modified"])
-        self.event(miniature, LedgerEvent.Kind.NOTED)
-        return miniature
+        return self._write_prose(miniature, "notes", notes, LedgerEvent.Kind.NOTED)
 
     def edit_lore(self, miniature, lore):
         """Store the model's story as written, and say it changed.
@@ -417,64 +412,60 @@ class Operation:
         As ``edit_notes``: the journal records the act and never the
         prose.
         """
-        if miniature.lore == lore:
-            return miniature
-        miniature.lore = lore
-        miniature.save(update_fields=["lore", "modified"])
-        self.event(miniature, LedgerEvent.Kind.LORE_EDITED)
-        return miniature
+        return self._write_prose(miniature, "lore", lore, LedgerEvent.Kind.LORE_EDITED)
 
     def set_image(self, miniature, upload, clear=False):
         """Give one model a picture, or take it away.
 
         ``upload`` replaces whatever was there; ``clear`` alone removes
         it. Neither given, nothing happens — the common case of saving
-        the form around the picture. The old file is left in storage:
-        an address someone shared keeps working, and files are cheap
-        where a broken image on a page is not.
+        the form around the picture.
         """
-        if upload:
-            miniature.image = upload
-            miniature.save(update_fields=["image", "modified"])
-            self.event(miniature, LedgerEvent.Kind.IMAGE_SET)
-        elif clear and miniature.image:
-            miniature.image = ""
-            miniature.save(update_fields=["image", "modified"])
-            self.event(miniature, LedgerEvent.Kind.IMAGE_CLEARED)
-        return miniature
+        return self._write_picture(miniature, upload, clear)
 
     def edit_gang_notes(self, notes):
         """The gang's own notes, as ``edit_notes`` keeps a model's."""
-        gang = self.gang
-        if gang.notes == notes:
-            return gang
-        gang.notes = notes
-        gang.save(update_fields=["notes", "modified"])
-        self.event(None, LedgerEvent.Kind.NOTED)
-        return gang
+        return self._write_prose(self.gang, "notes", notes, LedgerEvent.Kind.NOTED)
 
     def edit_gang_lore(self, lore):
         """The gang's story, as ``edit_lore`` keeps a model's."""
-        gang = self.gang
-        if gang.lore == lore:
-            return gang
-        gang.lore = lore
-        gang.save(update_fields=["lore", "modified"])
-        self.event(None, LedgerEvent.Kind.LORE_EDITED)
-        return gang
+        return self._write_prose(self.gang, "lore", lore, LedgerEvent.Kind.LORE_EDITED)
 
     def set_gang_image(self, upload, clear=False):
         """The gang's picture, handled as ``set_image`` handles a model's."""
-        gang = self.gang
+        return self._write_picture(self.gang, upload, clear)
+
+    def _write_prose(self, subject, field, value, kind):
+        """One written field on the gang or a model, changed and said.
+
+        An unchanged field writes nothing at all — no save, no event —
+        so saving a form around an untouched box leaves no trace.
+        """
+        if getattr(subject, field) == value:
+            return subject
+        setattr(subject, field, value)
+        subject.save(update_fields=[field, "modified"])
+        about = subject if isinstance(subject, Miniature) else None
+        self.event(about, kind)
+        return subject
+
+    def _write_picture(self, subject, upload, clear):
+        """The picture on the gang or a model, replaced or removed.
+
+        The old file is left in storage: an address someone shared
+        keeps working, and files are cheap where a broken image on a
+        page is not.
+        """
+        about = subject if isinstance(subject, Miniature) else None
         if upload:
-            gang.image = upload
-            gang.save(update_fields=["image", "modified"])
-            self.event(None, LedgerEvent.Kind.IMAGE_SET)
-        elif clear and gang.image:
-            gang.image = ""
-            gang.save(update_fields=["image", "modified"])
-            self.event(None, LedgerEvent.Kind.IMAGE_CLEARED)
-        return gang
+            subject.image = upload
+            subject.save(update_fields=["image", "modified"])
+            self.event(about, LedgerEvent.Kind.IMAGE_SET)
+        elif clear and subject.image:
+            subject.image = ""
+            subject.save(update_fields=["image", "modified"])
+            self.event(about, LedgerEvent.Kind.IMAGE_CLEARED)
+        return subject
 
     def set_stats(self, miniature, changes):
         """Set or clear the characteristics an owner has taken over.

--- a/n26/core/static/n26/imagecrop.js
+++ b/n26/core/static/n26/imagecrop.js
@@ -16,8 +16,6 @@
  * rules.
  */
 (function () {
-    var MAX_PX = 1600;
-
     function wire(input) {
         // Wiring runs again over a region redrawn in place; an element
         // already carrying its listeners must not gain a second set.
@@ -33,6 +31,14 @@
         // A malformed shape declaration falls back to square rather
         // than an unconstrained rectangle nobody asked for.
         if (!isFinite(ratio) || ratio <= 0) ratio = 1;
+
+        // The stored picture's long side, stated on the input by the
+        // server (n26/core/images.py). Encoding bigger than the server
+        // will keep only fattens the upload; without a declared cap the
+        // canvas is the crop at its natural size, and the server still
+        // brings it to shape.
+        var cap = parseInt(input.dataset.cropMax || "", 10);
+        if (!isFinite(cap) || cap <= 0) cap = undefined;
 
         var confirm = dialog.querySelector("[data-crop-confirm]");
         var cancel = dialog.querySelector("[data-crop-cancel]");
@@ -97,8 +103,8 @@
             confirm.disabled = true;
             cropper
                 .getCroppedCanvas({
-                    maxWidth: MAX_PX,
-                    maxHeight: MAX_PX,
+                    maxWidth: cap,
+                    maxHeight: cap,
                     imageSmoothingQuality: "high",
                 })
                 .toBlob(

--- a/n26/core/templates/cotton/n26/picture_box.html
+++ b/n26/core/templates/cotton/n26/picture_box.html
@@ -1,0 +1,68 @@
+{% comment %}
+<c-n26.picture-box> — an edit page's picture section, both of its acts.
+
+    <c-n26.picture-box action="{{ edit_url }}"
+                       id="model-image"
+                       crop="{{ picture_shape }}"
+                       max="{{ picture_max }}"
+                       image_url="{{ picture_url }}"
+                       alt="A picture of {{ miniature.name }}"
+                       img_class="w-40">
+        Shown from the card's picture control and printed in the card's
+        corner. Picking a file opens the crop, and using it saves.
+    </c-n26.picture-box>
+
+Two forms, because the two acts are different shapes: uploading stages
+a file and ends in a save, removing is one committed click with nothing
+to fill in. Both post act=picture to the given action, so the page
+behind it answers one act for both.
+
+The wrapper is the unit the crop script redraws in place
+(n26/imagecrop.js): after a background save it swaps this box for the
+same box from the fresh page, so the picture appears without the page
+moving. Without the script the fallback Save control submits the form
+plainly.
+
+  action — where both forms post; the page must answer act=picture.
+  id — the file input's own.
+  crop, max — the shape and size cap, str() of the server's own
+    constants (n26/core/images.py), passed on to <c-n26.picture-input>.
+  image_url — the stored picture's address, or empty for none.
+  alt — what the current picture is of.
+  img_class — the current picture's width; the shape decides it, so the
+    caller says it.
+  The body is the sentence above the file box saying where the picture
+  shows.
+{% endcomment %}
+<c-vars action="" id="" crop="" max="" image_url="" alt="" img_class="" class="" />
+
+<div data-picture-box class="{{ class }}">
+    {% if image_url %}
+        <img src="{{ image_url }}"
+             alt="{{ alt }}"
+             class="mb-3 rounded-control {{ img_class }}">
+        <form method="post" action="{{ action }}" class="mb-3">
+            {% csrf_token %}
+            <input type="hidden" name="act" value="picture">
+            <input type="hidden" name="remove_image" value="on">
+            <c-ui.button type="submit" variant="default" size="sm">
+                Remove picture
+            </c-ui.button>
+        </form>
+    {% endif %}
+    <form method="post" action="{{ action }}" enctype="multipart/form-data">
+        {% csrf_token %}
+        <input type="hidden" name="act" value="picture">
+        <p class="mb-2 text-sm text-muted">{{ slot }}</p>
+        <c-n26.picture-input id="{{ id }}"
+                             name="image"
+                             crop="{{ crop }}"
+                             max="{{ max }}"
+                             :submit_on_crop="True" />
+        <div class="mt-3 flex justify-end" data-crop-fallback>
+            <c-ui.button type="submit" variant="success" size="sm">
+                Save picture
+            </c-ui.button>
+        </div>
+    </form>
+</div>

--- a/n26/core/templates/cotton/n26/picture_input.html
+++ b/n26/core/templates/cotton/n26/picture_input.html
@@ -19,14 +19,18 @@ upload to the same shape regardless (n26/core/images.py), so the
 dialog chooses, it is not trusted.
 
   id, name — the input's own.
-  crop — the shape, "4:5" or "16:9", width to height.
+  crop — the shape, "4:5" or "16:9", width to height — a served page
+    hands it str() of the server's own ratio (n26/core/images.py).
+  max — the stored picture's long side, the server's cap handed the
+    same way; the dialog encodes no bigger, since the server would
+    only shrink it.
   submit_on_crop — confirming the crop submits the input's form, so the
     picture lands without a second click. Only for a form that is the
     picture's own: on a form carrying other fields it would save them
     all. The form's own submit control, marked data-crop-fallback, is
     hidden once the script is driving — it is the scriptless path.
 {% endcomment %}
-<c-vars id="" name="image" crop="" :submit_on_crop="False" class="" />
+<c-vars id="" name="image" crop="" max="" :submit_on_crop="False" class="" />
 
 <div class="n26-picture-input {{ class }}">
     <input type="file"
@@ -34,6 +38,7 @@ dialog chooses, it is not trusted.
            name="{{ name }}"
            accept="image/*"
            data-crop="{{ crop }}"
+           {% if max %}data-crop-max="{{ max }}"{% endif %}
            {% if submit_on_crop %}data-crop-submit{% endif %}
            class="block w-full text-sm text-ink-700 file:mr-3 file:rounded-control file:border file:border-ink-300 file:bg-ink-50 file:px-3 file:py-1.5 file:text-sm dark:text-ink-300 dark:file:border-ink-700 dark:file:bg-ink-800">
     <dialog data-crop-dialog

--- a/n26/core/templates/n26/edit_gang.html
+++ b/n26/core/templates/n26/edit_gang.html
@@ -119,45 +119,22 @@ reads the config after that listener has run.
     </c-n26.form-page>
     {% if tab == "notes" %}
         {% comment %}
-        The picture is its own act, outside the form above — a form inside a
-        form is not markup — in the fighter page's shape: a one-click
-        Remove, an upload whose crop confirms straight to a save, and the
-        box redrawn in place. The column matches the form's cap so the
+        The picture is its own act, outside the form above — a form inside
+        a form is not markup. The column matches the form's cap so the
         section reads as part of the same page.
         {% endcomment %}
         <div class="mt-8 max-w-3xl">
             <c-n26.form-section title="Picture">
-                <div data-picture-box>
-                    {% if gang.image %}
-                        <img src="{{ gang.image.url }}"
-                             alt="A picture of {{ gang.name }}"
-                             class="mb-3 w-full max-w-md rounded-control">
-                        <form method="post" action="{% url 'n26-edit-gang' gang.pk %}" class="mb-3">
-                            {% csrf_token %}
-                            <input type="hidden" name="act" value="picture">
-                            <input type="hidden" name="remove_image" value="on">
-                            <c-ui.button type="submit" variant="default" size="sm">
-                                Remove picture
-                            </c-ui.button>
-                        </form>
-                    {% endif %}
-                    <form method="post"
-                          action="{% url 'n26-edit-gang' gang.pk %}"
-                          enctype="multipart/form-data">
-                        {% csrf_token %}
-                        <input type="hidden" name="act" value="picture">
-                        <p class="mb-2 text-sm text-muted">
-                            Shown on the lore page and against the gang. Picking a
-                            file opens the crop, and using it saves.
-                        </p>
-                        <c-n26.picture-input id="gang-image" name="image" crop="16:9" :submit_on_crop="True" />
-                        <div class="mt-3 flex justify-end" data-crop-fallback>
-                            <c-ui.button type="submit" variant="success" size="sm">
-                                Save picture
-                            </c-ui.button>
-                        </div>
-                    </form>
-                </div>
+                <c-n26.picture-box action="{% url 'n26-edit-gang' gang.pk %}"
+                                   id="gang-image"
+                                   crop="{{ picture_shape }}"
+                                   max="{{ picture_max }}"
+                                   image_url="{{ picture_url }}"
+                                   alt="A picture of {{ gang.name }}"
+                                   img_class="w-full max-w-md">
+                    Shown on the lore page and against the gang. Picking a
+                    file opens the crop, and using it saves.
+                </c-n26.picture-box>
             </c-n26.form-section>
         </div>
     {% endif %}

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -99,47 +99,18 @@ is named by the page's own heading directly below.
                 </div>
             </form>
         </c-slot>
-        {% comment %}
-        Two forms, because the two acts are different shapes: uploading
-        stages a file and ends in a save, removing is one committed
-        click with nothing to fill in.
-        {% endcomment %}
         <c-slot name="picture">
-            {% comment %}
-            The wrapper is the unit the crop script redraws in place: after a
-            background save it swaps this box for the same box from the fresh
-            page, so the picture appears without the page moving.
-            {% endcomment %}
-            <div data-picture-box>
-                {% if miniature.image %}
-                    <img src="{{ miniature.image.url }}"
-                         alt="A picture of {{ miniature.name }}"
-                         class="mb-3 w-40 rounded-control">
-                    <form method="post" action="{{ edit_url }}" class="mb-3">
-                        {% csrf_token %}
-                        <input type="hidden" name="act" value="picture">
-                        <input type="hidden" name="remove_image" value="on">
-                        <c-ui.button type="submit" variant="default" size="sm">
-                            Remove picture
-                        </c-ui.button>
-                    </form>
-                {% endif %}
-                <form method="post" action="{{ edit_url }}" enctype="multipart/form-data">
-                    {% csrf_token %}
-                    <input type="hidden" name="act" value="picture">
-                    <p class="mb-2 text-sm text-muted">
-                        Shown from the card's picture control and printed in the
-                        card's corner. Picking a file opens the crop, and using
-                        it saves.
-                    </p>
-                    <c-n26.picture-input id="model-image" name="image" crop="4:5" :submit_on_crop="True" />
-                    <div class="mt-3 flex justify-end" data-crop-fallback>
-                        <c-ui.button type="submit" variant="success" size="sm">
-                            Save picture
-                        </c-ui.button>
-                    </div>
-                </form>
-            </div>
+            <c-n26.picture-box action="{{ edit_url }}"
+                               id="model-image"
+                               crop="{{ picture_shape }}"
+                               max="{{ picture_max }}"
+                               image_url="{{ picture_url }}"
+                               alt="A picture of {{ miniature.name }}"
+                               img_class="w-40">
+                Shown from the card's picture control and printed in the
+                card's corner. Picking a file opens the crop, and using
+                it saves.
+            </c-n26.picture-box>
         </c-slot>
         <c-slot name="lore">
             <form method="post" action="{{ edit_url }}">

--- a/n26/core/test_images.py
+++ b/n26/core/test_images.py
@@ -19,6 +19,15 @@ def size_of(upload):
         return image.size
 
 
+class TestTheSpelling:
+    """A ratio spells itself the way the crop dialog reads its
+    declaration, so a template can stamp the constant straight on."""
+
+    def test_the_pair_reads_width_to_height(self):
+        assert str(PORTRAIT) == "4:5"
+        assert str(LANDSCAPE) == "16:9"
+
+
 class TestTheShape:
     def test_a_wide_shot_comes_out_portrait(self):
         width, height = size_of(to_shape(upload_of(1000, 500), PORTRAIT))

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -243,6 +243,19 @@ class TestThePicture:
         # Refused with a reason on the page, never a server error.
         assert response.status_code == 200
 
+    def test_the_crop_dialog_is_told_the_servers_own_shape(
+        self, client, tester, gang, vex
+    ):
+        """The shape and cap on the file input are str() of the constants
+        the server crops with, so the dialog and the store cannot come
+        apart."""
+        from n26.core.images import MAX_PX, PORTRAIT
+
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+        assert f'data-crop="{PORTRAIT}"' in body
+        assert f'data-crop-max="{MAX_PX}"' in body
+
 
 class TestRenamingFromHere:
     """The pencil on this page's card opens the dialog here, and the act

--- a/n26/core/test_views_edit_gang.py
+++ b/n26/core/test_views_edit_gang.py
@@ -309,3 +309,14 @@ class TestNotesLoreAndPicture:
         recorded = LedgerEvent.objects.filter(gang=gang, miniature=None)
         assert recorded.filter(kind=LedgerEvent.Kind.IMAGE_SET).count() == 1
         assert recorded.filter(kind=LedgerEvent.Kind.IMAGE_CLEARED).count() == 1
+
+    def test_the_crop_dialog_is_told_the_servers_own_shape(self, client, tester, gang):
+        """The shape and cap on the file input are str() of the constants
+        the server crops with, so the dialog and the store cannot come
+        apart."""
+        from n26.core.images import LANDSCAPE, MAX_PX
+
+        client.force_login(tester)
+        body = client.get(edit_url(gang) + "?tab=notes").content.decode()
+        assert f'data-crop="{LANDSCAPE}"' in body
+        assert f'data-crop-max="{MAX_PX}"' in body

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -401,7 +401,7 @@ def edit_fighter(request, pk):
             messages.success(request, "Notes saved.")
         return redirect("n26-edit-fighter", pk=miniature.pk)
     elif request.method == "POST" and request.POST.get("act") == "picture":
-        form = PictureForm(PORTRAIT, request.POST, request.FILES)
+        form = PictureForm(request.POST, request.FILES, ratio=PORTRAIT)
         if form.is_valid():
             new_picture = bool(form.cleaned_data["image"])
             dropped_picture = (

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -249,9 +249,10 @@ def edit_fighter(request, pk):
     from n26.core.forms import (
         FighterLoreForm,
         FighterNotesForm,
-        FighterPictureForm,
+        PictureForm,
         statline_override_form_for,
     )
+    from n26.core.images import MAX_PX, PORTRAIT
     from n26.core.operations import Refusal, operation
     from n26.core.render import render_gang, roster, summarise_roster
     from n26.core.views.choose import link_slots
@@ -400,7 +401,7 @@ def edit_fighter(request, pk):
             messages.success(request, "Notes saved.")
         return redirect("n26-edit-fighter", pk=miniature.pk)
     elif request.method == "POST" and request.POST.get("act") == "picture":
-        form = FighterPictureForm(request.POST, request.FILES)
+        form = PictureForm(PORTRAIT, request.POST, request.FILES)
         if form.is_valid():
             new_picture = bool(form.cleaned_data["image"])
             dropped_picture = (
@@ -506,5 +507,11 @@ def edit_fighter(request, pk):
             "rule_edits_dirty": rule_edits_dirty,
             "renaming": _fighter_named(request, gang, "rename"),
             "edit_url": reverse("n26-edit-fighter", args=[miniature.pk]),
+            # The crop spec the picture box stamps onto the browser's
+            # dialog — handed from the same constants the server crops
+            # with, so the two cannot disagree.
+            "picture_shape": PORTRAIT,
+            "picture_max": MAX_PX,
+            "picture_url": miniature.image.url if miniature.image else "",
         },
     )

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -594,7 +594,7 @@ def edit_gang(request, pk):
     at = reverse("n26-edit-gang", args=[gang.pk])
     tab = "notes" if request.GET.get("tab") == "notes" else "general"
     if request.method == "POST" and request.POST.get("act") == "picture":
-        form = PictureForm(LANDSCAPE, request.POST, request.FILES)
+        form = PictureForm(request.POST, request.FILES, ratio=LANDSCAPE)
         if form.is_valid():
             new_picture = bool(form.cleaned_data["image"])
             dropped_picture = (

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -586,14 +586,15 @@ def edit_gang(request, pk):
     the spending history cannot fit, unwinding the whole change.
     """
     from n26.analytics import EventVerb, N26Noun, record
-    from n26.core.forms import EditGangForm, GangPictureForm, GangStoryForm
+    from n26.core.forms import EditGangForm, GangStoryForm, PictureForm
+    from n26.core.images import LANDSCAPE, MAX_PX
     from n26.core.operations import NotEnoughCredits, operation
 
     gang = _own_gang_or_404(request, pk)
     at = reverse("n26-edit-gang", args=[gang.pk])
     tab = "notes" if request.GET.get("tab") == "notes" else "general"
     if request.method == "POST" and request.POST.get("act") == "picture":
-        form = GangPictureForm(request.POST, request.FILES)
+        form = PictureForm(LANDSCAPE, request.POST, request.FILES)
         if form.is_valid():
             new_picture = bool(form.cleaned_data["image"])
             dropped_picture = (
@@ -695,6 +696,12 @@ def edit_gang(request, pk):
             "form": form,
             "wealth": gang.wealth,
             "tab": tab,
+            # The crop spec the picture box stamps onto the browser's
+            # dialog — handed from the same constants the server crops
+            # with, so the two cannot disagree.
+            "picture_shape": LANDSCAPE,
+            "picture_max": MAX_PX,
+            "picture_url": gang.image.url if gang.image else "",
             "edit_tabs": [
                 {"label": "General", "href": at, "current": tab == "general"},
                 {

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1851,6 +1851,25 @@ GROUPS: list[Group] = [
                 ),
             ),
             Component(
+                slug="picture-box",
+                tag="c-n26.picture-box",
+                template="n26/picture_box.html",
+                summary="An edit page's picture section: the picture, its removal, and its upload.",
+                needs=("n26/imagecrop.js", "Cropper.js"),
+                notes=(
+                    "Two forms posting act=picture to the same address: a "
+                    "one-click Remove drawn only while a picture is stored, "
+                    "and an upload through <c-n26.picture-input> whose "
+                    "confirmed crop saves at once. The wrapper is what "
+                    "n26/imagecrop.js redraws in place after a background "
+                    "save, so the page the action renders must carry the "
+                    "same box. The crop and max props are str() of the "
+                    "server's own constants (n26/core/images.py) — a call "
+                    "site hands them through from its view rather than "
+                    "spelling the shape itself."
+                ),
+            ),
+            Component(
                 slug="picture-input",
                 tag="c-n26.picture-input",
                 template="n26/picture_input.html",

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -25,6 +25,7 @@ from n26.core.hire import (
     HireOption,
     HireSection,
 )
+from n26.core.images import MAX_PX, PORTRAIT
 from n26.core.notes import INFO, WARNING, Note
 from n26.core.render import (
     AssignableLine,
@@ -809,6 +810,11 @@ def context():
         # A stored picture's address for the components that draw one —
         # a data URI, because the gallery renders with no uploads store.
         "sample_picture": CARD_IMAGE,
+        # The crop spec the picture components stamp onto the browser's
+        # dialog, handed through from the server's own constants the way
+        # a real page's view hands them — never spelt out in a demo.
+        "sample_picture_shape": PORTRAIT,
+        "sample_picture_max": MAX_PX,
         "sorts": SORTS,
         "choice_offer": choice_offer(),
         "empty_choice_offer": ChoiceOffer(label="Primary skill"),

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -806,6 +806,9 @@ def context():
         # string, because that is what the library stores and what the component
         # sanitises. One name for it, so the demos cannot show two drawings.
         "sample_gang_icon": SAMPLE_GANG_ICON,
+        # A stored picture's address for the components that draw one —
+        # a data URI, because the gallery renders with no uploads store.
+        "sample_picture": CARD_IMAGE,
         "sorts": SORTS,
         "choice_offer": choice_offer(),
         "empty_choice_offer": ChoiceOffer(label="Primary skill"),

--- a/n26/designsystem/templates/designsystem/demos/picture-box/10-empty.html
+++ b/n26/designsystem/templates/designsystem/demos/picture-box/10-empty.html
@@ -1,0 +1,12 @@
+{# title: No picture yet #}
+{# note: Only the upload half draws — Remove appears once there is a picture to remove. The body is the sentence saying where the picture shows. #}
+{# layout: col #}
+<c-n26.picture-box action="#"
+                   id="demo-picture-empty"
+                   crop="4:5"
+                   max="1600"
+                   alt="A picture of the model"
+                   img_class="w-40">
+    Shown from the card's picture control and printed in the card's
+    corner. Picking a file opens the crop, and using it saves.
+</c-n26.picture-box>

--- a/n26/designsystem/templates/designsystem/demos/picture-box/10-empty.html
+++ b/n26/designsystem/templates/designsystem/demos/picture-box/10-empty.html
@@ -1,10 +1,10 @@
 {# title: No picture yet #}
-{# note: Only the upload half draws — Remove appears once there is a picture to remove. The body is the sentence saying where the picture shows. #}
+{# note: Only the upload half draws — Remove appears once there is a picture to remove. The body is the sentence saying where the picture shows. The crop and max come through context from the server's own constants, as a real page's view hands them. #}
 {# layout: col #}
 <c-n26.picture-box action="#"
                    id="demo-picture-empty"
-                   crop="4:5"
-                   max="1600"
+                   crop="{{ sample_picture_shape }}"
+                   max="{{ sample_picture_max }}"
                    alt="A picture of the model"
                    img_class="w-40">
     Shown from the card's picture control and printed in the card's

--- a/n26/designsystem/templates/designsystem/demos/picture-box/20-with-picture.html
+++ b/n26/designsystem/templates/designsystem/demos/picture-box/20-with-picture.html
@@ -1,0 +1,13 @@
+{# title: A picture stored #}
+{# note: The picture at the width its caller declares, Remove beneath it, and the upload that replaces it. img_class is the caller's because the shape decides it — w-40 for a portrait model, w-full max-w-md for a landscape gang. #}
+{# layout: col #}
+<c-n26.picture-box action="#"
+                   id="demo-picture-stored"
+                   crop="4:5"
+                   max="1600"
+                   image_url="{{ sample_picture }}"
+                   alt="A picture of the model"
+                   img_class="w-40">
+    Shown from the card's picture control and printed in the card's
+    corner. Picking a file opens the crop, and using it saves.
+</c-n26.picture-box>

--- a/n26/designsystem/templates/designsystem/demos/picture-box/20-with-picture.html
+++ b/n26/designsystem/templates/designsystem/demos/picture-box/20-with-picture.html
@@ -3,8 +3,8 @@
 {# layout: col #}
 <c-n26.picture-box action="#"
                    id="demo-picture-stored"
-                   crop="4:5"
-                   max="1600"
+                   crop="{{ sample_picture_shape }}"
+                   max="{{ sample_picture_max }}"
                    image_url="{{ sample_picture }}"
                    alt="A picture of the model"
                    img_class="w-40">

--- a/n26/designsystem/templates/designsystem/demos/picture-input/10-basic.html
+++ b/n26/designsystem/templates/designsystem/demos/picture-input/10-basic.html
@@ -1,3 +1,6 @@
 {# title: A picture upload with a crop of its own #}
 {# note: Picking a file opens the crop dialog — a rectangle of the declared shape over the picture, opening at its largest, dragged and resized by its handles, staged on the input only when the crop is confirmed. This page does not load the crop scripts, so here the input stays a plain file box, which is also exactly what a reader without the script gets: the server centre-crops every upload to the same shape regardless. #}
-<c-n26.picture-input id="demo-picture" name="image" crop="4:5" />
+<c-n26.picture-input id="demo-picture"
+                     name="image"
+                     crop="{{ sample_picture_shape }}"
+                     max="{{ sample_picture_max }}" />

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -47,6 +47,26 @@ class TestTheQuickSwitchersPage:
         assert "#the-rust-sermon" in page
 
 
+class TestThePictureBoxPage:
+    """Its props and both of its states reach the gallery drawn."""
+
+    def test_the_page_documents_the_props_declared_in_the_template(self, reader):
+        page = reader.get("/n26/design/c/picture-box/").content.decode()
+        # Read from the component's own <c-vars>, so a prop added there and
+        # nowhere else still has to appear here.
+        assert "image_url" in page
+        assert "img_class" in page
+
+    def test_both_demos_render_rather_than_falling_back(self, reader):
+        page = reader.get("/n26/design/c/picture-box/").content.decode()
+        assert "No picture yet" in page
+        assert "A picture stored" in page
+        # From the markup the demos rendered, not their titles: the stored
+        # state must actually draw its input and its Remove.
+        assert 'id="demo-picture-stored"' in page
+        assert "Remove picture" in page
+
+
 class TestTheRadioCardsPage:
     """Its props, its card subcomponent and its demos all reach the gallery."""
 


### PR DESCRIPTION
Follow-up to the n26 notes/lore/pictures feature (#2269). That change shipped the model and gang halves as mirrored copies; this converges them on single sources with no behaviour change.

- The six operation verbs (`edit_notes`/`edit_lore`/`set_image` and their gang twins) keep their public names but delegate to two shared helpers in `n26/core/operations.py` — one for written fields, one for the picture — so the change/save/journal logic exists once.
- `FighterPictureForm` and `GangPictureForm`, identical but for the ratio, become one `PictureForm(ratio, ...)` in `n26/core/forms.py`.
- The picture section duplicated across `n26/core/templates/n26/fighter_edit.html` and `edit_gang.html` (current picture, one-click Remove, crop-and-save upload, the box the crop script redraws in place) becomes a shared `<c-n26.picture-box>` component, catalogued and demoed in the design gallery.
- The crop spec had four declarations: the ratio pair and `MAX_PX` in `n26/core/images.py`, `crop="4:5"`/`"16:9"` hardcoded in the two templates, and `MAX_PX = 1600` re-declared in `n26/core/static/n26/imagecrop.js`. Now `images.py` is the only source: the ratios are a `Ratio` NamedTuple whose `str()` is the `4:5` spelling the templates stamp, views hand ratio and cap into the templates, and the crop script reads both off the input's data attributes.

Tests pin the threading end to end: the served edit pages must carry `data-crop`/`data-crop-max` spelt from the server's own constants, and new gallery tests check the component's page and both demos render.

**Test plan**
- [x] `pytest n26` — 3966 passed, 1 xfailed
- [x] New assertions: crop spec on both edit pages, `Ratio` spelling, picture-box gallery page
- [x] `node --check` on `imagecrop.js`; `./scripts/fmt.sh` clean

Refs #2192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeG7bCxCSJr2wBYsGSR5Xd
