### PR TITLE
docs: add COMMIT_STYLE.md so commit and PR titles name what changed

### DIFF
--- a/.github/COMMIT_STYLE.md
+++ b/.github/COMMIT_STYLE.md
@@ -1,0 +1,85 @@
+# Commit and PR title style
+
+We squash-merge, so the PR title becomes the permanent commit subject. It is
+what anyone scanning `git log`, a blame, or a release page has to work from,
+long after the PR page has stopped being interesting. It is worth a minute.
+
+This file is the authority on title style for this repository. Read it instead
+of copying the phrasing of recent commits — the log has drifted before and may
+have drifted again.
+
+## The test
+
+**Name the thing that changed and what now happens to it.** Someone who has
+never seen the change should be able to guess which files it touches.
+
+## Rules
+
+- Open with the conventional-commit prefix — `feat:`, `fix:`, `refactor:`,
+  `perf:`, `docs:`, `test:`, `chore:`, `build:`, `ci:`, `style:` — then say what
+  changed.
+- **Name at least one real, findable thing**: the page, the model class, the
+  management command, the admin screen, the URL, the setting, the flag. If the
+  title contains no noun you could grep this codebase for, it fails.
+- **Never open with an article or "what" followed by a generic noun.** "the
+  sweep", "a question", "what the conversions left standing" read as riddles,
+  because the subject is a pronoun wearing a hat. This is by far our most common
+  failure.
+- **Don't give code intentions.** Code does not own up, admit, want or decide.
+  Say what it now does.
+- Under 72 characters where you can manage it.
+- Plain, natural English is right. Vagueness is not — the two are not the same
+  thing, and titles here have failed by confusing them.
+
+## Titles that work
+
+Real examples from this repository:
+
+```
+fix: show weapon profiles on equipment list item removal page
+perf: stop the equipment admin page rebuilding its dropdowns per row
+feat: nominate any fighter as leader when the gang's leader dies
+fix: replace leaky persistent DB connections with a psycopg connection pool
+feat: add admin action to recompute fighter cost caches from facts
+perf: fix N+1 query explosions in List and ListFighter admin
+fix: serve a real robots.txt and stop counting crawlers as engagement
+fix: show house-additional gear on the stash card
+```
+
+Note how conversational most of these are. "Stop the equipment admin page
+rebuilding its dropdowns per row" is not stiff or robotic — it just names the
+page and the behaviour.
+
+## Titles that failed, and why
+
+All shipped to `main`. Each one names nothing you could look up.
+
+| Shipped | Should have been |
+|---|---|
+| `fix: the sweep owns up to the one word it moves` | `fix: let the archived-answer sweep reword "archetype" to "gang legacy"` |
+| `feat: what the conversions left standing can be deleted` | `feat: maintenance op to delete empty Specialisation/Archetype/SkillTree rows` |
+| `feat: the answers a doubled click left behind can be cleared` | `feat: maintenance op to delete duplicate Assignments from double-clicked Choose` |
+| `fix: a question keeps one answer, however fast the second arrives` | `fix: lock the Gang row in choose() so a double click can't duplicate a pick` |
+| `fix: the page the gangs pager cannot turn to is dead, not a link to nowhere` | `fix: disable prev/next on the n26 gangs pager (cotton attrs take no expressions)` |
+| `perf: the app serves on one core, because it only ever used one` | `perf: cut Cloud Run to --cpu=1 — p99.9 use was 0.86 vCPU, saves ~£20/mo` |
+
+The pattern is the same every time: the change is described by its effect while
+the thing it happened to goes unnamed. Keep the effect, add the subject.
+
+## A note on our other language rules
+
+`CLAUDE.md` asks you to describe changes by their user-visible effect and to
+avoid internal shorthand. Various notes ban particular nouns in product copy
+("shelf", "shop", "row" for an assignment, and others).
+
+**None of that means "avoid naming the thing."** Avoiding internal shorthand
+means explaining a term rather than assuming it; the noun bans govern product
+copy, UI strings and identifiers, not commit titles. A title is allowed — and
+expected — to say `ListFighterEquipmentAssignment`, `choose()`, `--cpu=1`, or
+"the gangs pager". Those are the words that make it findable.
+
+## Bodies
+
+The same instinct applies to PR bodies: describe the effect, but name the
+subject. A body that says "34 of the 399 answers moved a word" is telling you
+something happened without telling you to what.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,7 +83,10 @@ still lacks canonical sections for badges, back links and form-field anatomy
 
 - Django management commands run via `manage`, not `python manage.py`.
 - Conventional-commit prefixes on commits and PR titles (`feat:`, `fix:`,
-  `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `style:`).
+  `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `style:`). Titles must also
+  name the thing that changed — see [COMMIT_STYLE.md](COMMIT_STYLE.md). Flag any
+  title that opens with an article or "what" plus a generic noun ("the sweep", "a
+  question"), or that names nothing you could grep for.
 - Mobile-first; design at 375px and enhance upwards. Dense over spacious.
 - Colour signals state, never decoration.
 - Avoid `alert` classes for neutral grouped content — use a bordered box. Bootstrap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,11 +194,20 @@ write for a tech lead reading cold, not a changelog:
   fixed price made the add-on's value vanish from the books"), then the mechanism
   only if it earns its place.
 - Avoid internal shorthand (test-group codes, harness jargon, fixture names) — or
-  explain it inline the first time it appears.
+  explain it inline the first time it appears. This means *explain the term*, not
+  *avoid naming the thing*: always name the page, model, command or setting you
+  are talking about.
 - End with concrete "how to try it" steps (URLs, commands) when there is something
   to see.
 
 Keep the fully technical version for commit messages and code comments.
+
+**Commit and PR titles have their own rules — see
+[.github/COMMIT_STYLE.md](.github/COMMIT_STYLE.md).** Read that file rather than
+copying the phrasing of recent commits; the log has drifted before. Note that the
+noun bans recorded elsewhere (no "shelf", no "shop", no "row" for an assignment)
+govern product copy, UI strings and identifiers — they do not apply to commit
+titles, which should freely name model classes, functions and flags.
 
 ## Critical Workflow
 

--- a/docs/developing-gyrinx/changelog-management.md
+++ b/docs/developing-gyrinx/changelog-management.md
@@ -74,7 +74,7 @@ _Last updated: YYYY-MM-DD_
 
 ### Best Practices
 
-1. **Commit Messages**: Use conventional commit prefixes (`feat:`, `fix:`, `docs:`, etc.) for better categorization
+1. **Commit Messages**: Use conventional commit prefixes (`feat:`, `fix:`, `docs:`, etc.) for better categorization. The subject after the prefix must name what changed — see [COMMIT_STYLE.md](../../.github/COMMIT_STYLE.md); a title nobody can decode makes a useless changelog entry
 2. **PR References**: Include PR numbers in commit messages (e.g., `#256`)
 3. **Regular Updates**: Run the script regularly to keep the changelog current
 4. **Review Generated Content**: Always review the generated changelog entries for accuracy


### PR DESCRIPTION
## Summary

Commit titles in this repo were good until 1 August, then drifted into riddles that name nothing you can look up — `fix: the sweep owns up to the one word it moves`, `feat: what the conversions left standing can be deleted`. Because we squash-merge, each one became a permanent commit subject.

The cause was mechanical rather than a matter of taste. The agent tooling had no title guidance at all, and two separate instructions telling it to infer style from recent commits. So each new title copied the last, and the drift compounded. The pattern is measurable: titles opening with an article or "what" plus a generic noun account for 34 of the last 51 non-dependency commits, and 0 of the 104 before 1 August.

This is the repository half of the fix. The tooling half is tgvashworth/agent-plugins#21, which teaches the commit and PR commands to read a repo style file and, when one exists, stop sampling the log for phrasing entirely. That is what makes this file authoritative rather than advisory.

- **`.github/COMMIT_STYLE.md`** (new) — the test ("name the thing that changed and what now happens to it"), the rules, eight working titles taken from our own pre-August log, and a before/after table of six that shipped broken.
- **`CLAUDE.md`** — clarifies that "avoid internal shorthand" means explain the term, not avoid naming the thing, and that the noun bans recorded elsewhere govern product copy and UI strings, not commit titles. That conflation is most of why the drift happened during the n26 work, when the domain vocabulary was being renamed week by week.
- **`.github/copilot-instructions.md`** — Copilot now flags the failing pattern in review, so the standard is held by something other than good intentions.
- **`docs/developing-gyrinx/changelog-management.md`** — points at the same file, so there is one source of truth rather than two.

Deliberately not included: rewriting history (about three weeks and forty commits — costs more than it recovers), and a CI check. If it recurs, the regex above is an unusually clean discriminator and would make a cheap `commit-msg` hook.

## Test plan

- [x] `markdownlint-cli2` passes on all four files
- [x] Relative links resolve from each file's directory
- [x] Full pre-commit suite passes
- [ ] Next agent-authored PR after agent-plugins#21 merges produces a title that names its subject

Docs only — no code paths touched.