### PR TITLE
feat: the content library names the slot types under their kind

### DIFF
--- a/n26/library/templates/authoring/index.html
+++ b/n26/library/templates/authoring/index.html
@@ -48,6 +48,24 @@
                         <td>{{ entry.summary }}</td>
                         <td class="text-right tabular-nums">{{ entry.count }}</td>
                     </tr>
+                    {% comment %}
+                    A few kinds are places other content is filed under, so the
+                    way in is one particular row rather than the listing. Those
+                    rows follow their kind, indented to say they are of it.
+                    The ! is needed twice over: the kit's [&_td] padding and
+                    colour rules both out-specify a plain utility on the cell.
+                    {% endcomment %}
+                    {% for row in entry.rows %}
+                        <tr>
+                            <td class="whitespace-nowrap pl-8!">
+                                <c-n26.link href="{{ row.url }}">
+                                    {{ row.label }}
+                                </c-n26.link>
+                            </td>
+                            <td class="text-ink-500! dark:text-ink-400!">{{ row.notes|join:" · " }}</td>
+                            <td></td>
+                        </tr>
+                    {% endfor %}
                 {% endfor %}
             </tbody>
         {% endfor %}

--- a/n26/library/test_authoring_index.py
+++ b/n26/library/test_authoring_index.py
@@ -1,0 +1,83 @@
+"""The content library's menu, and the kinds it lists out in full.
+
+Most kinds are a row that leads to a listing. A slot type is a place
+other content is filed under, so what an author wants is one particular
+one — and the menu names them rather than making that two hops.
+"""
+
+import pytest
+
+from n26.library.authoring import (
+    create_pickable,
+    create_picklist,
+    create_slot,
+    create_slot_type,
+)
+from n26.library.models import SlotType, Subtype
+from n26.library.views import INDEX_LISTS, _listed_beneath
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def two_slot_types(default_pack):
+    legacy = create_slot_type("Gang Legacy", plural_name="Gang Legacies")
+    guild = create_slot_type("Guild")
+    create_pickable("Cawdor", legacy)
+    create_pickable("Van Saar", legacy)
+    picklist = create_picklist("House Legacies", legacy)
+    create_slot("Gang Legacy", legacy, picklist=picklist)
+    return legacy, guild
+
+
+class TestWhatTheMenuListsOut:
+    def test_a_slot_type_row_carries_the_slot_types_themselves(self, two_slot_types):
+        listed = _listed_beneath("slot-type", SlotType)
+
+        assert [row["label"] for row in listed] == ["Gang Legacy", "Guild"]
+
+    def test_each_one_links_to_its_own_page(self, two_slot_types):
+        legacy, _ = two_slot_types
+
+        listed = _listed_beneath("slot-type", SlotType)
+
+        assert listed[0]["url"] == f"/n26/authoring/slot-type/{legacy.pk}/"
+
+    def test_each_one_says_what_has_been_built_in_it(self, two_slot_types):
+        listed = _listed_beneath("slot-type", SlotType)
+
+        assert listed[0]["notes"][:3] == ["2 pickables", "1 picklist", "1 slot"]
+
+    def test_it_counts_one_of_a_thing_as_one(self, two_slot_types):
+        """A menu row read at a glance should not say "1 slots"."""
+        listed = _listed_beneath("slot-type", SlotType)
+
+        assert "1 picklists" not in listed[0]["notes"]
+        assert "0 pickable" not in listed[1]["notes"]
+        assert listed[1]["notes"][:3] == ["0 pickables", "0 picklists", "0 slots"]
+
+    def test_a_kind_that_is_not_listed_out_carries_nothing(self, two_slot_types):
+        """Every kind would bury the menu; only the ones named are listed."""
+        assert "subtype" not in INDEX_LISTS
+        assert _listed_beneath("subtype", Subtype) == []
+
+
+class TestThePageItself:
+    def test_the_slot_types_are_drawn_under_their_kind(
+        self, admin_client, two_slot_types
+    ):
+        body = admin_client.get("/n26/authoring/").content.decode()
+        table = body[body.find("<table") : body.find("</table>", body.find("<table"))]
+
+        assert "Slot type" in table
+        assert table.index("Slot type") < table.index("Gang Legacy")
+        assert "2 pickables · 1 picklist · 1 slot" in table
+
+    def test_they_are_indented_so_they_read_as_of_that_kind(
+        self, admin_client, two_slot_types
+    ):
+        """The ! is load-bearing: the kit's own [&_td] padding rule
+        out-specifies a plain utility on the cell."""
+        body = admin_client.get("/n26/authoring/").content.decode()
+
+        assert "pl-8!" in body

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -756,9 +756,12 @@ def _describe_slot_type(slot_type):
     """How much has been built in this slot type, and whether one
     holder may pick the same pickable twice."""
     notes = [
-        f"{len(slot_type.pickables.all())} pickables",
-        f"{len(slot_type.picklists.all())} picklists",
-        f"{len(slot_type.slots.all())} slots",
+        f"{count} {word}{'' if count == 1 else 's'}"
+        for count, word in (
+            (len(slot_type.pickables.all()), "pickable"),
+            (len(slot_type.picklists.all()), "picklist"),
+            (len(slot_type.slots.all()), "slot"),
+        )
     ]
     if not slot_type.allows_repeats:
         notes.append("no repeats")
@@ -929,6 +932,37 @@ def _model_for(spec):
     return spec.creates
 
 
+#: Kinds the menu lists out in full underneath their own row.
+#:
+#: A slot type is a place other content is filed under rather than a
+#: thing in its own right, so what an author is after is nearly always
+#: one particular slot type — the Skill Tree one, the Gang Legacy one —
+#: and going by way of the listing to find it is a step for nothing.
+#: There are few enough to read at a glance, which is what makes this
+#: affordable; a kind with hundreds of rows would bury the menu it is
+#: part of.
+INDEX_LISTS = ("slot-type",)
+
+
+def _listed_beneath(kind, model):
+    """The rows the menu prints under a kind, in the kind's own order."""
+    if kind not in INDEX_LISTS:
+        return []
+    rows = model.objects.all()
+    hint = LEAF_LISTING_HINTS.get(kind)
+    if hint is not None:
+        rows = hint(rows)
+    describe = LEAF_DESCRIBE.get(kind)
+    return [
+        {
+            "label": str(row),
+            "url": reverse("authoring-detail", args=[kind, row.pk]),
+            "notes": describe(row) if describe else [],
+        }
+        for row in rows
+    ]
+
+
 @staff_member_required
 def index(request):
     """The menu, grouped by family — the plumbing, the model's own
@@ -944,6 +978,7 @@ def index(request):
                 "verbose_name": model._meta.verbose_name,
                 "summary": kind_summary(model),
                 "count": model.objects.count(),
+                "rows": _listed_beneath(kind, model),
             }
         )
     families = [


### PR DESCRIPTION
A slot type is a place other content is filed under rather than a thing in its own right, so what an author wants is nearly always one particular one — the Skill Tree one, the Gang Legacy one. The menu's row led to a listing, which made that two hops for something that belongs on the menu.

## What it looks like

The slot types now follow their kind's row, indented so they read as being of it:

```
Slot type    What is chosen: Gang Legacy is the first, and new ones are authored.    5
    Archetype        5 pickables · 1 picklist · 2 slots
    Gang Legacy      8 pickables · 1 picklist · 1 slot
    Path             2 pickables · 1 picklist · 1 slot
    Skill Tree       6 pickables · 1 picklist · 4 slots
    Specialisation   8 pickables · 2 picklists · 2 slots
```

Each links to its own page, and carries the same summary the listing page gives — so the two agree by construction rather than by anyone keeping them in step.

## Two decisions

**Which kinds get listed out is one tuple** (`INDEX_LISTS`). Only kinds with few enough rows to read at a glance belong in it; doing this for every kind would bury the menu it is part of. Slot types are the only one today — there are five in production.

**The summary now counts one of a thing as one**, rather than "1 picklists". That reads on the slot type listing page too; the menu is just where it is read at a glance, which is what made it worth fixing.

## A trap worth knowing

The indent needs Tailwind's `!` suffix. The table kit sets padding with `[&_td]:px-3`, which out-specifies a plain `pl-8` on the cell itself — the same trap the template already documents for its heading colour.

## Checked

- Full n26 suite: 3970 passed, 7 new.
- The new tests fail without the change (6 of the 7), so they hold it in place.
- Rendered the real page against the worktree database and read the table back.