### PR TITLE
feat: reconcile_defaults creates only what provenance says is missing

### DIFF
--- a/n26/core/builtins.py
+++ b/n26/core/builtins.py
@@ -125,7 +125,7 @@ class ReconcileOutcome:
     skipped: list
 
 
-def plan_defaults(carrier, kinds=None, built_ins=True):
+def plan_defaults(carrier, kinds=None, built_ins=True, fresh=()):
     """Walk a carrier's sets and say which members lack their copy.
 
     Only live members count — an archived member is a built-in an
@@ -133,11 +133,19 @@ def plan_defaults(carrier, kinds=None, built_ins=True):
     every copy it already materialised stands untouched. ``kinds``
     narrows what is owed; passed as None it is derived from the
     carrier's role (``kinds_for``).
+
+    ``fresh`` names sets the carrier is taking right now, whose members
+    are judged by live copies alone. Re-taking an option set the owner
+    once held must bring its kit again: the old copies were archived by
+    the set leaving, not by the owner parting with the things, so they
+    are history rather than a settled grant.
     """
     if kinds is None:
         kinds = kinds_for(carrier)
+    fresh_pks = {default_set.pk for default_set in fresh}
     entries = []
     for default_set in sets_for(carrier, built_ins=built_ins):
+        include_archived = default_set.pk not in fresh_pks
         for member in default_set.members.filter(archived=False):
             assignable = member.assignable
             if assignable is None:
@@ -145,6 +153,11 @@ def plan_defaults(carrier, kinds=None, built_ins=True):
             if kinds is not None and not isinstance(assignable, kinds):
                 continue
             entries.append(
-                MemberPlan(member=member, satisfied=is_satisfied(member, carrier))
+                MemberPlan(
+                    member=member,
+                    satisfied=copies_of(
+                        member, carrier, include_archived=include_archived
+                    ).exists(),
+                )
             )
     return DefaultsPlan(carrier=carrier, entries=tuple(entries))

--- a/n26/core/builtins.py
+++ b/n26/core/builtins.py
@@ -135,10 +135,11 @@ def plan_defaults(carrier, kinds=None, built_ins=True, fresh=()):
     carrier's role (``kinds_for``).
 
     ``fresh`` names sets the carrier is taking right now, whose members
-    are judged by live copies alone. Re-taking an option set the owner
-    once held must bring its kit again: the old copies were archived by
-    the set leaving, not by the owner parting with the things, so they
-    are history rather than a settled grant.
+    are judged by live copies alone. The archived-copy rule guards
+    against *unattended* re-grants — background reconciling must never
+    re-gift what an owner parted with — while taking a set is an
+    acquisition, and what is bought arrives: the copies a set's earlier
+    tenure left archived are history, not a settled grant.
     """
     if kinds is None:
         kinds = kinds_for(carrier)

--- a/n26/core/builtins.py
+++ b/n26/core/builtins.py
@@ -23,18 +23,18 @@ from dataclasses import dataclass
 from n26.core.models import Assignment, ProfileRole
 
 
-def copies_of(member, carrier=None, include_archived=True):
-    """The stored assignments one set membership materialised.
+def copies_of(member, carrier, include_archived=True):
+    """The stored assignments one set membership materialised for one
+    carrier — the pair that says whether the member is satisfied there.
 
-    ``carrier`` narrows to the copies made for one carrier — the pair
-    that says whether the member is satisfied there. This is the one
-    lookup that follows provenance; the member's own archival never
-    enters into it, because an archived member's copies still resolve
-    through the foreign key and unwinds rely on finding them.
+    This is the one lookup that follows provenance; the member's own
+    archival never enters into it, because an archived member's copies
+    still resolve through the foreign key and unwinds rely on finding
+    them.
     """
-    copies = Assignment.objects.filter(materialised_from=member)
-    if carrier is not None:
-        copies = copies.filter(materialised_for=carrier)
+    copies = Assignment.objects.filter(
+        materialised_from=member, materialised_for=carrier
+    )
     if not include_archived:
         copies = copies.filter(archived=False)
     return copies
@@ -51,13 +51,14 @@ def copies_of_set(default_set, carrier, include_archived=True):
     return copies
 
 
-def is_satisfied(member, carrier):
+def is_satisfied(member, carrier, include_archived=True):
     """Whether this member already has its copy for this carrier.
 
-    Archived copies count: a grant the owner removed or sold is
-    settled, not something to hand back.
+    Archived copies count by default: a grant the owner removed or
+    sold is settled, not something to hand back. A set being taken
+    right now is the one place they do not (``plan_defaults``).
     """
-    return copies_of(member, carrier).exists()
+    return copies_of(member, carrier, include_archived=include_archived).exists()
 
 
 def sets_for(carrier, built_ins=True):
@@ -156,9 +157,9 @@ def plan_defaults(carrier, kinds=None, built_ins=True, fresh=()):
             entries.append(
                 MemberPlan(
                     member=member,
-                    satisfied=copies_of(
+                    satisfied=is_satisfied(
                         member, carrier, include_archived=include_archived
-                    ).exists(),
+                    ),
                 )
             )
     return DefaultsPlan(carrier=carrier, entries=tuple(entries))

--- a/n26/core/builtins.py
+++ b/n26/core/builtins.py
@@ -1,0 +1,150 @@
+"""Built-ins as desired state — the read side of materialisation.
+
+A carrier — a model's membership, the gang's founding, a bought mount's
+own assignment — draws default assignments from its thing's built-ins
+and from the option sets recorded as taken (``ChosenProfileOption``).
+Each live member of those sets should have a stored copy: an assignment
+whose provenance names the member and the carrier
+(``materialised_from`` / ``materialised_for``).
+
+This module answers, without writing anything, which members already
+have their copy and which are missing. ``Operation.reconcile_defaults``
+creates what a plan says is missing; a preview renders a plan directly.
+
+Satisfaction is judged by provenance alone. An owner's own purchase of
+the same thing never satisfies a member — a visible duplicate is
+accepted rather than one acquisition silently standing in for another —
+and an archived copy still satisfies: the owner parted with the thing,
+and it is never re-granted behind their back.
+"""
+
+from dataclasses import dataclass
+
+from n26.core.models import Assignment, ProfileRole
+
+
+def copies_of(member, carrier=None, include_archived=True):
+    """The stored assignments one set membership materialised.
+
+    ``carrier`` narrows to the copies made for one carrier — the pair
+    that says whether the member is satisfied there. This is the one
+    lookup that follows provenance; the member's own archival never
+    enters into it, because an archived member's copies still resolve
+    through the foreign key and unwinds rely on finding them.
+    """
+    copies = Assignment.objects.filter(materialised_from=member)
+    if carrier is not None:
+        copies = copies.filter(materialised_for=carrier)
+    if not include_archived:
+        copies = copies.filter(archived=False)
+    return copies
+
+
+def copies_of_set(default_set, carrier, include_archived=True):
+    """Every copy any member of one set materialised for a carrier."""
+    copies = Assignment.objects.filter(
+        materialised_from__default_set=default_set,
+        materialised_for=carrier,
+    )
+    if not include_archived:
+        copies = copies.filter(archived=False)
+    return copies
+
+
+def is_satisfied(member, carrier):
+    """Whether this member already has its copy for this carrier.
+
+    Archived copies count: a grant the owner removed or sold is
+    settled, not something to hand back.
+    """
+    return copies_of(member, carrier).exists()
+
+
+def sets_for(carrier, built_ins=True):
+    """The sets a carrier draws default assignments from.
+
+    Its thing's built-ins, then every option set recorded as taken —
+    the same sets whether the carrier is being acquired, re-optioned,
+    or reconciled long after, so a member added to any of them later
+    still counts as owed.
+    """
+    sets = []
+    if built_ins:
+        held = getattr(carrier.assignable, "built_ins", None)
+        if held is not None:
+            sets.append(held)
+    for row in carrier.chosen_options.select_related("default_set"):
+        sets.append(row.default_set)
+    return sets
+
+
+def kinds_for(carrier):
+    """What kinds of member materialise for this carrier, or None for all.
+
+    A Legacy profile is an association, not a second hire: it brings
+    the other profile's equipment lists and nothing else — no second
+    helping of free kit however its sets grow.
+    """
+    from n26.library.models import Collection
+
+    role = getattr(carrier, "profile_role", None)
+    if role is not None and role.role == ProfileRole.Role.LEGACY:
+        return (Collection,)
+    return None
+
+
+@dataclass(frozen=True)
+class MemberPlan:
+    """One live set membership, and whether its copy already exists."""
+
+    member: object
+    satisfied: bool
+
+
+@dataclass(frozen=True)
+class DefaultsPlan:
+    """What one carrier's sets say it should hold, member by member."""
+
+    carrier: object
+    entries: tuple
+
+    @property
+    def missing(self):
+        return [entry.member for entry in self.entries if not entry.satisfied]
+
+
+@dataclass(frozen=True)
+class ReconcileOutcome:
+    """What one reconcile pass did: the plan it worked from, the copies
+    it created, and the members it had to leave unmet — each paired
+    with a sentence saying why."""
+
+    carrier: object
+    plan: DefaultsPlan
+    created: list
+    skipped: list
+
+
+def plan_defaults(carrier, kinds=None, built_ins=True):
+    """Walk a carrier's sets and say which members lack their copy.
+
+    Only live members count — an archived member is a built-in an
+    author has taken off, so future acquisitions come without it while
+    every copy it already materialised stands untouched. ``kinds``
+    narrows what is owed; passed as None it is derived from the
+    carrier's role (``kinds_for``).
+    """
+    if kinds is None:
+        kinds = kinds_for(carrier)
+    entries = []
+    for default_set in sets_for(carrier, built_ins=built_ins):
+        for member in default_set.members.filter(archived=False):
+            assignable = member.assignable
+            if assignable is None:
+                continue
+            if kinds is not None and not isinstance(assignable, kinds):
+                continue
+            entries.append(
+                MemberPlan(member=member, satisfied=is_satisfied(member, carrier))
+            )
+    return DefaultsPlan(carrier=carrier, entries=tuple(entries))

--- a/n26/core/migrations/0022_a_removal_carries_no_provenance.py
+++ b/n26/core/migrations/0022_a_removal_carries_no_provenance.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("n26", "0021_a_grant_names_the_member_it_came_from"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="assignment",
+            constraint=models.CheckConstraint(
+                condition=models.Q(("removes", False))
+                | models.Q(("materialised_from__isnull", True)),
+                name="assignment_removal_carries_no_provenance",
+            ),
+        ),
+    ]

--- a/n26/core/models/assignment.py
+++ b/n26/core/models/assignment.py
@@ -381,6 +381,15 @@ class Assignment(NamesAnAssignable, Base, Archived):
                 condition=models.Q(archived=False),
                 name="assignment_one_live_materialisation",
             ),
+            # A removal is machinery, never a grant: it suppresses its
+            # assignable rather than holding it, so it must never satisfy
+            # the provenance lookup that says a built-in member is already
+            # materialised for a carrier.
+            models.CheckConstraint(
+                condition=models.Q(removes=False)
+                | models.Q(materialised_from__isnull=True),
+                name="assignment_removal_carries_no_provenance",
+            ),
             # Provenance is a pair or nothing. A copy naming only half
             # would slip both grant lookups and the unique constraint
             # (NULLs never collide), so the half-written shape is refused

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -1015,21 +1015,35 @@ class Operation:
 
         created = []
         skipped = []
+        ammo = [
+            entry
+            for entry in plan.entries
+            if isinstance(entry.member.assignable, WeaponProfile)
+        ]
+        # A satisfied ammo line already sits on one particular gun. That
+        # gun is spoken for — claims resolve by provenance before queue
+        # position — so it never joins the queue and a missing ammo
+        # member cannot double onto it while another gun goes without.
+        occupied = set()
+        for entry in ammo:
+            if not entry.satisfied:
+                continue
+            copy = copies_of(entry.member, carrier, include_archived=False).first()
+            if copy is not None:
+                occupied.add(copy.parent_id)
         #: weapon pk -> guns of this plan still open to take ammo, in
         #: member order. One entry per weapon member, so twins stay
         #: distinct.
         guns = {}
-        ammo = []
         for entry in plan.entries:
             member = entry.member
             assignable = member.assignable
             if isinstance(assignable, WeaponProfile):
-                ammo.append(entry)
                 continue
             if entry.satisfied:
                 if isinstance(assignable, Weapon):
                     copy = copies_of(member, carrier, include_archived=False).first()
-                    if copy is not None:
+                    if copy is not None and copy.pk not in occupied:
                         guns.setdefault(assignable.pk, []).append(copy)
                 continue
             assignment = self.assign(
@@ -1044,6 +1058,8 @@ class Operation:
             created.append(assignment)
             if isinstance(assignable, Weapon):
                 self._grant_free_profiles(assignable, assignment)
+                # A gun created this pass cannot be occupied: a
+                # satisfied ammo copy predates it.
                 guns.setdefault(assignable.pk, []).append(assignment)
             elif member.default_pickable_id is not None:
                 # A slot arriving already settled. The pick goes
@@ -1053,21 +1069,6 @@ class Operation:
             elif member.counter_id is not None:
                 # A counter opens at its member's amount — Starting XP.
                 CounterValue.objects.create(assignment=assignment, value=member.amount)
-
-        # A satisfied ammo line already sits on one particular gun. That
-        # gun is spoken for: a missing ammo member must not double onto
-        # it while another of the plan's guns goes without.
-        for entry in ammo:
-            if not entry.satisfied:
-                continue
-            copy = copies_of(entry.member, carrier, include_archived=False).first()
-            if copy is None:
-                continue
-            queue = guns.get(entry.member.assignable.weapon_id, [])
-            for index, gun in enumerate(queue):
-                if gun.pk == copy.parent_id:
-                    del queue[index]
-                    break
 
         for entry in ammo:
             if entry.satisfied:

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -990,8 +990,10 @@ class Operation:
 
         ``kinds`` narrows what materialises (derived from the carrier's
         role when not given — a Legacy profile brings its lists but not
-        a second set of free kit); ``fresh`` names sets being taken
-        right now, judged by live copies alone (``plan_defaults``).
+        a second set of free kit). ``fresh`` names sets being taken
+        right now, judged by live copies alone: archived copies guard
+        against unattended re-grants, and taking a set is an acquisition
+        (``plan_defaults``). A bare reconcile passes neither.
         """
         from n26.core.builtins import ReconcileOutcome, copies_of, plan_defaults
         from n26.core.models import CounterValue, Reason

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -250,7 +250,7 @@ class Operation:
 
         ``materialised_from`` and ``materialised_for`` are the provenance
         of a built-in: which set membership this copy came from, and for
-        which carrier. Only ``_materialise_defaults`` sets them.
+        which carrier. Only ``reconcile_defaults`` sets them.
         """
         assignment = Assignment.objects.create(
             assignable=assignable,
@@ -700,7 +700,8 @@ class Operation:
         membership.save(update_fields=["miniature_root", "modified"])
         ProfileRole.objects.create(assignment=membership, role=ProfileRole.Role.PRIMARY)
         self.touched(miniature)
-        self._materialise_defaults(membership, taken)
+        self._record_options(membership, taken)
+        self.reconcile_defaults(membership)
         return miniature
 
     def found(self, gang_type, taken=(), **kwargs):
@@ -719,7 +720,8 @@ class Operation:
         self.gang.founding = founding
         self.gang.save(update_fields=["founding", "modified"])
         Stash.objects.get_or_create(gang=self.gang)
-        self._materialise_defaults(founding, list(taken), gang=self.gang)
+        self._record_options(founding, taken)
+        self.reconcile_defaults(founding, gang=self.gang)
         return founding
 
     def refound(self, gang_type):
@@ -769,7 +771,7 @@ class Operation:
         founding.gang_type = gang_type
         founding.save()
         Stash.objects.get_or_create(gang=self.gang)
-        self._materialise_defaults(founding, [], gang=self.gang)
+        self.reconcile_defaults(founding, gang=self.gang)
         return founding
 
     def rechoose(self, carrier, option=None, note=""):
@@ -826,7 +828,11 @@ class Operation:
             if carrier.miniature_root_id is None and carrier.gang_id is not None
             else None
         )
-        self._materialise_defaults(carrier, arriving, gang=gang, built_ins=False)
+        self._record_options(carrier, arriving)
+        # The arriving sets are fresh: their copies from an earlier
+        # taking were archived by that set leaving, and re-taking the
+        # set must bring its kit again.
+        self.reconcile_defaults(carrier, gang=gang, built_ins=False, fresh=arriving)
 
         delta = sum(chosen.price for chosen in taken) - sum(
             chosen.price for chosen in before
@@ -867,12 +873,9 @@ class Operation:
         Copies with no recorded provenance are found by the shape they
         were written in, below.
         """
-        tagged = list(
-            Assignment.objects.filter(
-                materialised_from__default_set=default_set,
-                materialised_for=carrier,
-            )
-        )
+        from n26.core.builtins import copies_of_set
+
+        tagged = list(copies_of_set(default_set, carrier))
         rows = [copy for copy in tagged if not copy.archived]
         rows.extend(self._granted_rows_without_provenance(carrier, default_set, tagged))
         return rows
@@ -930,39 +933,71 @@ class Operation:
             rows.extend(matches.order_by("-pk")[:count])
         return rows
 
-    def _materialise_defaults(
-        self, carrier, taken, kinds=None, gang=None, built_ins=True
+    def _record_options(self, carrier, taken):
+        """Record the sets taken with an acquisition, on the carrier.
+
+        Written before reconciling, because the plan reads what is
+        recorded — recording a set is what makes its members owed.
+        """
+        from n26.core.models import ChosenProfileOption
+
+        for chosen in taken:
+            ChosenProfileOption.objects.get_or_create(
+                assignment=carrier, default_set=chosen
+            )
+
+    def reconcile_defaults(
+        self, carrier, kinds=None, gang=None, built_ins=True, strict=True, fresh=()
     ):
-        """Grant a carrier's built-ins and the sets taken with it.
+        """Create what the carrier's sets say is missing, and nothing else.
 
         ``carrier`` is the assignment that brought the thing in — a
         model's membership, a bought mount's own assignment, a gang's
-        founding. Everything created is **caused by** it and hosted
+        founding. Its sets are its thing's built-ins and the option sets
+        recorded as taken (``_record_options``); a member is satisfied
+        when a copy naming it and this carrier exists, archived included
+        — the owner parted with the thing, and it is never re-granted
+        behind their back. Run twice, the second pass creates nothing,
+        which is what lets a set change reach carriers acquired long ago.
+
+        Everything created is **caused by** the carrier and hosted
         alongside it, so removing the carrier removes all of it, and a
-        card draws the grants as ordinary lines with the carrier as their
-        source. Pass ``gang`` for a gang-hosted carrier, which has no
-        model to hang things on.
+        card draws the grants as ordinary lines with the carrier as
+        their source. Pass ``gang`` for a gang-hosted carrier, which has
+        no model to hang things on. A satisfied member is skipped before
+        ``assign`` runs at all: stored effects fire inside it, and a
+        false "missing" would breed a second pet.
 
         Nothing is ever replaced: the option not taken is simply never
-        created, which is what keeps this free of v1's inheritance mess.
-        A thing that may be swapped for something else is an *option*,
-        not a built-in.
+        created. A thing that may be swapped for something else is an
+        *option*, not a built-in.
 
         A weapon-profile member is an extra ammo type: it stacks on its
-        weapon's assignment — the same shape ``buy_weapon_profile`` writes
-        — and that weapon may arrive from any of these sets, so the ammo
-        is granted after every weapon has been.
+        weapon's assignment — the same shape ``buy_weapon_profile``
+        writes — and that weapon may arrive from any of these sets, so
+        ammo is placed after every weapon has been. Each weapon member
+        keeps a gun of its own, so two members bringing the same weapon
+        feed their ammo to different guns. Ammo whose weapon is nowhere
+        on the host is a content bug at acquisition (``strict``) and a
+        recorded skip on a later reconcile — a carrier must not be
+        unrepairable because one member is.
 
-        A slot member brings the choice open. Where the member also names
-        a starting pick, the pick is written in the same breath, settling
-        the slot exactly as a click would — changing it later is the
-        ordinary rechoose.
+        A slot member brings the choice open. Where the member also
+        names a starting pick, the pick is written in the same breath,
+        settling the slot exactly as a click would — changing it later
+        is the ordinary rechoose. An already-settled slot is a satisfied
+        member: its pick stands untouched.
 
-        ``kinds`` narrows what materialises — a Legacy profile brings its
-        lists but not a second set of free kit.
+        ``kinds`` narrows what materialises (derived from the carrier's
+        role when not given — a Legacy profile brings its lists but not
+        a second set of free kit); ``fresh`` names sets being taken
+        right now, judged by live copies alone (``plan_defaults``).
         """
-        from n26.core.models import ChosenProfileOption, CounterValue, Reason
+        from n26.core.builtins import ReconcileOutcome, copies_of, plan_defaults
+        from n26.core.models import CounterValue, Reason
         from n26.library.models import Weapon, WeaponProfile
+
+        plan = plan_defaults(carrier, kinds=kinds, built_ins=built_ins, fresh=fresh)
 
         miniature = None if gang is not None else carrier.miniature_root
         if gang is not None:
@@ -975,52 +1010,70 @@ class Operation:
             # and whatever it *spawns* (``OpAddsMiniature``) is a gang
             # member like any other.
             host = {"stash": carrier.stash_root}
-        sets = [getattr(carrier.assignable, "built_ins", None) if built_ins else None]
-        sets += taken
-        weapon_assignments = {}
+
+        created = []
+        skipped = []
+        #: weapon pk -> guns of this plan still open to take ammo, in
+        #: member order. One entry per weapon member, so twins stay
+        #: distinct.
+        guns = {}
         ammo = []
-        for default_set in sets:
-            if default_set is None:
+        for entry in plan.entries:
+            member = entry.member
+            assignable = member.assignable
+            if isinstance(assignable, WeaponProfile):
+                ammo.append(entry)
                 continue
-            # An archived member is a built-in an author has taken off:
-            # future acquisitions come without it, while every copy it
-            # already materialised stands untouched.
-            for member in default_set.members.filter(archived=False):
-                assignable = member.assignable
-                if assignable is None:
-                    continue
-                if kinds is not None and not isinstance(assignable, kinds):
-                    continue
-                if isinstance(assignable, WeaponProfile):
-                    ammo.append(member)
-                    continue
-                assignment = self.assign(
-                    assignable,
-                    caused_by=carrier,
-                    materialised_from=member,
-                    materialised_for=carrier,
-                    paid=0,
-                    reason=Reason.DEFAULT,
-                    **host,
-                )
+            if entry.satisfied:
                 if isinstance(assignable, Weapon):
-                    self._grant_free_profiles(assignable, assignment)
-                    weapon_assignments[assignable.pk] = assignment
-                elif member.default_pickable_id is not None:
-                    # A slot arriving already settled. The pick goes
-                    # where the slot says, which need not be where the
-                    # slot itself landed.
-                    self._choose_for_slot(
-                        assignment, assignable, member.default_pickable
-                    )
-                elif member.counter_id is not None:
-                    # A counter opens at its member's amount — Starting XP.
-                    CounterValue.objects.create(
-                        assignment=assignment, value=member.amount
-                    )
-        for member in ammo:
+                    copy = copies_of(member, carrier, include_archived=False).first()
+                    if copy is not None:
+                        guns.setdefault(assignable.pk, []).append(copy)
+                continue
+            assignment = self.assign(
+                assignable,
+                caused_by=carrier,
+                materialised_from=member,
+                materialised_for=carrier,
+                paid=0,
+                reason=Reason.DEFAULT,
+                **host,
+            )
+            created.append(assignment)
+            if isinstance(assignable, Weapon):
+                self._grant_free_profiles(assignable, assignment)
+                guns.setdefault(assignable.pk, []).append(assignment)
+            elif member.default_pickable_id is not None:
+                # A slot arriving already settled. The pick goes
+                # where the slot says, which need not be where the
+                # slot itself landed.
+                self._choose_for_slot(assignment, assignable, member.default_pickable)
+            elif member.counter_id is not None:
+                # A counter opens at its member's amount — Starting XP.
+                CounterValue.objects.create(assignment=assignment, value=member.amount)
+
+        # A satisfied ammo line already sits on one particular gun. That
+        # gun is spoken for: a missing ammo member must not double onto
+        # it while another of the plan's guns goes without.
+        for entry in ammo:
+            if not entry.satisfied:
+                continue
+            copy = copies_of(entry.member, carrier, include_archived=False).first()
+            if copy is None:
+                continue
+            queue = guns.get(entry.member.assignable.weapon_id, [])
+            for index, gun in enumerate(queue):
+                if gun.pk == copy.parent_id:
+                    del queue[index]
+                    break
+
+        for entry in ammo:
+            if entry.satisfied:
+                continue
+            member = entry.member
             weapon_profile = member.assignable
-            gun = weapon_assignments.get(weapon_profile.weapon_id)
+            queue = guns.get(weapon_profile.weapon_id)
+            gun = queue.pop(0) if queue else None
             if gun is None:
                 # The weapon may already be there — a set chosen after the
                 # hire grants ammo for a gun the built-ins brought — so an
@@ -1036,29 +1089,42 @@ class Operation:
                     .first()
                 )
             if gun is None:
-                # A content bug, not a player mistake: the set names ammo
-                # for a weapon nothing here brings.
-                raise ValueError(
-                    f"{carrier.assignable} grants {weapon_profile}, but "
-                    f"nothing it brings is its weapon "
-                    f"({weapon_profile.weapon})."
+                if strict:
+                    # A content bug, not a player mistake: the set names
+                    # ammo for a weapon nothing here brings.
+                    raise ValueError(
+                        f"{carrier.assignable} grants {weapon_profile}, but "
+                        f"nothing it brings is its weapon "
+                        f"({weapon_profile.weapon})."
+                    )
+                skipped.append(
+                    (
+                        entry,
+                        f"{weapon_profile} is ammo for "
+                        f"{weapon_profile.weapon}, and nothing this "
+                        f"carrier's host holds is that weapon.",
+                    )
                 )
+                continue
             # Caused by the weapon, like its free profiles: the card says
             # "from the grenade launcher array", not "from the profile".
             # Provenance names the member and the carrier all the same —
             # it records which set membership this satisfies, and the gun
             # is only where the copy landed.
-            self.assign(
-                weapon_profile,
-                parent=gun,
-                caused_by=gun,
-                materialised_from=member,
-                materialised_for=carrier,
-                paid=0,
-                reason=Reason.DEFAULT,
+            created.append(
+                self.assign(
+                    weapon_profile,
+                    parent=gun,
+                    caused_by=gun,
+                    materialised_from=member,
+                    materialised_for=carrier,
+                    paid=0,
+                    reason=Reason.DEFAULT,
+                )
             )
-        for chosen in taken:
-            ChosenProfileOption.objects.create(assignment=carrier, default_set=chosen)
+        return ReconcileOutcome(
+            carrier=carrier, plan=plan, created=created, skipped=skipped
+        )
 
     def choose(self, anchor, chosen, slot=None, offer=None, **kwargs):
         """Make a choice — pick a specialisation, pick a gang legacy.
@@ -1217,11 +1283,11 @@ class Operation:
         Legacy's list — and nothing else. No free weapons, no subtypes,
         no second helping of default kit.
         """
-        from n26.library.models import Collection
-
         assignment = self.assign(profile, miniature=miniature, **kwargs)
         ProfileRole.objects.create(assignment=assignment, role=ProfileRole.Role.LEGACY)
-        self._materialise_defaults(assignment, [], kinds=(Collection,))
+        # The Legacy role narrows what reconciling grants to the lists
+        # alone (``n26.core.builtins.kinds_for``), so it is written first.
+        self.reconcile_defaults(assignment)
         return assignment
 
     def give_weapon(self, miniature, weapon, paid=0, free_profiles=True, **kwargs):
@@ -1344,7 +1410,8 @@ class Operation:
                 thing, bought, sold_separately=_sold_separately(line, entry, thing)
             )
         if hasattr(thing, "resolve_selection"):
-            self._materialise_defaults(bought, taken)
+            self._record_options(bought, taken)
+            self.reconcile_defaults(bought)
         return bought
 
     def learn(self, miniature, thing, note=""):

--- a/n26/tests/sandbox/test_builtin_reconciliation.py
+++ b/n26/tests/sandbox/test_builtin_reconciliation.py
@@ -1,0 +1,539 @@
+"""Reconciling a carrier against its sets — built-ins as desired state.
+
+``Operation.reconcile_defaults`` re-reads what a carrier's sets say it
+should hold and creates only what is missing, judged by provenance
+alone: a copy naming the member and the carrier. Run twice it creates
+nothing; an owner's own copy of the same thing never stands in for a
+built-in; an archived copy still satisfies, because what an owner
+parted with is never handed back. This is what lets a built-in added
+to a profile later reach the fighters already hired from it.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
+
+from n26.core.models import Assignment, ChosenProfileOption, Miniature, Reason
+from n26.core.operations import operation
+from n26.core.reconcile import assert_reconciled
+from n26.library.authoring import add_default_member
+from n26.library.models import WeaponProfile
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    add_legacy_profile,
+    choose,
+    create_collection,
+    create_counter,
+    create_default_set,
+    create_gang_type,
+    create_hidden,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_rule,
+    create_slot,
+    create_slot_type,
+    create_wargear,
+    create_weapon,
+    found_gang,
+    give_weapon,
+    hire,
+    hire_with_option,
+    modifier,
+    offer_option,
+    op_adds_model,
+    remove,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def player():
+    return User.objects.create_user("tom")
+
+
+@pytest.fixture
+def gang(gang_type, player):
+    return found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+
+
+@pytest.fixture
+def ganger(person_type, gang_type, default_pack):
+    """A profile whose built-ins carry a weapon and a rule."""
+    profile = create_profile("Ganger", person_type, gang_type, price=50)
+    add_built_in(profile, create_weapon("Stub gun", profiles=[("Standard", 0)]))
+    add_built_in(profile, create_rule("Gang Fighter"))
+    return profile
+
+
+def member_named(carrier, name):
+    """The built-in membership whose thing prints ``name``."""
+    return next(
+        member
+        for member in carrier.built_ins.members.all()
+        if str(member.assignable) == name
+    )
+
+
+def reconcile(gang, carrier, **kwargs):
+    """A bare reconcile pass — hosted on the gang for a gang-hosted
+    carrier about no model, the same inference rechoose makes."""
+    if carrier.miniature_root_id is None and carrier.gang_id is not None:
+        kwargs.setdefault("gang", carrier.gang)
+    with operation(gang, actor=gang.owner) as op:
+        return op.reconcile_defaults(carrier, **kwargs)
+
+
+def copies_by_member(carrier):
+    """Copy counts keyed by member, archived included — the provenance
+    pairs are what idempotency is asserted over, not a bare row count."""
+    counts = {}
+    for copy in Assignment.objects.filter(materialised_for=carrier):
+        counts[copy.materialised_from_id] = counts.get(copy.materialised_from_id, 0) + 1
+    return counts
+
+
+class TestReconcilingTwiceCreatesNothing:
+    """The engine is idempotent: a pass over a settled carrier is a no-op,
+    and a member added later arrives exactly once."""
+
+    def test_a_second_pass_over_a_fresh_hire_creates_nothing(self, gang, ganger):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        membership = fighter.membership
+        before = copies_by_member(membership)
+
+        outcome = reconcile(gang, membership)
+
+        assert outcome.created == []
+        assert outcome.skipped == []
+        assert copies_by_member(membership) == before
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_member_added_later_arrives_once_however_often_it_runs(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        member = add_built_in(ganger, create_rule("Nerves of Steel"))
+
+        reconcile(gang, fighter.membership)
+        reconcile(gang, fighter.membership)
+
+        assert copies_by_member(fighter.membership)[member.pk] == 1
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestAnOwnersOwnCopyNeverStandsIn:
+    """Satisfaction is provenance, not appearance: an independent copy of
+    the same thing does not block the grant, and the duplicate stands."""
+
+    def test_an_independent_copy_does_not_block_the_grant(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        steel = create_rule("Nerves of Steel")
+        with operation(gang, actor=gang.owner) as op:
+            op.assign(steel, miniature=fighter, paid=0)
+        member = add_built_in(ganger, steel)
+
+        reconcile(gang, fighter.membership)
+
+        copies = Assignment.objects.filter(
+            rule=steel, miniature_root=fighter, archived=False
+        )
+        assert copies.count() == 2
+        assert copies.filter(materialised_from=member).count() == 1
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestWhatAnOwnerPartedWithStaysGone:
+    """An archived copy still satisfies its member — removing or selling
+    a grant is settled, never quietly undone by a later reconcile."""
+
+    def test_an_archived_copy_blocks_the_regrant(self, gang, ganger):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        member = member_named(ganger, "Stub gun")
+        copy = Assignment.objects.get(
+            materialised_from=member, materialised_for=fighter.membership
+        )
+        remove(copy)
+
+        outcome = reconcile(gang, fighter.membership)
+
+        assert outcome.created == []
+        assert (
+            Assignment.objects.filter(
+                materialised_from=member, materialised_for=fighter.membership
+            ).count()
+            == 1
+        )
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestAnOwnersRemovalIsMachinery:
+    """A ``removes`` assignment suppresses a thing; it is not a copy of
+    one. It never satisfies a member, and the grant never disturbs it."""
+
+    def test_a_take_away_never_satisfies_and_survives_the_grant(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        fury = create_rule("Fury")
+        with operation(gang, actor=gang.owner) as op:
+            op.take_away(fighter, fury)
+        member = add_built_in(ganger, fury)
+
+        reconcile(gang, fighter.membership)
+
+        copy = Assignment.objects.get(
+            materialised_from=member, materialised_for=fighter.membership
+        )
+        assert copy.archived is False
+        removal = Assignment.objects.get(
+            rule=fury, removes=True, miniature_root=fighter
+        )
+        assert removal.archived is False
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_the_database_refuses_a_removal_carrying_provenance(self, gang, ganger):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        member = member_named(ganger, "Gang Fighter")
+
+        with pytest.raises(IntegrityError):
+            with transaction.atomic():
+                with operation(gang, actor=gang.owner) as op:
+                    op.assign(
+                        member.assignable,
+                        miniature=fighter,
+                        paid=0,
+                        reason=Reason.EDITED,
+                        removes=True,
+                        materialised_from=member,
+                        materialised_for=fighter.membership,
+                    )
+
+
+class TestWeaponsArriveWhole:
+    def test_a_weapon_added_later_brings_its_free_profiles_once(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        add_built_in(ganger, launcher)
+
+        reconcile(gang, fighter.membership)
+        reconcile(gang, fighter.membership)
+
+        guns = Assignment.objects.filter(
+            miniature_root=fighter, weapon=launcher, archived=False
+        )
+        assert guns.count() == 1
+        lines = Assignment.objects.filter(
+            parent=guns.get(), weapon_profile__isnull=False, archived=False
+        )
+        assert [line.weapon_profile.name for line in lines] == ["Frag"]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestAmmoFindsItsGun:
+    """A weapon-profile member stacks on a gun's assignment, and each
+    weapon member keeps a gun of its own."""
+
+    def test_twin_members_of_one_weapon_feed_their_own_guns(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        choke = WeaponProfile.objects.create(
+            name="Choke", weapon=launcher, price=10, position=2
+        )
+        profile = create_profile("Twin gunner", person_type, gang_type, price=50)
+        add_built_in(profile, launcher)
+        add_built_in(profile, launcher)
+        add_built_in(profile, smoke)
+        add_built_in(profile, choke)
+
+        fighter = hire(gang, profile, "Ana", paid=50)
+
+        guns = Assignment.objects.filter(
+            miniature_root=fighter, weapon=launcher, archived=False
+        )
+        assert guns.count() == 2
+        smoke_row = Assignment.objects.get(
+            weapon_profile=smoke, miniature_root=fighter, archived=False
+        )
+        choke_row = Assignment.objects.get(
+            weapon_profile=choke, miniature_root=fighter, archived=False
+        )
+        assert smoke_row.parent_id != choke_row.parent_id
+
+        outcome = reconcile(gang, fighter.membership)
+        assert outcome.created == []
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_ammo_lands_on_a_gun_the_owner_gave_by_hand(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        gun = give_weapon(fighter, launcher)
+        member = add_built_in(ganger, smoke)
+
+        reconcile(gang, fighter.membership)
+
+        row = Assignment.objects.get(
+            materialised_from=member, materialised_for=fighter.membership
+        )
+        assert row.parent_id == gun.pk
+        assert row.caused_by_id == gun.pk
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_orphan_ammo_is_recorded_on_a_reconcile_and_refused_at_hire(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        add_built_in(ganger, smoke)
+
+        outcome = reconcile(gang, fighter.membership, strict=False)
+
+        assert len(outcome.skipped) == 1
+        entry, why = outcome.skipped[0]
+        assert entry.member.assignable == smoke
+        assert "Launcher" in why
+        assert not Assignment.objects.filter(weapon_profile=smoke).exists()
+
+        with pytest.raises(ValueError):
+            hire(gang, ganger, "Bea", paid=50)
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+@pytest.fixture
+def legacy_slot_type(default_pack):
+    return create_slot_type(
+        "Gang Legacy", plural_name="Gang Legacies", allows_repeats=False
+    )
+
+
+@pytest.fixture
+def houses(legacy_slot_type):
+    return {
+        name: create_pickable(name, legacy_slot_type) for name in ("Cawdor", "Escher")
+    }
+
+
+@pytest.fixture
+def legacy_slot(legacy_slot_type, houses):
+    return create_slot(
+        "Gang Legacy",
+        legacy_slot_type,
+        create_picklist(
+            "Gang Legacies", legacy_slot_type, members=list(houses.values())
+        ),
+    )
+
+
+class TestSlotsAndPicks:
+    def test_an_answered_slot_is_left_untouched(
+        self, gang, person_type, gang_type, legacy_slot, houses
+    ):
+        profile = create_profile("Hunter", person_type, gang_type, price=100)
+        add_built_in(profile, legacy_slot)
+        fighter = hire(gang, profile, "Ana", paid=100)
+        slot_row = Assignment.objects.get(
+            miniature_root=fighter, slot__isnull=False, archived=False
+        )
+        choose(slot_row, houses["Cawdor"])
+
+        outcome = reconcile(gang, fighter.membership)
+
+        assert outcome.created == []
+        picks = Assignment.objects.filter(chosen_for=slot_row, archived=False)
+        assert picks.count() == 1
+        assert picks.get().pickable == houses["Cawdor"]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_slot_with_a_default_added_later_arrives_settled(
+        self, gang, ganger, legacy_slot, houses
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        member = add_built_in(ganger, legacy_slot, default_pickable=houses["Escher"])
+
+        reconcile(gang, fighter.membership)
+        reconcile(gang, fighter.membership)
+
+        slot_row = Assignment.objects.get(
+            materialised_from=member,
+            materialised_for=fighter.membership,
+            archived=False,
+        )
+        picks = Assignment.objects.filter(chosen_for=slot_row, archived=False)
+        assert picks.count() == 1
+        assert picks.get().pickable == houses["Escher"]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestCountersOpenOnce:
+    def test_a_counter_added_later_opens_once_at_its_amount(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        xp = create_counter("XP")
+        add_built_in(ganger, xp, amount=61)
+
+        reconcile(gang, fighter.membership)
+        reconcile(gang, fighter.membership)
+
+        rows = Assignment.objects.filter(
+            counter=xp, miniature_root=fighter, archived=False
+        )
+        assert rows.count() == 1
+        assert rows.get().counter_value.value == 61
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestStoredEffectsRunOnce:
+    """Stored effects fire inside ``assign``, so a satisfied member must
+    be skipped before assign runs at all — a false miss breeds pets."""
+
+    def test_a_pet_riding_a_built_in_is_spawned_exactly_once(
+        self, gang, ganger, person_type, gang_type, default_pack
+    ):
+        cat = create_profile("Gyrinx cat", person_type, gang_type, price=0)
+        collar = create_wargear("Cat collar")
+        modifier(
+            "Collar: brings the cat",
+            targets_model(),
+            op_adds_model(cat),
+            carried_by=collar,
+        )
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        add_built_in(ganger, collar)
+
+        reconcile(gang, fighter.membership)
+        reconcile(gang, fighter.membership)
+
+        assert Miniature.objects.filter(membership__profile=cat).count() == 1
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestGangAndStashHostedCarriers:
+    def test_the_founding_gains_a_member_added_to_the_gang_type(
+        self, gang, gang_type, default_pack
+    ):
+        member = add_built_in(gang_type, create_rule("Home Turf"))
+
+        reconcile(gang, gang.founding)
+        reconcile(gang, gang.founding)
+
+        copies = Assignment.objects.filter(
+            materialised_from=member, materialised_for=gang.founding
+        )
+        assert copies.count() == 1
+        assert copies.get().gang_id == gang.pk
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_stash_purchase_reconciles_where_it_lives(self, gang, default_pack):
+        toolkit = create_wargear("Toolkit", price=10)
+        with operation(gang, actor=gang.owner) as op:
+            bought = op.buy(gang.stash, thing=toolkit)
+        member = add_built_in(toolkit, create_hidden("Fine tools"))
+
+        reconcile(gang, bought)
+
+        copy = Assignment.objects.get(materialised_from=member, materialised_for=bought)
+        assert copy.stash_id == gang.stash.pk
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestLegacyProfilesBringOnlyLists:
+    """A Legacy association brings equipment lists and nothing else, and
+    a bare reconcile derives that from the carrier's role — no caller
+    has to remember to narrow it."""
+
+    def test_a_bare_reconcile_of_a_legacy_carrier_brings_only_collections(
+        self, gang, ganger, person_type, gang_type, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        legacy = create_profile("Legacy entry", person_type, gang_type, price=0)
+        association = add_legacy_profile(fighter, legacy)
+        list_member = add_built_in(legacy, create_collection("Legacy List"))
+        add_built_in(legacy, create_weapon("Legacy blade", profiles=[("Slash", 0)]))
+
+        outcome = reconcile(gang, association)
+
+        assert [copy.materialised_from_id for copy in outcome.created] == [
+            list_member.pk
+        ]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestRefoundingStaysSettled:
+    def test_refound_then_reconcile_duplicates_nothing(
+        self, gang_type, player, default_pack
+    ):
+        delaque = create_gang_type("Delaque")
+        member = add_built_in(delaque, create_rule("Shadowy"))
+        gang = found_gang("The Movers", gang_type, owner=player, budget=1000)
+        with operation(gang, actor=player) as op:
+            op.refound(delaque)
+        gang.refresh_from_db()
+
+        reconcile(gang, gang.founding)
+
+        assert Assignment.objects.filter(materialised_from=member).count() == 1
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestChosenSetsGrowLater:
+    def test_a_chosen_set_grown_later_reaches_the_carrier_once(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        profile = create_profile("Chooser", person_type, gang_type, price=100)
+        fancy = create_default_set(
+            "Fancy kit",
+            members=[create_weapon("Sword", profiles=[("Slash", 0)])],
+            price=25,
+        )
+        offer_option(profile, "Fancy kit", default_set=fancy)
+        fighter = hire_with_option(gang, profile, "Ana", option=fancy)
+        grown = add_default_member(fancy, create_rule("Flair"))
+
+        reconcile(gang, fighter.membership)
+        reconcile(gang, fighter.membership)
+
+        assert Assignment.objects.filter(materialised_from=grown).count() == 1
+        assert (
+            ChosenProfileOption.objects.filter(
+                assignment=fighter.membership, default_set=fancy
+            ).count()
+            == 1
+        )
+        gang.refresh_from_db()
+        assert_reconciled(gang)

--- a/n26/tests/sandbox/test_builtin_reconciliation.py
+++ b/n26/tests/sandbox/test_builtin_reconciliation.py
@@ -88,7 +88,7 @@ def reconcile(gang, carrier, **kwargs):
 
 def copies_by_member(carrier):
     """Copy counts keyed by member, archived included — the provenance
-    pairs are what idempotency is asserted over, not a bare row count."""
+    pairs are what idempotency is asserted over, not a bare copy count."""
     counts = {}
     for copy in Assignment.objects.filter(materialised_for=carrier):
         counts[copy.materialised_from_id] = counts.get(copy.materialised_from_id, 0) + 1
@@ -268,13 +268,13 @@ class TestAmmoFindsItsGun:
             miniature_root=fighter, weapon=launcher, archived=False
         )
         assert guns.count() == 2
-        smoke_row = Assignment.objects.get(
+        smoke_copy = Assignment.objects.get(
             weapon_profile=smoke, miniature_root=fighter, archived=False
         )
-        choke_row = Assignment.objects.get(
+        choke_copy = Assignment.objects.get(
             weapon_profile=choke, miniature_root=fighter, archived=False
         )
-        assert smoke_row.parent_id != choke_row.parent_id
+        assert smoke_copy.parent_id != choke_copy.parent_id
 
         outcome = reconcile(gang, fighter.membership)
         assert outcome.created == []
@@ -294,11 +294,11 @@ class TestAmmoFindsItsGun:
 
         reconcile(gang, fighter.membership)
 
-        row = Assignment.objects.get(
+        copy = Assignment.objects.get(
             materialised_from=member, materialised_for=fighter.membership
         )
-        assert row.parent_id == gun.pk
-        assert row.caused_by_id == gun.pk
+        assert copy.parent_id == gun.pk
+        assert copy.caused_by_id == gun.pk
         gang.refresh_from_db()
         assert_reconciled(gang)
 
@@ -358,15 +358,15 @@ class TestSlotsAndPicks:
         profile = create_profile("Hunter", person_type, gang_type, price=100)
         add_built_in(profile, legacy_slot)
         fighter = hire(gang, profile, "Ana", paid=100)
-        slot_row = Assignment.objects.get(
+        slot_copy = Assignment.objects.get(
             miniature_root=fighter, slot__isnull=False, archived=False
         )
-        choose(slot_row, houses["Cawdor"])
+        choose(slot_copy, houses["Cawdor"])
 
         outcome = reconcile(gang, fighter.membership)
 
         assert outcome.created == []
-        picks = Assignment.objects.filter(chosen_for=slot_row, archived=False)
+        picks = Assignment.objects.filter(chosen_for=slot_copy, archived=False)
         assert picks.count() == 1
         assert picks.get().pickable == houses["Cawdor"]
         gang.refresh_from_db()
@@ -381,12 +381,12 @@ class TestSlotsAndPicks:
         reconcile(gang, fighter.membership)
         reconcile(gang, fighter.membership)
 
-        slot_row = Assignment.objects.get(
+        slot_copy = Assignment.objects.get(
             materialised_from=member,
             materialised_for=fighter.membership,
             archived=False,
         )
-        picks = Assignment.objects.filter(chosen_for=slot_row, archived=False)
+        picks = Assignment.objects.filter(chosen_for=slot_copy, archived=False)
         assert picks.count() == 1
         assert picks.get().pickable == houses["Escher"]
         gang.refresh_from_db()
@@ -404,11 +404,11 @@ class TestCountersOpenOnce:
         reconcile(gang, fighter.membership)
         reconcile(gang, fighter.membership)
 
-        rows = Assignment.objects.filter(
+        copies = Assignment.objects.filter(
             counter=xp, miniature_root=fighter, archived=False
         )
-        assert rows.count() == 1
-        assert rows.get().counter_value.value == 61
+        assert copies.count() == 1
+        assert copies.get().counter_value.value == 61
         gang.refresh_from_db()
         assert_reconciled(gang)
 

--- a/n26/tests/sandbox/test_rechoosing.py
+++ b/n26/tests/sandbox/test_rechoosing.py
@@ -146,6 +146,31 @@ class TestSwappingAChoice:
         assert weapon_names(beast) == ["Chemical cloud breath", "Talons"]
         assert_reconciled(gang)
 
+    def test_leaving_a_set_and_returning_restores_its_kit(self, gang, khimerix):
+        """Re-taking a set is an acquisition, and what is bought arrives.
+        The copies the first tenure left archived are history — they
+        never stand in for the kit the owner is paying for again."""
+        eruption = sets_of(khimerix)["Eruption breath"]
+        beast = hire_with_option(gang, khimerix, "Vhast", option=eruption)
+        gang.refresh_from_db()
+        cash = gang.credits
+
+        rechoose(gang, beast, sets_of(khimerix)["Standard Khimerix"])
+        rechoose(gang, beast, eruption)
+
+        assert weapon_names(beast) == ["Gaseous eruption breath", "Talons"]
+        member = eruption.members.first()
+        copies = Assignment.objects.filter(
+            materialised_from=member, materialised_for=beast.membership
+        )
+        assert copies.count() == 2
+        assert copies.filter(archived=False).count() == 1
+        gang.refresh_from_db()
+        # The 25cr difference came back on leaving and went out again on
+        # returning.
+        assert gang.credits == cash
+        assert_reconciled(gang)
+
     def test_the_record_of_what_is_taken_follows(self, gang, khimerix):
         beast = hire_with_option(gang, khimerix, "Vhast")
         eruption = sets_of(khimerix)["Eruption breath"]


### PR DESCRIPTION
Chunk C2 of the built-in propagation programme (#2165): materialisation becomes an idempotent reconciliation engine. `_materialise_defaults` — which unconditionally created a copy of every set member at acquisition — is replaced by `Operation.reconcile_defaults`, which re-reads what a carrier's sets say it should hold and creates only what is missing, judged by provenance (`materialised_from` / `materialised_for`). Run twice it creates nothing, which is the property C4's live propagation and C7's backfill will stand on: a built-in added to a profile later can now be pushed to fighters already hired from it by simply reconciling them.

What changed:

- **New pure module `n26/core/builtins.py`** — the read side. `copies_of` / `copies_of_set` are the one provenance lookup (shared by the engine, `_granted_rows`, and later chunks); `sets_for` / `kinds_for` say what a carrier is owed (a Legacy profile's narrowing to equipment lists is now derived from its `ProfileRole` rather than passed by the caller); `plan_defaults` folds it into a `DefaultsPlan` of per-member satisfied flags. No writes — C5's preview will render a plan directly.
- **`Operation.reconcile_defaults`** applies a plan it computes itself, inside the operation's transaction — it never accepts a precomputed plan, so a stale preview can never authorise anything. A satisfied member is skipped before `assign()` runs at all, because stored effects fire inside it (a false miss would spawn a second pet — there is a test spanning two passes). Satisfaction rules: an owner's independent copy of the same thing never stands in (a visible duplicate is accepted); an archived copy still satisfies (what an owner parted with is never handed back).
- **The six acquisition call sites** (`hire`, `found`, `refound`, `rechoose`, `add_legacy_profile`, `buy`) now record their `ChosenProfileOption` rows first and then reconcile; the engine's `taken` parameter is gone. Every existing suite passes unchanged.
- **Ammo finds the right gun.** Weapon-profile members resolve their gun through a per-weapon FIFO of the plan's own weapon members, so two members bringing the identical weapon feed their ammo to different guns (previously both ammo lines piled onto one gun and the other went without). On a bare reconcile (`strict=False`) ammo whose gun is nowhere on the host is recorded in the outcome's `skipped` instead of raising, so one broken member cannot make a carrier unrepairable; genuine acquisition still raises.
- **Migration `n26.0022`** adds a CheckConstraint: a `removes=True` assignment may not carry `materialised_from`. A removal is machinery — it suppresses a thing rather than holding one — so it must never satisfy the provenance lookup, and that is now structural.

Two deliberate deviations from the reviewed design, both forced by the existing suites (the stated oracle) — reviewed and approved:

1. `plan_defaults` / `reconcile_defaults` accept `fresh=` — sets being taken right now, judged by live copies only. `rechoose` passes its arriving sets. Without this, rechoosing back to a formerly-held option set finds the copies its own earlier refund archived, deems every member satisfied, and charges the price delta while granting nothing. The archived-copy rule guards against unattended re-grants; an explicit re-take is an acquisition, and what is bought arrives. A bare reconcile passes no `fresh` sets, so the rule applies in full during propagation and backfill; there is an A-to-B-and-back test pinning the restored kit and the round-trip charge.
2. The ammo fallback keeps its existing shape (any live same-host assignment of the weapon, newest first) rather than the provenance-null filter from review: with `built_ins=False` the plan cannot see the built-in gun, so the filtered version breaks `test_an_arriving_sets_ammo_lands_under_the_standing_gun` and the buy-ammo-for-a-hired-gun case.

Refs #2165

## Test plan

- [x] `pytest n26` — 4015 passed, 1 xfailed (3996 pre-existing tests green before any new test was written)
- [x] New suite `n26/tests/sandbox/test_builtin_reconciliation.py` (19 tests): run-twice creates nothing; independent copy never blocks; archived copy blocks; `take_away` survives the grant and the DB refuses a removal with provenance; weapons + free profiles once; twin-gun ammo; hand-given-gun ammo; orphan ammo skipped on reconcile / raised at hire; answered slot untouched; slot-with-default added later arrives settled; counter opens once at its amount; `OpAddsMiniature` spawns one pet across two passes; founding, stash, Legacy and refound carriers; a chosen set grown later reaches its carrier once — every money-touching case ends `assert_reconciled(gang)` after `refresh_from_db`
- [x] Whole repo `pytest -n auto` — 8378 passed, 12 skipped, 1 xfailed
- [x] `./scripts/fmt.sh`, `./scripts/check_migrations.sh`, `manage migrate` smoke on a real database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

