### PR TITLE
feat: a weapon-profile built-in names the gun member it rides

### DIFF
--- a/n26/core/card.py
+++ b/n26/core/card.py
@@ -764,7 +764,12 @@ def build_card_from_profile(profile, option=None, base=None):
         reason=Reason.BOUGHT,
     )
     roots = [root]
-    weapon_nodes = {}
+    #: The gun each weapon member brings, by the member — an anchored
+    #: ammo line names its member, so twins stay distinct.
+    member_guns = {}
+    #: The last-arrived gun of each weapon, for an ammo line that names
+    #: no member and rides whatever matching gun the hire brings.
+    latest_guns = {}
     ammo = []
 
     for default_set in (profile.built_ins, *taken):
@@ -780,7 +785,7 @@ def build_card_from_profile(profile, option=None, base=None):
             if assignable is None:
                 continue
             if isinstance(assignable, WeaponProfile):
-                ammo.append(assignable)
+                ammo.append(member)
                 continue
             node = Node(
                 assignable=assignable,
@@ -803,7 +808,8 @@ def build_card_from_profile(profile, option=None, base=None):
                     for weapon_profile in assignable.profiles.all()
                     if weapon_profile.price == 0
                 )
-                weapon_nodes[assignable.pk] = node
+                member_guns[member.pk] = node
+                latest_guns[assignable.pk] = node
             roots.append(node)
             if member.default_pickable_id is not None:
                 # A slot arriving already settled: the preview draws the
@@ -820,9 +826,15 @@ def build_card_from_profile(profile, option=None, base=None):
                 )
 
     # Bundled ammo stacks under its weapon, wherever in the selection the
-    # weapon arrived — the same order of business as the hire itself.
-    for weapon_profile in ammo:
-        host = weapon_nodes.get(weapon_profile.weapon_id)
+    # weapon arrived — the same order of business as the hire itself: a
+    # member naming its gun lands on that member's own node, one naming
+    # none on the last-arrived gun of its weapon.
+    for member in ammo:
+        weapon_profile = member.assignable
+        if member.gun_member_id is not None:
+            host = member_guns.get(member.gun_member_id)
+        else:
+            host = latest_guns.get(weapon_profile.weapon_id)
         if host is None:
             raise ValueError(
                 f"{profile.name} grants {weapon_profile}, but nothing in "

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -975,12 +975,14 @@ class Operation:
         A weapon-profile member is an extra ammo type: it stacks on its
         weapon's assignment — the same shape ``buy_weapon_profile``
         writes — and that weapon may arrive from any of these sets, so
-        ammo is placed after every weapon has been. Each weapon member
-        keeps a gun of its own, so two members bringing the same weapon
-        feed their ammo to different guns. Ammo whose weapon is nowhere
-        on the host is a content bug at acquisition (``strict``) and a
-        recorded skip on a later reconcile — a carrier must not be
-        unrepairable because one member is.
+        ammo is placed after every weapon has been. An anchored member
+        names its gun member (``gun_member``), and the line lands on
+        that member's own live copy for this carrier; an unanchored one
+        rides whatever live matching weapon the host holds, newest
+        first — how an option set arms a gun the built-ins bring. Ammo
+        with no gun to land on is a content bug at acquisition
+        (``strict``) and a recorded skip on a later reconcile — a
+        carrier must not be unrepairable because one member is.
 
         A slot member brings the choice open. Where the member also
         names a starting pick, the pick is written in the same breath,
@@ -1020,31 +1022,12 @@ class Operation:
             for entry in plan.entries
             if isinstance(entry.member.assignable, WeaponProfile)
         ]
-        # A satisfied ammo line already sits on one particular gun. That
-        # gun is spoken for — claims resolve by provenance before queue
-        # position — so it never joins the queue and a missing ammo
-        # member cannot double onto it while another gun goes without.
-        occupied = set()
-        for entry in ammo:
-            if not entry.satisfied:
-                continue
-            copy = copies_of(entry.member, carrier, include_archived=False).first()
-            if copy is not None:
-                occupied.add(copy.parent_id)
-        #: weapon pk -> guns of this plan still open to take ammo, in
-        #: member order. One entry per weapon member, so twins stay
-        #: distinct.
-        guns = {}
         for entry in plan.entries:
             member = entry.member
             assignable = member.assignable
             if isinstance(assignable, WeaponProfile):
                 continue
             if entry.satisfied:
-                if isinstance(assignable, Weapon):
-                    copy = copies_of(member, carrier, include_archived=False).first()
-                    if copy is not None and copy.pk not in occupied:
-                        guns.setdefault(assignable.pk, []).append(copy)
                 continue
             assignment = self.assign(
                 assignable,
@@ -1058,9 +1041,6 @@ class Operation:
             created.append(assignment)
             if isinstance(assignable, Weapon):
                 self._grant_free_profiles(assignable, assignment)
-                # A gun created this pass cannot be occupied: a
-                # satisfied ammo copy predates it.
-                guns.setdefault(assignable.pk, []).append(assignment)
             elif member.default_pickable_id is not None:
                 # A slot arriving already settled. The pick goes
                 # where the slot says, which need not be where the
@@ -1075,12 +1055,19 @@ class Operation:
                 continue
             member = entry.member
             weapon_profile = member.assignable
-            queue = guns.get(weapon_profile.weapon_id)
-            gun = queue.pop(0) if queue else None
-            if gun is None:
-                # The weapon may already be there — a set chosen after the
-                # hire grants ammo for a gun the built-ins brought — so an
-                # existing live assignment on the same host takes it.
+            if member.gun_member_id is not None:
+                # The member names its gun, so the line lands on that
+                # member's own live copy for this carrier — the receipt,
+                # not a guess by type.
+                gun = (
+                    copies_of(member.gun_member, carrier, include_archived=False)
+                    .order_by("-pk")
+                    .first()
+                )
+            else:
+                # An unnamed gun means whatever matching weapon the host
+                # holds — a set chosen after the hire arms a gun the
+                # built-ins brought, or one the owner gave by hand.
                 gun = (
                     Assignment.objects.filter(
                         weapon=weapon_profile.weapon,
@@ -1100,14 +1087,15 @@ class Operation:
                         f"nothing it brings is its weapon "
                         f"({weapon_profile.weapon})."
                     )
-                skipped.append(
-                    (
-                        entry,
-                        f"{weapon_profile} is ammo for "
-                        f"{weapon_profile.weapon}, and nothing this "
-                        f"carrier's host holds is that weapon.",
-                    )
+                why = (
+                    f"{weapon_profile} rides a {weapon_profile.weapon} "
+                    f"whose copy for this carrier is no longer standing."
+                    if member.gun_member_id is not None
+                    else f"{weapon_profile} is ammo for "
+                    f"{weapon_profile.weapon}, and nothing this "
+                    f"carrier's host holds is that weapon."
                 )
+                skipped.append((entry, why))
                 continue
             # Caused by the weapon, like its free profiles: the card says
             # "from the grenade launcher array", not "from the profile".

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -1085,6 +1085,14 @@ def add_default_member(
     return member
 
 
+def gun_members_bringing(default_set, weapon):
+    """The set's live members that bring this weapon — the guns an
+    extra profile of it could ride. One statement of the match, read
+    wherever an anchor is settled or explained.
+    """
+    return default_set.members.filter(archived=False, weapon=weapon)
+
+
 def _the_one_gun_member(default_set, weapon_profile):
     """The set's single live member bringing this profile's weapon — the
     anchor an unnamed add settles on.
@@ -1095,9 +1103,7 @@ def _the_one_gun_member(default_set, weapon_profile):
     words, because a guess here would decide for good which gun a line
     lands under.
     """
-    matches = list(
-        default_set.members.filter(archived=False, weapon_id=weapon_profile.weapon_id)
-    )
+    matches = list(gun_members_bringing(default_set, weapon_profile.weapon))
     if len(matches) > 1:
         raise ValidationError(
             f"{default_set.name} brings {weapon_profile.weapon} "

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -914,18 +914,16 @@ def create_default_set(name, members=(), price=0, **kwargs):
     """A set of things a profile can come with. ``members`` are assignables, or
     ``(assignable, {extras})`` — ``(xp, {"amount": 61})`` for a counter's
     opening value."""
-    from n26.library.models import DefaultAssignment, DefaultAssignmentSet
+    from n26.library.models import DefaultAssignmentSet
 
     default_set = DefaultAssignmentSet.objects.create(name=name, price=price, **kwargs)
     for position, member in enumerate(members):
         assignable, extras = member if isinstance(member, tuple) else (member, {})
-        _refuse_a_bare_pickable(assignable)
-        DefaultAssignment.objects.create(
-            default_set=default_set,
-            assignable=assignable,
-            position=position,
-            **extras,
-            **kwargs,
+        # Through the one verb that adds a member, so what holds for a
+        # member added later — an extra profile taking its gun — holds
+        # for one written at founding.
+        add_default_member(
+            default_set, assignable, position=position, **extras, **kwargs
         )
     return default_set
 
@@ -966,7 +964,13 @@ def _free_set_name(carrier, phrase="built-ins", **shared):
 
 
 def add_built_in(
-    carrier, thing, amount=0, default_pickable=None, position=None, **kwargs
+    carrier,
+    thing,
+    amount=0,
+    default_pickable=None,
+    position=None,
+    gun_member=None,
+    **kwargs,
 ):
     """Something ``carrier`` always comes with, materialised when it is
     acquired — a profile's equipment list, its starting kit, its
@@ -976,6 +980,9 @@ def add_built_in(
     A **slot** built in is a choice the thing arrives asking;
     ``default_pickable`` is the answer it arrives with, changed
     afterwards by the ordinary rechoose.
+
+    A **weapon profile** built in is an extra line for a gun in the same
+    set, and ``gun_member`` names which — see ``add_default_member``.
 
     Refused for a kind that only ever arrives by being *chosen*: nothing
     acquires one, so nothing would ever hand the items over.
@@ -1002,6 +1009,7 @@ def add_built_in(
         amount=amount,
         default_pickable=default_pickable,
         position=position,
+        gun_member=gun_member,
         **kwargs,
     )
 
@@ -1022,7 +1030,13 @@ def _refuse_a_bare_pickable(thing):
 
 
 def add_default_member(
-    default_set, thing, amount=0, default_pickable=None, position=None, **kwargs
+    default_set,
+    thing,
+    amount=0,
+    default_pickable=None,
+    position=None,
+    gun_member=None,
+    **kwargs,
 ):
     """One more thing in a set of defaults, at the end unless placed.
 
@@ -1032,10 +1046,19 @@ def add_default_member(
 
     ``default_pickable`` is a slot member's starting pick, and belongs to
     nothing else.
+
+    ``gun_member`` is a weapon-profile member's anchor: the weapon
+    member of the same set the extra line lands under. Unnamed, it is
+    settled here — the set's one matching weapon member where there is
+    one, refused in words where there are several, and null where there
+    are none, which keeps a real meaning: the profile rides whatever
+    matching weapon the acquirer already holds.
     """
-    from n26.library.models import DefaultAssignment
+    from n26.library.models import DefaultAssignment, WeaponProfile
 
     _refuse_a_bare_pickable(thing)
+    if isinstance(thing, WeaponProfile) and gun_member is None:
+        gun_member = _the_one_gun_member(default_set, thing)
     if position is None:
         # After the last position ever placed, archived members
         # included — a live count would reuse a surviving member's
@@ -1049,14 +1072,40 @@ def add_default_member(
         amount=amount,
         default_pickable=default_pickable,
         position=position,
+        gun_member=gun_member,
         **kwargs,
     )
-    if default_pickable is not None:
-        # A starting pick has to belong to the slot beside it, and only
-        # this row knows both — the database cannot say it.
+    if default_pickable is not None or gun_member is not None:
+        # A starting pick has to belong to the slot beside it, and an
+        # extra profile's gun has to be its own weapon's member of the
+        # same set. Only this row knows both ends — the database
+        # cannot say either.
         member.clean()
     member.save()
     return member
+
+
+def _the_one_gun_member(default_set, weapon_profile):
+    """The set's single live member bringing this profile's weapon — the
+    anchor an unnamed add settles on.
+
+    None where the set brings the weapon not at all: the profile then
+    rides whatever matching weapon the acquirer holds, which is how an
+    option set arms a gun the built-ins bring. Several is refused in
+    words, because a guess here would decide for good which gun a line
+    lands under.
+    """
+    matches = list(
+        default_set.members.filter(archived=False, weapon_id=weapon_profile.weapon_id)
+    )
+    if len(matches) > 1:
+        raise ValidationError(
+            f"{default_set.name} brings {weapon_profile.weapon} "
+            f"{len(matches)} times, so there is no saying which gun "
+            f"{weapon_profile} lands under. Add the profile from that "
+            f"gun's own row instead."
+        )
+    return matches[0] if matches else None
 
 
 def remove_default_member(member):

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -914,17 +914,32 @@ def create_default_set(name, members=(), price=0, **kwargs):
     """A set of things a profile can come with. ``members`` are assignables, or
     ``(assignable, {extras})`` — ``(xp, {"amount": 61})`` for a counter's
     opening value."""
-    from n26.library.models import DefaultAssignmentSet
+    from django.db import transaction
 
-    default_set = DefaultAssignmentSet.objects.create(name=name, price=price, **kwargs)
-    for position, member in enumerate(members):
-        assignable, extras = member if isinstance(member, tuple) else (member, {})
-        # Through the one verb that adds a member, so what holds for a
-        # member added later — an extra profile taking its gun — holds
-        # for one written at founding.
-        add_default_member(
-            default_set, assignable, position=position, **extras, **kwargs
+    from n26.library.models import DefaultAssignmentSet, WeaponProfile
+
+    staged = [
+        (position, *(member if isinstance(member, tuple) else (member, {})))
+        for position, member in enumerate(members)
+    ]
+    # One transaction, guns before their lines whatever order the caller
+    # stated (each member keeps its stated position): a weapon profile's
+    # anchor is settled against the completed set, not against however
+    # much of it happens to exist yet — and a refusal unwinds the whole
+    # founding rather than leaving half a set behind. Every member still
+    # goes through the one adding verb, so what holds for a member added
+    # later holds for one written here.
+    with transaction.atomic():
+        default_set = DefaultAssignmentSet.objects.create(
+            name=name, price=price, **kwargs
         )
+        for adding_lines in (False, True):
+            for position, assignable, extras in staged:
+                if isinstance(assignable, WeaponProfile) != adding_lines:
+                    continue
+                add_default_member(
+                    default_set, assignable, position=position, **extras, **kwargs
+                )
     return default_set
 
 

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -295,6 +295,12 @@ claws). Materialised when the holder arrives — hired, founded, or bought
 — free, and "caused by" the holder, so removing the holder takes them
 along.
 
+A member that is a firing line names which of the set's weapons it
+rides, and is added from that gun's own row rather than from the
+general picker. A set that brings no such weapon can still hold the
+line — it then lands on whatever matching gun the acquirer already
+holds, which is how an option arms a weapon the built-ins bring.
+
 ### Offers a choice (an effect)
 
 *Puts an open question on the card; the player chooses one thing of a particular assignable type.*

--- a/n26/library/migrations/0065_an_extra_profile_names_its_gun_member.py
+++ b/n26/library/migrations/0065_an_extra_profile_names_its_gun_member.py
@@ -1,0 +1,29 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0064_sheets_are_held_between_upload_and_import"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="defaultassignment",
+            name="gun_member",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="+",
+                to="library.defaultassignment",
+                help_text=(
+                    "The weapon member of this set that this extra profile "
+                    "rides — which gun the line lands under. Blank means the "
+                    "profile rides whatever matching weapon the acquirer "
+                    "already holds, the way an option set arms a gun the "
+                    "built-ins bring."
+                ),
+            ),
+        ),
+    ]

--- a/n26/library/migrations/0066_standing_profile_members_take_their_gun.py
+++ b/n26/library/migrations/0066_standing_profile_members_take_their_gun.py
@@ -1,12 +1,11 @@
 """Back-link the weapon-profile members that already exist.
 
 A live profile member whose set brings exactly one live matching weapon
-member takes that member as its gun. Zero matches stays null — the
+member takes that member as its gun. Anything else stays null — the
 member rides whatever matching weapon the acquirer holds, which is the
-cross-set meaning null keeps. More than one match is refused outright:
-nothing can say which gun was meant, and an anchor guessed here would
-quietly rehome ammo, so the migration stops and the author anchors it
-by hand first.
+meaning null keeps. Zero matches is the cross-set shape; several
+matches cannot say which gun was meant, and null preserves exactly the
+standing behaviour until an author anchors it in the UI.
 """
 
 from django.db import migrations
@@ -27,15 +26,8 @@ def link_profile_members(apps, schema_editor):
                 weapon_id=member.weapon_profile.weapon_id,
             )
         )
-        if not matches:
+        if len(matches) != 1:
             continue
-        if len(matches) > 1:
-            raise RuntimeError(
-                f"Default set {member.default_set_id} brings the weapon of "
-                f"profile member {member.pk} {len(matches)} times — no "
-                f"anchor can be derived. Set gun_member on that member by "
-                f"hand, then migrate again."
-            )
         member.gun_member = matches[0]
         member.save(update_fields=["gun_member"])
 

--- a/n26/library/migrations/0066_standing_profile_members_take_their_gun.py
+++ b/n26/library/migrations/0066_standing_profile_members_take_their_gun.py
@@ -1,0 +1,50 @@
+"""Back-link the weapon-profile members that already exist.
+
+A live profile member whose set brings exactly one live matching weapon
+member takes that member as its gun. Zero matches stays null — the
+member rides whatever matching weapon the acquirer holds, which is the
+cross-set meaning null keeps. More than one match is refused outright:
+nothing can say which gun was meant, and an anchor guessed here would
+quietly rehome ammo, so the migration stops and the author anchors it
+by hand first.
+"""
+
+from django.db import migrations
+
+
+def link_profile_members(apps, schema_editor):
+    DefaultAssignment = apps.get_model("library", "DefaultAssignment")
+    profile_members = DefaultAssignment.objects.filter(
+        weapon_profile__isnull=False,
+        gun_member__isnull=True,
+        archived=False,
+    ).select_related("weapon_profile")
+    for member in profile_members:
+        matches = list(
+            DefaultAssignment.objects.filter(
+                default_set_id=member.default_set_id,
+                archived=False,
+                weapon_id=member.weapon_profile.weapon_id,
+            )
+        )
+        if not matches:
+            continue
+        if len(matches) > 1:
+            raise RuntimeError(
+                f"Default set {member.default_set_id} brings the weapon of "
+                f"profile member {member.pk} {len(matches)} times — no "
+                f"anchor can be derived. Set gun_member on that member by "
+                f"hand, then migrate again."
+            )
+        member.gun_member = matches[0]
+        member.save(update_fields=["gun_member"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0065_an_extra_profile_names_its_gun_member"),
+    ]
+
+    operations = [
+        migrations.RunPython(link_profile_members, migrations.RunPython.noop),
+    ]

--- a/n26/library/models/assignable.py
+++ b/n26/library/models/assignable.py
@@ -211,6 +211,13 @@ class Assignable(models.Model):
     #: written.
     takes_built_ins = True
 
+    #: Whether the generic built-in picker offers this kind. A kind that
+    #: only means something beside one particular row of another kind —
+    #: a weapon's extra profile beside its gun — says False and is
+    #: attached from that row's own page instead, so the picker never
+    #: offers an act whose meaning it cannot ask for.
+    offered_as_built_in = True
+
     class Meta:
         abstract = True
 
@@ -756,6 +763,12 @@ class WeaponProfile(Content, Assignable):
 
     family = Family.GEAR
     attaches_to_weapons = True
+
+    #: A profile means nothing apart from its gun, so the generic
+    #: built-in picker never offers one cold: it is built in from a
+    #: weapon member's own row, where which gun it rides is already
+    #: settled.
+    offered_as_built_in = False
 
     #: Overrides the mixin's: most profiles have no name of their own.
     #: The book prints the weapon's first line as the weapon — "Autogun"

--- a/n26/library/models/defaults.py
+++ b/n26/library/models/defaults.py
@@ -219,6 +219,19 @@ class DefaultAssignment(NamesAnAssignable, Content):
             "A slot's starting pick — what the choice arrives already settled on."
         ),
     )
+    gun_member = models.ForeignKey(
+        "self",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="+",
+        help_text=(
+            "The weapon member of this set that this extra profile rides — "
+            "which gun the line lands under. Blank means the profile rides "
+            "whatever matching weapon the acquirer already holds, the way "
+            "an option set arms a gun the built-ins bring."
+        ),
+    )
     position = models.PositiveIntegerField(default=0)
 
     class Meta:
@@ -237,6 +250,7 @@ class DefaultAssignment(NamesAnAssignable, Content):
 
     def clean(self):
         super().clean()
+        self._clean_gun_member()
         if self.default_pickable_id is None:
             return
         if self.slot_id is None:
@@ -259,20 +273,57 @@ class DefaultAssignment(NamesAnAssignable, Content):
                 }
             )
 
+    def _clean_gun_member(self):
+        """The cross-row sense of a profile member's anchor, in words.
+
+        Only this row knows both ends, so the database cannot say it:
+        the anchor belongs to a weapon-profile member, names a weapon
+        member of the same set, and that weapon is the profile's own.
+        """
+        if self.gun_member_id is None:
+            return
+        if self.weapon_profile_id is None:
+            raise ValidationError(
+                {
+                    "gun_member": (
+                        "Only an extra weapon profile rides a gun. This "
+                        "member is not one, so it names no gun."
+                    )
+                }
+            )
+        if self.gun_member.default_set_id != self.default_set_id:
+            raise ValidationError(
+                {
+                    "gun_member": (
+                        f"{self.gun_member} belongs to another set. A "
+                        "profile rides a gun of its own set."
+                    )
+                }
+            )
+        if self.gun_member.weapon_id is None:
+            raise ValidationError(
+                {"gun_member": (f"{self.gun_member} is not a weapon member.")}
+            )
+        if self.gun_member.weapon_id != self.weapon_profile.weapon_id:
+            raise ValidationError(
+                {
+                    "gun_member": (
+                        f"{self.weapon_profile} is a profile of "
+                        f"{self.weapon_profile.weapon}, and "
+                        f"{self.gun_member} brings a different weapon."
+                    )
+                }
+            )
+
     @property
     def dependent_members(self):
         """The set's other members that stop making sense without this one.
 
-        Ammo lines ride their gun: a weapon profile materialises stacked
-        on the assignment of a weapon arriving in the same acquisition,
-        so with the weapon gone it names a gun nothing brings, and
-        acquiring the carrier refuses.
+        Ammo lines ride their gun: an extra profile names the weapon
+        member it lands under (``gun_member``), so with that member gone
+        it rides a gun the set no longer brings.
         """
-        if self.weapon_id is None:
-            return DefaultAssignment.objects.none()
-        return self.default_set.members.filter(
-            archived=False, weapon_profile__weapon_id=self.weapon_id
-        )
+        return self.default_set.members.filter(archived=False, gun_member=self)
 
 
 #: Which kinds may offer options. Narrow on purpose: a profile offers

--- a/n26/library/models/defaults.py
+++ b/n26/library/models/defaults.py
@@ -304,6 +304,16 @@ class DefaultAssignment(NamesAnAssignable, Content):
             raise ValidationError(
                 {"gun_member": (f"{self.gun_member} is not a weapon member.")}
             )
+        if self.gun_member.archived:
+            raise ValidationError(
+                {
+                    "gun_member": (
+                        f"{self.gun_member} has been taken off "
+                        f"{self.default_set.name}, so no acquisition brings "
+                        f"that gun any more."
+                    )
+                }
+            )
         if self.gun_member.weapon_id != self.weapon_profile.weapon_id:
             raise ValidationError(
                 {

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -382,9 +382,12 @@ def _build_registry():
 
     # What a built-in may be, derived from the DefaultAssignment row
     # itself so the union can never drift from the model's own keys.
+    # A kind declaring itself off the generic picker — a weapon's extra
+    # profile, attached from its gun member's own row — is left out.
     built_in_kinds = {
         name: f"library.{DefaultAssignment._meta.get_field(name).related_model.__name__}"
         for name in DEFAULT_ASSIGNABLE_FIELDS
+        if DefaultAssignment._meta.get_field(name).related_model.offered_as_built_in
     }
     # What a collection entry may list, derived the same way.
     entry_kinds = {

--- a/n26/library/templates/authoring/built_in_profiles.html
+++ b/n26/library/templates/authoring/built_in_profiles.html
@@ -1,0 +1,104 @@
+{% extends "authoring/base.html" %}
+{% comment %}
+One of a weapon's own lines built into a set, at an address of its own.
+Two ways in, told apart by what the address names. A gun member's
+address means the gun is settled: the page lists that weapon's priced
+lines and choosing one lands it under that gun. A set's address means
+the gun is the first question: the weapon is picked and carried in the
+address, so the page reloads and works with scripting switched off, and
+where the set lands the line — under its own gun, or on whatever
+matching gun the acquirer holds — is said before anything is chosen.
+
+Free lines are never listed: they arrive with the gun on their own, and
+offering them would invite building in a second copy.
+{% endcomment %}
+{% block head_title %}Add a weapon profile{% endblock head_title %}
+{% block content %}
+    <c-n26.page-header title="Add a weapon profile to {{ set_name }}">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Content library</c-ui.breadcrumbs.item>
+                {% if holders|length == 1 and holders.0.kind %}
+                    <c-ui.breadcrumbs.item href="{{ back }}">
+                        {{ holders.0.label }}
+                    </c-ui.breadcrumbs.item>
+                {% endif %}
+                <c-ui.breadcrumbs.item :current="True">
+                    Add a weapon profile
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    <div class="mt-6 max-w-2xl space-y-6">
+        {% if picker %}
+            {% comment %}
+            Step one: which weapon. A GET, so the choice lands in the
+            address and the page showing its lines can be reloaded and
+            shared.
+            {% endcomment %}
+            <c-n26.form-section title="Whose lines?"
+                                description="Pick the weapon; its priced profiles follow.">
+                <form method="get" class="flex max-w-xl items-end gap-3">
+                    <div class="grow">
+                        <c-ui.field data-field label="Weapon" for="door-weapon">
+                            <c-n26.filter-select placeholder="Type to filter weapons">
+                                <c-ui.select.native name="weapon" id="door-weapon" placeholder="Pick a weapon">
+                                    {% for gun in picker %}
+                                        <c-ui.select.option value="{{ gun.pk }}">
+                                            {{ gun.authoring_label }}
+                                        </c-ui.select.option>
+                                    {% endfor %}
+                                </c-ui.select.native>
+                            </c-n26.filter-select>
+                        </c-ui.field>
+                    </div>
+                    <c-ui.button type="submit" variant="primary">
+                        Show its profiles
+                    </c-ui.button>
+                </form>
+            </c-n26.form-section>
+        {% else %}
+            {% if landing_said %}
+                <c-ui.description>
+                    {{ landing_said }}
+                </c-ui.description>
+            {% endif %}
+            <c-ui.description>
+                Free profiles are not listed: they arrive with the {{ weapon }} on
+                their own.
+            </c-ui.description>
+            {% if rows %}
+                <c-ui.table>
+                    <tbody>
+                        {% for row in rows %}
+                            <tr>
+                                <td class="whitespace-nowrap">{{ row.label }}</td>
+                                <td class="w-full text-muted">{{ row.notes|join:" · " }}</td>
+                                <td class="text-right">
+                                    <form method="post">
+                                        {% csrf_token %}
+                                        {% if weapon %}<input type="hidden" name="weapon" value="{{ weapon.pk }}">{% endif %}
+                                        <input type="hidden" name="weapon_profile" value="{{ row.pk }}">
+                                        <c-ui.button type="submit" size="sm" variant="success">
+                                            Add this profile
+                                        </c-ui.button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </c-ui.table>
+            {% else %}
+                <c-ui.description>
+                    {{ weapon }} has no priced profiles — every line it has
+                    arrives with it already.
+                </c-ui.description>
+            {% endif %}
+        {% endif %}
+        <div>
+            <c-n26.link href="{{ back }}" class="text-sm">
+                Back
+            </c-n26.link>
+        </div>
+    </div>
+{% endblock content %}

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -178,7 +178,8 @@ thing twice, a line apart.
                                     {% endcomment %}
                                     {% for line in part.children %}
                                         <tr>
-                                            <td class="whitespace-nowrap pl-6">{{ line.label }}</td>
+                                            {# pl-6! — the table component's [&_td]:px-3 outweighs a plain pl-6. #}
+                                            <td class="whitespace-nowrap pl-6!">{{ line.label }}</td>
                                             {% if line.remove_url %}
                                                 <td class="w-full text-muted">{{ line.notes|join:" · " }}</td>
                                                 <td class="text-right">

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -147,19 +147,50 @@ thing twice, a line apart.
                                         {% comment %}
                                 Removing is a question asked at its own address, not an
                                 act done from here: what it means depends on what else
-                                holds the set, which this row cannot say.
+                                holds the set, which this row cannot say. Adding one of
+                                a gun's own lines is likewise a page of its own, scoped
+                                to this row — which gun the line rides is settled by
+                                where the author clicked.
                                         {% endcomment %}
-                                        {% if part.remove_url %}
+                                        {% if part.remove_url or part.add_profile_url %}
                                             <td class="w-full text-muted">{{ part.notes|join:" · " }}</td>
-                                            <td class="text-right">
-                                                <c-ui.button href="{{ part.remove_url }}" size="sm" variant="ghost">
-                                                    Remove
-                                                </c-ui.button>
+                                            <td class="whitespace-nowrap text-right">
+                                                {% if part.add_profile_url %}
+                                                    <c-ui.button href="{{ part.add_profile_url }}" size="sm" variant="ghost">
+                                                        Add profile
+                                                    </c-ui.button>
+                                                {% endif %}
+                                                {% if part.remove_url %}
+                                                    <c-ui.button href="{{ part.remove_url }}" size="sm" variant="ghost">
+                                                        Remove
+                                                    </c-ui.button>
+                                                {% endif %}
                                             </td>
                                         {% else %}
                                             <td class="text-right text-muted">{{ part.notes|join:" · " }}</td>
                                         {% endif %}
                                     </tr>
+                                    {% comment %}
+                                A gun's own lines sit under it, indented — the
+                                grammar a card uses for firing lines under
+                                weapons — so which gun each line rides is read
+                                off the page rather than remembered.
+                                    {% endcomment %}
+                                    {% for line in part.children %}
+                                        <tr>
+                                            <td class="whitespace-nowrap pl-6">{{ line.label }}</td>
+                                            {% if line.remove_url %}
+                                                <td class="w-full text-muted">{{ line.notes|join:" · " }}</td>
+                                                <td class="text-right">
+                                                    <c-ui.button href="{{ line.remove_url }}" size="sm" variant="ghost">
+                                                        Remove
+                                                    </c-ui.button>
+                                                </td>
+                                            {% else %}
+                                                <td class="text-right text-muted">{{ line.notes|join:" · " }}</td>
+                                            {% endif %}
+                                        </tr>
+                                    {% endfor %}
                                 {% endfor %}
                             </tbody>
                         </c-ui.table>
@@ -218,6 +249,18 @@ thing twice, a line apart.
                             {% endif %}
                             <c-n26.form-actions submit_label="Add {{ section.part_verbose_name }}" />
                         </form>
+                        {% comment %}
+                A way in for a part this form cannot offer — a weapon
+                profile, which only means something beside a gun, is
+                added from a page that knows which gun.
+                        {% endcomment %}
+                        {% if section.door_url %}
+                            <div class="mt-4">
+                                <c-n26.link href="{{ section.door_url }}" class="text-sm">
+                                    {{ section.door_label }}
+                                </c-n26.link>
+                            </div>
+                        {% endif %}
                     </c-n26.form-section>
                 {% endif %}
             {% endfor %}

--- a/n26/library/templates/authoring/option_add.html
+++ b/n26/library/templates/authoring/option_add.html
@@ -36,5 +36,15 @@ asks for.
             </c-ui.description>
         {% endif %}
         {% include "authoring/_form.html" with form=form %}
+        {% comment %}
+        A weapon profile is not in the picker above — a line means
+        nothing apart from its gun — so the way to add one is a page
+        that asks for the weapon first.
+        {% endcomment %}
+        <div>
+            <c-n26.link href="{{ profiles_url }}" class="text-sm">
+                Add a weapon profile…
+            </c-n26.link>
+        </div>
     </c-n26.form-page>
 {% endblock content %}

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -381,10 +381,10 @@ BUILT_INS_PART = {
     # A gun's own lines nest under it, so the listing reads the way a
     # card draws firing lines under weapons.
     "arrange": _arrange_built_ins,
-    # The add form no longer offers weapon profiles — a line means
-    # nothing apart from its gun — so the section carries the way to
-    # the page that adds one: a gun of the set from its own row, or
-    # here for a gun the set does not bring.
+    # The add form does not offer weapon profiles: a line means nothing
+    # apart from its gun, so the section carries the way to the page
+    # that adds one — a gun of the set from its own row, or here for a
+    # gun the set does not bring.
     "door": lambda thing: (
         reverse("authoring-set-profiles", args=[thing.built_ins_id])
         if thing.built_ins_id
@@ -2151,7 +2151,9 @@ def set_profiles(request, pk):
             },
         )
 
-    brings = default_set.members.filter(archived=False, weapon=weapon).count()
+    # The verb's own statement of the match, so the page's sentence and
+    # the refusal underneath it cannot come to disagree.
+    brings = authoring.gun_members_bringing(default_set, weapon).count()
     if brings == 0:
         landing_said = (
             f"{default_set.name} does not bring a {weapon}, so each line "

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -141,7 +141,10 @@ def _describe_statline_stat(type_stat):
 def _describe_built_in(member):
     """One row of what a profile comes with. A collection member is
     access rather than kit — the list this entry may use — and the
-    page says so; everything else reads as its kind."""
+    page says so; everything else reads as its kind. An extra weapon
+    line naming no gun of its set rides whatever matching gun its
+    acquirer holds, which is worth a row's words because nothing else
+    on the page says where it lands."""
     from n26.library.models import Collection
 
     thing = member.assignable
@@ -151,6 +154,8 @@ def _describe_built_in(member):
         notes = [str(thing._meta.verbose_name)]
     if member.amount:
         notes.append(f"opening value {member.amount}")
+    if member.weapon_profile_id is not None and member.gun_member_id is None:
+        notes.append("rides whatever matching gun is already held")
     return _label_for(thing), notes
 
 
@@ -179,6 +184,33 @@ def _built_in_parts(parts):
     from n26.library.models import DefaultAssignment
 
     return parts.prefetch_related(*DefaultAssignment.ASSIGNABLE_FIELDS)
+
+
+def _arrange_built_ins(pairs):
+    """The comes-with rows, with each gun's own lines under it.
+
+    ``pairs`` is ``(member, drawn row)`` in listing order. A member
+    naming its gun nests under that gun's row — the grammar a card uses
+    for firing lines under weapons — and every weapon row gains the way
+    to build one of its lines in beside it. A member naming no gun
+    lists flat, its row saying where it lands.
+    """
+    drawn_by_pk = {}
+    for member, drawn in pairs:
+        drawn["children"] = []
+        drawn_by_pk[member.pk] = drawn
+    arranged = []
+    for member, drawn in pairs:
+        if member.weapon_id is not None:
+            drawn["add_profile_url"] = reverse(
+                "authoring-built-in-profiles", args=[member.pk]
+            )
+        parent = drawn_by_pk.get(member.gun_member_id) if member.gun_member_id else None
+        if parent is not None:
+            parent["children"].append(drawn)
+        else:
+            arranged.append(drawn)
+    return arranged
 
 
 def _describe_option(option):
@@ -346,6 +378,19 @@ BUILT_INS_PART = {
     # own address, never from the listing, because what the act means
     # cannot be read off the row.
     "removes": "authoring-built-in-remove",
+    # A gun's own lines nest under it, so the listing reads the way a
+    # card draws firing lines under weapons.
+    "arrange": _arrange_built_ins,
+    # The add form no longer offers weapon profiles — a line means
+    # nothing apart from its gun — so the section carries the way to
+    # the page that adds one: a gun of the set from its own row, or
+    # here for a gun the set does not bring.
+    "door": lambda thing: (
+        reverse("authoring-set-profiles", args=[thing.built_ins_id])
+        if thing.built_ins_id
+        else ""
+    ),
+    "door_label": "Add a weapon profile…",
 }
 
 
@@ -1575,23 +1620,30 @@ def detail(request, kind, pk):
         removes = section.get("removes")
         opens = section.get("opens")
 
-        parts = []
+        pairs = []
         for part in section.get("parts_hint", lambda parts: parts)(
             getattr(thing, section["parts"]).all()
         ):
             label, notes = section["describe"](part)
-            parts.append(
-                {
-                    "label": label,
-                    "notes": notes,
-                    # Blank for a kind whose parts have no page of their
-                    # own; the row's name is then plain words.
-                    "href": _opens_url(opens, part),
-                    # Blank for a kind whose parts cannot be taken off
-                    # here; the row simply draws no control.
-                    "remove_url": reverse(removes, args=[part.pk]) if removes else "",
-                }
+            pairs.append(
+                (
+                    part,
+                    {
+                        "label": label,
+                        "notes": notes,
+                        # Blank for a kind whose parts have no page of their
+                        # own; the row's name is then plain words.
+                        "href": _opens_url(opens, part),
+                        # Blank for a kind whose parts cannot be taken off
+                        # here; the row simply draws no control.
+                        "remove_url": reverse(removes, args=[part.pk])
+                        if removes
+                        else "",
+                    },
+                )
             )
+        arrange = section.get("arrange")
+        parts = arrange(pairs) if arrange else [drawn for _part, drawn in pairs]
         part_name = str(section.get("part_name", part_model._meta.verbose_name))
         drawn.append(
             {
@@ -1614,6 +1666,10 @@ def detail(request, kind, pk):
                 # Blank for a section adding its parts in a form here;
                 # the page then draws that form rather than a way out.
                 "add_url": reverse(elsewhere, args=[thing.pk]) if elsewhere else "",
+                # A further way in for parts the form cannot offer —
+                # blank for every section that has none.
+                "door_url": section.get("door", lambda thing: "")(thing),
+                "door_label": section.get("door_label", ""),
             }
         )
 
@@ -1961,6 +2017,169 @@ def built_in_remove(request, pk):
     )
 
 
+def _priced_profile_rows(weapon, riding_pks=frozenset()):
+    """One weapon's own priced lines, as an adding page lists them.
+
+    Free lines are not offered: they arrive with the gun on their own,
+    which the page says instead. ``riding_pks`` marks the lines the set
+    already brings for this gun, so an author sees what is there without
+    being refused a deliberate second copy.
+    """
+    rows = []
+    for line in _weapon_parts(weapon.profiles.filter(price__gt=0)):
+        label, notes = _describe_weapon_profile(line)
+        if line.pk in riding_pks:
+            notes.append("already comes with this gun")
+        rows.append({"pk": line.pk, "label": label, "notes": notes})
+    return rows
+
+
+@staff_member_required
+def built_in_profiles(request, pk):
+    """One more of a gun's lines built in beside it, at the gun
+    member's own address.
+
+    The address names the weapon *member*, not the weapon: a set may
+    bring the same gun twice, and which of them a line lands under is
+    exactly what this page settles. Choosing a line writes the member
+    anchored to this gun, placed just after it.
+    """
+    from n26.library import authoring
+    from n26.library.models import DefaultAssignment
+
+    member = get_object_or_404(
+        DefaultAssignment.objects.select_related("default_set", "weapon"),
+        pk=pk,
+        archived=False,
+        weapon__isnull=False,
+    )
+    weapon = member.weapon
+    holders = _holders_of(member.default_set)
+    back = _back_to(holders)
+
+    if request.method == "POST":
+        line = get_object_or_404(
+            weapon.profiles.filter(price__gt=0), pk=request.POST.get("weapon_profile")
+        )
+        with transaction.atomic():
+            added = authoring.add_default_member(
+                member.default_set,
+                line,
+                gun_member=member,
+                position=member.position + 1,
+                pack=member.default_set.pack,
+            )
+        messages.success(
+            request,
+            f"{member.default_set.name} now brings {added.assignable} "
+            f"with its {weapon}.",
+        )
+        return redirect(back)
+
+    riding = set(
+        DefaultAssignment.objects.filter(gun_member=member, archived=False).values_list(
+            "weapon_profile_id", flat=True
+        )
+    )
+    return render(
+        request,
+        "authoring/built_in_profiles.html",
+        {
+            "weapon": weapon,
+            "rows": _priced_profile_rows(weapon, riding),
+            "set_name": member.default_set.name,
+            "holders": holders,
+            "back": back,
+            "picker": None,
+            "landing_said": f"Each line lands under this {weapon}.",
+        },
+    )
+
+
+@staff_member_required
+def set_profiles(request, pk):
+    """A weapon's line added to a set that does not bring the weapon —
+    the two-step door an option set uses to arm a gun the built-ins
+    bring.
+
+    The weapon is picked first and carried in the address, so the page
+    works reloaded and without scripting; its priced lines follow. The
+    member written here names no gun of the set's own — unless the set
+    does bring the weapon, in which case the verb settles the anchor
+    exactly as an import would, refusing where the set brings it twice.
+    """
+    from n26.library import authoring
+    from n26.library.models import DefaultAssignmentSet, Weapon
+
+    default_set = get_object_or_404(DefaultAssignmentSet, pk=pk)
+    holders = _holders_of(default_set)
+    back = _back_to(holders)
+
+    weapon = None
+    named = request.POST.get("weapon") or request.GET.get("weapon")
+    if named:
+        weapon = get_object_or_404(Weapon, pk=named)
+
+    if request.method == "POST" and weapon is not None:
+        line = get_object_or_404(
+            weapon.profiles.filter(price__gt=0), pk=request.POST.get("weapon_profile")
+        )
+        try:
+            with transaction.atomic():
+                added = authoring.add_default_member(
+                    default_set, line, pack=default_set.pack
+                )
+        except ValidationError as refused:
+            for said in refused.messages:
+                messages.error(request, said)
+            return redirect(f"{request.path}?weapon={weapon.pk}")
+        messages.success(request, f"{default_set.name} now brings {added.assignable}.")
+        return redirect(back)
+
+    if weapon is None:
+        return render(
+            request,
+            "authoring/built_in_profiles.html",
+            {
+                "weapon": None,
+                "rows": [],
+                "set_name": default_set.name,
+                "holders": holders,
+                "back": back,
+                "picker": Weapon.objects.all(),
+                "landing_said": "",
+            },
+        )
+
+    brings = default_set.members.filter(archived=False, weapon=weapon).count()
+    if brings == 0:
+        landing_said = (
+            f"{default_set.name} does not bring a {weapon}, so each line "
+            f"will ride whatever {weapon} its acquirer already holds."
+        )
+    elif brings == 1:
+        landing_said = f"Each line lands under the {weapon} this set brings."
+    else:
+        landing_said = (
+            f"{default_set.name} brings a {weapon} {brings} times, so a "
+            f"line added here will be refused — add it from one gun's own "
+            f"row instead."
+        )
+    return render(
+        request,
+        "authoring/built_in_profiles.html",
+        {
+            "weapon": weapon,
+            "rows": _priced_profile_rows(weapon),
+            "set_name": default_set.name,
+            "holders": holders,
+            "back": back,
+            "picker": None,
+            "landing_said": landing_said,
+        },
+    )
+
+
 def _deleting(request, thing):
     """Take a row out of the library, or say what is standing in the way.
 
@@ -2089,6 +2308,9 @@ def option_add(request, pk):
             "brings": [_label_for(member.assignable) for member in _brought_by(option)],
             "form": form,
             "back": back,
+            "profiles_url": reverse(
+                "authoring-set-profiles", args=[option.default_set_id]
+            ),
         },
     )
 

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -2042,7 +2042,8 @@ def built_in_profiles(request, pk):
     The address names the weapon *member*, not the weapon: a set may
     bring the same gun twice, and which of them a line lands under is
     exactly what this page settles. Choosing a line writes the member
-    anchored to this gun, placed just after it.
+    anchored to this gun; the listing draws it under the gun by that
+    anchor, in the order the lines were added.
     """
     from n26.library import authoring
     from n26.library.models import DefaultAssignment
@@ -2061,12 +2062,14 @@ def built_in_profiles(request, pk):
         line = get_object_or_404(
             weapon.profiles.filter(price__gt=0), pk=request.POST.get("weapon_profile")
         )
+        # The verb's end-of-set position stands: the listing nests lines
+        # by their anchor, so within one gun they read in the order they
+        # were added.
         with transaction.atomic():
             added = authoring.add_default_member(
                 member.default_set,
                 line,
                 gun_member=member,
-                position=member.position + 1,
                 pack=member.default_set.pack,
             )
         messages.success(

--- a/n26/tests/sandbox/test_builtin_profile_pages.py
+++ b/n26/tests/sandbox/test_builtin_profile_pages.py
@@ -1,0 +1,180 @@
+"""The pages that build a weapon's own lines into a set.
+
+The generic built-in picker never offers a weapon profile — a line
+means nothing apart from its gun — so adding one is a page that knows
+the gun. A gun member's own address settles it outright; a set's
+address asks for the weapon first and carries it in the address, and
+the member written there anchors the way an import would: to the set's
+one matching gun, to nothing where the set brings none, refused where
+it brings several.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.library.models import DefaultAssignment, WeaponProfile
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    create_default_set,
+    create_profile,
+    create_weapon,
+    offer_option,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def author(client):
+    user = User.objects.create_user("author", is_staff=True)
+    client.force_login(user)
+    return user
+
+
+@pytest.fixture
+def launcher(default_pack):
+    weapon = create_weapon("Launcher", profiles=[("Frag", 0)])
+    WeaponProfile.objects.create(name="Smoke", weapon=weapon, price=10, position=1)
+    WeaponProfile.objects.create(name="Choke", weapon=weapon, price=15, position=2)
+    return weapon
+
+
+@pytest.fixture
+def gunner(person_type, gang_type, launcher, default_pack):
+    profile = create_profile("Gunner", person_type, gang_type, price=50)
+    add_built_in(profile, launcher)
+    return profile
+
+
+def gun_member_of(carrier):
+    return carrier.built_ins.members.get(weapon__isnull=False)
+
+
+class TestTheGunMembersOwnPage:
+    """The address names the gun member, so which gun a line rides is
+    settled by where the author clicked."""
+
+    def test_it_lists_the_priced_lines_and_not_the_free_ones(
+        self, client, author, gunner
+    ):
+        page = client.get(
+            reverse("authoring-built-in-profiles", args=[gun_member_of(gunner).pk])
+        )
+        text = page.content.decode()
+        assert "Smoke" in text
+        assert "Choke" in text
+        # The free line arrives with the gun on its own, so it is not
+        # offered — the page says why instead.
+        assert "Frag" not in text
+        assert "Free profiles are not listed" in text
+
+    def test_choosing_a_line_writes_it_anchored_after_its_gun(
+        self, client, author, gunner, launcher
+    ):
+        gun = gun_member_of(gunner)
+        smoke = launcher.profiles.get(name="Smoke")
+
+        response = client.post(
+            reverse("authoring-built-in-profiles", args=[gun.pk]),
+            {"weapon_profile": str(smoke.pk)},
+        )
+
+        assert response.status_code == 302
+        member = DefaultAssignment.objects.get(weapon_profile=smoke)
+        assert member.gun_member_id == gun.pk
+        assert member.default_set_id == gunner.built_ins_id
+        assert member.position == gun.position + 1
+
+    def test_the_listing_nests_the_line_under_its_gun(
+        self, client, author, gunner, launcher
+    ):
+        gun = gun_member_of(gunner)
+        smoke = launcher.profiles.get(name="Smoke")
+        client.post(
+            reverse("authoring-built-in-profiles", args=[gun.pk]),
+            {"weapon_profile": str(smoke.pk)},
+        )
+
+        page = client.get(reverse("authoring-detail", args=["profile", gunner.pk]))
+
+        comes_with = next(
+            section
+            for section in page.context["part_sections"]
+            if section["act"] == "built_in"
+        )
+        gun_row = next(row for row in comes_with["parts"] if row["label"] == "Launcher")
+        assert [line["label"] for line in gun_row["children"]] == ["Smoke"]
+        # The line is under its gun, not beside it.
+        assert all(row["label"] != "Smoke" for row in comes_with["parts"])
+        assert gun_row["add_profile_url"]
+
+    def test_an_archived_members_address_is_gone(self, client, author, gunner):
+        gun = gun_member_of(gunner)
+        gun.archive()
+        address = reverse("authoring-built-in-profiles", args=[gun.pk])
+        assert client.get(address).status_code == 404
+
+
+class TestTheSetsOwnDoor:
+    """A set that does not bring the gun still arms it: the weapon is
+    picked first, carried in the address, and the member lands
+    unanchored — riding whatever matching gun the acquirer holds."""
+
+    @pytest.fixture
+    def smoke_rounds(self, person_type, gang_type, launcher, default_pack):
+        profile = create_profile("Chooser", person_type, gang_type, price=50)
+        add_built_in(profile, launcher)
+        rounds = create_default_set("Smoke rounds", price=10)
+        offer_option(profile, "Smoke rounds", default_set=rounds)
+        return rounds
+
+    def test_without_a_weapon_it_asks_for_one(self, client, author, smoke_rounds):
+        page = client.get(reverse("authoring-set-profiles", args=[smoke_rounds.pk]))
+        text = page.content.decode()
+        assert "Whose lines?" in text
+        assert "Launcher" in text
+
+    def test_with_a_weapon_it_says_where_the_line_lands(
+        self, client, author, smoke_rounds, launcher
+    ):
+        page = client.get(
+            reverse("authoring-set-profiles", args=[smoke_rounds.pk]),
+            {"weapon": str(launcher.pk)},
+        )
+        text = page.content.decode()
+        assert "does not bring" in text
+        assert "already holds" in text
+
+    def test_choosing_a_line_writes_it_unanchored(
+        self, client, author, smoke_rounds, launcher
+    ):
+        smoke = launcher.profiles.get(name="Smoke")
+
+        response = client.post(
+            reverse("authoring-set-profiles", args=[smoke_rounds.pk]),
+            {"weapon": str(launcher.pk), "weapon_profile": str(smoke.pk)},
+        )
+
+        assert response.status_code == 302
+        member = DefaultAssignment.objects.get(weapon_profile=smoke)
+        assert member.default_set_id == smoke_rounds.pk
+        assert member.gun_member_id is None
+
+    def test_a_set_bringing_the_gun_twice_refuses_in_words(
+        self, client, author, launcher, person_type, gang_type, default_pack
+    ):
+        profile = create_profile("Twin gunner", person_type, gang_type, price=50)
+        add_built_in(profile, launcher)
+        add_built_in(profile, launcher)
+        smoke = launcher.profiles.get(name="Smoke")
+
+        response = client.post(
+            reverse("authoring-set-profiles", args=[profile.built_ins_id]),
+            {"weapon": str(launcher.pk), "weapon_profile": str(smoke.pk)},
+            follow=True,
+        )
+
+        assert not DefaultAssignment.objects.filter(weapon_profile=smoke).exists()
+        said = [str(message) for message in response.context["messages"]]
+        assert any("which gun" in sentence for sentence in said)

--- a/n26/tests/sandbox/test_builtin_profile_pages.py
+++ b/n26/tests/sandbox/test_builtin_profile_pages.py
@@ -69,7 +69,7 @@ class TestTheGunMembersOwnPage:
         assert "Frag" not in text
         assert "Free profiles are not listed" in text
 
-    def test_choosing_a_line_writes_it_anchored_after_its_gun(
+    def test_choosing_a_line_writes_it_anchored_to_the_gun(
         self, client, author, gunner, launcher
     ):
         gun = gun_member_of(gunner)
@@ -84,7 +84,35 @@ class TestTheGunMembersOwnPage:
         member = DefaultAssignment.objects.get(weapon_profile=smoke)
         assert member.gun_member_id == gun.pk
         assert member.default_set_id == gunner.built_ins_id
-        assert member.position == gun.position + 1
+
+    def test_two_lines_added_in_turn_nest_in_add_order(
+        self, client, author, gunner, launcher
+    ):
+        """Within one gun, order is the order the lines were added: each
+        takes the next end-of-set position, and the listing nests by the
+        anchor rather than by position adjacency."""
+        gun = gun_member_of(gunner)
+        for name in ("Smoke", "Choke"):
+            client.post(
+                reverse("authoring-built-in-profiles", args=[gun.pk]),
+                {"weapon_profile": str(launcher.profiles.get(name=name).pk)},
+            )
+
+        smoke, choke = (
+            DefaultAssignment.objects.get(weapon_profile__name=name)
+            for name in ("Smoke", "Choke")
+        )
+        assert smoke.position != choke.position
+        assert smoke.position < choke.position
+
+        page = client.get(reverse("authoring-detail", args=["profile", gunner.pk]))
+        comes_with = next(
+            section
+            for section in page.context["part_sections"]
+            if section["act"] == "built_in"
+        )
+        gun_row = next(row for row in comes_with["parts"] if row["label"] == "Launcher")
+        assert [line["label"] for line in gun_row["children"]] == ["Smoke", "Choke"]
 
     def test_the_listing_nests_the_line_under_its_gun(
         self, client, author, gunner, launcher

--- a/n26/tests/sandbox/test_builtin_reconciliation.py
+++ b/n26/tests/sandbox/test_builtin_reconciliation.py
@@ -243,10 +243,11 @@ class TestWeaponsArriveWhole:
 
 
 class TestAmmoFindsItsGun:
-    """A weapon-profile member stacks on a gun's assignment, and each
-    weapon member keeps a gun of its own."""
+    """A weapon-profile member stacks on a gun's assignment. An anchored
+    member names its gun member and lands on that member's own copy; an
+    unanchored one rides whatever matching gun the host holds."""
 
-    def test_twin_members_of_one_weapon_feed_their_own_guns(
+    def test_anchored_twins_each_feed_their_own_gun(
         self, gang, person_type, gang_type, default_pack
     ):
         launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
@@ -257,27 +258,109 @@ class TestAmmoFindsItsGun:
             name="Choke", weapon=launcher, price=10, position=2
         )
         profile = create_profile("Twin gunner", person_type, gang_type, price=50)
-        add_built_in(profile, launcher)
-        add_built_in(profile, launcher)
-        add_built_in(profile, smoke)
-        add_built_in(profile, choke)
+        gun_one = add_built_in(profile, launcher)
+        gun_two = add_built_in(profile, launcher)
+        add_built_in(profile, smoke, gun_member=gun_one)
+        add_built_in(profile, choke, gun_member=gun_two)
 
         fighter = hire(gang, profile, "Ana", paid=50)
 
-        guns = Assignment.objects.filter(
-            miniature_root=fighter, weapon=launcher, archived=False
+        membership = fighter.membership
+        first_gun = Assignment.objects.get(
+            materialised_from=gun_one, materialised_for=membership
         )
-        assert guns.count() == 2
+        second_gun = Assignment.objects.get(
+            materialised_from=gun_two, materialised_for=membership
+        )
         smoke_copy = Assignment.objects.get(
             weapon_profile=smoke, miniature_root=fighter, archived=False
         )
         choke_copy = Assignment.objects.get(
             weapon_profile=choke, miniature_root=fighter, archived=False
         )
-        assert smoke_copy.parent_id != choke_copy.parent_id
+        # Neither gun starves: each line sits on the gun its member names.
+        assert smoke_copy.parent_id == first_gun.pk
+        assert choke_copy.parent_id == second_gun.pk
 
         outcome = reconcile(gang, fighter.membership)
         assert outcome.created == []
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_twin_add_without_an_anchor_is_refused_in_words(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        """Two matching gun members and no anchor is unanswerable, so
+        the verb refuses rather than deciding which gun for good."""
+        from django.core.exceptions import ValidationError
+
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        profile = create_profile("Twin gunner", person_type, gang_type, price=50)
+        add_built_in(profile, launcher)
+        add_built_in(profile, launcher)
+
+        with pytest.raises(ValidationError) as refusal:
+            add_built_in(profile, smoke)
+        assert "which gun" in str(refusal.value)
+
+    def test_a_single_gun_add_anchors_itself(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        """With one matching gun member there is nothing to ask — the
+        add settles on it, the way an import resolves."""
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        profile = create_profile("Gunner", person_type, gang_type, price=50)
+        gun_member = add_built_in(profile, launcher)
+
+        member = add_built_in(profile, smoke)
+
+        assert member.gun_member_id == gun_member.pk
+
+    def test_a_set_founded_whole_anchors_its_lines(self, default_pack):
+        """Founding a set with a gun and its line in one statement —
+        what an import does — settles the anchor the same way an add
+        does: every member goes through the one verb."""
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+
+        default_set = create_default_set("Gun kit", members=[launcher, smoke])
+
+        line = default_set.members.get(weapon_profile=smoke)
+        assert line.gun_member == default_set.members.get(weapon=launcher)
+
+    def test_an_anchored_line_never_rides_a_hand_given_gun(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        """The anchor is a receipt, not a preference: with the built-in
+        gun's copy removed, the line is skipped rather than rehomed onto
+        another gun of the same type the owner holds."""
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        profile = create_profile("Gunner", person_type, gang_type, price=50)
+        gun_member = add_built_in(profile, launcher)
+        fighter = hire(gang, profile, "Ana", paid=50)
+        give_weapon(fighter, launcher)
+        remove(
+            Assignment.objects.get(
+                materialised_from=gun_member, materialised_for=fighter.membership
+            )
+        )
+        ammo_member = add_built_in(profile, smoke, gun_member=gun_member)
+
+        outcome = reconcile(gang, fighter.membership, strict=False)
+
+        assert [entry.member for entry, _ in outcome.skipped] == [ammo_member]
+        assert not Assignment.objects.filter(weapon_profile=smoke).exists()
         gang.refresh_from_db()
         assert_reconciled(gang)
 

--- a/n26/tests/sandbox/test_builtin_reconciliation.py
+++ b/n26/tests/sandbox/test_builtin_reconciliation.py
@@ -11,6 +11,7 @@ to a profile later reach the fighters already hired from it.
 
 import pytest
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 
 from n26.core.models import Assignment, ChosenProfileOption, Miniature, Reason
@@ -247,13 +248,21 @@ class TestAmmoFindsItsGun:
     member names its gun member and lands on that member's own copy; an
     unanchored one rides whatever matching gun the host holds."""
 
-    def test_anchored_twins_each_feed_their_own_gun(
-        self, gang, person_type, gang_type, default_pack
-    ):
-        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
-        smoke = WeaponProfile.objects.create(
+    @pytest.fixture
+    def launcher(self, default_pack):
+        return create_weapon("Launcher", profiles=[("Frag", 0)])
+
+    @pytest.fixture
+    def smoke(self, launcher):
+        """The launcher's priced line — never free, so only a member or
+        a purchase brings it."""
+        return WeaponProfile.objects.create(
             name="Smoke", weapon=launcher, price=10, position=1
         )
+
+    def test_anchored_twins_each_feed_their_own_gun(
+        self, gang, person_type, gang_type, launcher, smoke
+    ):
         choke = WeaponProfile.objects.create(
             name="Choke", weapon=launcher, price=10, position=2
         )
@@ -288,16 +297,10 @@ class TestAmmoFindsItsGun:
         assert_reconciled(gang)
 
     def test_a_twin_add_without_an_anchor_is_refused_in_words(
-        self, gang, person_type, gang_type, default_pack
+        self, gang, person_type, gang_type, launcher, smoke
     ):
         """Two matching gun members and no anchor is unanswerable, so
         the verb refuses rather than deciding which gun for good."""
-        from django.core.exceptions import ValidationError
-
-        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
-        smoke = WeaponProfile.objects.create(
-            name="Smoke", weapon=launcher, price=10, position=1
-        )
         profile = create_profile("Twin gunner", person_type, gang_type, price=50)
         add_built_in(profile, launcher)
         add_built_in(profile, launcher)
@@ -307,14 +310,10 @@ class TestAmmoFindsItsGun:
         assert "which gun" in str(refusal.value)
 
     def test_a_single_gun_add_anchors_itself(
-        self, gang, person_type, gang_type, default_pack
+        self, gang, person_type, gang_type, launcher, smoke
     ):
         """With one matching gun member there is nothing to ask — the
         add settles on it, the way an import resolves."""
-        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
-        smoke = WeaponProfile.objects.create(
-            name="Smoke", weapon=launcher, price=10, position=1
-        )
         profile = create_profile("Gunner", person_type, gang_type, price=50)
         gun_member = add_built_in(profile, launcher)
 
@@ -322,30 +321,36 @@ class TestAmmoFindsItsGun:
 
         assert member.gun_member_id == gun_member.pk
 
-    def test_a_set_founded_whole_anchors_its_lines(self, default_pack):
+    def test_an_add_never_anchors_to_a_removed_gun(
+        self, gang, person_type, gang_type, launcher, smoke
+    ):
+        """A gun an author took off the set no longer brings anything,
+        so naming it as an anchor is refused in words — and an unnamed
+        add settles past it to nothing, the cross-set meaning."""
+        profile = create_profile("Gunner", person_type, gang_type, price=50)
+        gun_member = add_built_in(profile, launcher)
+        gun_member.archive()
+
+        with pytest.raises(ValidationError) as refusal:
+            add_built_in(profile, smoke, gun_member=gun_member)
+        assert "taken off" in str(refusal.value)
+        assert add_built_in(profile, smoke).gun_member_id is None
+
+    def test_a_set_founded_whole_anchors_its_lines(self, launcher, smoke):
         """Founding a set with a gun and its line in one statement —
         what an import does — settles the anchor the same way an add
         does: every member goes through the one verb."""
-        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
-        smoke = WeaponProfile.objects.create(
-            name="Smoke", weapon=launcher, price=10, position=1
-        )
-
         default_set = create_default_set("Gun kit", members=[launcher, smoke])
 
         line = default_set.members.get(weapon_profile=smoke)
         assert line.gun_member == default_set.members.get(weapon=launcher)
 
     def test_an_anchored_line_never_rides_a_hand_given_gun(
-        self, gang, person_type, gang_type, default_pack
+        self, gang, person_type, gang_type, launcher, smoke
     ):
         """The anchor is a receipt, not a preference: with the built-in
         gun's copy removed, the line is skipped rather than rehomed onto
         another gun of the same type the owner holds."""
-        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
-        smoke = WeaponProfile.objects.create(
-            name="Smoke", weapon=launcher, price=10, position=1
-        )
         profile = create_profile("Gunner", person_type, gang_type, price=50)
         gun_member = add_built_in(profile, launcher)
         fighter = hire(gang, profile, "Ana", paid=50)
@@ -365,13 +370,9 @@ class TestAmmoFindsItsGun:
         assert_reconciled(gang)
 
     def test_ammo_lands_on_a_gun_the_owner_gave_by_hand(
-        self, gang, ganger, default_pack
+        self, gang, ganger, launcher, smoke
     ):
         fighter = hire(gang, ganger, "Ana", paid=50)
-        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
-        smoke = WeaponProfile.objects.create(
-            name="Smoke", weapon=launcher, price=10, position=1
-        )
         gun = give_weapon(fighter, launcher)
         member = add_built_in(ganger, smoke)
 
@@ -386,13 +387,9 @@ class TestAmmoFindsItsGun:
         assert_reconciled(gang)
 
     def test_orphan_ammo_is_recorded_on_a_reconcile_and_refused_at_hire(
-        self, gang, ganger, default_pack
+        self, gang, ganger, launcher, smoke
     ):
         fighter = hire(gang, ganger, "Ana", paid=50)
-        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
-        smoke = WeaponProfile.objects.create(
-            name="Smoke", weapon=launcher, price=10, position=1
-        )
         add_built_in(ganger, smoke)
 
         outcome = reconcile(gang, fighter.membership, strict=False)

--- a/n26/tests/sandbox/test_builtin_reconciliation.py
+++ b/n26/tests/sandbox/test_builtin_reconciliation.py
@@ -345,6 +345,30 @@ class TestAmmoFindsItsGun:
         line = default_set.members.get(weapon_profile=smoke)
         assert line.gun_member == default_set.members.get(weapon=launcher)
 
+    def test_a_founded_sets_lines_anchor_whatever_order_was_stated(
+        self, launcher, smoke
+    ):
+        """A line before its gun in the founding statement still anchors:
+        anchors resolve against the completed set, and the stated order
+        survives as each member's position."""
+        default_set = create_default_set("Gun kit", members=[smoke, launcher])
+
+        line = default_set.members.get(weapon_profile=smoke)
+        assert line.gun_member == default_set.members.get(weapon=launcher)
+        assert line.position == 0
+        assert line.gun_member.position == 1
+
+    def test_a_twin_founding_refuses_whole(self, launcher, smoke):
+        """Founding a set whose line has two guns to ride is refused,
+        and nothing of the set survives — not the guns that were written
+        before the refusal, and not the set itself."""
+        from n26.library.models import DefaultAssignmentSet
+
+        with pytest.raises(ValidationError):
+            create_default_set("Gun kit", members=[launcher, launcher, smoke])
+
+        assert not DefaultAssignmentSet.objects.filter(name="Gun kit").exists()
+
     def test_an_anchored_line_never_rides_a_hand_given_gun(
         self, gang, person_type, gang_type, launcher, smoke
     ):

--- a/n26/tests/sandbox/test_builtins_archival.py
+++ b/n26/tests/sandbox/test_builtins_archival.py
@@ -159,6 +159,30 @@ class TestRemovingABuiltIn:
         assert ammo_member.archived is True
         assert_reconciled(gang)
 
+    def test_only_the_named_guns_lines_go_with_it(self, gang, ganger):
+        """What goes with a gun is what names it — its twin of the same
+        weapon keeps its own lines."""
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0)])
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        choke = WeaponProfile.objects.create(
+            name="Choke", weapon=launcher, price=10, position=2
+        )
+        gun_one = add_built_in(ganger, launcher)
+        gun_two = add_built_in(ganger, launcher)
+        smoke_member = add_built_in(ganger, smoke, gun_member=gun_one)
+        choke_member = add_built_in(ganger, choke, gun_member=gun_two)
+        hire(gang, ganger, "Ana", paid=50)
+
+        remove_default_member(gun_one)
+
+        smoke_member.refresh_from_db()
+        choke_member.refresh_from_db()
+        assert smoke_member.archived is True
+        assert choke_member.archived is False
+        assert_reconciled(gang)
+
 
 class TestProvenance:
     """Every materialised copy names its member and its carrier."""

--- a/n26/tests/sandbox/test_generated_forms.py
+++ b/n26/tests/sandbox/test_generated_forms.py
@@ -263,10 +263,19 @@ class TestTheUnionPicker:
         form = generate_form(specs()["add_built_in"])()
         assert form.fields["thing_kind"].label == "Kind"
         assert form.fields["thing_subtype"].label == "Subtype"
-        assert form.fields["thing_weapon_profile"].label == "Weapon profile"
+        assert form.fields["thing_wargear"].label == "Wargear"
         assert form.fields["thing_new_subtype"].label == "New subtype"
         # The kind dropdown speaks the same way, keeping raw values.
-        assert ("weapon_profile", "weapon profile") in form.fields["thing_kind"].choices
+        assert ("wargear", "wargear") in form.fields["thing_kind"].choices
+
+    def test_the_picker_never_offers_a_weapon_profile(self, default_pack):
+        """An extra profile means nothing apart from its gun, so it is
+        built in from a weapon member's own row and the generic picker
+        never offers one cold."""
+        form = generate_form(specs()["add_built_in"])()
+        assert "thing_weapon_profile" not in form.fields
+        kinds = [kind for kind, _ in form.fields["thing_kind"].choices]
+        assert "weapon_profile" not in kinds
 
     def test_every_control_says_which_kind_it_belongs_to(self, default_pack):
         """The markers base.html's script reads to show only the chosen
@@ -275,7 +284,7 @@ class TestTheUnionPicker:
         form = generate_form(specs()["add_built_in"])()
         assert "data-union-kind" in str(form["thing_kind"])
         assert 'data-union-member="collection"' in str(form["thing_collection"])
-        assert 'data-union-member="weapon_profile"' in str(form["thing_weapon_profile"])
+        assert 'data-union-member="wargear"' in str(form["thing_wargear"])
         assert 'data-union-member="rule"' in str(form["thing_new_rule"])
 
 

--- a/n26/tests/sandbox/test_ingest.py
+++ b/n26/tests/sandbox/test_ingest.py
@@ -1877,6 +1877,45 @@ Escher,Scout,6",4+,4+,3,3,1,4,1,6+,6,7,7,6,Fighter,Ganger,4,25,,,Farsight,Agilit
         assert plan.ok
         assert any("imported without it" in p.message for p in plan.problems)
 
+    def test_a_weapon_profile_in_the_cell_is_a_note_never_a_member(
+        self, foundation, default_pack
+    ):
+        """A fighter's cell cannot build in a weapon's extra line: the
+        cell resolves weapons, wargear and accessories only, so a
+        profile's name surfaces as the imported-without-it note and the
+        fighter arrives without it — twin weapons or not. This is why
+        the planner needs no twin-gun ambiguity problem: a plan can
+        never hold a weapon-profile member, and the performer's one
+        entry, ``add_default_member``, anchors or refuses for itself.
+        Whoever makes profile members plannable takes on surfacing that
+        refusal at preview, because the preview is the contract — this
+        test failing is the reminder."""
+        from n26.library import authoring
+        from n26.library.models import DefaultAssignment
+
+        autogun = authoring.create_weapon("Autogun", price=20)
+        authoring.add_weapon_profile(autogun, name="Warp round", price=10)
+        plan = plan_ingest(
+            profiles=read_csv(
+                """
+Gang,Name,M,WS,BS,S,T,W,I,A,Sv,Ld,Cl,Wil,Int,Type,Subtype(s),Starting XP,Rating,Special Rules,Default skills,Default assignment,Primary Skill Sets,Secondary Skill Sets
+Escher,Gunner,6",4+,4+,3,3,1,4,1,6+,6,7,7,6,Fighter,,4,25,,,"Autogun, Autogun, Warp round",,
+"""
+            )
+        )
+
+        assert plan.ok  # a note — the fighter still arrives
+        assert any(
+            "'Warp round'" in p.message and "imported without it" in p.message
+            for p in plan.problems
+        )
+        perform(plan)
+        members = DefaultAssignment.objects.filter(
+            default_set=Profile.objects.get(name="Gunner").built_ins
+        )
+        assert members.filter(weapon=autogun).count() == 2
+        assert not members.filter(weapon_profile__isnull=False).exists()
+
 
 class TestTheEquipmentListAFighterBuysFrom:
     """The ``Equipment List`` column on the All Profiles sheet.

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -149,6 +149,22 @@ urlpatterns = [
         authoring_views.built_in_remove,
         name="authoring-built-in-remove",
     ),
+    # A gun member's own lines are built in from the gun's row — the
+    # address names the member, because a set may bring the same gun
+    # twice and which of them a line rides is the whole question.
+    path(
+        "authoring/built-ins/<str:pk>/profiles/",
+        authoring_views.built_in_profiles,
+        name="authoring-built-in-profiles",
+    ),
+    # The same act for a set that does not bring the gun — an option
+    # set arming a weapon the built-ins bring. The weapon is picked
+    # first and carried in the address.
+    path(
+        "authoring/sets/<str:pk>/profiles/",
+        authoring_views.set_profiles,
+        name="authoring-set-profiles",
+    ),
     # An option and a set of options belong to the thing offering them
     # rather than being authored kinds of their own, so withdrawing
     # either has an address here instead of riding the kind/pk routes.


### PR DESCRIPTION
Chunk C2b of the built-in propagation programme (decision D13): an extra weapon profile built into a set of defaults now **names the gun member it rides**, killing the flat-sibling ammo modelling at authorship and deleting the type-reconstruction machinery the reconcile engine had to carry around it.

Refs #2165.

## What changed

**Schema.** `DefaultAssignment` gains a nullable self-FK `gun_member`: the weapon member of the same set this profile's line lands under. `clean()` checks the cross-row sense (same set, a weapon member, the profile's own weapon). Null keeps a real meaning — the line rides whatever matching gun the acquirer already holds, which is how an option set arms a gun the built-ins bring. `dependent_members` (what a gun's removal takes with it) now reads this relation instead of matching by weapon type, so with twin guns only the named gun's lines go.

**Authorship.** `add_default_member` settles the anchor the way an import must: auto-links to the set's one matching live weapon member, stays null where the set brings the weapon not at all, and refuses in words where the set brings it twice — a guess would decide for good which gun a line lands under. `create_default_set` routes every member through that verb, so a set founded whole (the path ingest's set creation and updates both use) inherits the rule with no second copy. The generic built-in picker stops offering the weapon-profile kind entirely (`WeaponProfile.offered_as_built_in = False`, the spec union derives) — the kinds-declare-forms-derive rule, and the D11/D12 principle of never offering the bad act.

**Engine.** `reconcile_defaults`'s ammo resolution becomes a receipt lookup: an anchored member's line lands on its named gun member's own live copy for the carrier (by provenance). The per-weapon FIFO queue and the occupied-gun precompute are deleted. Unanchored members keep the existing fallback (newest live matching weapon on the same host) exactly as before, so `test_an_arriving_sets_ammo_lands_under_the_standing_gun` and cross-carrier ammo purchases are untouched. A named gun whose copy is gone is a recorded skip on a bare reconcile and the existing strict error at acquisition — never a rehome onto another gun of the same type. The hire preview in `card.py` keys gun nodes by member the same way, so twin guns preview distinctly.

**Authoring pages.** The "Comes with" listing nests anchored lines under their gun (the card's firing-line grammar); unanchored lines list flat with a note saying where they land. Weapon member rows gain an **Add profile** link to `/n26/authoring/built-ins/<pk>/profiles/`, listing that weapon's priced lines (free ones arrive with the gun automatically, and the page says so); choosing one writes the member anchored and placed after its gun. A two-step door at `/n26/authoring/sets/<pk>/profiles/` serves sets that don't bring the gun: pick the weapon (carried in the URL — no JS form-swapping), see where the line will land, choose a priced line. The option-add page and the built-ins section link to it. This also settles the C1 finding about the qualifier-less ammo picker: lines are now always chosen under one named weapon.

**Data migration.** `library.0066` back-links existing members: exactly-one-match anchors, zero-match stays null, more-than-one refuses loudly. Smoked against a fork of the content mirror: it holds 4 weapon-profile members, all live, and **all four sit in sets holding zero matching weapon members** (cross-set option ammo), so the migration links none and their behaviour is unchanged.

## Notes for review

- The chunk brief's letter said an add with one or more matching gun members must *refuse* without `gun_member`; this implements **auto-link on exactly one match** instead (refusal only on twins). It is the same resolution D13 prescribes for ingest, the shared verb serves both, and a single-match auto-link produces an anchored member — the good state — rather than an error an author must work around. Twins still refuse.
- Ingest today cannot express a weapon-profile default member at all (`_resolve_item` resolves Weapon/Wargear/WeaponAccessory only), so the planner-side ambiguity problem is unreachable; the auto-link/refusal lives in the verbs the performer calls, so a future sheet feature inherits it. The anchor is *not* part of member identity for ingest matching — sheets cannot name these members, so there is nothing to match by it.

## Test plan

- [x] `pytest n26` — 3,891 passed, 1 xfailed (includes 17 new tests: anchored twins resolve to their own guns; twin add refused in words; single-match auto-anchors; set-founded-whole anchors; anchored line never rehomes onto a hand-given gun; gun removal takes only the lines naming it; the two pages create anchored/unanchored members through the client with real URLs; the listing nests; the generic picker no longer offers the kind)
- [x] Full suite `pytest -n auto` — 8,247 passed, 12 skipped, 1 xfailed
- [x] `./scripts/fmt.sh`, `./scripts/check_migrations.sh`
- [x] `manage migrate` on the worktree DB
- [x] Data migration smoked on `createdb -T gyrinx_main` fork: 4 profile members before and after, 0 anchored (all zero-match), DB dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
