### PR TITLE
fix: the foundations page stops offering to plant specialisations

### DIFF
--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -168,13 +168,12 @@ INHERENT_SKILLS = ["Hit & Run", "Inspiring", "Juggernaut"]
 
 #: The eight fields a Specialist chooses between, and the skill each
 #: grants — the core rules' Specialist table, as ``(specialisation,
-#: skill)``. Every skill named here is one of the sets' own, so the
-#: grant resolves against rows the skills seed already created.
+#: skill)``.
 #:
-#: Which specialisations exist is *content*, which is why they are
-#: created here rather than invented by whatever first mentions one: an
-#: equipment list saying "(Gunner specialist only)" resolves against
-#: this, and says so plainly when it cannot.
+#: Nothing plants these: the Specialist's question is a slot now, and its
+#: answers are pickables. The table remains because the sheets still read
+#: it — an import naming one of these by hand is told the row is not
+#: there to resolve against, rather than quietly inventing it.
 SPECIALISATIONS = [
     ("Heavy", "Bulging Biceps"),
     ("Gunner", "Hip-shooting"),
@@ -471,49 +470,6 @@ def _check_skills():
     return present, 1 + len(SKILL_SETS) + 1 + len(names)
 
 
-def _create_specialisations():
-    """The Specialist's eight fields, each wired to the skill it grants.
-
-    A specialisation is only half itself without the skill it grants, so
-    this seed owns that dependency and creates the skills first rather than
-    relying on which button someone clicked. ``_create_skills`` is
-    get-or-create throughout, so saying so costs nothing when they are
-    already there.
-
-    Idempotent: a specialisation already present is left alone, because
-    ``create_specialisation`` builds the granting modifier and calling it
-    again would hang a second copy.
-    """
-    from n26.library.authoring import create_specialisation
-    from n26.library.models import Skill, Specialisation
-
-    _create_skills()
-    for name, skill_name in SPECIALISATIONS:
-        if Specialisation.objects.filter(name=name).exists():
-            continue
-        skill = Skill.objects.filter(name=skill_name).first()
-        if skill is None:
-            # The skills exist, so this can only be a typo in the
-            # table above — say which, rather than create it unwired.
-            raise LookupError(f"{name} grants {skill_name!r}, which no Skill Set names")
-        create_specialisation(name, grants_skill=skill)
-
-
-def _check_specialisations():
-    """Counts the rows *and* their grants: a specialisation that grants
-    nothing is created but not wired, which is half the point missing."""
-    from n26.library.models import Specialisation
-
-    names = [name for name, _ in SPECIALISATIONS]
-    present = _count(Specialisation, name__in=names)
-    present += (
-        Specialisation.objects.filter(name__in=names, modifiers__isnull=False)
-        .distinct()
-        .count()
-    )
-    return present, 2 * len(names)
-
-
 def trading_post_sweeps():
     """Every kind the post offers: whatever a fighter can buy with Trade
     Points. An accessory is bought there as readily as the gun it bolts
@@ -674,19 +630,6 @@ STANDARD_CONTENT = {
             ),
             check=_check_skills_collection,
             create=_create_skills_collection,
-        ),
-        StandardContent(
-            key="specialisations",
-            name="Specialisations",
-            help=(
-                "The eight fields a Specialist chooses between — Heavy, "
-                "Gunner, Gunslinger, Scout, Sniper, Brawler, Medic, Tech "
-                "— each wired to the skill it grants. An equipment list "
-                'narrowed to "(Gunner specialist only)" resolves against '
-                "these, so create them before importing one."
-            ),
-            check=_check_specialisations,
-            create=_create_specialisations,
         ),
         StandardContent(
             key="trading-post",

--- a/n26/tests/sandbox/test_foundations.py
+++ b/n26/tests/sandbox/test_foundations.py
@@ -163,45 +163,18 @@ class TestWhatTheSeedsCreate:
         assert GangType.objects.count() == 17
         assert GangType.objects.get(name="Escher").starting_credits is None
 
-    def test_the_specialisations_arrive_granting_their_skills(self, default_pack):
-        """The Specialist's eight fields, each wired to the one skill it
-        grants — the pair is the content, so a row without its grant is
-        only half created."""
+    def test_nothing_here_plants_a_specialisation(self, default_pack):
+        """The Specialist's question is a slot now and its answers are
+        pickables, so a button that planted the old rows would put back
+        content that was deliberately removed."""
         from n26.library.models import Specialisation
 
-        STANDARD_CONTENT["skills"].create()
-        STANDARD_CONTENT["specialisations"].create()
+        assert "specialisations" not in STANDARD_CONTENT
 
-        assert set(Specialisation.objects.values_list("name", flat=True)) == {
-            "Heavy",
-            "Gunner",
-            "Gunslinger",
-            "Scout",
-            "Sniper",
-            "Brawler",
-            "Medic",
-            "Tech",
-        }
-        granted = {
-            row.name: [str(modifier.effect.skill) for modifier in row.modifiers.all()]
-            for row in Specialisation.objects.all()
-        }
-        assert granted["Gunner"] == ["Hip-shooting"]
-        assert granted["Medic"] == ["Medicate"]
-        assert granted["Heavy"] == ["Bulging Biceps"]
+        for seed in STANDARD_CONTENT.values():
+            seed.create()
 
-    def test_specialisations_create_the_skills_they_grant(self, default_pack):
-        """Created alone — no skills yet — it still completes, because a
-        specialisation without its skill is half a thing and the seed
-        owns that dependency rather than the order of button clicks."""
-        from n26.library.models import Skill, Specialisation
-
-        seed = STANDARD_CONTENT["specialisations"]
-        seed.create()
-
-        assert seed.status() == "complete"
-        assert Specialisation.objects.count() == 8
-        assert Skill.objects.filter(name="Hip-shooting").exists()
+        assert not Specialisation.objects.exists()
 
 
 class TestThePage:

--- a/n26/tests/sandbox/test_ingest.py
+++ b/n26/tests/sandbox/test_ingest.py
@@ -153,9 +153,19 @@ def entry_key(collection_key, item_key):
 @pytest.fixture
 def foundation(default_pack):
     """Standard content, created exactly as the foundations page's
-    buttons would create it (library/standard_content.py)."""
+    buttons would create it (library/standard_content.py), plus the
+    specialisations a restriction resolves against.
+
+    Nothing plants those any more — the Specialist's question is a slot
+    and its answers are pickables — but the sheets still name them, so
+    a test about what a sheet resolves has to author them itself."""
+    from n26.library.authoring import create_specialisation
+    from n26.library.models import Skill
+
     for item in STANDARD_CONTENT.values():
         item.create()
+    for name, skill_name in SPECIALISATIONS:
+        create_specialisation(name, grants_skill=Skill.objects.get(name=skill_name))
 
 
 @pytest.fixture
@@ -615,8 +625,7 @@ Malstrain,Alpha,Malstrain,5",4+,4+,3,3,2,4,2,5+,7,7,7,7,Fighter,Leader,25,110,,,
     ):
         """ "(Gunner specialist only)" names the field a Specialist chose,
         which is an arm of usable-by like a subtype — so it becomes a real
-        restriction, not a note. Gunner is standard content, so this needs
-        nothing authored by hand."""
+        restriction, not a note."""
         from n26.library.models import Specialisation
 
         gunner = Specialisation.objects.get(name="Gunner")
@@ -636,8 +645,8 @@ Malstrain,Alpha,Malstrain,5",4+,4+,3,3,2,4,2,5+,7,7,7,7,Fighter,Leader,25,110,,,
 
     def test_a_specialisation_the_pack_lacks_is_said_not_invented(self, foundation):
         """Which specialisations exist is content — a restriction string
-        does not get to mint one. The eight the rules name are standard
-        content; a ninth the sheet invents is said, and stays unmade."""
+        does not get to mint one. A ninth the sheet invents is said, and
+        stays unmade."""
         from n26.library.models import Specialisation
 
         before = set(Specialisation.objects.values_list("name", flat=True))


### PR DESCRIPTION
The Specialist's question is a slot now and its answers are pickables. Production holds **no specialisation at all** — the conversions moved every answer across and what was left was deleted this weekend.

The foundations page still carried a **"Specialisations" button that would create eight of them**, each wired to a granting modifier. One click would have put back by hand exactly what was taken away. That is the whole reason this ships on its own, ahead of the rest of the wave.

## What changes

- The seed goes: `_create_specialisations`, `_check_specialisations`, and the `specialisations` entry in `STANDARD_CONTENT`.
- A test in its place plants **every** seed there is and asserts no specialisation appears — so this cannot quietly grow back with the next one somebody adds.
- The `SPECIALISATIONS` table of names stays. Nothing creates from it, but the spreadsheet sheets still read it: an import naming one is told the row is not there to resolve against, rather than quietly inventing it. It goes with the ingest work later in the wave.
- The ingest tests that got those rows from the seed now author them directly, which is what a test about *resolution* should have been doing anyway.

## Checked

- Full n26 suite: 3866 passed.
- The new guard genuinely bites: with the button restored it fails, and passes only once the seed is gone.

## Context

First of four stages retiring Archetype, SkillTree and Specialisation. The rest — rewriting the sandbox suites onto slots and picks, deleting the Archetypes ingest sheet, then dropping the models, columns and tables — follows separately.