### PR TITLE
test: the sandbox suites move onto slots and picks

### DIFF
--- a/n26/tests/sandbox/test_choosing.py
+++ b/n26/tests/sandbox/test_choosing.py
@@ -22,12 +22,11 @@ from n26.core.effects import compute, compute_gang
 from n26.core.models import Assignment
 from n26.core.reconcile import assert_reconciled
 from n26.core.render import build_choice_offer, render_gang
-from n26.library.models import Affiliation, Archetype, Skill, SkillTree
+from n26.library.models import Affiliation, Skill
 from n26.tests.sandbox.actions import (
     add_entry,
     choose,
     create_affiliation,
-    create_archetype,
     create_category,
     create_collection,
     create_default_set,
@@ -36,7 +35,6 @@ from n26.tests.sandbox.actions import (
     create_power,
     create_profile,
     create_skill,
-    create_skill_tree,
     create_subtype,
     found_gang,
     has_subtypes,
@@ -101,11 +99,11 @@ def subtypes(db):
 
 @pytest.fixture
 def archetypes(sets, skills_collection, subtypes):
-    """Two archetypes, each opening one skill set as Primary."""
+    """Two a gang may take, each opening one skill set as Primary."""
     _, tiers = skills_collection
     made = {}
     for name, set_key in [("Brawler", "combat"), ("Gunslinger", "shooting")]:
-        archetype = create_archetype(name)
+        archetype = create_affiliation(name)
         modifier(
             f"{name}: {set_key} is Primary",
             targets_every_model(has_subtypes(subtypes["leader"], subtypes["ganger"])),
@@ -124,12 +122,6 @@ def affiliations(db):
 
 
 @pytest.fixture
-def trees(sets):
-    """Pickable tokens for the offer that names a whole kind."""
-    return {key: create_skill_tree(cat.name, cat) for key, cat in sets.items()}
-
-
-@pytest.fixture
 def pick_lists(archetypes, affiliations):
     made = {}
     for key, name, things in [
@@ -142,7 +134,7 @@ def pick_lists(archetypes, affiliations):
 
 
 @pytest.fixture
-def gang_list(subtypes, skills_collection, pick_lists, trees):
+def gang_list(subtypes, skills_collection, pick_lists, affiliations):
     """The gang type: the gang's own affiliation question, a whole-kind
     question beside it, and the skill offer every Leader carries."""
     _, tiers = skills_collection
@@ -164,9 +156,9 @@ def gang_list(subtypes, skills_collection, pick_lists, trees):
         carried_by=questions,
     )
     modifier(
-        "Outcasts: the gang favours one set",
+        "Outcasts: the gang favours one of them outright",
         targets_gang(),
-        offers_choice(SkillTree, label="favoured set"),
+        offers_choice(Affiliation, label="favoured set"),
         carried_by=questions,
     )
     gang_type.built_ins = create_default_set("Outcast built-ins", members=[questions])
@@ -199,7 +191,7 @@ def profiles(gang_list, subtypes, pick_lists, person_type):
         "Outcast Leader: chooses the gang's Archetype",
         targets_model(),
         offers_choice(
-            Archetype,
+            Affiliation,
             from_section=pick_lists["archetypes"],
             label="archetype",
             will_be_assigned_to="gang",
@@ -385,9 +377,15 @@ class TestWhatOneCardMayPick:
         assert names_on(offer) == {"Berserker", "Parry"}
         assert [group.name for group in offer.groups] == ["Combat"]
 
-    def test_an_unnarrowed_offer_lists_the_whole_kind(self, gang, crew, trees):
+    def test_an_unnarrowed_offer_lists_the_whole_kind(self, gang, crew):
         offer = offer_for(sheet_slots(gang)["Favoured set"])
-        assert names_on(offer) == {"Combat", "Shooting"}
+        assert names_on(offer) == {
+            "Clanless",
+            "Mutant",
+            "Aranthian",
+            "Brawler",
+            "Gunslinger",
+        }
         # Nothing narrows it, so there is nothing to head the list with.
         assert [group.name for group in offer.groups] == [""]
 
@@ -543,7 +541,7 @@ class TestMakingOneChoice:
             client, sheet_slots(gang)["Sorrow: Archetype"].href, archetypes["Brawler"]
         )
 
-        chosen = Assignment.objects.get(archetype=archetypes["Brawler"])
+        chosen = Assignment.objects.get(affiliation=archetypes["Brawler"])
         assert chosen.gang == gang and chosen.miniature is None
         assert sheet_slots(gang)["Sorrow: Archetype"].chosen == "Brawler"
         assert_reconciled(gang)
@@ -625,7 +623,7 @@ class TestMakingOneChoice:
 
         remove(crew["leader"].assignments.get(profile__isnull=False))
         assert not Assignment.objects.filter(
-            archetype=archetypes["Brawler"], archived=False
+            affiliation=archetypes["Brawler"], archived=False
         ).exists()
         assert_reconciled(gang)
 
@@ -656,14 +654,14 @@ class TestMakingOneChoice:
         assert settled.is_resolved and settled.href
 
     def test_a_thing_that_is_not_on_offer_writes_nothing(
-        self, client, owner, gang, crew, trees
+        self, client, owner, gang, crew, subtypes
     ):
         """A stale page or a tampered form. The list comes back; nothing
         is written and nothing is explained at length."""
         client.force_login(owner)
         before = Assignment.objects.count()
         response = self.post(
-            client, sheet_slots(gang)["Affiliation"].href, trees["combat"]
+            client, sheet_slots(gang)["Affiliation"].href, subtypes["ganger"]
         )
         assert response.status_code == 302
         assert Assignment.objects.count() == before

--- a/n26/tests/sandbox/test_generated_forms.py
+++ b/n26/tests/sandbox/test_generated_forms.py
@@ -33,7 +33,7 @@ from n26.library.forms import (
 )
 from n26.library.specs import specs
 from n26.tests.sandbox.actions import (
-    create_archetype,
+    create_affiliation,
     create_category,
     create_collection,
     create_subtype,
@@ -311,7 +311,7 @@ class TestTheComposer:
         collection, tiers = skills_and_powers
         leader = create_subtype("Outcast Leader")
         combat = create_category("Skills", "Combat")
-        brawler = create_archetype("Brawler")
+        brawler = create_affiliation("Brawler")
 
         form = ModifierComposerForm(
             self.brawler_leader_data(leader, combat, tiers["primary"]),
@@ -341,7 +341,7 @@ class TestTheComposer:
         """
         collection, tiers = skills_and_powers
         combat = create_category("Skills", "Combat")
-        brawler = create_archetype("Brawler")
+        brawler = create_affiliation("Brawler")
 
         written = []
         for rank in ("Outcast Leader", "Outcast Champion"):
@@ -365,7 +365,7 @@ class TestTheComposer:
         collection, tiers = skills_and_powers
         leader = create_subtype("Outcast Leader")
         combat = create_category("Skills", "Combat")
-        brawler = create_archetype("Brawler")
+        brawler = create_affiliation("Brawler")
 
         data = self.brawler_leader_data(leader, combat, tiers["primary"])
         data["name"] = "Brawler leader: combat primary"
@@ -406,8 +406,8 @@ class TestTheComposer:
         collection, tiers = skills_and_powers
         leader = create_subtype("Outcast Leader")
         combat = create_category("Skills", "Combat")
-        brawler = create_archetype("Brawler")
-        crusher = create_archetype("Bone Crusher")
+        brawler = create_affiliation("Brawler")
+        crusher = create_affiliation("Bone Crusher")
 
         data = self.brawler_leader_data(leader, combat, tiers["primary"])
         data["make_reusable"] = "on"
@@ -425,7 +425,7 @@ class TestTheComposer:
         collection, tiers = skills_and_powers
         leader = create_subtype("Outcast Leader")
         combat = create_category("Skills", "Combat")
-        brawler = create_archetype("Brawler")
+        brawler = create_affiliation("Brawler")
 
         data = self.brawler_leader_data(leader, combat, tiers["primary"])
         form = ModifierComposerForm(data, attach_to=brawler)

--- a/n26/tests/sandbox/test_hire_view.py
+++ b/n26/tests/sandbox/test_hire_view.py
@@ -20,20 +20,20 @@ from n26.core.render_text import render_model_card
 from n26.core.taxonomy import UNCATEGORISED
 from n26.library.models import (
     AddsAssignable,
+    Affiliation,
     OpAddsMiniature,
     Profile,
-    Specialisation,
     Stat,
     TargetsMiniature,
 )
 from n26.tests.sandbox.actions import (
+    create_affiliation,
     create_default_set,
     create_hidden,
     create_option_group,
     create_profile,
     create_rule,
     create_skill,
-    create_specialisation,
     create_subtype,
     create_wargear,
     create_weapon,
@@ -287,12 +287,12 @@ class TestModifiersRunInAPreview:
     def test_an_unresolved_choice_shows_as_an_open_row(self, person_type, gang_type):
         specialist = create_subtype("Specialist")
         modifier(
-            "Specialist chooses a specialisation",
+            "Specialist chooses an affiliation",
             TargetsMiniature.objects.create(),
-            offers_choice(Specialisation),
+            offers_choice(Affiliation),
             carried_by=specialist,
         )
-        create_specialisation("Sharpshooter", grants_skill=create_skill("Fast Shot"))
+        create_affiliation("Clanless")
 
         profile = Profile.objects.create(
             name="Specialist Ganger",
@@ -305,7 +305,7 @@ class TestModifiersRunInAPreview:
 
         card = preview(profile)
         (choice,) = card.choices
-        assert choice.kind_label == "Specialisation"
+        assert choice.kind_label == "Affiliation"
         assert choice.is_resolved is False
 
     def test_a_pet_wargear_says_what_it_will_bring(self, person_type, gang_type):

--- a/n26/tests/sandbox/test_offer_swap_probe.py
+++ b/n26/tests/sandbox/test_offer_swap_probe.py
@@ -2,7 +2,7 @@
 
 The Subjugator Patrol Officer pattern: a Specialist subtype grants a
 hidden carrier whose modifier offers the general choice of
-specialisation; one profile with that subtype built in takes the
+affiliation; one profile with that subtype built in takes the
 general carrier away again and grants a narrower one of its own, so
 its card should ask the same question over a shorter list. The plain
 profile keeps the general offer untouched.
@@ -22,13 +22,13 @@ from django.contrib.auth.models import User
 from n26.core.card import build_card, build_modifier_index
 from n26.core.effects import compute
 from n26.core.render import build_choice_offer
-from n26.library.models import Specialisation
+from n26.library.models import Affiliation
 from n26.tests.sandbox.actions import (
+    create_affiliation,
     create_collection,
     create_default_set,
     create_hidden,
     create_profile,
-    create_specialisation,
     create_subtype,
     ef_adds,
     ef_removes,
@@ -52,32 +52,30 @@ def owner(db):
 
 
 @pytest.fixture
-def specialisations(default_pack):
+def affiliations(default_pack):
     return {
-        name: create_specialisation(name)
+        name: create_affiliation(name)
         for name in ("Sniper", "Gunner", "Medic", "Armourer")
     }
 
 
 @pytest.fixture
-def general_menu(specialisations):
+def general_menu(affiliations):
     """The whole menu: all four, in one default section."""
     collection = create_collection(
-        "Specialisation Offer", entries=list(specialisations.values())
+        "Affiliation Offer", entries=list(affiliations.values())
     )
-    return section_of(collection, "Specialisations", 0, is_default=True)
+    return section_of(collection, "Affiliations", 0, is_default=True)
 
 
 @pytest.fixture
 def general_offer(general_menu):
     """The hidden carrier every Specialist is granted."""
-    hidden = create_hidden("Specialisation Offer (general)")
+    hidden = create_hidden("Affiliation Offer (general)")
     modifier(
-        "General offer: a specialisation from the whole menu",
+        "General offer: a affiliation from the whole menu",
         targets_model(),
-        offers_choice(
-            Specialisation, from_section=general_menu, label="specialisation"
-        ),
+        offers_choice(Affiliation, from_section=general_menu, label="affiliation"),
         carried_by=hidden,
     )
     return hidden
@@ -98,20 +96,20 @@ def specialist(general_offer):
 
 
 @pytest.fixture
-def narrow_menu(specialisations):
+def narrow_menu(affiliations):
     collection = create_collection(
-        "Specialisation Offer (Subjugator)", entries=[specialisations["Gunner"]]
+        "Affiliation Offer (Subjugator)", entries=[affiliations["Gunner"]]
     )
-    return section_of(collection, "Specialisations", 0, is_default=True)
+    return section_of(collection, "Affiliations", 0, is_default=True)
 
 
 @pytest.fixture
 def narrow_offer(narrow_menu):
-    hidden = create_hidden("Specialisation offer (Subjugator)")
+    hidden = create_hidden("Affiliation offer (Subjugator)")
     modifier(
-        "Subjugator offer: a specialisation from the short menu",
+        "Subjugator offer: a affiliation from the short menu",
         targets_model(),
-        offers_choice(Specialisation, from_section=narrow_menu, label="specialisation"),
+        offers_choice(Affiliation, from_section=narrow_menu, label="affiliation"),
         carried_by=hidden,
     )
     return hidden
@@ -187,7 +185,7 @@ class TestThePlainPatrolOfficer:
 
     def test_the_card_asks_one_question_over_the_whole_menu(self, officers):
         ((slot, names),) = questions_on(officers["plain"])
-        assert slot.kind_label == "Specialisation"
+        assert slot.kind_label == "Affiliation"
         assert not slot.is_resolved
         assert names == {"Sniper", "Gunner", "Medic", "Armourer"}
 
@@ -198,7 +196,7 @@ class TestTheSubjugatorPatrolOfficer:
 
     def test_the_card_asks_one_question_over_the_short_menu(self, officers):
         ((slot, names),) = questions_on(officers["subjugator"])
-        assert slot.kind_label == "Specialisation"
+        assert slot.kind_label == "Affiliation"
         assert names == {"Gunner"}
 
     def test_the_plan_shows_the_general_offer_ran_and_was_then_retracted(
@@ -209,21 +207,19 @@ class TestTheSubjugatorPatrolOfficer:
             step
             for step in plan
             if str(step.source) == "Subjugator Patrol Officer"
-            and "Specialisation Offer (general)" in step.effect
+            and "Affiliation Offer (general)" in step.effect
         )
         assert removal.outcome == "reached"
-        assert removal.took_away == ("Specialisation Offer (general)",)
+        assert removal.took_away == ("Affiliation Offer (general)",)
         general = next(
-            step
-            for step in plan
-            if str(step.source) == "Specialisation Offer (general)"
+            step for step in plan if str(step.source) == "Affiliation Offer (general)"
         )
         assert general.outcome == "retracted"
         # The narrow carrier's own offer stands.
         narrow = next(
             step
             for step in plan
-            if str(step.source) == "Specialisation offer (Subjugator)"
+            if str(step.source) == "Affiliation offer (Subjugator)"
         )
         assert narrow.outcome == "reached"
 
@@ -312,7 +308,7 @@ class TestWhetherTheQuestionCanBeSettled:
             assert line.key != ""
 
     def test_the_narrow_question_settles_from_the_screen(
-        self, gang, officers, owner, client, specialisations
+        self, gang, officers, owner, client, affiliations
     ):
         """The whole point of an address: a player can click the question
         and the pick lands."""
@@ -332,14 +328,14 @@ class TestWhetherTheQuestionCanBeSettled:
         assert "Gunner" in body and "Sniper" not in body
         response = client.post(
             line.href,
-            {"thing": f"library.specialisation:{specialisations['Gunner'].pk}"},
+            {"thing": f"library.affiliation:{affiliations['Gunner'].pk}"},
         )
 
         assert response.status_code == 302
         (settled,) = computed_for(subjugator).choices
         assert settled.chosen_name == "Gunner"
         assert (
-            Assignment.objects.get(specialisation=specialisations["Gunner"]).miniature
+            Assignment.objects.get(affiliation=affiliations["Gunner"]).miniature
             == subjugator
         )
         assert_reconciled(gang)
@@ -361,21 +357,21 @@ class TestTheSameSwapBuiltAsSlotsAndPicks:
             create_slot_type,
         )
 
-        slot_type = create_slot_type("Specialisation")
+        slot_type = create_slot_type("Affiliation")
         picks = {
             name: create_pickable(name, slot_type)
             for name in ("Sniper", "Gunner", "Medic", "Armourer")
         }
         general = create_slot(
-            "Specialisation",
+            "Affiliation",
             slot_type,
-            create_picklist("Specialisations", slot_type, members=list(picks.values())),
+            create_picklist("Affiliations", slot_type, members=list(picks.values())),
         )
         narrow = create_slot(
-            "Specialisation (Subjugator)",
+            "Affiliation (Subjugator)",
             slot_type,
             create_picklist("Subjugator options", slot_type, members=[picks["Gunner"]]),
-            label="Specialisation",
+            label="Affiliation",
         )
         subtype = create_subtype("Slotted Specialist")
         modifier(

--- a/n26/tests/sandbox/test_outcast_gang.py
+++ b/n26/tests/sandbox/test_outcast_gang.py
@@ -42,21 +42,25 @@ from n26.library.authoring import (
     targets_every_model,
     targets_model,
 )
-from n26.library.models import Affiliation, Archetype, Skill
+from n26.library.models import Affiliation, Skill
 from n26.tests.sandbox.actions import (
     adds,
     choose,
     create_affiliation,
-    create_archetype,
     create_category,
     create_collection,
     create_default_set,
     create_gang_type,
     create_hidden,
+    create_pickable,
+    create_picklist,
     create_profile,
     create_rule,
     create_skill,
+    create_slot,
+    create_slot_type,
     create_subtype,
+    ef_adds,
     found_gang,
     hire_with_option,
     modifier,
@@ -178,7 +182,13 @@ ARCHETYPES = {
 
 
 @pytest.fixture
-def archetypes(sets, skills_collection, subtypes, profiles):
+def archetype_type(default_pack):
+    """One slot type for both choices. Nobody takes an archetype twice."""
+    return create_slot_type("Archetype", allows_repeats=False)
+
+
+@pytest.fixture
+def archetypes(sets, skills_collection, subtypes, profiles, archetype_type):
     """One carrier per printed archetype, all three rank rows aboard.
 
     Targeting reads off the printed sheet: the Leader row hangs off the
@@ -200,7 +210,7 @@ def archetypes(sets, skills_collection, subtypes, profiles):
     }
     made = {}
     for name, table in ARCHETYPES.items():
-        archetype = create_archetype(name)
+        archetype = create_pickable(name, archetype_type)
         for rank, row in table.items():
             for set_key, tier in row.items():
                 modifier(
@@ -398,38 +408,51 @@ def profiles(outcasts, subtypes, person_type):
 
 
 @pytest.fixture
-def archetype_question(archetypes, profiles):
-    """The pick list, and the offers that ask it.
+def archetype_question(archetypes, profiles, archetype_type):
+    """The pick list, and the two slots that ask it.
 
     Leader → Gang → fighters: every Leader variant carries the
     archetype choice, but what is chosen is for the gang — it lands as
     a gang row, radiates to the members, and dies with the Leader.
     Champions may choose a different Archetype to their gang's Leader:
     the same five archetypes, chosen on — and borne by — the fighter.
+
+    One list, asked twice. Where the pick lands is the slot's to say,
+    which is the whole difference between the two.
     """
-    collection = create_collection(
-        "Archetypes", entries=[(a, {}) for a in archetypes.values()]
+    offered = create_picklist(
+        "Outcast Archetypes", archetype_type, members=list(archetypes.values())
     )
-    section = section_of(collection, "Archetypes", 0, is_default=True)
+    asked = {
+        "gang": create_slot(
+            "Gang archetype",
+            archetype_type,
+            offered,
+            label="Archetype",
+            assigned_to="gang",
+        ),
+        "champion": create_slot(
+            "Champion archetype",
+            archetype_type,
+            offered,
+            label="Archetype",
+            assigned_to="bearer",
+        ),
+    }
     for leader in profiles["leaders"]:
         modifier(
             f"{leader.name}: chooses the gang's Archetype",
             targets_model(),
-            offers_choice(
-                Archetype,
-                from_section=section,
-                label="archetype",
-                will_be_assigned_to="gang",
-            ),
+            ef_adds(asked["gang"]),
             carried_by=leader,
         )
     modifier(
         "Outcast Champion: chooses an Archetype",
         targets_model(),
-        offers_choice(Archetype, from_section=section, label="archetype"),
+        ef_adds(asked["champion"]),
         carried_by=profiles["champion"],
     )
-    return section
+    return asked
 
 
 @pytest.fixture
@@ -492,7 +515,7 @@ class TestFoundingOffersTheChoices:
         computed = fighter_computed(crew["leader"])
         slot = next(s for s in computed.choices if s.kind_label == "Archetype")
         offerable = offered_by(slot, computed)
-        assert {line.name for line in offerable.all_lines()} == set(ARCHETYPES)
+        assert {pickable.name for pickable in offerable} == set(ARCHETYPES)
 
         gang_computed = the_gang_computed(gang)
         affiliations = offered_by(gang_computed.choice("Affiliation"), gang_computed)
@@ -504,15 +527,25 @@ class TestFoundingOffersTheChoices:
         }
 
 
+def _slot_named(name):
+    from n26.library.models import Slot
+
+    return Slot.objects.get(name=name)
+
+
 def leader_anchor(crew):
     """The assignment whose assignable (the Leader profile) offers the
     archetype — the Leader's membership row."""
     return crew["leader"].assignments.get(profile__isnull=False)
 
 
-def pick_archetype(crew, archetype):
-    """The Leader → Gang arrow: the Leader chooses; the gang carries it."""
-    return choose(leader_anchor(crew), archetype)
+def pick_archetype(crew, archetype, asked=None):
+    """The Leader → Gang arrow: the Leader chooses; the gang carries it.
+
+    A granted slot has no assignment of its own, so the anchor is the
+    Leader's own row and the slot being answered is named.
+    """
+    return choose(leader_anchor(crew), archetype, slot=_slot_named("Gang archetype"))
 
 
 class TestArchetypes:
@@ -581,7 +614,7 @@ class TestArchetypes:
         )
         leader = hire_with_option(other, profiles["leaders"][3], "Last Chance")
         anchor = leader.assignments.get(profile__isnull=False)
-        choose(anchor, archetypes["Brawler"])
+        choose(anchor, archetypes["Brawler"], slot=_slot_named("Gang archetype"))
 
         assert tiers_for(leader, skills_collection, sets) == {
             "combat": "Primary",
@@ -623,7 +656,9 @@ class TestArchetypes:
         the champion is neither."""
         pick_archetype(crew, archetypes["Brawler"])
         anchor = crew["champion"].assignments.get(profile__isnull=False)
-        chosen = choose(anchor, archetypes["Gunslinger"])
+        chosen = choose(
+            anchor, archetypes["Gunslinger"], slot=_slot_named("Champion archetype")
+        )
         assert chosen.miniature == crew["champion"]
 
         assert tiers_for(crew["champion"], skills_collection, sets) == {
@@ -774,7 +809,7 @@ class TestTheSheet:
         )
         choose(anchor, house_tokens["Goliath"])
         anchor = crew["champion"].assignments.get(profile__isnull=False)
-        choose(anchor, archetypes["Survivor"])
+        choose(anchor, archetypes["Survivor"], slot=_slot_named("Champion archetype"))
 
         text = gang_to_text(gang)
         print("\n" + text)

--- a/n26/tests/sandbox/test_specialist.py
+++ b/n26/tests/sandbox/test_specialist.py
@@ -1,14 +1,13 @@
-"""Specialist: a subtype that offers a choice of specialisation.
+"""Specialist: a subtype that grants the slot asking which field it took.
 
-The slot is computed; only what was chosen is stored. "Active but empty" is
-never a written state — it is the absence of a resolution next to a
-computed offer, so deferring the pick costs nothing and nothing pending
-can go stale.
+The slot is computed; only what was picked is stored. "Active but empty"
+is never a written state — it is the absence of a pick beside a computed
+slot, so deferring costs nothing and nothing pending can go stale.
 
-Three layers compose: the subtype (stored) offers the choice (computed
-slot); the pick (stored, caused by the subtype's assignment) resolves it;
-the specialisation's own modifier grants the skill (computed). Remove the
-subtype and the whole chain unwinds through machinery that already existed.
+Three layers compose: the subtype (stored) grants the slot (computed);
+the pick (stored, caused by the subtype's assignment) answers it; the
+pickable's own modifier grants the skill (computed). Remove the subtype
+and the whole chain unwinds through machinery that already existed.
 """
 
 import pytest
@@ -21,50 +20,72 @@ from n26.core.models import Assignment
 from n26.core.operations import Refusal
 from n26.core.render import build_model_card
 from n26.core.render_text import render_model_card
-from n26.library.models import (
-    OffersChoice,
-    Specialisation,
-    TargetsMiniature,
-    Trait,
-)
+from n26.library.models import OffersChoice, Trait
 from n26.tests.sandbox.actions import (
     assign,
     choose,
+    create_pickable,
+    create_picklist,
     create_skill,
-    create_specialisation,
+    create_slot,
+    create_slot_type,
     create_subtype,
+    ef_adds,
     found_gang,
     hire,
     modifier,
-    offers_choice,
     remove,
+    targets_model,
 )
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def specialist(db):
-    subtype = create_subtype("Specialist")
-    modifier(
-        "Specialist chooses a specialisation",
-        TargetsMiniature.objects.create(),
-        offers_choice(Specialisation),
-        carried_by=subtype,
-    )
-    return subtype
+def specialisation(db):
+    return create_slot_type("Specialisation")
 
 
 @pytest.fixture
-def specialisations(db):
-    return {
-        "sharpshooter": create_specialisation(
-            "Sharpshooter", grants_skill=create_skill("Fast Shot")
+def fields(specialisation):
+    """The two a Specialist may take, each granting its own skill."""
+    made = {}
+    for key, name, skill in (
+        ("sharpshooter", "Sharpshooter", "Fast Shot"),
+        ("medic", "Medicae", "Field Surgery"),
+    ):
+        pickable = create_pickable(name, specialisation)
+        modifier(
+            f"{name}: its skill",
+            targets_model(),
+            ef_adds(create_skill(skill)),
+            carried_by=pickable,
+        )
+        made[key] = pickable
+    return made
+
+
+@pytest.fixture
+def specialisation_slot(specialisation, fields):
+    return create_slot(
+        "Specialisation",
+        specialisation,
+        create_picklist(
+            "Specialisations", specialisation, members=list(fields.values())
         ),
-        "medic": create_specialisation(
-            "Medicae", grants_skill=create_skill("Field Surgery")
-        ),
-    }
+    )
+
+
+@pytest.fixture
+def specialist(specialisation_slot):
+    subtype = create_subtype("Specialist")
+    modifier(
+        "Specialist is asked its specialisation",
+        targets_model(),
+        ef_adds(specialisation_slot),
+        carried_by=subtype,
+    )
+    return subtype
 
 
 @pytest.fixture
@@ -82,12 +103,30 @@ def card_for(miniature):
     return build_model_card(miniature, card=card, computed=compute(card, index))
 
 
+def slots_of(miniature):
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([n.assignable for n in card.all_nodes()])
+    return compute(card, index).choices
+
+
 def anchor_of(miniature):
-    return Assignment.objects.get(subtype__name="Specialist", miniature=miniature)
+    (slot,) = slots_of(miniature)
+    return slot.anchor.assignment
+
+
+def pick(miniature, pickable, source="Specialist"):
+    """Answer the slot the named carrier granted.
+
+    A granted slot has no assignment of its own, so the anchor is the
+    line the grant stands on — which may carry several — and the one
+    being answered is named.
+    """
+    slot = next(row for row in slots_of(miniature) if row.source == source)
+    return choose(slot.anchor.assignment, pickable, slot=slot.slot)
 
 
 class TestTheUnresolvedSlot:
-    def test_the_offer_is_a_slot_on_the_card(self, yolanda):
+    def test_the_grant_is_a_slot_on_the_card(self, yolanda):
         card = card_for(yolanda)
         (choice,) = card.choices
         assert choice.kind_label == "Specialisation"
@@ -96,7 +135,7 @@ class TestTheUnresolvedSlot:
 
     def test_nothing_pending_is_stored(self, yolanda):
         """Deferral is free because unresolved is absence, not state."""
-        assert Assignment.objects.filter(specialisation__isnull=False).count() == 0
+        assert Assignment.objects.filter(pickable__isnull=False).count() == 0
 
     def test_it_renders_as_a_row_like_any_other_assignable(self, yolanda):
         text = "\n".join(render_model_card(card_for(yolanda)))
@@ -115,18 +154,16 @@ class TestTheUnresolvedSlot:
 
 
 class TestChoosing:
-    def test_the_pick_resolves_the_slot(self, yolanda, specialisations):
-        choose(anchor_of(yolanda), specialisations["sharpshooter"])
+    def test_the_pick_resolves_the_slot(self, yolanda, fields):
+        pick(yolanda, fields["sharpshooter"])
         card = card_for(yolanda)
         (choice,) = card.choices
         assert choice.chosen == "Sharpshooter"
         assert choice.is_resolved is True
 
-    def test_the_pick_is_the_choice_row_not_loose_equipment(
-        self, yolanda, specialisations
-    ):
-        """What was chosen draws as the choice's own row, and nowhere else."""
-        choose(anchor_of(yolanda), specialisations["sharpshooter"])
+    def test_the_pick_is_the_choice_row_not_loose_equipment(self, yolanda, fields):
+        """What was picked draws as the slot's own row, and nowhere else."""
+        pick(yolanda, fields["sharpshooter"])
         card = card_for(yolanda)
         assert card.equipment == []
 
@@ -136,37 +173,40 @@ class TestChoosing:
         # It grants a skill computedly, but is itself nobody's equipment.
         assert "Equipment:" not in text
 
-    def test_the_skill_arrives_computed(self, yolanda, specialisations):
+    def test_the_skill_arrives_computed(self, yolanda, fields):
         """Stored subtype -> stored pick -> computed skill: three layers."""
-        choose(anchor_of(yolanda), specialisations["sharpshooter"])
+        pick(yolanda, fields["sharpshooter"])
         card = card_for(yolanda)
         (skill,) = card.skills
         assert skill.name == "Fast Shot"
         assert skill.provenance.source == "Sharpshooter"
-        assert skill.provenance.source_kind == "specialisation"
+        # No sort-of-thing word: "pickable" is plumbing, and a player is
+        # never shown it — the source names the field they took instead.
+        assert skill.provenance.source_kind == ""
         assert skill.provenance.computed is True
 
-    def test_the_pick_is_free_and_caused_by_the_subtype(self, yolanda, specialisations):
-        picked = choose(anchor_of(yolanda), specialisations["sharpshooter"])
+    def test_the_pick_is_free_and_caused_by_the_subtype(self, yolanda, fields):
+        anchor = anchor_of(yolanda)
+        picked = pick(yolanda, fields["sharpshooter"])
         assert picked.ledger_entry.paid == 0
-        assert picked.caused_by == anchor_of(yolanda)
+        assert picked.caused_by == anchor
 
-    def test_only_offered_kinds_may_be_chosen(self, yolanda):
+    def test_only_what_the_slot_lists_may_be_picked(self, yolanda):
         """A refusal rather than an error: the sentence is one a player
         could be shown, because a screen that drew the click has to say
         something."""
-        with pytest.raises(Refusal, match="does not offer a choice of trait"):
+        with pytest.raises(Refusal):
             choose(anchor_of(yolanda), Trait.objects.create(name="Melee"))
 
-    def test_an_unoffering_anchor_refuses(self, yolanda, specialisations):
+    def test_an_anchor_granting_no_slot_refuses(self, yolanda, fields):
         ganger_assignment = assign(create_subtype("Ganger"), miniature=yolanda)
-        with pytest.raises(Refusal, match="does not offer"):
-            choose(ganger_assignment, specialisations["sharpshooter"])
+        with pytest.raises(Refusal):
+            choose(ganger_assignment, fields["sharpshooter"])
 
 
 class TestChangingYourMind:
-    def test_unchoosing_reopens_the_slot(self, yolanda, specialisations):
-        picked = choose(anchor_of(yolanda), specialisations["sharpshooter"])
+    def test_unchoosing_reopens_the_slot(self, yolanda, fields):
+        picked = pick(yolanda, fields["sharpshooter"])
         remove(picked)
 
         card = card_for(yolanda)
@@ -174,10 +214,10 @@ class TestChangingYourMind:
         assert choice.chosen is None
         assert card.skills == []
 
-    def test_rechoosing_works_and_the_ledger_remembers(self, yolanda, specialisations):
-        first = choose(anchor_of(yolanda), specialisations["sharpshooter"])
+    def test_rechoosing_works_and_the_ledger_remembers(self, yolanda, fields):
+        first = pick(yolanda, fields["sharpshooter"])
         remove(first)
-        choose(anchor_of(yolanda), specialisations["medic"])
+        pick(yolanda, fields["medic"])
 
         card = card_for(yolanda)
         (choice,) = card.choices
@@ -185,17 +225,16 @@ class TestChangingYourMind:
         assert [s.name for s in card.skills] == ["Field Surgery"]
         # The abandoned pick survives, archived, in the ledger.
         assert (
-            Assignment.objects.filter(
-                specialisation__isnull=False, archived=True
-            ).count()
+            Assignment.objects.filter(pickable__isnull=False, archived=True).count()
             == 1
         )
 
 
 class TestRemovingTheSubtype:
-    def test_the_whole_chain_unwinds(self, yolanda, specialisations):
-        choose(anchor_of(yolanda), specialisations["sharpshooter"])
-        remove(anchor_of(yolanda))
+    def test_the_whole_chain_unwinds(self, yolanda, fields):
+        anchor = anchor_of(yolanda)
+        pick(yolanda, fields["sharpshooter"])
+        remove(anchor)
 
         card = card_for(yolanda)
         assert card.choices == []
@@ -204,18 +243,25 @@ class TestRemovingTheSubtype:
 
 
 class TestTwoSlots:
-    def test_two_offering_subtypes_are_two_independent_slots(
-        self, yolanda, specialisations
+    def test_two_granting_subtypes_are_two_independent_slots(
+        self, yolanda, specialisation, fields
     ):
+        second_slot = create_slot(
+            "Second Specialisation",
+            specialisation,
+            create_picklist(
+                "Second Specialisations", specialisation, members=list(fields.values())
+            ),
+        )
         second = create_subtype("Twice-Specialised")
         modifier(
-            "Twice-Specialised also chooses",
-            TargetsMiniature.objects.create(),
-            offers_choice(Specialisation),
+            "Twice-Specialised is asked as well",
+            targets_model(),
+            ef_adds(second_slot),
             carried_by=second,
         )
         assign(second, miniature=yolanda)
-        choose(anchor_of(yolanda), specialisations["sharpshooter"])
+        pick(yolanda, fields["sharpshooter"])
 
         card = card_for(yolanda)
         # Two slots of the same kind — the provenance, though never
@@ -227,30 +273,29 @@ class TestTwoSlots:
         }
 
 
-class TestTheAllowList:
+class TestTheOfferAllowList:
+    """Offering a choice of a kind outright is the older mechanism, still
+    used where the answer is any row of a kind rather than a listed one.
+    Its allow-list governs which kinds that may be."""
+
     def test_unofferable_kinds_are_refused_at_authoring_time(self, db):
         from n26.library.models import Weapon
 
         with pytest.raises(ValidationError, match="cannot be offered"):
             OffersChoice.of(Weapon).clean()
 
-    def test_the_modifier_validates_whole(self, db, specialist):
-        offer = specialist.modifiers.get()
-        offer.full_clean()  # scope + effect + compatibility all pass
+    def test_the_granting_modifier_validates_whole(self, db, specialist):
+        grant = specialist.modifiers.get()
+        grant.full_clean()  # scope + effect + compatibility all pass
 
 
 class TestThePicker:
-    def test_the_offer_says_what_may_be_picked(self, yolanda, specialisations):
+    def test_the_slot_says_what_may_be_picked(self, yolanda, fields):
         """The first real database consumer: a choice UI's queryset."""
-        from n26.library.models.modifier import OffersChoice
+        (slot,) = slots_of(yolanda)
 
-        offer = next(
-            modifier.effect
-            for modifier in anchor_of(yolanda).assignable.modifiers.all()
-            if isinstance(modifier.effect, OffersChoice)
-        )
-        assert sorted(s.name for s in offer.choosables()) == [
+        listed = [member.pickable for member in slot.slot.picklist.members.all()]
+        assert sorted(pickable.name for pickable in listed) == [
             "Medicae",
             "Sharpshooter",
         ]
-        assert str(offer.selector()) == "any specialisation"

--- a/n26/tests/sandbox/test_specs.py
+++ b/n26/tests/sandbox/test_specs.py
@@ -410,12 +410,12 @@ class TestTheFullAssembly:
         """The modifier row from the plan's table: WHO and WHAT each
         compiled from their spec, glued by the modifier verb, hung on
         the archetype — the composer's whole save() in miniature."""
-        from n26.tests.sandbox.actions import create_archetype, create_category
+        from n26.tests.sandbox.actions import create_affiliation, create_category
 
         collection, tiers = skills_and_powers
         leader = create_subtype("Outcast Leader")
         combat = create_category("Skills", "Combat")
-        brawler = create_archetype("Brawler")
+        brawler = create_affiliation("Brawler")
 
         row = authoring.modifier(
             "Brawler leader: combat primary",

--- a/n26/tests/sandbox/test_venator_skill_trees.py
+++ b/n26/tests/sandbox/test_venator_skill_trees.py
@@ -12,10 +12,10 @@ fighter's rank:
 
 The unlock is reading that table **per column**: each rank slot is one
 gang-hosted assignable carrying everything except which tree was picked
-— a gang-level choice (``TargetsGang`` + ``OffersChoice`` of a
-``SkillTree`` token) and per-rank chosen-mode placements
+— a gang-level choice (``TargetsGang`` granting a ``Slot`` over the
+trees) and per-rank chosen-mode placements
 (``PlacesCategory.the_chosen``). The tree pick contributes exactly one
-datum, the token's ``category`` home; the whole mapping is authored
+datum, the pickable's ``category`` home; the whole mapping is authored
 content, known to no code.
 """
 
@@ -26,7 +26,7 @@ from n26.core.browse import offered_by, placements_for
 from n26.core.card import build_card, build_gang_card, build_modifier_index
 from n26.core.effects import compute, compute_gang
 from n26.core.render_text import gang_to_text
-from n26.library.models import Skill, SkillTree
+from n26.library.models import Skill
 from n26.tests.sandbox.actions import (
     choose,
     create_category,
@@ -34,10 +34,14 @@ from n26.tests.sandbox.actions import (
     create_default_set,
     create_gang_type,
     create_hidden,
+    create_pickable,
+    create_picklist,
     create_profile,
     create_skill,
-    create_skill_tree,
+    create_slot,
+    create_slot_type,
     create_subtype,
+    ef_adds,
     found_gang,
     has_subtypes,
     hire_with_option,
@@ -96,12 +100,30 @@ def skills_collection(skills):
 
 
 @pytest.fixture
-def tokens(sets):
-    """One pickable token per set, homed where the set lives."""
+def tree_type(db):
+    """The game ranks four *different* trees, so the same one picked for
+    two ranks is worth a word — which is what refusing repeats means
+    here: informed, never policed."""
+    return create_slot_type("Skill Tree", allows_repeats=False)
+
+
+@pytest.fixture
+def tokens(sets, tree_type):
+    """One pickable per set, homed where the set lives.
+
+    The home is the whole of what a pick contributes: a rule placing
+    "the chosen set" reads the pickable's category to learn which set
+    the pick stands for."""
     return {
-        key: create_skill_tree(category.name, category)
+        key: create_pickable(category.name, tree_type, category=category)
         for key, category in sets.items()
     }
+
+
+@pytest.fixture
+def trees(tokens, tree_type):
+    """One list, offered by all four rank slots."""
+    return create_picklist("Skill Trees", tree_type, members=list(tokens.values()))
 
 
 @pytest.fixture
@@ -123,7 +145,7 @@ RANKS = {
 
 
 @pytest.fixture
-def venators(subtypes, skills_collection):
+def venators(subtypes, skills_collection, tree_type, trees):
     """The gang type: four rank slots, each carrying the pick and what
     the pick means per fighter rank. No code knows this table."""
     _, tiers = skills_collection
@@ -135,7 +157,14 @@ def venators(subtypes, skills_collection):
         modifier(
             f"Skill Tree {rank}: the gang picks",
             targets_gang(),
-            offers_choice(SkillTree, label=f"skill tree {rank}"),
+            ef_adds(
+                create_slot(
+                    f"Skill Tree {rank}",
+                    tree_type,
+                    trees,
+                    label=f"Skill tree {rank}",
+                )
+            ),
             carried_by=slot,
         )
         for tier, ranks in meanings:
@@ -206,9 +235,19 @@ def slot_row(gang, rank):
 
 
 def pick(gang, tokens, ranked):
-    """Choose for the rank slots: ``pick(gang, tokens, ["agility", ...])``."""
+    """Choose for the rank slots: ``pick(gang, tokens, ["agility", ...])``.
+
+    A granted slot has no assignment of its own, so the anchor is the
+    marker the grant stands on and the slot being answered is named.
+    """
+    from n26.library.models import Slot
+
     return [
-        choose(slot_row(gang, rank), tokens[key])
+        choose(
+            slot_row(gang, rank),
+            tokens[key],
+            slot=Slot.objects.get(name=f"Skill Tree {rank}"),
+        )
         for rank, key in enumerate(ranked, start=1)
     ]
 
@@ -347,7 +386,7 @@ class TestChangingYourMind:
         )
 
         remove(picks[0])
-        choose(slot_row(gang, 1), tokens["shooting"])
+        pick(gang, tokens, ["shooting"])
 
         placed = tiers_for(hunters["specialist"], skills_collection, sets)
         assert placed["shooting"] == "Primary"
@@ -359,7 +398,7 @@ class TestChangingYourMind:
         """Inform, not police: the owner may double-pick. The gang sheet
         says so, and the fighter's view takes the better tier — lowest
         section position wins, the ordering rule as everywhere."""
-        pick(gang, tokens, ["agility", "cunning", "agility"])
+        pick(gang, tokens, ["agility", "cunning", "agility", "shooting"])
 
         notes = the_gang_computed(gang).notes
         assert [note.about for note in notes] == [tokens["agility"]]


### PR DESCRIPTION
Stage 2 of retiring Archetype, SkillTree and Specialisation. **No production code changes** — this is entirely the test suite, moved off the kinds that are about to go.

## The design documents, rebuilt

Three suites proved how a real rulebook setup behaves, built on the kinds those systems used *before* they moved onto slots and picks. They were proving a shape production no longer has. Each is now built the way production is — a slot type, its pickables, one picklist, a carrier granting the slot — with its assertions unchanged, so the setups keep their proof.

- `test_specialist.py` — the Specialist and the field it takes
- `test_venator_skill_trees.py` — four ranked trees the gang picks
- `test_outcast_gang.py` — the Leader picking for the gang, the Champion for himself

`test_outcast_archetype_shape.py` needed nothing: it was already slots-and-picks, with "Archetype" only ever the slot type's name.

## Three things the move surfaced

Each is now written down in the suite that met it:

1. **A slot a modifier *grants* has no assignment of its own**, so answering it has to name the slot. Only a slot assigned as a built-in speaks for itself. That is production's shape, and the difference is easy to miss.
2. **A pick contributes no sort-of-thing word.** A skill from a pickable has an empty `source_kind` where a specialisation used to name itself — deliberate, because "pickable" is plumbing a player never sees.
3. **A slot says when it is short**, which an offer never did. A suite counting notes now sees the open ones too.

## The borrowed samples

Other suites reached for one of these kinds only as a convenient example. They now borrow a kind that is staying. Two swaps were not free:

- A **subtype** is the wrong stand-in where the carrier also has built-in subtypes — the built-in reads as having answered the offer. Affiliation has no such collision.
- The **whole-kind offer** had used skill trees, whose rows existed only for it. Offered over affiliations it lists the ones the suite already has, sitting beside the narrowed offer on the same carrier — which is precisely what that suite is about.

## Checked

- Full n26 suite: 3917 passed.
- Every rewritten suite keeps its original test count and assertions.

## What is deliberately left

`test_ingest.py` (the ingest's specialisation restriction) goes with stage 3; `test_authoring_views.py` and `actions.py` test and re-export the retired kinds' own pages and verbs, so they go with stage 4.