### PR TITLE
style: drop the solid badge behind the n26 model card's rating

### DIFF
--- a/n26/core/templates/cotton/n26/model_card/index.html
+++ b/n26/core/templates/cotton/n26/model_card/index.html
@@ -63,7 +63,7 @@ control by the actions opens it.
 
             <div class="flex shrink-0 flex-col items-end gap-1.5">
                 <c-ui.tooltip size="sm">
-                    <c-ui.badge size="sm" variant="solid">{{ card.rating }}¢<span class="sr-only"> rating, including weapons and wargear</span></c-ui.badge>
+                    <span class="text-sm font-medium tabular-nums">{{ card.rating }}¢<span class="sr-only"> rating, including weapons and wargear</span></span>
                     <c-slot name="content">Rating, including weapons and wargear</c-slot>
                 </c-ui.tooltip>
 


### PR DESCRIPTION
The rating figure in the header of a model card — the `135¢` in the top-right
corner of every fighter card on the gang sheet and in the hire screen's filtered
card list — was drawn as a filled chip whose background is deliberately inverted
against the page. In light mode it was a near-black block with white text; in
dark mode a pale block with near-black text. It was the only element on those
screens working against the theme rather than with it.

It now renders as plain text in the card's own foreground colour. The tooltip
("Rating, including weapons and wargear") and the screen-reader wording are
unchanged, as is its position in the corner above the card's buttons.

## Summary

- `c-n26.model-card` draws its rating as a plain `<span>` rather than a
  `c-ui.badge` with `variant="solid"` (which paints `bg-ink-700 text-white` in
  light mode and `bg-ink-300 text-ink-900` in dark).
- One line in `n26/core/templates/cotton/n26/model_card/index.html`. This was
  the only `variant="solid"` badge in the application outside the design-system
  demos, so nothing else changes.

## Test plan

- [x] `pytest n26` — 3917 passed, 1 xfailed
- [x] `pytest n26/designsystem/tests.py` — 37 passed, including the test that
      asserts the card draws and its rating tooltip is present
- [x] Checked `/n26/design/c/model-card/` in the browser in both light and dark
      mode: the rating reads clearly in both, with no background behind it, and
      every card variant on that page picks up the change
- [x] `./scripts/fmt.sh` clean

No open issue covers this.
