### PR TITLE
fix: FeatureFlag admin takes a typed slug, slugified and checked unique

### DIFF
--- a/gyrinx/site/admin.py
+++ b/gyrinx/site/admin.py
@@ -16,8 +16,8 @@ from django.core.exceptions import PermissionDenied
 from django.db import models
 from django.shortcuts import redirect, render
 from django.urls import path
+from django.utils.text import slugify
 
-from gyrinx.site.flags import known_flags
 from gyrinx.site.models import (
     ChangelogEntry,
     ChangelogEntryTag,
@@ -200,29 +200,37 @@ class ChangelogEntryAdmin(admin.ModelAdmin):
 
 
 class FeatureFlagForm(forms.ModelForm):
-    """The slug is offered as a choice rather than typed.
+    """The slug is typed, cleaned, and checked rather than chosen.
 
-    A row whose slug no code asks for is inert: nothing reads it, so the
-    switch on it controls nothing, and it sits on the page reading as a
-    control over something. Free text is how that gets made — one typo and
-    the feature it was meant to open stays shut with no sign why.
+    Any word can be a flag: a row whose slug no code asks for is inert —
+    nothing reads it — so a slug typed ahead of the code is harmless,
+    where a fixed list would demand a deploy before this page could name
+    the feature at all. What typing must not do is make two rows for one
+    feature or a slug code cannot ask for, so the value is slugified on
+    the way in and uniqueness is checked against the cleaned form.
 
-    The choices are whatever the editions claimed as they started, so a
-    feature appears here by being registered rather than by being typed.
+    Declared as a plain text field: the model field's own slug validation
+    would refuse dirty input before the cleaning here could tidy it.
     """
+
+    slug = forms.CharField(
+        max_length=50,
+        label="Slug",
+        help_text=(
+            "What the code asks for. Cleaned to lower-case letters, digits "
+            "and dashes; fixed once the row exists."
+        ),
+    )
 
     class Meta:
         model = FeatureFlag
         fields = "__all__"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if "slug" in self.fields:
-            self.fields["slug"] = forms.ChoiceField(
-                choices=[(slug, slug) for slug in sorted(known_flags())],
-                label="Slug",
-                help_text="What the code asks for. Fixed once the row exists.",
-            )
+    def clean_slug(self):
+        slug = slugify(self.cleaned_data["slug"])
+        if not slug:
+            raise forms.ValidationError("A slug needs at least one letter or digit.")
+        return slug
 
 
 @admin.register(FeatureFlag)

--- a/gyrinx/tests/test_feature_flags.py
+++ b/gyrinx/tests/test_feature_flags.py
@@ -228,24 +228,39 @@ class TestTheAdminPage:
     def test_the_slug_is_settable_when_creating(self):
         assert "slug" not in self._admin().get_readonly_fields(None, obj=None)
 
-    def test_only_a_slug_the_code_asks_for_may_be_stored(self, group):
-        """A row whose slug nothing reads is inert — it sits on the page
-        reading as a control over something and controls nothing. The form
-        offers the known slugs rather than taking free text."""
+    def test_a_typed_slug_is_cleaned_on_the_way_in(self):
+        """Any word can be a flag — a slug no code reads yet is inert —
+        but what is stored must be one code could ask for, so the typed
+        value is slugified rather than refused."""
         from gyrinx.site.admin import FeatureFlagForm
-        from gyrinx.site.flags import known_flags
 
-        good = FeatureFlagForm(
-            data={"slug": FLAG, "name": "Test Feature", "availability": "off"}
+        form = FeatureFlagForm(
+            data={"slug": "  My Fancy Flag! ", "name": "Fancy", "availability": "off"}
         )
-        assert good.is_valid(), good.errors
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["slug"] == "my-fancy-flag"
 
-        bad = FeatureFlagForm(
-            data={"slug": "campiagns", "name": "Typo", "availability": "off"}
+    def test_a_slug_that_cleans_to_nothing_is_refused(self):
+        from gyrinx.site.admin import FeatureFlagForm
+
+        form = FeatureFlagForm(
+            data={"slug": "!!!", "name": "Noise", "availability": "off"}
         )
-        assert not bad.is_valid()
-        assert "slug" in bad.errors
-        assert set(dict(bad.fields["slug"].choices)) == set(known_flags())
+        assert not form.is_valid()
+        assert "slug" in form.errors
+
+    def test_the_same_flag_cannot_be_configured_twice(self, make_flag):
+        """Two rows for one slug would be two switches for one feature.
+        The check runs against the cleaned value, so a dressed-up variant
+        of an existing slug is caught too."""
+        from gyrinx.site.admin import FeatureFlagForm
+
+        make_flag(Availability.OFF)
+        dupe = FeatureFlagForm(
+            data={"slug": FLAG.upper(), "name": "Again", "availability": "off"}
+        )
+        assert not dupe.is_valid()
+        assert "slug" in dupe.errors
 
     def test_the_slug_is_fixed_once_the_row_exists(self, make_flag):
         """Editing it later would not rename a feature — it would turn one


### PR DESCRIPTION
Creating a feature flag in the admin required its slug to already be declared in code — the form offered a fixed dropdown built from the registered flags, which made the create step pointless ceremony.

The slug field is now free text:

- Cleaned with `slugify` on the way in ("  My Fancy Flag! " stores as `my-fancy-flag`), declared as a plain `CharField` on the form so the model `SlugField`'s own format validation can't refuse dirty input before the cleaning runs; input that cleans to nothing is refused with a message.
- Uniqueness is enforced against the *cleaned* value via the model's existing `unique=True`, so a dressed-up variant of an existing slug (`CAMPAIGNS `) is caught as a duplicate rather than stored as a second switch for the same feature.
- A row whose slug no code reads is inert and harmless — nothing reads it, nothing breaks. The code-side registry (`register_flags` / the unknown-slug refusal in `enabled`/`switched_on`) is unchanged: it still guards against typos at the call site.

Slug remains fixed once the row exists, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
