### PR TITLE
docs: record that stacked PRs use gh stack, not a hand-rolled base chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,6 +595,11 @@ and override the `owner` kwarg on the factory fixtures.
 - At the end of work, ship with the `commit-push-pr` skill — open the PR ready for
   review (not a draft) so bot reviews and the review-agent watcher kick off
   immediately. Only use `commit-push-draft` when a draft is explicitly requested.
+- **Stacked PRs are a GitHub built-in — use `gh stack`, never hand-roll one.**
+  Do not chain PRs by pointing one's base at another's branch and managing the
+  merges yourself: merging the parent with `--delete-branch` removes the child's
+  base branch, and GitHub then *closes* the child rather than retargeting it —
+  and a closed PR whose base is gone cannot be reopened.
 - Use conventional commit prefixes for commit messages and PR titles:
   - `feat:` — new feature or capability
   - `fix:` — bug fix


### PR DESCRIPTION
One line in `CLAUDE.md` under **Git Workflow**.

Merging a parent PR with `--delete-branch` removes the child PR's base branch. GitHub then **closes** the child rather than retargeting it to main, and a closed pull request whose base branch is gone cannot be reopened — the work has to go up as a new pull request.

That is what happened to #2312, which had been chained onto #2310 by hand. It is now #2314.

GitHub has stacked PRs as a built-in and `gh stack` is the toolchain for them, so there is no reason to hand-roll the chain.