### PR TITLE
feat: authoring pages preview how far a built-in change reaches

### DIFF
--- a/n26/core/propagation.py
+++ b/n26/core/propagation.py
@@ -32,14 +32,21 @@ The running side sits behind a feature flag; the filing does not.
 Shut loses no work: every edit still files its row, deliveries stand
 down leaving it PENDING, and the sweep — which stands down too —
 drains the whole backlog when the flag opens.
+
+The same carrier resolution also answers, without writing anything,
+how far a change would travel (:func:`reach_of` and its siblings) —
+what the authoring and ingest previews say before an author commits.
+The preview is informative only: the pass recomputes against the
+library as it stands when it runs.
 """
 
 import logging
 import traceback
+from dataclasses import dataclass
 from datetime import timedelta
 
 from django.db import transaction
-from django.db.models import OuterRef, Subquery
+from django.db.models import Count, OuterRef, Q, Subquery
 from django.tasks import task
 from django.utils import timezone
 
@@ -138,8 +145,8 @@ def _finish(propagation, status, metadata):
         )
 
 
-def _holders(default_set):
-    """The library things whose built-ins are this set."""
+def _holders(default_sets):
+    """The library things whose built-ins are one of these sets."""
     from django.apps import apps
 
     from n26.library.models.assignable import Assignable
@@ -147,34 +154,79 @@ def _holders(default_set):
     found = []
     for model in apps.get_app_config("library").get_models():
         if issubclass(model, Assignable):
-            found.extend(model.objects.filter(built_ins=default_set))
+            found.extend(model.objects.filter(built_ins__in=default_sets))
     return found
 
 
-def _carrier_ids(default_set):
+def _carriers_of(default_sets):
     """The assignments owed a pass: every use of a holder, and every
-    carrier that chose the set as an option. A removal is machinery,
-    not a use; an archived carrier is settled history."""
-    ids = set()
+    carrier that chose one of the sets as an option. A removal is
+    machinery, not a use; an archived carrier is settled history.
+
+    This one queryset is what the pass reconciles and what the reach
+    counts count, so the two can never come to disagree.
+    """
+    holds = Q(chosen_options__default_set__in=default_sets)
     by_field = {}
-    for holder in _holders(default_set):
+    for holder in _holders(default_sets):
         by_field.setdefault(Assignment.field_for(holder), []).append(holder)
     for field, holders in by_field.items():
-        ids.update(
-            Assignment.objects.filter(
-                archived=False,
-                removes=False,
-                **{f"{field}__in": holders},
-            ).values_list("pk", flat=True)
-        )
-    ids.update(
+        holds |= Q(**{f"{field}__in": holders})
+    return Assignment.objects.filter(holds, archived=False, removes=False).distinct()
+
+
+def _carrier_ids(default_set):
+    return set(_carriers_of([default_set]).values_list("pk", flat=True))
+
+
+@dataclass(frozen=True)
+class Reach:
+    """How far a change to a set's members travels: the live uses that
+    a pass would visit, and the gangs they sit in."""
+
+    uses: int
+    gangs: int
+
+
+def reach_of(default_set):
+    """The reach of a member added to this set, counted without writing
+    anything. A member being added does not exist yet, so the reach is
+    simply every current use of the set — holders' uses and option
+    selectors alike, outside archived gangs, exactly the carriers a
+    pass then visits."""
+    return _reach(_carriers_of([default_set]))
+
+
+def reach_of_all(default_sets):
+    """The combined reach of several sets, each use counted once even
+    where one carrier holds more than one of them."""
+    sets = list(default_sets)
+    if not sets:
+        return Reach(uses=0, gangs=0)
+    return _reach(_carriers_of(sets))
+
+
+def reach_of_new_built_ins(holder):
+    """The reach of the built-ins set a first built-in would found on
+    this thing. No set exists yet, so its only uses are the thing's
+    own."""
+    return _reach(
         Assignment.objects.filter(
-            chosen_options__default_set=default_set,
             archived=False,
             removes=False,
-        ).values_list("pk", flat=True)
+            **{Assignment.field_for(holder): holder},
+        )
     )
-    return ids
+
+
+def _reach(carriers):
+    # An archived gang is skipped by the pass, so its uses are outside
+    # the reach; a carrier belonging to no gang likewise.
+    counted = carriers.filter(gang_root__archived=False).aggregate(
+        uses=Count("pk", distinct=True),
+        gangs=Count("gang_root", distinct=True),
+    )
+    return Reach(**counted)
 
 
 def _reconcile_holders(default_set):

--- a/n26/library/templates/authoring/built_in_profiles.html
+++ b/n26/library/templates/authoring/built_in_profiles.html
@@ -30,6 +30,11 @@ offering them would invite building in a second copy.
         </c-slot>
     </c-n26.page-header>
     <div class="mt-6 max-w-2xl space-y-6">
+        {% if reach_said %}
+            <c-ui.description>
+                {{ reach_said }}
+            </c-ui.description>
+        {% endif %}
         {% if picker %}
             {% comment %}
             Step one: which weapon. A GET, so the choice lands in the

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -227,6 +227,11 @@ thing twice, a line apart.
                                 {% for paragraph in section.part_help %}<p>{{ paragraph }}</p>{% endfor %}
                             </c-n26.prose>
                         {% endif %}
+                        {% if section.reach_said %}
+                            <c-ui.description>
+                                {{ section.reach_said }}
+                            </c-ui.description>
+                        {% endif %}
                         <form method="post"
                               {% if section.form.is_multipart %}enctype="multipart/form-data"{% endif %}
                               class="max-w-xl space-y-5">

--- a/n26/library/templates/authoring/ingest_preview.html
+++ b/n26/library/templates/authoring/ingest_preview.html
@@ -85,6 +85,11 @@
                 {% endfor %}
             </tbody>
         </c-ui.table>
+        {% if preview.reach_said %}
+            <c-n26.prose class="mt-3">
+                <p class="text-muted">{{ preview.reach_said }}</p>
+            </c-n26.prose>
+        {% endif %}
         {% if preview.ok %}
             <form method="post" class="mt-6">
                 {% csrf_token %}

--- a/n26/library/templates/authoring/option_add.html
+++ b/n26/library/templates/authoring/option_add.html
@@ -35,6 +35,11 @@ asks for.
                 Brings nothing yet.
             </c-ui.description>
         {% endif %}
+        {% if reach_said %}
+            <c-ui.description>
+                {{ reach_said }}
+            </c-ui.description>
+        {% endif %}
         {% include "authoring/_form.html" with form=form %}
         {% comment %}
         A weapon profile is not in the picker above — a line means

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -697,6 +697,48 @@ def _holders_of(default_set):
     )
 
 
+def _reach_said(reach, adding):
+    """How far an addition to a set of defaults travels, in a sentence.
+
+    Says who already holds the set and what the addition does to them.
+    The consequence follows the feature flag, because reach is only
+    promised while the passes that deliver it actually run: shut, the
+    sentence says the change waits instead.
+    """
+    from n26.flags import BUILT_IN_PROPAGATION, switched_on
+
+    if reach.uses == 0:
+        return (
+            f"Held by no gang yet, so {adding} changes only what is "
+            f"acquired from now on."
+        )
+    times = "once" if reach.uses == 1 else f"{reach.uses} times"
+    where = "in one gang" if reach.gangs == 1 else f"across {reach.gangs} gangs"
+    standing = f"Already held {times}, {where}"
+    if switched_on(BUILT_IN_PROPAGATION):
+        reached = "it" if reach.uses == 1 else "every one of them"
+        return f"{standing} — {adding} reaches {reached} within seconds."
+    reached = "it" if reach.uses == 1 else "them"
+    return (
+        f"{standing} — {adding} will reach {reached} when built-in "
+        f"propagation is switched on."
+    )
+
+
+def _built_in_reach_said(thing):
+    """The reach sentence for a thing's own built-ins: the set it has,
+    or — before a first built-in founds one — the set it would get,
+    whose uses are the thing's own."""
+    from n26.core.propagation import reach_of, reach_of_new_built_ins
+
+    reach = (
+        reach_of(thing.built_ins)
+        if thing.built_ins_id
+        else reach_of_new_built_ins(thing)
+    )
+    return _reach_said(reach, "a built-in added here")
+
+
 def _article_for(word):
     """ "a" or "an" in front of a word we chose ourselves.
 
@@ -1658,6 +1700,15 @@ def detail(request, kind, pk):
                 ),
                 "parts_description": section.get("parts_description", ""),
                 "nothing_yet": section.get("nothing_yet", ""),
+                # Said beside the add form, so an author knows how far
+                # the addition travels before committing it. Only the
+                # built-ins section: a new option founds a set nobody
+                # holds yet, so there is nothing to say there.
+                "reach_said": (
+                    _built_in_reach_said(thing)
+                    if section.get("act") == "built_in"
+                    else ""
+                ),
                 "part_help": kind_help(part_model),
                 "wants_statline": section["statline"],
                 "parts": parts,
@@ -2045,6 +2096,7 @@ def built_in_profiles(request, pk):
     anchored to this gun; the listing draws it under the gun by that
     anchor, in the order the lines were added.
     """
+    from n26.core.propagation import reach_of
     from n26.library import authoring
     from n26.library.models import DefaultAssignment
 
@@ -2095,6 +2147,9 @@ def built_in_profiles(request, pk):
             "back": back,
             "picker": None,
             "landing_said": f"Each line lands under this {weapon}.",
+            "reach_said": _reach_said(
+                reach_of(member.default_set), "a line added here"
+            ),
         },
     )
 
@@ -2111,12 +2166,14 @@ def set_profiles(request, pk):
     does bring the weapon, in which case the verb settles the anchor
     exactly as an import would, refusing where the set brings it twice.
     """
+    from n26.core.propagation import reach_of
     from n26.library import authoring
     from n26.library.models import DefaultAssignmentSet, Weapon
 
     default_set = get_object_or_404(DefaultAssignmentSet, pk=pk)
     holders = _holders_of(default_set)
     back = _back_to(holders)
+    reach_said = _reach_said(reach_of(default_set), "a line added here")
 
     weapon = None
     named = request.POST.get("weapon") or request.GET.get("weapon")
@@ -2151,6 +2208,7 @@ def set_profiles(request, pk):
                 "back": back,
                 "picker": Weapon.objects.all(),
                 "landing_said": "",
+                "reach_said": reach_said,
             },
         )
 
@@ -2181,6 +2239,7 @@ def set_profiles(request, pk):
             "back": back,
             "picker": None,
             "landing_said": landing_said,
+            "reach_said": reach_said,
         },
     )
 
@@ -2278,6 +2337,7 @@ def option_add(request, pk):
     row control because the picker is a whole form: a kind, the row of
     that kind, and whatever attaching it asks for.
     """
+    from n26.core.propagation import reach_of
     from n26.library.models import Option
 
     option = get_object_or_404(
@@ -2311,6 +2371,11 @@ def option_add(request, pk):
             "label": option.name,
             "carrier": carrier,
             "brings": [_label_for(member.assignable) for member in _brought_by(option)],
+            # Held only by the carriers that took this option, so the
+            # sentence counts choosers rather than every use of the thing.
+            "reach_said": _reach_said(
+                reach_of(option.default_set), "anything added here"
+            ),
             "form": form,
             "back": back,
             "profiles_url": reverse(
@@ -3617,6 +3682,35 @@ def _value_said(value):
     return "—" if value is None or value == "" else value
 
 
+def _ingest_reach_said(plan):
+    """The preview's one line about existing gangs: which sets these
+    sheets would add members to, and how far those additions travel.
+
+    Only additions count — an amount corrected or a member superseded
+    changes what is acquired next, not what anything already holds —
+    and a set the sheets create is held by nobody, so an upload adding
+    to no standing set says nothing at all.
+    """
+    from n26.core.propagation import reach_of_all
+    from n26.library.models import DefaultAssignmentSet
+
+    grown = {
+        row.existing
+        for row in plan.planned
+        if row.kind == "DefaultAssignmentSet"
+        and row.action == "update"
+        and row.changes.get("members", {}).get("added")
+    }
+    if not grown:
+        return ""
+    reach = reach_of_all(DefaultAssignmentSet.objects.filter(pk__in=grown))
+    said = _reach_said(reach, "each addition")
+    return (
+        f"Some of these additions grow what a thing comes with: "
+        f"{said[0].lower()}{said[1:]}"
+    )
+
+
 def _sheets_standing(user):
     """Every sheet, held or not, in the order they are planned.
 
@@ -3759,6 +3853,7 @@ def ingest_preview(request):
     preview["errors"] = sum(1 for p in plan.problems if p.severity == "error")
     preview["notes"] = len(plan.problems) - preview["errors"]
     preview["diffs"] = _changes_by_shape(preview["changes"])
+    preview["reach_said"] = _ingest_reach_said(plan)
     # Uploading last year's export over this year's content is the
     # realistic accident, and it is invisible row by row and
     # unmistakable in the aggregate.

--- a/n26/tests/sandbox/test_builtin_reach_preview.py
+++ b/n26/tests/sandbox/test_builtin_reach_preview.py
@@ -1,0 +1,390 @@
+"""An author sees how far a built-in change travels before committing.
+
+The reach of an addition — how many live uses of the set exist, in how
+many gangs — is counted by the same carrier resolution the propagation
+pass walks, so the number the author reads is the number of uses a pass
+then visits. The pages that add a member say it in a sentence whose
+promise follows the feature flag: reach within seconds while passes
+run, a plain "when it is switched on" while they stand down, and its
+own quiet sentence when nothing holds the set at all. The preview is
+informative only — the pass recomputes when it runs.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from gyrinx.site.models import Availability, FeatureFlag
+from n26.core.models import BuiltInPropagationTask
+from n26.core.operations import operation
+from n26.core.propagation import Reach, reach_of, reach_of_new_built_ins
+from n26.flags import BUILT_IN_PROPAGATION
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    assign,
+    create_profile,
+    create_rule,
+    found_gang,
+    hire,
+    hire_with_option,
+    offer_option,
+    remove,
+)
+from n26.tests.sandbox.test_ingest_page import PREVIEW_URL, hold, hold_all
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def flag(db):
+    """Passes run only while the flag is open; the wording tests that
+    want the within-seconds promise request this row."""
+    return FeatureFlag.objects.create(
+        slug=BUILT_IN_PROPAGATION,
+        name="Built-in propagation",
+        availability=Availability.EVERYONE,
+    )
+
+
+@pytest.fixture
+def player():
+    return User.objects.create_user("tom")
+
+
+@pytest.fixture
+def author(client):
+    user = User.objects.create_user("author", is_staff=True)
+    client.force_login(user)
+    return user
+
+
+@pytest.fixture
+def ganger(person_type, gang_type, default_pack):
+    profile = create_profile("Ganger", person_type, gang_type, price=50)
+    add_built_in(profile, create_rule("Gang Fighter"))
+    return profile
+
+
+@pytest.fixture
+def foundation(default_pack):
+    """The seed rows the sheets resolve against, planted the way the
+    Foundations page plants them."""
+    from n26.library.standard_content import STANDARD_CONTENT
+
+    for item in STANDARD_CONTENT.values():
+        item.create()
+
+
+def comes_with_section(page):
+    return next(
+        section
+        for section in page.context["part_sections"]
+        if section["act"] == "built_in"
+    )
+
+
+class TestTheReachPlanner:
+    """The counts are the carriers a pass visits: holders' live uses
+    and option selectors, outside archived gangs, nothing else."""
+
+    def test_the_counts_agree_with_what_a_pass_then_touches(
+        self, ganger, gang_type, player, default_pack, task_queue, flag
+    ):
+        here = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        there = found_gang("The Movers", gang_type, owner=player, budget=1000)
+        hire(here, ganger, "Ana", paid=50)
+        hire(here, ganger, "Bea", paid=50)
+        hire(there, ganger, "Cat", paid=50)
+
+        reach = reach_of(ganger.built_ins)
+        assert reach == Reach(uses=3, gangs=2)
+
+        with task_queue.capture():
+            member = add_built_in(ganger, create_rule("Nerves of Steel"))
+        task_queue.deliver_all()
+
+        filed = (
+            BuiltInPropagationTask.objects.filter(
+                status="DONE", default_set=member.default_set
+            )
+            .order_by("created")
+            .last()
+        )
+        ending = filed.states.history.get(to_status="DONE")
+        assert ending.metadata["gangs"] == reach.gangs
+        assert ending.metadata["granted"] == reach.uses
+
+    def test_an_option_set_counts_only_the_gangs_that_chose_it(
+        self, gang_type, person_type, player, default_pack
+    ):
+        profile = create_profile("Chooser", person_type, gang_type, price=100)
+        offer_option(profile, "Plain", thing=create_rule("Plain Style"))
+        fancy = offer_option(profile, "Fancy", thing=create_rule("Fancy Style"))
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire_with_option(gang, profile, "Ana", option=fancy.default_set)
+        hire(gang, profile, "Bea", paid=100)
+
+        assert reach_of(fancy.default_set) == Reach(uses=1, gangs=1)
+
+    def test_archived_gangs_and_parted_with_uses_are_outside_the_reach(
+        self, ganger, gang_type, player, default_pack
+    ):
+        here = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        there = found_gang("The Leavers", gang_type, owner=player, budget=1000)
+        hire(here, ganger, "Ana", paid=50)
+        bea = hire(here, ganger, "Bea", paid=50)
+        hire(there, ganger, "Cat", paid=50)
+
+        remove(bea.membership)
+        there.archived = True
+        there.save()
+
+        assert reach_of(ganger.built_ins) == Reach(uses=1, gangs=1)
+
+    def test_an_owners_removal_of_the_thing_is_not_a_use(
+        self, ganger, gang_type, player, default_pack
+    ):
+        """A removes assignment is the owner striking the thing off, so
+        nothing rides it — a pass skips it and the count does too."""
+        cursed = create_rule("Cursed")
+        add_built_in(cursed, create_rule("Curse Mark"))
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        ana = hire(gang, ganger, "Ana", paid=50)
+        bea = hire(gang, ganger, "Bea", paid=50)
+        assign(cursed, miniature=ana)
+        with operation(gang, actor=gang.owner) as op:
+            op.take_away(bea, cursed)
+
+        assert reach_of(cursed.built_ins) == Reach(uses=1, gangs=1)
+
+    def test_a_set_nobody_holds_reports_zero(self, ganger, default_pack):
+        assert reach_of(ganger.built_ins) == Reach(uses=0, gangs=0)
+
+    def test_a_thing_with_no_set_yet_counts_its_own_uses(
+        self, person_type, gang_type, player, default_pack
+    ):
+        """The first built-in founds the set on the thing, so before it
+        exists the reach is the thing's own live uses."""
+        bare = create_profile("Plain Hand", person_type, gang_type, price=50)
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire(gang, bare, "Ana", paid=50)
+
+        assert bare.built_ins_id is None
+        assert reach_of_new_built_ins(bare) == Reach(uses=1, gangs=1)
+
+    def test_the_query_count_stays_flat_as_the_holders_grow(
+        self, ganger, gang_type, player, default_pack
+    ):
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire(gang, ganger, "Ana", paid=50)
+        with CaptureQueriesContext(connection) as small:
+            reach_of(ganger.built_ins)
+
+        for name in ("The Movers", "The Stayers", "The Walkers"):
+            grown = found_gang(name, gang_type, owner=player, budget=1000)
+            hire(grown, ganger, f"{name} One", paid=50)
+            hire(grown, ganger, f"{name} Two", paid=50)
+        with CaptureQueriesContext(connection) as large:
+            assert reach_of(ganger.built_ins) == Reach(uses=7, gangs=4)
+
+        assert len(large) == len(small)
+
+
+class TestTheAuthoringPagesSayIt:
+    """Each page that adds a member carries the sentence, rendered
+    server-side, its promise following the feature flag."""
+
+    def test_the_comes_with_form_says_the_reach(
+        self, client, author, ganger, gang_type, player, default_pack, flag
+    ):
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire(gang, ganger, "Ana", paid=50)
+
+        page = client.get(reverse("authoring-detail", args=["profile", ganger.pk]))
+
+        said = comes_with_section(page)["reach_said"]
+        assert said == (
+            "Already held once, in one gang — a built-in added here "
+            "reaches it within seconds."
+        )
+        assert said in page.content.decode()
+
+    def test_several_uses_are_counted_in_the_plural(
+        self, client, author, ganger, gang_type, player, default_pack, flag
+    ):
+        here = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        there = found_gang("The Movers", gang_type, owner=player, budget=1000)
+        hire(here, ganger, "Ana", paid=50)
+        hire(here, ganger, "Bea", paid=50)
+        hire(there, ganger, "Cat", paid=50)
+
+        page = client.get(reverse("authoring-detail", args=["profile", ganger.pk]))
+
+        assert comes_with_section(page)["reach_said"] == (
+            "Already held 3 times, across 2 gangs — a built-in added here "
+            "reaches every one of them within seconds."
+        )
+
+    def test_shut_the_sentence_promises_nothing_until_the_flag_opens(
+        self, client, author, ganger, gang_type, player, default_pack
+    ):
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire(gang, ganger, "Ana", paid=50)
+
+        page = client.get(reverse("authoring-detail", args=["profile", ganger.pk]))
+
+        assert comes_with_section(page)["reach_said"] == (
+            "Already held once, in one gang — a built-in added here will "
+            "reach it when built-in propagation is switched on."
+        )
+
+    def test_no_holders_reads_as_its_own_sentence(
+        self, client, author, ganger, default_pack, flag
+    ):
+        page = client.get(reverse("authoring-detail", args=["profile", ganger.pk]))
+
+        said = comes_with_section(page)["reach_said"]
+        assert said == (
+            "Held by no gang yet, so a built-in added here changes only "
+            "what is acquired from now on."
+        )
+        assert said in page.content.decode()
+
+    def test_a_thing_without_a_set_counts_its_uses_all_the_same(
+        self, client, author, person_type, gang_type, player, default_pack, flag
+    ):
+        bare = create_profile("Plain Hand", person_type, gang_type, price=50)
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire(gang, bare, "Ana", paid=50)
+
+        page = client.get(reverse("authoring-detail", args=["profile", bare.pk]))
+
+        assert (
+            "Already held once, in one gang" in (comes_with_section(page)["reach_said"])
+        )
+
+    def test_the_gun_members_page_says_the_reach(
+        self, client, author, person_type, gang_type, player, default_pack, flag
+    ):
+        from n26.library.authoring import create_weapon
+
+        launcher = create_weapon("Launcher", profiles=[("Frag", 0), ("Smoke", 10)])
+        gunner = create_profile("Gunner", person_type, gang_type, price=50)
+        add_built_in(gunner, launcher)
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire(gang, gunner, "Ana", paid=50)
+        gun_member = gunner.built_ins.members.get(weapon__isnull=False)
+
+        page = client.get(reverse("authoring-built-in-profiles", args=[gun_member.pk]))
+
+        said = page.context["reach_said"]
+        assert said == (
+            "Already held once, in one gang — a line added here reaches "
+            "it within seconds."
+        )
+        assert said in page.content.decode()
+
+    def test_the_set_door_page_says_the_reach(
+        self, client, author, ganger, gang_type, player, default_pack, flag
+    ):
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire(gang, ganger, "Ana", paid=50)
+
+        page = client.get(reverse("authoring-set-profiles", args=[ganger.built_ins_id]))
+
+        said = page.context["reach_said"]
+        assert "Already held once, in one gang" in said
+        assert said in page.content.decode()
+
+    def test_the_option_page_counts_choosers_only(
+        self, client, author, person_type, gang_type, player, default_pack, flag
+    ):
+        profile = create_profile("Chooser", person_type, gang_type, price=100)
+        offer_option(profile, "Plain", thing=create_rule("Plain Style"))
+        fancy = offer_option(profile, "Fancy", thing=create_rule("Fancy Style"))
+        gang = found_gang("The Bad Girls", gang_type, owner=player, budget=1000)
+        hire_with_option(gang, profile, "Ana", option=fancy.default_set)
+        hire(gang, profile, "Bea", paid=100)
+        option = profile.options.get(name="Fancy")
+
+        page = client.get(reverse("authoring-option-add", args=[option.pk]))
+
+        said = page.context["reach_said"]
+        assert said == (
+            "Already held once, in one gang — anything added here reaches "
+            "it within seconds."
+        )
+        assert said in page.content.decode()
+
+
+#: The profiles sheet with one line grown: Way-Brethren gains the
+#: Witch special rule the pack already holds, so a re-upload plans one
+#: set update whose only difference is the added member.
+def grown_profiles_csv():
+    from n26.tests.sandbox.test_ingest import PROFILES_CSV
+
+    return PROFILES_CSV.replace(
+        'Specialist",13,45,,,,Cawdor', 'Specialist",13,45,Witch,,,Cawdor'
+    )
+
+
+class TestTheIngestPreviewSaysIt:
+    """The upload preview carries the same sentence for the sets the
+    sheets would add members to — counted by the same planner, said in
+    the same words."""
+
+    def test_the_reach_line_reflects_the_standing_uses(
+        self, client, author, foundation, player, default_pack
+    ):
+        from n26.library.models import Profile
+
+        hold_all(client)
+        client.post(PREVIEW_URL)
+        brethren = Profile.objects.get(name="Way-Brethren")
+        gang = found_gang(
+            "The Bad Girls", brethren.gang_type, owner=player, budget=1000
+        )
+        hire(gang, brethren, "Ana", paid=45)
+
+        hold(client, "profiles", text=grown_profiles_csv())
+        page = client.get(PREVIEW_URL)
+
+        said = page.context["preview"]["reach_said"]
+        assert said == (
+            "Some of these additions grow what a thing comes with: already "
+            "held once, in one gang — each addition will reach it when "
+            "built-in propagation is switched on."
+        )
+        assert said in page.content.decode()
+
+    def test_open_the_line_promises_the_reach_within_seconds(
+        self, client, author, foundation, player, default_pack, flag
+    ):
+        from n26.library.models import Profile
+
+        hold_all(client)
+        client.post(PREVIEW_URL)
+        brethren = Profile.objects.get(name="Way-Brethren")
+        gang = found_gang(
+            "The Bad Girls", brethren.gang_type, owner=player, budget=1000
+        )
+        hire(gang, brethren, "Ana", paid=45)
+
+        hold(client, "profiles", text=grown_profiles_csv())
+        page = client.get(PREVIEW_URL)
+
+        assert page.context["preview"]["reach_said"].endswith(
+            "each addition reaches it within seconds."
+        )
+
+    def test_an_upload_growing_no_standing_set_says_nothing(
+        self, client, author, foundation, default_pack
+    ):
+        hold_all(client)
+        client.post(PREVIEW_URL)
+
+        page = client.get(PREVIEW_URL)
+
+        assert page.context["preview"]["reach_said"] == ""


### PR DESCRIPTION
Part of #2165 (built-in propagation programme, chunk C5).

Authoring pages now say, before an author adds a built-in, how far the change will travel: "Already held 2 times, in one gang — a built-in added here reaches every one of them within seconds." Zero holders reads as "Held by no gang yet, so a built-in added here changes only what is acquired from now on", and while the built-in-propagation flag is shut the sentence says "…will reach it when built-in propagation is switched on" instead of promising speed. The ingest preview line gets the same treatment.

The counts come from the same carrier queryset the propagation pass reconciles (`_carriers_of`, shared by `reach_of()` and C4's `_carrier_ids`), so preview and pass cannot disagree. Read-only, server-rendered, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
