### PR TITLE
fix: Edit ticks on the Choose list answer a Primary skill question

### DIFF
--- a/n26/core/views/learn.py
+++ b/n26/core/views/learn.py
@@ -23,9 +23,16 @@ than the gap: it is theirs whether or not anybody has graded them, so
 the switcher on the next fighter's screen can offer it without knowing
 which of them have a grid.
 
-What clicking writes is ``Operation.learn``: free, recorded, and caused
-by nothing, so what a fighter earned survives the assignment that opened
-the set up to them.
+What clicking writes is usually ``Operation.learn``: free, recorded, and
+caused by nothing, so what a fighter earned survives the assignment that
+opened the set up to them.
+
+If the card is still asking for a starting skill, and the thing selected
+is on that question's Choose list, the click is that answer — written the
+way Choose writes it. A Secondary skill is not a Primary skill, so it
+stays a standing selection and the question stays open. Otherwise the
+card would keep asking beside a skill the owner just picked from the
+list, and a later Choose would hand out a second starting skill.
 
 The same listing is offered a second way, as a box to tick on the
 fighter's own edit page (``ticked_offer`` and ``apply_ticks``). One
@@ -153,6 +160,85 @@ def ticked_offer(card, computed):
     return ChoiceOffer(label="", groups=groups)
 
 
+def _offered_keys(slot, computed):
+    """What the Choose page lists for this question, keyed as the tick
+    list keys its options.
+
+    That list is the match: a Secondary skill is not a Primary skill,
+    even though both are skills and both appear on the edit page.
+    """
+    from n26.core.browse import offered_by
+
+    listed = offered_by(slot, computed)
+    if listed is None:
+        return frozenset()
+    if hasattr(listed, "all_lines"):
+        things = (line.thing for line in listed.all_lines())
+    else:
+        things = (getattr(item, "thing", item) for item in listed)
+    return frozenset(_key(thing) for thing in things if thing is not None)
+
+
+def _open_questions(computed):
+    """Founding questions this card still asks, with what Choose lists
+    for each.
+
+    A slot of pickables is not one of these: this surface never writes
+    those. Only a modifier's offer is — the Leader's starting skill, a
+    Haunt's first power.
+    """
+    return [
+        slot
+        for slot in computed.choices
+        if not slot.is_resolved and slot.offer is not None
+    ]
+
+
+def _answered_by(computed):
+    """Which held thing currently answers which founding question."""
+    found = {}
+    for slot in computed.choices:
+        if slot.offer is None:
+            continue
+        for pick in slot.picks:
+            if pick.assignment is None:
+                continue
+            found[_key(pick.assignable)] = slot
+    return found
+
+
+def _question_for(thing, questions, lists):
+    """The first open question whose Choose list names this thing."""
+    key = _key(thing)
+    for slot in questions:
+        if key in lists[id(slot)]:
+            return slot
+    return None
+
+
+def _answer_with(op, miniature, thing, questions, lists):
+    """Write ``thing`` as the answer to an open founding question if it
+    is on that question's Choose list, otherwise as a standing selection.
+
+    A tick on the edit page and a click on the skills screen are the
+    same write. Selecting a second skill, or a skill the Choose page
+    would not have listed, stays a standing selection — caused by
+    nothing, surviving a profile swap — because it is not the starting
+    pick.
+    """
+    slot = _question_for(thing, questions, lists)
+    if slot is None:
+        return op.learn(miniature, thing)
+    anchor = getattr(slot.anchor, "assignment", None)
+    if anchor is None:
+        return op.learn(miniature, thing)
+    questions.remove(slot)
+    host = {}
+    if getattr(slot.anchor, "broadcast", False):
+        host["miniature"] = miniature
+    return op.choose(anchor, thing, offer=slot.offer, **host)
+
+
 def apply_ticks(op, miniature, card, computed, ticked):
     """Make what a model holds match what was ticked, and say what moved.
 
@@ -163,16 +249,25 @@ def apply_ticks(op, miniature, card, computed, ticked):
     not being offered and so cannot have been cleared.
 
     A newly ticked thing is selected — free, and caused by nothing, the
-    same write the skills screen makes — and a cleared one is removed the
-    way anything is taken off a card: archived, with the ledger still
-    saying it was there. Granted things are on neither side of the
-    difference, because a fixed box submits nothing and reading its
-    silence as a clearing would take away the assignment of anything a
-    modifier also grants.
+    same write the skills screen makes — unless the card is still asking
+    for a starting skill and this thing is on that question's Choose
+    list. Then the tick is that answer, written the way Choose writes
+    it, so the question leaves the card rather than sitting beside the
+    skill as if nobody had picked. A Secondary skill cannot answer
+    "Primary skill". Clearing the skill that answered a question opens
+    it again; a replacement ticked in the same save answers it afresh
+    if it is on the list.
+
+    Granted things are on neither side of the difference, because a
+    fixed box submits nothing and reading its silence as a clearing
+    would take away the assignment of anything a modifier also grants.
     """
     offer = ticked_offer(card, computed)
     rows = _rows_on(card)
     granted = _grants_on(computed)
+    questions = _open_questions(computed)
+    lists = {id(slot): _offered_keys(slot, computed) for slot in questions}
+    answered = _answered_by(computed)
 
     # One entry per thing: two collections may both list a skill, and a
     # second sighting of a ticked one must not select it twice.
@@ -181,17 +276,26 @@ def apply_ticks(op, miniature, card, computed, ticked):
         for option in group.options:
             options.setdefault(option.key, option)
 
+    # Removals first: clearing the skill that answered a question opens
+    # it again, so a replacement ticked in the same save can answer it
+    # rather than land as a second starting skill beside a fresh Choose.
     learned, cleared = [], []
+    for key, option in options.items():
+        if key in granted or key in ticked or key not in rows:
+            continue
+        op.remove(rows[key])
+        cleared.append(option.name)
+        slot = answered.get(key)
+        if slot is not None and slot not in questions:
+            questions.append(slot)
+            lists.setdefault(id(slot), _offered_keys(slot, computed))
+
     for key, option in options.items():
         if key in granted:
             continue
-        if key in ticked:
-            if key not in rows:
-                op.learn(miniature, option.thing)
-                learned.append(option.name)
-        elif key in rows:
-            op.remove(rows[key])
-            cleared.append(option.name)
+        if key in ticked and key not in rows:
+            _answer_with(op, miniature, option.thing, questions, lists)
+            learned.append(option.name)
     return learned, cleared
 
 
@@ -353,7 +457,9 @@ def learn(request, pk):
             return redirect(here)
         try:
             with operation(gang, actor=request.user) as op:
-                learned = op.learn(miniature, picked.thing)
+                questions = _open_questions(computed)
+                lists = {id(slot): _offered_keys(slot, computed) for slot in questions}
+                learned = _answer_with(op, miniature, picked.thing, questions, lists)
         except Refusal as refusal:
             messages.error(request, str(refusal))
             return redirect(here)

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -19,6 +19,10 @@ The rules this file pins:
 * **What a rule grants is fixed.** It is drawn ticked and disabled,
   saying what grants it — there is no stored row behind it, so the
   square never offers a removal it could not do.
+* **An open starting-skill question is answered only by a tick on that
+  question's Choose list.** A Leader asking for a Primary skill is
+  settled by Catfall, not by Connected. A Secondary tick is a standing
+  selection and leaves the question open.
 * None of it is money. Selecting is free, and a gang still reconciles.
 """
 
@@ -30,13 +34,14 @@ from django.urls import reverse
 
 from n26.core.card import build_card, build_modifier_index
 from n26.core.effects import compute
-from n26.core.models import LedgerEntry
+from n26.core.models import Assignment, LedgerEntry
 from n26.core.reconcile import assert_reconciled
 from n26.core.render import build_model_card
 from n26.library.models import Power, Skill
 from n26.tests.sandbox.actions import (
     adds,
     assign,
+    choose,
     create_category,
     create_collection,
     create_power,
@@ -46,6 +51,7 @@ from n26.tests.sandbox.actions import (
     hire_with_option,
     learn,
     modifier,
+    offers_choice,
     places,
     section_of,
     targets_model,
@@ -531,7 +537,178 @@ class TestSavingTheSquare:
         assert_reconciled(gang)
 
 
-# --- The budget ------------------------------------------------------------
+# --- An open starting-skill question ---------------------------------------
+
+
+def _live_skill(miniature, skill):
+    return miniature.assignments.get(skill=skill, archived=False)
+
+
+class TestAnOpenStartingSkill:
+    """While the card still asks, a tick on that question's Choose list
+    is the starting skill. A Secondary skill is not Primary, so it does
+    not close the question."""
+
+    @pytest.fixture
+    def leader(self, tiers):
+        subtype = create_subtype("Leader")
+        modifier(
+            "A Leader starts with a Primary skill",
+            targets_model(),
+            offers_choice(Skill, from_section=tiers["primary"]),
+            carried_by=subtype,
+        )
+        return subtype
+
+    @pytest.fixture
+    def leader_yolanda(self, yolanda, leader):
+        assign(leader, miniature=yolanda)
+        return yolanda
+
+    def test_ticking_a_primary_skill_answers_the_question(
+        self, client, player, gang, leader_yolanda, library
+    ):
+        catfall = library["skills"]["Catfall"]
+        client.force_login(player)
+        post_skills(client, leader_yolanda, catfall)
+
+        card = card_for(leader_yolanda)
+        assert card.skill_choices == []
+        assert "Catfall" in held_by(leader_yolanda)
+        row = _live_skill(leader_yolanda, catfall)
+        assert row.chosen_for_offer_id is not None
+        assert row.caused_by_id is not None
+        assert_reconciled(gang)
+
+    def test_replacing_the_starting_skill_keeps_the_question_closed(
+        self, client, player, gang, leader_yolanda, library
+    ):
+        """Choose Catfall, then Edit to Dodge: the new tick is the
+        starting skill, not a second one beside a reopened prompt."""
+        catfall = library["skills"]["Catfall"]
+        dodge = library["skills"]["Dodge"]
+        choose(
+            leader_yolanda.assignments.get(subtype__name="Leader"),
+            catfall,
+        )
+        client.force_login(player)
+        post_skills(client, leader_yolanda, dodge)
+
+        card = card_for(leader_yolanda)
+        assert card.skill_choices == []
+        assert held_by(leader_yolanda) == ["Dodge"]
+        row = _live_skill(leader_yolanda, dodge)
+        assert row.chosen_for_offer_id is not None
+        assert row.caused_by_id is not None
+        assert not Assignment.objects.filter(
+            miniature_root=leader_yolanda, skill=catfall, archived=False
+        ).exists()
+        assert_reconciled(gang)
+
+    def test_a_secondary_tick_does_not_answer_the_question(
+        self, client, player, gang, leader_yolanda, library
+    ):
+        """Connected is on the edit square (Savant is Secondary) but not
+        on the Choose page for a Primary skill."""
+        connected = library["skills"]["Connected"]
+        client.force_login(player)
+        post_skills(client, leader_yolanda, connected)
+
+        card = card_for(leader_yolanda)
+        assert [line.kind_label for line in card.skill_choices] == ["Primary skill"]
+        assert held_by(leader_yolanda) == ["Connected"]
+        row = _live_skill(leader_yolanda, connected)
+        assert row.chosen_for_offer_id is None
+        assert row.caused_by_id is None
+        assert_reconciled(gang)
+
+    def test_a_primary_tick_answers_and_a_secondary_tick_is_extra(
+        self, client, player, gang, leader_yolanda, library
+    ):
+        catfall = library["skills"]["Catfall"]
+        connected = library["skills"]["Connected"]
+        client.force_login(player)
+        post_skills(client, leader_yolanda, catfall, connected)
+
+        card = card_for(leader_yolanda)
+        assert card.skill_choices == []
+        assert sorted(held_by(leader_yolanda)) == ["Catfall", "Connected"]
+        starting = _live_skill(leader_yolanda, catfall)
+        extra = _live_skill(leader_yolanda, connected)
+        assert starting.chosen_for_offer_id is not None
+        assert extra.chosen_for_offer_id is None
+        assert extra.caused_by_id is None
+        assert_reconciled(gang)
+
+    def test_clearing_the_starting_skill_reopens_the_question(
+        self, client, player, gang, leader_yolanda, library
+    ):
+        catfall = library["skills"]["Catfall"]
+        choose(
+            leader_yolanda.assignments.get(subtype__name="Leader"),
+            catfall,
+        )
+        client.force_login(player)
+        post_skills(client, leader_yolanda)
+
+        card = card_for(leader_yolanda)
+        assert [line.kind_label for line in card.skill_choices] == ["Primary skill"]
+        assert held_by(leader_yolanda) == []
+        assert_reconciled(gang)
+
+    def test_keeping_the_starting_skill_and_ticking_another_learns_the_extra(
+        self, client, player, gang, leader_yolanda, library
+    ):
+        catfall = library["skills"]["Catfall"]
+        dodge = library["skills"]["Dodge"]
+        choose(
+            leader_yolanda.assignments.get(subtype__name="Leader"),
+            catfall,
+        )
+        client.force_login(player)
+        post_skills(client, leader_yolanda, catfall, dodge)
+
+        card = card_for(leader_yolanda)
+        assert card.skill_choices == []
+        assert sorted(held_by(leader_yolanda)) == ["Catfall", "Dodge"]
+        starting = _live_skill(leader_yolanda, catfall)
+        extra = _live_skill(leader_yolanda, dodge)
+        assert starting.chosen_for_offer_id is not None
+        assert extra.chosen_for_offer_id is None
+        assert extra.caused_by_id is None
+        assert_reconciled(gang)
+
+    def test_one_new_matching_skill_answers_and_further_ticks_are_ordinary(
+        self, client, player, gang, leader_yolanda, library
+    ):
+        catfall = library["skills"]["Catfall"]
+        dodge = library["skills"]["Dodge"]
+        client.force_login(player)
+        post_skills(client, leader_yolanda, catfall, dodge)
+
+        card = card_for(leader_yolanda)
+        assert card.skill_choices == []
+        rows = [
+            _live_skill(leader_yolanda, catfall),
+            _live_skill(leader_yolanda, dodge),
+        ]
+        picks = [row for row in rows if row.chosen_for_offer_id is not None]
+        extras = [row for row in rows if row.chosen_for_offer_id is None]
+        assert len(picks) == 1
+        assert len(extras) == 1
+        assert extras[0].caused_by_id is None
+        assert_reconciled(gang)
+
+    def test_the_edit_page_stops_asking_once_a_primary_skill_is_ticked(
+        self, client, player, leader_yolanda, library
+    ):
+        client.force_login(player)
+        page = post_skills(
+            client, leader_yolanda, library["skills"]["Catfall"], follow=True
+        ).content.decode()
+
+        assert "Choose primary skill" not in page
+        assert "Catfall" in held_by(leader_yolanda)
 
 
 class TestTheQueryBudget:

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -746,3 +746,179 @@ class TestTheQueryBudget:
 
         assert few == many, f"{few} queries knowing 2, {many} knowing 8"
         assert_reconciled(gang)
+
+
+def _gang_url(gang):
+    return reverse("n26-gang", args=[gang.pk])
+
+
+def _skills_url(miniature):
+    return reverse("n26-learn", args=[miniature.pk])
+
+
+def _learn_views():
+    """The learn *module* — ``n26.core.views.learn`` is the view function
+    on the package, which shadows the submodule for a normal import."""
+    import importlib
+
+    return importlib.import_module("n26.core.views.learn")
+
+
+class TestAnsweringDoesNotTouchTheReadPath:
+    """The Choose-list match is a write. Drawing the sheet, the edit
+    page or the skills screen must not browse that list to decide what
+    to show."""
+
+    @pytest.fixture
+    def leader(self, tiers):
+        subtype = create_subtype("Leader")
+        modifier(
+            "A Leader starts with a Primary skill",
+            targets_model(),
+            offers_choice(Skill, from_section=tiers["primary"]),
+            carried_by=subtype,
+        )
+        return subtype
+
+    @pytest.fixture
+    def leader_yolanda(self, yolanda, leader):
+        assign(leader, miniature=yolanda)
+        return yolanda
+
+    def test_reading_the_edit_page_does_not_build_the_choose_list(
+        self, client, player, leader_yolanda, monkeypatch
+    ):
+        learn_views = _learn_views()
+
+        calls = []
+        monkeypatch.setattr(
+            learn_views,
+            "_offered_keys",
+            lambda *args, **kwargs: calls.append(1) or frozenset(),
+        )
+        client.force_login(player)
+        assert client.get(edit_url(leader_yolanda)).status_code == 200
+        assert calls == []
+
+    def test_reading_the_gang_sheet_does_not_build_the_choose_list(
+        self, client, player, leader_yolanda, monkeypatch
+    ):
+        learn_views = _learn_views()
+
+        calls = []
+        monkeypatch.setattr(
+            learn_views,
+            "_offered_keys",
+            lambda *args, **kwargs: calls.append(1) or frozenset(),
+        )
+        client.force_login(player)
+        assert client.get(_gang_url(leader_yolanda.gang)).status_code == 200
+        assert calls == []
+
+    def test_reading_the_skills_screen_does_not_build_the_choose_list(
+        self, client, player, leader_yolanda, monkeypatch
+    ):
+        learn_views = _learn_views()
+
+        calls = []
+        monkeypatch.setattr(
+            learn_views,
+            "_offered_keys",
+            lambda *args, **kwargs: calls.append(1) or frozenset(),
+        )
+        client.force_login(player)
+        assert client.get(_skills_url(leader_yolanda)).status_code == 200
+        assert calls == []
+
+    def test_saving_a_tick_builds_the_choose_list_once(
+        self, client, player, leader_yolanda, library, monkeypatch
+    ):
+        learn_views = _learn_views()
+
+        real = learn_views._offered_keys
+        calls = []
+
+        def counted(*args, **kwargs):
+            result = real(*args, **kwargs)
+            calls.append(result)
+            return result
+
+        monkeypatch.setattr(learn_views, "_offered_keys", counted)
+        client.force_login(player)
+        post_skills(client, leader_yolanda, library["skills"]["Catfall"])
+        assert len(calls) == 1
+
+    def test_the_choose_list_lookup_does_not_grow_with_skills_already_held(
+        self, client, player, leader_yolanda, sets, library, monkeypatch
+    ):
+        """One browse of the offer, not one query per skill on the card."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        learn_views = _learn_views()
+
+        real = learn_views._offered_keys
+        counts = []
+
+        def wrapped(*args, **kwargs):
+            with CaptureQueriesContext(connection) as captured:
+                result = real(*args, **kwargs)
+            counts.append(len(captured.captured_queries))
+            return result
+
+        monkeypatch.setattr(learn_views, "_offered_keys", wrapped)
+        extras = [
+            create_skill(f"Trick {index}", category=sets["agility"], position=index)
+            for index in range(10, 18)
+        ]
+        client.force_login(player)
+
+        post_skills(client, leader_yolanda, library["skills"]["Connected"])
+        few = counts[-1]
+        counts.clear()
+
+        post_skills(
+            client,
+            leader_yolanda,
+            library["skills"]["Connected"],
+            *extras,
+        )
+        many = counts[-1]
+
+        assert few == many, f"{few} queries holding 1, {many} holding 9"
+        assert few > 0
+
+    def test_the_gang_sheet_stays_flat_as_leaders_accumulate(
+        self, client, player, gang, gang_sister, leader, monkeypatch
+    ):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        learn_views = _learn_views()
+
+        calls = []
+        monkeypatch.setattr(
+            learn_views,
+            "_offered_keys",
+            lambda *args, **kwargs: calls.append(1) or frozenset(),
+        )
+        client.force_login(player)
+
+        first = hire_with_option(gang, gang_sister, "Leader 0")
+        assign(leader, miniature=first)
+
+        def measure():
+            with CaptureQueriesContext(connection) as captured:
+                response = client.get(_gang_url(gang))
+                assert response.status_code == 200
+            return len(captured.captured_queries)
+
+        measure()
+        few = measure()
+        for index in range(1, 5):
+            fighter = hire_with_option(gang, gang_sister, f"Leader {index}")
+            assign(leader, miniature=fighter)
+        many = measure()
+
+        assert calls == []
+        assert few == many, f"{few} queries for 1 Leader, {many} for 5"

--- a/n26/tests/sandbox/test_learning_skills.py
+++ b/n26/tests/sandbox/test_learning_skills.py
@@ -687,6 +687,43 @@ class TestTheSkillsRow:
         assert card.skill_choices == []
         assert "Catfall" in [line.name for line in card.skills]
 
+    def test_selecting_a_primary_skill_on_the_skills_screen_answers_the_question(
+        self, client, player, leader_yolanda, library
+    ):
+        catfall = library["skills"]["Catfall"]
+        client.force_login(player)
+        client.post(
+            skills_url(leader_yolanda),
+            {"thing": f"{catfall._meta.label_lower}:{catfall.pk}"},
+        )
+
+        card = card_for(leader_yolanda)
+        assert card.skill_choices == []
+        assert "Catfall" in [line.name for line in card.skills]
+        row = leader_yolanda.assignments.get(skill=catfall, archived=False)
+        assert row.chosen_for_offer_id is not None
+        assert row.caused_by_id is not None
+
+    def test_selecting_a_secondary_skill_on_the_skills_screen_leaves_the_question_open(
+        self, client, player, leader_yolanda, library
+    ):
+        """Connected is selectable (Savant is Secondary) but is not on
+        the Choose list for a Primary skill, so it is a standing
+        selection and the card keeps asking."""
+        connected = library["skills"]["Connected"]
+        client.force_login(player)
+        client.post(
+            skills_url(leader_yolanda),
+            {"thing": f"{connected._meta.label_lower}:{connected.pk}"},
+        )
+
+        card = card_for(leader_yolanda)
+        assert [line.kind_label for line in card.skill_choices] == ["Primary skill"]
+        assert "Connected" in [line.name for line in card.skills]
+        row = leader_yolanda.assignments.get(skill=connected, archived=False)
+        assert row.chosen_for_offer_id is None
+        assert row.caused_by_id is None
+
     def test_a_card_says_which_collections_its_grid_reaches(
         self, yolanda, catalogue, gang, gridless
     ):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was the problem

After choosing a Hunt Champion's (or Leader's) starting skill, changing it on the fighter's Edit page brought **Choose primary skill** back. Following Choose then showed empty Primary trees, so you could pick a second starting skill. The same hole opened if you never used Choose and only ticked a skill on Edit.

Two writes were in play. Choose writes a pick (`Operation.choose`: `caused_by` the offerer, `chosen_for_offer` set) so the question is resolved. Edit (`apply_ticks`) archived the unticked pick and `Operation.learn`ed the new skill, caused by nothing. The card kept asking.

## Why it was complex

The Edit square lists everything the fighter's grid reaches — Primary and Secondary together. A kind-only match would treat a Secondary tick as the answer to "Choose primary skill". The product rule is tighter: only a skill on **that question's Choose list** answers it.

## How it was solved

While the card is still asking, the next matching skill added on Edit or on the skills screen is that starting skill — the same write Choose makes. After that, Edit is ordinary add/remove.

The match is `n26.core.browse.offered_by(slot, computed)`, not kind. A Secondary tick is a standing `learn` and leaves the question open.

Removals run first in the same save, so unticking the starting skill and ticking another on the Choose list answers the question afresh. Untick with no matching replacement and the prompt returns. Keep the starting skill and tick another: the extra is `learn`.

Existing broken rows (a standing skill beside an open prompt) are not rewritten.

## Queries

The Choose-list match is a write. `_offered_keys` / `offered_by` run from `apply_ticks` (Edit skills POST) and the skills-screen POST only. GET of the gang sheet, the edit page and the skills screen never call them.

The gang sheet stays flat as Leaders accumulate (44 queries for 1, 44 for 5). The write-path lookup is one collection browse, not one query per skill already held (12 queries holding 1, 12 holding 9).

## How to try it

1. Hire a Leader (or Hunt Champion) whose card asks **Choose primary skill**.
2. On Edit (`/n26/fighters/<id>/edit/`), tick a Primary skill and save. The prompt should leave; the skill should be the starting pick.
3. Tick a Secondary skill instead while the prompt is showing. The skill is held, but **Choose primary skill** stays.
4. Choose a Primary skill, then Edit to a different Primary. The prompt stays gone; only the new skill is held as the starting pick.

Sandbox coverage: `n26/tests/sandbox/test_editing_skills.py` (`TestAnOpenStartingSkill`, `TestAnsweringDoesNotTouchTheReadPath`) and `n26/tests/sandbox/test_learning_skills.py` (`TestTheSkillsRow`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03e25-e271-7542-a79e-493d803a8284?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03e25-e271-7542-a79e-493d803a8284&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

