### PR TITLE
feat: run_batched runs maintenance work in resumable per-row batches

### DIFF
--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -15,13 +15,19 @@ read, and the pin needed to express that contradicts the recorded
 history of any database that already ran it — so a repair runs after a
 deploy instead, on a schema that is fully migrated by construction.
 
-A run is one transaction, and deliberately all-or-nothing: interrupted
-by a killed request or a lost connection it rolls back whole, so it is a
-no-op that can simply be run again rather than a half-repaired library.
-Delivery is at-least-once, so two guards stand between that promise and
-a second copy running alongside the first: a lock only one run can hold,
-and a cap on how many times an attempt may be started before the record
-gives up and says so.
+Runs come in two shapes, and each states its own promise. A small
+repair (``_run_recorded``) is one transaction, deliberately
+all-or-nothing: interrupted, it rolls back whole and can simply be run
+again. Work too large for one transaction (``run_batched``) commits row
+by row instead, writes how far it got onto the record, and continues
+from there after any interruption — which trades the clean rollback for
+a requirement that each row's work be idempotent. Delivery is
+at-least-once, so two guards stand between either promise and a second
+copy running alongside the first: a lock only one run can hold, and a
+cap on how many times an attempt may start before the record gives up
+and says so — counted per start for the one-transaction shape, and per
+start *from the same place* for the batched one, so a long run's many
+deliveries are not mistaken for a stuck one.
 
 A repair that has been run and cannot recur keeps its slug registered
 with no view. It leaves the menu, and the record of the run still reads
@@ -31,7 +37,7 @@ as a name rather than a bare slug.
 import logging
 import traceback
 from contextlib import contextmanager
-from datetime import date
+from datetime import date, timedelta
 
 from django.contrib import messages
 from django.db import connection, models, transaction
@@ -39,6 +45,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.tasks import task
 from django.urls import reverse
+from django.utils import timezone
 
 from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import MaintenanceOperation, register_operation
@@ -253,6 +260,186 @@ def _run_recorded(backfill_id, operation, what, work, refusals):
             backfill_id,
             status=Backfill.Status.DONE,
             summary_patch={"report": list(report)},
+        )
+
+
+#: How long one batched attempt may work before handing the rest back
+#: to the queue. Well inside the delivery acknowledgement deadline, so
+#: an attempt always ends by choice rather than by timeout.
+BATCH_BUDGET = timedelta(minutes=8)
+
+#: How many rows a batched run settles between progress writes. Small
+#: enough that a crash replays little; large enough that the record is
+#: not written per row.
+BATCH_SIZE = 50
+
+
+def _claim_batched(backfill_id):
+    """Count this attempt and say whether it may start, forgiving the
+    attempts that got somewhere.
+
+    A batched run returns to the queue many times by design, so a flat
+    count would strangle any run long enough to need this shape. Only
+    an attempt starting from the same cursor as the last one counts
+    against the cap: a moved cursor is a run making progress, however
+    many deliveries it takes. The count survives a rolled-back attempt
+    for the same reason ``_claim``'s does — a run stuck on one row must
+    be noticed rather than repeated for ever.
+    """
+    with transaction.atomic():
+        try:
+            backfill = Backfill.objects.select_for_update().get(pk=backfill_id)
+        except Backfill.DoesNotExist:
+            return False, "the record this run would write to is gone"
+        if backfill.status != Backfill.Status.RUNNING:
+            return False, f"the record is already {backfill.get_status_display()}"
+        cursor = backfill.summary.get("cursor", "")
+        moved = cursor != backfill.summary.get("claimed_at", "")
+        attempts = 1 if moved else int(backfill.summary.get("attempts", 0)) + 1
+        backfill.summary = {
+            **backfill.summary,
+            "attempts": attempts,
+            "claimed_at": cursor,
+        }
+        backfill.save()
+        if attempts > MAX_ATTEMPTS:
+            return False, (
+                f"started {attempts} times from the same place without "
+                "moving. Whatever stands at the cursor breaks every "
+                "attempt; fix that before running again."
+            )
+        return True, ""
+
+
+def run_batched(
+    backfill_id,
+    *,
+    lock_key,
+    what,
+    items,
+    do_one,
+    again,
+    batch_size=BATCH_SIZE,
+    budget=BATCH_BUDGET,
+):
+    """Work through ``items`` one at a time, each on its own commit,
+    remembering how far it got.
+
+    ``_run_recorded`` holds a whole run inside one transaction; this is
+    the shape for work too large for that. ``items`` is a queryset with
+    a unique primary key — ordered here, because the cursor is only
+    sound over a total order — and ``do_one(pk)`` settles one row
+    completely, committing its own writes and leaving nothing behind
+    when it fails. It must be idempotent: a crashed attempt replays at
+    most one batch, and a rerun replays everything.
+
+    Progress lands on the record after every batch — how many are
+    settled, of how many, and the cursor the next attempt continues
+    from. That write doubles as the cancel check: an operator's
+    CANCELLED is an ending, endings are final, so the refused write is
+    the signal to stop, and the rows already settled stay settled.
+
+    A failing row is written down and stepped past. The ending is DONE
+    only when nothing failed; a rerun is a fresh record that retries
+    the failures while every settled row no-ops. Past ``budget`` the
+    attempt hands the rest back: it writes the cursor, calls ``again``
+    to enqueue a fresh delivery, and returns — a run of any length is
+    many short deliveries, each acknowledged inside its deadline.
+
+    Never raises, for ``_run_recorded``'s reason: a raised error is
+    only redelivered, and there is nowhere for it to go but round
+    again.
+    """
+    with _single_flight(lock_key) as mine:
+        if not mine:
+            logger.info("%s already running; this copy stands down", what)
+            return
+        may_start, why_not = _claim_batched(backfill_id)
+        if not may_start:
+            logger.info("%s not started: %s", what, why_not)
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"Not started: {why_not}",
+            )
+            return
+        try:
+            _work_through(backfill_id, what, items, do_one, again, batch_size, budget)
+        except Exception as broke:  # noqa: BLE001 — the ending must be recorded
+            logger.exception("%s broke", what)
+            _write(
+                backfill_id,
+                status=Backfill.Status.FAILED,
+                error=f"{broke}\n\n{traceback.format_exc()}",
+            )
+
+
+def _work_through(backfill_id, what, items, do_one, again, batch_size, budget):
+    started = timezone.now()
+    backfill = Backfill.objects.get(pk=backfill_id)
+    cursor = backfill.summary.get("cursor", "")
+    settled = int(backfill.summary.get("done", 0))
+    failures = dict(backfill.summary.get("failures", {}))
+
+    items = items.order_by("pk")
+    total = items.count()
+    remaining = items.filter(pk__gt=cursor) if cursor else items
+    # Read up front rather than streamed: settling a row commits, and a
+    # commit closes a server-side cursor mid-walk. At the scale this
+    # runner serves, a list of ids is nothing.
+    pks = list(remaining.values_list("pk", flat=True))
+
+    def record(position):
+        return _write(
+            backfill_id,
+            summary_patch={
+                "done": settled,
+                "total": total,
+                "cursor": str(position),
+                "failures": failures,
+            },
+        )
+
+    since_flush = 0
+    for pk in pks:
+        try:
+            do_one(pk)
+        except Exception as broke:  # noqa: BLE001 — one row never starves the rest
+            logger.exception("%s could not settle %s", what, pk)
+            failures[str(pk)] = str(broke)
+        settled += 1
+        since_flush += 1
+        if since_flush >= batch_size:
+            if not record(pk):
+                logger.info("%s cancelled; stopping where it stands", what)
+                return
+            since_flush = 0
+            if timezone.now() - started > budget:
+                again()
+                return
+
+    if since_flush and pks and not record(pks[-1]):
+        logger.info("%s cancelled; stopping where it stands", what)
+        return
+    if failures:
+        _write(
+            backfill_id,
+            status=Backfill.Status.FAILED,
+            summary_patch={
+                "done": settled,
+                "total": total,
+                "failures": failures,
+            },
+            error=(
+                f"{len(failures)} of {total} could not be settled; the "
+                "rest are done. A rerun retries only what failed."
+            ),
+        )
+    else:
+        _write(
+            backfill_id,
+            status=Backfill.Status.DONE,
+            summary_patch={"done": settled, "total": total, "failures": {}},
         )
 
 

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -322,9 +322,12 @@ def run_batched(
     held, stand down, and leave the record RUNNING with no delivery
     left to finish it.
 
-    Never raises, for ``_run_recorded``'s reason: a raised error is
-    only redelivered, and there is nowhere for it to go but round
-    again.
+    The work never raises, for ``_run_recorded``'s reason: a raised
+    error is only redelivered, and there is nowhere for it to go but
+    round again. The hand-back is the one deliberate exception: an
+    enqueue that fails is allowed to raise, because the failed delivery
+    is then redelivered and the retry re-summons the continuation —
+    swallowing it would leave no delivery to finish the run.
     """
     continued = False
     with _single_flight(LOCK_KEYS[operation]) as mine:
@@ -401,6 +404,15 @@ def _work_through(backfill_id, what, items, do_one, batch_size, budget):
             )
 
     while True:
+        # Checked before the batch as well as written after it, so a
+        # cancel landing between batches stops the very next one rather
+        # than one batch later. One cheap read per batch.
+        still_running = Backfill.objects.filter(
+            pk=backfill_id, status=Backfill.Status.RUNNING
+        ).exists()
+        if not still_running:
+            stopped()
+            return False
         narrowed = items.filter(pk__gt=cursor) if cursor else items
         batch = list(narrowed.values_list("pk", flat=True)[:batch_size])
         if not batch:

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -24,10 +24,10 @@ from there after any interruption — which trades the clean rollback for
 a requirement that each row's work be idempotent. Delivery is
 at-least-once, so two guards stand between either promise and a second
 copy running alongside the first: a lock only one run can hold, and a
-cap on how many times an attempt may start before the record gives up
-and says so — counted per start for the one-transaction shape, and per
-start *from the same place* for the batched one, so a long run's many
-deliveries are not mistaken for a stuck one.
+cap on how many attempts may start without recording any progress
+before the record gives up and says so. A batched run resets that count
+with every batch it records, so a long run's many deliveries are never
+mistaken for a stuck one.
 
 A repair that has been run and cannot recur keeps its slug registered
 with no view. It leaves the menu, and the record of the run still reads
@@ -58,13 +58,15 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "Operation",
     "delete_nameless_gang_type",
+    "run_batched",
     "task_routes",
 ]
 
-#: How many times a run may be started before the record gives up. A
-#: run that exhausts the request budget leaves nothing behind and is
-#: redelivered, so without a cap a run too large to finish would repeat
-#: for ever, each attempt paying the whole cost again.
+#: How many times a run may start without recording any progress before
+#: the record gives up. A one-transaction run that dies leaves nothing
+#: behind and is redelivered; a batched run resets the count every time
+#: it records a batch. Either way, without the cap a run that always
+#: dies would repeat for ever, each attempt paying its cost again.
 MAX_ATTEMPTS = 2
 
 #: The locks a run holds for as long as it is working — one per
@@ -206,9 +208,10 @@ def _claim(backfill_id):
         backfill.save()
         if attempts > MAX_ATTEMPTS:
             return False, (
-                f"started {attempts} times without finishing — each attempt "
-                "left nothing behind. The repair needs longer than one "
-                "request allows; raise the limit before running it again."
+                f"started {attempts} times without getting anywhere — each "
+                "attempt died before recording an ending or any progress. "
+                "Look at what kills the attempt (its deadline, its size) "
+                "before running again."
             )
         return True, ""
 
@@ -264,9 +267,12 @@ def _run_recorded(backfill_id, operation, what, work, refusals):
 
 
 #: How long one batched attempt may work before handing the rest back
-#: to the queue. Well inside the delivery acknowledgement deadline, so
-#: an attempt always ends by choice rather than by timeout.
-BATCH_BUDGET = timedelta(minutes=8)
+#: to the queue. The invariant a consumer's route must satisfy: this
+#: budget plus the time one batch takes must fit inside the route's
+#: acknowledgement deadline, or the queue redelivers an attempt that is
+#: still working. The default fits the framework's default deadline
+#: with a minute to spare for the batch in flight.
+BATCH_BUDGET = timedelta(minutes=4)
 
 #: How many rows a batched run settles between progress writes. Small
 #: enough that a crash replays little; large enough that the record is
@@ -274,47 +280,10 @@ BATCH_BUDGET = timedelta(minutes=8)
 BATCH_SIZE = 50
 
 
-def _claim_batched(backfill_id):
-    """Count this attempt and say whether it may start, forgiving the
-    attempts that got somewhere.
-
-    A batched run returns to the queue many times by design, so a flat
-    count would strangle any run long enough to need this shape. Only
-    an attempt starting from the same cursor as the last one counts
-    against the cap: a moved cursor is a run making progress, however
-    many deliveries it takes. The count survives a rolled-back attempt
-    for the same reason ``_claim``'s does — a run stuck on one row must
-    be noticed rather than repeated for ever.
-    """
-    with transaction.atomic():
-        try:
-            backfill = Backfill.objects.select_for_update().get(pk=backfill_id)
-        except Backfill.DoesNotExist:
-            return False, "the record this run would write to is gone"
-        if backfill.status != Backfill.Status.RUNNING:
-            return False, f"the record is already {backfill.get_status_display()}"
-        cursor = backfill.summary.get("cursor", "")
-        moved = cursor != backfill.summary.get("claimed_at", "")
-        attempts = 1 if moved else int(backfill.summary.get("attempts", 0)) + 1
-        backfill.summary = {
-            **backfill.summary,
-            "attempts": attempts,
-            "claimed_at": cursor,
-        }
-        backfill.save()
-        if attempts > MAX_ATTEMPTS:
-            return False, (
-                f"started {attempts} times from the same place without "
-                "moving. Whatever stands at the cursor breaks every "
-                "attempt; fix that before running again."
-            )
-        return True, ""
-
-
 def run_batched(
     backfill_id,
     *,
-    lock_key,
+    operation,
     what,
     items,
     do_one,
@@ -328,33 +297,41 @@ def run_batched(
     ``_run_recorded`` holds a whole run inside one transaction; this is
     the shape for work too large for that. ``items`` is a queryset with
     a unique primary key — ordered here, because the cursor is only
-    sound over a total order — and ``do_one(pk)`` settles one row
-    completely, committing its own writes and leaving nothing behind
-    when it fails. It must be idempotent: a crashed attempt replays at
-    most one batch, and a rerun replays everything.
+    sound over a total order — and it must be stable: a queryset that
+    stops matching rows as they are settled moves the finish line while
+    the cursor chases it. ``do_one(pk)`` settles one row completely,
+    committing its own writes and leaving nothing behind when it fails.
+    It must be idempotent: a crashed attempt replays at most one batch,
+    and a rerun is a fresh record that walks every row again, settling
+    only what the earlier run missed.
 
-    Progress lands on the record after every batch — how many are
-    settled, of how many, and the cursor the next attempt continues
-    from. That write doubles as the cancel check: an operator's
-    CANCELLED is an ending, endings are final, so the refused write is
-    the signal to stop, and the rows already settled stay settled.
+    Progress lands on the record after every batch — how many rows are
+    settled, of how many, the failures so far, and the cursor the next
+    attempt continues from. That write doubles as the cancel check: an
+    operator's CANCELLED is an ending, endings are final, so the
+    refused write is the signal to stop, and the rows already settled
+    stay settled. It also starts the attempt count over, which is what
+    lets ``_claim`` serve both run shapes: only an attempt that dies
+    before recording any progress counts towards giving up.
 
-    A failing row is written down and stepped past. The ending is DONE
-    only when nothing failed; a rerun is a fresh record that retries
-    the failures while every settled row no-ops. Past ``budget`` the
-    attempt hands the rest back: it writes the cursor, calls ``again``
-    to enqueue a fresh delivery, and returns — a run of any length is
-    many short deliveries, each acknowledged inside its deadline.
+    A failing row is written down and stepped past; one that settles on
+    a later walk is struck off. The ending is DONE only when nothing
+    failed. Past ``budget`` the attempt records the cursor and hands
+    the rest to a fresh delivery — enqueued only after the lock is
+    released, so the delivery it summons can never find the lock still
+    held, stand down, and leave the record RUNNING with no delivery
+    left to finish it.
 
     Never raises, for ``_run_recorded``'s reason: a raised error is
     only redelivered, and there is nowhere for it to go but round
     again.
     """
-    with _single_flight(lock_key) as mine:
+    continued = False
+    with _single_flight(LOCK_KEYS[operation]) as mine:
         if not mine:
             logger.info("%s already running; this copy stands down", what)
             return
-        may_start, why_not = _claim_batched(backfill_id)
+        may_start, why_not = _claim(backfill_id)
         if not may_start:
             logger.info("%s not started: %s", what, why_not)
             _write(
@@ -364,7 +341,9 @@ def run_batched(
             )
             return
         try:
-            _work_through(backfill_id, what, items, do_one, again, batch_size, budget)
+            continued = _work_through(
+                backfill_id, what, items, do_one, batch_size, budget
+            )
         except Exception as broke:  # noqa: BLE001 — the ending must be recorded
             logger.exception("%s broke", what)
             _write(
@@ -372,24 +351,28 @@ def run_batched(
                 status=Backfill.Status.FAILED,
                 error=f"{broke}\n\n{traceback.format_exc()}",
             )
+    if continued:
+        again()
 
 
-def _work_through(backfill_id, what, items, do_one, again, batch_size, budget):
+def _work_through(backfill_id, what, items, do_one, batch_size, budget):
+    """One attempt's walk. True means a fresh delivery must continue."""
     started = timezone.now()
     backfill = Backfill.objects.get(pk=backfill_id)
     cursor = backfill.summary.get("cursor", "")
     settled = int(backfill.summary.get("done", 0))
     failures = dict(backfill.summary.get("failures", {}))
+    # Counted once, on the first attempt: the finish line must not move
+    # while the cursor chases it.
+    total = backfill.summary.get("total")
+    if total is None:
+        total = items.count()
 
     items = items.order_by("pk")
-    total = items.count()
-    remaining = items.filter(pk__gt=cursor) if cursor else items
-    # Read up front rather than streamed: settling a row commits, and a
-    # commit closes a server-side cursor mid-walk. At the scale this
-    # runner serves, a list of ids is nothing.
-    pks = list(remaining.values_list("pk", flat=True))
 
     def record(position):
+        # Resetting the attempt count is what marks this attempt as
+        # having got somewhere — see the docstring above.
         return _write(
             backfill_id,
             summary_patch={
@@ -397,50 +380,63 @@ def _work_through(backfill_id, what, items, do_one, again, batch_size, budget):
                 "total": total,
                 "cursor": str(position),
                 "failures": failures,
+                "attempts": 0,
             },
         )
 
-    since_flush = 0
-    for pk in pks:
-        try:
-            do_one(pk)
-        except Exception as broke:  # noqa: BLE001 — one row never starves the rest
-            logger.exception("%s could not settle %s", what, pk)
-            failures[str(pk)] = str(broke)
-        settled += 1
-        since_flush += 1
-        if since_flush >= batch_size:
-            if not record(pk):
-                logger.info("%s cancelled; stopping where it stands", what)
-                return
-            since_flush = 0
-            if timezone.now() - started > budget:
-                again()
-                return
+    def stopped():
+        still = (
+            Backfill.objects.filter(pk=backfill_id)
+            .values_list("status", flat=True)
+            .first()
+        )
+        if still is None:
+            logger.warning(
+                "%s: the record is gone mid-run; stopping with the work half-applied",
+                what,
+            )
+        else:
+            logger.info(
+                "%s ended by the operator (%s); stopping where it stands", what, still
+            )
 
-    if since_flush and pks and not record(pks[-1]):
-        logger.info("%s cancelled; stopping where it stands", what)
-        return
+    while True:
+        narrowed = items.filter(pk__gt=cursor) if cursor else items
+        batch = list(narrowed.values_list("pk", flat=True)[:batch_size])
+        if not batch:
+            break
+        for pk in batch:
+            try:
+                do_one(pk)
+            except Exception as broke:  # noqa: BLE001 — one row never starves the rest
+                logger.exception("%s could not settle %s", what, pk)
+                failures[str(pk)] = str(broke)
+            else:
+                settled += 1
+                failures.pop(str(pk), None)
+        cursor = str(batch[-1])
+        if not record(cursor):
+            stopped()
+            return False
+        # Hand back only while something remains — a spent budget on
+        # the final batch ends the run rather than summoning a
+        # delivery with nothing to do.
+        if timezone.now() - started > budget and items.filter(pk__gt=cursor).exists():
+            return True
+
     if failures:
         _write(
             backfill_id,
             status=Backfill.Status.FAILED,
-            summary_patch={
-                "done": settled,
-                "total": total,
-                "failures": failures,
-            },
             error=(
                 f"{len(failures)} of {total} could not be settled; the "
-                "rest are done. A rerun retries only what failed."
+                "rest are done. A rerun walks everything again and "
+                "settles only what failed."
             ),
         )
     else:
-        _write(
-            backfill_id,
-            status=Backfill.Status.DONE,
-            summary_patch={"done": settled, "total": total, "failures": {}},
-        )
+        _write(backfill_id, status=Backfill.Status.DONE)
+    return False
 
 
 def _who_asked(backfill_id):

--- a/n26/tests/test_batched_runner.py
+++ b/n26/tests/test_batched_runner.py
@@ -205,6 +205,23 @@ class TestCancel:
         assert record.status == Backfill.Status.CANCELLED
         assert len(seen) == 20
 
+    def test_a_cancel_while_handed_back_stops_the_next_delivery_at_the_claim(
+        self, record, rows
+    ):
+        """A run waiting between deliveries has nothing running to
+        interrupt; the cancel lands on the record, and the summoned
+        delivery finds it ended and settles nothing more."""
+        seen = []
+        run(record, rows, seen.append, budget=timedelta(0))
+        assert len(seen) == 10
+
+        Backfill.objects.filter(pk=record.pk).update(status=Backfill.Status.CANCELLED)
+        run(record, rows, seen.append, budget=timedelta(0))
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.CANCELLED
+        assert len(seen) == 10
+
 
 class TestTheAttemptCount:
     """``_claim`` serves both run shapes: every recorded batch resets

--- a/n26/tests/test_batched_runner.py
+++ b/n26/tests/test_batched_runner.py
@@ -1,32 +1,44 @@
 """The batched runner: large work as many short, resumable deliveries.
 
 ``run_batched`` walks an ordered work-list committing each row alone,
-writes its position onto the ``Backfill`` record as it goes, and picks
-up from that position on the next delivery. Proven here with a plain
-work-list and a recording ``do_one``: a run finishes and records DONE;
-a spent budget hands the rest to a fresh delivery and nothing is done
-twice; a failing row is recorded and stepped past; a cancel between
-batches stops the run where it stands; and the attempt count forgives
-deliveries that moved the cursor while refusing ones stuck in place.
+writes its position onto the ``Backfill`` record after every batch, and
+picks up from that position on the next delivery. Proven here with a
+plain work-list and a recording ``do_one``: a run finishes and records
+DONE; a spent budget hands the rest to a fresh delivery — after the
+lock is released — and nothing is done twice; a failing row is recorded
+and stepped past, and struck off if a later walk settles it; a cancel
+between batches stops the run where it stands; and the attempt count is
+reset by every recorded batch, so only attempts that die before getting
+anywhere exhaust it.
 """
 
+from contextlib import contextmanager
 from datetime import timedelta
 
 import pytest
 from django.contrib.auth.models import User
 
 from gyrinx.maintenance.models import Backfill
-from n26.maintenance import MAX_ATTEMPTS, _claim_batched, run_batched
+from n26 import maintenance
+from n26.maintenance import MAX_ATTEMPTS, _claim, run_batched
 
 pytestmark = pytest.mark.django_db
 
+OPERATION = "n26_test_batched_runner"
 LOCK_KEY = 999_826_031
+
+
+@pytest.fixture(autouse=True)
+def lock_key(monkeypatch):
+    """The runner looks its lock up in the one auditable registry, so
+    the test operation registers its key there like any real one."""
+    monkeypatch.setitem(maintenance.LOCK_KEYS, OPERATION, LOCK_KEY)
 
 
 @pytest.fixture
 def record(db):
     return Backfill.objects.create(
-        operation="n26_test_batched_runner",
+        operation=OPERATION,
         status=Backfill.Status.RUNNING,
     )
 
@@ -45,7 +57,7 @@ def run(record, rows, do_one, again=None, **kwargs):
     kwargs.setdefault("batch_size", 10)
     return run_batched(
         record.pk,
-        lock_key=LOCK_KEY,
+        operation=OPERATION,
         what="Batched runner under test",
         items=rows,
         do_one=do_one,
@@ -55,6 +67,9 @@ def run(record, rows, do_one, again=None, **kwargs):
 
 
 class TestARunThatFits:
+    """One delivery is enough: everything settles once and the record
+    ends DONE with the counts telling the whole story."""
+
     def test_it_settles_everything_once_and_records_done(self, record, rows):
         seen = []
         run(record, rows, seen.append)
@@ -68,12 +83,13 @@ class TestARunThatFits:
 
 
 class TestASpentBudget:
+    """An attempt past its budget records the cursor and summons a
+    fresh delivery, which continues exactly where it stopped — so the
+    run finishes without any row being settled twice."""
+
     def test_the_rest_is_handed_to_fresh_deliveries_and_nothing_repeats(
         self, record, rows
     ):
-        """A zero budget ends every attempt after its first batch, so
-        the run only finishes if each delivery continues exactly where
-        the last one stopped."""
         seen = []
         handed_back = []
 
@@ -101,8 +117,37 @@ class TestASpentBudget:
         assert len(set(seen)) == 25
         assert len(handed_back) == 2
 
+    def test_the_fresh_delivery_is_summoned_only_after_the_lock_is_freed(
+        self, record, rows, monkeypatch
+    ):
+        """The delivery the hand-back summons must never find the lock
+        still held — it would stand down, acknowledge its message, and
+        leave the record RUNNING with nothing left to finish it."""
+        order = []
+        real_lock = maintenance._single_flight
+
+        @contextmanager
+        def watched_lock(key):
+            order.append("locked")
+            with real_lock(key) as mine:
+                yield mine
+            order.append("unlocked")
+
+        monkeypatch.setattr(maintenance, "_single_flight", watched_lock)
+        run(
+            record,
+            rows,
+            lambda pk: None,
+            again=lambda: order.append("summoned"),
+            budget=timedelta(0),
+        )
+        assert order == ["locked", "unlocked", "summoned"]
+
 
 class TestAFailingRow:
+    """A broken row is written down and stepped past — and struck off
+    again if a later walk settles it."""
+
     def test_it_is_recorded_and_the_rest_still_settle(self, record, rows):
         bad = sorted(rows.values_list("pk", flat=True))[12]
         seen = []
@@ -118,17 +163,33 @@ class TestAFailingRow:
         assert record.status == Backfill.Status.FAILED
         assert list(record.summary["failures"]) == [str(bad)]
         assert "1 of 25" in record.error
-        assert record.summary["done"] == 25
+        assert record.summary["done"] == 24
         assert len(seen) == 24
+
+    def test_a_row_that_settles_on_a_later_walk_is_struck_off(self, record, rows):
+        """A crash can replay a batch whose failure was already
+        recorded; the replay settling the row must clear the entry, or
+        the run ends FAILED over a row that is actually fine."""
+        bad = sorted(rows.values_list("pk", flat=True))[3]
+        Backfill.objects.filter(pk=record.pk).update(
+            summary={"failures": {str(bad): "broke last time"}}
+        )
+
+        run(record, rows, lambda pk: None)
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["failures"] == {}
 
 
 class TestCancel:
+    """An operator's cancel is an ending, endings are final, and the
+    run finds out at its next progress write — stopping where it
+    stands, with everything already settled staying settled."""
+
     def test_a_cancel_lands_between_batches_and_the_settled_stay_settled(
         self, record, rows
     ):
-        """The operator cancels while a batch is mid-flight; the next
-        progress write is refused and the run stops where it stands,
-        keeping the ending the operator wrote."""
         seen = []
 
         def do_one(pk):
@@ -146,25 +207,31 @@ class TestCancel:
 
 
 class TestTheAttemptCount:
-    def test_a_moved_cursor_forgives_and_a_stuck_one_exhausts(self, record):
-        for _attempt in range(MAX_ATTEMPTS):
-            may_start, _ = _claim_batched(record.pk)
-            assert may_start
-        may_start, why_not = _claim_batched(record.pk)
-        assert not may_start
-        assert "same place" in why_not
+    """``_claim`` serves both run shapes: every recorded batch resets
+    the count, so only attempts dying before any progress exhaust it,
+    and a record that has ended refuses the claim outright."""
 
-        Backfill.objects.filter(pk=record.pk).update(
-            summary={**record.summary, "cursor": "somewhere-new", "attempts": 99}
-        )
-        record.refresh_from_db()
-        may_start, _ = _claim_batched(record.pk)
-        assert may_start
-        record.refresh_from_db()
-        assert record.summary["attempts"] == 1
+    def test_attempts_without_progress_exhaust_the_cap(self, record):
+        for _attempt in range(MAX_ATTEMPTS):
+            may_start, _ = _claim(record.pk)
+            assert may_start
+        may_start, why_not = _claim(record.pk)
+        assert not may_start
+        assert "without getting anywhere" in why_not
+
+    def test_a_recorded_batch_starts_the_count_over(self, record, rows):
+        """A long run is many deliveries; each one claims afresh, and
+        the progress its predecessor recorded is what keeps the run
+        from reading as stuck."""
+        for _delivery in range(MAX_ATTEMPTS + 2):
+            run(record, rows, lambda pk: None, budget=timedelta(0))
+            record.refresh_from_db()
+            if record.status != Backfill.Status.RUNNING:
+                break
+        assert record.status == Backfill.Status.DONE
 
     def test_a_record_already_ended_refuses_the_claim(self, record):
         Backfill.objects.filter(pk=record.pk).update(status=Backfill.Status.DONE)
-        may_start, why_not = _claim_batched(record.pk)
+        may_start, why_not = _claim(record.pk)
         assert not may_start
         assert "already" in why_not

--- a/n26/tests/test_batched_runner.py
+++ b/n26/tests/test_batched_runner.py
@@ -1,0 +1,170 @@
+"""The batched runner: large work as many short, resumable deliveries.
+
+``run_batched`` walks an ordered work-list committing each row alone,
+writes its position onto the ``Backfill`` record as it goes, and picks
+up from that position on the next delivery. Proven here with a plain
+work-list and a recording ``do_one``: a run finishes and records DONE;
+a spent budget hands the rest to a fresh delivery and nothing is done
+twice; a failing row is recorded and stepped past; a cancel between
+batches stops the run where it stands; and the attempt count forgives
+deliveries that moved the cursor while refusing ones stuck in place.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth.models import User
+
+from gyrinx.maintenance.models import Backfill
+from n26.maintenance import MAX_ATTEMPTS, _claim_batched, run_batched
+
+pytestmark = pytest.mark.django_db
+
+LOCK_KEY = 999_826_031
+
+
+@pytest.fixture
+def record(db):
+    return Backfill.objects.create(
+        operation="n26_test_batched_runner",
+        status=Backfill.Status.RUNNING,
+    )
+
+
+@pytest.fixture
+def rows(db):
+    """Twenty-five rows with unique, orderable primary keys. Any table
+    serves; the runner only ever reads pks."""
+    User.objects.bulk_create(
+        User(username=f"batched-runner-row-{n:03d}") for n in range(25)
+    )
+    return User.objects.filter(username__startswith="batched-runner-row-")
+
+
+def run(record, rows, do_one, again=None, **kwargs):
+    kwargs.setdefault("batch_size", 10)
+    return run_batched(
+        record.pk,
+        lock_key=LOCK_KEY,
+        what="Batched runner under test",
+        items=rows,
+        do_one=do_one,
+        again=again or (lambda: None),
+        **kwargs,
+    )
+
+
+class TestARunThatFits:
+    def test_it_settles_everything_once_and_records_done(self, record, rows):
+        seen = []
+        run(record, rows, seen.append)
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["done"] == 25
+        assert record.summary["total"] == 25
+        assert record.summary["failures"] == {}
+        assert sorted(seen) == sorted(rows.values_list("pk", flat=True))
+
+
+class TestASpentBudget:
+    def test_the_rest_is_handed_to_fresh_deliveries_and_nothing_repeats(
+        self, record, rows
+    ):
+        """A zero budget ends every attempt after its first batch, so
+        the run only finishes if each delivery continues exactly where
+        the last one stopped."""
+        seen = []
+        handed_back = []
+
+        def deliver():
+            run(
+                record,
+                rows,
+                seen.append,
+                again=lambda: handed_back.append(True),
+                budget=timedelta(0),
+            )
+
+        deliver()
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.RUNNING
+        assert record.summary["done"] == 10
+        assert record.summary["cursor"]
+
+        while record.status == Backfill.Status.RUNNING:
+            deliver()
+            record.refresh_from_db()
+
+        assert record.status == Backfill.Status.DONE
+        assert len(seen) == 25
+        assert len(set(seen)) == 25
+        assert len(handed_back) == 2
+
+
+class TestAFailingRow:
+    def test_it_is_recorded_and_the_rest_still_settle(self, record, rows):
+        bad = sorted(rows.values_list("pk", flat=True))[12]
+        seen = []
+
+        def do_one(pk):
+            if pk == bad:
+                raise RuntimeError("this row is broken")
+            seen.append(pk)
+
+        run(record, rows, do_one)
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.FAILED
+        assert list(record.summary["failures"]) == [str(bad)]
+        assert "1 of 25" in record.error
+        assert record.summary["done"] == 25
+        assert len(seen) == 24
+
+
+class TestCancel:
+    def test_a_cancel_lands_between_batches_and_the_settled_stay_settled(
+        self, record, rows
+    ):
+        """The operator cancels while a batch is mid-flight; the next
+        progress write is refused and the run stops where it stands,
+        keeping the ending the operator wrote."""
+        seen = []
+
+        def do_one(pk):
+            seen.append(pk)
+            if len(seen) == 12:
+                Backfill.objects.filter(pk=record.pk).update(
+                    status=Backfill.Status.CANCELLED
+                )
+
+        run(record, rows, do_one)
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.CANCELLED
+        assert len(seen) == 20
+
+
+class TestTheAttemptCount:
+    def test_a_moved_cursor_forgives_and_a_stuck_one_exhausts(self, record):
+        for _attempt in range(MAX_ATTEMPTS):
+            may_start, _ = _claim_batched(record.pk)
+            assert may_start
+        may_start, why_not = _claim_batched(record.pk)
+        assert not may_start
+        assert "same place" in why_not
+
+        Backfill.objects.filter(pk=record.pk).update(
+            summary={**record.summary, "cursor": "somewhere-new", "attempts": 99}
+        )
+        record.refresh_from_db()
+        may_start, _ = _claim_batched(record.pk)
+        assert may_start
+        record.refresh_from_db()
+        assert record.summary["attempts"] == 1
+
+    def test_a_record_already_ended_refuses_the_claim(self, record):
+        Backfill.objects.filter(pk=record.pk).update(status=Backfill.Status.DONE)
+        may_start, why_not = _claim_batched(record.pk)
+        assert not may_start
+        assert "already" in why_not


### PR DESCRIPTION
**Summary**

- `n26/maintenance.py` gains `run_batched`, a second maintenance-run shape for work too large for one transaction: it walks an ordered work-list committing each row alone (each batch fetched by cursor, never the whole remainder), records `{done, total, cursor, failures}` on the `Backfill` record after every batch of 50, and resumes from the cursor after any interruption.
- Past a 4-minute budget an attempt records the cursor and hands the rest to a fresh delivery — enqueued only after the advisory lock is released — so a run of any length becomes many short task deliveries, each acknowledged inside the framework's default deadline. A failing row is recorded and stepped past (and struck off if a later walk settles it); cancel is checked before every batch as well as at each progress write, and everything already settled stays settled.
- Every recorded batch resets the attempt count, so the existing `_claim` serves both run shapes: only attempts that die before recording any progress count toward giving up. The one-transaction `_run_recorded` shape is untouched; the module docstring states both shapes and when each applies.

Rows must be idempotent — a crashed attempt replays at most one batch, and a rerun (a fresh record) walks everything again, settling only what the earlier run missed. The first consumer is the retroactive built-ins backfill, whose per-gang reconcile has exactly that property.

**Test plan**

- [x] `pytest n26/tests/test_batched_runner.py` — a run that fits records DONE; a spent budget hands the rest to fresh deliveries with nothing done twice, and the summons happens only after the lock is freed; a failing row is recorded while the rest settle, and is struck off when a later walk settles it; cancels landing mid-batch, between batches, and between deliveries all stop the run where it stands; attempt counting resets on recorded progress, exhausts without it, and refuses ended records
- [x] Full `pytest n26` green; `./scripts/check_migrations.sh` clean — no migration, progress lives in the record's existing JSON summary

**Next steps**

- The #2165 retroactive backfill (chunk C7) is built on this runner.
- #2321 moves the `Backfill` record onto `gyrinx.state_machine` (deferred deliberately — a platform-model migration in its own right).

Refs #2165
Refs #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
