### PR TITLE
fix: remove the rename pencil from the n26 gang-sheet model card

### DIFF
--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -66,8 +66,10 @@ is named by the page's own heading directly below.
                                 trade_points_href="{{ trade_points_href }}" />
         </c-slot>
         {% comment %}
-        The rename pencil, as the sheet draws it — a link, so the dialog
-        is an address; ?back=edit brings the act back to this page.
+        The rename pencil — a link, so the dialog is an address;
+        ?back=edit brings the act back to this page. The gang sheet
+        does not carry one: next to the name it is too easy to take
+        for Edit.
         {% endcomment %}
         <c-slot name="name_action">
             <c-ui.button variant="ghost"

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -209,25 +209,7 @@ that said it twice would be spending the width the name needs.
                                   mode="{{ card_mode }}"
                                   notes_href="{% if yours %}{% url 'n26-edit-fighter' member.id %}{% endif %}"
                                   lore_href="{% if yours %}{% url 'n26-edit-fighter' member.id %}{% endif %}">
-                    {% comment %}
-                    The way to a fighter's own name: a quiet pencil on the
-                    name's line, leading to the rename dialog the URL opens
-                    below. A link, so it works with no script and an open
-                    dialog is an address someone can send.
-                    {% endcomment %}
                     {% if yours %}
-                        <c-slot name="name_action">
-                            <c-ui.button variant="ghost"
-                                         size="xs"
-                                         class="ms-1 -mt-0.5 px-1! align-middle"
-                                         href="?rename={{ member.id }}"
-                                         aria-label="Rename {{ member.name }}"
-                                         title="Rename">
-                                <span class="n26-icon-only">
-                                    <c-n26.icon name="pencil" class="size-3.5 text-ink-500 dark:text-ink-400" />
-                                </span>
-                            </c-ui.button>
-                        </c-slot>
                         <c-slot name="actions">
                             {% comment %}
                         Equip is the one you came for and the only per-model act
@@ -285,8 +267,9 @@ that said it twice would be spending the width the name needs.
     </c-n26.view.gang-sheet>
     {% comment %}
     The rename dialog, when the URL names a member. Open is a server
-    state — the pencil is a link to ?rename=<pk>, so the question works
-    with scripting off and an open dialog is a page someone can reload.
+    state — ?rename=<pk> draws the question, so an address can be
+    followed or reloaded with scripting off. The pencil that writes
+    this address lives on the model's own page.
     {% endcomment %}
     {% comment %}
     The leaving dialogs, when the URL asks about a member. One question,

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -261,6 +261,12 @@ class TestRenamingFromHere:
     """The pencil on this page's card opens the dialog here, and the act
     comes back here — ?back=edit is a named place, never a URL."""
 
+    def test_the_card_offers_the_rename(self, client, tester, gang, vex):
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+        assert 'aria-label="Rename Vex"' in body
+        assert f"?rename={vex.pk}" in body
+
     def test_the_url_opens_the_dialog_on_this_page(self, client, tester, gang, vex):
         client.force_login(tester)
         body = client.get(f"{edit_url(vex)}?rename={vex.pk}").content.decode()

--- a/n26/core/test_views_rename.py
+++ b/n26/core/test_views_rename.py
@@ -1,11 +1,9 @@
-"""Renaming a fighter: the pencil on the card, the dialog the URL opens,
-and the act behind it.
+"""Renaming a fighter: the dialog the URL opens, and the act behind it.
 
 The hire form promises "you can name them later", and this is the later
-it promised. Open is a server state — the pencil is a link to
-``?rename=<pk>`` and the sheet draws the dialog only when that names one
-of the gang's own live members — so everything here works with no script
-and an open dialog is an address someone can send.
+it promised. The pencil lives on the model's own page; the sheet still
+draws the dialog when ``?rename=<pk>`` names one of the gang's own live
+members, so an address can be followed or reloaded with no script.
 """
 
 import pytest
@@ -45,13 +43,14 @@ def vex(tester, gang, make_profile, make_statline):
 
 
 class TestThePencilOnTheCard:
-    """The sheet says a name can be edited by carrying the way to do it."""
+    """A name is edited from the model's own page. The pencil next to
+    the name on the sheet is too easy to take for Edit."""
 
-    def test_every_card_offers_the_rename(self, client, tester, gang, vex):
+    def test_the_sheet_does_not_offer_the_rename(self, client, tester, gang, vex):
         client.force_login(tester)
         body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
-        assert 'aria-label="Rename Vex"' in body
-        assert f"?rename={vex.pk}" in body
+        assert 'aria-label="Rename Vex"' not in body
+        assert f"?rename={vex.pk}" not in body
 
     def test_the_url_opens_the_dialog_with_the_name_in_it(
         self, client, tester, gang, vex

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -451,7 +451,7 @@ def _dismiss(request, pk, kind):
 
 @login_required
 def rename_fighter(request, pk):
-    """Rename one model: the act behind the gang sheet's dialog.
+    """Rename one model: the act behind the model's own-page dialog.
 
     No rating moves and nothing is priced, but a rename is part of the
     gang's story, so it goes through an operation and the history keeps
@@ -464,10 +464,10 @@ def rename_fighter(request, pk):
     from n26.core.views.permissions import _own_miniature_or_404
 
     miniature = _own_miniature_or_404(request, pk)
-    # Two screens carry the rename pencil — the sheet and the model's
-    # own edit page — and the act should land back on whichever asked.
-    # ``?back=edit`` is a named place, never a URL, so there is nothing
-    # here for an open redirect to ride.
+    # The model's own page carries the rename pencil; the sheet still
+    # draws the dialog when ``?rename=`` names a member. The act lands
+    # back on whichever asked. ``?back=edit`` is a named place, never a
+    # URL, so there is nothing here for an open redirect to ride.
     if request.GET.get("back") == "edit":
         back_url = reverse("n26-edit-fighter", args=[miniature.pk])
     else:

--- a/n26/tests/sandbox/test_sharing_a_gang.py
+++ b/n26/tests/sandbox/test_sharing_a_gang.py
@@ -142,8 +142,8 @@ class TestNothingToClick:
         client.force_login(owner)
         mine = read(client, at)
 
-        assert "?rename=" in mine
-        assert "?rename=" not in theirs
+        assert "/fighters/" in mine
+        assert "/fighters/" not in theirs
         assert "?delete=" in mine
         assert "?delete=" not in theirs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The pencil next to a fighter's name on the gang sheet opened rename, which is easy to hit when you meant Edit.

It is gone from that card. Rename stays on the model's own page (`/fighters/<id>/edit/`), still as a `?rename=` dialog. Opening `?rename=` on the sheet still draws the dialog, so a bookmarked or GET-reopened act still works.

**How to try it**
- Open a gang you own: the model card name has no pencil; Equip and Edit are unchanged.
- Open Edit on a fighter: the pencil is still next to the name and still opens Rename.

[Gang sheet model card with no rename pencil](https://cursor.com/agents/bc-2227a2e2-c699-5963-be6b-e2f7eef9e7c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgang-sheet-no-rename.png)
[Fighter edit page with rename pencil next to the name](https://cursor.com/agents/bc-2227a2e2-c699-5963-be6b-e2f7eef9e7c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffighter-edit-has-rename.png)
[Rename dialog on the fighter edit page](https://cursor.com/agents/bc-2227a2e2-c699-5963-be6b-e2f7eef9e7c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffighter-edit-rename-dialog.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQKP2AW20/p1787774773585969?thread_ts=1787774773.585969&cid=C0BQKP2AW20)

<div><a href="https://cursor.com/agents/bc-2227a2e2-c699-5963-be6b-e2f7eef9e7c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2227a2e2-c699-5963-be6b-e2f7eef9e7c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

