### PR TITLE
feat: audit_reconcile checks every gang's books from the maintenance console

### DIFF
--- a/n26/core/templates/admin/maintenance/n26/audit.html
+++ b/n26/core/templates/admin/maintenance/n26/audit.html
@@ -1,0 +1,57 @@
+{% extends "admin/base_site.html" %}
+{% comment %}
+The books audit's console page: how many gangs would be checked, a run
+button, and the recent runs. The audit reads everything and changes
+nothing, so there is no plan to preview and no confirmation to extract.
+Context from audit_reconcile_view (n26/maintenance.py): title, gangs,
+apply_url, recent.
+{% endcomment %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        Checks every unarchived gang's pinned totals against what its ledger
+        sums to. Reads everything, changes nothing; a gang whose books
+        disagree is listed on the run's record with the discrepancy in words.
+    </p>
+    <p>{{ gangs }} gang{{ gangs|pluralize }} would be checked.</p>
+    <form method="post" class="mt-form">
+        {% csrf_token %}
+        <button type="submit" class="button default">Check every gang's books</button>
+    </form>
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -125,11 +125,16 @@ class Operation(models.TextChoices):
         "n26_merge_wargear_into_weapon",
         "n26: duplicated wargear becomes its weapon",
     )
+    AUDIT_RECONCILE = (
+        "n26_audit_reconcile",
+        "n26: every gang's books are checked against its ledger",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
 LOCK_KEYS = {
     Operation.DELETE_NAMELESS_GANG_TYPE: 826_020_606,
+    Operation.AUDIT_RECONCILE: 826_020_607,
 }
 
 
@@ -576,6 +581,81 @@ def delete_nameless_gang_type_view(request):
     )
 
 
+@task
+def audit_reconcile(backfill_id, **said_by_whoever_enqueued_it):
+    """Check every unarchived gang's books against its ledger.
+
+    Reads everything, writes nothing to any gang: a gang whose pinned
+    totals or entries disagree with its ledger lands in the record's
+    failures with the discrepancy in words. Batched, because the whole
+    estate is walked and each gang stands alone.
+    """
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+
+    run_batched(
+        backfill_id,
+        operation=Operation.AUDIT_RECONCILE,
+        what="Gang books audit",
+        items=Gang.objects.filter(archived=False),
+        do_one=lambda pk: assert_reconciled(Gang.objects.get(pk=pk)),
+        again=lambda: audit_reconcile.enqueue(backfill_id=backfill_id),
+    )
+
+
+def audit_reconcile_view(request):
+    """Say what would be checked (GET), or record a run and enqueue it."""
+    from n26.core.models import Gang
+
+    operation = Operation.AUDIT_RECONCILE
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That audit is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": 0},
+        )
+        audit_reconcile.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The audit is running. This page shows what it finds."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+    context = page_context(
+        request,
+        operation.label,
+        gangs=Gang.objects.filter(archived=False).count(),
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+    )
+    return render(request, "admin/maintenance/n26/audit.html", context)
+
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.AUDIT_RECONCILE.value,
+        name=Operation.AUDIT_RECONCILE.label,
+        added=date(2026, 8, 26),
+        description=(
+            "Walk every unarchived gang and check its pinned totals — "
+            "rating, credits, each model's worth — against what its "
+            "ledger sums to. Reads everything and changes nothing; a "
+            "gang whose books disagree is listed on the run's record "
+            "with the discrepancy in words."
+        ),
+        view=audit_reconcile_view,
+    )
+)
+
+
 register_operation(
     MaintenanceOperation(
         operation=Operation.DELETE_NAMELESS_GANG_TYPE.value,
@@ -614,6 +694,7 @@ task_routes = [
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
     TaskRoute(propagate_built_ins, ack_deadline=600),
     TaskRoute(sweep_built_in_propagations, schedule="*/5 * * * *"),
+    TaskRoute(audit_reconcile),
 ]
 
 

--- a/n26/tests/sandbox/test_books_audit.py
+++ b/n26/tests/sandbox/test_books_audit.py
@@ -1,0 +1,70 @@
+"""The books audit: every gang checked against its ledger, changing nothing.
+
+The audit walks the estate on the batched runner. Proven here: a gang
+whose books agree passes and the record ends DONE; a gang whose pinned
+rating has drifted from its ledger lands in the record's failures with
+the discrepancy in words, and is untouched by the audit itself.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from gyrinx.maintenance.models import Backfill
+from n26.core.models import Gang
+from n26.maintenance import Operation, audit_reconcile
+from n26.tests.sandbox.actions import found_gang, hire
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def player():
+    return User.objects.create_user("auditee")
+
+
+@pytest.fixture
+def record(db):
+    return Backfill.objects.create(
+        operation=Operation.AUDIT_RECONCILE,
+        status=Backfill.Status.RUNNING,
+    )
+
+
+def audit(record):
+    audit_reconcile.func(backfill_id=str(record.pk))
+    record.refresh_from_db()
+    return record
+
+
+class TestTheAudit:
+    """Reads everything, changes nothing: agreement passes, drift is
+    named on the record."""
+
+    def test_a_gang_whose_books_agree_passes(
+        self, gang_type, player, person_type, default_pack, record
+    ):
+        found_gang("Clean Books", gang_type, owner=player, budget=1000)
+
+        audit(record)
+
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["failures"] == {}
+        assert record.summary["done"] >= 1
+
+    def test_a_drifted_pin_is_named_and_the_gang_is_untouched(
+        self, gang_type, player, person_type, default_pack, record
+    ):
+        from n26.tests.sandbox.actions import create_profile
+
+        gang = found_gang("Cooked Books", gang_type, owner=player, budget=1000)
+        profile = create_profile("Clerk", person_type, gang_type, price=50)
+        hire(gang, profile, "Fiddler", paid=50)
+        Gang.objects.filter(pk=gang.pk).update(rating=gang.rating + 7)
+
+        audit(record)
+
+        assert record.status == Backfill.Status.FAILED
+        assert str(gang.pk) in record.summary["failures"]
+        assert "rating pinned" in record.summary["failures"][str(gang.pk)]
+        gang.refresh_from_db()
+        assert gang.rating != 0  # untouched, still the drifted pin


### PR DESCRIPTION
The maintenance console gains a read-only audit: walk every unarchived gang and check its pinned totals — rating, credits, each model's worth — against what its ledger sums to. A gang whose books disagree is listed on the run's record with the discrepancy in words; nothing is written to any gang.

Runs on `run_batched` (#2322) — its first consumer — so it doubles as the runner's first production exercise at full estate scale: real deliveries, cursor continuations, the progress display, and (deliberately pokeable, since the work is read-only) duplicate-delivery lock contention.

Refs #2165
Refs #2322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
