### PR TITLE
fix: pin the app-move migrations to n23 core so empty databases migrate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,3 +84,68 @@ jobs:
         run: |
           source .venv/bin/activate && \
           bandit -c pyproject.toml -r . --baseline bandit/bandit-baseline.json
+
+  # Applies the whole migration graph to an empty database, which nothing else
+  # here does: pytest builds the schema straight from the models
+  # (--nomigrations), and the conflict check reads the graph without running
+  # it. Both stay green while a from-scratch apply is broken, which is how
+  # #2231 survived — a state-only app-move migration ran before the n23 core
+  # migration that made the table it had adopted, and only a database that
+  # already had the table hid it.
+  #
+  # Its own job rather than a step in `test` so a four-minute migrate does not
+  # sit in front of the test result.
+  fresh-database:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DB_NAME: gyrinx_fresh
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_CONFIG: '{"user":"postgres","password":"postgres"}'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Write to .env file
+        run: |
+          echo "SECRET_KEY=test-secret" >> .env
+          echo "DJANGO_SUPERUSER_PASSWORD=password" >> .env
+
+      # A database of its own, so the run starts from genuinely nothing rather
+      # than from whatever the service image left in `postgres`.
+      - name: Create an empty database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -c 'CREATE DATABASE gyrinx_fresh;'
+
+      - name: Migrate the empty database
+        timeout-minutes: 30
+        run: |
+          source .venv/bin/activate
+          manage migrate

--- a/gyrinx/accounts/migrations/0001_move_userprofile_to_accounts.py
+++ b/gyrinx/accounts/migrations/0001_move_userprofile_to_accounts.py
@@ -20,6 +20,10 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        # State-only: this adopts core_userprofile rather than making it. Naming the
+        # core migration the paired release depends on is what holds this
+        # app's chain back until the table exists — #2231.
+        ("core", "0202_migrate_stat_overrides_operation"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/gyrinx/accounts/migrations/0001_move_userprofile_to_accounts.py
+++ b/gyrinx/accounts/migrations/0001_move_userprofile_to_accounts.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
     State-only. The tables (core_userprofile, core_historicaluserprofile) are
     pinned via db_table and already exist — this migration teaches Django that
     they now belong to `accounts`, and touches no data. Paired with
-    core.0201, which drops them from `core`'s state the same way.
+    core.0203, which drops them from `core`'s state the same way.
     """
 
     initial = True

--- a/gyrinx/accounts/migrations/0001_move_userprofile_to_accounts.py
+++ b/gyrinx/accounts/migrations/0001_move_userprofile_to_accounts.py
@@ -20,9 +20,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        # State-only: this adopts core_userprofile rather than making it. Naming the
-        # core migration the paired release depends on is what holds this
-        # app's chain back until the table exists — #2231.
         ("core", "0202_migrate_stat_overrides_operation"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/gyrinx/analytics/migrations/0001_move_event_to_analytics.py
+++ b/gyrinx/analytics/migrations/0001_move_event_to_analytics.py
@@ -17,6 +17,10 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        # State-only: this adopts core_event rather than making it. Naming the
+        # core migration the paired release depends on is what holds this
+        # app's chain back until the table exists — #2231.
+        ("core", "0204_move_site_models_to_platform"),
         ("contenttypes", "0002_remove_content_type_name"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/gyrinx/analytics/migrations/0001_move_event_to_analytics.py
+++ b/gyrinx/analytics/migrations/0001_move_event_to_analytics.py
@@ -17,9 +17,9 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        # State-only: this adopts core_event rather than making it. Naming the
-        # core migration the paired release depends on is what holds this
-        # app's chain back until the table exists — #2231.
+        # State-only: this adopts core_event rather than making it, so the
+        # core dependency is what holds the analytics chain back until the
+        # table exists.
         ("core", "0204_move_site_models_to_platform"),
         ("contenttypes", "0002_remove_content_type_name"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/gyrinx/maintenance/migrations/0001_move_backfill_to_maintenance.py
+++ b/gyrinx/maintenance/migrations/0001_move_backfill_to_maintenance.py
@@ -19,6 +19,10 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        # State-only: this adopts core_backfill rather than making it. Naming the
+        # core migration the paired release depends on is what holds this
+        # app's chain back until the table exists — #2231.
+        ("core", "0213_document_pre_mod_advancement_flag"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/gyrinx/maintenance/migrations/0001_move_backfill_to_maintenance.py
+++ b/gyrinx/maintenance/migrations/0001_move_backfill_to_maintenance.py
@@ -19,9 +19,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        # State-only: this adopts core_backfill rather than making it. Naming the
-        # core migration the paired release depends on is what holds this
-        # app's chain back until the table exists — #2231.
         ("core", "0213_document_pre_mod_advancement_flag"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/gyrinx/site/migrations/0001_move_site_models_to_platform.py
+++ b/gyrinx/site/migrations/0001_move_site_models_to_platform.py
@@ -19,9 +19,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        # State-only: this adopts the site tables rather than making it. Naming the
-        # core migration the paired release depends on is what holds this
-        # app's chain back until the table exists — #2231.
         ("core", "0203_move_userprofile_to_accounts"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/gyrinx/site/migrations/0001_move_site_models_to_platform.py
+++ b/gyrinx/site/migrations/0001_move_site_models_to_platform.py
@@ -19,6 +19,10 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        # State-only: this adopts the site tables rather than making it. Naming the
+        # core migration the paired release depends on is what holds this
+        # app's chain back until the table exists — #2231.
+        ("core", "0203_move_userprofile_to_accounts"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/gyrinx/site/migrations/0002_move_notification_to_platform.py
+++ b/gyrinx/site/migrations/0002_move_notification_to_platform.py
@@ -17,9 +17,6 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        # State-only: this adopts core_notification rather than making it. Naming the
-        # core migration the paired release depends on is what holds this
-        # app's chain back until the table exists — #2231.
         ("core", "0211_drop_notification_related_columns"),
         ("contenttypes", "0002_remove_content_type_name"),
         ("gyrinxsite", "0001_move_site_models_to_platform"),

--- a/gyrinx/site/migrations/0002_move_notification_to_platform.py
+++ b/gyrinx/site/migrations/0002_move_notification_to_platform.py
@@ -17,6 +17,10 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
+        # State-only: this adopts core_notification rather than making it. Naming the
+        # core migration the paired release depends on is what holds this
+        # app's chain back until the table exists — #2231.
+        ("core", "0211_drop_notification_related_columns"),
         ("contenttypes", "0002_remove_content_type_name"),
         ("gyrinxsite", "0001_move_site_models_to_platform"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),


### PR DESCRIPTION
## Summary

- A brand-new database could not be migrated at all. `manage migrate` on an empty database died at `analytics.0002_event_edition` with `relation "core_event" does not exist`, so a from-scratch install — a new contributor setting up, or any rebuild from empty — was broken. Nobody noticed because the local workflow always forks a worktree database from the `gyrinx_main` template, where the table is already there.
- Five migrations adopt a model out of `n23 core` as a state-only change: they declare the model but build no table, because the table belongs to `core` and a paired `core` migration releases it. None of them named a `core` dependency, so nothing in the migration graph held them back until `core` had actually built the table. Each now names the `core` migration its paired release depends on — the last point at which `core` still owned the table, so the table both exists and has the shape the adopted state declares.
- Adds a `fresh-database` CI job that creates an empty database and migrates it.

## The five migrations

`analytics.0001` is the one that bites today, through the real `AddField` in `analytics.0002`. The other four — `accounts.0001`, `gyrinxsite.0001`, `gyrinxsite.0002`, `maintenance.0001` — carry the identical defect and escape only because Django's topological tiebreak happens to sort them late. `gyrinxsite.0006_banner_live_per_edition` adds a real column to `core_banner` and is one reordering away from the same failure, so all five are fixed rather than just the one that fails now.

Fixing the adoption migration rather than `analytics.0002` means every future migration in those apps is transitively safe too, not just today's.

## Why CI stayed green

Nothing exercised a from-scratch apply. `pytest` runs with `--nomigrations` and builds the schema straight from the models, and `scripts/check_migration_conflicts.sh` reads the graph without running it. Both stay green while an empty-database migrate is broken.

The new `fresh-database` job in `.github/workflows/test.yaml` closes that gap. It is a separate job rather than a step in `test` so the migrate does not sit in front of the test result. It takes about 7 minutes on a runner.

## Existing databases

Unaffected. All five migrations are long since applied, as are the `core` migrations they now depend on, so adding the dependencies re-runs nothing.

## Test plan

- [x] Reproduced on an empty database before the change: `createdb gyrinx_freshtest && DB_NAME=gyrinx_freshtest manage migrate` fails with `relation "core_event" does not exist`
- [x] Same command after the change applies the whole graph; `manage migrate --check` then exits 0
- [x] `manage makemigrations --check --dry-run` reports no changes
- [x] `scripts/check_migration_conflicts.sh` reports no conflicts
- [x] An existing database (`gyrinx_main`) shows none of the five as unapplied, so nothing re-runs
- [x] Full suite: 8426 passed, 12 skipped, 1 xfailed
- [x] `scripts/fmt.sh` and `scripts/fmt-check.sh` clean
- [x] CI green on the branch: `test`, `fresh-database`, `ci-checks`, CodeQL

## Note

The new `fresh-database` job is not in the required-status-checks ruleset. Worth adding if it should block merges.

Closes #2231.
