### PR TITLE
fix: n26 page-header stacks actions under the title on phones

### DIFF
--- a/n26/core/templates/cotton/n26/flair_link.html
+++ b/n26/core/templates/cotton/n26/flair_link.html
@@ -39,5 +39,7 @@ surrounding sentence.
 />{% comment %}The em sizing sits on the badge wrapper and reaches the svg by a
 descendant selector, so any artwork works without carrying a class. slot.strip
 because an artwork file's own leading and trailing newlines would otherwise pad
-the inline-block badge.
-{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="{{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="ml-[0.25em] inline-block [&_svg]:inline [&_svg]:size-[1em] [&_svg]:align-[-0.125em]" {% if label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>
+the inline-block badge. inline-flex keeps the badge on the text's line: an
+inline-block after a short word still wraps under it when the drawing's
+own size is larger than the line.
+{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="inline-flex items-center {{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="ml-[0.25em] inline-block shrink-0 [&_svg]:inline [&_svg]:size-[1em] [&_svg]:align-[-0.125em]" {% if label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>

--- a/n26/core/templates/cotton/n26/flair_link.html
+++ b/n26/core/templates/cotton/n26/flair_link.html
@@ -36,10 +36,11 @@ surrounding sentence.
     tone="accent"
     label=""
     class=""
-/>{% comment %}The em sizing sits on the badge wrapper and reaches the svg by a
-descendant selector, so any artwork works without carrying a class. slot.strip
-because an artwork file's own leading and trailing newlines would otherwise pad
-the inline-block badge. inline-flex keeps the badge on the text's line: an
-inline-block after a short word still wraps under it when the drawing's
-own size is larger than the line.
-{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="inline-flex items-center {{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="ml-[0.25em] inline-block shrink-0 [&_svg]:inline [&_svg]:size-[1em] [&_svg]:align-[-0.125em]" {% if label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>
+/>{% comment %}The badge is .n26-icon-inline, which sizes a child svg in em
+in app.css. The utilities that would have done the same — [&_svg]:size-[1em]
+and friends — never left the extractor: nested brackets in one class are
+silently dropped, and an unsized svg is 300×150, which wraps under a short
+word. whitespace-nowrap holds the text and the badge as one unit so a 1em
+mark cannot take the next line by itself. slot.strip because an artwork
+file's own leading and trailing newlines would otherwise pad the badge.
+{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="inline-flex items-center whitespace-nowrap {{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="ml-[0.25em] n26-icon-inline shrink-0 [--n26-icon-size:1em]" {% if label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>

--- a/n26/core/templates/cotton/n26/page_header.html
+++ b/n26/core/templates/cotton/n26/page_header.html
@@ -62,9 +62,14 @@ works on a string and on slot content alike.
             back the marking .strip drops, so markup in the slot survives.
             {% endcomment %}
             {% if trailing.strip %}
-                <div class="flex flex-wrap items-center gap-2">
-                    <h1 class="text-2xl font-semibold text-ink-900 dark:text-ink-100 sm:text-3xl">{{ leading.strip|safe }}{{ title }}</h1>
-                    <div>{{ trailing }}</div>
+                {% comment %}
+                No wrap: the h1 is a block, so wrapping this row always drops
+                the control under the name, on a line of its own. min-w-0 lets
+                the heading take the squeeze and wrap inside itself instead.
+                {% endcomment %}
+                <div class="flex items-center gap-2">
+                    <h1 class="min-w-0 text-2xl font-semibold text-ink-900 dark:text-ink-100 sm:text-3xl">{{ leading.strip|safe }}{{ title }}</h1>
+                    <div class="shrink-0">{{ trailing }}</div>
                 </div>
             {% else %}
                 <h1 class="text-2xl font-semibold text-ink-900 dark:text-ink-100 sm:text-3xl">{{ leading.strip|safe }}{{ title }}</h1>
@@ -78,7 +83,7 @@ works on a string and on slot content alike.
             lead is usually the sentence saying what the page is for, and small
             text is for what a reader is meant to scan past.
             {% endcomment %}
-            {% if lead.strip %}<p class="text-muted">{{ lead }}</p>{% endif %}
+            {% if lead.strip %}<p class="flex items-center text-muted">{{ lead }}</p>{% endif %}
         </div>
 
         {% if actions %}<div class="flex w-full shrink-0 flex-wrap items-center gap-2 sm:w-auto">{{ actions }}</div>{% endif %}

--- a/n26/core/templates/cotton/n26/page_header.html
+++ b/n26/core/templates/cotton/n26/page_header.html
@@ -24,7 +24,7 @@ works on a string and on slot content alike.
   trailing — a control after the title, on its line but outside the h1, where it
     would otherwise be read out as part of the name. A switcher to the page's
     siblings is the case it exists for.
-  actions — controls for the page as a whole. They wrap under the title on a
+  actions — controls for the page as a whole. They sit under the title on a
     narrow screen rather than squeezing it.
 {% endcomment %}
 {# The slots are declared: an undeclared slot name is not empty when nobody #}
@@ -43,16 +43,18 @@ works on a string and on slot content alike.
 <div class="flex flex-col gap-1 {{ class }}">
     {% if breadcrumb %}<div class="mb-1">{{ breadcrumb }}</div>{% endif %}
 
-    <div class="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+    <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-start sm:justify-between sm:gap-x-4">
         {% comment %}
-        basis-full on a phone, so the title takes the row and the actions wrap
-        under it rather than shrinking the heading. sm:flex-1 from there, so
+        A column on a phone, so the title and its lead keep the first rows and
+        the actions sit under them. Wrapping with min-w-0 lets the heading
+        shrink beside a wide strip — a gang's figures — and the name then
+        reads as a second block under the numbers. sm:flex-1 from there, so
         the words take the slack and what sits at the far end stays there.
         Sized to their own content instead, a lead of any length is wider than
         the room left over and pushes the actions onto a line of their own,
         where "the far end" means the left.
         {% endcomment %}
-        <div class="min-w-0 basis-full sm:flex-1">
+        <div class="min-w-0 w-full sm:w-auto sm:flex-1">
             {% comment %}
             leading.strip, and hard against the title: a slot written across
             several lines arrives wrapped in newlines, which collapse into a
@@ -79,6 +81,6 @@ works on a string and on slot content alike.
             {% if lead.strip %}<p class="text-muted">{{ lead }}</p>{% endif %}
         </div>
 
-        {% if actions %}<div class="flex shrink-0 flex-wrap items-center gap-2">{{ actions }}</div>{% endif %}
+        {% if actions %}<div class="flex w-full shrink-0 flex-wrap items-center gap-2 sm:w-auto">{{ actions }}</div>{% endif %}
     </div>
 </div>

--- a/n26/core/templates/cotton/n26/page_header.html
+++ b/n26/core/templates/cotton/n26/page_header.html
@@ -45,12 +45,14 @@ works on a string and on slot content alike.
 
     <div class="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
         {% comment %}
-        flex-1, so the words take the slack and what sits at the far end stays
-        there. Sized to their own content instead, a lead of any length is
-        wider than the room left over and pushes the actions onto a line of
-        their own, where "the far end" means the left.
+        basis-full on a phone, so the title takes the row and the actions wrap
+        under it rather than shrinking the heading. sm:flex-1 from there, so
+        the words take the slack and what sits at the far end stays there.
+        Sized to their own content instead, a lead of any length is wider than
+        the room left over and pushes the actions onto a line of their own,
+        where "the far end" means the left.
         {% endcomment %}
-        <div class="min-w-0 flex-1">
+        <div class="min-w-0 basis-full sm:flex-1">
             {% comment %}
             leading.strip, and hard against the title: a slot written across
             several lines arrives wrapped in newlines, which collapse into a

--- a/n26/core/templates/cotton/n26/page_header.html
+++ b/n26/core/templates/cotton/n26/page_header.html
@@ -83,15 +83,13 @@ works on a string and on slot content alike.
 
             Body size, quiet from its colour rather than from shrinking: the
             lead is usually the sentence saying what the page is for, and small
-            text is for what a reader is meant to scan past.
-
-            whitespace-nowrap with the type's badge: a 1em mark after a short
-            word still wraps under it if the drawing is left to the svg default
-            size, and the type then reads as a heading of its own.
+            text is for what a reader is meant to scan past. The type's badge
+            keeps itself on the words; nowrap on this line would clip a real
+            sentence on a phone.
             {% endcomment %}
-            {% if lead.strip %}<p class="flex items-center whitespace-nowrap text-muted">{{ lead }}</p>{% endif %}
+            {% if lead.strip %}<p class="flex items-center text-muted">{{ lead }}</p>{% endif %}
         </div>
 
-        {% if actions %}<div class="flex w-full shrink-0 flex-wrap items-center gap-2 sm:w-auto">{{ actions }}</div>{% endif %}
+        {% if actions.strip %}<div class="flex w-full shrink-0 flex-wrap items-center gap-2 sm:w-auto">{{ actions }}</div>{% endif %}
     </div>
 </div>

--- a/n26/core/templates/cotton/n26/page_header.html
+++ b/n26/core/templates/cotton/n26/page_header.html
@@ -64,10 +64,12 @@ works on a string and on slot content alike.
             {% if trailing.strip %}
                 {% comment %}
                 No wrap: the h1 is a block, so wrapping this row always drops
-                the control under the name, on a line of its own. min-w-0 lets
-                the heading take the squeeze and wrap inside itself instead.
+                the control under the name, on a line of its own. items-start
+                keeps the chevron on the first line of a wrapping name rather
+                than vertically centred between the two. min-w-0 lets the
+                heading take the squeeze and wrap inside itself instead.
                 {% endcomment %}
-                <div class="flex items-center gap-2">
+                <div class="flex flex-nowrap items-start gap-2">
                     <h1 class="min-w-0 text-2xl font-semibold text-ink-900 dark:text-ink-100 sm:text-3xl">{{ leading.strip|safe }}{{ title }}</h1>
                     <div class="shrink-0">{{ trailing }}</div>
                 </div>
@@ -82,8 +84,12 @@ works on a string and on slot content alike.
             Body size, quiet from its colour rather than from shrinking: the
             lead is usually the sentence saying what the page is for, and small
             text is for what a reader is meant to scan past.
+
+            whitespace-nowrap with the type's badge: a 1em mark after a short
+            word still wraps under it if the drawing is left to the svg default
+            size, and the type then reads as a heading of its own.
             {% endcomment %}
-            {% if lead.strip %}<p class="flex items-center text-muted">{{ lead }}</p>{% endif %}
+            {% if lead.strip %}<p class="flex items-center whitespace-nowrap text-muted">{{ lead }}</p>{% endif %}
         </div>
 
         {% if actions %}<div class="flex w-full shrink-0 flex-wrap items-center gap-2 sm:w-auto">{{ actions }}</div>{% endif %}

--- a/n26/core/test_form_page.py
+++ b/n26/core/test_form_page.py
@@ -43,7 +43,7 @@ class TestTheHeadingIsAPageHeading:
         # Beside the title rather than after the whole heading: same row,
         # which is the group page-header draws for it.
         assert html.index("Doug") < html.index('href="/others/"')
-        assert "flex items-center gap-2" in html
+        assert "flex flex-nowrap items-start gap-2" in html
 
     def test_slot_markup_survives_the_forwarding(self):
         """Handed on as a slot, not written into an attribute — an attribute
@@ -91,7 +91,7 @@ class TestNothingArrivesUninvited:
 
         assert "Doug" in html
         assert "<a" not in html
-        assert "flex items-center gap-2" not in html
+        assert "flex flex-nowrap items-start gap-2" not in html
 
     def test_a_variable_of_the_same_name_in_the_page_is_not_a_slot(self):
         """The undeclared-slot trap. A page holding `trailing` for its own

--- a/n26/core/test_form_page.py
+++ b/n26/core/test_form_page.py
@@ -41,9 +41,9 @@ class TestTheHeadingIsAPageHeading:
 
         assert 'href="/others/"' in html
         # Beside the title rather than after the whole heading: same row,
-        # which is the wrap-together group page-header draws for it.
+        # which is the group page-header draws for it.
         assert html.index("Doug") < html.index('href="/others/"')
-        assert "flex flex-wrap items-center gap-2" in html
+        assert "flex items-center gap-2" in html
 
     def test_slot_markup_survives_the_forwarding(self):
         """Handed on as a slot, not written into an attribute — an attribute
@@ -91,7 +91,7 @@ class TestNothingArrivesUninvited:
 
         assert "Doug" in html
         assert "<a" not in html
-        assert "flex flex-wrap items-center gap-2" not in html
+        assert "flex items-center gap-2" not in html
 
     def test_a_variable_of_the_same_name_in_the_page_is_not_a_slot(self):
         """The undeclared-slot trap. A page holding `trailing` for its own

--- a/n26/core/test_page_header.py
+++ b/n26/core/test_page_header.py
@@ -1,0 +1,43 @@
+"""How a page heading yields to its own controls.
+
+No database: a component is a template and a set of props, and everything
+claimed here is decided before a request exists. The heading's contract is
+that the title keeps the row on a phone and the actions wrap under it —
+min-w-0 flex-1 at every width lets the words shrink beside the buttons,
+and a greeting that wraps mid-name is the wrong thing to have shortened.
+"""
+
+from django.template import Context, Template
+from django_cotton.compiler_regex import CottonCompiler
+
+
+def render(source: str, **context) -> str:
+    """Compile a call site the way the template loader would, then render it.
+
+    Cotton's `<c-…>` tags are rewritten by a loader, so a template built from a
+    string never sees them. Running the compiler by hand is what lets a test
+    write the call site it is testing.
+    """
+    return Template(CottonCompiler().process(source)).render(Context(context))
+
+
+class TestTheTitleKeepsTheRowOnAPhone:
+    """Actions wrap under the heading rather than squeezing it."""
+
+    def test_the_title_takes_the_full_row_until_there_is_room_beside_it(self):
+        html = render(
+            '<c-n26.page-header title="Hello, player">'
+            '<c-slot name="actions"><a href="/gangs/new/">Create Gang</a></c-slot>'
+            "</c-n26.page-header>"
+        )
+
+        heading = html[html.index("<h1") : html.index("</h1>")]
+        wrapper = html[: html.index("<h1")]
+        # The last class list before the h1 is the title's column: basis-full
+        # is what forces the wrap, and sm:flex-1 is what gives the slack back
+        # once the row is wide enough to hold both. An un-prefixed flex-1
+        # beside min-w-0 is the squeeze — the heading would share the row
+        # and wrap mid-name rather than keeping it.
+        assert 'class="min-w-0 basis-full sm:flex-1"' in wrapper
+        assert "Hello, player" in heading
+        assert html.index("Hello, player") < html.index("Create Gang")

--- a/n26/core/test_page_header.py
+++ b/n26/core/test_page_header.py
@@ -73,7 +73,7 @@ class TestTheTitleKeepsItsControl:
         )
 
         group = html[html.index("<h1") - 80 : html.index("</h1>") + 80]
-        assert "flex items-center gap-2" in html
+        assert "flex flex-nowrap items-start gap-2" in html
         assert "flex-wrap items-center gap-2" not in html
         assert 'class="min-w-0 text-2xl' in group
         assert "shrink-0" in html
@@ -91,6 +91,7 @@ class TestTheTypeKeepsItsMark:
             "</c-n26.flair-link>"
         )
 
-        assert "inline-flex items-center" in html
-        assert "shrink-0" in html
+        assert "inline-flex items-center whitespace-nowrap" in html
+        assert "n26-icon-inline" in html
+        assert "[--n26-icon-size:1em]" in html
         assert html.index("Outcast") < html.index("<svg")

--- a/n26/core/test_page_header.py
+++ b/n26/core/test_page_header.py
@@ -57,7 +57,24 @@ class TestTheTitleKeepsTheRowOnAPhone:
         )
 
         assert html.index("Ozostium") < html.index("Outcast") < html.index("1000¢")
-        assert "flex flex-col" in html
+        assert (
+            "flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-start "
+            "sm:justify-between sm:gap-x-4"
+        ) in html
+        assert '<p class="flex items-center text-muted">' in html
+
+    def test_whitespace_alone_does_not_draw_an_actions_row(self):
+        """A slot written across several lines is still whitespace, and
+        Django treats that as true. The row is w-full below sm, so an
+        empty one is a blank band under the title."""
+        html = render(
+            '<c-n26.page-header title="Hello, player">'
+            '<c-slot name="actions">\n  \n</c-slot>'
+            "</c-n26.page-header>"
+        )
+
+        assert "Hello, player" in html
+        assert "w-full shrink-0" not in html
 
 
 class TestTheTitleKeepsItsControl:

--- a/n26/core/test_page_header.py
+++ b/n26/core/test_page_header.py
@@ -58,3 +58,39 @@ class TestTheTitleKeepsTheRowOnAPhone:
 
         assert html.index("Ozostium") < html.index("Outcast") < html.index("1000¢")
         assert "flex flex-col" in html
+
+
+class TestTheTitleKeepsItsControl:
+    """A switcher after the name stays on the name's line. flex-wrap plus a
+    block h1 put it on a line of its own under the heading, which then
+    read as part of the type underneath."""
+
+    def test_the_control_does_not_wrap_under_the_heading(self):
+        html = render(
+            '<c-n26.page-header title="Ozostium\'s War Host">'
+            '<c-slot name="trailing"><button type="button">Switch</button></c-slot>'
+            "</c-n26.page-header>"
+        )
+
+        group = html[html.index("<h1") - 80 : html.index("</h1>") + 80]
+        assert "flex items-center gap-2" in html
+        assert "flex-wrap items-center gap-2" not in html
+        assert 'class="min-w-0 text-2xl' in group
+        assert "shrink-0" in html
+        assert html.index("Ozostium") < html.index("Switch")
+
+
+class TestTheTypeKeepsItsMark:
+    """The badge sits after the type on the same line. An inline-block after
+    a short word still wraps under it when the drawing is larger than the
+    line — which is how a gang type's icon ended up on a row of its own."""
+
+    def test_the_badge_is_held_on_the_text_s_line(self):
+        html = render(
+            '<c-n26.flair-link text="Outcast"><svg viewBox="0 0 24 24"></svg>'
+            "</c-n26.flair-link>"
+        )
+
+        assert "inline-flex items-center" in html
+        assert "shrink-0" in html
+        assert html.index("Outcast") < html.index("<svg")

--- a/n26/core/test_page_header.py
+++ b/n26/core/test_page_header.py
@@ -2,9 +2,9 @@
 
 No database: a component is a template and a set of props, and everything
 claimed here is decided before a request exists. The heading's contract is
-that the title keeps the row on a phone and the actions wrap under it —
-min-w-0 flex-1 at every width lets the words shrink beside the buttons,
-and a greeting that wraps mid-name is the wrong thing to have shortened.
+that the title keeps the first rows on a phone and the actions sit under
+it — a wrapping row with min-w-0 lets a wide strip shrink the heading
+beside it, and the name then reads as a second block under the numbers.
 """
 
 from django.template import Context, Template
@@ -22,9 +22,9 @@ def render(source: str, **context) -> str:
 
 
 class TestTheTitleKeepsTheRowOnAPhone:
-    """Actions wrap under the heading rather than squeezing it."""
+    """Actions sit under the heading rather than squeezing it."""
 
-    def test_the_title_takes_the_full_row_until_there_is_room_beside_it(self):
+    def test_the_heading_is_a_column_until_there_is_room_beside_it(self):
         html = render(
             '<c-n26.page-header title="Hello, player">'
             '<c-slot name="actions"><a href="/gangs/new/">Create Gang</a></c-slot>'
@@ -32,12 +32,29 @@ class TestTheTitleKeepsTheRowOnAPhone:
         )
 
         heading = html[html.index("<h1") : html.index("</h1>")]
-        wrapper = html[: html.index("<h1")]
-        # The last class list before the h1 is the title's column: basis-full
-        # is what forces the wrap, and sm:flex-1 is what gives the slack back
-        # once the row is wide enough to hold both. An un-prefixed flex-1
-        # beside min-w-0 is the squeeze — the heading would share the row
-        # and wrap mid-name rather than keeping it.
-        assert 'class="min-w-0 basis-full sm:flex-1"' in wrapper
+        before = html[: html.index("<h1")]
+        # flex-col is what stacks: wrapping with min-w-0 lets the heading
+        # shrink beside the actions and the name drops under them. sm:flex-row
+        # gives the side-by-side layout back once there is room.
+        assert (
+            "flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-start "
+            "sm:justify-between sm:gap-x-4"
+        ) in before
+        assert 'class="min-w-0 w-full sm:w-auto sm:flex-1"' in before
         assert "Hello, player" in heading
         assert html.index("Hello, player") < html.index("Create Gang")
+
+    def test_a_gang_sheet_keeps_its_figures_under_the_name_and_type(self):
+        """The wealth strip is wide enough that sharing a row with the
+        heading pushes the name under the numbers. Source order is the
+        phone's — name, type, then the figures — and flex-col is what
+        keeps that order on the screen."""
+        html = render(
+            '<c-n26.page-header title="Ozostium\'s War Host">'
+            '<c-slot name="lead">Outcast</c-slot>'
+            '<c-slot name="actions"><span>1000¢</span></c-slot>'
+            "</c-n26.page-header>"
+        )
+
+        assert html.index("Ozostium") < html.index("Outcast") < html.index("1000¢")
+        assert "flex flex-col" in html

--- a/n26/core/test_views_create_gang.py
+++ b/n26/core/test_views_create_gang.py
@@ -27,7 +27,7 @@ ICON = (
 #: What <c-n26.flair-link> wraps a badge in. Counting these counts the badges
 #: actually drawn, which is the only way to tell "no artwork" from "an empty
 #: box where the artwork would go".
-_FLAIR_WRAPPER = 'class="ml-[0.25em] inline-block'
+_FLAIR_WRAPPER = 'class="ml-[0.25em] n26-icon-inline'
 
 
 def _is_checked(body, pk):

--- a/n26/designsystem/templates/designsystem/demos/page-header/20-everything.html
+++ b/n26/designsystem/templates/designsystem/demos/page-header/20-everything.html
@@ -1,5 +1,5 @@
 {# title: With a trail and controls #}
-{# note: The trail above, a lead under, and controls that belong to the page rather than to anything on it. They wrap under the title on a phone rather than squeezing it: a title truncated to make room for a button is the wrong thing to have shortened. #}
+{# note: The trail above, a lead under, and controls that belong to the page rather than to anything on it. They sit under the title on a phone rather than squeezing it: a title truncated to make room for a button is the wrong thing to have shortened. #}
 <c-n26.page-header title="The Ashen Choir">
     <c-slot name="breadcrumb">
         <c-ui.breadcrumbs>

--- a/n26/tests/test_badges.py
+++ b/n26/tests/test_badges.py
@@ -31,7 +31,7 @@ GUILDER = badge_by_slug("guilder")
 # The wrapper <c-n26.flair-link> puts round a badge. Nothing else in the
 # edition emits it, so its absence is the claim that no empty span was
 # drawn where a badge would have gone.
-FLAIR_WRAPPER = 'class="ml-[0.25em] inline-block'
+FLAIR_WRAPPER = 'class="ml-[0.25em] n26-icon-inline'
 
 
 @pytest.fixture
@@ -170,7 +170,8 @@ class TestTheHomePageGreeting:
         heading = body[body.index("Hello,") :]
         heading = heading[: heading.index("</h1>")]
         assert FLAIR_WRAPPER in heading
-        assert "size-[1em]" in heading
+        assert "n26-icon-inline" in heading
+        assert "[--n26-icon-size:1em]" in heading
 
     def test_a_reader_entitled_to_nothing_is_greeted_by_name_alone(
         self, tester, client, default_pack


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
On a phone, the n26 home greeting and the gang sheet heading were sharing a row with their actions. The title column used `min-w-0 flex-1`, so it shrank beside Create Gang / Set up campaign, or beside a gang's wealth strip, and the name wrapped underneath the numbers.

`c-n26.page-header` now stacks as a column below `sm`: the title and lead (name, type) keep the first rows and the actions sit under them. From `sm` up, `flex-row` still puts the actions at the far end. Empty whitespace-only action slots do not draw that row.

The gang type was wrapping in two more ways. A block `h1` plus `flex-wrap` dropped the heading switcher onto its own line — that row is now `flex-nowrap`. The type's icon rendered at the SVG default of 300×150 because Tailwind never emitted `[&_svg]:size-[1em]` (nested brackets are dropped by the extractor), so the mark wrapped under the type name. `c-n26.flair-link` now sizes the badge with `.n26-icon-inline` at `1em`, and `whitespace-nowrap` on the flair-link keeps the words and the mark on one line without clipping a longer lead sentence.

**How to try it:** sign in, open `/n26/` and a gang sheet at a phone width. The greeting / gang name should stay on their own lines with the buttons or wealth strip on the row below. The gang type and its icon should stay on one line. Widen past `sm` (640px) and the heading actions should sit side by side again.

The design-system shell at `/n26/design/shell/gang/` is the same heading with sample data if the local database has no gangs.

[Phone gang header: type and house icon on one line, wealth below](https://cursor.com/agents/bc-01a041d4-730f-748d-9d43-fb634b0b0f90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgang_header_phone_type_icon.webp)
[Phone homepage: Hello, tom on its own line with buttons beneath](https://cursor.com/agents/bc-01a041d4-730f-748d-9d43-fb634b0b0f90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_header_phone.webp)
[Desktop gang header: name left, wealth right, type still with icon](https://cursor.com/agents/bc-01a041d4-730f-748d-9d43-fb634b0b0f90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgang_header_desktop_side_by_side.webp)
[n26_headers_phone_type_icon_and_stacking.mp4](https://cursor.com/agents/bc-01a041d4-730f-748d-9d43-fb634b0b0f90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fn26_headers_phone_type_icon_and_stacking.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a041d4-730f-748d-9d43-fb634b0b0f90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a041d4-730f-748d-9d43-fb634b0b0f90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

