### PR TITLE
fix: save n26 notes and lore without wiping the other box

### DIFF
--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -203,11 +203,12 @@ class PictureForm(forms.Form):
         return to_shape(upload, self.ratio) if upload else upload
 
 
-class GangStoryForm(forms.Form):
-    """The gang edit page's written tab: notes and lore together.
+class GangNotesForm(forms.Form):
+    """The gang edit page's notes box. One field, one save.
 
-    Both optional, because an emptied box is a real answer — it clears
-    the field. Stored as written, sanitised at render.
+    Optional, because an emptied box is a real answer — it clears the
+    notes. Stored as written, sanitised at render. Lore is a form of
+    its own, so saving one cannot throw the other away.
     """
 
     notes = forms.CharField(
@@ -216,6 +217,11 @@ class GangStoryForm(forms.Form):
         label="Notes",
         help_text="Printed with the gang sheet. Anyone reading the gang can see them.",
     )
+
+
+class GangLoreForm(forms.Form):
+    """The gang edit page's lore box. One field, the notes box's shape."""
+
     lore = forms.CharField(
         required=False,
         widget=RichText(),

--- a/n26/core/static/n26/richtext.js
+++ b/n26/core/static/n26/richtext.js
@@ -78,6 +78,21 @@
         });
     });
 
+    /* htmx serialises the textarea, not TinyMCE's iframe. A native submit
+     * copies the live content back because TinyMCE binds the form; htmx
+     * intercepts that event and would otherwise post whatever was in the
+     * box when the page loaded. Capture so this runs before htmx reads
+     * the fields. Saving one box must not send the other: triggerSave
+     * writes every editor to its textarea, and only this form is posted.
+     */
+    document.addEventListener(
+        "submit",
+        function () {
+            if (window.tinymce) window.tinymce.triggerSave();
+        },
+        true,
+    );
+
     /* The edit / render toggle.
      *
      * Preview reads the editor's *live* content rather than the saved value, so it

--- a/n26/core/templates/n26/edit_gang.html
+++ b/n26/core/templates/n26/edit_gang.html
@@ -3,12 +3,14 @@
 {% load static %}
 {% comment %}
 Editing a standing gang, in two tabs the URL picks (?tab=notes): General —
-the create form's shape over a gang that exists — and Notes and Lore, the
-written fields with the picture beneath them. Each tab is one render and
-one form; a tab is a link, so the choice survives a reload and works with
-no script. The one difference of substance from the create form: the type
-is a fact rather than a question, because it fixed who could be hired and
-what the founding brought, and those rows exist.
+the create form's shape over a gang that exists — and Notes and Lore, each
+its own form so one save cannot throw the other box's words away. htmx
+saves without rebuilding the page; TinyMCE stays, because swapping the
+editor out would throw its undo history away. A tab is a link, so the
+choice survives a reload and works with no script. The one difference of
+substance from the create form: the type is a fact rather than a
+question, because it fixed who could be hired and what the founding
+brought, and those rows exist.
 {% endcomment %}
 {% block head_title %}Edit {{ gang.name }}{% endblock head_title %}
 {% comment %}
@@ -22,7 +24,7 @@ reads the config after that listener has run.
           href="{% static 'designsystem/vendor/cropper.min.css' %}">
     <script defer src="{% static 'designsystem/vendor/cropper.min.js' %}"></script>
     <script defer src="{% static 'n26/imagecrop.js' %}"></script>
-    {{ form.media }}
+    {% if tab == "notes" %}{{ notes_form.media }}{% else %}{{ form.media }}{% endif %}
 {% endblock extra_head %}
 {% block nav_switcher %}
     {% gang_switcher gang as gang_switcher_ %}
@@ -32,41 +34,103 @@ reads the config after that listener has run.
     {% include 'n26/_nav.html' with here='gangs' %}
 {% endblock %}
 {% block content %}
-    <c-n26.form-page action="{% url 'n26-edit-gang' gang.pk %}"
-                     :form="form"
-                     title="Edit {{ gang.name }}"
-                     lead="{% if tab == 'notes' %}What the gang says about itself.{% else %}Required fields are marked with an asterisk (*).{% endif %}"
-                     submit_label="{% if tab == 'notes' %}Save notes and lore{% else %}Save changes{% endif %}"
-                     cancel_url="{% url 'n26-gang' gang.pk %}">
-        <c-slot name="breadcrumb">
-            <c-ui.breadcrumbs>
-                <c-ui.breadcrumbs.item>
-                    <c-n26.user-link :user="gang.owner" tone="current" href="{% url 'n26-dashboard' %}" />
-                </c-ui.breadcrumbs.item>
-                <c-ui.breadcrumbs.item href="{% url 'n26-gang' gang.pk %}">{{ gang.name }}</c-ui.breadcrumbs.item>
-                <c-ui.breadcrumbs.item :current="True">
-                    Edit
-                </c-ui.breadcrumbs.item>
-            </c-ui.breadcrumbs>
-        </c-slot>
-        {% csrf_token %}
-        <c-n26.tab-links label="What to edit" :tabs="edit_tabs" />
-        {% if tab == "notes" %}
-            <input type="hidden" name="act" value="story">
-            <c-n26.form-section title="Notes and Lore">
-                {% comment %}
-                The editor wraps itself in the field — label, description and
-                errors ride the component, and a second wrapper would draw the
-                frame twice.
-                {% endcomment %}
-                <c-n26.rich-text :field="form.notes"
-                                 label="Notes"
-                                 description="{{ form.notes.help_text }}" />
-                <c-n26.rich-text :field="form.lore"
-                                 label="Lore"
-                                 description="{{ form.lore.help_text }}" />
+    {% url 'n26-edit-gang' gang.pk as edit_url %}
+    {% if tab == "notes" %}
+        {% comment %}
+        Two forms, not one wrapping page: a form inside a form is not
+        markup, and each box has to post without the other. The column
+        matches form-page's cap so the tab still reads as the same page.
+        {% endcomment %}
+        <div class="max-w-3xl space-y-8">
+            <c-n26.page-header title="Edit {{ gang.name }}" lead="What the gang says about itself.">
+                <c-slot name="breadcrumb">
+                    <c-ui.breadcrumbs>
+                        <c-ui.breadcrumbs.item>
+                            <c-n26.user-link :user="gang.owner" tone="current" href="{% url 'n26-dashboard' %}" />
+                        </c-ui.breadcrumbs.item>
+                        <c-ui.breadcrumbs.item href="{% url 'n26-gang' gang.pk %}">{{ gang.name }}</c-ui.breadcrumbs.item>
+                        <c-ui.breadcrumbs.item :current="True">
+                            Edit
+                        </c-ui.breadcrumbs.item>
+                    </c-ui.breadcrumbs>
+                </c-slot>
+            </c-n26.page-header>
+            <c-n26.tab-links label="What to edit" :tabs="edit_tabs" />
+            <form method="post"
+                  action="{{ edit_url }}"
+                  hx-post="{{ edit_url }}"
+                  hx-swap="none">
+                {% csrf_token %}
+                <input type="hidden" name="act" value="notes">
+                <c-n26.form-section title="Notes">
+                    {% comment %}
+                    The editor wraps itself in the field — label, description
+                    and errors ride the component, and a second wrapper would
+                    draw the frame twice.
+                    {% endcomment %}
+                    <c-n26.rich-text :field="notes_form.notes"
+                                     label="Notes"
+                                     description="{{ notes_form.notes.help_text }}" />
+                    <div class="flex justify-end">
+                        <c-ui.button type="submit" variant="success" size="sm">
+                            Save notes
+                        </c-ui.button>
+                    </div>
+                </c-n26.form-section>
+            </form>
+            <form method="post"
+                  action="{{ edit_url }}"
+                  hx-post="{{ edit_url }}"
+                  hx-swap="none">
+                {% csrf_token %}
+                <input type="hidden" name="act" value="lore">
+                <c-n26.form-section title="Lore">
+                    <c-n26.rich-text :field="lore_form.lore"
+                                     label="Lore"
+                                     description="{{ lore_form.lore.help_text }}" />
+                    <div class="flex justify-end">
+                        <c-ui.button type="submit" variant="success" size="sm">
+                            Save lore
+                        </c-ui.button>
+                    </div>
+                </c-n26.form-section>
+            </form>
+            {% comment %}
+            The picture is its own act — a form inside a form is not markup.
+            {% endcomment %}
+            <c-n26.form-section title="Picture">
+                <c-n26.picture-box action="{{ edit_url }}"
+                                   id="gang-image"
+                                   crop="{{ picture_shape }}"
+                                   max="{{ picture_max }}"
+                                   image_url="{{ picture_url }}"
+                                   alt="A picture of {{ gang.name }}"
+                                   img_class="w-full max-w-md">
+                    Shown on the lore page and against the gang. Picking a
+                    file opens the crop, and using it saves.
+                </c-n26.picture-box>
             </c-n26.form-section>
-        {% else %}
+        </div>
+    {% else %}
+        <c-n26.form-page action="{{ edit_url }}"
+                         :form="form"
+                         title="Edit {{ gang.name }}"
+                         lead="Required fields are marked with an asterisk (*)."
+                         submit_label="Save changes"
+                         cancel_url="{% url 'n26-gang' gang.pk %}">
+            <c-slot name="breadcrumb">
+                <c-ui.breadcrumbs>
+                    <c-ui.breadcrumbs.item>
+                        <c-n26.user-link :user="gang.owner" tone="current" href="{% url 'n26-dashboard' %}" />
+                    </c-ui.breadcrumbs.item>
+                    <c-ui.breadcrumbs.item href="{% url 'n26-gang' gang.pk %}">{{ gang.name }}</c-ui.breadcrumbs.item>
+                    <c-ui.breadcrumbs.item :current="True">
+                        Edit
+                    </c-ui.breadcrumbs.item>
+                </c-ui.breadcrumbs>
+            </c-slot>
+            {% csrf_token %}
+            <c-n26.tab-links label="What to edit" :tabs="edit_tabs" />
             <c-n26.form-section title="General">
                 <c-ui.field label="Gang name *"
                             error="x"
@@ -115,27 +179,6 @@ reads the config after that listener has run.
                                      label="Colour"
                                      description="Shown against the gang wherever it is listed." />
             </c-n26.form-section>
-        {% endif %}
-    </c-n26.form-page>
-    {% if tab == "notes" %}
-        {% comment %}
-        The picture is its own act, outside the form above — a form inside
-        a form is not markup. The column matches the form's cap so the
-        section reads as part of the same page.
-        {% endcomment %}
-        <div class="mt-8 max-w-3xl">
-            <c-n26.form-section title="Picture">
-                <c-n26.picture-box action="{% url 'n26-edit-gang' gang.pk %}"
-                                   id="gang-image"
-                                   crop="{{ picture_shape }}"
-                                   max="{{ picture_max }}"
-                                   image_url="{{ picture_url }}"
-                                   alt="A picture of {{ gang.name }}"
-                                   img_class="w-full max-w-md">
-                    Shown on the lore page and against the gang. Picking a
-                    file opens the crop, and using it saves.
-                </c-n26.picture-box>
-            </c-n26.form-section>
-        </div>
+        </c-n26.form-page>
     {% endif %}
 {% endblock content %}

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -88,7 +88,16 @@ is named by the page's own heading directly below.
         controls on the card beside it all start one.
         {% endcomment %}
         <c-slot name="notes">
-            <form method="post" action="{{ edit_url }}">
+            {% comment %}
+            htmx saves without rebuilding the page, so lore typed in the
+            other box survives this submit. TinyMCE stays: swapping the
+            editor out would throw its undo history away. Without
+            JavaScript this is an ordinary POST.
+            {% endcomment %}
+            <form method="post"
+                  action="{{ edit_url }}"
+                  hx-post="{{ edit_url }}"
+                  hx-swap="none">
                 {% csrf_token %}
                 <input type="hidden" name="act" value="notes">
                 <p class="mb-2 text-sm text-muted">
@@ -117,7 +126,10 @@ is named by the page's own heading directly below.
             </c-n26.picture-box>
         </c-slot>
         <c-slot name="lore">
-            <form method="post" action="{{ edit_url }}">
+            <form method="post"
+                  action="{{ edit_url }}"
+                  hx-post="{{ edit_url }}"
+                  hx-swap="none">
                 {% csrf_token %}
                 <input type="hidden" name="act" value="lore">
                 <p class="mb-2 text-sm text-muted">

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -184,6 +184,78 @@ class TestSavingLore:
         assert vex.lore == ""
 
 
+class TestSavingWithoutRebuildingThePage:
+    """Notes and lore sit on the same screen. Rebuilding it when one
+    saves throws away whatever is typed in the other box, so htmx
+    answers with nothing to draw and a toast — TinyMCE stays put."""
+
+    def asked(self, client, vex, **data):
+        return client.post(edit_url(vex), data, headers={"HX-Request": "true"})
+
+    def test_saving_notes_answers_with_a_toast_and_not_a_page(
+        self, client, tester, gang, vex
+    ):
+        import json
+
+        client.force_login(tester)
+        response = self.asked(
+            client, vex, act="notes", notes="<p>Owes Kaine a favour.</p>"
+        )
+        assert response.status_code == 204
+        assert "<html" not in response.content.decode()
+        said = json.loads(response["HX-Trigger"])["n26-toasts"]
+        assert said[0]["variant"] == "success"
+        assert said[0]["message"] == "Notes saved."
+        vex.refresh_from_db()
+        assert vex.notes == "<p>Owes Kaine a favour.</p>"
+
+    def test_saving_lore_leaves_the_notes_alone(self, client, tester, gang, vex):
+        vex.notes = "<p>Owes Kaine a favour.</p>"
+        vex.save(update_fields=["notes"])
+        client.force_login(tester)
+        self.asked(client, vex, act="lore", lore="<p>Third dome, third life.</p>")
+        vex.refresh_from_db()
+        assert vex.lore == "<p>Third dome, third life.</p>"
+        assert vex.notes == "<p>Owes Kaine a favour.</p>"
+
+    def test_saving_notes_leaves_the_lore_alone(self, client, tester, gang, vex):
+        vex.lore = "<p>Third dome, third life.</p>"
+        vex.save(update_fields=["lore"])
+        client.force_login(tester)
+        self.asked(client, vex, act="notes", notes="<p>Owes Kaine a favour.</p>")
+        vex.refresh_from_db()
+        assert vex.notes == "<p>Owes Kaine a favour.</p>"
+        assert vex.lore == "<p>Third dome, third life.</p>"
+
+    def test_the_boxes_post_in_place(self, client, tester, gang, vex):
+        """Each box is its own form, posting to this page, swapping
+        nothing — so the other editor is not rebuilt."""
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+        assert body.count('hx-swap="none"') == 2
+        assert f'hx-post="{edit_url(vex)}"' in body
+        assert 'name="act" value="notes"' in body
+        assert 'name="act" value="lore"' in body
+        # Skills and the rest still rebuild the page: they are ticks, not
+        # a live editor sitting next to another one.
+        assert "Save notes" in body
+        assert "Save lore" in body
+
+    def test_the_editor_copies_live_content_before_htmx_reads_the_form(self):
+        """TinyMCE keeps what you type in an iframe. htmx serialises the
+        textarea, so without copying first a save would store whatever
+        was in the box when the page loaded."""
+        from pathlib import Path
+
+        import n26.core
+
+        js = (
+            Path(n26.core.__file__).parent / "static" / "n26" / "richtext.js"
+        ).read_text()
+        assert "tinymce.triggerSave()" in js
+        assert 'addEventListener(\n        "submit"' in js
+
+
 class TestThePicture:
     """The picture is an act of its own: a file replaces, the remove
     button clears, and the notes never ride along."""

--- a/n26/core/test_views_edit_gang.py
+++ b/n26/core/test_views_edit_gang.py
@@ -220,20 +220,20 @@ def png_upload(name="banner.png"):
 
 
 class TestNotesLoreAndPicture:
-    """The gang's own written fields and picture, saved with the rest of
-    the form and recorded as acts on the gang itself."""
+    """The gang's own written fields and picture. Notes and lore each
+    save as their own act, so one cannot throw the other away."""
 
     def test_notes_and_lore_save_and_are_recorded(self, client, tester, gang):
         client.force_login(tester)
-        response = client.post(
-            edit_url(gang),
-            {
-                "act": "story",
-                "notes": "<p>Meet at the sump gate.</p>",
-                "lore": "<p>Founded on a debt.</p>",
-            },
+        notes = client.post(
+            edit_url(gang), {"act": "notes", "notes": "<p>Meet at the sump gate.</p>"}
         )
-        assert response.status_code == 302
+        lore = client.post(
+            edit_url(gang), {"act": "lore", "lore": "<p>Founded on a debt.</p>"}
+        )
+        assert notes.status_code == 302
+        assert notes.url == edit_url(gang) + "?tab=notes"
+        assert lore.url == edit_url(gang) + "?tab=notes"
         gang.refresh_from_db()
         assert gang.notes == "<p>Meet at the sump gate.</p>"
         assert gang.lore == "<p>Founded on a debt.</p>"
@@ -241,9 +241,20 @@ class TestNotesLoreAndPicture:
         assert recorded.filter(kind=LedgerEvent.Kind.NOTED).count() == 1
         assert recorded.filter(kind=LedgerEvent.Kind.LORE_EDITED).count() == 1
 
+    def test_saving_notes_leaves_the_lore_alone(self, client, tester, gang):
+        gang.lore = "<p>Founded on a debt.</p>"
+        gang.save(update_fields=["lore"])
+        client.force_login(tester)
+        client.post(
+            edit_url(gang), {"act": "notes", "notes": "<p>Meet at the sump gate.</p>"}
+        )
+        gang.refresh_from_db()
+        assert gang.notes == "<p>Meet at the sump gate.</p>"
+        assert gang.lore == "<p>Founded on a debt.</p>"
+
     def test_an_unchanged_field_writes_no_event(self, client, tester, gang):
         client.force_login(tester)
-        words = {"act": "story", "notes": "<p>same</p>", "lore": ""}
+        words = {"act": "notes", "notes": "<p>same</p>"}
         client.post(edit_url(gang), words)
         client.post(edit_url(gang), words)
         assert (
@@ -254,12 +265,10 @@ class TestNotesLoreAndPicture:
     def test_the_history_says_what_happened_in_gang_words(self, client, tester, gang):
         client.force_login(tester)
         client.post(
-            edit_url(gang),
-            {
-                "act": "story",
-                "notes": "<p>Meet at the sump gate.</p>",
-                "lore": "<p>Founded on a debt.</p>",
-            },
+            edit_url(gang), {"act": "notes", "notes": "<p>Meet at the sump gate.</p>"}
+        )
+        client.post(
+            edit_url(gang), {"act": "lore", "lore": "<p>Founded on a debt.</p>"}
         )
         body = client.get(reverse("n26-gang-history", args=[gang.pk])).content.decode()
         assert (
@@ -288,6 +297,46 @@ class TestNotesLoreAndPicture:
         # The tab strip on both, saying which is current.
         assert "?tab=notes" in general
         assert 'aria-current="page"' in notes_tab
+        # Each box is its own form, posting in place.
+        assert "Save notes" in notes_tab
+        assert "Save lore" in notes_tab
+        assert "Save notes and lore" not in notes_tab
+        assert notes_tab.count('hx-swap="none"') == 2
+        assert "hx-post" not in general
+
+    def test_saving_notes_answers_with_a_toast_and_not_a_page(
+        self, client, tester, gang
+    ):
+        import json
+
+        client.force_login(tester)
+        response = client.post(
+            edit_url(gang),
+            {"act": "notes", "notes": "<p>Meet at the sump gate.</p>"},
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 204
+        said = json.loads(response["HX-Trigger"])["n26-toasts"]
+        assert said[0]["message"] == "Notes saved."
+        gang.refresh_from_db()
+        assert gang.notes == "<p>Meet at the sump gate.</p>"
+
+    def test_saving_lore_answers_with_a_toast_and_not_a_page(
+        self, client, tester, gang
+    ):
+        import json
+
+        client.force_login(tester)
+        response = client.post(
+            edit_url(gang),
+            {"act": "lore", "lore": "<p>Founded on a debt.</p>"},
+            headers={"HX-Request": "true"},
+        )
+        assert response.status_code == 204
+        said = json.loads(response["HX-Trigger"])["n26-toasts"]
+        assert said[0]["message"] == "Lore saved."
+        gang.refresh_from_db()
+        assert gang.lore == "<p>Founded on a debt.</p>"
 
     def test_the_picture_is_stored_removed_and_otherwise_left_be(
         self, client, tester, gang, own_storage

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -228,9 +228,10 @@ def edit_fighter(request, pk):
     one goes through an operation: notes and characteristics price
     nothing and move no rating, but they are part of the gang's story,
     so each writes a journal event and the history can say what the
-    owner did. What the notes editor produced is stored as written and
-    sanitised on the way out, so a tightened allowlist reaches old
-    notes too.
+    owner did. Notes and lore each save on their own, and htmx leaves
+    the page as drawn so typing in one box survives saving the other.
+    What the notes editor produced is stored as written and sanitised
+    on the way out, so a tightened allowlist reaches old notes too.
 
     The subtypes and rules box edits what the model *is*: ticking adds
     in the owner's name, clearing stores a removal whatever route the
@@ -257,6 +258,7 @@ def edit_fighter(request, pk):
     from n26.core.render import render_gang, roster, summarise_roster
     from n26.core.views.choose import link_slots
     from n26.core.views.gangs import _fighter_named
+    from n26.core.views.htmx import stay_or_redirect
     from n26.core.views.learn import apply_ticks, link_skills, ticked_offer
 
     miniature = _own_miniature_or_404(request, pk)
@@ -391,7 +393,9 @@ def edit_fighter(request, pk):
                 op.edit_lore(miniature, form.cleaned_data["lore"])
             record(request, N26Noun.MODEL, EventVerb.UPDATE, miniature, lore=True)
             messages.success(request, "Lore saved.")
-        return redirect("n26-edit-fighter", pk=miniature.pk)
+        return stay_or_redirect(
+            request, reverse("n26-edit-fighter", args=[miniature.pk])
+        )
     elif request.method == "POST" and request.POST.get("act") == "notes":
         form = FighterNotesForm(request.POST)
         if form.is_valid():
@@ -399,7 +403,9 @@ def edit_fighter(request, pk):
                 op.edit_notes(miniature, form.cleaned_data["notes"])
             record(request, N26Noun.MODEL, EventVerb.UPDATE, miniature, notes=True)
             messages.success(request, "Notes saved.")
-        return redirect("n26-edit-fighter", pk=miniature.pk)
+        return stay_or_redirect(
+            request, reverse("n26-edit-fighter", args=[miniature.pk])
+        )
     elif request.method == "POST" and request.POST.get("act") == "picture":
         form = PictureForm(request.POST, request.FILES, ratio=PORTRAIT)
         if form.is_valid():

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -606,11 +606,16 @@ def edit_gang(request, pk):
     operation so ``settle`` recomputes the credits from the ledger —
     the budget less everything actually spent — and refuses a budget
     the spending history cannot fit, unwinding the whole change.
+
+    Notes and lore each have their own form and save. htmx leaves the
+    page as drawn so typing in one box survives saving the other; a
+    full submit lands back on this tab.
     """
     from n26.analytics import EventVerb, N26Noun, record
-    from n26.core.forms import EditGangForm, GangStoryForm, PictureForm
+    from n26.core.forms import EditGangForm, GangLoreForm, GangNotesForm, PictureForm
     from n26.core.images import LANDSCAPE, MAX_PX
     from n26.core.operations import NotEnoughCredits, operation
+    from n26.core.views.htmx import stay_or_redirect
 
     gang = _own_gang_or_404(request, pk)
     at = reverse("n26-edit-gang", args=[gang.pk])
@@ -649,15 +654,22 @@ def edit_gang(request, pk):
             for wrong in form.errors.get("image", []):
                 messages.error(request, wrong)
         return redirect(f"{at}?tab=notes")
-    elif request.method == "POST" and request.POST.get("act") == "story":
-        form = GangStoryForm(request.POST)
+    elif request.method == "POST" and request.POST.get("act") == "notes":
+        form = GangNotesForm(request.POST)
         if form.is_valid():
             with operation(gang, actor=request.user) as op:
                 op.edit_gang_notes(form.cleaned_data["notes"])
+            record(request, N26Noun.GANG, EventVerb.UPDATE, gang, notes=True)
+            messages.success(request, "Notes saved.")
+        return stay_or_redirect(request, f"{at}?tab=notes")
+    elif request.method == "POST" and request.POST.get("act") == "lore":
+        form = GangLoreForm(request.POST)
+        if form.is_valid():
+            with operation(gang, actor=request.user) as op:
                 op.edit_gang_lore(form.cleaned_data["lore"])
-            record(request, N26Noun.GANG, EventVerb.UPDATE, gang, story=True)
-            messages.success(request, f"Saved {gang.name}.")
-            return redirect("n26-gang", pk=gang.pk)
+            record(request, N26Noun.GANG, EventVerb.UPDATE, gang, lore=True)
+            messages.success(request, "Lore saved.")
+        return stay_or_redirect(request, f"{at}?tab=notes")
     elif request.method == "POST" and not request.POST.get("act"):
         form = EditGangForm(gang, request.POST)
         if form.is_valid():
@@ -694,7 +706,7 @@ def edit_gang(request, pk):
                 messages.success(request, f"Saved {gang.name}.")
                 return redirect("n26-gang", pk=gang.pk)
     elif tab == "notes":
-        form = GangStoryForm(initial={"notes": gang.notes, "lore": gang.lore})
+        form = None
     else:
         form = EditGangForm(
             gang,
@@ -706,9 +718,10 @@ def edit_gang(request, pk):
         )
 
     # A failed save re-renders on the tab its form lives on, whatever
-    # the address said.
+    # the address said. Notes and lore each redirect (or stay, under
+    # htmx) and never reach here.
     if request.method == "POST":
-        tab = "notes" if request.POST.get("act") == "story" else "general"
+        tab = "general"
 
     return render(
         request,
@@ -716,6 +729,8 @@ def edit_gang(request, pk):
         {
             "gang": gang,
             "form": form,
+            "notes_form": GangNotesForm(initial={"notes": gang.notes}),
+            "lore_form": GangLoreForm(initial={"lore": gang.lore}),
             "wealth": gang.wealth,
             "tab": tab,
             # The crop spec the picture box stamps onto the browser's

--- a/n26/core/views/htmx.py
+++ b/n26/core/views/htmx.py
@@ -20,20 +20,24 @@ The pattern, end to end:
   :func:`with_toasts` drains them into the ``HX-Trigger`` response header as
   one ``n26-toasts`` event; the client shows them as toasts
   (``n26/core/static/n26/htmx_support.js``). A response that changes nothing
-  on the page is :func:`no_update` — a 204 carrying only that header.
+  on the page is :func:`no_update` — a 204 carrying only that header. That is
+  also the answer when the page must keep a live editor: swapping the box
+  out would rebuild TinyMCE and throw away whatever is typed in the other
+  one. :func:`stay_or_redirect` is that 204, or a redirect without htmx.
 - The URL stays the authority on UI state. A response that opens or closes a
   panel sets ``HX-Replace-Url`` to the address that renders that state, so a
   reload draws the same screen and links keep working.
 
-The equip screens are the pattern's first use — ``n26.core.views.equip``
-builds their update responses; this module holds only the parts any screen
-would need.
+The equip screens were the pattern's first use — ``n26.core.views.equip``
+builds their update responses; notes and lore saves use :func:`no_update`
+so the editors stay. This module holds only the parts any screen would need.
 """
 
 import json
 
 from django.contrib.messages import get_messages
 from django.http import HttpResponse
+from django.shortcuts import redirect
 
 #: How long a toast stays before it dismisses itself. An error toast is
 #: given no timeout at all: the reason a click did nothing is worth more
@@ -77,6 +81,21 @@ def no_update(request):
     """A response that changes nothing on the page.
 
     204, plus any queued messages as toasts — the one channel a refusal
-    still has into a page that is not re-rendered.
+    still has into a page that is not re-rendered, and the answer a
+    successful save uses when the page must keep a live editor.
     """
     return with_toasts(request, HttpResponse(status=204))
+
+
+def stay_or_redirect(request, to):
+    """Finish an act: leave the page as drawn, or go ``to`` without htmx.
+
+    The notes and lore boxes keep a live TinyMCE editor. Rebuilding the
+    page would throw away whatever is typed in the other box, so a save
+    that htmx sent answers with :func:`no_update` — the confirmation is
+    a toast, the editors stay. Without JavaScript the same act is a
+    redirect, as every other form on the site is.
+    """
+    if is_htmx(request):
+        return no_update(request)
+    return redirect(to)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Saving notes or lore on a fighter or gang used to rebuild the whole page, so anything typed in the other TinyMCE box vanished.

Notes and lore now each have their own form and save. With JavaScript, htmx posts in place (`hx-swap=none`) and the confirmation is a toast, so TinyMCE is left standing. Without JavaScript the same submit still lands back on the edit page. The gang notes tab is no longer one combined “Save notes and lore”.

TinyMCE is not swapped out or replaced: it keeps what you type in an iframe, so `richtext.js` copies that into the textarea on submit before htmx serialises the form.

**How to try it**
- Open a fighter’s edit page. Type in both Notes and Lore, save one, and check the other still has what you typed. A toast should say it saved; the page should not reload.
- Same on a gang’s Edit → Notes and Lore tab. Each box has its own Save. Saving notes must not clear lore, and the other way around.

[Fighter edit: notes saved toast, lore still in its editor](https://cursor.com/agents/bc-9229dd13-c527-5eb6-a8e1-50eb31226871/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffighter-notes-saved.png)
[Gang notes tab: separate Save notes and Save lore, notes saved toast](https://cursor.com/agents/bc-9229dd13-c527-5eb6-a8e1-50eb31226871/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgang-notes-saved.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQDG3RRN2/p1787802544861859?thread_ts=1787802544.861859&cid=C0BQDG3RRN2)

<div><a href="https://cursor.com/agents/bc-9229dd13-c527-5eb6-a8e1-50eb31226871?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9229dd13-c527-5eb6-a8e1-50eb31226871&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

