### PR TITLE
docs: tell agents how to log in locally via a session cookie

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -2,7 +2,8 @@
 description: |
   Knowledge about starting, stopping, and connecting to the Gyrinx dev server. Load this skill when
   you need to start the dev server, tell Claude in Chrome where to point, check if the server is
-  running, or read dev server logs. Also useful when debugging port conflicts or server startup issues.
+  running, or read dev server logs. Also useful when debugging port conflicts or server startup issues,
+  and when an agent needs to log in to the local app for browser testing.
 ---
 
 # Dev Server
@@ -138,3 +139,77 @@ echo "http://localhost:$(worktree_port)"
 
 The CSRF_TRUSTED_ORIGINS in `settings_dev.py` dynamically includes the worktree port, so
 form submissions work correctly on any port.
+
+## Logging in for browser testing
+
+Do **not** submit `/accounts/login/` from an agent session. The form always includes
+reCAPTCHA v3 (`gyrinx.account_forms.LoginForm`). Computer-use cannot complete that
+challenge, empty `RECAPTCHA_*` keys in `.env` do not skip it, and pytest only passes
+because tests mock `django_recaptcha.fields.ReCaptchaField.validate`. Two more traps
+sit behind a successful POST: `ACCOUNT_EMAIL_VERIFICATION = "mandatory"`, and
+`manage ensuresuperuser` does not create a verified allauth `EmailAddress`.
+`/admin/login/` redirects into the same allauth form.
+
+Cloud Agent `.cursor/install.sh` runs `setupenv` but not `ensuresuperuser`, so there
+may be no users in the database. Do not guess `tom` / `admin` / the password in `.env`.
+
+Mint a session cookie instead. From the repo root with the venv active (the same
+path `scripts/screenshot.py` uses):
+
+```bash
+python <<'PY'
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gyrinx.settings_dev")
+django.setup()
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import Client
+from allauth.account.models import EmailAddress
+
+User = get_user_model()
+username = os.environ.get("AGENT_LOGIN_AS", "agent")
+email = f"{username}@localhost"
+u, created = User.objects.get_or_create(
+    username=username,
+    defaults={"email": email, "is_staff": True, "is_superuser": True},
+)
+if created:
+    u.set_password("password")
+u.is_staff = True
+u.is_superuser = True
+if not u.email:
+    u.email = email
+u.save()
+EmailAddress.objects.get_or_create(
+    user=u, email=u.email, defaults={"verified": True, "primary": True},
+)
+client = Client()
+client.force_login(u)
+cookie = client.cookies[settings.SESSION_COOKIE_NAME]
+print(f"{settings.SESSION_COOKIE_NAME}={cookie.value}")
+print(f"user={u.username}")
+PY
+```
+
+`settings_dev.py` names the cookie `gyrinx_sessionid_<DJANGO_PORT>` (and the CSRF
+cookie `gyrinx_csrftoken_<port>`) so worktrees on different ports do not overwrite
+each other. Setting a cookie called `sessionid` does nothing.
+
+**curl** (replace the name and value with what the snippet printed):
+
+```bash
+curl -sS -D - -o /dev/null -b 'gyrinx_sessionid_8000=…' http://localhost:8000/n26/design/ | head
+```
+
+A staff session returns `200` on `/n26/design/`; anonymous is `302` to `/accounts/login/`.
+
+**Browser / computer-use:**
+
+1. Open any page on `http://localhost:<port>/` first, so the cookie is set on the
+   right origin.
+2. In the DevTools console: `document.cookie = "<name>=<value>; path=/";`
+3. Navigate to the page under test. Confirm the nav shows the username.
+
+n26's gallery (`/n26/design/…`) and authoring screens are `staff_member_required`.
+The snippet sets `is_staff`. To inspect gangs owned by an existing user, rerun it
+with `AGENT_LOGIN_AS=<their username>` — `force_login` does not need their password.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,10 @@ there — deliberately a pointer rather than a copy, so the two cannot drift apa
 
 GitHub Copilot additionally reads [.github/copilot-instructions.md](.github/copilot-instructions.md)
 and the path-scoped files under [.github/instructions/](.github/instructions/).
+
+## Cursor Cloud specific instructions
+
+Local login in a Cloud Agent (reCAPTCHA on `/accounts/login/`, port-suffixed
+session cookies, minting a staff session) is documented in
+[CLAUDE.md](CLAUDE.md) under **Logging in locally**. Do not POST the login form;
+load the `dev-server` skill and mint a session cookie.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,13 +170,85 @@ Skills are loaded automatically by agents that need them. They can also be refer
   (implement / acknowledge / decline), plan changes, and implement approved fixes. Invoke with
   `/pr-feedback [PR number or URL]`. Uses the `pr-comments` fetch script for data.
 - **dev-server** — Knowledge about starting/stopping the dev server, reading ports, telling Claude in Chrome
-  where to point, log file locations
+  where to point, log file locations, **and how to mint a session cookie for the browser**. Do not POST
+  `/accounts/login/` from an agent session; reCAPTCHA and mandatory email verification block it.
 - **worktree-db** — Knowledge about per-worktree database isolation: forking, resetting, migrating, cleanup,
   template workflow, pgAdmin access
 
 ## Browser automation
 
 Only use ONE of Chrome DevTools MCP or Claude in Chrome MCP in a session — they cannot work together. Prefer Claude in Chrome for browser testing.
+
+### Logging in locally
+
+The allauth form at `/accounts/login/` is not a reliable way in for an agent.
+`LoginForm` always carries reCAPTCHA v3 (`gyrinx/account_forms.py`); computer-use
+and curl cannot complete it, and tests only pass because they mock
+`django_recaptcha.fields.ReCaptchaField.validate`. Email verification is
+`mandatory`, and `manage ensuresuperuser` does not create a verified
+`EmailAddress`. `/admin/login/` redirects into the same form.
+
+Cloud Agent install (`.cursor/install.sh`) runs `setupenv` but not
+`ensuresuperuser`, so the database may have no users at all. Do not guess
+usernames (`tom`, `admin`) or passwords from `.env`.
+
+Mint a session instead. From the repo root, with the venv active:
+
+```bash
+python <<'PY'
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gyrinx.settings_dev")
+django.setup()
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import Client
+from allauth.account.models import EmailAddress
+
+User = get_user_model()
+username = os.environ.get("AGENT_LOGIN_AS", "agent")
+email = f"{username}@localhost"
+u, created = User.objects.get_or_create(
+    username=username,
+    defaults={"email": email, "is_staff": True, "is_superuser": True},
+)
+if created:
+    u.set_password("password")
+u.is_staff = True
+u.is_superuser = True
+if not u.email:
+    u.email = email
+u.save()
+EmailAddress.objects.get_or_create(
+    user=u, email=u.email, defaults={"verified": True, "primary": True},
+)
+client = Client()
+client.force_login(u)
+cookie = client.cookies[settings.SESSION_COOKIE_NAME]
+print(f"{settings.SESSION_COOKIE_NAME}={cookie.value}")
+print(f"user={u.username}")
+PY
+```
+
+The cookie name is `gyrinx_sessionid_<DJANGO_PORT>` (see `settings_dev.py`), not
+`sessionid`. Setting the default name is a silent no-op.
+
+**curl:** `curl -b "$COOKIE" http://localhost:8000/n26/`
+
+**Browser / computer-use:** open any `http://localhost:<port>/` page so the
+origin is right, then in the console:
+
+```js
+document.cookie = "gyrinx_sessionid_8000=<value>; path=/";
+```
+
+Use the name the snippet printed. Navigate to the page under test. n26's gallery
+(`/n26/design/`) and authoring screens are `staff_member_required`; the snippet
+sets `is_staff`. To use an existing account that already owns gangs, run the
+same snippet with `AGENT_LOGIN_AS=<username>` — `force_login` does not need
+their password.
+
+This is the same cookie `scripts/screenshot.py` mints. The full SOP lives in
+`.claude/skills/dev-server/SKILL.md`.
 
 ## Long sessions
 
@@ -217,6 +289,8 @@ titles, which should freely name model classes, functions and flags.
 2. **Start the dev server** (`./scripts/dev.sh`) near the start of any coding session —
    don't wait to be asked. Share the URL (per-worktree port, printed in the startup
    banner) so changes can be tested in the browser as they land.
+   If the page needs a signed-in user, **mint a session cookie** — do not submit
+   `/accounts/login/`. See **Logging in locally** below, or load the `dev-server` skill.
 3. **Label the issue (Claude Code on the Web only):** If working on a GitHub issue in a Claude Code for Web session
    (`CLAUDE_CODE_REMOTE=true`), label it so the team knows it's being handled:
    `gh issue edit <NUMBER> --add-label claude-code-web`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agents trying to exercise the local app in a browser keep failing at `/accounts/login/`. The allauth `LoginForm` always includes reCAPTCHA v3, email verification is mandatory, `ensuresuperuser` does not create a verified `EmailAddress`, `/admin/login/` redirects into the same form, and `settings_dev.py` names the session cookie `gyrinx_sessionid_<port>` rather than `sessionid`. Cloud Agent install also never runs `ensuresuperuser`, so the database may have no users at all.

The agent docs now say not to POST that form. They give a copy-paste snippet that `get_or_create`s a staff user with a verified email, mints a session via `Client.force_login` (the same path `scripts/screenshot.py` uses), and prints the cookie to set in curl or the browser console. `AGENT_LOGIN_AS` selects an existing account when the page under test belongs to someone else.

**How to try it:** from the repo root with the venv active, run the snippet in `CLAUDE.md` under **Logging in locally**. Then `curl -b "$COOKIE" http://localhost:8000/n26/design/` — staff gets 200, anonymous is 302 to `/accounts/login/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a041d4-730f-748d-9d43-fb634b0b0f90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a041d4-730f-748d-9d43-fb634b0b0f90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

