### PR TITLE
feat: convert Outcast Affiliation onto slots and picks

### DIFF
--- a/.claude/notes/affiliation-conversion-eval.md
+++ b/.claude/notes/affiliation-conversion-eval.md
@@ -2,7 +2,9 @@
 
 An evaluation, not a plan to run. Measured from production on
 2026-08-27, read-only. The other four chosen kinds have already moved;
-Affiliation is what is left.
+Affiliation is what is left. The how — batched runner, the window,
+each system's apply — is
+[`affiliation-conversion-plan.md`](affiliation-conversion-plan.md).
 
 **It should move.** Not as one slot type named Affiliation covering
 everything the kind currently holds — as three systems, the same split
@@ -204,8 +206,9 @@ not both a Helot Cult and a corrupted house.
    either. Paths taught this — the capture check caught `min_picks=1`
    on the first rehearsal.
 5. **A corruption suppresses house rules and opens its own lists.**
-   The modifiers move with the pickable. Shared modifiers (Brutes/Pets
-   removal, the rules-stripping hidden) stay shared.
+   The modifiers are shared onto the pickable (not moved, until
+   cleanup). Shared modifiers (Brutes/Pets removal, the rules-stripping
+   hidden) stay shared.
 6. **Chaos Corrupted is what asks the god question.** Helot Cult asks
    it independently via its own hidden. Two grants of one slot type,
    not two types.
@@ -218,7 +221,7 @@ not both a Helot Cult and a corrupted house.
 # System 1
 create slot type "Affiliation", refusing repeats
 create pickables Clanless, Clan House, Mutant, Aranthian
-  (move their modifiers; Clan House's offer becomes a grant of the house slot)
+  (share their modifiers; Clan House's offer becomes a grant of the house slot)
 create picklist "Affiliations"
 create slot "Affiliation", landing on the gang, 1..1
 on hidden "Affiliation": replace the offer with a grant of that slot
@@ -230,25 +233,27 @@ create slot "Clan House", landing on the gang, 1..1
   granted by the Clan House pickable
 rewrite 79 Outcast + 22 house picks
 
-# System 2 — after, or with, system 3
-create slot type "Variant", refusing repeats
-create pickables Chaos Corrupted, Genestealer Cult Corrupted, Malstrain Corrupted
-  (not None)
-create picklist "Variants"
-create slot "Variant", landing on the gang, 0..1
-on the seven gang types: replace "Offer Variants" with a grant of that slot
-rewrite 65 corruption picks
-delete 187 live "None" picks (and 17 archived), declared on the page
-
-# System 3 — with or immediately before system 2
+# System 3 — before Variants, both doors
 create slot type "Chaos God", refusing repeats
 create pickables Architect of Fate, Blood God, Dark Prince, Plague Lord
 create picklist "Chaos Gods"
 create slot "Chaos God", landing on the gang, 0..1
-  (Helots do not nag; corrupted gangs that picked Chaos Corrupted do)
-on hidden "Chaos God — Helots": replace the offer with a grant
-on pickable Chaos Corrupted: replace the offer with a grant of the same slot
+  on hidden "Chaos God — Helots"
+create slot "Chaos God", landing on the gang, 0..1
+  on the Chaos Corrupted affiliation (both doors in this run;
+  neither nags — the offers did not)
 rewrite 57 god picks
+
+# System 2 — last
+create slot type "Variant", refusing repeats
+create pickables Chaos Corrupted, Genestealer Cult Corrupted, Malstrain Corrupted
+  (not None; share modifiers, including Chaos Corrupted's Chaos God grant)
+create picklist "Variants"
+create slot "Variant", landing on the gang, 0..1
+on the seven gang types: replace "Offer Variants" with a grant of that slot
+rewrite 65 corruption picks
+archive 187 live "None" picks (and 17 archived); pages capture equal
+  under a conversion-local comparator
 ```
 
 Nothing of the old kind is deleted in these runs. The 18 Affiliation
@@ -274,49 +279,47 @@ other word that would have moved was a refusal.
 Declare the rewording on each system's page. Pin it with a story test.
 Do not fold Variant into Affiliation to avoid the reword.
 
-## Decisions that need taking before a first PR
+## Decisions, taken
 
-**"None".** Delete the 187 live (and 17 archived) picks, slot
-`min_picks=0`. An open optional Variant and a picked None must capture
-equal. This is the one place a conversion *means* to change a page's
-stored answers; the proof is that the pages match *minus exactly
-those*. Name every gang on the preview.
+Locked in the conversion plan. Short form:
 
-**Aranthian Gangers.** Keep the modifier as authored (capture stays
-empty) or correct it as a named exception. Do not silently fix it
-inside the rewrite.
+**"None".** Archive the 187 live (and 17 archived) picks, slot
+`min_picks=0`. An open optional Variant and a picked None capture
+equal under a conversion-local comparator. Preview names every gang
+whose stored answer is cleared.
 
-**Clan House as its own slot type.** Yes. It is a different question,
-opened by a pick, retracted through cause. Putting it on the
-Affiliation type would make a house pick's kind word "affiliation"
-after conversion, which is worse than today only in that we had the
-chance to tell the truth.
+**Aranthian Gangers.** Keep the modifier as authored. Do not silently
+fix it inside the rewrite.
 
-**Repeats.** All three types refuse them. A gang has one affiliation,
-one variant, one god. Nothing in production holds two of the same
-question.
+**Clan House as its own slot type.** Yes.
 
-**The four Leader-style copies.** There aren't any. Affiliation is one
-hidden on one gang type; Variant is one shared modifier on seven types;
-Chaos God is two grants of one slot. No per-profile wart to preserve.
+**Repeats.** All four types (Affiliation, Clan House, Variant, Chaos
+God) refuse them.
 
-**Rebuild the conversion engine.** #2287 deleted it after the five
-runs. `n26.core.capture.gang_state` is still here — the proof half.
-The plan/apply half (CreatePickable, SwapCarrier, CreateSlot,
-RewritePick, the console runner, the refuse-and-unwind) is not. A new
-Affiliation conversion is a new maintenance operation in that shape,
-not a resurrection of the old module. Paths' first run shipping as a
-migration is the thing not to repeat; the console-after-deploy
-discipline in `backfill-lessons.md` is the one to copy.
+**The four Leader-style copies.** There aren't any.
+
+**Runner.** Do not resurrect the deleted one-transaction engine.
+Library swap uses `_run_recorded` (spread, refuse-and-unwind). Player
+rewrite uses `run_batched` (one gang per `do_one`, frozen pk list).
+Modifiers are **shared** onto pickables until cleanup, not moved —
+the window between swap and rewrite would otherwise strip payload.
+The dual-read shim that covers that window is specified in the plan.
 
 ## Engine work
 
-Nothing new in the player engine. `_choose_for_slot` already routes a
-pick to the gang when the slot says so; chained grants already retract
-through cause; optional slots already offer a None row; `has_pickable`
+Nothing new in the player engine except the temporary dual-read shim
+specified in the conversion plan (`_fill_slot_choices`, query-free,
+deleted at cleanup). `_choose_for_slot` already routes a pick to the
+gang when the slot says so; chained grants already retract through
+cause; optional slots already offer a None row; `has_pickable`
 already exists (and is the condition Affiliation never had — today
 nothing can say "models whose gang picked Malstrain" except by hanging
 the behaviour on Malstrain itself).
+
+The runner is not a resurrection of `n26.library.conversion`. Library
+swap is `_run_recorded`; player rewrite is `run_batched` with a
+prologue. Capture (`n26.core.capture.gang_state`) is still here. The
+plan/apply step helpers are new and small.
 
 Authoring already refuses a bare pickable built in. Recipes and
 `concepts.md` still teach Affiliation as the way to author a gang-level
@@ -346,12 +349,13 @@ Per system, the suite that already exists is the shape to follow:
 - `test_gang_books.py` builds Chaos corruption as an Affiliation. It
   follows system 2.
 
-Then the standing rule: capture every reached gang's pages before and
-after; refuse and unwind on any difference (with the declared "None"
-removals and any declared Aranthian correction as the only allowed
-diffs); every touched gang reconciles. History is pinned per system
-with a same-words test, plus a declared-rewording test for Variant and
-Chaos God.
+Then the standing rule, now split across the two phases: the library
+prologue captures a spread and unwinds on any difference; the batched
+walk captures **every** reached gang and refuses that gang on a diff
+(None equals unanswered Variant under a conversion-local comparator;
+Aranthian is not an exception). Every touched gang reconciles. History
+is pinned per system with a same-words test, plus a declared-rewording
+test for Variant, Chaos God, and Clan House.
 
 Volume, so the sample can be sized:
 
@@ -371,28 +375,29 @@ every None.
 
 ## Order of battle
 
-1. **Rebuild the conversion runner** — plan/apply, capture, refuse in
-   words, console operation, one lock, delete nothing. No system in
-   the first PR; a Paths-shaped no-op against a database that has
-   nothing to convert is the test.
+The conversion plan is the authority on the apply. Short form:
+
+1. **Machinery, no system** — dual-read shim, batched prologue,
+   small step helpers. No Affiliation row is rewritten.
 2. **Outcast Affiliation + Clan House.** Independent of the others,
    sandbox already green, no None, no shared-across-types offer. The
    chain is the thing to prove. 101 picks rewritten.
-3. **Chaos God**, Helot door only if Variants is not ready; both doors
-   if it is. Empty pickables, optional on Helots (`min_picks=0` — 52 of
-   81 have not answered, and the offer does not nag).
-4. **Variants**, which adds the second Chaos God door on the Chaos
-   Corrupted pickable. The "None" clearing is this system's declared
-   change. Shared modifier on seven gang types, same swap Gang Legacy
-   already did.
+3. **Chaos God, both doors**, before Variants. Empty pickables,
+   `min_picks=0` on Helots *and* on the Chaos Corrupted grant (the
+   inner offer never nagged either).
+4. **Variants**, which shares the already-swapped Chaos God grant
+   onto the Chaos Corrupted pickable. The "None" clearing is this
+   system's declared ledger change. Shared modifier on seven gang
+   types; `SwapSharedCarrier` with `reach=gang_alone`.
 5. **Cleanup, later, separate.** Empty the 18 kind rows, the four
    menus, the two fossil offers, the Variant hidden. Drop Affiliation
    from `OFFERABLE_KINDS`, `LEAF_KINDS`, `ENTRY_ASSIGNABLE_FIELDS`,
-   recipes, concepts. Then drop the model and the Assignment column,
-   the way #2314 dropped Archetype/SkillTree/Specialisation.
+   recipes, concepts. Delete the shim. Then drop the model and the
+   Assignment column, the way #2314 dropped
+   Archetype/SkillTree/Specialisation.
 
-Do not convert all three in one operation. The chains cross 2 and 3;
-1 is free. One PR and deploy per system, same as last time.
+Do not convert all three in one operation. One PR and deploy per
+system, same as last time.
 
 ## What would make this the wrong next step
 
@@ -411,4 +416,5 @@ for new gang-level choices, stop here: the three systems can stay, the
 column can stay, and slots are for new domains only. That is a coherent
 position. It is also how we got Gang Legacy stored as Archetype.
 
-The recommendation is the split, system 1 first.
+The recommendation is the split, system 1 first, batched. See
+[`affiliation-conversion-plan.md`](affiliation-conversion-plan.md).

--- a/.claude/notes/affiliation-conversion-eval.md
+++ b/.claude/notes/affiliation-conversion-eval.md
@@ -2,8 +2,8 @@
 
 An evaluation, not a plan to run. Measured from production on
 2026-08-27, read-only. The other four chosen kinds have already moved;
-Affiliation is what is left. The how — batched runner, the window,
-each system's apply — is
+Affiliation is what is left. The how — one flip per system, then a
+batched check — is
 [`affiliation-conversion-plan.md`](affiliation-conversion-plan.md).
 
 **It should move.** Not as one slot type named Affiliation covering
@@ -206,8 +206,8 @@ not both a Helot Cult and a corrupted house.
    either. Paths taught this — the capture check caught `min_picks=1`
    on the first rehearsal.
 5. **A corruption suppresses house rules and opens its own lists.**
-   The modifiers are shared onto the pickable (not moved, until
-   cleanup). Shared modifiers (Brutes/Pets removal, the rules-stripping
+   The modifiers move with the pickable in the same transaction as the
+   rewrite. Shared modifiers (Brutes/Pets removal, the rules-stripping
    hidden) stay shared.
 6. **Chaos Corrupted is what asks the god question.** Helot Cult asks
    it independently via its own hidden. Two grants of one slot type,
@@ -221,7 +221,7 @@ not both a Helot Cult and a corrupted house.
 # System 1
 create slot type "Affiliation", refusing repeats
 create pickables Clanless, Clan House, Mutant, Aranthian
-  (share their modifiers; Clan House's offer becomes a grant of the house slot)
+  (move their modifiers; Clan House's offer becomes a grant of the house slot)
 create picklist "Affiliations"
 create slot "Affiliation", landing on the gang, 1..1
 on hidden "Affiliation": replace the offer with a grant of that slot
@@ -247,7 +247,7 @@ rewrite 57 god picks
 # System 2 — last
 create slot type "Variant", refusing repeats
 create pickables Chaos Corrupted, Genestealer Cult Corrupted, Malstrain Corrupted
-  (not None; share modifiers, including Chaos Corrupted's Chaos God grant)
+  (not None; move modifiers, including Chaos Corrupted's Chaos God grant)
 create picklist "Variants"
 create slot "Variant", landing on the gang, 0..1
 on the seven gang types: replace "Offer Variants" with a grant of that slot
@@ -298,28 +298,25 @@ God) refuse them.
 
 **The four Leader-style copies.** There aren't any.
 
-**Runner.** Do not resurrect the deleted one-transaction engine.
-Library swap uses `_run_recorded` (spread, refuse-and-unwind). Player
-rewrite uses `run_batched` (one gang per `do_one`, frozen pk list).
-Modifiers are **shared** onto pickables until cleanup, not moved —
-the window between swap and rewrite would otherwise strip payload.
-The dual-read shim that covers that window is specified in the plan.
+**Runner.** One write per system: create, move modifiers, swap, rewrite
+every pick, in one transaction, with the reached gangs locked. Prove a
+spread in that transaction and unwind on a diff. `run_batched` walks
+every reached gang afterwards and reconciles — it does not drip the
+switch. No dual-read, no per-gang flag, no dormant slots.
 
 ## Engine work
 
-Nothing new in the player engine except the temporary dual-read shim
-specified in the conversion plan (`_fill_slot_choices`, query-free,
-deleted at cleanup). `_choose_for_slot` already routes a pick to the
-gang when the slot says so; chained grants already retract through
-cause; optional slots already offer a None row; `has_pickable`
+Nothing new in the player engine. `_choose_for_slot` already routes a
+pick to the gang when the slot says so; chained grants already retract
+through cause; optional slots already offer a None row; `has_pickable`
 already exists (and is the condition Affiliation never had — today
 nothing can say "models whose gang picked Malstrain" except by hanging
 the behaviour on Malstrain itself).
 
-The runner is not a resurrection of `n26.library.conversion`. Library
-swap is `_run_recorded`; player rewrite is `run_batched` with a
-prologue. Capture (`n26.core.capture.gang_state`) is still here. The
-plan/apply step helpers are new and small.
+Put back a small `n26.library.conversion` — frozen plan, typed steps,
+one apply — not the 7,000-line module #2287 deleted. Console operations
+call it through `_run_recorded`, then enqueue `run_batched` for the
+reconcile walk. Capture (`n26.core.capture.gang_state`) is still here.
 
 Authoring already refuses a bare pickable built in. Recipes and
 `concepts.md` still teach Affiliation as the way to author a gang-level
@@ -349,13 +346,13 @@ Per system, the suite that already exists is the shape to follow:
 - `test_gang_books.py` builds Chaos corruption as an Affiliation. It
   follows system 2.
 
-Then the standing rule, now split across the two phases: the library
-prologue captures a spread and unwinds on any difference; the batched
-walk captures **every** reached gang and refuses that gang on a diff
-(None equals unanswered Variant under a conversion-local comparator;
-Aranthian is not an exception). Every touched gang reconciles. History
-is pinned per system with a same-words test, plus a declared-rewording
-test for Variant, Chaos God, and Clan House.
+Then the standing rule: the write captures a spread and unwinds on any
+difference (None equals unanswered Variant under a conversion-local
+comparator; Aranthian is not an exception). Every reached gang
+reconciles in that transaction, and again on a batched walk after it
+commits. On a fork, every reached gang's pages are diffed from outside
+the run. History is pinned per system with a same-words test, plus a
+declared-rewording test for Variant, Chaos God, and Clan House.
 
 Volume, so the sample can be sized:
 
@@ -377,24 +374,23 @@ every None.
 
 The conversion plan is the authority on the apply. Short form:
 
-1. **Machinery, no system** — dual-read shim, batched prologue,
-   small step helpers. No Affiliation row is rewritten.
+1. **Machinery, no system** — small conversion module, apply helper,
+   spread capture, batched reconcile. No Affiliation row is rewritten.
 2. **Outcast Affiliation + Clan House.** Independent of the others,
    sandbox already green, no None, no shared-across-types offer. The
    chain is the thing to prove. 101 picks rewritten.
 3. **Chaos God, both doors**, before Variants. Empty pickables,
    `min_picks=0` on Helots *and* on the Chaos Corrupted grant (the
    inner offer never nagged either).
-4. **Variants**, which shares the already-swapped Chaos God grant
-   onto the Chaos Corrupted pickable. The "None" clearing is this
-   system's declared ledger change. Shared modifier on seven gang
-   types; `SwapSharedCarrier` with `reach=gang_alone`.
+4. **Variants**, which moves the already-swapped Chaos God grant onto
+   the Chaos Corrupted pickable. The "None" clearing is this system's
+   declared ledger change. Shared modifier on seven gang types;
+   `SwapSharedCarrier` with `reach=gang_alone`.
 5. **Cleanup, later, separate.** Empty the 18 kind rows, the four
    menus, the two fossil offers, the Variant hidden. Drop Affiliation
    from `OFFERABLE_KINDS`, `LEAF_KINDS`, `ENTRY_ASSIGNABLE_FIELDS`,
-   recipes, concepts. Delete the shim. Then drop the model and the
-   Assignment column, the way #2314 dropped
-   Archetype/SkillTree/Specialisation.
+   recipes, concepts. Then drop the model and the Assignment column,
+   the way #2314 dropped Archetype/SkillTree/Specialisation.
 
 Do not convert all three in one operation. One PR and deploy per
 system, same as last time.
@@ -416,5 +412,5 @@ for new gang-level choices, stop here: the three systems can stay, the
 column can stay, and slots are for new domains only. That is a coherent
 position. It is also how we got Gang Legacy stored as Archetype.
 
-The recommendation is the split, system 1 first, batched. See
+The recommendation is the split, system 1 first, one flip each. See
 [`affiliation-conversion-plan.md`](affiliation-conversion-plan.md).

--- a/.claude/notes/affiliation-conversion-eval.md
+++ b/.claude/notes/affiliation-conversion-eval.md
@@ -1,0 +1,414 @@
+# Converting Affiliation onto slots and picks
+
+An evaluation, not a plan to run. Measured from production on
+2026-08-27, read-only. The other four chosen kinds have already moved;
+Affiliation is what is left.
+
+**It should move.** Not as one slot type named Affiliation covering
+everything the kind currently holds — as three systems, the same split
+Gang Legacy and Archetype already took. The kind is a bucket. The
+systems are distinct. Converting them as one Affiliation would keep the
+vocabulary lie the slots work existed to retire.
+
+n23 is out of scope. Nothing here reads or writes it.
+
+## Why it was considered, and why it was dropped
+
+Slots and picks shipped as #2177 with this as a known later job:
+
+> Content authors were repurposing Affiliation as a general-purpose
+> labelled assignable because every new named-value type cost an
+> engineering change.
+>
+> Migrating the existing chosen kinds (Affiliation, Archetype,
+> SkillTree, Specialisation) is out of scope here by design.
+
+A survey on the `chosen-kinds-plan` branch (never merged) then mapped
+**eight** authored systems across those four kinds. Affiliation the
+kind was four of them: Cawdor Paths, Variants, Chaos God, and Outcast
+Affiliation (with a Clan House chain). The other four sat on Archetype,
+SkillTree and Specialisation.
+
+What actually ran was five conversions, then the programme was declared
+done:
+
+| # | system | kind it sat on | ran? |
+|---|---|---|---|
+| 1 | Cawdor Paths | Affiliation | yes — the pilot, #2214 |
+| 2 | Specialisation | Specialisation | yes |
+| 3 | Variants | Affiliation | **no** |
+| 4 | Chaos God | Affiliation | **no** |
+| 5 | Outcast Affiliation + Clan House | Affiliation | **no** |
+| 6 | Outcast Archetype | Archetype | yes |
+| 7 | Venator Skill Trees | SkillTree | yes |
+| 8 | Venator Gang Legacy | Archetype (hack) | yes |
+
+#2287 then deleted the conversion machinery (~7,000 lines) with the
+claim that every hand-built choice system had moved. Affiliation stayed
+on the authoring menu as the remaining chosen-carrier kind; the
+sandbox's stand-in after the other three retired; the recipes' word for
+a gang-level choice (corruption, a god, an alliance).
+
+Three reasons that skip was the right call *then*, and are weaker now:
+
+1. **Variants was next, and Variants deletes.** The original order put
+   Variants after Specialisation. Specialisation's first attempt retired
+   old rows and failed; the standing rule became *delete nothing*.
+   Variants' original write-up deleted the "None" affiliation's picks
+   (82 live then, **187 now**) in favour of `min_picks=0`. That is the
+   one lossy step in the whole map, and it sat on the far side of a
+   lesson just learned the hard way.
+2. **The three leftover systems chain.** Chaos Corrupted is a Variant
+   pick that offers Chaos God; Clan House is an Affiliation pick that
+   offers a house. Converting one without the others leaves a chain
+   half on each machinery. Paths, Specialisation, Skill Trees, Gang
+   Legacy and Archetype were each a closed system.
+3. **The kinds they wanted gone were the borrowed ones.** Archetype had
+   been used for Gang Legacy; SkillTree and Specialisation were
+   retiring. Affiliation is the honest kind for Outcast affiliation, so
+   keeping it as a generic chosen-carrier looked cheaper than splitting
+   it.
+
+What has changed: the engine is proven, the other kinds are gone, and
+Affiliation is now the last `OffersChoice` chosen-carrier (skill and
+power remain, and should — they are not labelled-assignable hacks).
+Every new gang-level choice still has to be an Affiliation or a new
+coded kind. That is the situation slots were built to end.
+
+## What is there
+
+18 live Affiliation rows, 0 archived, one pack. Four menus, seven
+offers, 410 live picks on 359 gangs, 101 archived picks. Every live
+pick is gang-hosted and has `caused_by` set. No pickable already uses
+any of these names, and no slot type is named Affiliation, Variant, or
+Chaos God.
+
+The 51 gangs that hold two live affiliations are all chains — Clan
+House plus a house, or Chaos Corrupted plus a god — not doubled
+answers.
+
+### System 1 — Outcast Affiliation (the original)
+
+Hidden **"Affiliation"** built into gang type **Outcast** (116 live
+assignments; 119 live foundings). Gang-scoped offer, label
+"Affiliation", menu *Affiliations*: Clanless, Clan House, Mutant,
+Aranthian. The pick lands on the gang.
+
+| pick | live | payload |
+|---|---|---|
+| Clan House | 25 | offers Clan House from *Clan House* / Clan Houses |
+| Mutant | 23 | Mutations list to Champion or Ganger or Leader |
+| Clanless | 19 | nothing (Trade Points are still parked) |
+| Aranthian | 12 | Aranthian list to Champion or Ganger or Leader, *and* to the gang alone |
+
+**Chained:** Clan House carries a gang-scoped offer, label "Clan House",
+menu of the six houses. Each house opens that house's equipment list to
+Champion or Leader, and to the gang alone. 22 live house picks; three
+Clan House gangs have not picked a house. **House Goliath has never
+been picked.**
+
+The house rows carry qualifier `"Affiliation"` (so the authoring label
+reads `House Cawdor — Affiliation`). The printed name is `House
+Cawdor`. No pickable collides with that.
+
+⚠ Aranthian's list still names Gangers. The rules say Leaders and
+Champions only — flagged in the original survey, still uncorrected.
+
+Fossils, neither held by anyone: a whole-kind Affiliation offer
+(unlabelled), and a "Corruption" offer from the Affiliations menu
+landing on the bearer.
+
+### System 2 — Variants
+
+One shared modifier **"Offer Variants"**, label "Variant", menu
+*Variants*: Chaos Corrupted, Genestealer Cult Corrupted, Malstrain
+Corrupted, and **"None"**. Carried by seven gang types (Cawdor, Delaque,
+Escher, Goliath, Orlock, Palanite Enforcers, Van Saar) and by a
+vestigial hidden **"Variant"** that nothing builds in and nobody holds
+(0 live assignments).
+
+`will_be_assigned_to` is **bearer**. That is not a contradiction: the
+carrier is the gang type, hosted on the gang, so the bearer *is* the
+gang. Every Variant pick in production is gang-hosted. A converted slot
+must land the same way — `assigned_to="gang"`, granted by those seven
+gang types.
+
+| pick | live | on which types (live foundings in parens) |
+|---|---|---|
+| None | 187 | Cawdor 38 (177), Escher 34 (255), Enforcers 29 (214), Van Saar 28 (186), Delaque 25 (152), Orlock 17 (135), Goliath 16 (197) |
+| Chaos Corrupted | 33 | spread across all seven |
+| Malstrain Corrupted | 18 | Goliath 6, the rest 1–3 |
+| Genestealer Cult Corrupted | 14 | Enforcers 3, the rest 1–3 |
+
+"None" is 45% of all live affiliation picks, and the explicit
+nothing-option the offer cannot otherwise express. An unanswered
+optional slot (`min_picks=0`) says the same thing on the page; the
+picker already has a None row for optional choices. The original map
+deleted these picks. That is still the right page, and it is still the
+one step that *means* to change the ledger (187 live, 17 archived).
+
+Payloads, all riding the corruption itself:
+
+- each corruption **gives** its collection to the gang and to all
+  models (Chaos and GSC say it twice; Malstrain the same shape)
+- each **gives** a hidden that strips the house's special rules
+- each **removes** Gang Brutes and Pets (one shared modifier)
+- Chaos Corrupted additionally **offers Chaos God** (the chain)
+
+House types do **not** carry Variant in their built-ins. The offer
+rides the gang type as a modifier, the same shared-offer pattern Gang
+Legacy used across twelve profiles. Cawdor therefore asks two gang
+questions: Path (already a slot, granted by hidden "Path") and Variant
+(still an Affiliation offer on the gang type).
+
+### System 3 — Chaos God (two doors, one menu)
+
+Menu *Chaos Gods*: Architect of Fate, Blood God, Dark Prince, Plague
+Lord. All four carry **no payload**; the pick is a record. Two offers,
+both labelled "Chaos God", both `will_be_assigned_to=bearer`, both
+landing on the gang in practice:
+
+- granted by **Chaos Corrupted** (the Variant chain) — 28 of the 33
+  Chaos Corrupted gangs have picked a god
+- hidden **"Chaos God — Helots"** built into **Chaos Helot Cult** (78
+  live assignments; 81 live foundings) — 29 god picks, so most Helot
+  gangs have not answered
+
+| pick | live | of which on Helot Cult |
+|---|---|---|
+| Dark Prince | 26 | 9 |
+| Architect of Fate | 12 | 11 |
+| Plague Lord | 11 | 6 |
+| Blood God | 8 | 3 |
+
+One slot type, two slots, same list. Repeats do not arise: a gang is
+not both a Helot Cult and a corrupted house.
+
+## The behaviour that must survive
+
+1. **Outcast: founding asks Affiliation; the pick is the gang's.** The
+   hidden stays as the anchor. The slot is granted by it, the pick
+   keeps `caused_by` the hidden's assignment, and removing the hidden
+   (or the gang type) retracts the pick.
+2. **Clan House opens a second question, and only while it is the
+   pick.** Un-choosing Clan House takes the house slot, the house pick,
+   and the house list with it. Already proven in
+   `test_outcast_affiliation_shape.py`.
+3. **A house list reaches Leaders and Champions, not Gangers.** Move
+   the modifiers wholesale. Do not "fix" Aranthian onto this; say it
+   on the page if the Ganger reach is kept, or correct it as a named
+   content change with a capture exception.
+4. **Variant is optional and mostly unanswered.** "None" and an open
+   `min_picks=0` slot must read the same on every page that currently
+   shows "Variant: None". The offer never nagged; the slot must not
+   either. Paths taught this — the capture check caught `min_picks=1`
+   on the first rehearsal.
+5. **A corruption suppresses house rules and opens its own lists.**
+   The modifiers move with the pickable. Shared modifiers (Brutes/Pets
+   removal, the rules-stripping hidden) stay shared.
+6. **Chaos Corrupted is what asks the god question.** Helot Cult asks
+   it independently via its own hidden. Two grants of one slot type,
+   not two types.
+7. **Every pick stays gang-hosted.** No affiliation pick has ever
+   landed on a model. `assigned_to="gang"` throughout.
+
+## The shape
+
+```
+# System 1
+create slot type "Affiliation", refusing repeats
+create pickables Clanless, Clan House, Mutant, Aranthian
+  (move their modifiers; Clan House's offer becomes a grant of the house slot)
+create picklist "Affiliations"
+create slot "Affiliation", landing on the gang, 1..1
+on hidden "Affiliation": replace the offer with a grant of that slot
+create slot type "Clan House", refusing repeats
+create pickables House Cawdor … House Van Saar (qualifier "Affiliation" if
+  a name collides; none does today)
+create picklist "Clan Houses"
+create slot "Clan House", landing on the gang, 1..1
+  granted by the Clan House pickable
+rewrite 79 Outcast + 22 house picks
+
+# System 2 — after, or with, system 3
+create slot type "Variant", refusing repeats
+create pickables Chaos Corrupted, Genestealer Cult Corrupted, Malstrain Corrupted
+  (not None)
+create picklist "Variants"
+create slot "Variant", landing on the gang, 0..1
+on the seven gang types: replace "Offer Variants" with a grant of that slot
+rewrite 65 corruption picks
+delete 187 live "None" picks (and 17 archived), declared on the page
+
+# System 3 — with or immediately before system 2
+create slot type "Chaos God", refusing repeats
+create pickables Architect of Fate, Blood God, Dark Prince, Plague Lord
+create picklist "Chaos Gods"
+create slot "Chaos God", landing on the gang, 0..1
+  (Helots do not nag; corrupted gangs that picked Chaos Corrupted do)
+on hidden "Chaos God — Helots": replace the offer with a grant
+on pickable Chaos Corrupted: replace the offer with a grant of the same slot
+rewrite 57 god picks
+```
+
+Nothing of the old kind is deleted in these runs. The 18 Affiliation
+rows, the four menus, the two unattached offers, and the Variant hidden
+stay until a later cleanup, the way the other conversions left their
+emptied rows.
+
+### Why three slot types, not one
+
+The card already says three different words: Affiliation, Variant,
+Chaos God. History currently says "affiliation" for all of them,
+because that is the kind column. A pick's kind word after conversion
+is the **slot type's name**, not the slot's label — that is how Gang
+Legacy stopped being an Archetype in the story.
+
+One Affiliation slot type would leave history untouched and keep the
+lie. Three types reword Variant and Chaos God (and Clan House) picks
+from "affiliation" to the word the card already uses. That is the Gang
+Legacy precedent, and it is the one the archived-answer sweep had to
+declare: 34 of 399 answers moved a word, the page said so, and every
+other word that would have moved was a refusal.
+
+Declare the rewording on each system's page. Pin it with a story test.
+Do not fold Variant into Affiliation to avoid the reword.
+
+## Decisions that need taking before a first PR
+
+**"None".** Delete the 187 live (and 17 archived) picks, slot
+`min_picks=0`. An open optional Variant and a picked None must capture
+equal. This is the one place a conversion *means* to change a page's
+stored answers; the proof is that the pages match *minus exactly
+those*. Name every gang on the preview.
+
+**Aranthian Gangers.** Keep the modifier as authored (capture stays
+empty) or correct it as a named exception. Do not silently fix it
+inside the rewrite.
+
+**Clan House as its own slot type.** Yes. It is a different question,
+opened by a pick, retracted through cause. Putting it on the
+Affiliation type would make a house pick's kind word "affiliation"
+after conversion, which is worse than today only in that we had the
+chance to tell the truth.
+
+**Repeats.** All three types refuse them. A gang has one affiliation,
+one variant, one god. Nothing in production holds two of the same
+question.
+
+**The four Leader-style copies.** There aren't any. Affiliation is one
+hidden on one gang type; Variant is one shared modifier on seven types;
+Chaos God is two grants of one slot. No per-profile wart to preserve.
+
+**Rebuild the conversion engine.** #2287 deleted it after the five
+runs. `n26.core.capture.gang_state` is still here — the proof half.
+The plan/apply half (CreatePickable, SwapCarrier, CreateSlot,
+RewritePick, the console runner, the refuse-and-unwind) is not. A new
+Affiliation conversion is a new maintenance operation in that shape,
+not a resurrection of the old module. Paths' first run shipping as a
+migration is the thing not to repeat; the console-after-deploy
+discipline in `backfill-lessons.md` is the one to copy.
+
+## Engine work
+
+Nothing new in the player engine. `_choose_for_slot` already routes a
+pick to the gang when the slot says so; chained grants already retract
+through cause; optional slots already offer a None row; `has_pickable`
+already exists (and is the condition Affiliation never had — today
+nothing can say "models whose gang picked Malstrain" except by hanging
+the behaviour on Malstrain itself).
+
+Authoring already refuses a bare pickable built in. Recipes and
+`concepts.md` still teach Affiliation as the way to author a gang-level
+choice; those rewrite after the first system lands, not before.
+
+`OFFERABLE_KINDS` still names `affiliation`. It shrinks when the last
+offer is gone, in the cleanup, not in the first conversion.
+`ENTRY_ASSIGNABLE_FIELDS` still names it for the same reason. The
+Assignment column stays until the kind is dropped, the way Archetype's
+did.
+
+There is no Affiliation ingest sheet. Nothing to delete there.
+
+## The proof
+
+Sandbox first, then a fork of the content mirror at the measured
+volume.
+
+Per system, the suite that already exists is the shape to follow:
+
+- `test_outcast_affiliation_shape.py` already builds system 1 on slots
+  and plays it through the pages. Convert the *live* content to match
+  that suite; do not rewrite the suite to match a different shape.
+- `test_outcast_affiliation_flow.py` and `test_outcast_gang.py` still
+  build the old kind. They move onto slots the way #2307 moved the
+  Archetype/SkillTree/Specialisation suites — assertions unchanged.
+- `test_gang_books.py` builds Chaos corruption as an Affiliation. It
+  follows system 2.
+
+Then the standing rule: capture every reached gang's pages before and
+after; refuse and unwind on any difference (with the declared "None"
+removals and any declared Aranthian correction as the only allowed
+diffs); every touched gang reconciles. History is pinned per system
+with a same-words test, plus a declared-rewording test for Variant and
+Chaos God.
+
+Volume, so the sample can be sized:
+
+| system | live picks | gangs (approx.) | archived |
+|---|---|---|---|
+| Outcast Affiliation | 79 | 119 foundings, 79 answered | 34 |
+| Clan House (chain) | 22 | 22 of the 25 Clan House gangs | 7 |
+| Variant (corruptions) | 65 | 65 | 33 |
+| Variant "None" | 187 | 187 | 17 |
+| Chaos God | 57 | 28 corrupted + 29 Helot | 10 |
+| **total live to rewrite** | **223** (plus 187 Nones to clear) | **359** gangs hold at least one | **101** |
+
+Smaller than Specialisation (939) and in the Gang Legacy / Archetype
+band. The expensive gang is the one that holds a chain (Clan House +
+house, or Chaos Corrupted + god). Prove those shapes; do not prove
+every None.
+
+## Order of battle
+
+1. **Rebuild the conversion runner** — plan/apply, capture, refuse in
+   words, console operation, one lock, delete nothing. No system in
+   the first PR; a Paths-shaped no-op against a database that has
+   nothing to convert is the test.
+2. **Outcast Affiliation + Clan House.** Independent of the others,
+   sandbox already green, no None, no shared-across-types offer. The
+   chain is the thing to prove. 101 picks rewritten.
+3. **Chaos God**, Helot door only if Variants is not ready; both doors
+   if it is. Empty pickables, optional on Helots (`min_picks=0` — 52 of
+   81 have not answered, and the offer does not nag).
+4. **Variants**, which adds the second Chaos God door on the Chaos
+   Corrupted pickable. The "None" clearing is this system's declared
+   change. Shared modifier on seven gang types, same swap Gang Legacy
+   already did.
+5. **Cleanup, later, separate.** Empty the 18 kind rows, the four
+   menus, the two fossil offers, the Variant hidden. Drop Affiliation
+   from `OFFERABLE_KINDS`, `LEAF_KINDS`, `ENTRY_ASSIGNABLE_FIELDS`,
+   recipes, concepts. Then drop the model and the Assignment column,
+   the way #2314 dropped Archetype/SkillTree/Specialisation.
+
+Do not convert all three in one operation. The chains cross 2 and 3;
+1 is free. One PR and deploy per system, same as last time.
+
+## What would make this the wrong next step
+
+- Rebuilding the runner for a single leftover kind, if Affiliation is
+  going to stay as the generic chosen-carrier on purpose. That is a
+  product decision: either authors make new slot types, or they keep
+  making Affiliations. The recipes currently teach the latter.
+- Folding Variant and Chaos God into one Affiliation slot type to
+  "finish the column" without splitting. That ships the conversion and
+  keeps the hack.
+- Deleting the kind in the same PR as the first rewrite. Every early
+  failure came from that.
+
+If the decision is that Affiliation remains the authored chosen-carrier
+for new gang-level choices, stop here: the three systems can stay, the
+column can stay, and slots are for new domains only. That is a coherent
+position. It is also how we got Gang Legacy stored as Archetype.
+
+The recommendation is the split, system 1 first.

--- a/.claude/notes/affiliation-conversion-plan.md
+++ b/.claude/notes/affiliation-conversion-plan.md
@@ -1,0 +1,481 @@
+# Converting Affiliation onto slots and picks — the plan
+
+How the three leftover Affiliation systems move. Why they should, and
+the split, live in
+[`affiliation-conversion-eval.md`](affiliation-conversion-eval.md).
+This file is the how: the runner, the window, each system's apply,
+and the PR sequence.
+
+Measured from production on 2026-08-27, read-only. n23 is out of
+scope. Nothing here reads or writes it.
+
+The old conversions ran `plan()` / `apply()` in **one transaction**
+over a spread of gangs, and #2287 deleted that engine. What we have
+now, proven in production by `audit_reconcile`, is `run_batched`
+(`n26/maintenance.py`): a stable queryset of pks, `do_one(pk)` per
+row on its own commit, a cursor on the `Backfill` record, a four-minute
+budget, re-enqueue via `again()`, failures recorded and skipped.
+Affiliation is too large for one transaction (359 gangs hold a live
+pick) and is the first conversion that can use that runner for the
+player rewrite. The library swap stays one-shot — it is pack-wide and
+small.
+
+## Decisions locked
+
+| | |
+|---|---|
+| Three slot types | Affiliation, Variant, Chaos God. Clan House is a fourth type, chained off the Clan House pickable. Not one Affiliation type covering all three systems. |
+| Order | Machinery → Outcast + Clan House → Chaos God (both doors) → Variants (including None) → cleanup later. |
+| "None" | Archive the 187 live and 17 archived picks. Variant slot `min_picks=0`. An open optional Variant and a picked None must capture equal under a **conversion-local** comparator (`chosen` in `{"None", ""}` for that question). Preview names every gang whose stored answer is cleared. |
+| Aranthian Gangers | Keep the modifier as authored. Do not fix it inside the rewrite. |
+| Repeats | All four types refuse them. |
+| Modifiers | **Share, do not move**, until cleanup. The affiliation row and the new pickable both carry the same `Modifier` rows (the M2M already allows this). Moving them at library time would strip payload from every gang not yet rewritten. |
+| Kind column | Stays until cleanup. Do not drop `Affiliation`, `OFFERABLE_KINDS`, or the Assignment column in any rewrite PR. |
+| Writes | Assignment updates are the sanctioned conversion exception (`n26/core/CLAUDE.md`): no `operation()`, no money, no ledger events. |
+| Unit of work | A **gang**, not a pick. Chains (Clan House + house, Chaos Corrupted + god) live on one gang and must rewrite together. |
+
+## Why the old engine cannot be replayed
+
+The deleted runner (`n26/library/conversion/base.py` at `000f2022^`)
+did library create, carrier swap, and pick rewrite in **one
+`REPEATABLE READ` transaction**, captured a **spread**, and refused
+and unwound the whole run on any page diff. That cannot hold 359
+gangs. It also never showed the window below, because swap and
+rewrite committed together.
+
+`run_batched` is the opposite promise: each gang commits alone, the
+cursor survives an interruption, a failing gang is recorded and
+stepped past, an operator can cancel between batches. The queryset
+**must not drop unprocessed rows as work proceeds** — do not filter
+on "still has an affiliation pick". Freeze the pk list at enqueue.
+
+What we do not resurrect: the 7,000-line module, the console-in-the-
+library, or `plan()` returning a giant step list that apply runs
+blind. New, small step helpers (create slot type / pickable / picklist
+/ slot, swap carrier, rewrite pick) plus one maintenance operation per
+system. The preview is still the contract; the apply performs exactly
+those steps.
+
+## The window
+
+Library swap is pack-wide. Pick rewrite is per-gang. Between them:
+
+1. The granted slot looks unanswered (`chosen_for_slot` is unset on
+   the affiliation pick).
+2. The affiliation pick may still draw as its own row.
+3. If modifiers had been **moved** off the affiliation row, every
+   unconverted gang would lose its payload.
+
+(3) is why we share, not move. (1) and (2) are why there is a
+temporary dual-read in `compute`.
+
+After library swap the offer assignment is archived and a slot grant
+stands in its place. Existing picks still have `caused_by` pointing
+at the **old offer** (a different assignment than the grant) and
+`chosen_for_slot` unset. Matching on `caused_by == grant.id` never
+works for those rows. Name against the slot's picklist does.
+
+The window cannot create **new** affiliation picks of a converted
+system: the offer is gone, so a player can only answer through the
+slot. Gangs founded after the library swap are native and are not on
+the frozen work-list.
+
+### Dual-read shim
+
+In `_fill_slot_choices` (`n26/core/effects.py`), query-free, no
+system names hardcoded.
+
+For each granted slot with no native pick (`chosen_for_slot_id ==
+slot.pk`):
+
+1. **Name match.** A live affiliation assignment on the same holder
+   whose printed name is a member of this slot's picklist settles the
+   slot. At most one such assignment per slot; two is a refuse in
+   `do_one` (production has none — the 51 double-affiliation gangs
+   are all chains, and the two names sit on different picklists).
+2. **Hide.** That affiliation assignment does not draw as its own
+   row. It is the answer, not a second fact.
+3. **Empty choice.** After name-match, a remaining live affiliation
+   assignment with **no modifiers**, on a holder that has an
+   unanswered `min_picks=0` slot, is the explicit nothing-option of
+   that slot: hide it, leave the slot unanswered. Clanless has no
+   modifiers **and** is on the Affiliation picklist, so name-match
+   wins first and this rule never fires on Outcast. "None" is not on
+   the Variant picklist, so this is what hides it. Two unanswered
+   `min_picks=0` slots competing for one empty-choice affiliation is
+   a refuse; production does not have that shape (Helot Cult is not
+   on Offer Variants).
+
+`compute()` issues no queries. Names come off assignables already
+loaded by `n26.core.card`. The shim must not fetch.
+
+Delete the shim in cleanup, once no affiliation assignment remains.
+A discovering test fails while the shim is still needed and fails
+the other way once it is dead — that is the signal to remove it, not
+a comment.
+
+The shim is not a second source of truth for converted gangs:
+`do_one` writes `chosen_for_slot`, and native `_fill_slot_choices`
+takes over. After the last system, the shim is unreached.
+
+## The runner shape
+
+One console operation per system. One `Backfill` record. Two phases
+in one task.
+
+```
+prologue  (library)     _run_recorded shape: one transaction,
+                        REPEATABLE READ, spread capture, refuse-and-unwind
+then
+run_batched (player)    one gang per do_one, own commit, cursor, budget
+```
+
+`run_batched` as it stands has no prologue. Add an optional
+`prologue(backfill)` (or a thin `run_library_then_batched` next to
+it) that:
+
+- runs once under the same lock and claim as the walk
+- writes `summary["prologue"] = "done"` (and resets `attempts`)
+  before any gang is rewritten
+- is skipped on later deliveries when that flag is set
+- on failure writes FAILED and walks nothing
+
+Test it in `n26/tests/test_batched_runner.py` the way the walk is
+already tested: prologue runs once; a crash after it does not rerun
+it; a prologue refusal never starts the walk.
+
+Do not nest `run_batched` inside `_run_recorded`. Do not split one
+system across two slugs — the operator should have one button, and
+the player phase is meaningless if the library has not landed. The
+player preview refuses if the slot type is missing, so a half-run
+cannot be started from a second direction.
+
+### Frozen work-list
+
+Computed at GET preview, stored on the record at POST, applied as
+`Gang.objects.filter(pk__in=frozen).order_by("pk")`.
+
+A gang is on the list if it holds a live **or archived** assignment
+of this system's affiliation rows, **or** a live assignment of this
+system's carrier (the unanswered case — capture is then a no-op
+rewrite). Do not filter on "needs rewrite". Do not filter
+`archived=False` on the affiliation *content* when finding picks a
+subscriber already holds.
+
+Gangs founded after enqueue are not on the list; they are native.
+
+### `do_one(pk)`
+
+Idempotent.
+
+1. `select_for_update` the `Gang` row so a Choose mid-rewrite waits.
+2. Fast path: every live and archived pick of this system on this
+   gang already has `chosen_for_slot` set (and, for Variants, every
+   None assignment is already archived) → return, **no capture**.
+   A rerun of settled gangs must be cheap.
+3. Capture `gang_state` before.
+4. Rewrite live and archived picks in place (same `Assignment` pk):
+   set `pickable`, `chosen_for=caused_by`, `chosen_for_slot`, clear
+   the affiliation FK and `chosen_for_offer`. Kind-word history
+   follows `chosen_for_slot.slot_type.name` (`n26/core/history.py`
+   `_kindword`). Children keep `caused_by_id` because the parent row
+   did not change pk — that is why Clan House's house pick and Chaos
+   Corrupted's god grant survive the outer rewrite.
+5. Variants only: archive remaining None assignments.
+6. `assert_reconciled`.
+7. Capture after. Refuse **this gang** on a diff (the runner records
+   the failure and continues). Conversion-local comparator for
+   Variant None as above; nowhere else.
+
+`REPEATABLE READ` on the per-gang transaction so the two captures
+see one world. A player purchase on a *different* gang is irrelevant;
+on this gang the row lock holds them off.
+
+Archived picks are rewritten even though `gang_state` does not see
+them. Cleanup cannot drop the kind while archived rows still name it,
+and history of an archived answer should tell the same truth as a
+live one.
+
+### Batch size
+
+Default `BATCH_SIZE` is 50 and `BATCH_BUDGET` is four minutes.
+`do_one` that captures renders the gang twice. Measure on a fork of
+the content mirror before production; start at **20** if two renders
+do not comfortably fit fifty into the budget. The attempt count
+resets on every recorded batch, so a long walk is not mistaken for a
+stuck one. Cancel is checked between batches.
+
+### What the preview names
+
+- Library steps (slot types, pickables, swaps), in words.
+- Frozen gang count, and the spread the prologue will prove.
+- Every gang whose stored answer will be cleared (Variants: the 187
+  None).
+- The history reword (Variant, Chaos God, Clan House).
+- Problems: shared modifiers that are not this system's, name
+  collisions with existing pickables, a slot type that already
+  exists from a previous attempt (idempotent skip vs refuse — skip
+  if it is ours, refuse if it is not).
+
+## System 1 — Outcast Affiliation + Clan House
+
+Independent of the others. Sandbox already green:
+`n26/tests/sandbox/test_outcast_affiliation_shape.py`. No None. No
+shared-across-types offer. The chain is the thing to prove.
+
+```
+create slot type "Affiliation", refusing repeats
+create pickables Clanless, Clan House, Mutant, Aranthian
+  (share their modifiers; Clan House's offer stays on both until
+   the house slot grant replaces it)
+create picklist "Affiliations"
+create slot "Affiliation", assigned_to="gang", 1..1
+on hidden "Affiliation": replace the offer with a grant of that slot
+
+create slot type "Clan House", refusing repeats
+create pickables House Cawdor … House Van Saar
+create picklist "Clan Houses"
+create slot "Clan House", assigned_to="gang", 1..1
+  granted by the Clan House pickable
+  (the offer on the affiliation row is swapped to this grant; the
+   pickable shares it)
+
+rewrite every Outcast affiliation pick and every house pick, live
+and archived, on the frozen gangs
+```
+
+Work-list: Outcast foundings that hold the hidden (answered or not)
+plus any gang that holds a house pick (should be a subset). ~119
+gangs, 79 + 22 live picks, 34 + 7 archived.
+
+Declared page diffs: none. History: Clan House picks reword from
+"affiliation" to "clan house"; Affiliation picks stay "affiliation".
+Pin both with a story test.
+
+House Goliath has never been picked. Still create the pickable.
+
+Fossils (unattached whole-kind Affiliation offer, unattached
+"Corruption" offer): do not swap. Cleanup deletes them.
+
+Live-content tests that still build the old kind, moved the way
+#2307 moved the others — assertions unchanged:
+
+- `n26/tests/sandbox/test_outcast_affiliation_flow.py`
+- `n26/tests/sandbox/test_outcast_gang.py`
+
+Do not rewrite `test_outcast_affiliation_shape.py` to match a
+different shape. Convert live content to match that suite.
+
+## System 3 — Chaos God, both doors, before Variants
+
+One slot type, two slots, same picklist. A gang is never both a
+Helot Cult and a corrupted house.
+
+```
+create slot type "Chaos God", refusing repeats
+create pickables Architect of Fate, Blood God, Dark Prince, Plague Lord
+create picklist "Chaos Gods"
+create slot "Chaos God", assigned_to="gang", 0..1
+  on hidden "Chaos God — Helots" (built into Chaos Helot Cult)
+create slot "Chaos God", assigned_to="gang", 0..1
+  on the Chaos Corrupted *affiliation* (the Variant chain's inner
+  door — still an affiliation when this runs)
+rewrite every god pick, live and archived
+```
+
+`min_picks=0` on both doors. The Helot offer never nagged (52 of 81
+unanswered). Paths taught that `min_picks=1` on an offer that did
+not nag is a capture failure. Chaos Corrupted's inner offer is the
+same shape (5 of 33 unanswered). Do not introduce a nag.
+
+Work-list: Helot Cult foundings (carrier, answered or not) plus
+every gang that holds a god pick (the 28 corrupted). God pickables
+carry no payload.
+
+Declared page diffs: none. History: reword "affiliation" to "chaos
+god". Pin with a story test.
+
+Both doors in this operation, not Helot-only with Variants adding
+the second later. Variants then shares the already-swapped grant
+onto the Chaos Corrupted pickable; it does not create a second Chaos
+God conversion.
+
+## System 2 — Variants, last
+
+Shared modifier "Offer Variants" on seven gang types (Cawdor,
+Delaque, Escher, Goliath, Orlock, Palanite Enforcers, Van Saar).
+`will_be_assigned_to=bearer`; the carrier is the gang type, hosted
+on the gang, so every production pick is gang-hosted. Converted
+slot: `assigned_to="gang"`. The swap is `SwapSharedCarrier` with
+`reach=gang_alone` — not Gang Legacy's `reach=model`. Asked once on
+the gang card, not echoed onto members as a choice.
+
+```
+create slot type "Variant", refusing repeats
+create pickables Chaos Corrupted, Genestealer Cult Corrupted,
+                 Malstrain Corrupted
+  (not None; share modifiers, including Chaos Corrupted's grant of
+   the Chaos God slot)
+create picklist "Variants"
+create slot "Variant", assigned_to="gang", 0..1
+on the seven gang types: replace "Offer Variants" with a grant of
+  that slot
+rewrite the 65 corruption picks, live and archived
+archive the 187 live and 17 archived "None" picks
+```
+
+Vestigial hidden "Variant" (0 assignments, not built in): do not
+swap. Cleanup deletes it.
+
+House types do not carry Variant in their built-ins. The offer rides
+the gang type. Cawdor therefore keeps two gang questions: Path
+(already a slot) and Variant.
+
+Work-list: live foundings of the seven types (so unanswered / None /
+corruption are all in), plus any gang that holds a Variant
+affiliation pick. None is 45% of all live affiliation picks; the
+fast path and the local comparator exist because of them.
+
+Declared: the ledger loses 187 stored Nones. Pages capture equal
+because the shim hides None against an unanswered `min_picks=0`
+Variant, and `do_one` then archives the hidden assignment. Preview
+names the 187. History: reword "affiliation" to "variant" for the
+corruptions; None's archived history follows whatever `_kindword`
+reads after the rewrite-or-archive — declare it, pin it.
+
+`test_gang_books.py` builds Chaos corruption as an Affiliation. It
+moves with this system.
+
+### Why Chaos God before Variants
+
+If Variants ran first, Chaos Corrupted would already be a pickable
+and the inner offer would still be `OffersChoice(of_kind=affiliation)`
+on that pickable until a later Chaos God run found it there. That
+works, but it leaves a chain half on each machinery and makes the
+Chaos God operation search two carrier kinds. Converting the inner
+door while Chaos Corrupted is still the affiliation row matches
+production as measured, and Variants then shares a grant that already
+exists. Do not reverse this.
+
+## What capture does not see
+
+History wording. `gang_state` (`n26/core/capture.py`) holds names,
+numbers, and `(kind_label, chosen)` — not provenance, not addresses,
+not the ledger's kind word. A conversion may change where a control
+leads and which machinery asks a question; it may not change what
+the reader is told, except the declared None clearing (which the
+local comparator makes a non-diff on the page) and the declared
+history rewords (which capture never saw).
+
+## Proof
+
+Sandbox first, then a fork of the content mirror at the measured
+volume. `backfill-lessons.md` still applies: plan frozen, refuse in
+words, delete nothing (except the declared Nones), run as a task,
+one lock per operation, verify from outside.
+
+Per system, on the fork:
+
+1. Snapshot `gang_state` for **every** reached gang, not the spread,
+   from outside the operation.
+2. Run the real console path (prologue then batched). Time it.
+   Include at least one chain gang, one unanswered, one archived-
+   only, one ordinary.
+3. Diff the outside snapshots after. The operation's own capture is
+   not the proof that ships.
+4. Rehearse a Choose landing on a gang mid-`do_one` (the row lock)
+   and a delivery dying after prologue (the flag). The Specialisation
+   production failure was concurrent writes; do not skip this.
+
+Spread the prologue proves, so a library mistake still unwinds
+before any player row is rewritten. The batched walk then proves
+every gang, which is the upgrade batching buys over the old "25 of
+65" sample.
+
+Volume:
+
+| system | live picks | gangs (approx.) | archived |
+|---|---|---|---|
+| Outcast Affiliation | 79 | 119 foundings, 79 answered | 34 |
+| Clan House (chain) | 22 | 22 of 25 Clan House gangs | 7 |
+| Chaos God | 57 | 28 corrupted + 29 Helot (81 Helot foundings on the work-list) | 10 |
+| Variant (corruptions) | 65 | 65 | 33 |
+| Variant "None" | 187 | 187 | 17 |
+| **total live to rewrite** | **223** (plus 187 Nones to clear) | **359** gangs hold at least one | **101** |
+
+## PR sequence
+
+One PR and deploy per system, same as last time. Do not convert all
+three in one operation.
+
+0. **Machinery, no system.** Dual-read shim + discovering tests;
+   `prologue` on `run_batched`; the small step helpers; a Paths-
+   shaped no-op against a database that has nothing to convert.
+   Ship this first so the shim can sit in production empty (unreached)
+   before anything swaps.
+1. **Outcast + Clan House.** Operation, live-content test port,
+   story tests for the Clan House reword. Recipes / `concepts.md`
+   start teaching a slot type for a new gang-level choice after this
+   lands, not before.
+2. **Chaos God**, both doors.
+3. **Variants**, including None.
+4. **Cleanup, later, separate.** Empty the 18 kind rows, the four
+   menus, the two fossil offers, the Variant hidden. Drop
+   `affiliation` from `OFFERABLE_KINDS`, `LEAF_KINDS`,
+   `ENTRY_ASSIGNABLE_FIELDS`. Delete the shim. Then drop the model
+   and the Assignment column, the way #2314 dropped
+   Archetype / SkillTree / Specialisation.
+
+Retire each operation afterwards by keeping its slug registered with
+`view=None`, same as the five that already ran.
+
+## What not to do
+
+- Replay the old one-transaction engine over 359 gangs.
+- Move modifiers at library time.
+- Filter the batched queryset on "still needs rewrite".
+- Convert all three systems in one operation, or Variants before
+  Chaos God.
+- Drop the kind, the column, or `OFFERABLE_KINDS` in a rewrite PR.
+- Hardcode system names in the shim.
+- Silently correct Aranthian Gangers.
+- Put a None pickable on the Variant list so capture can pretend the
+  stored answer survived. Unanswered `min_picks=0` is the page;
+  archiving None is the ledger change; the local comparator is the
+  proof they read the same.
+- Ship any of this as a migration.
+- Query from `compute()`.
+- Fold Variant and Chaos God into one Affiliation slot type to
+  avoid the history reword.
+
+## Worked example — one Clan House gang through the window
+
+Before. Hidden "Affiliation" on the Outcast type offers the menu.
+The gang holds Clan House (affiliation, `caused_by` the offer) and
+House Cawdor (affiliation, `caused_by` the Clan House assignment).
+Pages say Affiliation: Clan House, Clan House: House Cawdor. History
+says "affiliation" twice.
+
+Prologue. Slot types Affiliation and Clan House exist. Pickables
+share the modifiers. Hidden offer becomes a grant of the Affiliation
+slot. Clan House affiliation's offer becomes a grant of the Clan
+House slot; the Clan House pickable shares that grant. Spread
+captures, including this shape, match. This gang has not been
+rewritten: `chosen_for_slot` is unset, `caused_by` still names the
+archived offer.
+
+Window, this gang. Dual-read: "Clan House" is on the Affiliation
+picklist so that assignment settles the Affiliation slot and does
+not draw as an affiliation row; "House Cawdor" is on the Clan House
+picklist so that assignment settles the Clan House slot. Payload
+still rides the affiliation rows. A visitor sees the same words. A
+Choose goes through the slot, not the offer.
+
+`do_one`. Both assignments rewritten in place. Clan House pick's pk
+is unchanged, so House Cawdor's `caused_by` still points at it.
+`chosen_for_slot` set. Native fill takes over. Capture matches.
+History of the house pick now says "clan house".
+
+Cleanup (later). No affiliation assignment remains on this gang. The
+empty Clan House affiliation row can go. The shim no longer matches
+anything here.

--- a/.claude/notes/affiliation-conversion-plan.md
+++ b/.claude/notes/affiliation-conversion-plan.md
@@ -3,231 +3,83 @@
 How the three leftover Affiliation systems move. Why they should, and
 the split, live in
 [`affiliation-conversion-eval.md`](affiliation-conversion-eval.md).
-This file is the how: the runner, the window, each system's apply,
-and the PR sequence.
+Production counts there are from 2026-08-27, read-only. n23 is out of
+scope.
 
-Measured from production on 2026-08-27, read-only. n23 is out of
-scope. Nothing here reads or writes it.
+The cutover is the same shape the earlier conversions used, minus the
+part that made them slow: **one write per system, then a batched
+check**. Do not run the old offer and the new slot on the same gang.
+Do not rewrite picks one gang at a time.
 
-The old conversions ran `plan()` / `apply()` in **one transaction**
-over a spread of gangs, and #2287 deleted that engine. What we have
-now, proven in production by `audit_reconcile`, is `run_batched`
-(`n26/maintenance.py`): a stable queryset of pks, `do_one(pk)` per
-row on its own commit, a cursor on the `Backfill` record, a four-minute
-budget, re-enqueue via `again()`, failures recorded and skipped.
-Affiliation is too large for one transaction (359 gangs hold a live
-pick) and is the first conversion that can use that runner for the
-player rewrite. The library swap stays one-shot — it is pack-wide and
-small.
+The writes are a few hundred assignment rows. What used to hold the
+transaction for minutes was rendering pages inside it. `run_batched`
+is for the check afterwards, not for dripping the switch.
 
-## Decisions locked
+## Decisions
 
 | | |
 |---|---|
-| Three slot types | Affiliation, Variant, Chaos God. Clan House is a fourth type, chained off the Clan House pickable. Not one Affiliation type covering all three systems. |
+| Three systems | Affiliation (Outcast + Clan House), Chaos God, Variant. Four slot types: Clan House is its own type, chained off the Clan House pickable. |
 | Order | Machinery → Outcast + Clan House → Chaos God (both doors) → Variants (including None) → cleanup later. |
-| "None" | Archive the 187 live and 17 archived picks. Variant slot `min_picks=0`. An open optional Variant and a picked None must capture equal under a **conversion-local** comparator (`chosen` in `{"None", ""}` for that question). Preview names every gang whose stored answer is cleared. |
-| Aranthian Gangers | Keep the modifier as authored. Do not fix it inside the rewrite. |
+| One flip | Create the slots, move modifiers onto pickables, swap offer → grant, rewrite every pick of that system, in **one transaction**. Lock the reached gangs first so a Choose cannot land mid-write. |
+| Proof in that transaction | A **spread** of shapes, `gang_state` before and after, refuse and unwind on any difference. Every reached gang `assert_reconciled`. |
+| Proof after | `run_batched` walks every reached gang and reconciles again (read-only). On a content-mirror fork, also diff **every** gang's pages from outside the run, and time the write. |
+| "None" | Archive the 187 live and 17 archived picks. Variant `min_picks=0`. Spread compare treats chosen `"None"` and `""` as equal for that question. Preview names the 187. |
+| Aranthian Gangers | Keep the modifier as authored. |
 | Repeats | All four types refuse them. |
-| Modifiers | **Share, do not move**, until cleanup. The affiliation row and the new pickable both carry the same `Modifier` rows (the M2M already allows this). Moving them at library time would strip payload from every gang not yet rewritten. |
-| Kind column | Stays until cleanup. Do not drop `Affiliation`, `OFFERABLE_KINDS`, or the Assignment column in any rewrite PR. |
+| Kind column | Stays until cleanup. |
 | Writes | Assignment updates are the sanctioned conversion exception (`n26/core/CLAUDE.md`): no `operation()`, no money, no ledger events. |
-| Unit of work | A **gang**, not a pick. Chains (Clan House + house, Chaos Corrupted + god) live on one gang and must rewrite together. |
 
-## Why the old engine cannot be replayed
+If the fork write is not short (seconds, not minutes), stop and look
+again. Do not then invent a per-gang window.
 
-The deleted runner (`n26/library/conversion/base.py` at `000f2022^`)
-did library create, carrier swap, and pick rewrite in **one
-`REPEATABLE READ` transaction**, captured a **spread**, and refused
-and unwound the whole run on any page diff. That cannot hold 359
-gangs. It also never showed the window below, because swap and
-rewrite committed together.
+## Reusable machinery
 
-`run_batched` is the opposite promise: each gang commits alone, the
-cursor survives an interruption, a failing gang is recorded and
-stepped past, an operator can cancel between batches. The queryset
-**must not drop unprocessed rows as work proceeds** — do not filter
-on "still has an affiliation pick". Freeze the pk list at enqueue.
+#2287 deleted `n26/library/conversion/`. Put back a **small** module,
+not the 7,000 lines: frozen plan, typed steps, one apply, refuse in
+words. Console operations in `n26/maintenance.py` call it through
+`_run_recorded`, then enqueue the batched reconcile.
 
-What we do not resurrect: the 7,000-line module, the console-in-the-
-library, or `plan()` returning a giant step list that apply runs
-blind. New, small step helpers (create slot type / pickable / picklist
-/ slot, swap carrier, rewrite pick) plus one maintenance operation per
-system. The preview is still the contract; the apply performs exactly
-those steps.
+Steps the three systems share (copy from `000f2022^`, keep thin):
 
-## The window
+- `CreateSlotType`, `CreatePickable` (moves modifiers; qualifier if a
+  name collides), `CreatePicklist`, `CreateSlot`
+- `SwapCarrier`, `SwapSharedCarrier` (Variant needs `reach=gang_alone`)
+- `RewritePick` — same `Assignment` pk: set `pickable`,
+  `chosen_for=caused_by`, `chosen_for_slot`, clear the affiliation FK
+  and `chosen_for_offer`. Children keep `caused_by_id`.
 
-Library swap is pack-wide. Pick rewrite is per-gang. Between them:
+Apply helper, used three times:
 
-1. The granted slot looks unanswered (`chosen_for_slot` is unset on
-   the affiliation pick).
-2. The affiliation pick may still draw as its own row.
-3. If modifiers had been **moved** off the affiliation row, every
-   unconverted gang would lose its payload.
+1. `select_for_update` the reached gangs.
+2. `REPEATABLE READ`.
+3. Capture the spread.
+4. Perform exactly the frozen steps.
+5. Capture the spread again; refuse and unwind on a diff.
+6. `assert_reconciled` every reached gang.
 
-(3) is why we share, not move. (1) and (2) are why there is a
-temporary dual-read in `compute`.
+Nothing new in `compute`. `_choose_for_slot` already lands a pick on
+the gang; chained grants already retract through cause; optional
+slots already offer a None row.
 
-After library swap the offer assignment is archived and a slot grant
-stands in its place. Existing picks still have `caused_by` pointing
-at the **old offer** (a different assignment than the grant) and
-`chosen_for_slot` unset. Matching on `caused_by == grant.id` never
-works for those rows. Name against the slot's picklist does.
+Idempotent: a retry whose slot type already exists and is ours skips
+the creates; a pick that already has `chosen_for_slot` is left.
+Refuse if a foreign slot type of the same name is in the way.
 
-The window cannot create **new** affiliation picks of a converted
-system: the offer is gone, so a player can only answer through the
-slot. Gangs founded after the library swap are native and are not on
-the frozen work-list.
-
-### Dual-read shim
-
-In `_fill_slot_choices` (`n26/core/effects.py`), query-free, no
-system names hardcoded.
-
-For each granted slot with no native pick (`chosen_for_slot_id ==
-slot.pk`):
-
-1. **Name match.** A live affiliation assignment on the same holder
-   whose printed name is a member of this slot's picklist settles the
-   slot. At most one such assignment per slot; two is a refuse in
-   `do_one` (production has none — the 51 double-affiliation gangs
-   are all chains, and the two names sit on different picklists).
-2. **Hide.** That affiliation assignment does not draw as its own
-   row. It is the answer, not a second fact.
-3. **Empty choice.** After name-match, a remaining live affiliation
-   assignment with **no modifiers**, on a holder that has an
-   unanswered `min_picks=0` slot, is the explicit nothing-option of
-   that slot: hide it, leave the slot unanswered. Clanless has no
-   modifiers **and** is on the Affiliation picklist, so name-match
-   wins first and this rule never fires on Outcast. "None" is not on
-   the Variant picklist, so this is what hides it. Two unanswered
-   `min_picks=0` slots competing for one empty-choice affiliation is
-   a refuse; production does not have that shape (Helot Cult is not
-   on Offer Variants).
-
-`compute()` issues no queries. Names come off assignables already
-loaded by `n26.core.card`. The shim must not fetch.
-
-Delete the shim in cleanup, once no affiliation assignment remains.
-A discovering test fails while the shim is still needed and fails
-the other way once it is dead — that is the signal to remove it, not
-a comment.
-
-The shim is not a second source of truth for converted gangs:
-`do_one` writes `chosen_for_slot`, and native `_fill_slot_choices`
-takes over. After the last system, the shim is unreached.
-
-## The runner shape
-
-One console operation per system. One `Backfill` record. Two phases
-in one task.
-
-```
-prologue  (library)     _run_recorded shape: one transaction,
-                        REPEATABLE READ, spread capture, refuse-and-unwind
-then
-run_batched (player)    one gang per do_one, own commit, cursor, budget
-```
-
-`run_batched` as it stands has no prologue. Add an optional
-`prologue(backfill)` (or a thin `run_library_then_batched` next to
-it) that:
-
-- runs once under the same lock and claim as the walk
-- writes `summary["prologue"] = "done"` (and resets `attempts`)
-  before any gang is rewritten
-- is skipped on later deliveries when that flag is set
-- on failure writes FAILED and walks nothing
-
-Test it in `n26/tests/test_batched_runner.py` the way the walk is
-already tested: prologue runs once; a crash after it does not rerun
-it; a prologue refusal never starts the walk.
-
-Do not nest `run_batched` inside `_run_recorded`. Do not split one
-system across two slugs — the operator should have one button, and
-the player phase is meaningless if the library has not landed. The
-player preview refuses if the slot type is missing, so a half-run
-cannot be started from a second direction.
-
-### Frozen work-list
-
-Computed at GET preview, stored on the record at POST, applied as
-`Gang.objects.filter(pk__in=frozen).order_by("pk")`.
-
-A gang is on the list if it holds a live **or archived** assignment
-of this system's affiliation rows, **or** a live assignment of this
-system's carrier (the unanswered case — capture is then a no-op
-rewrite). Do not filter on "needs rewrite". Do not filter
-`archived=False` on the affiliation *content* when finding picks a
-subscriber already holds.
-
-Gangs founded after enqueue are not on the list; they are native.
-
-### `do_one(pk)`
-
-Idempotent.
-
-1. `select_for_update` the `Gang` row so a Choose mid-rewrite waits.
-2. Fast path: every live and archived pick of this system on this
-   gang already has `chosen_for_slot` set (and, for Variants, every
-   None assignment is already archived) → return, **no capture**.
-   A rerun of settled gangs must be cheap.
-3. Capture `gang_state` before.
-4. Rewrite live and archived picks in place (same `Assignment` pk):
-   set `pickable`, `chosen_for=caused_by`, `chosen_for_slot`, clear
-   the affiliation FK and `chosen_for_offer`. Kind-word history
-   follows `chosen_for_slot.slot_type.name` (`n26/core/history.py`
-   `_kindword`). Children keep `caused_by_id` because the parent row
-   did not change pk — that is why Clan House's house pick and Chaos
-   Corrupted's god grant survive the outer rewrite.
-5. Variants only: archive remaining None assignments.
-6. `assert_reconciled`.
-7. Capture after. Refuse **this gang** on a diff (the runner records
-   the failure and continues). Conversion-local comparator for
-   Variant None as above; nowhere else.
-
-`REPEATABLE READ` on the per-gang transaction so the two captures
-see one world. A player purchase on a *different* gang is irrelevant;
-on this gang the row lock holds them off.
-
-Archived picks are rewritten even though `gang_state` does not see
-them. Cleanup cannot drop the kind while archived rows still name it,
-and history of an archived answer should tell the same truth as a
-live one.
-
-### Batch size
-
-Default `BATCH_SIZE` is 50 and `BATCH_BUDGET` is four minutes.
-`do_one` that captures renders the gang twice. Measure on a fork of
-the content mirror before production; start at **20** if two renders
-do not comfortably fit fifty into the budget. The attempt count
-resets on every recorded batch, so a long walk is not mistaken for a
-stuck one. Cancel is checked between batches.
-
-### What the preview names
-
-- Library steps (slot types, pickables, swaps), in words.
-- Frozen gang count, and the spread the prologue will prove.
-- Every gang whose stored answer will be cleared (Variants: the 187
-  None).
-- The history reword (Variant, Chaos God, Clan House).
-- Problems: shared modifiers that are not this system's, name
-  collisions with existing pickables, a slot type that already
-  exists from a previous attempt (idempotent skip vs refuse — skip
-  if it is ours, refuse if it is not).
+Preview is the contract. The apply performs those steps and no
+others. Ship as a console operation after deploy, never as a
+migration.
 
 ## System 1 — Outcast Affiliation + Clan House
 
-Independent of the others. Sandbox already green:
-`n26/tests/sandbox/test_outcast_affiliation_shape.py`. No None. No
-shared-across-types offer. The chain is the thing to prove.
+Independent. Sandbox already green:
+`n26/tests/sandbox/test_outcast_affiliation_shape.py`. Convert live
+content to match that suite.
 
 ```
 create slot type "Affiliation", refusing repeats
 create pickables Clanless, Clan House, Mutant, Aranthian
-  (share their modifiers; Clan House's offer stays on both until
-   the house slot grant replaces it)
+  (move their modifiers; Clan House's offer becomes a grant of the house slot)
 create picklist "Affiliations"
 create slot "Affiliation", assigned_to="gang", 1..1
 on hidden "Affiliation": replace the offer with a grant of that slot
@@ -237,245 +89,86 @@ create pickables House Cawdor … House Van Saar
 create picklist "Clan Houses"
 create slot "Clan House", assigned_to="gang", 1..1
   granted by the Clan House pickable
-  (the offer on the affiliation row is swapped to this grant; the
-   pickable shares it)
 
-rewrite every Outcast affiliation pick and every house pick, live
-and archived, on the frozen gangs
+rewrite live and archived Outcast + house picks
 ```
 
-Work-list: Outcast foundings that hold the hidden (answered or not)
-plus any gang that holds a house pick (should be a subset). ~119
-gangs, 79 + 22 live picks, 34 + 7 archived.
+Spread must include: answered, unanswered, Clan House without a house,
+Clan House + house, archived re-choice. History: Affiliation stays
+"affiliation"; house picks reword to "clan house". Pin with a story
+test.
 
-Declared page diffs: none. History: Clan House picks reword from
-"affiliation" to "clan house"; Affiliation picks stay "affiliation".
-Pin both with a story test.
+Live-content tests that still build the old kind, moved the way #2307
+moved the others — assertions unchanged:
 
-House Goliath has never been picked. Still create the pickable.
+- `test_outcast_affiliation_flow.py`
+- `test_outcast_gang.py`
 
-Fossils (unattached whole-kind Affiliation offer, unattached
-"Corruption" offer): do not swap. Cleanup deletes them.
-
-Live-content tests that still build the old kind, moved the way
-#2307 moved the others — assertions unchanged:
-
-- `n26/tests/sandbox/test_outcast_affiliation_flow.py`
-- `n26/tests/sandbox/test_outcast_gang.py`
-
-Do not rewrite `test_outcast_affiliation_shape.py` to match a
-different shape. Convert live content to match that suite.
+Fossils (unattached whole-kind offer, "Corruption" offer): do not
+swap. Cleanup deletes them. House Goliath has never been picked;
+still create the pickable.
 
 ## System 3 — Chaos God, both doors, before Variants
-
-One slot type, two slots, same picklist. A gang is never both a
-Helot Cult and a corrupted house.
 
 ```
 create slot type "Chaos God", refusing repeats
 create pickables Architect of Fate, Blood God, Dark Prince, Plague Lord
 create picklist "Chaos Gods"
 create slot "Chaos God", assigned_to="gang", 0..1
-  on hidden "Chaos God — Helots" (built into Chaos Helot Cult)
+  on hidden "Chaos God — Helots"
 create slot "Chaos God", assigned_to="gang", 0..1
-  on the Chaos Corrupted *affiliation* (the Variant chain's inner
-  door — still an affiliation when this runs)
-rewrite every god pick, live and archived
+  on the Chaos Corrupted affiliation
+rewrite live and archived god picks
 ```
 
-`min_picks=0` on both doors. The Helot offer never nagged (52 of 81
-unanswered). Paths taught that `min_picks=1` on an offer that did
-not nag is a capture failure. Chaos Corrupted's inner offer is the
-same shape (5 of 33 unanswered). Do not introduce a nag.
-
-Work-list: Helot Cult foundings (carrier, answered or not) plus
-every gang that holds a god pick (the 28 corrupted). God pickables
-carry no payload.
-
-Declared page diffs: none. History: reword "affiliation" to "chaos
-god". Pin with a story test.
-
-Both doors in this operation, not Helot-only with Variants adding
-the second later. Variants then shares the already-swapped grant
-onto the Chaos Corrupted pickable; it does not create a second Chaos
-God conversion.
+`min_picks=0` on both doors — neither offer nagged. History rewords
+to "chaos god". Both doors in this run, so Variants only shares an
+existing grant onto the Chaos Corrupted pickable.
 
 ## System 2 — Variants, last
-
-Shared modifier "Offer Variants" on seven gang types (Cawdor,
-Delaque, Escher, Goliath, Orlock, Palanite Enforcers, Van Saar).
-`will_be_assigned_to=bearer`; the carrier is the gang type, hosted
-on the gang, so every production pick is gang-hosted. Converted
-slot: `assigned_to="gang"`. The swap is `SwapSharedCarrier` with
-`reach=gang_alone` — not Gang Legacy's `reach=model`. Asked once on
-the gang card, not echoed onto members as a choice.
 
 ```
 create slot type "Variant", refusing repeats
 create pickables Chaos Corrupted, Genestealer Cult Corrupted,
                  Malstrain Corrupted
-  (not None; share modifiers, including Chaos Corrupted's grant of
-   the Chaos God slot)
+  (not None; move modifiers, including Chaos Corrupted's Chaos God grant)
 create picklist "Variants"
 create slot "Variant", assigned_to="gang", 0..1
-on the seven gang types: replace "Offer Variants" with a grant of
-  that slot
-rewrite the 65 corruption picks, live and archived
-archive the 187 live and 17 archived "None" picks
+on the seven gang types: SwapSharedCarrier, reach=gang_alone
+rewrite live and archived corruption picks
+archive live and archived "None" picks
 ```
 
-Vestigial hidden "Variant" (0 assignments, not built in): do not
-swap. Cleanup deletes it.
-
-House types do not carry Variant in their built-ins. The offer rides
-the gang type. Cawdor therefore keeps two gang questions: Path
-(already a slot) and Variant.
-
-Work-list: live foundings of the seven types (so unanswered / None /
-corruption are all in), plus any gang that holds a Variant
-affiliation pick. None is 45% of all live affiliation picks; the
-fast path and the local comparator exist because of them.
-
-Declared: the ledger loses 187 stored Nones. Pages capture equal
-because the shim hides None against an unanswered `min_picks=0`
-Variant, and `do_one` then archives the hidden assignment. Preview
-names the 187. History: reword "affiliation" to "variant" for the
-corruptions; None's archived history follows whatever `_kindword`
-reads after the rewrite-or-archive — declare it, pin it.
-
-`test_gang_books.py` builds Chaos corruption as an Affiliation. It
+Vestigial hidden "Variant" (0 assignments): do not swap. `test_gang_books.py`
 moves with this system.
 
-### Why Chaos God before Variants
+## PRs
 
-If Variants ran first, Chaos Corrupted would already be a pickable
-and the inner offer would still be `OffersChoice(of_kind=affiliation)`
-on that pickable until a later Chaos God run found it there. That
-works, but it leaves a chain half on each machinery and makes the
-Chaos God operation search two carrier kinds. Converting the inner
-door while Chaos Corrupted is still the affiliation row matches
-production as measured, and Variants then shares a grant that already
-exists. Do not reverse this.
+0. **Machinery.** The small conversion module, apply helper, spread
+   capture, batched reconcile enqueue. A no-op against a database that
+   has nothing to convert. No Affiliation row rewritten.
+1. **Outcast + Clan House.**
+2. **Chaos God.**
+3. **Variants.**
+4. **Cleanup, later.** Empty the 18 kind rows, four menus, fossil
+   offers, Variant hidden. Drop `affiliation` from `OFFERABLE_KINDS`,
+   `LEAF_KINDS`, `ENTRY_ASSIGNABLE_FIELDS`. Then drop the model and
+   the Assignment column, the way #2314 dropped the other three.
 
-## What capture does not see
-
-History wording. `gang_state` (`n26/core/capture.py`) holds names,
-numbers, and `(kind_label, chosen)` — not provenance, not addresses,
-not the ledger's kind word. A conversion may change where a control
-leads and which machinery asks a question; it may not change what
-the reader is told, except the declared None clearing (which the
-local comparator makes a non-diff on the page) and the declared
-history rewords (which capture never saw).
-
-## Proof
-
-Sandbox first, then a fork of the content mirror at the measured
-volume. `backfill-lessons.md` still applies: plan frozen, refuse in
-words, delete nothing (except the declared Nones), run as a task,
-one lock per operation, verify from outside.
-
-Per system, on the fork:
-
-1. Snapshot `gang_state` for **every** reached gang, not the spread,
-   from outside the operation.
-2. Run the real console path (prologue then batched). Time it.
-   Include at least one chain gang, one unanswered, one archived-
-   only, one ordinary.
-3. Diff the outside snapshots after. The operation's own capture is
-   not the proof that ships.
-4. Rehearse a Choose landing on a gang mid-`do_one` (the row lock)
-   and a delivery dying after prologue (the flag). The Specialisation
-   production failure was concurrent writes; do not skip this.
-
-Spread the prologue proves, so a library mistake still unwinds
-before any player row is rewritten. The batched walk then proves
-every gang, which is the upgrade batching buys over the old "25 of
-65" sample.
-
-Volume:
-
-| system | live picks | gangs (approx.) | archived |
-|---|---|---|---|
-| Outcast Affiliation | 79 | 119 foundings, 79 answered | 34 |
-| Clan House (chain) | 22 | 22 of 25 Clan House gangs | 7 |
-| Chaos God | 57 | 28 corrupted + 29 Helot (81 Helot foundings on the work-list) | 10 |
-| Variant (corruptions) | 65 | 65 | 33 |
-| Variant "None" | 187 | 187 | 17 |
-| **total live to rewrite** | **223** (plus 187 Nones to clear) | **359** gangs hold at least one | **101** |
-
-## PR sequence
-
-One PR and deploy per system, same as last time. Do not convert all
-three in one operation.
-
-0. **Machinery, no system.** Dual-read shim + discovering tests;
-   `prologue` on `run_batched`; the small step helpers; a Paths-
-   shaped no-op against a database that has nothing to convert.
-   Ship this first so the shim can sit in production empty (unreached)
-   before anything swaps.
-1. **Outcast + Clan House.** Operation, live-content test port,
-   story tests for the Clan House reword. Recipes / `concepts.md`
-   start teaching a slot type for a new gang-level choice after this
-   lands, not before.
-2. **Chaos God**, both doors.
-3. **Variants**, including None.
-4. **Cleanup, later, separate.** Empty the 18 kind rows, the four
-   menus, the two fossil offers, the Variant hidden. Drop
-   `affiliation` from `OFFERABLE_KINDS`, `LEAF_KINDS`,
-   `ENTRY_ASSIGNABLE_FIELDS`. Delete the shim. Then drop the model
-   and the Assignment column, the way #2314 dropped
-   Archetype / SkillTree / Specialisation.
+One PR and deploy per system. Do not convert all three in one
+operation. Do not drop the kind in a rewrite PR. Recipes and
+`concepts.md` start teaching a slot type for a new gang-level choice
+after system 1 lands, not before.
 
 Retire each operation afterwards by keeping its slug registered with
-`view=None`, same as the five that already ran.
+`view=None`.
 
 ## What not to do
 
-- Replay the old one-transaction engine over 359 gangs.
-- Move modifiers at library time.
-- Filter the batched queryset on "still needs rewrite".
-- Convert all three systems in one operation, or Variants before
-  Chaos God.
-- Drop the kind, the column, or `OFFERABLE_KINDS` in a rewrite PR.
-- Hardcode system names in the shim.
+- Render every reached gang inside the write.
+- Dual-read in `compute`, per-gang flags, or dormant slots.
+- Move modifiers in a transaction that has not yet rewritten the
+  picks (there is no such transaction).
+- Convert Variants before Chaos God.
 - Silently correct Aranthian Gangers.
-- Put a None pickable on the Variant list so capture can pretend the
-  stored answer survived. Unanswered `min_picks=0` is the page;
-  archiving None is the ledger change; the local comparator is the
-  proof they read the same.
 - Ship any of this as a migration.
-- Query from `compute()`.
-- Fold Variant and Chaos God into one Affiliation slot type to
-  avoid the history reword.
-
-## Worked example — one Clan House gang through the window
-
-Before. Hidden "Affiliation" on the Outcast type offers the menu.
-The gang holds Clan House (affiliation, `caused_by` the offer) and
-House Cawdor (affiliation, `caused_by` the Clan House assignment).
-Pages say Affiliation: Clan House, Clan House: House Cawdor. History
-says "affiliation" twice.
-
-Prologue. Slot types Affiliation and Clan House exist. Pickables
-share the modifiers. Hidden offer becomes a grant of the Affiliation
-slot. Clan House affiliation's offer becomes a grant of the Clan
-House slot; the Clan House pickable shares that grant. Spread
-captures, including this shape, match. This gang has not been
-rewritten: `chosen_for_slot` is unset, `caused_by` still names the
-archived offer.
-
-Window, this gang. Dual-read: "Clan House" is on the Affiliation
-picklist so that assignment settles the Affiliation slot and does
-not draw as an affiliation row; "House Cawdor" is on the Clan House
-picklist so that assignment settles the Clan House slot. Payload
-still rides the affiliation rows. A visitor sees the same words. A
-Choose goes through the slot, not the offer.
-
-`do_one`. Both assignments rewritten in place. Clan House pick's pk
-is unchanged, so House Cawdor's `caused_by` still points at it.
-`chosen_for_slot` set. Native fill takes over. Capture matches.
-History of the house pick now says "clan house".
-
-Cleanup (later). No affiliation assignment remains on this gang. The
-empty Clan House affiliation row can go. The shim no longer matches
-anything here.

--- a/.claude/notes/affiliation-conversion-plan.md
+++ b/.claude/notes/affiliation-conversion-plan.md
@@ -7,13 +7,15 @@ Production counts there are from 2026-08-27, read-only. n23 is out of
 scope.
 
 The cutover is the same shape the earlier conversions used, minus the
-part that made them slow: **one write per system, then a batched
-check**. Do not run the old offer and the new slot on the same gang.
-Do not rewrite picks one gang at a time.
+part that made them slow: **one write per system**, then an operator
+runs `audit_reconcile` afterwards. Do not run the old offer and the
+new slot on the same gang. Do not rewrite picks one gang at a time.
 
 The writes are a few hundred assignment rows. What used to hold the
-transaction for minutes was rendering pages inside it. `run_batched`
-is for the check afterwards, not for dripping the switch.
+transaction for minutes was rendering pages inside it. Do not enqueue
+`run_batched` on the same Backfill — the conversion already marks
+that record DONE. The after-the-fact check is the existing
+`audit_reconcile` operation, run by hand.
 
 ## Decisions
 
@@ -23,7 +25,7 @@ is for the check afterwards, not for dripping the switch.
 | Order | Machinery → Outcast + Clan House → Chaos God (both doors) → Variants (including None) → cleanup later. |
 | One flip | Create the slots, move modifiers onto pickables, swap offer → grant, rewrite every pick of that system, in **one transaction**. Lock the reached gangs first so a Choose cannot land mid-write. |
 | Proof in that transaction | A **spread** of shapes, `gang_state` before and after, refuse and unwind on any difference. Every reached gang `assert_reconciled`. |
-| Proof after | `run_batched` walks every reached gang and reconciles again (read-only). On a content-mirror fork, also diff **every** gang's pages from outside the run, and time the write. |
+| Proof after | Operators run `audit_reconcile` (read-only) after the flip. Do not nest `run_batched` on the conversion's Backfill. On a content-mirror fork, also diff **every** gang's pages from outside the run, and time the write. |
 | "None" | Archive the 187 live and 17 archived picks. Variant `min_picks=0`. Spread compare treats chosen `"None"` and `""` as equal for that question. Preview names the 187. |
 | Aranthian Gangers | Keep the modifier as authored. |
 | Repeats | All four types refuse them. |
@@ -38,7 +40,8 @@ again. Do not then invent a per-gang window.
 #2287 deleted `n26/library/conversion/`. Put back a **small** module,
 not the 7,000 lines: frozen plan, typed steps, one apply, refuse in
 words. Console operations in `n26/maintenance.py` call it through
-`_run_recorded`, then enqueue the batched reconcile.
+`_run_recorded`. After a successful flip, operators run
+`audit_reconcile`; the conversion does not enqueue it.
 
 Steps the three systems share (copy from `000f2022^`, keep thin):
 
@@ -51,20 +54,24 @@ Steps the three systems share (copy from `000f2022^`, keep thin):
 
 Apply helper, used three times:
 
-1. `select_for_update` the reached gangs.
-2. `REPEATABLE READ`.
+1. `REPEATABLE READ` (`SET SESSION CHARACTERISTICS` **before**
+   `transaction.atomic()` — isolation can only be chosen before the
+   transaction has read anything).
+2. `select_for_update` the reached gangs (holders first, ordered by
+   pk).
 3. Capture the spread.
 4. Perform exactly the frozen steps.
 5. Capture the spread again; refuse and unwind on a diff.
-6. `assert_reconciled` every reached gang.
+6. `assert_reconciled` every reached gang. That is a read-only check
+   — it does not call `reconcile_defaults` or `self.assign`.
 
 Nothing new in `compute`. `_choose_for_slot` already lands a pick on
 the gang; chained grants already retract through cause; optional
 slots already offer a None row.
 
-Idempotent: a retry whose slot type already exists and is ours skips
-the creates; a pick that already has `chosen_for_slot` is left.
-Refuse if a foreign slot type of the same name is in the way.
+A successful flip leaves the offers gone, so a retry is
+`nothing_here`. A standing slot type of the same name is a refusal,
+not a skip. A pick that already has `chosen_for_slot` is left.
 
 Preview is the contract. The apply performs those steps and no
 others. Ship as a console operation after deploy, never as a
@@ -81,17 +88,22 @@ create slot type "Affiliation", refusing repeats
 create pickables Clanless, Clan House, Mutant, Aranthian
   (move their modifiers; Clan House's offer becomes a grant of the house slot)
 create picklist "Affiliations"
-create slot "Affiliation", assigned_to="gang", 1..1
+create slot "Affiliation", assigned_to="gang", 0..1
 on hidden "Affiliation": replace the offer with a grant of that slot
 
 create slot type "Clan House", refusing repeats
 create pickables House Cawdor … House Van Saar
 create picklist "Clan Houses"
-create slot "Clan House", assigned_to="gang", 1..1
+create slot "Clan House", assigned_to="gang", 0..1
   granted by the Clan House pickable
 
 rewrite live and archived Outcast + house picks
 ```
+
+`min_picks=0` on both slots — a modifier offer never nagged;
+`min_picks=1` added "Affiliation — 0 of 1 chosen" and broke capture
+plus `Lead the Masses`. Clan House slot `label="Clan house"` so
+`choice_label` matches `capfirst` of the old offer.
 
 Spread must include: answered, unanswered, Clan House without a house,
 Clan House + house, archived re-choice. History: Affiliation stays
@@ -108,7 +120,7 @@ Fossils (unattached whole-kind offer, "Corruption" offer): do not
 swap. Cleanup deletes them. House Goliath has never been picked;
 still create the pickable.
 
-## System 3 — Chaos God, both doors, before Variants
+## System 2 — Chaos God, both doors, before Variants
 
 ```
 create slot type "Chaos God", refusing repeats
@@ -125,7 +137,7 @@ rewrite live and archived god picks
 to "chaos god". Both doors in this run, so Variants only shares an
 existing grant onto the Chaos Corrupted pickable.
 
-## System 2 — Variants, last
+## System 3 — Variants, last
 
 ```
 create slot type "Variant", refusing repeats
@@ -145,8 +157,9 @@ moves with this system.
 ## PRs
 
 0. **Machinery.** The small conversion module, apply helper, spread
-   capture, batched reconcile enqueue. A no-op against a database that
-   has nothing to convert. No Affiliation row rewritten.
+   capture. A no-op against a database that has nothing to convert.
+   No Affiliation row rewritten. After the flip, operators run
+   `audit_reconcile` by hand.
 1. **Outcast + Clan House.**
 2. **Chaos God.**
 3. **Variants.**

--- a/.claude/notes/conversion-cleanup-order.md
+++ b/.claude/notes/conversion-cleanup-order.md
@@ -1,9 +1,17 @@
 # Finishing the conversions — the plan, and where it has got to
 
-n26's hand-built choice systems have all been moved onto slots and
-picks. This is the tidying that follows: what is left, the order it can
-be done in, and the decisions already taken. Written to be picked up
-cold.
+n26's hand-built choice systems on Archetype, SkillTree and
+Specialisation have all been moved onto slots and picks. This is the
+tidying that follows those five conversions: what is left, the order
+it can be done in, and the decisions already taken. Written to be
+picked up cold.
+
+**Late addition (2026-08-27):** Affiliation was not in this programme.
+Three systems remain on that kind (Outcast + Clan House, Variants,
+Chaos God). They move next, batched, as
+[`affiliation-conversion-plan.md`](affiliation-conversion-plan.md).
+The "all converted" claim below is true of the three retired kinds
+only.
 
 **Nothing here names a player, a gang or an assignment id.** The counts
 are shapes; every operation finds its own rows by query. The repository

--- a/.claude/notes/conversion-cleanup-order.md
+++ b/.claude/notes/conversion-cleanup-order.md
@@ -8,7 +8,7 @@ picked up cold.
 
 **Late addition (2026-08-27):** Affiliation was not in this programme.
 Three systems remain on that kind (Outcast + Clan House, Variants,
-Chaos God). They move next, batched, as
+Chaos God). They move next, one flip per system, as
 [`affiliation-conversion-plan.md`](affiliation-conversion-plan.md).
 The "all converted" claim below is true of the three retired kinds
 only.

--- a/.claude/notes/conversion-cleanup-order.md
+++ b/.claude/notes/conversion-cleanup-order.md
@@ -1,14 +1,17 @@
 # Finishing the conversions — the plan, and where it has got to
 
 n26's hand-built choice systems on Archetype, SkillTree and
-Specialisation have all been moved onto slots and picks. This is the
-tidying that follows those five conversions: what is left, the order
+Specialisation have all been moved onto slots and picks. This note is
+the tidying that follows those three kinds: what is left, the order
 it can be done in, and the decisions already taken. Written to be
 picked up cold.
 
-**Late addition (2026-08-27):** Affiliation was not in this programme.
-Three systems remain on that kind (Outcast + Clan House, Variants,
-Chaos God). They move next, one flip per system, as
+The table below still names five conversion operations (Paths,
+Specialisation, Skill Trees, Gang Legacies, Archetypes) — those are
+the runs that emptied the three kinds. Affiliation is a late addition
+and was not in this programme. Three systems remain on that kind
+(Outcast + Clan House, Chaos God, Variants). They move next, one flip
+per system, as
 [`affiliation-conversion-plan.md`](affiliation-conversion-plan.md).
 The "all converted" claim below is true of the three retired kinds
 only.

--- a/n26/core/templates/admin/maintenance/n26/_convert_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_convert_detail.html
@@ -1,0 +1,23 @@
+{% comment %}
+    The summary of one conversion run, on the Backfill detail page: what
+    it was going to do, and — once it has finished — what it did.
+{% endcomment %}
+{% if backfill.summary.report %}
+    <h2>What it did</h2>
+    <ul>
+        {% for line in backfill.summary.report %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% elif backfill.summary.preview %}
+    <h2>What it is doing</h2>
+    <p>
+        These are the steps it planned. The conversion writes nothing until every
+        affected gang has been proven to read the same, so a run still working has
+        changed nothing yet.
+    </p>
+    <ul>
+        {% for line in backfill.summary.preview %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+{% if backfill.summary.attempts %}
+    <p>Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }}.</p>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/convert.html
+++ b/n26/core/templates/admin/maintenance/n26/convert.html
@@ -1,0 +1,82 @@
+{% extends "admin/base_site.html" %}
+{% comment %}
+A conversion's console page, shared by every conversion operation:
+the plan as a preview, an apply button, and the recent runs. Context
+from _conversion_view (n26/maintenance.py): title, plan, preview,
+reaches, proven, apply_url, recent.
+{% endcomment %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-plan { font-family: monospace; line-height: 1.6; }
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    .mt-problems { color: var(--error-fg, #ba2121); }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        This is the plan. Nothing has been changed. Every line below is a step
+        the conversion would perform, in order.
+    </p>
+    {% if plan.nothing_here %}
+        <h2>Nothing to convert</h2>
+        <p>This system is not here. It has been converted already, or was never present.</p>
+    {% elif not plan.ok %}
+        <h2 class="mt-problems">The conversion refuses</h2>
+        <ul class="mt-problems">
+            {% for problem in plan.problems %}<li>{{ problem }}</li>{% endfor %}
+        </ul>
+        <p>Nothing can be applied while any of these stands.</p>
+    {% else %}
+        <p>{{ reach_words }}</p>
+        <p>
+            Applying runs the whole of it in one transaction. It reads what the gangs
+            it proves say, performs the steps, reads them again, and commits only if
+            the two readings match and each of them still reconciles. Anything else —
+            a difference, a refusal, an interruption — writes nothing at all, so a run
+            that does not finish can simply be run again.
+        </p>
+        {% if leaves_behind %}<p>{{ leaves_behind }}</p>{% endif %}
+        <h2>What it would do</h2>
+        <ul class="mt-plan">
+            {% for line in preview %}<li>{{ line }}</li>{% endfor %}
+        </ul>
+        <form method="post"
+              class="mt-form"
+              onsubmit="return confirm('{{ confirm_words }}')">
+            {% csrf_token %}
+            <button type="submit" class="button default">{{ button_words }}</button>
+        </form>
+    {% endif %}
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/library/conversion/__init__.py
+++ b/n26/library/conversion/__init__.py
@@ -1,0 +1,20 @@
+"""Conversions that move a hand-built choice system onto slots and picks.
+
+Each system's ``plan_*`` reads the database and returns a frozen Plan.
+``apply`` performs exactly those steps, or refuses and unwinds.
+"""
+
+from n26.library.conversion.affiliation import plan_outcast_affiliation
+from n26.library.conversion.base import ConversionRefused, Plan, apply
+
+SYSTEMS = {
+    "outcast_affiliation": plan_outcast_affiliation,
+}
+
+__all__ = [
+    "ConversionRefused",
+    "Plan",
+    "SYSTEMS",
+    "apply",
+    "plan_outcast_affiliation",
+]

--- a/n26/library/conversion/affiliation.py
+++ b/n26/library/conversion/affiliation.py
@@ -1,0 +1,437 @@
+"""The Outcast Affiliation conversion — Affiliation and Clan House.
+
+Today: the Outcast gang type builds in a Hidden that offers a choice of
+the affiliation kind, narrowed to the Affiliations menu; one of those
+affiliations (Clan House) itself offers a second choice of the six
+Houses. Both answers land on the gang.
+
+After: an "Affiliation" slot type and a "Clan House" slot type; the
+menu's affiliations and houses as pickables carrying those same
+modifiers, moved not copied; the Hidden grants the Affiliation slot;
+the Clan House pickable grants the house slot; every stored choice —
+live and archived — is re-said as a pick on its same anchor.
+
+Nothing is deleted. Emptied affiliation rows, the menus, and any
+detached fossil offer stay where they are.
+
+The system is found by structure, not by production names: a live
+affiliation-labelled offer carried by one Hidden, whose menu's live
+entries become the top pickables, and among those the one that itself
+offers affiliation labelled "clan house" is the house chain.
+
+Production converts from the maintenance console, once, after the code
+deploys — see :mod:`n26.maintenance`.
+"""
+
+from n26.library.conversion.base import (
+    CreatePickable,
+    CreatePicklist,
+    CreateSlot,
+    CreateSlotType,
+    Plan,
+    RewritePick,
+    SwapCarrier,
+    carriers_of,
+    duplicate_names,
+    one_answer_per_question,
+    refuse_if_granted,
+    solely_carried,
+    spread,
+)
+
+SYSTEM = "outcast_affiliation"
+AFFILIATION_TYPE = "Affiliation"
+AFFILIATION_PLURAL = "Affiliations"
+AFFILIATION_SLOT = "Affiliation"
+HOUSE_TYPE = "Clan House"
+HOUSE_PLURAL = "Clan Houses"
+HOUSE_SLOT = "Clan House"
+#: What the card already calls the house question — the offer's label
+#: after ``capfirst``, which a slot name of "Clan House" would not match.
+HOUSE_SLOT_LABEL = "Clan house"
+OFFER_LABEL = "affiliation"
+HOUSE_OFFER_LABEL = "clan house"
+PROVEN = 15
+
+
+def _affiliations_on(section):
+    """Live affiliations on a live section, in the menu's own order."""
+    if section is None:
+        return []
+    return [
+        entry.affiliation
+        for entry in section.collection.entries.filter(
+            affiliation__isnull=False,
+            affiliation__archived=False,
+            archived=False,
+        )
+        .select_related("affiliation")
+        .order_by("position", "affiliation__name")
+    ]
+
+
+def _offers_of_kind(carrier, kind, label):
+    """The carrier's choice offers of one kind wearing this label."""
+    wanted = label.casefold()
+    return [
+        m
+        for m in carrier.modifiers.all()
+        if getattr(m, "offers_choice", None) is not None
+        and m.offers_choice.of_kind.model == kind
+        and m.offers_choice.label.casefold() == wanted
+    ]
+
+
+def _qualifier_for(name, slot_type_name, pack, taken_pairs, problems):
+    """Empty unless this name is already spoken for; then the slot type.
+
+    A name is unique per pack and qualifier. When the empty qualifier is
+    taken, this conversion qualifies as the slot type — author-facing
+    only. If that pair is taken too, refuse rather than crash.
+    """
+    from django.db.models.functions import Lower
+
+    from n26.library.models import Pickable
+
+    folded = name.lower()
+    standing = {
+        (n.lower(), q.lower())
+        for n, q in Pickable.objects.filter(pack_id=pack)
+        .annotate(folded=Lower("name"), folded_q=Lower("qualifier"))
+        .values_list("folded", "folded_q")
+    }
+    standing |= taken_pairs
+    if (folded, "") not in standing:
+        taken_pairs.add((folded, ""))
+        return ""
+    qualified = slot_type_name.lower()
+    if (folded, qualified) in standing:
+        problems.append(
+            f"a pickable named “{name}” already stands"
+            + (f", told apart as “{slot_type_name}”" if slot_type_name else "")
+        )
+        return slot_type_name
+    taken_pairs.add((folded, qualified))
+    return slot_type_name
+
+
+def plan_outcast_affiliation():
+    from n26.core.models import Assignment, Gang
+    from n26.library.models import Modifier, Picklist, Slot, SlotType
+    from n26.library.models.pack import default_pack_id
+
+    problems = []
+
+    # Live affiliation-labelled offers carried by something. A detached
+    # one is a fossil: carried by nothing, it does nothing on any page,
+    # and it is left where it lies. Offers wearing another label
+    # (Variant, Chaos God, Corruption) are other systems.
+    carried = []
+    for modifier in Modifier.objects.filter(
+        offers_choice__isnull=False,
+        offers_choice__of_kind__model="affiliation",
+    ).select_related("offers_choice", "offers_choice__from_section"):
+        if modifier.offers_choice.label.casefold() != OFFER_LABEL:
+            continue
+        held = carriers_of(modifier)
+        if held:
+            carried.append((modifier, held))
+    involves_hidden = [
+        (modifier, held)
+        for modifier, held in carried
+        if any(kind == "Hidden" for kind, _ in held)
+    ]
+    if not involves_hidden:
+        return Plan(system=SYSTEM, nothing_here=True)
+    hidden_offers = [
+        (modifier, held)
+        for modifier, held in involves_hidden
+        if len(held) == 1 and held[0][0] == "Hidden"
+    ]
+    if len(involves_hidden) != 1 or len(hidden_offers) != 1:
+        problems.append(
+            f"{len(involves_hidden)} Affiliation-labelled offer(s) involve a "
+            "Hidden — expected one, carried by that Hidden alone"
+        )
+        return Plan(system=SYSTEM, problems=tuple(problems))
+
+    offer, held = hidden_offers[0]
+    hidden = held[0][1]
+    solely_carried(offer, hidden, problems)
+    refuse_if_granted(hidden, f"the “{hidden.name}” hidden", problems)
+
+    section = offer.offers_choice.from_section
+    if section is None:
+        problems.append("the offer names no menu — expected the Affiliations list")
+        top_rows = []
+    else:
+        top_rows = _affiliations_on(section)
+        if not top_rows:
+            problems.append("the menu offers no affiliations to convert")
+
+    twice = duplicate_names(top_rows)
+    if twice:
+        problems.append("more than one live affiliation is called: " + ", ".join(twice))
+
+    house_row = house_offer = house_section = None
+    house_rows = []
+    chained = []
+    for row in top_rows:
+        house_offers = _offers_of_kind(row, "affiliation", HOUSE_OFFER_LABEL)
+        if house_offers:
+            chained.append((row, house_offers))
+    if len(chained) > 1:
+        problems.append(
+            f"{len(chained)} affiliations offer a Clan House choice — expected one"
+        )
+    elif not chained:
+        problems.append("no affiliation on the menu offers a Clan House choice")
+    else:
+        house_row, house_offers = chained[0]
+        if len(house_offers) != 1:
+            problems.append(
+                f"“{house_row.name}” carries {len(house_offers)} Clan House "
+                "offers — expected one"
+            )
+        else:
+            house_offer = house_offers[0]
+            solely_carried(house_offer, house_row, problems)
+            refuse_if_granted(
+                house_row, f"the “{house_row.name}” affiliation", problems
+            )
+            house_section = house_offer.offers_choice.from_section
+            if house_section is None:
+                problems.append(
+                    "the Clan House offer names no menu — expected the house list"
+                )
+            else:
+                house_rows = _affiliations_on(house_section)
+                if not house_rows:
+                    problems.append("the Clan House menu offers no houses to convert")
+                twice_houses = duplicate_names(house_rows)
+                if twice_houses:
+                    problems.append(
+                        "more than one live house is called: " + ", ".join(twice_houses)
+                    )
+
+    both = duplicate_names([*top_rows, *house_rows])
+    if both and not (duplicate_names(top_rows) or duplicate_names(house_rows)):
+        problems.append(
+            "a top affiliation and a house share a name: " + ", ".join(both)
+        )
+
+    pack = default_pack_id()
+    if SlotType.objects.filter(name__iexact=AFFILIATION_TYPE, pack_id=pack).exists():
+        problems.append(f"a slot type named “{AFFILIATION_TYPE}” already stands")
+    if SlotType.objects.filter(name__iexact=HOUSE_TYPE, pack_id=pack).exists():
+        problems.append(f"a slot type named “{HOUSE_TYPE}” already stands")
+
+    top_picklist = (
+        section.collection.name if section is not None else AFFILIATION_PLURAL
+    )
+    house_picklist = (
+        house_section.collection.name if house_section is not None else HOUSE_PLURAL
+    )
+    if Picklist.objects.filter(pack_id=pack, name__iexact=top_picklist).exists():
+        problems.append(f"a picklist named “{top_picklist}” already stands")
+    if Picklist.objects.filter(pack_id=pack, name__iexact=house_picklist).exists():
+        problems.append(f"a picklist named “{house_picklist}” already stands")
+    for name in (AFFILIATION_SLOT, HOUSE_SLOT):
+        if Slot.objects.filter(pack_id=pack, name__iexact=name).exists():
+            problems.append(f"a slot named “{name}” already stands")
+
+    taken_pairs = set()
+    top_qualifiers = {
+        row.pk: _qualifier_for(row.name, AFFILIATION_TYPE, pack, taken_pairs, problems)
+        for row in top_rows
+    }
+    house_qualifiers = {
+        row.pk: _qualifier_for(row.name, HOUSE_TYPE, pack, taken_pairs, problems)
+        for row in house_rows
+    }
+
+    top_ids = {row.pk: row.name for row in top_rows}
+    house_ids = {row.pk: row.name for row in house_rows}
+    becoming = {**top_ids, **house_ids}
+
+    live_picks = list(
+        Assignment.objects.filter(affiliation__in=list(becoming), archived=False)
+        .exclude(removes=True)
+        .select_related("affiliation", "gang_root", "caused_by")
+        .order_by("created")
+    )
+    answers, spares = one_answer_per_question(live_picks)
+    archived_picks = list(
+        Assignment.objects.filter(affiliation__in=list(becoming), archived=True)
+        .exclude(removes=True)
+        .select_related("affiliation", "gang_root", "caused_by")
+        .order_by("created")
+    )
+
+    def slot_for(affiliation_id):
+        return AFFILIATION_SLOT if affiliation_id in top_ids else HOUSE_SLOT
+
+    for pick in [*answers, *archived_picks]:
+        if pick.caused_by_id is None:
+            problems.append(f"pick {pick.pk} has no caused_by to settle against")
+
+    # A live pick of an affiliation the menus do not offer, hanging from
+    # the Hidden or from a top-menu pick, would keep its line and lose
+    # its question when the offer is swapped. Refuse rather than strand it.
+    hidden_anchors = set(
+        Assignment.objects.filter(hidden=hidden, archived=False)
+        .exclude(removes=True)
+        .values_list("pk", flat=True)
+    )
+    top_anchors = set(
+        Assignment.objects.filter(affiliation__in=list(top_ids))
+        .exclude(removes=True)
+        .values_list("pk", flat=True)
+    )
+    strays = (
+        Assignment.objects.filter(
+            affiliation__isnull=False,
+            archived=False,
+            caused_by_id__in=hidden_anchors | top_anchors,
+        )
+        .exclude(removes=True)
+        .exclude(affiliation__in=list(becoming))
+        .select_related("affiliation")
+    )
+    for stray in strays:
+        problems.append(
+            f"pick {stray.pk} names “{stray.affiliation.name}”, which the menu "
+            "does not offer — it would lose its question unanswered"
+        )
+
+    if problems:
+        return Plan(system=SYSTEM, problems=tuple(problems))
+
+    def pickable_steps(rows, slot_type, qualifiers):
+        return [
+            CreatePickable(
+                name=row.name,
+                slot_type=slot_type,
+                moved_modifier_ids=tuple(m.pk for m in row.modifiers.all()),
+                moved_from=("library.Affiliation", row.pk),
+                qualifier=qualifiers[row.pk],
+            )
+            for row in rows
+        ]
+
+    steps = [
+        CreateSlotType(
+            name=AFFILIATION_TYPE,
+            plural_name=AFFILIATION_PLURAL,
+            allows_repeats=False,
+        ),
+        *pickable_steps(top_rows, AFFILIATION_TYPE, top_qualifiers),
+        CreatePicklist(
+            name=top_picklist,
+            slot_type=AFFILIATION_TYPE,
+            members=tuple(row.name for row in top_rows),
+        ),
+        CreateSlot(
+            name=AFFILIATION_SLOT,
+            slot_type=AFFILIATION_TYPE,
+            picklist=top_picklist,
+            label=AFFILIATION_SLOT,
+            assigned_to="gang",
+            min_picks=0,
+            max_picks=1,
+        ),
+        CreateSlotType(name=HOUSE_TYPE, plural_name=HOUSE_PLURAL, allows_repeats=False),
+        *pickable_steps(house_rows, HOUSE_TYPE, house_qualifiers),
+        CreatePicklist(
+            name=house_picklist,
+            slot_type=HOUSE_TYPE,
+            members=tuple(row.name for row in house_rows),
+        ),
+        CreateSlot(
+            name=HOUSE_SLOT,
+            slot_type=HOUSE_TYPE,
+            picklist=house_picklist,
+            label=HOUSE_SLOT_LABEL,
+            assigned_to="gang",
+            min_picks=0,
+            max_picks=1,
+        ),
+        SwapCarrier(
+            carrier=("library.Hidden", hidden.pk),
+            carrier_name=f"the “{hidden.name}” hidden",
+            drop_modifier_id=offer.pk,
+            drop_modifier_name=offer.name,
+            grant_name=f"{hidden.name}: the gang is asked its Affiliation",
+            slot=AFFILIATION_SLOT,
+            reach="gang",
+        ),
+        SwapCarrier(
+            carrier=("library.Affiliation", house_row.pk),
+            carrier_name=f"the “{house_row.name}” pickable",
+            drop_modifier_id=house_offer.pk,
+            drop_modifier_name=house_offer.name,
+            grant_name=f"{house_row.name}: the gang is asked its Clan House",
+            slot=HOUSE_SLOT,
+            reach="gang",
+            made_pickable=house_row.name,
+        ),
+    ]
+    steps += [
+        RewritePick(
+            assignment_id=pick.pk,
+            old_column="affiliation",
+            pickable=becoming[pick.affiliation_id],
+            slot=slot_for(pick.affiliation_id),
+            gang=str(pick.gang_root),
+        )
+        for pick in [*answers, *archived_picks]
+    ]
+
+    holders = set(
+        Assignment.objects.filter(hidden=hidden, archived=False)
+        .exclude(removes=True)
+        .values_list("gang_root_id", flat=True)
+        .distinct()
+    )
+    holders |= set(
+        Assignment.objects.filter(affiliation__in=list(becoming))
+        .exclude(removes=True)
+        .values_list("gang_root_id", flat=True)
+        .distinct()
+    )
+    holders.discard(None)
+
+    live_holders = set(
+        Gang.objects.filter(pk__in=holders, archived=False).values_list("pk", flat=True)
+    )
+    answered = {pick.gang_root_id for pick in answers}
+    house_answered = {
+        pick.gang_root_id for pick in answers if pick.affiliation_id in house_ids
+    }
+    clan_house_top = {
+        pick.gang_root_id
+        for pick in answers
+        if house_row is not None and pick.affiliation_id == house_row.pk
+    }
+    archived_gangs = {pick.gang_root_id for pick in archived_picks}
+
+    proven = spread(
+        live_holders,
+        [
+            [pick.gang_root_id for pick in spares],
+            sorted(archived_gangs, key=str),
+            sorted(clan_house_top - house_answered, key=str),
+            sorted(clan_house_top & house_answered, key=str),
+            sorted(live_holders - answered, key=str),
+            sorted(answered - clan_house_top, key=str),
+        ],
+        PROVEN,
+    )
+    return Plan(
+        system=SYSTEM,
+        steps=tuple(steps),
+        gang_ids=tuple(proven),
+        holder_ids=tuple(sorted(holders, key=str)),
+        reaches=len(holders),
+        left_alone=len(spares),
+    )

--- a/n26/library/conversion/affiliation.py
+++ b/n26/library/conversion/affiliation.py
@@ -431,7 +431,9 @@ def plan_outcast_affiliation():
         system=SYSTEM,
         steps=tuple(steps),
         gang_ids=tuple(proven),
-        holder_ids=tuple(sorted(holders, key=str)),
-        reaches=len(holders),
+        # Live gangs only: archived ones still have their picks rewritten,
+        # but a stale archived gang must not lock or refuse the write.
+        holder_ids=tuple(sorted(live_holders, key=str)),
+        reaches=len(live_holders),
         left_alone=len(spares),
     )

--- a/n26/library/conversion/affiliation.py
+++ b/n26/library/conversion/affiliation.py
@@ -46,9 +46,6 @@ AFFILIATION_SLOT = "Affiliation"
 HOUSE_TYPE = "Clan House"
 HOUSE_PLURAL = "Clan Houses"
 HOUSE_SLOT = "Clan House"
-#: What the card already calls the house question — the offer's label
-#: after ``capfirst``, which a slot name of "Clan House" would not match.
-HOUSE_SLOT_LABEL = "Clan house"
 OFFER_LABEL = "affiliation"
 HOUSE_OFFER_LABEL = "clan house"
 PROVEN = 15
@@ -319,6 +316,15 @@ def plan_outcast_affiliation():
             for row in rows
         ]
 
+    # What the card calls each question today, taken from the offer that
+    # asks it rather than guessed. A slot's ``choice_label`` lands where
+    # an offer's ``kind_label`` did, so carrying the offer's own wording
+    # across is the only way it survives whatever the authors typed: a
+    # label is stored as written apart from its first letter, and to the
+    # proof "Clan House" and "Clan house" are different words.
+    top_label = offer.offers_choice.kind_label
+    house_label = house_offer.offers_choice.kind_label
+
     steps = [
         CreateSlotType(
             name=AFFILIATION_TYPE,
@@ -335,7 +341,7 @@ def plan_outcast_affiliation():
             name=AFFILIATION_SLOT,
             slot_type=AFFILIATION_TYPE,
             picklist=top_picklist,
-            label=AFFILIATION_SLOT,
+            label=top_label,
             assigned_to="gang",
             min_picks=0,
             max_picks=1,
@@ -351,7 +357,7 @@ def plan_outcast_affiliation():
             name=HOUSE_SLOT,
             slot_type=HOUSE_TYPE,
             picklist=house_picklist,
-            label=HOUSE_SLOT_LABEL,
+            label=house_label,
             assigned_to="gang",
             min_picks=0,
             max_picks=1,

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -1,0 +1,690 @@
+"""The conversion discipline: plan, check, apply — the preview is the contract.
+
+A conversion moves one hand-built choice system (an offer, its menu
+collection, its chosen-kind rows) onto slots and picks without changing
+what any page says. Three stages, the ingest discipline:
+
+* ``plan()`` — each system's module reads the database and returns a
+  frozen :class:`Plan`: typed steps, the gangs the system touches, and
+  any problems. It never writes. ``plan.preview()`` says everything the
+  apply would do, one line per step.
+* ``apply(plan)`` — performs exactly the plan's steps in one
+  transaction. Before writing it captures what every affected gang's
+  pages say (``n26.core.capture``); after writing it captures again and
+  **refuses** — unwinding the whole transaction — on any difference, and
+  on any touched gang that no longer reconciles. A conversion that would
+  change what a reader is told never lands.
+* A plan whose system is absent (``plan.nothing_here``) applies as a
+  no-op, so the migration that ships a conversion is safe on databases
+  that never held the system — a fresh environment, a pack without it.
+
+Pick rewrites touch ``Assignment`` rows outside ``operation()`` — the
+one sanctioned place: a conversion moves no money. Nothing is created or
+priced, columns change on existing free rows, the ledger is untouched,
+and the reconcile assertion proves it gang by gang.
+
+What the ledger *says*, though, is not untouched, and the captures do
+not see it. The gang's history describes an old event by looking up what
+its assignment names now, so moving an assignment from one kind to
+another rewrites the wording of things that already happened. Every
+conversion must check the history page against a converted assignment
+and keep those words the same — see the note in ``n26/core/CLAUDE.md``.
+"""
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+from django.db import transaction
+
+logger = logging.getLogger(__name__)
+
+
+def carriers_of(modifier):
+    """Everything carrying this modifier, across every library kind — a
+    plan that detaches or deletes one must know it is not shared."""
+    from django.apps import apps as django_apps
+
+    found = []
+    for model in django_apps.get_app_config("library").get_models():
+        if not any(f.name == "modifiers" for f in model._meta.many_to_many):
+            continue
+        for row in model.objects.filter(modifiers=modifier):
+            found.append((model.__name__, row))
+    return found
+
+
+def offers_of(carrier, kind):
+    """The carrier's choice offers of one kind, by the kind's model name."""
+    return [
+        m
+        for m in carrier.modifiers.all()
+        if getattr(m, "offers_choice", None) is not None
+        and m.offers_choice.of_kind.model == kind
+    ]
+
+
+def the_offer(carrier, kind, kind_word, said, problems):
+    """The carrier's one offer of the kind, or a stated problem."""
+    offers = offers_of(carrier, kind)
+    if len(offers) != 1:
+        problems.append(
+            f"{said} carries {len(offers)} {kind_word} offers — expected one"
+        )
+        return None
+    return offers[0]
+
+
+def solely_carried(offer, carrier, problems):
+    """Deleting an offer's modifier detaches it from every carrier at
+    once, so the plan must know no third thing shares it — a sharer's
+    gangs are outside the proven set and would lose their question
+    unnoticed."""
+    others = [
+        f"{kind} “{row}”"
+        for kind, row in carriers_of(offer)
+        if not (kind == type(carrier).__name__ and row.pk == carrier.pk)
+    ]
+    if others:
+        problems.append(
+            f"“{offer.name}” is shared — also carried by " + ", ".join(others)
+        )
+
+
+def duplicate_names(rows):
+    """Names two or more of the rows share. A pick is matched to its
+    pickable by name, and a name is only unique within a pack and
+    qualifier — so two live rows called the same thing would quietly
+    become one pickable, and half the picks would land on the wrong
+    one."""
+    names = [row.name for row in rows]
+    return sorted({name for name in names if names.count(name) > 1})
+
+
+def refuse_if_granted(held, said, problems):
+    """A carrier that arrives by grant has no assignment to find it by,
+    so the gangs it reaches can be neither counted nor drawn into the
+    spread a plan proves. The apply page would understate the change,
+    and pages nothing checked would move — refuse instead, and whoever
+    makes such a grant decides what a conversion ought to do.
+
+    A kind that cannot be granted is skipped: asking the grant table
+    about it is a FieldError, and there is nothing to find.
+    """
+    from n26.library.models import AddsAssignable, Modifier
+    from n26.library.models.modifier import GRANTABLE_FIELDS
+
+    path = f"library.{type(held).__name__}"
+    field = next(
+        (name for name, model in GRANTABLE_FIELDS.items() if model == path), None
+    )
+    if field is None:
+        return
+    for granter in Modifier.objects.filter(
+        adds_assignable__in=AddsAssignable.objects.filter(**{field: held})
+    ):
+        if carriers_of(granter):
+            problems.append(
+                f"“{granter.name}” grants {said}, so the gangs it reaches "
+                "cannot be counted or proven"
+            )
+
+
+def one_answer_per_question(picks):
+    """One pick per question, and the spares left behind.
+
+    The same question answered twice — a click that landed twice — shows
+    on the page as the answer plus a spare line. Moving the answer keeps
+    the page: the pick becomes a pick, and the spare goes on being the
+    ordinary assignment it already is.
+    """
+    answers, spares, seen = [], [], set()
+    for pick in picks:
+        question = (pick.miniature_id, pick.caused_by_id)
+        if question in seen:
+            spares.append(pick)
+        else:
+            seen.add(question)
+            answers.append(pick)
+    return answers, spares
+
+
+def spread(gang_ids, kinds, limit):
+    """A sample wide enough to hold every shape, in a stable order.
+
+    One from each kind, round and round, so no kind crowds the others
+    out — a plentiful ordinary kind must not fill the sample before a
+    later kind's only gang is seen. The odd shapes lead each round, and
+    whatever room is left goes back around the kinds that still have
+    gangs to give.
+    """
+    chosen, used = [], set()
+    remaining = [list(wanted) for wanted in kinds]
+    while len(chosen) < limit and any(remaining):
+        for wanted in remaining:
+            while wanted:
+                gang_id = wanted.pop(0)
+                if gang_id in used or gang_id not in gang_ids:
+                    continue
+                used.add(gang_id)
+                chosen.append(gang_id)
+                break
+            if len(chosen) >= limit:
+                break
+    return chosen
+
+
+class ConversionRefused(Exception):
+    """The apply found the world changed by its own hand — or not shaped
+    the way the plan promised — and unwound. The message says exactly
+    what differed."""
+
+
+@dataclass(frozen=True)
+class CreateSlotType:
+    name: str
+    plural_name: str = ""
+    allows_repeats: bool = True
+
+    def say(self):
+        refused = "" if self.allows_repeats else ", refusing repeats"
+        return f"create slot type “{self.name}”{refused}"
+
+    def perform(self, made):
+        from n26.library.authoring import create_slot_type
+
+        made.slot_types[self.name] = create_slot_type(
+            self.name, plural_name=self.plural_name, allows_repeats=self.allows_repeats
+        )
+
+
+@dataclass(frozen=True)
+class CreatePickable:
+    name: str
+    slot_type: str
+    #: Modifier rows to move from the old kind's row onto the pickable —
+    #: the same rows, so scopes, conditions and effects are untouched.
+    moved_modifier_ids: tuple = ()
+    #: The old row the modifiers come off, as (model label, pk).
+    moved_from: tuple = ()
+    #: The pickable's linked category, as (pk, name) — for a system
+    #: whose whole payload is the link itself: a chosen-mode placement
+    #: reads the chosen thing's ``category`` and nothing else.
+    linked: tuple = ()
+    #: What tells this one apart from another pickable of the same name
+    #: — author-facing only, and never drawn for a player. A name is
+    #: unique per pack and qualifier, so a system whose names are
+    #: already spoken for by another slot type's pickables converts by
+    #: qualifying its own.
+    qualifier: str = ""
+
+    def say(self):
+        n = len(self.moved_modifier_ids)
+        moved = f", moving {n} modifier{'' if n == 1 else 's'}" if n else ""
+        linked = f", linked to category “{self.linked[1]}”" if self.linked else ""
+        told = f", told apart as “{self.qualifier}”" if self.qualifier else ""
+        return f"create pickable “{self.name}” ({self.slot_type}){moved}{linked}{told}"
+
+    def perform(self, made):
+        from django.apps import apps
+
+        from n26.library.authoring import create_pickable
+        from n26.library.models import Modifier
+
+        linking = {"category_id": self.linked[0]} if self.linked else {}
+        pickable = create_pickable(
+            self.name,
+            made.slot_types[self.slot_type],
+            qualifier=self.qualifier,
+            **linking,
+        )
+        if self.moved_modifier_ids:
+            app_label, model_name = self.moved_from[0].split(".")
+            old = apps.get_model(app_label, model_name).objects.get(
+                pk=self.moved_from[1]
+            )
+            for modifier in Modifier.objects.filter(pk__in=self.moved_modifier_ids):
+                old.modifiers.remove(modifier)
+                pickable.modifiers.add(modifier)
+        made.pickables[self.name] = pickable
+
+
+@dataclass(frozen=True)
+class CreatePicklist:
+    name: str
+    slot_type: str
+    members: tuple = ()
+
+    def say(self):
+        return f"create picklist “{self.name}” offering {', '.join(self.members)}"
+
+    def perform(self, made):
+        from n26.library.authoring import create_picklist
+
+        made.picklists[self.name] = create_picklist(
+            self.name,
+            made.slot_types[self.slot_type],
+            members=[made.pickables[name] for name in self.members],
+        )
+
+
+@dataclass(frozen=True)
+class CreateSlot:
+    name: str
+    slot_type: str
+    picklist: str
+    label: str = ""
+    assigned_to: str = "bearer"
+    min_picks: int = 1
+    max_picks: int = 1
+
+    def say(self):
+        return (
+            f"create slot “{self.name}” drawing on “{self.picklist}”, "
+            f"pick landing on the {self.assigned_to}"
+        )
+
+    def perform(self, made):
+        from n26.library.authoring import create_slot
+
+        made.slots[self.name] = create_slot(
+            self.name,
+            made.slot_types[self.slot_type],
+            made.picklists[self.picklist],
+            label=self.label,
+            assigned_to=self.assigned_to,
+            min_picks=self.min_picks,
+            max_picks=self.max_picks,
+        )
+
+
+def _grant_scope(reach):
+    """The scope a swapped grant reaches with.
+
+    ``gang`` is ``targets_gang()`` (the gang and its models); ``gang_alone``
+    keeps the grant on the gang's card; anything else is the bearer.
+    """
+    from n26.library.authoring import targets_gang, targets_gang_alone, targets_model
+
+    if reach == "gang":
+        return targets_gang()
+    if reach == "gang_alone":
+        return targets_gang_alone()
+    return targets_model()
+
+
+@dataclass(frozen=True)
+class SwapCarrier:
+    """The carrier stops offering and starts granting the slot."""
+
+    carrier: tuple  # (model label, pk)
+    carrier_name: str
+    drop_modifier_id: object
+    drop_modifier_name: str
+    grant_name: str
+    slot: str
+    #: The scope the grant reaches with — "gang" for a question the gang
+    #: asks (and whose payload may reach its models), "gang_alone" for a
+    #: question that stays on the gang's card, "model" for one each
+    #: bearer's card asks.
+    reach: str = "gang_alone"
+    #: When the offer was moved onto a pickable earlier in this plan,
+    #: perform looks the pickable up here rather than the plan-time
+    #: carrier — which by then no longer holds the modifier.
+    made_pickable: str = ""
+
+    def say(self):
+        return (
+            f"on {self.carrier_name}: replace “{self.drop_modifier_name}” "
+            f"with a grant of the “{self.slot}” slot"
+        )
+
+    def perform(self, made):
+        from django.apps import apps
+
+        from n26.library.authoring import ef_adds, modifier
+        from n26.library.models import Modifier
+
+        if self.made_pickable:
+            carrier = made.pickables[self.made_pickable]
+            model_name = type(carrier).__name__
+            expected = {(model_name, carrier.pk)}
+        else:
+            app_label, model_name = self.carrier[0].split(".")
+            carrier = apps.get_model(app_label, model_name).objects.get(
+                pk=self.carrier[1]
+            )
+            expected = {(model_name, self.carrier[1])}
+        dropped = Modifier.objects.get(pk=self.drop_modifier_id)
+        # The plan proved this modifier solely carried, but the plan was
+        # read outside this transaction: a carrier attached since would
+        # be detached silently by the delete below. Prove it again here,
+        # where the snapshot holds.
+        holders = {(kind, row.pk) for kind, row in carriers_of(dropped)}
+        if holders != expected:
+            raise ConversionRefused(
+                f"“{self.drop_modifier_name}” is no longer carried only by "
+                f"{self.carrier_name} — the world moved since the plan was made"
+            )
+        scope_row, effect_row = dropped.scope, dropped.effect
+        carrier.modifiers.remove(dropped)
+        dropped.delete()
+        scope_row.delete()
+        effect_row.delete()
+        modifier(
+            self.grant_name,
+            _grant_scope(self.reach),
+            ef_adds(made.slots[self.slot]),
+            attach_to=carrier,
+        )
+
+
+@dataclass(frozen=True)
+class SwapSharedCarrier:
+    """One offer shared by many carriers becomes one shared grant.
+
+    The offer modifier is a single row every carrier holds, so dropping
+    it detaches all of them at once — which is why the plan proves the
+    carriers are exactly the ones named here before this step exists.
+    The grant is one shared modifier too, so the factoring the authors
+    chose is preserved: one question's wiring, held in one place.
+    """
+
+    carriers: tuple  # ((model label, pk), ...) — every carrier, proven
+    carriers_said: str
+    drop_modifier_id: object
+    drop_modifier_name: str
+    grant_name: str
+    slot: str
+    #: Same reach vocabulary as :class:`SwapCarrier`.
+    reach: str = "model"
+
+    def say(self):
+        return (
+            f"on {self.carriers_said}: replace the shared "
+            f"“{self.drop_modifier_name}” with a shared grant of the "
+            f"“{self.slot}” slot"
+        )
+
+    def perform(self, made):
+        from django.apps import apps
+
+        from n26.library.authoring import attach_modifiers_to, ef_adds, modifier
+        from n26.library.models import Modifier
+
+        rows = [
+            apps.get_model(*label.split(".")).objects.get(pk=pk)
+            for label, pk in self.carriers
+        ]
+        dropped = Modifier.objects.get(pk=self.drop_modifier_id)
+        # The plan proved exactly these carriers, but the plan was read
+        # outside this transaction: a carrier attached since would be
+        # detached silently by the delete below. Prove it again here,
+        # where the snapshot holds.
+        holders = {(kind, row.pk) for kind, row in carriers_of(dropped)}
+        named = {(label.split(".")[1], pk) for label, pk in self.carriers}
+        if holders != named:
+            raise ConversionRefused(
+                f"“{self.drop_modifier_name}” is no longer carried by exactly "
+                f"{self.carriers_said} — the world moved since the plan was made"
+            )
+        scope_row, effect_row = dropped.scope, dropped.effect
+        for carrier in rows:
+            carrier.modifiers.remove(dropped)
+        dropped.delete()
+        scope_row.delete()
+        effect_row.delete()
+        grant = modifier(
+            self.grant_name,
+            _grant_scope(self.reach),
+            ef_adds(made.slots[self.slot]),
+            attach_to=rows[0],
+        )
+        for carrier in rows[1:]:
+            attach_modifiers_to(carrier, [grant])
+
+
+@dataclass(frozen=True)
+class RewritePick:
+    """One stored choice, re-said as a pick: the old kind's column moves
+    to ``pickable``, the anchor it already hangs from (``caused_by``)
+    becomes the choice it settles, and the slot is named."""
+
+    assignment_id: object
+    old_column: str
+    pickable: str
+    slot: str
+    gang: str
+
+    def say(self):
+        return f"rewrite pick {self.assignment_id} ({self.gang}) -> “{self.pickable}”"
+
+    def perform(self, made):
+        from n26.core.models import Assignment
+
+        pick = Assignment.objects.get(pk=self.assignment_id)
+        pick.pickable = made.pickables[self.pickable]
+        pick.chosen_for_id = pick.caused_by_id
+        pick.chosen_for_slot = made.slots[self.slot]
+        # The question it used to answer is not the one it answers now,
+        # and a pick naming both a slot and an offer says two things.
+        pick.chosen_for_offer = None
+        setattr(pick, self.old_column, None)
+        pick.save()
+
+
+@dataclass(frozen=True)
+class Retire:
+    """An old row the system no longer needs, deleted by identity."""
+
+    model: str  # app_label.ModelName
+    pk: object
+    name: str
+
+    def say(self):
+        return f"retire {self.model} “{self.name}”"
+
+    def perform(self, made):
+        from django.apps import apps
+
+        app_label, model_name = self.model.split(".")
+        apps.get_model(app_label, model_name).objects.get(pk=self.pk).delete()
+
+
+@dataclass
+class _Made:
+    """What the apply has created so far, by the plan's own names."""
+
+    slot_types: dict = field(default_factory=dict)
+    picklists: dict = field(default_factory=dict)
+    pickables: dict = field(default_factory=dict)
+    slots: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Plan:
+    system: str
+    steps: tuple = ()
+    #: The gangs the apply proves unchanged before committing — a spread
+    #: chosen by the system's own plan to hold every shape it comes in,
+    #: not every gang it reaches. Rendering everyone with the transaction
+    #: open is the part that used to take minutes; a few hundred row
+    #: updates do not.
+    gang_ids: tuple = ()
+    problems: tuple = ()
+    #: How many gangs the change reaches in all, proven or not.
+    reaches: int = 0
+    #: Every gang the write reaches: locked before capture, reconciled
+    #: after. Broader than ``gang_ids`` (the spread whose pages are
+    #: compared). Empty means "the spread is everyone".
+    holder_ids: tuple = ()
+    #: Assignments the plan deliberately leaves as they are.
+    left_alone: int = 0
+    #: True when the system simply is not here — nothing to convert and
+    #: nothing wrong: the apply is a clean no-op.
+    nothing_here: bool = False
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    def preview(self):
+        if self.nothing_here:
+            return [f"[{self.system}] nothing to convert — the system is not here"]
+        lines = [f"[{self.system}] {step.say()}" for step in self.steps]
+        if self.left_alone:
+            lines.append(
+                f"[{self.system}] leave {self.left_alone} spare assignment"
+                f"{'' if self.left_alone == 1 else 's'} exactly as they are"
+            )
+        reaches = self.reaches or len(self.holder_ids) or len(self.gang_ids)
+        many = "gangs read" if reaches != 1 else "gang reads"
+        lines.append(
+            f"[{self.system}] prove {len(self.gang_ids)} of {reaches} reached "
+            f"{many} the same, or refuse"
+        )
+        holders = self.holder_ids or self.gang_ids
+        if holders:
+            n = len(holders)
+            lines.append(
+                f"[{self.system}] reconcile all {n} reached "
+                f"gang{'' if n == 1 else 's'}, or refuse"
+            )
+        return lines
+
+
+def apply(plan):
+    """Perform exactly the plan, prove the pages unchanged, or refuse.
+
+    Returns the report lines. Raises :class:`ConversionRefused` — after
+    unwinding everything — if the plan carries problems, any affected
+    gang's pages change, or any touched gang stops reconciling.
+    """
+    if plan.problems:
+        raise ConversionRefused(
+            f"[{plan.system}] not applied: " + "; ".join(plan.problems)
+        )
+    if plan.nothing_here:
+        return list(plan.preview())
+
+    report = list(plan.preview())
+    _perform(plan, report)
+    report.append(f"[{plan.system}] applied; every page reads the same")
+    return report
+
+
+#: What Postgres may call an isolation level. The restore has to be
+#: written into the statement rather than passed as a value, so what
+#: goes in is checked against this rather than trusted — an answer
+#: nobody expected should stop the run, not travel into SQL.
+ISOLATION_LEVELS = frozenset(
+    {"read uncommitted", "read committed", "repeatable read", "serializable"}
+)
+
+
+@contextmanager
+def _one_snapshot():
+    """Ask for the whole run to read one unchanging view of the database.
+
+    The proof compares what the pages said before with what they say
+    after, and takes any difference to be this conversion's doing. On a
+    live database that only holds if both readings are of the same world.
+    Proving hundreds of gangs takes minutes and players go on playing
+    throughout, so reading whatever is committed at the time — the
+    ordinary way — puts their purchases in the second reading, and the
+    conversion is blamed for a hazard suit somebody bought while it
+    worked, refusing for a reason nobody can act on.
+
+    Reading from one snapshot instead, what differs is what the run did.
+    Somebody changing an assignment it also writes ends it in a refusal
+    rather than a guess, which is the right ending for work that cannot
+    be half done. Set on the session, because a transaction's isolation can only
+    be chosen before it has read anything, and put back afterwards so a
+    pooled connection is handed on as it was found.
+    """
+    from django.db import connection
+
+    outermost = not connection.in_atomic_block
+    if not (outermost and connection.vendor == "postgresql"):
+        # Nested inside a transaction somebody else opened — a test, a
+        # shell. Isolation can only be chosen before a transaction reads
+        # anything, so it is theirs to set and too late to ask here. That
+        # is not the same as being safe: at the ordinary level each
+        # statement reads afresh, so a caller nesting this while players
+        # are writing would not get the one snapshot promised above.
+        # Nothing does that today — a conversion from the console or the
+        # command opens the transaction itself.
+        yield
+        return
+    with connection.cursor() as cursor:
+        cursor.execute("SHOW default_transaction_isolation")
+        was = cursor.fetchone()[0]
+        if was.lower() not in ISOLATION_LEVELS:
+            raise ConversionRefused(
+                f"the database calls its isolation “{was}”, which is not a "
+                "level this knows how to put back"
+            )
+        cursor.execute(
+            "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ"
+        )
+    try:
+        yield
+    finally:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL {was}"
+                )
+        except Exception:
+            # Putting the setting back is courtesy to the next borrower of
+            # this connection, and must never be the thing the caller hears
+            # about. A run that ended badly can leave the connection unable
+            # to answer at all — and one that cannot answer is also one
+            # nobody will be handed again.
+            logger.warning(
+                "could not put the isolation level back to %s", was, exc_info=True
+            )
+
+
+def _perform(plan, report):
+    from n26.core.capture import differences, gang_state
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+
+    with _one_snapshot(), transaction.atomic():
+        lock_ids = plan.holder_ids or plan.gang_ids
+        list(Gang.objects.filter(pk__in=lock_ids).order_by("pk").select_for_update())
+        before = {
+            str(gang.pk): gang_state(gang)
+            for gang in Gang.objects.filter(pk__in=plan.gang_ids)
+        }
+        made = _Made()
+        for step in plan.steps:
+            try:
+                step.perform(made)
+            except Exception as failed:
+                # A step that cannot be performed is a refusal too: the
+                # command and the migration both promise words, never a
+                # traceback, and the transaction unwinds either way.
+                raise ConversionRefused(
+                    f"[{plan.system}] failed at “{step.say()}”: {failed}"
+                ) from failed
+        # Fresh instances: the steps may have moved column-backed facts,
+        # and a stale row would compare stale with stale.
+        after = {
+            str(gang.pk): gang_state(gang)
+            for gang in Gang.objects.filter(pk__in=plan.gang_ids)
+        }
+        changed = differences(before, after)
+        if changed:
+            raise ConversionRefused(
+                f"[{plan.system}] refused — the pages would change:\n  "
+                + "\n  ".join(changed)
+            )
+        for gang in Gang.objects.filter(pk__in=lock_ids):
+            try:
+                assert_reconciled(gang)
+            except Exception as failed:
+                raise ConversionRefused(
+                    f"[{plan.system}] refused — {gang} no longer reconciles: {failed}"
+                ) from failed

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -499,18 +499,20 @@ def convert_outcast_affiliation(backfill_id, **said_by_whoever_enqueued_it):
 
 def _proof_words(plan):
     """What a conversion's page says about its own proof."""
-    holders = len(plan.holder_ids) or plan.reaches
+    # Same fallback as Plan.preview — a plan may omit `reaches`.
+    reaches = plan.reaches or len(plan.holder_ids) or len(plan.gang_ids)
+    holders = len(plan.holder_ids) or reaches
     return {
         "reach_words": (
-            f"It reaches {plan.reaches} gang"
-            f"{'' if plan.reaches == 1 else 's'}, locks them, and proves "
+            f"It reaches {reaches} gang"
+            f"{'' if reaches == 1 else 's'}, locks them, and proves "
             f"{len(plan.gang_ids)} of them read the same before committing — "
             "a spread wide enough to hold every shape the system comes in. "
             f"Every reached gang is then reconciled ({holders} of them); "
             "a mismatch unwinds the whole write."
         ),
         "confirm_words": (
-            f"Convert {plan.reaches} gang(s)? It writes nothing unless every "
+            f"Convert {reaches} gang(s)? It writes nothing unless every "
             "page it proves reads the same, and every reached gang still "
             "reconciles."
         ),

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -105,6 +105,10 @@ class Operation(models.TextChoices):
         "n26_convert_archetype",
         "n26: the Outcast archetypes become picks",
     )
+    CONVERT_OUTCAST_AFFILIATION = (
+        "n26_convert_outcast_affiliation",
+        "n26: the Outcast affiliations become picks",
+    )
     SWEEP_ARCHIVED = (
         "n26_sweep_archived",
         "n26: the answers already taken back become picks",
@@ -135,6 +139,7 @@ class Operation(models.TextChoices):
 LOCK_KEYS = {
     Operation.DELETE_NAMELESS_GANG_TYPE: 826_020_606,
     Operation.AUDIT_RECONCILE: 826_020_607,
+    Operation.CONVERT_OUTCAST_AFFILIATION: 826_020_608,
 }
 
 
@@ -456,6 +461,121 @@ def _work_through(backfill_id, what, items, do_one, batch_size, budget):
     return False
 
 
+def _plan(system):
+    from n26.library.conversion import SYSTEMS
+
+    return SYSTEMS[system]()
+
+
+def _run_conversion(backfill_id, operation, system, **said_by_whoever_enqueued_it):
+    """Run one conversion, once, and write down the outcome.
+
+    Takes whatever else it is handed and ignores it. Delivery outlives a
+    deploy, so a message can arrive naming arguments the version that
+    enqueued it had and this one does not — and a task that refuses its
+    own message is retried for ever, there being nowhere for it to go.
+    """
+    from n26.library.conversion import ConversionRefused, apply
+
+    _run_recorded(
+        backfill_id,
+        operation,
+        f"{system.replace('_', ' ').capitalize()} conversion",
+        lambda: apply(_plan(system)),
+        ConversionRefused,
+    )
+
+
+@task
+def convert_outcast_affiliation(backfill_id, **said_by_whoever_enqueued_it):
+    """The Outcast Affiliation conversion, as a task."""
+    _run_conversion(
+        backfill_id,
+        Operation.CONVERT_OUTCAST_AFFILIATION,
+        "outcast_affiliation",
+        **said_by_whoever_enqueued_it,
+    )
+
+
+def _proof_words(plan):
+    """What a conversion's page says about its own proof."""
+    holders = len(plan.holder_ids) or plan.reaches
+    return {
+        "reach_words": (
+            f"It reaches {plan.reaches} gang"
+            f"{'' if plan.reaches == 1 else 's'}, locks them, and proves "
+            f"{len(plan.gang_ids)} of them read the same before committing — "
+            "a spread wide enough to hold every shape the system comes in. "
+            f"Every reached gang is then reconciled ({holders} of them); "
+            "a mismatch unwinds the whole write."
+        ),
+        "confirm_words": (
+            f"Convert {plan.reaches} gang(s)? It writes nothing unless every "
+            "page it proves reads the same, and every reached gang still "
+            "reconciles."
+        ),
+        "button_words": "Apply conversion",
+        "leaves_behind": "",
+    }
+
+
+def _conversion_view(request, operation, system, task_fn):
+    """Preview a conversion (GET), or record a run and enqueue it (POST)."""
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That conversion is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        plan = _plan(system)
+        if plan.nothing_here:
+            messages.info(request, "There is nothing to convert.")
+            return HttpResponseRedirect(address)
+        if not plan.ok:
+            messages.error(
+                request, "The conversion refuses: " + "; ".join(plan.problems)
+            )
+            return HttpResponseRedirect(address)
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"preview": list(plan.preview()), "attempts": 0},
+        )
+        task_fn.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The conversion is running. This page shows what it did."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+
+    plan = _plan(system)
+    context = page_context(
+        request,
+        operation.label,
+        plan=plan,
+        preview=list(plan.preview()),
+        reaches=plan.reaches,
+        proven=len(plan.gang_ids),
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+        **_proof_words(plan),
+    )
+    return render(request, "admin/maintenance/n26/convert.html", context)
+
+
+def convert_outcast_affiliation_view(request):
+    return _conversion_view(
+        request,
+        Operation.CONVERT_OUTCAST_AFFILIATION,
+        "outcast_affiliation",
+        convert_outcast_affiliation,
+    )
+
+
 def _who_asked(backfill_id):
     """The operator a run acts as, for the history it writes.
 
@@ -658,6 +778,26 @@ register_operation(
 
 register_operation(
     MaintenanceOperation(
+        operation=Operation.CONVERT_OUTCAST_AFFILIATION.value,
+        name=Operation.CONVERT_OUTCAST_AFFILIATION.label,
+        added=date(2026, 8, 27),
+        description=(
+            "Move the Outcast affiliations onto slots and picks: the Hidden "
+            "built into the gang type grants an Affiliation slot instead of "
+            "offering a choice, Clan House grants a chained Clan House slot, "
+            "and every stored choice — live and archived — is re-said as a "
+            "pick. What an affiliation does travels with it untouched. "
+            "Proves a spread of gangs' pages read the same and every reached "
+            "gang still reconciles, or writes nothing."
+        ),
+        view=convert_outcast_affiliation_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
+
+register_operation(
+    MaintenanceOperation(
         operation=Operation.DELETE_NAMELESS_GANG_TYPE.value,
         name=Operation.DELETE_NAMELESS_GANG_TYPE.label,
         added=date(2026, 8, 21),
@@ -692,6 +832,7 @@ register_operation(
 #: schedules, so dev and tests invoke the sweep function directly.
 task_routes = [
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(convert_outcast_affiliation, ack_deadline=600, min_retry_delay=60),
     TaskRoute(propagate_built_ins, ack_deadline=600),
     TaskRoute(sweep_built_in_propagations, schedule="*/5 * * * *"),
     TaskRoute(audit_reconcile),

--- a/n26/tests/sandbox/test_conversion_affiliation.py
+++ b/n26/tests/sandbox/test_conversion_affiliation.py
@@ -200,6 +200,8 @@ def build_world(prod_shape, owner):
         )
     )
     choose(hidden_line(gangs["rechosen"]), top["Mutant"])
+    for gang in gangs.values():
+        assert_reconciled(gang)
     return gangs, fighters, hidden
 
 
@@ -246,6 +248,20 @@ class TestThePlan:
         # house, mutant) plus the rechosen gang's live Mutant and its
         # archived Clanless.
         assert said.count("rewrite pick") >= 7
+
+    def test_an_archived_gang_is_rewritten_but_not_held(self, world):
+        """Archived gangs still have their picks moved, but a stale
+        archived gang must not lock or refuse the whole conversion."""
+        gangs, _, _ = world
+        gone = gangs["clanless"]
+        gone.archive()
+
+        plan = plan_outcast_affiliation()
+
+        assert gone.pk not in plan.holder_ids
+        apply(plan)
+        pick = Assignment.objects.get(gang=gone, pickable__isnull=False, archived=False)
+        assert pick.pickable.name == "Clanless Outcast"
 
     def test_nothing_here_when_the_system_is_absent(self, default_pack):
         plan = plan_outcast_affiliation()

--- a/n26/tests/sandbox/test_conversion_affiliation.py
+++ b/n26/tests/sandbox/test_conversion_affiliation.py
@@ -1,0 +1,522 @@
+"""The Outcast Affiliation conversion, proven on a prod-shaped world.
+
+A Hidden built into the gang type offers the Affiliations menu; Clan
+House chains a second menu of houses. After the conversion those are
+slots and pickables, the modifiers have moved not copied, and every
+page still says the same things.
+"""
+
+import pytest
+
+from n26.core.capture import differences, gang_state
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.conversion import apply, plan_outcast_affiliation
+from n26.library.models import Affiliation, Pickable, Slot
+from n26.tests.sandbox.actions import (
+    adds,
+    choose,
+    create_affiliation,
+    create_collection,
+    create_default_set,
+    create_gang_type,
+    create_hidden,
+    create_profile,
+    create_slot_type,
+    create_subtype,
+    create_wargear,
+    found_gang,
+    has_subtypes,
+    hire,
+    modifier,
+    offers_choice,
+    remove,
+    section_of,
+    targets_every_model,
+    targets_gang,
+)
+
+pytestmark = pytest.mark.django_db
+
+HOUSES = ("Cawdor", "Delaque", "Escher", "Goliath", "Van Saar", "Orlock")
+AFFILIATIONS = ("Clanless", "Clan House", "Mutant", "Aranthian")
+
+
+@pytest.fixture
+def prod_shape(default_pack, person_type):
+    return build_prod_shape(person_type)
+
+
+@pytest.fixture
+def world(prod_shape, owner):
+    return build_world(prod_shape, owner)
+
+
+def build_prod_shape(person_type):
+    """The system as production holds it: a Hidden offering Affiliation,
+    four affiliations, Clan House chaining the six houses."""
+    subtypes = {
+        "leader": create_subtype("Outcast Leader"),
+        "champion": create_subtype("Outcast Champion"),
+        "ganger": create_subtype("Outcast Ganger"),
+    }
+    leaders_and_champions = [subtypes["leader"], subtypes["champion"]]
+    houses = {
+        house: create_affiliation(
+            f"House {house}",
+            effects=[
+                (
+                    targets_every_model(has_subtypes(*leaders_and_champions)),
+                    adds(
+                        create_collection(
+                            f"House {house} Equipment List",
+                            entries=[(create_wargear(f"{house} blade"), {})],
+                        )
+                    ),
+                )
+            ],
+        )
+        for house in HOUSES
+    }
+    house_section = section_of(
+        create_collection("Clan Houses", entries=[(houses[h], {}) for h in HOUSES]),
+        "Clan Houses",
+        0,
+        is_default=True,
+    )
+    top = {
+        "Clanless": create_affiliation("Clanless Outcast"),
+        "Clan House": create_affiliation("Clan House Outcast"),
+        "Mutant": create_affiliation(
+            "Mutant Outcast",
+            effects=[
+                (
+                    targets_every_model(),
+                    adds(
+                        create_collection(
+                            "Mutations",
+                            entries=[(create_wargear("Extra Arm", price=30), {})],
+                        )
+                    ),
+                )
+            ],
+        ),
+        "Aranthian": create_affiliation(
+            "Aranthian Outcast",
+            effects=[
+                (
+                    targets_every_model(has_subtypes(*leaders_and_champions)),
+                    adds(create_collection("Aranthian Equipment List")),
+                )
+            ],
+        ),
+    }
+    modifier(
+        "Clan House: choose one of the six Houses",
+        targets_gang(),
+        offers_choice(Affiliation, from_section=house_section, label="clan house"),
+        carried_by=top["Clan House"],
+    )
+    # Fossils: unattached offers the conversion must not swap.
+    modifier(
+        "a whole-kind Affiliation offer",
+        targets_gang(),
+        offers_choice(Affiliation, label="affiliation"),
+    )
+    modifier(
+        "Corruption",
+        targets_gang(),
+        offers_choice(Affiliation, label="corruption"),
+    )
+    menu = section_of(
+        create_collection(
+            "Affiliations", entries=[(top[name], {}) for name in AFFILIATIONS]
+        ),
+        "Affiliations",
+        0,
+        is_default=True,
+    )
+    hidden = create_hidden("Affiliation")
+    modifier(
+        "Outcasts: the Leader chooses an Affiliation",
+        targets_gang(),
+        offers_choice(Affiliation, from_section=menu, label="affiliation"),
+        carried_by=hidden,
+    )
+    gang_type = create_gang_type("Outcasts", starting_credits=2000)
+    gang_type.built_ins = create_default_set("Outcast built-ins", members=[hidden])
+    gang_type.save()
+    profiles = {}
+    for rank, name, price in [
+        ("leader", "Outcast Leader", 100),
+        ("champion", "Outcast Champion", 80),
+        ("ganger", "Outcast Ganger", 30),
+    ]:
+        profile = create_profile(name, person_type, gang_type, price=price)
+        profile.built_ins = create_default_set(
+            f"{name} built-ins", members=[subtypes[rank]]
+        )
+        profile.save()
+        profiles[rank] = profile
+    return gang_type, top, houses, hidden, profiles, subtypes
+
+
+def build_world(prod_shape, owner):
+    gang_type, top, houses, hidden, profiles, _ = prod_shape
+    gangs = {
+        "unanswered": found_gang("The Unspoken", gang_type, owner=owner, budget=2000),
+        "clanless": found_gang("The Clanless", gang_type, owner=owner, budget=2000),
+        "open_house": found_gang("The Unhoused", gang_type, owner=owner, budget=2000),
+        "housed": found_gang("The Cawdor Kin", gang_type, owner=owner, budget=2000),
+        "rechosen": found_gang("The Twice Told", gang_type, owner=owner, budget=2000),
+        "mutant": found_gang("The Changed", gang_type, owner=owner, budget=2000),
+    }
+    fighters = {}
+    for key in ("housed", "mutant"):
+        fighters[key] = {
+            rank: hire(
+                gangs[key], profiles[rank], rank.title(), paid=profiles[rank].price
+            )
+            for rank in ("leader", "champion", "ganger")
+        }
+
+    def hidden_line(gang):
+        return Assignment.objects.get(hidden=hidden, gang=gang, archived=False)
+
+    choose(hidden_line(gangs["clanless"]), top["Clanless"])
+    choose(hidden_line(gangs["open_house"]), top["Clan House"])
+    choose(hidden_line(gangs["housed"]), top["Clan House"])
+    choose(
+        Assignment.objects.get(
+            affiliation=top["Clan House"], gang=gangs["housed"], archived=False
+        ),
+        houses["Cawdor"],
+    )
+    choose(hidden_line(gangs["mutant"]), top["Mutant"])
+    choose(hidden_line(gangs["rechosen"]), top["Clanless"])
+    remove(
+        Assignment.objects.get(
+            affiliation=top["Clanless"], gang=gangs["rechosen"], archived=False
+        )
+    )
+    choose(hidden_line(gangs["rechosen"]), top["Mutant"])
+    return gangs, fighters, hidden
+
+
+def _story(acts):
+    told = []
+    for act in acts:
+        told.append("".join(span.text for span in act.spans))
+        told.extend(f"{sub.name}|{sub.kind}|{sub.note}" for sub in act.subs)
+    return told
+
+
+def _lists_of(miniature):
+    from n26.core.card import build_card, build_modifier_index
+    from n26.core.effects import compute
+
+    card = build_card(miniature)
+    index = build_modifier_index([n.assignable for n in card.all_nodes()])
+    return [c.name for c in compute(card, index).collections]
+
+
+class TestThePlan:
+    def test_it_says_everything_it_would_do(self, world):
+        plan = plan_outcast_affiliation()
+
+        assert plan.ok and not plan.nothing_here
+        said = "\n".join(plan.preview())
+        assert "create slot type “Affiliation”, refusing repeats" in said
+        assert "create slot type “Clan House”, refusing repeats" in said
+        assert said.count("create pickable") == 10
+        assert "create pickable “Clanless Outcast”" in said
+        assert "create pickable “House Goliath”" in said
+        assert "create slot “Affiliation”" in said
+        assert "create slot “Clan House”" in said
+        assert "pick landing on the gang" in said
+        assert "the “Affiliation” hidden" in said
+        assert "the “Clan House Outcast” pickable" in said
+        assert "retire" not in said
+        assert "prove " in said
+        assert "reconcile all" in said
+
+    def test_it_rewrites_the_archived_answer_too(self, world):
+        said = "\n".join(plan_outcast_affiliation().preview())
+        # Five live answers (clanless, open house, housed top, housed
+        # house, mutant) plus the rechosen gang's live Mutant and its
+        # archived Clanless.
+        assert said.count("rewrite pick") >= 7
+
+    def test_nothing_here_when_the_system_is_absent(self, default_pack):
+        plan = plan_outcast_affiliation()
+
+        assert plan.nothing_here
+        assert apply(plan) == plan.preview()
+
+
+class TestTheApply:
+    def test_every_page_reads_the_same(self, world):
+        gangs, _, _ = world
+        before = {key: gang_state(g) for key, g in gangs.items()}
+
+        apply(plan_outcast_affiliation())
+
+        for key, gang in gangs.items():
+            assert differences(before[key], gang_state(gang)) == []
+            assert_reconciled(gang)
+
+    def test_the_pick_still_lands_on_the_gang(self, world):
+        gangs, _, _ = world
+
+        apply(plan_outcast_affiliation())
+
+        pick = Assignment.objects.get(
+            gang=gangs["clanless"], pickable__isnull=False, archived=False
+        )
+        assert pick.pickable.name == "Clanless Outcast"
+        assert pick.affiliation_id is None
+        assert pick.chosen_for_slot == Slot.objects.get(name="Affiliation")
+        assert pick.miniature_id is None
+        assert pick.chosen_for_id == pick.caused_by_id
+
+    def test_the_house_pick_lands_on_the_clan_house_slot(self, world):
+        gangs, _, _ = world
+
+        apply(plan_outcast_affiliation())
+
+        pick = Assignment.objects.get(
+            gang=gangs["housed"], pickable__name="House Cawdor", archived=False
+        )
+        assert pick.chosen_for_slot == Slot.objects.get(name="Clan House")
+        assert pick.affiliation_id is None
+
+    def test_the_archived_answer_is_rewritten_too(self, world):
+        gangs, _, _ = world
+
+        apply(plan_outcast_affiliation())
+
+        archived = Assignment.objects.get(gang=gangs["rechosen"], archived=True)
+        assert archived.pickable.name == "Clanless Outcast"
+        assert archived.affiliation_id is None
+        assert archived.chosen_for_slot == Slot.objects.get(name="Affiliation")
+
+    def test_house_goliath_is_a_pickable_even_though_nobody_picked_it(self, world):
+        apply(plan_outcast_affiliation())
+
+        assert Pickable.objects.filter(name="House Goliath").exists()
+
+    def test_the_fossils_are_left_standing(self, world):
+        from n26.library.models import Modifier
+
+        before = Modifier.objects.filter(name="a whole-kind Affiliation offer").count()
+        apply(plan_outcast_affiliation())
+        assert (
+            Modifier.objects.filter(name="a whole-kind Affiliation offer").count()
+            == before
+            == 1
+        )
+        assert Modifier.objects.filter(name="Corruption").exists()
+
+
+class TestTheBehaviourThatMustSurvive:
+    def test_the_house_list_still_opens_to_the_right_ranks(self, world):
+        _, fighters, _ = world
+        before = {
+            rank: _lists_of(fighters["housed"][rank])
+            for rank in ("leader", "champion", "ganger")
+        }
+        assert "House Cawdor Equipment List" in before["leader"]
+        assert "House Cawdor Equipment List" in before["champion"]
+        assert "House Cawdor Equipment List" not in before["ganger"]
+
+        apply(plan_outcast_affiliation())
+
+        for rank, was in before.items():
+            assert _lists_of(fighters["housed"][rank]) == was
+
+    def test_mutants_still_open_the_mutation_list_to_every_rank(self, world):
+        _, fighters, _ = world
+        before = [_lists_of(m) for m in fighters["mutant"].values()]
+
+        apply(plan_outcast_affiliation())
+
+        after = [_lists_of(m) for m in fighters["mutant"].values()]
+        assert after == before
+        assert all("Mutations" in lists for lists in after)
+
+    def test_the_chain_still_opens_and_closes(self, world, prod_shape):
+        gangs, _, hidden = world
+        apply(plan_outcast_affiliation())
+        gang = gangs["clanless"]
+        hidden_line = Assignment.objects.get(hidden=hidden, gang=gang, archived=False)
+        affiliation = Slot.objects.get(name="Affiliation")
+        house = Slot.objects.get(name="Clan House")
+
+        def standing():
+            return Assignment.objects.get(
+                gang=gang,
+                chosen_for_slot=affiliation,
+                archived=False,
+            )
+
+        remove(standing())
+        choose(
+            hidden_line,
+            Pickable.objects.get(name="Clan House Outcast"),
+            slot=affiliation,
+        )
+        assert ("Clan house", "") in gang_state(gang)["choices"]
+
+        choose(
+            Assignment.objects.get(
+                gang=gang, pickable__name="Clan House Outcast", archived=False
+            ),
+            Pickable.objects.get(name="House Escher"),
+            slot=house,
+        )
+        assert ("Clan house", "House Escher") in gang_state(gang)["choices"]
+
+        remove(standing())
+        choose(
+            hidden_line,
+            Pickable.objects.get(name="Mutant Outcast"),
+            slot=affiliation,
+        )
+        assert all(label != "Clan house" for label, _ in gang_state(gang)["choices"])
+        assert_reconciled(gang)
+        assert_reconciled(gang)
+
+
+class TestTheStory:
+    def test_affiliation_keeps_its_kind_word(self, world):
+        from n26.core.history import _kindword
+
+        gangs, _, _ = world
+        apply(plan_outcast_affiliation())
+
+        pick = Assignment.objects.get(
+            gang=gangs["clanless"], pickable__isnull=False, archived=False
+        )
+        assert _kindword(pick) == "affiliation"
+
+    def test_a_house_pick_is_reworded_to_clan_house(self, world):
+        from n26.core.history import _kindword
+
+        gangs, _, _ = world
+        apply(plan_outcast_affiliation())
+
+        pick = Assignment.objects.get(
+            gang=gangs["housed"], pickable__name="House Cawdor", archived=False
+        )
+        assert _kindword(pick) == "clan house"
+
+    def test_a_clanless_gangs_story_does_not_move(self, world):
+        from n26.core import history
+
+        gangs, _, _ = world
+        said = _story(history.build(gangs["clanless"]))
+
+        apply(plan_outcast_affiliation())
+
+        assert _story(history.build(gangs["clanless"])) == said
+
+
+class TestRechoosing:
+    def test_the_new_machinery_answers_again(self, world, prod_shape):
+        gangs, _, hidden = world
+        apply(plan_outcast_affiliation())
+        gang = gangs["unanswered"]
+        hidden_line = Assignment.objects.get(hidden=hidden, gang=gang, archived=False)
+
+        choose(
+            hidden_line,
+            Pickable.objects.get(name="Aranthian Outcast"),
+            slot=Slot.objects.get(name="Affiliation"),
+        )
+
+        state = gang_state(gang)
+        assert ("Affiliation", "Aranthian Outcast") in state["choices"]
+        assert_reconciled(gang)
+
+    def test_a_second_run_is_a_clean_no_op(self, world):
+        apply(plan_outcast_affiliation())
+
+        assert plan_outcast_affiliation().nothing_here
+
+
+class TestTheRefusals:
+    def test_a_standing_slot_type_is_refused(self, world):
+        create_slot_type("Affiliation")
+
+        plan = plan_outcast_affiliation()
+
+        assert not plan.ok
+        assert any("already stands" in problem for problem in plan.problems)
+
+    def test_a_differently_cased_slot_type_is_refused(self, world):
+        create_slot_type("AFFILIATION")
+
+        plan = plan_outcast_affiliation()
+
+        assert not plan.ok
+        assert any("already stands" in problem for problem in plan.problems)
+
+    def test_a_colliding_pickable_is_qualified(self, world):
+        from n26.tests.sandbox.actions import create_pickable
+
+        other = create_slot_type("Something Else")
+        create_pickable("Clanless Outcast", other)
+
+        plan = plan_outcast_affiliation()
+
+        assert plan.ok
+        said = "\n".join(plan.preview())
+        assert "told apart as “Affiliation”" in said
+
+    def test_a_colliding_qualified_pickable_is_refused(self, world):
+        from n26.tests.sandbox.actions import create_pickable
+
+        other = create_slot_type("Something Else")
+        create_pickable("Clanless Outcast", other)
+        create_pickable("Clanless Outcast", other, qualifier="Affiliation")
+
+        plan = plan_outcast_affiliation()
+
+        assert not plan.ok
+        assert any("already stands" in p for p in plan.problems)
+
+    def test_a_shared_offer_is_refused(self, world, prod_shape):
+        from n26.library.authoring import attach_modifiers_to
+
+        _, top, _, hidden, _, _ = prod_shape
+        offer = next(
+            m
+            for m in hidden.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        attach_modifiers_to(top["Mutant"], [offer])
+
+        plan = plan_outcast_affiliation()
+
+        assert not plan.ok
+        assert any("shared" in p or "Hidden alone" in p for p in plan.problems)
+
+    def test_an_off_menu_pick_is_refused(self, world, prod_shape):
+        gang_type, top, houses, hidden, _, _ = prod_shape
+        gangs, _, _ = world
+        offmenu = create_affiliation("Something Else Entirely")
+        line = Assignment.objects.get(
+            hidden=hidden, gang=gangs["unanswered"], archived=False
+        )
+        Assignment.objects.create(
+            affiliation=offmenu,
+            gang=gangs["unanswered"],
+            caused_by=line,
+            chosen_for=line,
+            gang_root=gangs["unanswered"],
+        )
+
+        plan = plan_outcast_affiliation()
+
+        assert not plan.ok
+        assert any("the menu does not offer" in p for p in plan.problems)

--- a/n26/tests/sandbox/test_conversion_affiliation.py
+++ b/n26/tests/sandbox/test_conversion_affiliation.py
@@ -114,14 +114,14 @@ def build_prod_shape(person_type):
     modifier(
         "Clan House: choose one of the six Houses",
         targets_gang(),
-        offers_choice(Affiliation, from_section=house_section, label="clan house"),
+        offers_choice(Affiliation, from_section=house_section, label="Clan House"),
         carried_by=top["Clan House"],
     )
     # Fossils: unattached offers the conversion must not swap.
     modifier(
         "a whole-kind Affiliation offer",
         targets_gang(),
-        offers_choice(Affiliation, label="affiliation"),
+        offers_choice(Affiliation, label="Affiliation"),
     )
     modifier(
         "Corruption",
@@ -140,7 +140,7 @@ def build_prod_shape(person_type):
     modifier(
         "Outcasts: the Leader chooses an Affiliation",
         targets_gang(),
-        offers_choice(Affiliation, from_section=menu, label="affiliation"),
+        offers_choice(Affiliation, from_section=menu, label="Affiliation"),
         carried_by=hidden,
     )
     gang_type = create_gang_type("Outcasts", starting_credits=2000)
@@ -306,6 +306,30 @@ class TestTheApply:
         assert pick.chosen_for_slot == Slot.objects.get(name="Clan House")
         assert pick.affiliation_id is None
 
+    def test_each_slot_is_labelled_the_way_the_offer_already_was(self, world):
+        """The card's own words, carried across rather than guessed.
+
+        A label is stored as the author typed it (only its first letter
+        is forced up), so a conversion that hardcodes the wording gets
+        "Clan house" where production says "Clan House" — and every
+        housed gang's card changes a word, which the proof rejects after
+        doing all the work. Production's own casing is the fixture's, so
+        this fails the moment the label stops being derived.
+        """
+        _, _, hidden = world
+        offer = next(
+            m
+            for m in hidden.modifiers.all()
+            if getattr(m, "offers_choice", None) is not None
+        )
+        said = offer.offers_choice.kind_label
+
+        apply(plan_outcast_affiliation())
+
+        assert said == "Affiliation"
+        assert Slot.objects.get(name="Affiliation").choice_label == said
+        assert Slot.objects.get(name="Clan House").choice_label == "Clan House"
+
     def test_the_archived_answer_is_rewritten_too(self, world):
         gangs, _, _ = world
 
@@ -381,7 +405,7 @@ class TestTheBehaviourThatMustSurvive:
             Pickable.objects.get(name="Clan House Outcast"),
             slot=affiliation,
         )
-        assert ("Clan house", "") in gang_state(gang)["choices"]
+        assert ("Clan House", "") in gang_state(gang)["choices"]
 
         choose(
             Assignment.objects.get(
@@ -390,7 +414,7 @@ class TestTheBehaviourThatMustSurvive:
             Pickable.objects.get(name="House Escher"),
             slot=house,
         )
-        assert ("Clan house", "House Escher") in gang_state(gang)["choices"]
+        assert ("Clan House", "House Escher") in gang_state(gang)["choices"]
 
         remove(standing())
         choose(
@@ -398,7 +422,7 @@ class TestTheBehaviourThatMustSurvive:
             Pickable.objects.get(name="Mutant Outcast"),
             slot=affiliation,
         )
-        assert all(label != "Clan house" for label, _ in gang_state(gang)["choices"])
+        assert all(label != "Clan House" for label, _ in gang_state(gang)["choices"])
         assert_reconciled(gang)
         assert_reconciled(gang)
 

--- a/n26/tests/sandbox/test_outcast_affiliation_flow.py
+++ b/n26/tests/sandbox/test_outcast_affiliation_flow.py
@@ -198,17 +198,20 @@ def picker_url(gang, kind_label):
     return reverse("n26-choose", args=[gang.pk, slot_line(gang, kind_label).key])
 
 
-def as_pickable(chosen):
+def as_pickable(chosen, kind_label="Affiliation"):
     """The conversion re-says affiliations as pickables; the fixture still
-    hands the old row, so the picker is given the pickable of that name."""
+    hands the old row, so the picker is given the pickable of that name
+    on the slot type that question uses."""
     if isinstance(chosen, Pickable):
         return chosen
-    return Pickable.objects.get(name=chosen.name)
+    slot_type = "Clan House" if kind_label == "Clan house" else kind_label
+    return Pickable.objects.get(name=chosen.name, slot_type__name=slot_type)
 
 
 def pick(client, gang, kind_label, affiliation):
     return client.post(
-        picker_url(gang, kind_label), {"thing": thing_key(as_pickable(affiliation))}
+        picker_url(gang, kind_label),
+        {"thing": thing_key(as_pickable(affiliation, kind_label))},
     )
 
 

--- a/n26/tests/sandbox/test_outcast_affiliation_flow.py
+++ b/n26/tests/sandbox/test_outcast_affiliation_flow.py
@@ -26,7 +26,7 @@ from django.urls import reverse
 from n26.core.owned import thing_key
 from n26.core.reconcile import assert_reconciled
 from n26.core.render import render_gang
-from n26.library.models import Affiliation
+from n26.library.models import Affiliation, Pickable
 from n26.tests.sandbox.actions import (
     adds,
     create_affiliation,
@@ -153,6 +153,9 @@ def outcasts(affiliations):
     gang_type = create_gang_type("Outcasts")
     gang_type.built_ins = create_default_set("Outcast built-ins", members=[slot])
     gang_type.save()
+    from n26.library.conversion import apply, plan_outcast_affiliation
+
+    apply(plan_outcast_affiliation())
     return gang_type
 
 
@@ -195,15 +198,27 @@ def picker_url(gang, kind_label):
     return reverse("n26-choose", args=[gang.pk, slot_line(gang, kind_label).key])
 
 
+def as_pickable(chosen):
+    """The conversion re-says affiliations as pickables; the fixture still
+    hands the old row, so the picker is given the pickable of that name."""
+    if isinstance(chosen, Pickable):
+        return chosen
+    return Pickable.objects.get(name=chosen.name)
+
+
 def pick(client, gang, kind_label, affiliation):
-    return client.post(picker_url(gang, kind_label), {"thing": thing_key(affiliation)})
+    return client.post(
+        picker_url(gang, kind_label), {"thing": thing_key(as_pickable(affiliation))}
+    )
 
 
 def top_level_rows(gang):
     return [
         a
         for a in gang.assignments.filter(archived=False)
-        if isinstance(a.assignable, Affiliation)
+        if isinstance(a.assignable, Pickable)
+        and a.chosen_for_slot_id
+        and a.chosen_for_slot.name == "Affiliation"
     ]
 
 
@@ -238,7 +253,7 @@ class TestAnAnswerArrivingTwice:
 
         top, _ = affiliations
         url = picker_url(gang, "Affiliation")
-        payload = {"thing": thing_key(top["Clanless"])}
+        payload = {"thing": thing_key(as_pickable(top["Clanless"]))}
         both_have_read = threading.Barrier(2, timeout=30)
         guard = threading.Lock()
         has_read = set()

--- a/n26/tests/sandbox/test_outcast_gang.py
+++ b/n26/tests/sandbox/test_outcast_gang.py
@@ -378,6 +378,9 @@ def outcasts(subtypes, skills_collection, affiliations, affiliation_lists):
         requires_companions(subtypes["champion"], 3, subtypes["scum"]),
         carried_by=gang_type,
     )
+    from n26.library.conversion import apply, plan_outcast_affiliation
+
+    apply(plan_outcast_affiliation())
     return gang_type
 
 
@@ -519,7 +522,7 @@ class TestFoundingOffersTheChoices:
 
         gang_computed = the_gang_computed(gang)
         affiliations = offered_by(gang_computed.choice("Affiliation"), gang_computed)
-        assert {line.name for line in affiliations.all_lines()} == {
+        assert {line.name for line in affiliations} == {
             "Clanless Outcast",
             "Clan House Outcast",
             "Mutant Outcast",
@@ -531,6 +534,29 @@ def _slot_named(name):
     from n26.library.models import Slot
 
     return Slot.objects.get(name=name)
+
+
+def _pickable_named(name):
+    from n26.library.models import Pickable
+
+    return Pickable.objects.get(name=name)
+
+
+def pick_affiliation(gang, token):
+    return choose(
+        gang_slot(gang, "Affiliation"),
+        _pickable_named(token.name),
+        slot=_slot_named("Affiliation"),
+    )
+
+
+def pick_house(gang, token):
+    anchor = next(
+        row
+        for row in gang.assignments.filter(archived=False)
+        if row.assignable.name == "Clan House Outcast"
+    )
+    return choose(anchor, _pickable_named(token.name), slot=_slot_named("Clan House"))
 
 
 def leader_anchor(crew):
@@ -737,17 +763,12 @@ class TestAffiliationChains:
         computed = the_gang_computed(gang)
         assert computed.choice("Clan house") is None  # not until it's chosen
 
-        choose(gang_slot(gang, "Affiliation"), tokens["clan_house"])
+        pick_affiliation(gang, tokens["clan_house"])
         computed = the_gang_computed(gang)
         slot = computed.choice("Clan house")
         assert slot is not None and not slot.is_resolved
 
-        anchor = next(
-            row
-            for row in gang.assignments.all()
-            if row.assignable.name == "Clan House Outcast"
-        )
-        choose(anchor, house_tokens["Escher"])
+        pick_house(gang, house_tokens["Escher"])
         assert (
             the_gang_computed(gang).choice("Clan house").chosen_name == "House Escher"
         )
@@ -756,13 +777,8 @@ class TestAffiliationChains:
         self, gang, crew, affiliations
     ):
         tokens, house_tokens = affiliations
-        choose(gang_slot(gang, "Affiliation"), tokens["clan_house"])
-        anchor = next(
-            row
-            for row in gang.assignments.all()
-            if row.assignable.name == "Clan House Outcast"
-        )
-        choose(anchor, house_tokens["Escher"])
+        pick_affiliation(gang, tokens["clan_house"])
+        pick_house(gang, house_tokens["Escher"])
 
         for rank, expected in [("leader", True), ("champion", True), ("scum", False)]:
             computed = fighter_computed(crew[rank])
@@ -773,7 +789,7 @@ class TestAffiliationChains:
 
     def test_mutants_open_the_mutation_list_to_all(self, gang, crew, affiliations):
         tokens, _ = affiliations
-        choose(gang_slot(gang, "Affiliation"), tokens["mutant"])
+        pick_affiliation(gang, tokens["mutant"])
 
         for member in crew.values():
             computed = fighter_computed(member)
@@ -801,15 +817,13 @@ class TestTheSheet:
     ):
         tokens, house_tokens = affiliations
         pick_archetype(crew, archetypes["Wyrd"])
-        choose(gang_slot(gang, "Affiliation"), tokens["clan_house"])
-        anchor = next(
-            row
-            for row in gang.assignments.all()
-            if row.assignable.name == "Clan House Outcast"
+        pick_affiliation(gang, tokens["clan_house"])
+        pick_house(gang, house_tokens["Goliath"])
+        choose(
+            crew["champion"].assignments.get(profile__isnull=False),
+            archetypes["Survivor"],
+            slot=_slot_named("Champion archetype"),
         )
-        choose(anchor, house_tokens["Goliath"])
-        anchor = crew["champion"].assignments.get(profile__isnull=False)
-        choose(anchor, archetypes["Survivor"], slot=_slot_named("Champion archetype"))
 
         text = gang_to_text(gang)
         print("\n" + text)

--- a/n26/tests/sandbox/test_outcast_gang.py
+++ b/n26/tests/sandbox/test_outcast_gang.py
@@ -536,16 +536,16 @@ def _slot_named(name):
     return Slot.objects.get(name=name)
 
 
-def _pickable_named(name):
+def _pickable_named(name, slot_type):
     from n26.library.models import Pickable
 
-    return Pickable.objects.get(name=name)
+    return Pickable.objects.get(name=name, slot_type__name=slot_type)
 
 
 def pick_affiliation(gang, token):
     return choose(
         gang_slot(gang, "Affiliation"),
-        _pickable_named(token.name),
+        _pickable_named(token.name, "Affiliation"),
         slot=_slot_named("Affiliation"),
     )
 
@@ -556,7 +556,11 @@ def pick_house(gang, token):
         for row in gang.assignments.filter(archived=False)
         if row.assignable.name == "Clan House Outcast"
     )
-    return choose(anchor, _pickable_named(token.name), slot=_slot_named("Clan House"))
+    return choose(
+        anchor,
+        _pickable_named(token.name, "Clan House"),
+        slot=_slot_named("Clan House"),
+    )
 
 
 def leader_anchor(crew):

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -303,4 +303,6 @@ class TestTheOutcastAffiliationConversion:
         assert run.status == Backfill.Status.DONE
         assert any("applied" in line for line in run.summary["report"])
         assert Slot.objects.filter(name="Affiliation").exists()
-        assert Pickable.objects.filter(name="Clanless Outcast").exists()
+        assert Pickable.objects.filter(
+            name="Clanless Outcast", slot_type__name="Affiliation"
+        ).exists()

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -220,6 +220,25 @@ class TestTheOutcastAffiliationConversion:
         assert found.name == Operation.CONVERT_OUTCAST_AFFILIATION.label
         assert found.view is convert_outcast_affiliation_view
 
+    def test_proof_words_count_holders_when_the_plan_omits_reaches(self):
+        """The confirm dialog must not say “0 gangs” just because a
+        future conversion leaves ``Plan.reaches`` at its default."""
+        from n26.library.conversion.base import Plan
+        from n26.maintenance import _proof_words
+
+        words = _proof_words(
+            Plan(
+                system="outcast_affiliation",
+                holder_ids=(1, 2, 3),
+                gang_ids=(1,),
+            )
+        )
+
+        assert "It reaches 3 gangs" in words["reach_words"]
+        assert "Convert 3 gang(s)" in words["confirm_words"]
+        assert "0 gang" not in words["reach_words"]
+        assert "0 gang" not in words["confirm_words"]
+
     def test_only_a_superuser_may_reach_it(self, client, staffer):
         client.force_login(staffer)
 

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -22,7 +22,11 @@ from gyrinx.maintenance.registry import (
     resolve_operation,
 )
 from n26.core.reconcile import assert_reconciled
-from n26.maintenance import Operation, delete_nameless_gang_type_view
+from n26.maintenance import (
+    Operation,
+    convert_outcast_affiliation_view,
+    delete_nameless_gang_type_view,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -203,3 +207,81 @@ class TestTheNamelessGangTypeRetirement:
         assert GangType.objects.filter(name="").exists()
         assert Gang.objects.get(pk=nameless_world.pk).gang_type.name == ""
         assert_reconciled(Gang.objects.get(pk=nameless_world.pk))
+
+
+class TestTheOutcastAffiliationConversion:
+    """The repair still on offer: the Outcast affiliations become picks."""
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.CONVERT_OUTCAST_AFFILIATION.value in registered
+        found = resolve_operation(Operation.CONVERT_OUTCAST_AFFILIATION.value)
+        assert found.name == Operation.CONVERT_OUTCAST_AFFILIATION.label
+        assert found.view is convert_outcast_affiliation_view
+
+    def test_only_a_superuser_may_reach_it(self, client, staffer):
+        client.force_login(staffer)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_convert_outcast_affiliation")
+        )
+
+        assert response.status_code in (302, 403)
+
+    def test_its_page_shows_nothing_to_convert_when_the_system_is_absent(
+        self, client, superuser, default_pack
+    ):
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_convert_outcast_affiliation")
+        )
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "Nothing to convert" in page
+        assert not Backfill.objects.exists()
+
+    def test_its_page_shows_the_plan_and_writes_nothing(
+        self, client, superuser, default_pack, person_type, owner
+    ):
+        from n26.tests.sandbox.test_conversion_affiliation import (
+            build_prod_shape,
+            build_world,
+        )
+
+        build_world(build_prod_shape(person_type), owner)
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_convert_outcast_affiliation")
+        )
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "create slot type “Affiliation”" in page
+        assert not Backfill.objects.exists()
+
+    def test_applying_records_what_it_converted(
+        self, client, superuser, default_pack, person_type, owner
+    ):
+        from n26.library.models import Pickable, Slot
+        from n26.tests.sandbox.test_conversion_affiliation import (
+            build_prod_shape,
+            build_world,
+        )
+
+        build_world(build_prod_shape(person_type), owner)
+        client.force_login(superuser)
+
+        response = client.post(
+            reverse("admin:maintenance_n26_convert_outcast_affiliation")
+        )
+
+        assert response.status_code == 302
+        run = Backfill.objects.get(operation=Operation.CONVERT_OUTCAST_AFFILIATION)
+        assert run.status == Backfill.Status.DONE
+        assert any("applied" in line for line in run.summary["report"])
+        assert Slot.objects.filter(name="Affiliation").exists()
+        assert Pickable.objects.filter(name="Clanless Outcast").exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Outcast Affiliations menu, and the Clan House chain it opens, now convert onto slots and picks in one maintenance-console run. Chaos God and Variants are not in this operation.

Until now those choices lived as `Affiliation` rows behind a Hidden offer. After this run they are an Affiliation slot and a chained Clan House slot; the modifiers move onto pickables rather than being copied; every stored answer — live and archived — is rewritten as a pick on the same assignment. A spread of gangs must still read the same, and every reached gang must still reconcile, or the write unwinds.

The `Affiliation` model and column stay. Fossils (an unattached whole-kind offer, an unattached Corruption offer) are left standing.

## How to try it

1. Deploy, then open the maintenance console as a superuser.
2. Run **n26: the Outcast affiliations become picks**.
3. Preview lists the creates, the two offer-to-grant swaps, and every pick rewrite. Apply is one transaction.
4. Check an unanswered Outcast gang, a Clan House gang that never picked a house, one that did, and one that re-chose: the sheets should match what they said before.
5. Re-choosing Affiliation on the converted machinery should still retract the house pick.

A second run is a no-op (`nothing to convert`). Do not run this against a database that already has an Affiliation or Clan House slot type of those names in the default pack.

Chaos God (both doors) and Variants (including None) stay as follow-up operations. Do not drop `OFFERABLE_KINDS` or the Assignment column in this PR.

## Tests

`pytest n26/tests/sandbox/test_conversion_affiliation.py n26/tests/sandbox/test_outcast_affiliation_flow.py n26/tests/sandbox/test_outcast_gang.py n26/tests/test_maintenance_console.py` — 89 passed. The live-content Outcast suites now apply this conversion in their content fixture so they play on slots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04238-8df2-7d6f-9e39-b3ec77dec286?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04238-8df2-7d6f-9e39-b3ec77dec286&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

