### PR TITLE
fix: drop the help lead from n26 gang edit tabs

### DIFF
--- a/n26/core/templates/n26/edit_gang.html
+++ b/n26/core/templates/n26/edit_gang.html
@@ -42,7 +42,7 @@ reads the config after that listener has run.
         matches form-page's cap so the tab still reads as the same page.
         {% endcomment %}
         <div class="max-w-3xl space-y-8">
-            <c-n26.page-header title="Edit {{ gang.name }}" lead="What the gang says about itself.">
+            <c-n26.page-header title="Edit {{ gang.name }}">
                 <c-slot name="breadcrumb">
                     <c-ui.breadcrumbs>
                         <c-ui.breadcrumbs.item>
@@ -115,7 +115,6 @@ reads the config after that listener has run.
         <c-n26.form-page action="{{ edit_url }}"
                          :form="form"
                          title="Edit {{ gang.name }}"
-                         lead="Required fields are marked with an asterisk (*)."
                          submit_label="Save changes"
                          cancel_url="{% url 'n26-gang' gang.pk %}">
             <c-slot name="breadcrumb">
@@ -132,7 +131,7 @@ reads the config after that listener has run.
             {% csrf_token %}
             <c-n26.tab-links label="What to edit" :tabs="edit_tabs" />
             <c-n26.form-section title="General">
-                <c-ui.field label="Gang name *"
+                <c-ui.field label="Gang name (required)"
                             error="x"
                             :form="form"
                             name="name"

--- a/n26/core/templates/n26/trade_points.html
+++ b/n26/core/templates/n26/trade_points.html
@@ -27,8 +27,7 @@ Plain checkboxes and no script, so the whole screen works with scripting off.
 {% endblock messages %}
 {% block content %}
     <div class="max-w-3xl space-y-8">
-        <c-n26.page-header title="Edit {{ gang.name }}"
-                           lead="What {{ gang.name }} may spend at the Trading Post.">
+        <c-n26.page-header title="Edit {{ gang.name }}">
             <c-slot name="breadcrumb">
                 <c-ui.breadcrumbs>
                     <c-ui.breadcrumbs.item>

--- a/n26/core/test_views_edit_gang.py
+++ b/n26/core/test_views_edit_gang.py
@@ -70,6 +70,12 @@ class TestThePage:
         # The type is a fact, not a field: stated, never offered.
         assert "Fixed at founding." in body
         assert 'name="gang_type"' not in body
+        # The heading is just the name of the act. Help about required
+        # fields, or about what a tab is for, would sit above the strip
+        # and change as the reader moved — the tab already says that.
+        assert "Required fields are marked" not in body
+        assert "Gang name (required)" in body
+        assert "Gang name *" not in body
 
     def test_a_stranger_gets_a_404(self, client, gang):
         client.force_login(User.objects.create_user("someone-else"))
@@ -294,6 +300,8 @@ class TestNotesLoreAndPicture:
         notes_tab = client.get(edit_url(gang) + "?tab=notes").content.decode()
         assert "Meet at the sump gate" not in general
         assert "Meet at the sump gate" in notes_tab
+        assert "What the gang says about itself." not in notes_tab
+        assert "Required fields are marked" not in notes_tab
         # The tab strip on both, saying which is current.
         assert "?tab=notes" in general
         assert 'aria-current="page"' in notes_tab

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -112,6 +112,11 @@ class TestTheWayIn:
         client.force_login(tester)
         body = client.get(reverse("n26-edit-gang", args=[gang.pk])).content.decode()
         assert page(gang) in body
+        # Same heading as the other edit tabs, with no lead restating
+        # what the tab already says.
+        here = client.get(page(gang)).content.decode()
+        assert "may spend at the Trading Post" not in here
+        assert "Required fields are marked" not in here
 
     def test_somebody_elses_gang_is_not_theirs_to_visit(self, client, gang):
         client.force_login(User.objects.create_user("stranger"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The sentence under the title on the n26 gang edit page changed with each tab and restated what the tab already said.

General, Notes and Lore, and Trade Points now share a heading with no lead. On General, Gang name says it is required instead of using an asterisk the page no longer explains.

Create a gang is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQKP2AW20/p1787789770213619?thread_ts=1787789770.213619&cid=C0BQKP2AW20)

<div><a href="https://cursor.com/agents/bc-9a60584c-b85a-5bd6-8fbb-b279ee548647?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a60584c-b85a-5bd6-8fbb-b279ee548647&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

