### PR TITLE
fix: n26 lore page empty state names the gap as gang-wide

### DIFF
--- a/n26/core/templates/n26/gang_lore.html
+++ b/n26/core/templates/n26/gang_lore.html
@@ -69,8 +69,8 @@ prose; a section with no picture is just its words.
                 </c-n26.prose>
             {% elif yours %}
                 <p class="text-muted">
-                    Nothing written yet — the gang's lore is written on
-                    <c-n26.link href="{% url 'n26-edit-gang' gang.pk %}?tab=notes">its edit page</c-n26.link>.
+                    No gang-wide Lore yet. Add it via
+                    <c-n26.link href="{% url 'n26-edit-gang' gang.pk %}?tab=notes">the edit page</c-n26.link>.
                 </p>
             {% endif %}
             {% if yours and gang.lore %}

--- a/n26/core/test_views_gang_lore.py
+++ b/n26/core/test_views_gang_lore.py
@@ -73,6 +73,24 @@ class TestTheEditAffordance:
         assert reverse("n26-edit-gang", args=[gang.pk]) + "?tab=notes" in body
         assert reverse("n26-edit-fighter", args=[vex.pk]) in body
 
+    def test_empty_gang_lore_names_the_gap_as_gang_wide(
+        self, client, tester, gang, make_profile, make_statline
+    ):
+        """A gang with no lore of its own can still show a model's
+        story. The empty line must name that gap, not read as if
+        nothing is written at all."""
+        profile = make_profile("Ganger", price=0)
+        make_statline(profile)
+        with operation(gang, actor=tester) as op:
+            vex = op.hire(profile, "Vex")
+            op.edit_lore(vex, "<p>Nobody knows where Vex came from.</p>")
+        client.force_login(tester)
+        body = client.get(lore_url(gang)).content.decode()
+        assert "No gang-wide Lore yet" in body
+        assert "Nobody knows where Vex came from" in body
+        assert reverse("n26-edit-gang", args=[gang.pk]) + "?tab=notes" in body
+        assert "Nothing written yet" not in body
+
     def test_a_reader_gets_none(self, client, gang, roster):
         vex, _ = roster
         body = client.get(lore_url(gang)).content.decode()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a gang has no lore of its own, the lore page still lists models that do. The empty line used to say "Nothing written yet", which read as if the whole page was blank.

It now says "No gang-wide Lore yet. Add it via the edit page." — Louis's wording, with the same link to the Notes tab on the gang edit page.

## How to try it

1. Open a gang you own that has no gang-level lore, but at least one model with lore written.
2. Go to Lore.
3. The empty line above the model stories should name the gap as gang-wide, not as nothing written.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQKP2AW20/p1787787662635529?thread_ts=1787787662.635529&cid=C0BQKP2AW20)

<div><a href="https://cursor.com/agents/bc-d2b46496-c644-548b-8454-f902b449d57b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2b46496-c644-548b-8454-f902b449d57b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

