### PR TITLE
feat: default CampaignForm gang budget to 1000 on set-up

### DIFF
--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -333,10 +333,9 @@ class CampaignForm(forms.Form):
 
     ``budget`` is the starting credit limit a gang may spend to join.
     Blank is not zero: it means no limit, which is how a campaign runs
-    where the table has not agreed one. On set-up, with no ``initial``,
-    the field opens at 1000, the usual starting figure. Edit supplies
-    the stored value, so an unlimited campaign stays blank. Clearing
-    it lands as ``budget=None``.
+    where the table has not agreed one. The field's ``initial`` is 1000,
+    so set-up opens at that figure. Edit supplies the stored value, so
+    an unlimited campaign stays blank. Clearing it lands as ``budget=None``.
     """
 
     name = forms.CharField(

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -331,10 +331,10 @@ class RenameFighterForm(forms.Form):
 class CampaignForm(forms.Form):
     """Setting a campaign up, and editing one afterwards.
 
-    ``budget`` reads the way the gang create form's does: blank is not zero
-    and is not a default, it means no ceiling — which is how a campaign runs
-    where the table has not agreed one. So it is ``required=False`` with no
-    ``initial``, and blank lands as ``budget=None``.
+    ``budget`` is the starting credit limit a gang may spend to join.
+    Blank is not zero: it means no limit, which is how a campaign runs
+    where the table has not agreed one. The field opens at 1000, the
+    usual starting figure; clearing it lands as ``budget=None``.
     """
 
     name = forms.CharField(
@@ -345,8 +345,9 @@ class CampaignForm(forms.Form):
     budget = forms.IntegerField(
         required=False,
         min_value=0,
+        initial=1000,
         label="Gang budget",
-        help_text="What a gang may spend to join. Leave blank for no ceiling.",
+        help_text="Leave blank for no starting credit limit.",
     )
     summary = forms.CharField(
         required=False,

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -333,8 +333,10 @@ class CampaignForm(forms.Form):
 
     ``budget`` is the starting credit limit a gang may spend to join.
     Blank is not zero: it means no limit, which is how a campaign runs
-    where the table has not agreed one. The field opens at 1000, the
-    usual starting figure; clearing it lands as ``budget=None``.
+    where the table has not agreed one. On set-up, with no ``initial``,
+    the field opens at 1000, the usual starting figure. Edit supplies
+    the stored value, so an unlimited campaign stays blank. Clearing
+    it lands as ``budget=None``.
     """
 
     name = forms.CharField(

--- a/n26/core/templates/n26/includes/campaign_form_fields.html
+++ b/n26/core/templates/n26/includes/campaign_form_fields.html
@@ -2,10 +2,10 @@
 The answers a campaign is made of, shared by the set-up and edit screens so
 the two cannot drift into asking different questions.
 
-The budget is the one worth reading twice. Blank is not zero and is not a
-default — it means the campaign sets no ceiling, and gangs enter at whatever
-they are worth. The placeholder says so, because a reader who leaves it blank
-expecting a default gets a campaign that refuses nobody.
+The budget is the one worth reading twice. It opens at 1000, the usual
+starting figure. Blank is not zero — it means the campaign sets no starting
+credit limit, and gangs enter at whatever they are worth. A reader who
+clears the field gets a campaign that refuses nobody.
 
 Unlike a gang's budget, this one has no floor: a campaign holds no money and
 owns nothing, so there is no sum it has to cover.
@@ -22,7 +22,7 @@ owns nothing, so there is no sum it has to cover.
                     value="{{ form.name.value|default:'' }}" />
     </c-ui.field>
     <c-ui.field label="Gang budget"
-                description="What a gang may spend to join. Leave blank for no ceiling."
+                description="Leave blank for no starting credit limit."
                 error="x"
                 :form="form"
                 name="budget"
@@ -32,7 +32,7 @@ owns nothing, so there is no sum it has to cover.
                     type="number"
                     min="0"
                     inputmode="numeric"
-                    placeholder="No ceiling"
+                    placeholder="No limit"
                     right_addon="¢"
                     value="{{ form.budget.value|default:'' }}" />
     </c-ui.field>

--- a/n26/core/templates/n26/includes/campaign_form_fields.html
+++ b/n26/core/templates/n26/includes/campaign_form_fields.html
@@ -2,10 +2,12 @@
 The answers a campaign is made of, shared by the set-up and edit screens so
 the two cannot drift into asking different questions.
 
-The budget is the one worth reading twice. It opens at 1000, the usual
-starting figure. Blank is not zero — it means the campaign sets no starting
-credit limit, and gangs enter at whatever they are worth. A reader who
-clears the field gets a campaign that refuses nobody.
+The budget is the one worth reading twice. Blank is not zero — it means
+the campaign sets no starting credit limit, and gangs enter at whatever
+they are worth. A reader who clears the field gets a campaign that
+refuses nobody. The 1000 default lives on the unbound form, so it is
+only for set-up; edit supplies the stored value, including blank. The
+box uses default_if_none so a stored 0 still draws as 0.
 
 Unlike a gang's budget, this one has no floor: a campaign holds no money and
 owns nothing, so there is no sum it has to cover.
@@ -34,7 +36,7 @@ owns nothing, so there is no sum it has to cover.
                     inputmode="numeric"
                     placeholder="No limit"
                     right_addon="¢"
-                    value="{{ form.budget.value|default:'' }}" />
+                    value="{{ form.budget.value|default_if_none:'' }}" />
     </c-ui.field>
 </c-n26.form-section>
 {% comment %}

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -202,11 +202,21 @@ class TestSettingOneUp:
         assert response.status_code == 302
         assert response["Location"] == f"/n26/campaigns/{made.pk}/"
 
-    def test_a_blank_budget_means_no_ceiling_rather_than_zero(
+    def test_the_form_opens_with_a_thousand_credit_budget(
         self, client, arbitrator, open_to_everyone
     ):
-        """The one answer worth checking: blank is not a default and is not
-        a zero, and a campaign that read it as zero would refuse everybody."""
+        response = client.get("/n26/campaigns/new/")
+        assert response.context["form"]["budget"].value() == 1000
+        body = response.content.decode()
+        assert 'value="1000"' in body
+        assert "Leave blank for no starting credit limit." in body
+
+    def test_a_blank_budget_means_no_limit_rather_than_zero(
+        self, client, arbitrator, open_to_everyone
+    ):
+        """Blank is not a zero, and a campaign that read it as zero would
+        refuse everybody. Clearing the default is how a table that has
+        not agreed a limit says so."""
         client.post("/n26/campaigns/new/", {"name": "Open House", "budget": ""})
         assert Campaign.objects.get(name="Open House").budget is None
 
@@ -254,7 +264,7 @@ class TestEditing:
         campaign.refresh_from_db()
         assert (campaign.name, campaign.budget) == ("Dust Falls Reborn", 1500)
 
-    def test_clearing_the_budget_removes_the_ceiling(
+    def test_clearing_the_budget_removes_the_limit(
         self, client, campaign, open_to_everyone
     ):
         client.post(
@@ -263,6 +273,19 @@ class TestEditing:
         )
         campaign.refresh_from_db()
         assert campaign.budget is None
+
+    def test_an_unlimited_campaign_stays_blank_on_the_edit_form(
+        self, client, arbitrator, open_to_everyone
+    ):
+        """The 1000 default is for a campaign being set up. Filling it in
+        on edit would make a campaign that had no limit look as if it did."""
+        campaign = Campaign.objects.create(
+            name="Open House", owner=arbitrator, budget=None
+        )
+        response = client.get(f"/n26/campaigns/{campaign.pk}/edit/")
+        assert response.context["form"]["budget"].value() is None
+        assert 'id="campaign-budget"' in response.content.decode()
+        assert 'value="1000"' not in response.content.decode()
 
 
 class TestArchiving:

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -287,6 +287,18 @@ class TestEditing:
         assert 'id="campaign-budget"' in response.content.decode()
         assert 'value="1000"' not in response.content.decode()
 
+    def test_a_zero_budget_stays_zero_on_the_edit_form(
+        self, client, arbitrator, open_to_everyone
+    ):
+        """Nought is a figure, not an absence: `default` would draw the
+        box empty and a save would clear the limit."""
+        campaign = Campaign.objects.create(
+            name="Broke House", owner=arbitrator, budget=0
+        )
+        response = client.get(f"/n26/campaigns/{campaign.pk}/edit/")
+        assert response.context["form"]["budget"].value() == 0
+        assert 'value="0"' in response.content.decode()
+
 
 class TestArchiving:
     def test_the_question_page_changes_nothing(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The campaign set-up form now opens Gang budget at **1000**, and the help text is “Leave blank for no starting credit limit.” Clearing the field still stores no limit, so a table that has not agreed one is not refused.

Edit is unchanged: a campaign that already has no budget still opens blank, rather than filling in 1000.

**How to try it**
1. Open `/n26/campaigns/new/`
2. Gang budget should already be 1000, with the new help text
3. Submit as-is and the campaign should have a 1000 credit limit
4. Clear the field and submit: the campaign should have no limit
5. Edit a campaign that has no limit: the field should stay blank

[Set up a campaign form with Gang budget defaulted to 1000](https://cursor.com/agents/bc-a0f5d686-d816-5768-9296-ca9f93305163/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcampaign_setup_gang_budget_default.webp)
[Hive Secundus campaign page showing Gang budget 1000](https://cursor.com/agents/bc-a0f5d686-d816-5768-9296-ca9f93305163/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcampaign_hive_secundus_budget_1000.webp)
[campaign_setup_submits_default_1000_budget.mp4](https://cursor.com/agents/bc-a0f5d686-d816-5768-9296-ca9f93305163/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcampaign_setup_submits_default_1000_budget.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQKP2AW20/p1787831025418769?thread_ts=1787831025.418769&cid=C0BQKP2AW20)

<div><a href="https://cursor.com/agents/bc-a0f5d686-d816-5768-9296-ca9f93305163?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f5d686-d816-5768-9296-ca9f93305163&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

