### PR TITLE
feat: live TP total and add-not-bring copy on Visit Trading Post

### DIFF
--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -542,7 +542,7 @@ def _tell(e, row, alive):
             return (Span("visited the trading post"),), "money"
         case Kind.VISITED_TRADING_POST:
             # The rank they went as rides the note, so the line says what
-            # they brought rather than what they happen to be now.
+            # they added rather than what they happen to be now.
             went_as = f" as {e.note}" if e.note else ""
             return (
                 Span("sent "),

--- a/n26/core/models/ledger.py
+++ b/n26/core/models/ledger.py
@@ -141,15 +141,15 @@ class LedgerEvent(Base):
         # A Visit Trading Post action opening or closing. Like the budget
         # it moves nothing of its own, and unlike it the event is the
         # boundary the spending is measured from: what a visit has left
-        # is what it brought less every Trade Point the log records after
+        # is what it added less every Trade Point the log records after
         # it, so writing one both opens a visit and closes the one before.
         TRADE_POINTS_SET = "trade_points_set", "Trade Points set"
-        # One fighter performing that action. The Trade Points they bring
+        # One fighter performing that action. The Trade Points they add
         # are the gang's, counted once on the event above, so this
         # carries none of its own — it says who went, which is what
         # answers "has this model already used their action" and what a
         # receipt names. The note holds the rank they went as, since
-        # that is what they brought rather than what they are now.
+        # that is what they added rather than what they are now.
         VISITED_TRADING_POST = "visited_post", "Visited the trading post"
 
     assignment = models.ForeignKey(

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -408,8 +408,8 @@ class Operation:
     def visit_trading_post(self, visitors=(), brought=None):
         """Open a Visit Trading Post action, performed by these fighters.
 
-        What they bring between them becomes what the gang has to spend;
-        two ranks bring Trade Points and the rest bring none, which is
+        What they add between them becomes what the gang has to spend;
+        two ranks add Trade Points and the rest add none, which is
         not the same as not going — one fighter going is what opens the
         post at all.
 
@@ -460,7 +460,7 @@ class Operation:
 
         Written every time, even where the figure has not changed —
         which is the one place this parts company with ``set_budget``. A
-        second visit bringing the same amount is a second visit, and a
+        second visit adding the same amount is a second visit, and a
         guard that skipped the write would leave the first one's
         spending counting against it.
         """

--- a/n26/core/templates/n26/trade_points.html
+++ b/n26/core/templates/n26/trade_points.html
@@ -15,9 +15,10 @@ ticks: the number is then the box's, not a sum. Starting one while another is
 open replaces it, and the form says as much.
 
 The running total and the shutting of the ticks are Alpine, reading state
-already on the page. Without scripting the ticks stay live, the box stays
-empty unless someone types, and the server still takes a typed figure over
-the ticks.
+already on the page. A figure in the box drops the total: that help is
+the ticks', and the box is then the amount. Without scripting the ticks
+stay live, the box stays empty unless someone types, and the server still
+takes a typed figure over the ticks.
 {% endcomment %}
 {% block head_title %}Trade Points — {{ gang.name }}{% endblock head_title %}
 {% block nav_switcher %}
@@ -116,7 +117,7 @@ the ticks.
         {% endif %}
         <form method="post"
               action="{{ action }}"
-              x-data="{ override: '', tick: 0, locked: {{ visit_open|yesno:'true,false' }}, points: {{ points_json }}, get overridden() { return String(this.override).trim() !== ''; }, selected() { this.tick; let n = 0; for (const box of $el.querySelectorAll('input[name=visiting]:checked')) { n += this.points[box.value] || 0; } return n; }, get added() { if (this.overridden) { const n = parseInt(this.override, 10); return Number.isFinite(n) ? n : 0; } return this.selected(); } }"
+              x-data="{ override: '', tick: 0, locked: {{ visit_open|yesno:'true,false' }}, points: {{ points_json }}, get overridden() { return String(this.override).trim() !== ''; }, selected() { this.tick; let n = 0; for (const box of $el.querySelectorAll('input[name=visiting]:checked')) { n += this.points[box.value] || 0; } return n; }, get added() { return this.selected(); } }"
               @change="tick++"
               @input="tick++">
             {% csrf_token %}
@@ -188,7 +189,12 @@ the ticks.
                                 Start TP visit
                             </c-ui.button>
                         {% endif %}
-                        <p class="text-sm text-muted">
+                        {% comment %}
+                        The running total is the ticks' figure. A number in
+                        the box is already the amount, so repeating it as
+                        "Selected fighters add N" would be a lie.
+                        {% endcomment %}
+                        <p class="text-sm text-muted" x-show="!overridden">
                             Selected fighters add
                             <span class="font-medium tabular-nums text-ink-900 dark:text-ink-100"
                                   x-text="added">0</span>

--- a/n26/core/templates/n26/trade_points.html
+++ b/n26/core/templates/n26/trade_points.html
@@ -4,16 +4,20 @@
 The Visit Trading Post action — the one open, and starting another.
 
 Two posts, no query string. The card is the open visit, read as a receipt: what
-it brought, what has gone, what is left, and who performed the action. Its
+it added, what has gone, what is left, and who performed the action. Its
 button finishes the visit, which shuts the post and loses the remainder — the
 book's rule, so the button says so rather than asking again.
 
-The form beneath starts one. The ticks are the whole of the question in the
-ordinary case — a visit brings what its fighters bring — with a box beneath
-them for an owner who knows the figure and wants to say it outright. Starting
-one while another is open replaces it, and the form says as much.
+The form beneath starts one. The ticks are the usual way to name a figure — a
+visit adds what its fighters add — with a box beneath them for an owner who
+knows the number and wants to say it outright. A figure in that box shuts the
+ticks: the number is then the box's, not a sum. Starting one while another is
+open replaces it, and the form says as much.
 
-Plain checkboxes and no script, so the whole screen works with scripting off.
+The running total and the shutting of the ticks are Alpine, reading state
+already on the page. Without scripting the ticks stay live, the box stays
+empty unless someone types, and the server still takes a typed figure over
+the ticks.
 {% endcomment %}
 {% block head_title %}Trade Points — {{ gang.name }}{% endblock head_title %}
 {% block nav_switcher %}
@@ -63,8 +67,8 @@ Plain checkboxes and no script, so the whole screen works with scripting off.
                     <c-n26.tally :facts="receipt.facts" />
                     {% comment %}
                     Every fighter, not only those who performed the action:
-                    what a visit brought is the gang's, and it is spent on
-                    whoever it was for. Which ranks brought it is the line
+                    what a visit added is the gang's, and it is spent on
+                    whoever it was for. Which ranks added it is the line
                     under Available.
                     {% endcomment %}
                     {% if roster %}
@@ -101,30 +105,37 @@ Plain checkboxes and no script, so the whole screen works with scripting off.
                                     Complete action
                                 </span>
                             </c-ui.button>
-                            <p class="text-sm text-muted">Click when you have finished at the Trading Post.</p>
+                            <p class="text-sm text-muted">
+                                Click when you have finished at the Trading Post.
+                                Any unused TP will be discarded.
+                            </p>
                         </div>
                     </form>
                 </div>
             </c-ui.card>
         {% endif %}
-        <form method="post" action="{{ action }}">
+        <form method="post"
+              action="{{ action }}"
+              x-data="{ override: '', tick: 0, locked: {{ visit_open|yesno:'true,false' }}, points: {{ points_json }}, get overridden() { return String(this.override).trim() !== ''; }, selected() { this.tick; let n = 0; for (const box of $el.querySelectorAll('input[name=visiting]:checked')) { n += this.points[box.value] || 0; } return n; }, get added() { if (this.overridden) { const n = parseInt(this.override, 10); return Number.isFinite(n) ? n : 0; } return this.selected(); } }"
+              @change="tick++"
+              @input="tick++">
             {% csrf_token %}
-            <c-n26.form-section title="Start Visit Trading Post action"
-                                description="{% if visit_open %}Finish the action above first. A gang performs one Visit Trading Post action at a time.{% else %}A Leader brings 2 Trade Points and a Champion 1. Nobody else brings any, so the ones who do are the ones to tick; anyone in the gang may then be equipped from the post.{% endif %}">
+            <c-n26.form-section title="Visit Trading Post (post-cycle action)"
+                                description="{% if visit_open %}Finish the action above first. A gang performs one Visit Trading Post action at a time.{% else %}A Leader adds 2 Trade Points and a Champion 1.{% endif %}">
                 {% if visitors %}
                     {% comment %}
                     Shut while an action is open: starting another would discard
                     what the one above has left. The reason is said once in the
                     section description rather than under every fighter.
+
+                    A figure in the box is the whole of the amount, so the
+                    ticks shut then — a native fieldset, so every box inside
+                    is disabled together and submits nothing. locked is the
+                    open action, already computed; overridden is typed here.
                     {% endcomment %}
-                    <c-n26.tick-list :offer="offer" name="visiting" :disabled="visit_open" />
-                    {% comment %}
-                    `brought_default` is the figure the box was drawn with.
-                    Without it the server could not tell a figure somebody
-                    typed from one the page happened to draw, the box being
-                    unable to follow the ticks with no script here.
-                    {% endcomment %}
-                    <input type="hidden" name="brought_default" value="{{ suggestion }}">
+                    <fieldset class="min-w-0 border-0 p-0" :disabled="overridden || locked">
+                        <c-n26.tick-list :offer="offer" name="visiting" :disabled="visit_open" />
+                    </fieldset>
                     {% comment %}
                     No `class` on the input: c-ui.input does not declare one, so
                     it would arrive through {{ attrs }} as a second class
@@ -140,7 +151,7 @@ Plain checkboxes and no script, so the whole screen works with scripting off.
                                         min="0"
                                         max="999"
                                         inputmode="numeric"
-                                        value="{{ suggestion }}"
+                                        x-model="override"
                                         disabled />
                         {% else %}
                             <c-ui.input id="brought"
@@ -149,7 +160,7 @@ Plain checkboxes and no script, so the whole screen works with scripting off.
                                         min="0"
                                         max="999"
                                         inputmode="numeric"
-                                        value="{{ suggestion }}" />
+                                        x-model="override" />
                         {% endif %}
                     </c-ui.field>
                     {% comment %}
@@ -159,12 +170,12 @@ Plain checkboxes and no script, so the whole screen works with scripting off.
                     looking shut. The shut one is wrapped because a disabled
                     button emits no mouse events for a tooltip to use.
                     {% endcomment %}
-                    <div>
+                    <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
                         {% if visit_open %}
                             <c-ui.tooltip size="sm">
                                 <span class="inline-block cursor-not-allowed">
                                     <c-ui.button type="submit" size="sm" variant="primary" disabled>
-                                        Start action
+                                        Start TP visit
                                     </c-ui.button>
                                 </span>
                                 <c-slot name="content">
@@ -174,14 +185,20 @@ Plain checkboxes and no script, so the whole screen works with scripting off.
                             </c-ui.tooltip>
                         {% else %}
                             <c-ui.button type="submit" size="sm" variant="primary">
-                                Start action
+                                Start TP visit
                             </c-ui.button>
                         {% endif %}
+                        <p class="text-sm text-muted">
+                            Selected fighters add
+                            <span class="font-medium tabular-nums text-ink-900 dark:text-ink-100"
+                                  x-text="added">0</span>
+                            TP
+                        </p>
                     </div>
                 {% else %}
                     <p class="text-sm text-muted">
                         {{ gang.name }} has no Leader or Champion to send, and
-                        nobody else brings Trade Points.
+                        nobody else adds Trade Points.
                     </p>
                 {% endif %}
             </c-n26.form-section>

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -1,7 +1,7 @@
 """The Visit Trading Post action: the open one, and starting another.
 
 Two posts and no query string. Starting names the fighters who perform
-the action and takes what they bring; finishing shuts the post and loses
+the action and takes what they add; finishing shuts the post and loses
 whatever is left, which is the book's rule rather than this screen's
 idea. What the page must get right is that neither is a GET — following
 a link must not open or close an action — and that the receipt is read
@@ -45,7 +45,7 @@ def ranks(db):
 
 @pytest.fixture
 def roster(tester, gang, ranks, make_profile, make_statline):
-    """A Leader, a Champion and a Ganger, who brings nothing but may go."""
+    """A Leader, a Champion and a Ganger, who adds nothing but may go."""
     made = {}
     for name, rank in [("Vex", "Leader"), ("Sura", "Champion"), ("Nix", None)]:
         profile = make_profile(f"{name} entry", price=50)
@@ -63,16 +63,13 @@ def page(gang):
     return reverse("n26-gang-trade-points", args=[gang.pk])
 
 
-def start(client, gang, *models, brought=None, opened=None):
+def start(client, gang, *models, brought=None):
     """Perform the action, as the form posts it.
 
-    ``opened`` is the figure the box was drawn with; ``brought`` is what
-    was typed over it. Left alone by a caller, neither is sent — which is
-    a form submitted with the box untouched and empty of overrides.
+    ``brought`` is a figure typed in the box. Left alone, the box is not
+    sent — an empty override, so the ticks decide.
     """
     data = {"visiting": [str(m.pk) for m in models]}
-    if opened is not None:
-        data["brought_default"] = str(opened)
     if brought is not None:
         data["brought"] = str(brought)
     return client.post(page(gang), data)
@@ -216,10 +213,10 @@ class TestTheStashCard:
 
 
 class TestWhoIsOffered:
-    def test_only_the_ranks_that_bring_something_are_offered(
+    def test_only_the_ranks_that_add_something_are_offered(
         self, client, tester, roster, gang
     ):
-        """Picking a fighter who brings nothing is a choice with no
+        """Picking a fighter who adds nothing is a choice with no
         consequence, so the form asks one question rather than listing a
         roster to say no to most of it."""
         client.force_login(tester)
@@ -229,35 +226,51 @@ class TestWhoIsOffered:
         )
         assert set(boxes) == {str(roster["Vex"].pk), str(roster["Sura"].pk)}
 
-    def test_they_open_ticked(self, client, tester, roster, gang):
+    def test_they_open_unticked(self, client, tester, roster, gang):
         client.force_login(tester)
         body = client.get(page(gang)).content.decode()
         for name in ("Vex", "Sura"):
             box = body[body.index(f'value="{roster[name].pk}"') :][:200]
-            assert "checked" in box
+            assert "checked" not in box
 
-    def test_each_rank_says_what_it_brings(self, client, tester, roster, gang):
+    def test_each_rank_says_what_it_adds(self, client, tester, roster, gang):
         client.force_login(tester)
         body = client.get(page(gang)).content.decode()
         assert "2 Trade Points each" in body
         assert "1 Trade Point each" in body
 
+    def test_the_start_form_says_how_it_adds_up(self, client, tester, roster, gang):
+        """The ticks start clear, the box empty, and the running total
+        follows them — or a typed figure, which shuts the ticks."""
+        client.force_login(tester)
+        body = client.get(page(gang)).content.decode()
+        assert "Visit Trading Post (post-cycle action)" in body
+        assert "A Leader adds 2 Trade Points and a Champion 1." in body
+        assert "Nobody else" not in body
+        assert "Start TP visit" in body
+        assert "Start action" not in body
+        assert "Selected fighters add" in body
+        assert 'x-text="added"' in body
+        assert 'x-model="override"' in body
+        assert ':disabled="overridden || locked"' in body
+
     def test_a_gang_with_nobody_says_so(self, client, tester, gang):
         """The page names the ranks it wanted, not a bare roster.
 
-        A gang can be full of Gangers and still have nobody who brings
+        A gang can be full of Gangers and still have nobody who adds
         anything, so "nobody to send" would read as a lie.
         """
         client.force_login(tester)
         body = client.get(page(gang)).content.decode()
         assert "no Leader or Champion to send" in body
+        assert "nobody else adds Trade Points" in body
 
     def test_a_rank_taken_away_is_not_one_held(
         self, client, tester, roster, gang, ranks
     ):
         """A removal is machinery, not a line: reading the assignments
         straight from the database has to cancel the pair itself, or a
-        Leader the owner took away goes on bringing two points."""
+        Leader the owner took away goes on adding two points."""
         with operation(gang, actor=tester) as op:
             op.assign(ranks["Leader"], miniature=roster["Vex"], removes=True)
 
@@ -273,7 +286,7 @@ class TestStartingTheAction:
     def signed_in(self, client, tester):
         client.force_login(tester)
 
-    def test_it_takes_what_the_visitors_bring(self, client, roster, gang):
+    def test_it_takes_what_the_visitors_add(self, client, roster, gang):
         start(client, gang, roster["Vex"], roster["Sura"])
 
         gang.refresh_from_db()
@@ -281,7 +294,7 @@ class TestStartingTheAction:
         assert gang.starting_trade_points == 3
         assert gang.trade_points_left == 3
 
-    def test_a_fighter_who_brings_nothing_is_not_a_visitor(self, client, roster, gang):
+    def test_a_fighter_who_adds_nothing_is_not_a_visitor(self, client, roster, gang):
         """They are not offered, so a post naming one names nobody the
         form could have named — and a visit nobody performed is not one."""
         answer = client.post(
@@ -294,8 +307,7 @@ class TestStartingTheAction:
         assert any("at least one fighter" in line for line in told)
 
     def test_sending_nobody_is_refused(self, client, roster, gang):
-        """The rules want a fighter to perform the action; a visit nobody
-        performed is not one."""
+        """Neither ticks nor a typed amount: there is nothing to start."""
         answer = client.post(page(gang), {}, follow=True)
 
         gang.refresh_from_db()
@@ -349,58 +361,73 @@ class TestStartingTheAction:
         assert answer.status_code == 302
         assert answer["Location"] == page(gang)
 
+    def test_it_says_what_the_fighters_added(self, client, roster, gang):
+        answer = client.post(
+            page(gang), {"visiting": [str(roster["Vex"].pk)]}, follow=True
+        )
+
+        told = [str(m) for m in answer.context["messages"]]
+        assert any("adding 2 Trade Points" in line for line in told)
+        assert not any("bringing" in line for line in told)
+
 
 class TestATypedFigure:
-    """The box opens on what the ticked fighters bring. Left alone the
-    ticks decide; changed, the typed figure wins — a territory that adds
-    a point, or an arbitrator's own number."""
+    """The box opens empty. Left empty the ticks decide; filled, the typed
+    figure wins — a territory that adds a point, or an arbitrator's own
+    number — and the ticks shut, because the number is then the box's."""
 
     @pytest.fixture(autouse=True)
     def signed_in(self, client, tester):
         client.force_login(tester)
 
-    def test_the_box_opens_on_what_the_ticked_fighters_bring(
-        self, client, roster, gang
-    ):
+    def test_the_box_opens_empty(self, client, roster, gang):
         body = client.get(page(gang)).content.decode()
-        # A Leader and a Champion open ticked, so three.
-        assert 'name="brought_default" value="3"' in body
-        assert 'value="3"' in body
+        assert "brought_default" not in body
+        tag = re.search(r'<input[^>]*name="brought"[^>]*>', body).group()
+        assert "value=" not in tag
 
     def test_left_alone_the_ticks_decide(self, client, roster, gang):
-        """Re-ticking without touching the box does what a reader expects,
-        which no client-side arithmetic could promise with scripting off."""
-        start(client, gang, roster["Vex"], opened=3, brought=3)
+        start(client, gang, roster["Vex"])
 
         gang.refresh_from_db()
         assert gang.starting_trade_points == 2
 
     def test_a_typed_figure_wins(self, client, roster, gang):
-        start(client, gang, roster["Vex"], opened=3, brought=7)
+        start(client, gang, roster["Vex"], brought=7)
 
         gang.refresh_from_db()
         assert gang.starting_trade_points == 7
 
     def test_a_typed_nought_wins_too(self, client, roster, gang):
         """Nought is a figure somebody meant, not an empty box."""
-        start(client, gang, roster["Vex"], roster["Sura"], opened=3, brought=0)
+        start(client, gang, roster["Vex"], roster["Sura"], brought=0)
 
         gang.refresh_from_db()
         assert gang.visiting_trading_post is True
         assert gang.starting_trade_points == 0
 
     def test_an_empty_box_falls_back_to_the_ticks(self, client, roster, gang):
-        start(client, gang, roster["Vex"], opened=3, brought="")
+        start(client, gang, roster["Vex"], brought="")
 
         gang.refresh_from_db()
         assert gang.starting_trade_points == 2
+
+    def test_a_typed_figure_needs_nobody_ticked(self, client, roster, gang):
+        """The box replaces the ticks: a number there is the amount, and
+        who went is not asked."""
+        answer = client.post(page(gang), {"brought": "4"}, follow=True)
+
+        gang.refresh_from_db()
+        assert gang.visiting_trading_post is True
+        assert gang.starting_trade_points == 4
+        told = [str(m) for m in answer.context["messages"]]
+        assert any("adding 4 Trade Points" in line for line in told)
 
     def test_a_figure_that_is_not_a_whole_number_is_refused(self, client, roster, gang):
         answer = client.post(
             page(gang),
             {
                 "visiting": [str(roster["Vex"].pk)],
-                "brought_default": "3",
                 "brought": "-4",
             },
             follow=True,
@@ -416,7 +443,6 @@ class TestATypedFigure:
             page(gang),
             {
                 "visiting": [str(roster["Vex"].pk)],
-                "brought_default": "3",
                 "brought": "100000",
             },
             follow=True,
@@ -459,14 +485,21 @@ class TestTheReceipt:
 
         assert "Complete action" in client.get(page(gang)).content.decode()
 
-    def test_it_names_the_ranks_that_brought_the_figure(self, client, roster, gang):
+    def test_it_warns_that_unused_points_will_be_discarded(self, client, roster, gang):
+        start(client, gang, roster["Vex"])
+
+        body = client.get(page(gang)).content.decode()
+        assert "Click when you have finished at the Trading Post." in body
+        assert "Any unused TP will be discarded." in body
+
+    def test_it_names_the_ranks_that_added_the_figure(self, client, roster, gang):
         start(client, gang, roster["Vex"], roster["Sura"])
 
         body = client.get(page(gang)).content.decode()
         assert "Leader, Champion" in body
 
     def test_it_offers_every_fighter_to_equip(self, client, roster, gang):
-        """What a visit brought is the gang's, and it is spent on whoever
+        """What a visit added is the gang's, and it is spent on whoever
         it was for — including the fighters who did not go."""
         start(client, gang, roster["Vex"])
 
@@ -475,7 +508,7 @@ class TestTheReceipt:
         for name in ("Vex", "Sura", "Nix"):
             assert name in body
 
-    def test_each_fighter_gets_a_way_to_spend_what_they_brought(
+    def test_each_fighter_gets_a_way_to_spend_what_they_added(
         self, client, roster, gang
     ):
         """Having sent a fighter to the post, the next thing an owner
@@ -566,13 +599,13 @@ class TestFinishingTheAction:
         assert gang.starting_trade_points is None
         assert gang.trade_points_left is None
 
-    def test_it_says_what_went_with_it(self, client, roster, gang):
+    def test_it_says_unspent_points_were_discarded(self, client, roster, gang):
         start(client, gang, roster["Vex"])
 
         answer = client.post(page(gang), {"act": "finish"}, follow=True)
 
         told = [str(m) for m in answer.context["messages"]]
-        assert any("2 unspent went with it" in line for line in told)
+        assert any("2 unspent Trade Points were discarded" in line for line in told)
 
     def test_finishing_a_shut_post_changes_nothing(self, client, roster, gang):
         answer = client.post(page(gang), {"act": "finish"})
@@ -595,7 +628,7 @@ class TestFinishingTheAction:
 
         assert "left the Trading Post" in body
         assert body.index("left the Trading Post") < body.index(
-            "Start Visit Trading Post action"
+            "Visit Trading Post (post-cycle action)"
         )
         assert body.index("What to edit") < body.index("left the Trading Post")
 

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -241,7 +241,9 @@ class TestWhoIsOffered:
 
     def test_the_start_form_says_how_it_adds_up(self, client, tester, roster, gang):
         """The ticks start clear, the box empty, and the running total
-        follows them — or a typed figure, which shuts the ticks."""
+        follows them. A typed figure shuts the ticks and drops that
+        help — the box is then the amount, so "selected fighters" would
+        be a lie."""
         client.force_login(tester)
         body = client.get(page(gang)).content.decode()
         assert "Visit Trading Post (post-cycle action)" in body
@@ -251,6 +253,7 @@ class TestWhoIsOffered:
         assert "Start action" not in body
         assert "Selected fighters add" in body
         assert 'x-text="added"' in body
+        assert 'x-show="!overridden"' in body
         assert 'x-model="override"' in body
         assert ':disabled="overridden || locked"' in body
 

--- a/n26/core/trading.py
+++ b/n26/core/trading.py
@@ -1,4 +1,4 @@
-"""The Visit Trading Post action — who performs it, and what it brings.
+"""The Visit Trading Post action — who performs it, and what it adds.
 
 A gang's Trade Points are not a standing figure. They arrive when a
 fighter performs the action, are spent at the post, and what is left is
@@ -9,9 +9,9 @@ measured from (``n26.core.reconcile.trade_points_spent``). There is no
 visit table: what a visit *is* is the events one act wrote, which is
 already how the ledger describes everything else.
 
-Two ranks bring Trade Points, and only they are offered: picking a
-fighter who brings none is a choice with no consequence, and the form
-asks one question rather than listing a roster to say no to most of it.
+        Two ranks add Trade Points, and only they are offered: picking a
+        fighter who adds none is a choice with no consequence, and the form
+        asks one question rather than listing a roster to say no to most of it.
 Equipping is the other half and has no such limit — anything the gang
 bought is handed to whoever it is for.
 
@@ -22,14 +22,14 @@ promoted into the rank counts and one who has lost it does not.
 
 from dataclasses import dataclass
 
-#: What each rank brings to a post, by the subtype's own name. The book
-#: names two; every other model brings nothing and may still go.
+#: What each rank adds to a post, by the subtype's own name. The book
+#: names two; every other model adds nothing and may still go.
 TRADE_POINTS_FOR_RANK = {"Leader": 2, "Champion": 1}
 
 
 @dataclass(frozen=True)
 class Visitor:
-    """One model who could perform the action, and what they would bring."""
+    """One model who could perform the action, and what they would add."""
 
     miniature: object
     rank: str
@@ -47,20 +47,21 @@ def brings(rank):
 
 
 def visitors(gang, going=None):
-    """The fighters who could bring Trade Points, in rank order then by name.
+    """The fighters who could add Trade Points, in rank order then by name.
 
     ``going`` is the set of model ids the owner has ticked; ``None``
     opens with all of them ticked, which is what a post-cycle almost
-    always wants.
+    always wants. The form itself starts with none ticked, and passes
+    an empty set.
 
-    A model holding both ranks brings the better of the two: the same
+    A model holding both ranks adds the better of the two: the same
     fighter cannot perform the action twice.
 
     Two queries — the roster, then the ranks anybody holds. Removals are
     read with them: an assignment with ``removes`` set is machinery
     rather than a line, so anything reading assignments straight from
     the database has to cancel the pair itself, or a Leader an owner
-    took away goes on bringing two points.
+    took away goes on adding two points.
     """
     from n26.core.models import Assignment
     from n26.core.render import roster
@@ -94,7 +95,7 @@ def visitors(gang, going=None):
 
 
 def minted(going):
-    """What a set of visitors brings between them."""
+    """What a set of visitors adds between them."""
     return sum(visitor.trade_points for visitor in going if visitor.visiting)
 
 
@@ -104,7 +105,7 @@ def as_offer(going, label="Who is visiting"):
     ``ChoiceOffer`` is the shape the edition already ticks lists in, and
     ``<c-n26.tick-list>`` draws it with plain checkboxes and no script.
     The headings are the ranks, which is what a heading is for here: what
-    a model brings follows from the rank they are filed under, so the
+    a model adds follows from the rank they are filed under, so the
     figure is said once per group rather than once per model.
 
     The better rank leads.
@@ -164,7 +165,7 @@ class Contributor:
 class Receipt:
     """An open Visit Trading Post action, as the figures it is read by.
 
-    Built for the screen rather than stored: what a visit brought is the
+    Built for the screen rather than stored: what a visit added is the
     amount on the gang, what it has spent is the ledger's answer, and who
     went is the events the opening act wrote. Nothing here is a second
     copy of any of them.
@@ -177,7 +178,7 @@ class Receipt:
 
     @property
     def facts(self):
-        """The visit as a tally: what it brought, what has gone, what is
+        """The visit as a tally: what it added, what has gone, what is
         left. Drawn by ``<c-n26.tally>``, which the overspend
         confirmation draws too — one arithmetic, one shape."""
         from n26.core.confirm import Fact

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -1,5 +1,7 @@
 """Where a player lands, what they own, and founding one more."""
 
+import json
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
@@ -753,21 +755,14 @@ TRADE_POINT_CEILING = 999
 def _brought(data, ticked):
     """What the visit is worth: the ticks, or a figure typed over them.
 
-    The box opens showing what the ticked fighters bring, and the form
-    submits that opening figure alongside it. Left alone, the two match
-    and the ticks decide — so re-ticking without touching the box does
-    what a reader expects, which no amount of client-side arithmetic
-    could promise them with scripting off.
-
-    Changed, the typed figure wins. A territory that adds a point and an
-    arbitrator's own number are the same act with a different total, and
-    the operation takes what it is given.
+    The box opens empty. Left empty, the ticks decide. A figure typed
+    there is the amount, even nought — nought is a number somebody
+    meant, not an empty box.
 
     Raises ValueError on a figure that is not a whole number in range.
     """
     typed = (data.get("brought") or "").strip()
-    opened = (data.get("brought_default") or "").strip()
-    if not typed or typed == opened:
+    if not typed:
         return ticked
     if not typed.isdigit() or int(typed) > TRADE_POINT_CEILING:
         raise ValueError(typed)
@@ -819,24 +814,23 @@ def gang_trade_points(request, pk):
     """The Visit Trading Post action: the one open, and starting another.
 
     One act per post. Starting names the fighters who perform it and
-    takes what they bring between them; finishing shuts the post and
+    takes what they add between them; finishing shuts the post and
     loses whatever is left, which is the book's own rule rather than
     this screen's idea. Both go through an operation, and the event each
     writes is what the spending is measured against.
 
-    The figures are not a form. A visit brings what its fighters bring,
-    and the box beneath the ticks is for an owner who would rather say
-    the figure outright — `brought_default` is how a typed figure is
-    told from one the page drew, there being no script here to follow
-    the ticks. The screen stays two plain posts and no query string.
+    The figures are not a form. A visit adds what its fighters add, and
+    the box beneath the ticks is for an owner who would rather say the
+    figure outright. Empty, the ticks decide; a number there is the
+    amount. The screen stays two plain posts and no query string.
 
     Two things are refused, and both are refusals a reader cannot reach
-    from the page as drawn. An empty visit: the rules want at least one
-    fighter to perform the action, and a visit nobody performed is not
-    one. And a second visit while one is open: the form is shut then, so
-    a start arriving anyway is a stale page rather than an intention.
+    from the page as drawn. An empty visit: with neither a ticked
+    fighter nor a typed amount there is nothing to start. And a second
+    visit while one is open: the form is shut then, so a start arriving
+    anyway is a stale page rather than an intention.
 
-    Spending past what a visit brought is not among them — the purchase
+    Spending past what a visit added is not among them — the purchase
     asks whether that was meant, and then does it.
     """
     from n26.analytics import EventVerb, N26Noun, record
@@ -853,7 +847,12 @@ def gang_trade_points(request, pk):
             with operation(gang, actor=request.user) as op:
                 op.leave_trading_post()
             record(request, N26Noun.GANG, EventVerb.UPDATE, gang, trade_points=None)
-            lost = f" {left} unspent went with it." if left > 0 else ""
+            if left == 1:
+                lost = " 1 unspent Trade Point was discarded."
+            elif left > 0:
+                lost = f" {left} unspent Trade Points were discarded."
+            else:
+                lost = ""
             messages.success(request, f"{gang.name} left the Trading Post.{lost}")
         return redirect(at)
 
@@ -872,11 +871,12 @@ def gang_trade_points(request, pk):
         # roster, so a tampered form simply sends nobody.
         going = visitors(gang, set(request.POST.getlist("visiting")))
         performing = [visitor for visitor in going if visitor.visiting]
-        if not performing:
+        typed = (request.POST.get("brought") or "").strip()
+        if not performing and not typed:
             messages.error(
                 request,
-                "Pick at least one fighter to visit the trading post — "
-                "somebody has to perform the action.",
+                "Pick at least one fighter to visit the trading post, or "
+                "enter a Trade Point amount.",
             )
             return redirect(at)
         try:
@@ -890,15 +890,20 @@ def gang_trade_points(request, pk):
         with operation(gang, actor=request.user) as op:
             op.visit_trading_post(going, brought=brought)
         record(request, N26Noun.GANG, EventVerb.UPDATE, gang, trade_points=brought)
+        if performing:
+            who = (
+                f"{len(performing)} fighter{'' if len(performing) == 1 else 's'} "
+                f"visited the Trading Post, adding "
+            )
+        else:
+            who = f"{gang.name} visited the Trading Post, adding "
         messages.success(
             request,
-            f"{len(performing)} fighter{'' if len(performing) == 1 else 's'} "
-            f"visited the Trading Post, bringing "
-            f"{brought} Trade Point{'' if brought == 1 else 's'}.",
+            f"{who}{brought} Trade Point{'' if brought == 1 else 's'}.",
         )
         return redirect(at)
 
-    offered = visitors(gang)
+    offered = visitors(gang, going=set())
     return render(
         request,
         "n26/trade_points.html",
@@ -907,7 +912,7 @@ def gang_trade_points(request, pk):
             "action": at,
             # Each fighter on the receipt gets a way to their own equip
             # screen, opened on the post itself: having sent them there,
-            # spending what they brought is the next thing an owner
+            # spending what they added is the next thing an owner
             # wants. Empty where the library has no post, which leaves
             # the buttons off rather than sending anybody nowhere.
             "post": _the_trading_post(),
@@ -915,17 +920,19 @@ def gang_trade_points(request, pk):
             # drawn from this and the form below it either way, so the
             # page reads the same whichever state it is in.
             "receipt": receipt_for(gang),
-            # What the ticked fighters bring, as the box opens. Left at
-            # this the ticks decide, so changing who goes without
-            # touching the box does what a reader expects.
-            "suggestion": minted(offered),
+            # What each offered fighter adds, keyed by the box value, so
+            # the running total can follow the ticks without a second
+            # copy of who is on the list.
+            "points_json": json.dumps(
+                {visitor.key: visitor.trade_points for visitor in offered}
+            ),
             # Whether an action is open, as a plain boolean: the start form
             # reads it to shut itself, and a cotton :attribute takes a
             # variable rather than an expression.
             "visit_open": gang.visiting_trading_post,
             "visitors": offered,
             # Every fighter, not only those who performed the action:
-            # what a visit brought is the gang's, and it is spent on
+            # what a visit added is the gang's, and it is spent on
             # whoever it was for. Who went is the ranks on the receipt.
             "roster": roster(gang),
             "offer": as_offer(offered),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Visit Trading Post start form was pre-filling the override box with the total of every eligible fighter, so the override looked like the default rather than an exception. Ticks opened already checked, the start button just said “Start action”, and finishing a visit said unspent points “went with it”.

This changes that screen so:

- The start button is **Start TP visit**, with live help text **Selected fighters add N TP** (N is the ticked total). Typing a figure in the override box **hides that help** and disables the ticks: the box is then the amount, so “selected fighters” would be a lie.
- Ticks open **unchecked**. The override box opens **empty**.
- Fighters **add** Trade Points rather than bring them (form copy, start flash, empty-gang line).
- Completing a visit says **X unspent Trade Points were discarded**, and the complete-action help adds **Any unused TP will be discarded.**

The running total and the shutting of the ticks are Alpine on state already on the page. Without scripting the ticks stay live, an empty box still means the ticks decide, and a typed figure still wins.

**How to try it:** gang edit → Trade Points. Tick a Leader/Champion and watch the total; type in the override box and the ticks should shut and the “Selected fighters…” line should disappear. Start a visit, then complete it and check the flash.

[Ticked fighters add 4 TP](https://cursor.com/agents/bc-9634d4ea-2a92-52c7-8571-b4f04cd0dbbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftp_tick_total_visible.webp)
[Override of 7 hides the Selected fighters help](https://cursor.com/agents/bc-9634d4ea-2a92-52c7-8571-b4f04cd0dbbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftp_override_hides_help.webp)
[tp_override_hides_tick_total_help.mp4](https://cursor.com/agents/bc-9634d4ea-2a92-52c7-8571-b4f04cd0dbbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftp_override_hides_tick_total_help.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQKP2AW20/p1787785922319189?thread_ts=1787785922.319189&cid=C0BQKP2AW20)

<div><a href="https://cursor.com/agents/bc-9634d4ea-2a92-52c7-8571-b4f04cd0dbbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9634d4ea-2a92-52c7-8571-b4f04cd0dbbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

