### PR TITLE
fix: Operation.refund, sell and remove re-read the root under the gang lock

### DIFF
--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -732,7 +732,7 @@ class Operation:
         """
         assignment = _under_the_lock(assignment)
         if assignment.archived:
-            return assignment
+            return None
         for target in [assignment, *subtree(assignment)]:
             if target.archived:
                 continue
@@ -765,7 +765,7 @@ class Operation:
         """
         assignment = _under_the_lock(assignment)
         if assignment.archived:
-            return assignment
+            return None
         rows, _ = refund_of(assignment)
         for target in rows:
             self.touched(target.miniature_root)
@@ -825,12 +825,12 @@ class Operation:
         events therefore still reproduces the entry, which is the invariant
         ``n26.reconcile`` exists to check.
 
-        Returns what the gang was paid — nothing, for something already
+        Returns what the gang was paid, or None for something already
         gone: see :func:`_under_the_lock`.
         """
         assignment = _under_the_lock(assignment)
         if assignment.archived:
-            return 0
+            return None
         rows, _, proceeds = sale_of(assignment)
         for target in rows:
             self.touched(target.miniature_root)
@@ -1778,9 +1778,10 @@ def _under_the_lock(assignment):
     a thing already archived and hand its money back a second time, with
     the entry settled to zero twice while its events fold to minus what
     it was worth. So the act reads the row afresh, entry beside it, and
-    every removal treats an already-archived root as done: nothing to
-    write, nothing to return. The rows beneath it are always read fresh,
-    so they need no such care.
+    every removal treats an already-archived root as done: nothing
+    written, and None returned so a caller can say so rather than report
+    an act that did not happen. The rows beneath it are always read
+    fresh, so they need no such care.
     """
     from n26.core.models import Assignment
 

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -727,7 +727,12 @@ class Operation:
         record of having owned the thing survives. Its rating stops counting
         because rating sums skip archived assignments; the entry keeps
         saying what the thing was worth.
+
+        Already gone means nothing to do: see :func:`_under_the_lock`.
         """
+        assignment = _under_the_lock(assignment)
+        if assignment.archived:
+            return assignment
         for target in [assignment, *subtree(assignment)]:
             if target.archived:
                 continue
@@ -755,7 +760,12 @@ class Operation:
         neither the spending nor its undoing counts any more — the trip
         a refund belongs to is the trip the purchase belonged to, not
         whenever the owner got round to handing it back.
+
+        Already gone means nothing comes back: see :func:`_under_the_lock`.
         """
+        assignment = _under_the_lock(assignment)
+        if assignment.archived:
+            return assignment
         rows, _ = refund_of(assignment)
         for target in rows:
             self.touched(target.miniature_root)
@@ -815,8 +825,12 @@ class Operation:
         events therefore still reproduces the entry, which is the invariant
         ``n26.reconcile`` exists to check.
 
-        Returns what the gang was paid.
+        Returns what the gang was paid — nothing, for something already
+        gone: see :func:`_under_the_lock`.
         """
+        assignment = _under_the_lock(assignment)
+        if assignment.archived:
+            return 0
         rows, _, proceeds = sale_of(assignment)
         for target in rows:
             self.touched(target.miniature_root)
@@ -1752,6 +1766,25 @@ def _now():
     from django.utils import timezone
 
     return timezone.now()
+
+
+def _under_the_lock(assignment):
+    """The root of a removal, read again now that the gang's line is held.
+
+    A caller loads what it means to remove, refund or sell before the
+    operation begins, and so before :func:`_hold` — two clicks of the same
+    button each load a live, paid-for line, and the second waits its turn
+    holding a copy that still says so. Acting on that copy would archive
+    a thing already archived and hand its money back a second time, with
+    the entry settled to zero twice while its events fold to minus what
+    it was worth. So the act reads the row afresh, entry beside it, and
+    every removal treats an already-archived root as done: nothing to
+    write, nothing to return. The rows beneath it are always read fresh,
+    so they need no such care.
+    """
+    from n26.core.models import Assignment
+
+    return Assignment.objects.select_related("ledger_entry").get(pk=assignment.pk)
 
 
 def subtree(assignment):

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -601,6 +601,9 @@ def sell_assignment(request, pk):
     except Refusal as refusal:
         messages.error(request, str(refusal))
         return _unchanged(request, back)
+    if proceeds is None:
+        messages.info(request, f"{name} had already gone.")
+        return _unchanged(request, back)
 
     record(
         request,
@@ -881,9 +884,12 @@ def remove_assignment(request, pk):
 
     try:
         with operation(gang, actor=request.user) as op:
-            op.remove(assignment)
+            removed = op.remove(assignment)
     except Refusal as refusal:
         messages.error(request, str(refusal))
+        return _unchanged(request, back)
+    if removed is None:
+        messages.info(request, f"{name} had already gone.")
         return _unchanged(request, back)
 
     record(
@@ -927,9 +933,12 @@ def refund_assignment(request, pk):
 
     try:
         with operation(gang, actor=request.user) as op:
-            op.refund(assignment)
+            refunded = op.refund(assignment)
     except Refusal as refusal:
         messages.error(request, str(refusal))
+        return _unchanged(request, back)
+    if refunded is None:
+        messages.info(request, f"{name} had already gone.")
         return _unchanged(request, back)
 
     record(

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -115,8 +115,11 @@ def _own_assignment_or_404(request, pk):
     hangs off — so a weapon on a fighter, a sight on that weapon and a
     crate in the stash are all reached the same way, and none of them by
     somebody else. Archived assignments are out: a thing already sold is not
-    something to sell again, and a second click of a stale button must
-    find nothing rather than charge the gang twice.
+    something to sell again. That is a courtesy to a stale button, not
+    what keeps the gang from being charged twice — this runs before the
+    operation holds the gang's line, so two clicks can both pass it. The
+    operation reads the row again under the lock and stands down if it
+    has gone (``n26.core.operations._under_the_lock``).
     """
     from n26.core.models import Assignment
 

--- a/n26/tests/sandbox/test_leaving_the_roster.py
+++ b/n26/tests/sandbox/test_leaving_the_roster.py
@@ -212,3 +212,33 @@ class TestAGangWithNoBudget:
         assert unbudgeted.credits == credits_before
         assert unbudgeted.rating == 0
         assert_reconciled(unbudgeted)
+
+
+class TestTheSameRefundArrivingTwice:
+    """A refund is one act however many times the click reaches the server.
+
+    Two requests for the same refund each load the line — with its ledger
+    entry beside it — before either holds the gang's line. The second
+    waits its turn and then acts on what it loaded, which still says the
+    thing is on the roster and paid for, so it hands the money back
+    again: the entry folds to minus what it was worth while its pins say
+    zero, and the gang is paid twice for one refund.
+    """
+
+    def test_a_second_refund_of_the_same_line_returns_nothing(self, gang, vex):
+        from n26.core.models import Assignment
+        from n26.tests.sandbox.actions import refund
+
+        gun = give_weapon(
+            vex, create_weapon("Autogun", price=GUN_PRICE), paid=GUN_PRICE
+        )
+        as_loaded = Assignment.objects.select_related("ledger_entry")
+        first = as_loaded.get(pk=gun.pk)
+        second = as_loaded.get(pk=gun.pk)
+
+        refund(first)
+        refund(second)
+
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+        assert gang.credits == 1000 - HIRE_PRICE

--- a/n26/tests/sandbox/test_leaving_the_roster.py
+++ b/n26/tests/sandbox/test_leaving_the_roster.py
@@ -215,30 +215,62 @@ class TestAGangWithNoBudget:
 
 
 class TestTheSameRefundArrivingTwice:
-    """A refund is one act however many times the click reaches the server.
+    """A removal is one act however many times the click reaches the server.
 
-    Two requests for the same refund each load the line — with its ledger
+    Two requests for the same act each load the line — with its ledger
     entry beside it — before either holds the gang's line. The second
-    waits its turn and then acts on what it loaded, which still says the
-    thing is on the roster and paid for, so it hands the money back
-    again: the entry folds to minus what it was worth while its pins say
-    zero, and the gang is paid twice for one refund.
+    waits its turn holding a copy that still says the thing is on the
+    roster and paid for. Were the act to trust that copy it would hand
+    the money back again: the entry would fold to minus what it was worth
+    while its pins say zero, and the gang would be paid twice for one
+    refund. Instead the second arrival finds the thing gone and does
+    nothing.
     """
 
-    def test_a_second_refund_of_the_same_line_returns_nothing(self, gang, vex):
+    @pytest.fixture
+    def loaded_twice(self, vex):
         from n26.core.models import Assignment
-        from n26.tests.sandbox.actions import refund
 
         gun = give_weapon(
             vex, create_weapon("Autogun", price=GUN_PRICE), paid=GUN_PRICE
         )
         as_loaded = Assignment.objects.select_related("ledger_entry")
-        first = as_loaded.get(pk=gun.pk)
-        second = as_loaded.get(pk=gun.pk)
+        return as_loaded.get(pk=gun.pk), as_loaded.get(pk=gun.pk)
 
+    def test_a_second_refund_of_the_same_line_returns_nothing(self, gang, loaded_twice):
+        from n26.core.models import LedgerEvent
+        from n26.tests.sandbox.actions import refund
+
+        first, second = loaded_twice
         refund(first)
         refund(second)
 
         gang.refresh_from_db()
         assert_reconciled(gang)
         assert gang.credits == 1000 - HIRE_PRICE
+        assert first.ledger_events.filter(kind=LedgerEvent.Kind.REFUNDED).count() == 1
+
+    def test_a_second_sale_of_the_same_line_pays_nothing(self, gang, loaded_twice):
+        from n26.core.models import LedgerEvent
+        from n26.tests.sandbox.actions import sell
+
+        first, second = loaded_twice
+        proceeds = sell(first)
+        assert sell(second) == 0
+
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+        assert gang.credits == 1000 - HIRE_PRICE - GUN_PRICE + proceeds
+        assert first.ledger_events.filter(kind=LedgerEvent.Kind.SOLD).count() == 1
+
+    def test_a_second_removal_of_the_same_line_writes_nothing(self, gang, loaded_twice):
+        from n26.core.models import LedgerEvent
+        from n26.tests.sandbox.actions import remove
+
+        first, second = loaded_twice
+        remove(first)
+        remove(second)
+
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+        assert first.ledger_events.filter(kind=LedgerEvent.Kind.REMOVED).count() == 1

--- a/n26/tests/sandbox/test_leaving_the_roster.py
+++ b/n26/tests/sandbox/test_leaving_the_roster.py
@@ -243,7 +243,7 @@ class TestTheSameRefundArrivingTwice:
 
         first, second = loaded_twice
         refund(first)
-        refund(second)
+        assert refund(second) is None
 
         gang.refresh_from_db()
         assert_reconciled(gang)
@@ -256,7 +256,7 @@ class TestTheSameRefundArrivingTwice:
 
         first, second = loaded_twice
         proceeds = sell(first)
-        assert sell(second) == 0
+        assert sell(second) is None
 
         gang.refresh_from_db()
         assert_reconciled(gang)
@@ -269,7 +269,7 @@ class TestTheSameRefundArrivingTwice:
 
         first, second = loaded_twice
         remove(first)
-        remove(second)
+        assert remove(second) is None
 
         gang.refresh_from_db()
         assert_reconciled(gang)


### PR DESCRIPTION
## What changed

Refunding, selling or removing something in an n26 gang now reads the line again *after* the gang's lock is taken, and does nothing if it has already gone. Before this, a refund click that reached the server twice paid the gang back twice.

## The bug, as a player saw it

Click Refund on a weapon (or a fighter); the request lands twice — a double-click, a retry, a slow connection. The line is archived once, but the books record two refunds: the ledger entry's `paid` and `rating_contribution` are pinned to 0 while its events fold to minus what the thing cost, and the gang's credits are higher than the budget less spend. The books audit (#2326) found this shape in two gangs; the repair for those is a separate PR.

## Mechanism

`_own_assignment_or_404` loads the assignment with `select_related("ledger_entry")` and filters `archived=False` — but it runs before `operation()` takes `_hold(gang)`. Two concurrent requests both pass the filter; the second waits at the lock, then `Operation.refund` trusts its stale copy: `refund_of` keeps the root because its `archived` still reads False, and `entry.paid` is the cached pre-refund figure, so it writes another `REFUNDED` −paid event and settles the entry to zero again. `sell` had the same fault (a second `SOLD` and `paid` dropped twice); `remove` wrote a duplicate `REMOVED` line.

## Fix

`Operation.remove`, `refund` and `sell` call a new `_under_the_lock(assignment)` that re-reads the root by pk (entry beside it) and return without writing if it is already archived. The subtree was always read fresh, so only the root needed this. The docstring on `_own_assignment_or_404` no longer claims its filter prevents double-charging.

## Tests

`n26/tests/sandbox/test_leaving_the_roster.py::TestTheSameRefundArrivingTwice` — three tests that load the same bought line twice (as two requests would) and refund, sell or remove each copy in turn. All three fail on main with the production fold shape (`paid pinned 0, events fold to -30`, proceeds paid twice, two `REMOVED` lines) and pass here.

`pytest n26 -n 4`: 4175 passed, 1 xfailed. `./scripts/check_migrations.sh`: clean.

Refs #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
