### PR TITLE
feat: maintenance op n26_repair_doubled_refunds drops surplus refund and sale events

### DIFF
--- a/n26/core/doubled_refunds.py
+++ b/n26/core/doubled_refunds.py
@@ -1,0 +1,191 @@
+"""Dropping the second refund a doubled click wrote.
+
+A refund, a sale and a removal each archive a line and write one event
+saying so; a refund or a sale also settles the line's ledger entry. Where
+the same click reached the server twice before the operation read the
+line again under the gang's lock, the second arrival acted on a copy
+loaded before the first had finished and wrote the same event again: two
+``refunded`` or two ``sold`` legs for one purchase, and — for a fighter —
+the removal legs of what they brought written twice as well. The entry's
+pins say zero, the events fold to minus what the thing was worth, and
+the gang's credits stand higher than its budget less its spending.
+
+The books' invariant is that folding an entry's events reproduces the
+entry, and the surplus legs are the only thing between these gangs and
+it. Dropping them — every leg of a kind after the first on its line, and
+every removal leg that rode in the same act — leaves one true story per
+line, so the entries' pins already fit and the gang's pinned numbers
+need only be written again. Deleting from an append-only ledger is the
+sanctioned exception a repair earns the way a conversion does: it moves
+no money of its own, and proves every affected gang reconciles or
+unwinds whole.
+"""
+
+from dataclasses import dataclass
+
+from django.db import transaction
+from django.db.models import Count
+
+
+class Refused(Exception):
+    """The repair found something other than the fault it was written for."""
+
+
+@dataclass(frozen=True)
+class Doubled:
+    """Every surplus leg, grouped by the gang whose books carry it."""
+
+    #: ``(gang id, surplus event ids, credits the gang was over)``, one
+    #: per gang. The credits figure is what the surplus legs handed back:
+    #: the gang's pinned credits fall by exactly this when they go.
+    gangs: tuple = ()
+    problems: tuple = ()
+    nothing_here: bool = False
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    @property
+    def event_ids(self):
+        return tuple(pk for _, ids, _ in self.gangs for pk in ids)
+
+    def preview(self):
+        if self.nothing_here:
+            return ["nothing to drop — no line carries a second refund or sale"]
+        lines = []
+        for gang_id, ids, credits in self.gangs:
+            lines.append(
+                f"gang {gang_id}: drop {len(ids)} surplus "
+                f"event{'' if len(ids) == 1 else 's'}; "
+                f"its credits fall by {credits}"
+            )
+        total = len(self.event_ids)
+        over = sum(credits for _, _, credits in self.gangs)
+        lines.append(
+            f"{total} surplus event{'' if total == 1 else 's'} across "
+            f"{len(self.gangs)} gang{'' if len(self.gangs) == 1 else 's'}, "
+            f"{over} credits handed back that were never owed"
+        )
+        return lines
+
+
+def _surplus_events():
+    """Every leg after the first of its kind on a line, and every removal
+    leg written in the same act as one of those.
+
+    Found in the ledger's own terms rather than by folding every gang's
+    books: a line with two ``refunded`` or two ``sold`` events is the
+    fault by definition, and the act that wrote the second is named by
+    its batch mark — so the removal legs it wrote for the lines beneath
+    are the ones sharing that mark that repeat an earlier removal.
+    """
+    from n26.core.models import LedgerEvent
+
+    money_kinds = (LedgerEvent.Kind.REFUNDED, LedgerEvent.Kind.SOLD)
+    doubled = (
+        LedgerEvent.objects.filter(kind__in=money_kinds, assignment__isnull=False)
+        .values("assignment_id", "kind")
+        .annotate(count=Count("id"))
+        .filter(count__gt=1)
+    )
+    surplus = []
+    for row in doubled:
+        legs = list(
+            LedgerEvent.objects.filter(
+                assignment_id=row["assignment_id"], kind=row["kind"]
+            ).order_by("created", "id")
+        )
+        surplus.extend(legs[1:])
+
+    batches = {event.batch for event in surplus if event.batch is not None}
+    if batches:
+        repeats = LedgerEvent.objects.filter(
+            batch__in=batches, kind=LedgerEvent.Kind.REMOVED
+        ).order_by("created", "id")
+        for event in repeats:
+            earlier = (
+                LedgerEvent.objects.filter(
+                    assignment_id=event.assignment_id,
+                    kind=LedgerEvent.Kind.REMOVED,
+                )
+                .exclude(pk=event.pk)
+                .filter(created__lte=event.created)
+                .exists()
+            )
+            if earlier:
+                surplus.append(event)
+    return surplus
+
+
+def find():
+    """What stands to be dropped, gang by gang."""
+    surplus = _surplus_events()
+    if not surplus:
+        return Doubled(nothing_here=True)
+
+    problems = []
+    by_gang = {}
+    for event in surplus:
+        if not event.assignment.archived:
+            problems.append(
+                f"a surplus {event.get_kind_display().lower()} leg stands on a "
+                f"line still on the roster (gang {event.gang_id}) — not the "
+                "doubled removal this repairs"
+            )
+        ids, credits = by_gang.setdefault(event.gang_id, ([], 0))
+        ids.append(event.pk)
+        by_gang[event.gang_id] = (ids, credits - event.credits_delta)
+    gangs = tuple(
+        (gang_id, tuple(ids), credits)
+        for gang_id, (ids, credits) in sorted(by_gang.items(), key=lambda kv: kv[0])
+    )
+    return Doubled(gangs=gangs, problems=tuple(problems))
+
+
+def apply(doubled):
+    """Drop exactly what the plan names, and prove each gang's books whole.
+
+    One transaction: a gang whose books still disagree after its surplus
+    legs are gone unwinds the whole run, with the disagreement in words.
+    """
+    from n26.core.models import Gang, LedgerEvent
+    from n26.core.reconcile import check_gang, repin_everything
+
+    if doubled.problems:
+        raise Refused("not repaired: " + "; ".join(doubled.problems))
+    if doubled.nothing_here:
+        return list(doubled.preview())
+
+    report = list(doubled.preview())
+    gang_ids = [gang_id for gang_id, _, _ in doubled.gangs]
+    with transaction.atomic():
+        # The gangs first, so nothing lands on their books while their
+        # legs are being dropped; then the plan again, because it was
+        # read before this transaction opened.
+        list(Gang.objects.select_for_update().filter(pk__in=gang_ids).order_by("pk"))
+        now = find()
+        if now.problems or set(now.gangs) != set(doubled.gangs):
+            raise Refused(
+                "not repaired: the books have changed since the plan was "
+                "read — read it again"
+            )
+        deleted, _ = LedgerEvent.objects.filter(pk__in=doubled.event_ids).delete()
+        if deleted != len(doubled.event_ids):
+            raise Refused(
+                f"not repaired: {len(doubled.event_ids)} legs named, {deleted} found"
+            )
+        for gang_id in gang_ids:
+            gang = Gang.objects.get(pk=gang_id)
+            repin_everything(gang)
+            gang.refresh_from_db()
+            problems = check_gang(gang)
+            if problems:
+                raise Refused(
+                    f"refused — gang {gang_id} still does not reconcile "
+                    "with its surplus legs gone: " + "; ".join(problems)
+                )
+
+    report.append("dropped events " + ", ".join(str(pk) for pk in doubled.event_ids))
+    report.append("repaired; every affected gang reconciles")
+    return report

--- a/n26/core/doubled_refunds.py
+++ b/n26/core/doubled_refunds.py
@@ -24,7 +24,7 @@ unwinds whole.
 from dataclasses import dataclass
 
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, Q
 
 
 class Refused(Exception):
@@ -104,13 +104,19 @@ def _surplus_events():
             batch__in=batches, kind=LedgerEvent.Kind.REMOVED
         ).order_by("created", "id")
         for event in repeats:
+            # "Earlier" in the same total order the surplus legs above
+            # were ranked by: created, then id. Two legs written in the
+            # same instant still have one first, so an exact tie names
+            # one of them and never both.
             earlier = (
                 LedgerEvent.objects.filter(
                     assignment_id=event.assignment_id,
                     kind=LedgerEvent.Kind.REMOVED,
                 )
-                .exclude(pk=event.pk)
-                .filter(created__lte=event.created)
+                .filter(
+                    Q(created__lt=event.created)
+                    | Q(created=event.created, id__lt=event.id)
+                )
                 .exists()
             )
             if earlier:

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -58,6 +58,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "Operation",
     "delete_nameless_gang_type",
+    "repair_doubled_refunds",
     "run_batched",
     "task_routes",
 ]
@@ -133,6 +134,10 @@ class Operation(models.TextChoices):
         "n26_audit_reconcile",
         "n26: every gang's books are checked against its ledger",
     )
+    REPAIR_DOUBLED_REFUNDS = (
+        "n26_repair_doubled_refunds",
+        "n26: the second refund a doubled click wrote is dropped",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -140,6 +145,7 @@ LOCK_KEYS = {
     Operation.DELETE_NAMELESS_GANG_TYPE: 826_020_606,
     Operation.AUDIT_RECONCILE: 826_020_607,
     Operation.CONVERT_OUTCAST_AFFILIATION: 826_020_608,
+    Operation.REPAIR_DOUBLED_REFUNDS: 826_020_609,
 }
 
 
@@ -704,6 +710,62 @@ def delete_nameless_gang_type_view(request):
 
 
 @task
+def repair_doubled_refunds(backfill_id, **said_by_whoever_enqueued_it):
+    """Drop the surplus refund, sale and removal legs a doubled click
+    wrote, and prove every affected gang's books whole, once.
+
+    Two gangs' worth of events in one transaction: small enough to hold,
+    and a gang that still fails to reconcile unwinds the lot.
+    """
+    from n26.core.doubled_refunds import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.REPAIR_DOUBLED_REFUNDS,
+        "Doubled refund repair",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
+DOUBLED_WORDS = {
+    "noun": "repair",
+    "intro": (
+        "This deletes ledger events from players' gangs. A refund, sale or "
+        "removal whose click reached the server twice used to be written "
+        "twice: the line was archived once, but a second refunded or sold "
+        "leg — and, for a fighter, a second removed leg for each thing "
+        "they brought — went into the books, so the entry's events fold "
+        "to minus what it was worth while its pins say zero, and the gang "
+        "holds credits it was never owed. Every leg after the first of its "
+        "kind on a line is dropped, along with the removal legs written in "
+        "the same act, and each gang's pinned numbers are written again "
+        "from what remains. A line still on the roster with a doubled leg "
+        "is refused rather than touched."
+    ),
+    "nothing_heading": "Nothing to drop",
+    "nothing_flash": "There was nothing to drop — no line carries a second refund or sale.",
+    "nothing_words": "No line in any gang carries a second refund or sale.",
+    "refuses_heading": "The repair refuses",
+    "button": "Drop the surplus legs",
+    "confirm": "Drop every surplus refund, sale and removal leg and rewrite the affected gangs' pinned numbers? This cannot be undone.",
+}
+
+
+def repair_doubled_refunds_view(request):
+    """Preview the repair (GET), or record a run and enqueue it."""
+    from n26.core.doubled_refunds import find
+
+    return _deletion_view(
+        request,
+        Operation.REPAIR_DOUBLED_REFUNDS,
+        find,
+        repair_doubled_refunds,
+        DOUBLED_WORDS,
+    )
+
+
+@task
 def audit_reconcile(backfill_id, **said_by_whoever_enqueued_it):
     """Check every unarchived gang's books against its ledger.
 
@@ -817,6 +879,23 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.REPAIR_DOUBLED_REFUNDS.value,
+        name=Operation.REPAIR_DOUBLED_REFUNDS.label,
+        added=date(2026, 8, 28),
+        description=(
+            "Drop the second refunded or sold leg a doubled click wrote onto "
+            "a line, and the removal legs written in the same act, then "
+            "write each affected gang's pinned numbers again. The books "
+            "audit reports these gangs as entries pinned 0 whose events "
+            "fold to minus what the thing was worth."
+        ),
+        view=repair_doubled_refunds_view,
+        detail_template="admin/maintenance/n26/_delete_detail.html",
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a repair holds one
 #: transaction for as long as proving what it touched takes. It is also
@@ -838,6 +917,7 @@ task_routes = [
     TaskRoute(propagate_built_ins, ack_deadline=600),
     TaskRoute(sweep_built_in_propagations, schedule="*/5 * * * *"),
     TaskRoute(audit_reconcile),
+    TaskRoute(repair_doubled_refunds, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/tests/sandbox/test_doubled_refunds.py
+++ b/n26/tests/sandbox/test_doubled_refunds.py
@@ -30,6 +30,7 @@ from n26.tests.sandbox.actions import (
     hire,
     refund,
     remove,
+    sell,
 )
 
 pytestmark = pytest.mark.django_db
@@ -95,10 +96,22 @@ class TestFindingTheSurplus:
     """The plan names each gang, how many legs go, and what its credits
     lose — and nothing at all when no line carries a second leg."""
 
-    def test_a_clean_estate_has_nothing_to_drop(self, gang, vex):
+    @pytest.fixture
+    def played(self, gang, vex, default_pack):
+        """A gang with a real history: one refund, one sale and one plain
+        removal, each on its own line and each written once."""
+        refund(give_weapon(vex, create_weapon("Autogun", price=30), paid=30))
+        sell(give_weapon(vex, create_weapon("Shotgun", price=40), paid=40))
+        remove(give_weapon(vex, create_weapon("Knife", price=0), paid=0))
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+        return gang
+
+    def test_a_gang_with_real_history_has_nothing_to_drop(self, played):
         plan = find()
 
         assert plan.nothing_here
+        assert plan.event_ids == ()
         assert "nothing to drop" in plan.preview()[0]
 
     def test_the_plan_names_the_gang_its_legs_and_its_credits(self, doubled):
@@ -170,7 +183,7 @@ class TestDroppingTheSurplus:
 
         assert find().nothing_here
 
-    def test_a_clean_estate_applies_to_nothing(self, gang, vex):
+    def test_a_gang_with_real_history_applies_to_nothing(self, gang, vex):
         report = apply(find())
 
         assert "nothing to drop" in report[0]

--- a/n26/tests/sandbox/test_doubled_refunds.py
+++ b/n26/tests/sandbox/test_doubled_refunds.py
@@ -1,0 +1,201 @@
+"""Repairing the books where one refund was written twice.
+
+A refund whose click reached the server twice was written twice: the
+line was archived once, but a second ``refunded`` leg went into the
+books, so the entry's pins say zero while its events fold to minus what
+the thing cost, and the gang holds credits it was never owed. The repair
+drops every leg after the first of its kind on a line — and the removal
+legs written in the same act — then writes the gang's pinned numbers
+again, and proves the books whole before it commits.
+
+The fault is planted directly here rather than by racing two clicks:
+the operations refuse to write it, and what the repair has to undo is
+the shape in the books, not the path that led there.
+"""
+
+from uuid import uuid4
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.doubled_refunds import Refused, apply, find
+from n26.core.models import LedgerEvent
+from n26.core.reconcile import assert_reconciled, check_gang
+from n26.maintenance import Operation, repair_doubled_refunds_view
+from n26.tests.sandbox.actions import (
+    create_weapon,
+    found_gang,
+    give_weapon,
+    hire,
+    refund,
+    remove,
+)
+
+pytestmark = pytest.mark.django_db
+
+HIRE_PRICE = 55
+GUN_PRICE = 30
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def gang(gang_type, owner):
+    return found_gang("The Ashen Choir", gang_type, owner=owner, budget=1000)
+
+
+@pytest.fixture
+def vex(gang, make_profile, make_statline):
+    profile = make_profile("Ganger", price=HIRE_PRICE)
+    make_statline(profile)
+    return hire(gang, profile, "Vex", paid=HIRE_PRICE)
+
+
+def _written_again(event):
+    """The same leg, written a second time in an act of its own."""
+    return LedgerEvent.objects.create(
+        assignment=event.assignment,
+        gang=event.gang,
+        kind=event.kind,
+        batch=uuid4(),
+        actor=event.actor,
+        credits_delta=event.credits_delta,
+        rating_delta=event.rating_delta,
+        trade_points_delta=event.trade_points_delta,
+    )
+
+
+@pytest.fixture
+def doubled(gang, vex, default_pack):
+    """A refunded gun whose refund leg stands twice, and a removed knife
+    whose removal leg was written again in the same second act. The
+    gang's credits carry the second refund, as they did when the books
+    were written this way."""
+    gun = give_weapon(vex, create_weapon("Autogun", price=GUN_PRICE), paid=GUN_PRICE)
+    knife = give_weapon(vex, create_weapon("Knife", price=0), paid=0)
+    refund(gun)
+    remove(knife)
+
+    again = _written_again(gun.ledger_events.get(kind=LedgerEvent.Kind.REFUNDED))
+    knife_again = _written_again(knife.ledger_events.get(kind=LedgerEvent.Kind.REMOVED))
+    knife_again.batch = again.batch
+    knife_again.save(update_fields=["batch"])
+    gang.repin_credits()
+    gang.refresh_from_db()
+    assert gang.credits == 1000 - HIRE_PRICE + GUN_PRICE
+    assert check_gang(gang)
+    return gang
+
+
+class TestFindingTheSurplus:
+    """The plan names each gang, how many legs go, and what its credits
+    lose — and nothing at all when no line carries a second leg."""
+
+    def test_a_clean_estate_has_nothing_to_drop(self, gang, vex):
+        plan = find()
+
+        assert plan.nothing_here
+        assert "nothing to drop" in plan.preview()[0]
+
+    def test_the_plan_names_the_gang_its_legs_and_its_credits(self, doubled):
+        plan = find()
+
+        assert plan.ok and not plan.nothing_here
+        assert [len(ids) for _, ids, _ in plan.gangs] == [2]
+        assert [credits for _, _, credits in plan.gangs] == [GUN_PRICE]
+        lines = plan.preview()
+        assert f"gang {doubled.pk}: drop 2 surplus events" in lines[0]
+        assert f"credits fall by {GUN_PRICE}" in lines[0]
+        assert "2 surplus events across 1 gang" in lines[-1]
+
+    def test_the_first_leg_of_each_kind_is_never_named(self, doubled):
+        plan = find()
+
+        surplus = set(plan.event_ids)
+        first_refund = LedgerEvent.objects.filter(
+            gang=doubled, kind=LedgerEvent.Kind.REFUNDED
+        ).earliest("created")
+        first_removal = LedgerEvent.objects.filter(
+            gang=doubled, kind=LedgerEvent.Kind.REMOVED
+        ).earliest("created")
+        assert first_refund.pk not in surplus
+        assert first_removal.pk not in surplus
+
+    def test_a_doubled_leg_on_a_live_line_refuses(self, doubled):
+        """Not the shape this repairs: a line still on the roster with a
+        refund on it is a different fault, and refusing keeps this one
+        honest about what it does."""
+        line = LedgerEvent.objects.filter(
+            gang=doubled, kind=LedgerEvent.Kind.REFUNDED
+        ).earliest("created")
+        line.assignment.archived = False
+        line.assignment.save(update_fields=["archived"])
+
+        plan = find()
+
+        assert not plan.ok
+        assert "still on the roster" in plan.problems[0]
+        with pytest.raises(Refused):
+            apply(plan)
+
+
+class TestDroppingTheSurplus:
+    def test_the_gang_reconciles_and_loses_what_it_was_never_owed(self, doubled):
+        report = apply(find())
+
+        doubled.refresh_from_db()
+        assert_reconciled(doubled)
+        assert doubled.credits == 1000 - HIRE_PRICE
+        assert (
+            LedgerEvent.objects.filter(
+                gang=doubled, kind=LedgerEvent.Kind.REFUNDED
+            ).count()
+            == 1
+        )
+        assert (
+            LedgerEvent.objects.filter(
+                gang=doubled, kind=LedgerEvent.Kind.REMOVED
+            ).count()
+            == 1
+        )
+        assert report[-1].startswith("repaired")
+        assert any(line.startswith("dropped events") for line in report)
+
+    def test_a_second_run_finds_nothing(self, doubled):
+        apply(find())
+
+        assert find().nothing_here
+
+    def test_a_clean_estate_applies_to_nothing(self, gang, vex):
+        report = apply(find())
+
+        assert "nothing to drop" in report[0]
+
+
+class TestTheConsole:
+    def test_the_operation_is_registered_and_named(self):
+        from gyrinx.maintenance.registry import operations, resolve_operation
+
+        assert Operation.REPAIR_DOUBLED_REFUNDS.value in {
+            op.operation for op in operations()
+        }
+        found = resolve_operation(Operation.REPAIR_DOUBLED_REFUNDS.value)
+        assert found.view is repair_doubled_refunds_view
+
+    def test_its_page_shows_the_plan_and_writes_nothing(self, client, doubled):
+        from gyrinx.maintenance.models import Backfill
+
+        superuser = User.objects.create_superuser("root", "root@example.com", "x")
+        client.force_login(superuser)
+
+        page = client.get(
+            reverse("admin:maintenance_n26_repair_doubled_refunds")
+        ).content.decode()
+
+        assert f"gang {doubled.pk}: drop 2 surplus events" in page
+        assert not Backfill.objects.exists()
+        assert check_gang(doubled)


### PR DESCRIPTION
## What this is

A maintenance-console operation, **n26: the second refund a doubled click wrote is dropped** (`n26_repair_doubled_refunds`), that repairs the two gangs the books audit (#2326) reported and re-proves their books before committing. The writer is fixed separately in #2340; this clears what it left behind.

## The fault it repairs

A refund or sale whose click reached the server twice was written twice. The line was archived once, but a second `refunded` (or `sold`) event went into the books — and, for a fighter, a second `removed` event for each thing they brought. So the ledger entry's `paid` and `rating_contribution` pins read 0 while its events fold to minus what the thing cost, and the gang's credits sit above its budget less its spending. In production the preview (run read-only from this branch) names 4 gangs — the 2 the audit reported plus 2 archived ones the audit does not walk — with 17 surplus events (11 refund legs, 6 removal legs) and 455 credits handed back that were never owed. All four wrote their doubled legs before the gang lock landed.

## How it works

`n26/core/doubled_refunds.py`:

- `find()` locates the fault in SQL rather than by folding every gang's books: `LedgerEvent` rows grouped by `(assignment, kind)` for `REFUNDED`/`SOLD` with more than one row. Every leg after the first (by `created`, `id`) is surplus, along with any `REMOVED` legs in those surplus legs' batches that repeat an earlier removal on their line. It refuses if a doubled leg stands on a line still on the roster — that is a different fault. The preview names each gang, how many legs go and by how much its credits fall, plus totals.
- `apply()` runs in one transaction: locks the gangs, re-reads the plan and refuses if it moved, deletes exactly the named events, runs `repin_everything` per gang, and requires `check_gang` to come back clean — otherwise the whole run unwinds with the disagreement in words. The report lists what was dropped.

`n26/maintenance.py`: `Operation.REPAIR_DOUBLED_REFUNDS`, a `LOCK_KEYS` entry, the `repair_doubled_refunds` task on `_run_recorded`, a view on `_deletion_view` with its own words, registration on the shared `_delete_detail` template, and a `TaskRoute`.

## Tests

`n26/tests/sandbox/test_doubled_refunds.py` plants the fault directly (a refunded gun with its refund leg written again, a removed knife with its removal leg written again in the same act, credits repinned to carry the surplus) and checks: a clean estate is `nothing_here`; the plan names one gang, two legs and the right credits; the first leg of each kind is never named; a doubled leg on a live line refuses; `apply` leaves the gang reconciled with credits reduced by the worth and one leg of each kind; a second run finds nothing; the console page shows the plan and writes nothing.

`pytest n26 -n 4`: 4181 passed, 1 xfailed. `./scripts/check_migrations.sh`: clean.

## To run it

Merge #2340 first (so nothing new of this shape is written), then Maintenance console → *n26: the second refund a doubled click wrote is dropped* → check the preview says 4 gangs / 17 surplus events / 455 credits → apply. Then re-run *n26: every gang's books are checked against its ledger* and expect zero.

Closes #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
