### PR TITLE
feat: busy.js spins and disables the clicked n26 button until work ends

### DIFF
--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -7,9 +7,10 @@
  * the difference between a page that looks broken and one that is plainly
  * working, and it is what stops a second click buying a second of something.
  *
- * Nothing here calls preventDefault: every form still submits and every link
+ * A first click is never cancelled: every form still submits and every link
  * still navigates exactly as it would with this file missing, so a failure to
- * load costs the affordance and nothing else.
+ * load costs the affordance and nothing else. The one thing cancelled is a
+ * second activation of a control already busy.
  *
  * The state is one attribute, `data-busy="on"`, written here and drawn by the
  * design library's stylesheet (n26/designsystem/assets/app.css) — this file
@@ -101,6 +102,34 @@
             "[data-busy-applied], [data-busy-disabled]",
         ).forEach(release);
     }
+
+    /*
+     * A second go at a control that is already working.
+     *
+     * A busy button is disabled, which is refusal enough — but a link cannot
+     * be disabled, and the stylesheet's `pointer-events: none` turns away a
+     * mouse and nothing else: Enter on a focused link still activates it. So
+     * the click is stopped here, for every busy control, whatever raised it.
+     *
+     * In the capture phase, and stopping the event where it is caught, because
+     * this is the only place ahead of the handlers that act on the click:
+     * htmx listens on the control itself, and by the time an event has reached
+     * the document on the way back up, the request has already gone.
+     */
+    document.addEventListener(
+        "click",
+        function (event) {
+            var target = event.target;
+            /* Every click on the page passes through here, including ones
+             * raised on nodes that are not elements, which have nothing to
+             * ask. */
+            if (!target || !target.closest) return;
+            if (!target.closest('[data-busy="on"]')) return;
+            event.preventDefault();
+            event.stopPropagation();
+        },
+        true,
+    );
 
     /*
      * A form that posts.
@@ -205,10 +234,12 @@
         "htmx:abort",
     ].forEach(function (name) {
         document.addEventListener(name, function (event) {
-            var element = (event.detail && event.detail.elt) || document.body;
-            releaseWithin(
-                (element.closest && element.closest("form")) || element,
-            );
+            /* Only what this request made busy. A form releases the controls
+             * inside it, because its submit disabled all of them; anything
+             * else releases itself alone. Two links in one form can have
+             * requests in flight at once, and the first to settle must not
+             * hand back the other one. */
+            releaseWithin((event.detail && event.detail.elt) || document.body);
         });
     });
 

--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -33,33 +33,45 @@
         "[hx-get],[hx-post],[hx-put],[hx-patch],[hx-delete]," +
         "[data-hx-get],[data-hx-post],[data-hx-put],[data-hx-patch],[data-hx-delete]";
 
-    /* Every control a form sends itself with. A <button> in a form with no
+    /* The controls a form sends itself with. A <button> in a form with no
      * type at all is a submit — HTML's default, and easy to forget. */
     var SUBMITS =
-        'button[type="submit"], input[type="submit"], button:not([type])';
+        'button[type="submit"], input[type="submit"], input[type="image"], ' +
+        "button:not([type])";
 
-    function isHtmx(element) {
-        return !!element && !!element.closest && !!element.closest(HTMX_VERBS);
+    /* Every element reaching these came from an event, and an event's target
+     * is not always an element with questions to answer. */
+    function element(candidate) {
+        return candidate && candidate.closest && candidate.matches
+            ? candidate
+            : null;
     }
 
-    function optedOut(element) {
-        return !!element.closest('[data-busy="off"]');
+    function isHtmx(candidate) {
+        var el = element(candidate);
+        return !!el && !!el.closest(HTMX_VERBS);
     }
 
-    function markBusy(element) {
-        if (!element || optedOut(element)) return;
+    function optedOut(candidate) {
+        var el = element(candidate);
+        return !!el && !!el.closest('[data-busy="off"]');
+    }
+
+    function markBusy(candidate) {
+        var el = element(candidate);
+        if (!el || optedOut(el)) return;
         /* The spinner is a pseudo-element, and a replaced element has none:
          * an <input type="submit"> marked busy would lose its label and show
          * nothing in its place. It is still disabled, just not painted. */
-        if (!element.matches("button, a")) return;
-        if (element.getAttribute("data-busy") === "on") return;
+        if (!el.matches("button, a")) return;
+        if (el.getAttribute("data-busy") === "on") return;
 
-        element.setAttribute("data-busy", "on");
-        element.setAttribute("aria-busy", "true");
-        /* What the script put on is what the script takes off. A page can
-         * carry the state in its own markup — the gallery's demo does — and a
-         * sweep that could not tell the two apart would quietly undo it. */
-        element.setAttribute("data-busy-applied", "");
+        el.setAttribute("data-busy", "on");
+        el.setAttribute("aria-busy", "true");
+        /* What the script put on is what the script takes off: markup may
+         * carry the state itself, and a sweep that could not tell the two
+         * apart would quietly undo it. */
+        el.setAttribute("data-busy-applied", "");
     }
 
     function disable(element) {
@@ -92,15 +104,27 @@
         }
     }
 
-    /* Undo every busy control at or inside `root`. Scoped rather than
-     * document-wide: one settled request must not hand back the buttons of a
-     * form that is still posting somewhere else on the page. */
-    function releaseWithin(root) {
-        if (!root) return;
-        if (root.nodeType === 1) release(root);
-        root.querySelectorAll(
-            "[data-busy-applied], [data-busy-disabled]",
-        ).forEach(release);
+    /* Undo one request, and only what that request made busy.
+     *
+     * A form gets its submit controls back, which is exactly the set its
+     * submission touched — the button that went busy and the ones disabled
+     * beside it. Nothing else inside it is released: a catalogue is one form,
+     * and a row's own link can have a request of its own still in flight
+     * while a purchase in another row settles. Anything that is not a form
+     * asked on its own behalf and is released on its own. */
+    function releaseRequest(root) {
+        var el = element(root);
+        if (!el) return;
+        release(el);
+        if (el.tagName === "FORM")
+            el.querySelectorAll(SUBMITS).forEach(release);
+    }
+
+    /* Undo everything this script has applied anywhere on the page. */
+    function releaseEverything() {
+        document
+            .querySelectorAll("[data-busy-applied], [data-busy-disabled]")
+            .forEach(release);
     }
 
     /*
@@ -119,12 +143,8 @@
     document.addEventListener(
         "click",
         function (event) {
-            var target = event.target;
-            /* Every click on the page passes through here, including ones
-             * raised on nodes that are not elements, which have nothing to
-             * ask. */
-            if (!target || !target.closest) return;
-            if (!target.closest('[data-busy="on"]')) return;
+            var target = element(event.target);
+            if (!target || !target.closest('[data-busy="on"]')) return;
             event.preventDefault();
             event.stopPropagation();
         },
@@ -152,7 +172,11 @@
         if (event.defaultPrevented && !handledByHtmx) return;
         if (optedOut(form)) return;
 
-        markBusy(submitter);
+        /* A form submitted from a script carries no submitter. Its first
+         * submit is the button a reader would have pressed to do the same
+         * thing, and the one to show working — without it the form is left
+         * dead, every control disabled and nothing saying why. */
+        markBusy(submitter || form.querySelector(SUBMITS));
         form.querySelectorAll(SUBMITS).forEach(function (control) {
             /* An opted-out control is out of all of it: a button left alive on
              * purpose is one the reader is meant to still be able to click. */
@@ -214,13 +238,14 @@
      * A control that fetches its own fragment is marked when the request goes
      * out and released when it settles, in whatever way it settles. What sends
      * the request is not always a button: a form sends its own, and a request
-     * made from script has no source element at all, so the element here is
-     * offered as it comes and markBusy keeps the ones it can paint. A form's
-     * button is already busy from the submit above, which is the control the
-     * reader is watching.
+     * made from a script names whichever control it came from. A form's button
+     * is already busy from the submit above, which is the control the reader
+     * is watching.
      *
-     * The scope released is the whole form where there is one: the submit
-     * above disabled every control in it, not just the one that went busy.
+     * A request naming no source at all is reported against the document body.
+     * Nothing was marked for it, so there is nothing to release — and reaching
+     * for its element would hand back every busy control on the page,
+     * including one whose own request is still in flight.
      */
     document.addEventListener("htmx:beforeRequest", function (event) {
         markBusy(event.detail && event.detail.elt);
@@ -234,12 +259,12 @@
         "htmx:abort",
     ].forEach(function (name) {
         document.addEventListener(name, function (event) {
-            /* Only what this request made busy. A form releases the controls
-             * inside it, because its submit disabled all of them; anything
-             * else releases itself alone. Two links in one form can have
-             * requests in flight at once, and the first to settle must not
-             * hand back the other one. */
-            releaseWithin((event.detail && event.detail.elt) || document.body);
+            var source = event.detail && event.detail.elt;
+            /* A request naming no source is reported against the document
+             * body. Nothing was marked for it, and treating the body as the
+             * control would hand back every busy thing on the page. */
+            if (!source || source === document.body) return;
+            releaseRequest(source);
         });
     });
 
@@ -251,6 +276,6 @@
      * else undoes that, so the whole document is handed back here.
      */
     window.addEventListener("pageshow", function (event) {
-        if (event.persisted) releaseWithin(document);
+        if (event.persisted) releaseEverything();
     });
 })();

--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -1,0 +1,225 @@
+/*
+ * Busy controls.
+ *
+ * A click that starts work — a form that posts, a link to a page the server
+ * has to build, an htmx request — leaves the control that started it looking
+ * busy and refuses further clicks until the work ends. On a slow post that is
+ * the difference between a page that looks broken and one that is plainly
+ * working, and it is what stops a second click buying a second of something.
+ *
+ * Nothing here calls preventDefault: every form still submits and every link
+ * still navigates exactly as it would with this file missing, so a failure to
+ * load costs the affordance and nothing else.
+ *
+ * The state is one attribute, `data-busy="on"`, written here and drawn by the
+ * design library's stylesheet (n26/designsystem/assets/app.css) — this file
+ * holds no styling and reads none. A control that must never go busy carries
+ * `data-busy="off"` from its call site; so does a form, which opts out
+ * everything inside it.
+ *
+ * What is deliberately left alone: a button that only moves something on
+ * screen — a tab, a filter, a disclosure — starts no work and never goes
+ * busy. The rules below reach a control through a submit, an htmx request or
+ * a navigation, so those buttons are missed by construction rather than by a
+ * list this file would have to keep.
+ */
+(function () {
+    "use strict";
+
+    /* An htmx control asks for its own page fragment: nothing navigates, so
+     * the busy state has to be taken off again when the request settles. */
+    var HTMX_VERBS =
+        "[hx-get],[hx-post],[hx-put],[hx-patch],[hx-delete]," +
+        "[data-hx-get],[data-hx-post],[data-hx-put],[data-hx-patch],[data-hx-delete]";
+
+    /* Every control a form sends itself with. A <button> in a form with no
+     * type at all is a submit — HTML's default, and easy to forget. */
+    var SUBMITS =
+        'button[type="submit"], input[type="submit"], button:not([type])';
+
+    function isHtmx(element) {
+        return !!element && !!element.closest && !!element.closest(HTMX_VERBS);
+    }
+
+    function optedOut(element) {
+        return !!element.closest('[data-busy="off"]');
+    }
+
+    function markBusy(element) {
+        if (!element || optedOut(element)) return;
+        /* The spinner is a pseudo-element, and a replaced element has none:
+         * an <input type="submit"> marked busy would lose its label and show
+         * nothing in its place. It is still disabled, just not painted. */
+        if (!element.matches("button, a")) return;
+        if (element.getAttribute("data-busy") === "on") return;
+
+        element.setAttribute("data-busy", "on");
+        element.setAttribute("aria-busy", "true");
+        /* What the script put on is what the script takes off. A page can
+         * carry the state in its own markup — the gallery's demo does — and a
+         * sweep that could not tell the two apart would quietly undo it. */
+        element.setAttribute("data-busy-applied", "");
+    }
+
+    function disable(element) {
+        /* A control disabled before the click is not ours to hand back. */
+        if (element.disabled) return;
+
+        /* After the current task, so the clicked button's name and value are
+         * still part of what the form sends: a disabled control is not
+         * submitted, and the equip screens tell buy from sell by exactly
+         * that pair. */
+        element.dataset.busyDisabled = "pending";
+        window.setTimeout(function () {
+            /* A request that settled inside the tick has already given the
+             * button back; disabling it now would strand it. */
+            if (element.dataset.busyDisabled !== "pending") return;
+            element.dataset.busyDisabled = "yes";
+            element.disabled = true;
+        }, 0);
+    }
+
+    function release(element) {
+        if (element.hasAttribute("data-busy-applied")) {
+            element.removeAttribute("data-busy-applied");
+            element.removeAttribute("data-busy");
+            element.removeAttribute("aria-busy");
+        }
+        if (element.dataset.busyDisabled) {
+            delete element.dataset.busyDisabled;
+            element.disabled = false;
+        }
+    }
+
+    /* Undo every busy control at or inside `root`. Scoped rather than
+     * document-wide: one settled request must not hand back the buttons of a
+     * form that is still posting somewhere else on the page. */
+    function releaseWithin(root) {
+        if (!root) return;
+        if (root.nodeType === 1) release(root);
+        root.querySelectorAll(
+            "[data-busy-applied], [data-busy-disabled]",
+        ).forEach(release);
+    }
+
+    /*
+     * A form that posts.
+     *
+     * The submitter is the button that goes busy; every control that could
+     * send the form is disabled, so a second click lands on nothing whichever
+     * button it lands on.
+     *
+     * A submit something else has already handled (`defaultPrevented`) is left
+     * alone — a script that stopped the submission owns what happens next, and
+     * a control marked busy for a request nobody sent would spin for ever. The
+     * exception is htmx, which prevents the default *because* it is sending
+     * the form; those clear on the settle events below.
+     */
+    document.addEventListener("submit", function (event) {
+        var form = event.target;
+        var submitter = event.submitter;
+        var handledByHtmx = isHtmx(form) || isHtmx(submitter);
+
+        if (event.defaultPrevented && !handledByHtmx) return;
+        if (optedOut(form)) return;
+
+        markBusy(submitter);
+        form.querySelectorAll(SUBMITS).forEach(function (control) {
+            /* An opted-out control is out of all of it: a button left alive on
+             * purpose is one the reader is meant to still be able to click. */
+            if (!optedOut(control)) disable(control);
+        });
+    });
+
+    /*
+     * A link to a page the server draws.
+     *
+     * Only link *buttons*: `rounded-button` is what the library puts on both
+     * shapes of <c-ui.button>, and app.css already reads it as "this is a
+     * button". A plain link in a sentence stays a plain link.
+     *
+     * Everything that is not a plain navigation of this tab is passed over —
+     * a modified click opens elsewhere, a fragment goes nowhere the server is
+     * involved in, and a download leaves the page exactly where it is, which
+     * would strand the button spinning.
+     */
+    document.addEventListener("click", function (event) {
+        if (event.defaultPrevented || event.button !== 0) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+            return;
+
+        var link = event.target.closest("a[href].rounded-button");
+        if (!link || link.hasAttribute("download")) return;
+        if (link.target && link.target !== "_self") return;
+
+        var href = link.getAttribute("href");
+        if (!href || href.charAt(0) === "#") return;
+
+        var destination;
+        try {
+            destination = new URL(link.href);
+        } catch (error) {
+            return;
+        }
+        if (
+            destination.protocol !== "http:" &&
+            destination.protocol !== "https:"
+        )
+            return;
+        /* A fragment on the page already open: the browser scrolls, it does
+         * not fetch. A link to the same address with no fragment is a
+         * reload, which does. */
+        if (
+            destination.hash &&
+            destination.href.split("#")[0] ===
+                window.location.href.split("#")[0]
+        )
+            return;
+
+        markBusy(link);
+    });
+
+    /*
+     * htmx.
+     *
+     * A control that fetches its own fragment is marked when the request goes
+     * out and released when it settles, in whatever way it settles. What sends
+     * the request is not always a button: a form sends its own, and a request
+     * made from script has no source element at all, so the element here is
+     * offered as it comes and markBusy keeps the ones it can paint. A form's
+     * button is already busy from the submit above, which is the control the
+     * reader is watching.
+     *
+     * The scope released is the whole form where there is one: the submit
+     * above disabled every control in it, not just the one that went busy.
+     */
+    document.addEventListener("htmx:beforeRequest", function (event) {
+        markBusy(event.detail && event.detail.elt);
+    });
+
+    [
+        "htmx:afterRequest",
+        "htmx:responseError",
+        "htmx:sendError",
+        "htmx:timeout",
+        "htmx:abort",
+    ].forEach(function (name) {
+        document.addEventListener(name, function (event) {
+            var element = (event.detail && event.detail.elt) || document.body;
+            releaseWithin(
+                (element.closest && element.closest("form")) || element,
+            );
+        });
+    });
+
+    /*
+     * Back.
+     *
+     * A page restored from the back/forward cache comes back exactly as it was
+     * left — mid-submission, with its buttons disabled and spinning. Nothing
+     * else undoes that, so the whole document is handed back here.
+     */
+    window.addEventListener("pageshow", function (event) {
+        if (event.persisted) releaseWithin(document);
+    });
+})();

--- a/n26/core/static/n26/htmx_support.js
+++ b/n26/core/static/n26/htmx_support.js
@@ -17,6 +17,11 @@
  * A control htmx did wire handles its own click and calls preventDefault
  * before this listener runs, so the defaultPrevented test is what stops a
  * second request being sent for the same click.
+ *
+ * The request names the link it came from. A request with no source is
+ * reported against the document body, and anything watching the request —
+ * the busy state a control takes on while it works, for one — then has no
+ * way to tell which control to act on, or reaches the whole page.
  */
 document.body.addEventListener("click", function (event) {
     if (event.defaultPrevented || event.button !== 0) return;
@@ -25,7 +30,10 @@ document.body.addEventListener("click", function (event) {
     var link = event.target.closest("a[hx-get]");
     if (!link || !window.htmx) return;
     event.preventDefault();
-    window.htmx.ajax("GET", link.getAttribute("hx-get"), { swap: "none" });
+    window.htmx.ajax("GET", link.getAttribute("hx-get"), {
+        source: link,
+        swap: "none",
+    });
 });
 
 /*

--- a/n26/core/templates/cotton/ui/button.html
+++ b/n26/core/templates/cotton/ui/button.html
@@ -9,6 +9,11 @@ app.css gives solid buttons their inset shadow by matching background utility
 classes by name (`:is(.bg-accent, .bg-red-500, .bg-ink-100, .bg-green-700)`).
 A new solid variant must be added to that list there too, or its button
 renders flatter than every other button.
+
+A button that submits, fetches or navigates goes busy — spinner, no label, no
+second click — until the work ends. Nothing is declared here for it: the shell
+loads n26/core/static/n26/busy.js, which finds the control through the event.
+Pass `data-busy="off"` on the button or on its form to keep a control out of it.
 {% endcomment %}
 <c-vars
     variant="default"

--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -596,6 +596,14 @@ banner, is_impersonating / impersonator, gtm_container_id, messages, user.
         {% endcomment %}
         <meta name="htmx-config" content='{"historyCacheSize": 0}'>
         <script defer src="{% static 'n26/htmx_support.js' %}"></script>
+        {% comment %}
+        The control that started a submission, a request or a navigation goes
+        busy until it ends, so a slow post is visibly working and a second
+        click cannot buy a second of something. It listens at the document, so
+        it covers every page this shell draws without a call site opting in;
+        what it does to a control is drawn by [data-busy] in app.css.
+        {% endcomment %}
+        <script defer src="{% static 'n26/busy.js' %}"></script>
         <script defer src="{% static 'designsystem/vendor/htmx.min.js' %}"></script>
         {% comment %}
         Order matters: the kit's factories must be defined before Alpine walks

--- a/n26/core/test_busy.py
+++ b/n26/core/test_busy.py
@@ -1,0 +1,98 @@
+"""The busy state a control takes on while its click is being served.
+
+What it does is JavaScript, and nothing here runs that. What can be checked
+from Python is the wiring it needs to work at all, and every one of these
+would fail silently in a browser: a shell that stops loading the file, a
+stylesheet that draws an attribute the script no longer writes, or a link
+button that loses the class the script recognises buttons by.
+"""
+
+from pathlib import Path
+
+from django.contrib.staticfiles import finders
+from django.template import Context, Template
+from django.template.loader import get_template
+from django_cotton.compiler_regex import CottonCompiler
+
+BUSY_JS = "n26/busy.js"
+
+#: The state the script writes and the stylesheet draws. Written out here
+#: rather than derived, so a rename has to be made in three places on purpose.
+BUSY_STATE = 'data-busy="on"'
+
+#: What the script takes to mean "this link is a button".
+BUTTON_CLASS = "rounded-button"
+
+
+def source_of(template_name: str) -> str:
+    return Path(get_template(template_name).origin.name).read_text()
+
+
+def script() -> str:
+    found = finders.find(BUSY_JS)
+    assert found, f"{BUSY_JS} is not where the static files are looked for"
+    return Path(found).read_text()
+
+
+def stylesheet() -> str:
+    """The Tailwind input, not the build: the build is generated and gitignored,
+    so a worktree that has not run the CSS build has no copy of it."""
+    return (
+        Path(__file__).resolve().parents[1] / "designsystem" / "assets" / "app.css"
+    ).read_text()
+
+
+class TestEveryPageLoads:
+    """Neither shell may drop the script: it listens at the document and no
+    call site opts in, so a page that does not load it has no busy state
+    anywhere and says nothing about it."""
+
+    def test_the_app_shell_loads_it(self):
+        assert BUSY_JS in source_of("n26/layouts/base.html")
+
+    def test_the_gallery_shell_loads_it(self):
+        """Otherwise the button page documents behaviour it cannot show."""
+        assert BUSY_JS in source_of("designsystem/base.html")
+
+
+class TestTheScriptAndTheStylesheetAgree:
+    """The script writes one attribute; the stylesheet is the only thing that
+    turns it into something a reader can see. Renaming either half alone leaves
+    a button that goes quiet and never looks busy."""
+
+    def test_both_halves_name_the_same_state(self):
+        assert BUSY_STATE in script()
+        assert BUSY_STATE in stylesheet()
+
+    def test_the_stylesheet_hides_the_label_without_taking_the_spinner(self):
+        """The spinner is drawn in the button's own colour. Hiding the label
+        with `color: transparent` would hide the spinner too, and the colour
+        would have to be measured in the browser and handed back."""
+        assert "-webkit-text-fill-color: transparent" in stylesheet()
+
+
+class TestWhatTheScriptCanReach:
+    """A click reaches a control through what the component renders."""
+
+    def test_a_link_button_carries_the_class_the_script_looks_for(self):
+        """The script marks a navigating link only when it is a button rather
+        than a word in a sentence, and this class is how it tells."""
+        html = Template(
+            CottonCompiler().process('<c-ui.button href="/gangs/">Gangs</c-ui.button>')
+        ).render(Context())
+
+        assert "<a" in html
+        assert BUTTON_CLASS in html
+        assert BUTTON_CLASS in script()
+
+    def test_a_control_can_be_kept_out_of_it(self):
+        """The escape hatch is a plain attribute, which means it has to survive
+        the component: an undeclared prop that the template swallowed would
+        leave the control going busy with nothing to say why."""
+        html = Template(
+            CottonCompiler().process(
+                '<c-ui.button type="submit" data-busy="off">Stay</c-ui.button>'
+            )
+        ).render(Context())
+
+        assert 'data-busy="off"' in html

--- a/n26/designsystem/assets/app.css
+++ b/n26/designsystem/assets/app.css
@@ -1250,3 +1250,76 @@
 [data-variant="segmented"] label:has(input:checked) :is(div, span) {
     color: inherit;
 }
+
+/* A control that is working — unlayered for the same reason as the rules above.
+ *
+ * n26/core/static/n26/busy.js writes data-busy="on" on the button or link that
+ * started a submission, an htmx request or a navigation, and takes it off again
+ * when the work ends. Everything the reader sees for it is here: the script
+ * writes one attribute and holds no styling of its own.
+ *
+ * The label is hidden rather than removed, and element children are hidden
+ * rather than detached, so the button keeps the width it had — a control that
+ * shrinks under the cursor as it is clicked reads as a mis-click.
+ *
+ * -webkit-text-fill-color, not `color`, is what hides the label. It paints the
+ * glyphs and nothing else, so the button's own colour survives and the spinner
+ * below can be drawn in it. `color: transparent` would take the spinner with
+ * the label, and the real colour would then have to be measured in the browser
+ * and handed back through a variable — which a call site writing the attribute
+ * by hand would have to supply too. Prefixed, but every engine has it; where it
+ * is missing the label stays visible under the spinner and nothing else changes.
+ *
+ * No !important is needed because layer order settles it: the variant's `text-*`
+ * classes are utilities, and an unlayered rule beats every layer whatever the
+ * selector says. */
+:is(button, a)[data-busy="on"] {
+    position: relative;
+    -webkit-text-fill-color: transparent;
+    cursor: progress;
+}
+
+/* Pseudo-elements are not element children, so the spinner below is not caught
+ * by this. */
+:is(button, a)[data-busy="on"] > * {
+    visibility: hidden;
+}
+
+/* A link cannot be disabled the way a button can, so the second click is
+ * refused here instead. */
+a[data-busy="on"] {
+    pointer-events: none;
+}
+
+/* The spinner: the kit's <c-ui.spinner> as a ring rather than an SVG, because
+ * an SVG would have to be built per click on screens that draw hundreds of
+ * buttons. Sized in em so it tracks the button's own scale, from xs to 2xl,
+ * and drawn in the button's own text colour, so every variant and size gets a
+ * spinner that reads against its fill without being told which. */
+:is(button, a)[data-busy="on"]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 1.15em;
+    height: 1.15em;
+    border-radius: 9999px;
+    border: 2px solid color-mix(in oklab, currentColor 25%, transparent);
+    border-top-color: currentColor;
+    animation: n26-busy-spin 0.85s linear infinite;
+}
+
+/* Slowed rather than stopped, the way Bootstrap treats its own spinner: a
+ * still ring says the same thing as a broken one, and this is the only sign
+ * the click was heard. */
+@media (prefers-reduced-motion: reduce) {
+    :is(button, a)[data-busy="on"]::after {
+        animation-duration: 1.5s;
+    }
+}
+
+@keyframes n26-busy-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/n26/designsystem/assets/app.css
+++ b/n26/designsystem/assets/app.css
@@ -1279,16 +1279,33 @@
     cursor: progress;
 }
 
-/* Pseudo-elements are not element children, so the spinner below is not caught
- * by this. */
+/* Element children — an icon, or the span a label is often wrapped in — go
+ * with the label.
+ *
+ * Faded rather than hidden, because `visibility: hidden` takes them out of the
+ * accessibility tree as well as off the screen: a button whose label lives in
+ * a span would be left with no name at all for the moment it is working, which
+ * is exactly the moment a reader might ask what it is. Both this and the label
+ * above are visual-only hides, so what the button announces never changes.
+ *
+ * Pseudo-elements are not element children, so the spinner below is untouched. */
 :is(button, a)[data-busy="on"] > * {
-    visibility: hidden;
+    opacity: 0;
 }
 
 /* A link cannot be disabled the way a button can, so the second click is
  * refused here instead. */
 a[data-busy="on"] {
     pointer-events: none;
+}
+
+/* A control the script disabled for the moment a click is in flight keeps its
+ * normal weight. It is not disabled in the sense a reader knows — it comes
+ * back on its own — and a screen whose whole catalogue is one form would
+ * otherwise grey out every button on it because a purchase is under way in
+ * one row. The one that was clicked says so with its spinner. */
+:is(button, a)[data-busy-disabled] {
+    opacity: 1;
 }
 
 /* The spinner: the kit's <c-ui.spinner> as a ring rather than an SVG, because
@@ -1309,9 +1326,8 @@ a[data-busy="on"] {
     animation: n26-busy-spin 0.85s linear infinite;
 }
 
-/* Slowed rather than stopped, the way Bootstrap treats its own spinner: a
- * still ring says the same thing as a broken one, and this is the only sign
- * the click was heard. */
+/* Slowed rather than stopped: a still ring says the same thing as a broken
+ * one, and this is the only sign the click was heard. */
 @media (prefers-reduced-motion: reduce) {
     :is(button, a)[data-busy="on"]::after {
         animation-duration: 1.5s;

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -105,7 +105,12 @@ GROUPS: list[Group] = [
                     'attrs }} is emitted first, your own type="submit" still wins. '
                     "The success variant is a local override of the kit's template, "
                     "so app.css must list .bg-green-700 alongside the other solid "
-                    "fills for the shadow rule to reach it."
+                    "fills for the shadow rule to reach it. A button that submits, "
+                    "fetches over htmx or navigates goes busy on click — spinner, "
+                    "hidden label, no second click — until the work ends; that comes "
+                    "from n26/core/static/n26/busy.js and the [data-busy] rules in "
+                    'app.css, and data-busy="off" on the button or its form opts a '
+                    "control out."
                 ),
             ),
             Component(

--- a/n26/designsystem/templates/designsystem/base.html
+++ b/n26/designsystem/templates/designsystem/base.html
@@ -180,6 +180,12 @@ document.addEventListener('alpine:init', () => {
     }));
 });
         </script>
+        {% comment %}
+        The busy state a control takes on while its click is being served. The
+        app loads this from its own shell; the gallery loads it so the button
+        page demonstrates the real behaviour rather than a picture of it.
+        {% endcomment %}
+        <script defer src="{% static 'n26/busy.js' %}"></script>
         <script defer src="{% static 'django_cotton_ui/cotton-ui.min.js' %}"></script>
         <script defer src="{% static 'designsystem/vendor/alpine-collapse.min.js' %}"></script>
         <script defer src="{% static 'designsystem/vendor/alpine-focus.min.js' %}"></script>

--- a/n26/designsystem/templates/designsystem/demos/button/60-busy.html
+++ b/n26/designsystem/templates/designsystem/demos/button/60-busy.html
@@ -1,0 +1,28 @@
+{# title: Busy #}
+{# note: Click either of the first two: a button that submits a form, fetches over htmx or navigates goes busy until the work ends — spinner, hidden label, and no second click. Nothing is declared for it at the call site; busy.js finds the control through the event and app.css draws it. The third is the escape hatch, data-busy="off", for a control that must stay clickable. The row below writes the state out by hand, which is all it takes: the spinner is drawn in the button's own text colour and sized from its own text, so every variant and size has one without being told. #}
+{# layout: col #}
+<form method="get" action="" class="flex items-center gap-3">
+    <c-ui.button type="submit" variant="primary">
+        Submit this form
+    </c-ui.button>
+    <c-ui.button href="?">
+        Follow this link
+    </c-ui.button>
+    <c-ui.button type="submit" variant="subtle" data-busy="off">
+        Submit, never busy
+    </c-ui.button>
+</form>
+<div class="flex items-center gap-3">
+    <c-ui.button variant="primary" data-busy="on">
+        Working
+    </c-ui.button>
+    <c-ui.button data-busy="on">
+        Working
+    </c-ui.button>
+    <c-ui.button variant="danger" size="xs" data-busy="on">
+        Working
+    </c-ui.button>
+    <c-ui.button variant="success" size="lg" data-busy="on">
+        Working
+    </c-ui.button>
+</div>


### PR DESCRIPTION
n23 disables a button and shows a spinner the moment it is clicked, which is what stops a slow post looking like a dead page and what stops a second click sending the form twice. n26 had nothing of the kind. This adds it, as a property of the design library rather than something each screen opts into.

## Summary

- **The mechanism** is `n26/core/static/n26/busy.js`, loaded once by the page shell. It marks the control the reader clicked with `data-busy="on"` and disables every submit in that form one tick later — late enough that the clicked button's `name` and `value` still reach the server, which is how the equip screens tell a buy from a sell.
- **Three ways a click reaches it**: a form submit, an htmx request, and a link button leading to a page the server has to draw. A button that only moves something already on screen — a tab, a filter, a disclosure — starts no work and is never touched.
- **A busy control refuses a second activation** from any source, not just a second mouse click: a link cannot be disabled, and `pointer-events` turns away a pointer and nothing else, so a capture-phase guard cancels the repeat — early enough to be ahead of htmx, which listens on the control itself.
- **A settled request undoes only what it made busy.** A form releases its own submit controls; anything else releases itself. This matters because the equip catalogue is a single form: a row's confirmation link can be working while a purchase in another row settles, and neither may hand the other back. Requests made from script now name the control they came from (`n26/core/static/n26/htmx_support.js`), because a request with no source is reported against the document body — which left those controls with no affordance at all and made their settle reach the whole page.
- **The look lives in the design library**, in `n26/designsystem/assets/app.css`: the label is hidden and the button keeps its width, with a ring spinner sized from the button's own text and drawn in its own text colour, so every variant and size gets one that reads against its fill without being told which. Both hides are visual only — `-webkit-text-fill-color` for the label, opacity for element children — so a busy button keeps its accessible name, and a control disabled for the moment keeps its normal weight rather than greying out a catalogue of hundreds because one row is working.
- **It only undoes what it applied** — including on a back/forward-cache restore, where a page otherwise comes back mid-submission with its buttons stuck disabled and spinning. A page carrying `data-busy="on"` in its own markup keeps it.
- **The escape hatch** is `data-busy="off"`, on a control or on a whole form.
- The gallery's `<c-ui.button>` page gains a **Busy** demo (live: click and watch) and the coupling is written into the catalog notes and the component's own comment. `n26/core/test_busy.py` guards the pieces that would otherwise fail silently — a shell that stops loading the script, a stylesheet that draws an attribute the script no longer writes, and a link button losing the class the script recognises buttons by.

This is separate from the wait spinner `<c-n26.tab-links>` already has: that one greys a *panel* while a tab's page loads, and its tabs are plain links rather than buttons, so the two do not overlap or double up.

Known gap, left alone deliberately: saving a cropped picture posts in the background from a button whose dialog has already closed (`n26/core/static/n26/imagecrop.js`), so there is no control left on screen to mark. The right affordance there is a busy panel on the picture box, which is a separate piece of design.

## Test plan

- [x] `pytest n26` — 4178 passed, 1 xfailed
- [x] Gallery button page: the new demo renders, props table and notes intact
- [x] Real POST on `/n26/gangs/new/`: clicking **Create gang** hides the label, draws the ring, sets `aria-busy`, and disables the button a tick later; the page that comes back is clean
- [x] `data-busy="off"` control stays enabled and unmarked while its form's other submit goes busy
- [x] A busy control refuses a repeat activation, including one raised without a pointer; ordinary clicks on everything else are untouched
- [x] Catalogue shape (an htmx form with a row-action link inside it): both can be in flight at once, each releases only on its own settle, and the rest of the form is neither dimmed nor handed back early
- [x] A busy button whose label sits in a `<span>` still reports its name to the accessibility tree
- [x] Back/forward-cache restore leaves nothing busy or disabled, and leaves hand-written busy state alone
- [x] Light and dark mode, across variants and sizes

Refs #2297