### PR TITLE
feat: save the picture from the open crop dialog, and refuse it there

### DIFF
--- a/n26/core/static/n26/imagecrop.js
+++ b/n26/core/static/n26/imagecrop.js
@@ -9,6 +9,13 @@
  * form's own save sends exactly what the dialog showed. Leaving the
  * dialog any other way clears the pick.
  *
+ * On a form that is the picture's own, confirming also saves, and the
+ * dialog stays open until that lands: the reader watches the button
+ * work, a picture the server would not take is refused in the dialog
+ * on the same rectangle they can send again, and only a save that
+ * landed closes it. A refusal read on a page nobody sees is a refusal
+ * nobody gets.
+ *
  * Without this script — or without Cropper.js beside it — the input is
  * an ordinary file box and the server centre-crops to the same ratio
  * (n26/core/images.py). The server does that to every upload
@@ -42,6 +49,8 @@
 
         var confirm = dialog.querySelector("[data-crop-confirm]");
         var cancel = dialog.querySelector("[data-crop-cancel]");
+        var problem = dialog.querySelector("[data-crop-error]");
+        var problemText = dialog.querySelector("[data-crop-error-text]");
 
         var cropper = null;
         var name = "";
@@ -64,6 +73,70 @@
                 URL.revokeObjectURL(picture.src);
                 picture.removeAttribute("src");
             }
+        }
+
+        /* The dialog while its save is in flight.
+         *
+         * The busy state is the design library's, set here rather than by
+         * n26/busy.js: this save is a background post from a plain button,
+         * which is none of the three things that script watches. Both controls
+         * are shut for the duration — the save cannot be sent twice, and
+         * leaving halfway would strand a post nothing is waiting for. */
+        function working(on) {
+            if (on) {
+                confirm.setAttribute("data-busy", "on");
+                confirm.setAttribute("aria-busy", "true");
+            } else {
+                confirm.removeAttribute("data-busy");
+                confirm.removeAttribute("aria-busy");
+            }
+            confirm.disabled = on;
+            cancel.disabled = on;
+        }
+
+        /* What the server said, at one level, from a page fetched rather than
+         * drawn. Alerts state their level in data-message
+         * (n26/includes/messages.html). */
+        function saidAt(page, level) {
+            var found = [];
+            page.querySelectorAll('[data-message="' + level + '"]').forEach(
+                function (alert) {
+                    var said = alert.textContent.replace(/\s+/g, " ").trim();
+                    if (said) found.push(said);
+                },
+            );
+            return found;
+        }
+
+        function forget() {
+            if (!problem) return;
+            problem.hidden = true;
+            if (problemText) problemText.textContent = "";
+        }
+
+        /* A refusal, shown where the reader is standing.
+         *
+         * The dialog stays open on the same rectangle, so the answer to a
+         * picture the server would not take is to choose again and send
+         * again. The pick stops counting as confirmed, so leaving now clears
+         * it: nothing was stored, and a file left on the input would ride the
+         * next save of any other field on the page. */
+        function refuse(said) {
+            confirmed = false;
+            working(false);
+            if (!problem || !problemText) return;
+            problemText.textContent = said;
+            problem.hidden = false;
+        }
+
+        /* Said out loud on the page the reader stays on, since the page the
+         * server said it on is one nobody sees. */
+        function announce(said) {
+            window.dispatchEvent(
+                new CustomEvent("toast", {
+                    detail: { variant: "success", message: said },
+                }),
+            );
         }
 
         input.addEventListener("change", function () {
@@ -100,7 +173,8 @@
             if (!cropper) return;
             // One encoding, on confirm — dragging only ever moves the
             // rectangle, so there is no stale result to race it.
-            confirm.disabled = true;
+            forget();
+            working(true);
             cropper
                 .getCroppedCanvas({
                     maxWidth: cap,
@@ -109,7 +183,6 @@
                 })
                 .toBlob(
                     function (blob) {
-                        confirm.disabled = false;
                         if (blob) {
                             var transfer = new DataTransfer();
                             var stem = name.replace(/\.[^.]+$/, "");
@@ -121,14 +194,20 @@
                             input.files = transfer.files;
                             confirmed = true;
                         }
-                        dialog.close();
+                        // A form that is the picture's own saves from
+                        // here, with the dialog still open: a refusal is
+                        // read where the reader is standing, and the
+                        // dialog closes on a save that landed.
                         if (
                             confirmed &&
                             "cropSubmit" in input.dataset &&
                             input.form
                         ) {
                             save(input.form);
+                            return;
                         }
+                        working(false);
+                        dialog.close();
                     },
                     "image/jpeg",
                     0.9,
@@ -144,49 +223,72 @@
         // uncropped behind the reader's back.
         dialog.addEventListener("close", function () {
             if (!confirmed) input.value = "";
+            forget();
             settle();
         });
-    }
 
-    /* Post the picture form in the background and redraw its box in
-     * place, so the save does not move the reader's place on the page.
-     * The response is the page the plain submit would have landed on;
-     * only its picture box is taken. Anything unexpected — no marker on
-     * either side, a bad status, the network — falls back to the plain
-     * submit, which is the same act with a page load. */
-    function save(form) {
-        var here = form.closest("[data-picture-box]");
-        if (!here || typeof DOMParser === "undefined") {
-            plain(form);
-            return;
-        }
-        fetch(form.action, {
-            method: "POST",
-            body: new FormData(form),
-            credentials: "same-origin",
-        })
-            .then(function (response) {
-                // A refusal or a broken response: the plain submit
-                // repeats the act and lands wherever the server says.
-                if (!response.ok) throw new Error(response.status);
-                return response.text();
-            })
-            .then(function (html) {
-                var fresh = new DOMParser()
-                    .parseFromString(html, "text/html")
-                    .querySelector("[data-picture-box]");
-                // Saved, but the page holds no box to swap: a reload
-                // shows what landed rather than posting it again.
-                if (!fresh) {
-                    window.location.reload();
-                    return;
-                }
-                here.replaceWith(fresh);
-                start();
-            })
-            .catch(function () {
+        /* Post the picture form from the open dialog and redraw its box in
+         * place, so the save does not move the reader's place on the page.
+         *
+         * The response is the page the plain submit would have landed on, and
+         * it is read twice: for what the server said, and for the picture box
+         * to put in place of this one. A page fetched in the background is the
+         * only copy of those words — reading it is what marks them read — so a
+         * refusal shown in the dialog and a save said in a toast are the
+         * difference between an answer and silence.
+         *
+         * A save that landed closes the dialog before the box is swapped: the
+         * dialog stands inside that box, and replacing it while open would
+         * take a modal off the page without ever closing it, leaving the
+         * picture it was showing held in memory.
+         *
+         * Anything unexpected — no marker on either side, a bad status, the
+         * network — falls back to the plain submit, which is the same act with
+         * a page load. A refusal the server put into words is not that: it has
+         * somewhere to be read, and repeating the post would only earn it
+         * again. */
+        function save(form) {
+            var here = form.closest("[data-picture-box]");
+            if (!here || typeof DOMParser === "undefined") {
                 plain(form);
-            });
+                return;
+            }
+            fetch(form.action, {
+                method: "POST",
+                body: new FormData(form),
+                credentials: "same-origin",
+            })
+                .then(function (response) {
+                    if (!response.ok) throw new Error(response.status);
+                    return response.text();
+                })
+                .then(function (html) {
+                    var page = new DOMParser().parseFromString(
+                        html,
+                        "text/html",
+                    );
+                    var refused = saidAt(page, "error");
+                    if (refused.length) {
+                        refuse(refused.join(" "));
+                        return;
+                    }
+                    var fresh = page.querySelector("[data-picture-box]");
+                    // Saved, but the page holds no box to swap: a reload
+                    // shows what landed rather than posting it again.
+                    if (!fresh) {
+                        window.location.reload();
+                        return;
+                    }
+                    saidAt(page, "success").forEach(announce);
+                    working(false);
+                    dialog.close();
+                    here.replaceWith(fresh);
+                    start();
+                })
+                .catch(function () {
+                    plain(form);
+                });
+        }
     }
 
     function plain(form) {

--- a/n26/core/templates/cotton/n26/picture_box.html
+++ b/n26/core/templates/cotton/n26/picture_box.html
@@ -18,10 +18,11 @@ to fill in. Both post act=picture to the given action, so the page
 behind it answers one act for both.
 
 The wrapper is the unit the crop script redraws in place
-(n26/imagecrop.js): after a background save it swaps this box for the
+(n26/imagecrop.js): after a save that landed it swaps this box for the
 same box from the fresh page, so the picture appears without the page
-moving. Without the script the fallback Save control submits the form
-plainly.
+moving. A save the server refuses swaps nothing and is read in the crop
+dialog instead. Without the script the fallback Save control submits the
+form plainly.
 
   action — where both forms post; the page must answer act=picture.
   id — the file input's own.

--- a/n26/core/templates/cotton/n26/picture_input.html
+++ b/n26/core/templates/cotton/n26/picture_input.html
@@ -24,11 +24,15 @@ dialog chooses, it is not trusted.
   max — the stored picture's long side, the server's cap handed the
     same way; the dialog encodes no bigger, since the server would
     only shrink it.
-  submit_on_crop — confirming the crop submits the input's form, so the
+  submit_on_crop — confirming the crop saves the input's form, so the
     picture lands without a second click. Only for a form that is the
     picture's own: on a form carrying other fields it would save them
     all. The form's own submit control, marked data-crop-fallback, is
     hidden once the script is driving — it is the scriptless path.
+    The save happens from the open dialog: the confirm button works,
+    and a picture the server refuses says why in the dialog, on the
+    same rectangle that can be sent again. Only a save that landed
+    closes it.
 {% endcomment %}
 <c-vars id="" name="image" crop="" max="" :submit_on_crop="False" class="" />
 
@@ -50,6 +54,16 @@ dialog chooses, it is not trusted.
             <div class="n26-crop-stage">
                 <img data-crop-image alt="">
             </div>
+            {% comment %}
+            Where a refused save is read. Drawn empty and hidden; the crop
+            script fills it with what the server said and shows it, leaving the
+            dialog open so the same rectangle can be sent again. The alert
+            carries role="alert", so a reason arriving while the dialog is open
+            is announced rather than only drawn.
+            {% endcomment %}
+            <c-ui.alert data-crop-error hidden variant="error" class="text-left">
+                <span data-crop-error-text></span>
+            </c-ui.alert>
             <div class="flex justify-end gap-2">
                 <c-ui.button type="button" variant="default" size="sm" data-crop-cancel>
                     Cancel

--- a/n26/core/templates/n26/includes/messages.html
+++ b/n26/core/templates/n26/includes/messages.html
@@ -7,11 +7,18 @@ confirmation inside the form, above the list it was clicked in — overrides tha
 block to nothing and includes this where it wants them instead. Iterating the
 storage is what marks it read, so including this twice on one page would draw
 the same message twice; there is only ever one place per page.
+
+Each alert states its level in `data-message`. A page fetched in the background
+is read for what the server said rather than drawn — the crop dialog
+(n26/imagecrop.js) shows a refusal where the reader is standing instead of
+letting it land on a page nobody sees — and that attribute is the hook it reads.
+Styling is not: the variant below is a mapping and would tell a reader nothing.
 {% endcomment %}
 {% if messages %}
     <div class="mb-4 flex flex-col gap-2">
         {% for message in messages %}
-            <c-ui.alert variant="{% if message.level_tag == 'success' %}success{% elif message.level_tag == 'warning' %}warning{% elif message.level_tag == 'error' %}error{% else %}info{% endif %}"
+            <c-ui.alert data-message="{{ message.level_tag }}"
+                        variant="{% if message.level_tag == 'success' %}success{% elif message.level_tag == 'warning' %}warning{% elif message.level_tag == 'error' %}error{% else %}info{% endif %}"
                         dismissible="1">{{ message }}</c-ui.alert>
         {% endfor %}
     </div>

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -315,6 +315,61 @@ class TestThePicture:
         # Refused with a reason on the page, never a server error.
         assert response.status_code == 200
 
+    def test_a_refusal_says_which_level_it_is(
+        self, client, tester, gang, vex, own_storage
+    ):
+        """The crop dialog saves in the background and shows a refusal
+        where the reader is standing, so it has to tell a refusal from a
+        save by reading the page it fetched. Every alert states its level
+        (n26/includes/messages.html); without that the dialog draws an
+        empty box and the reason is lost with the page nobody sees."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        client.force_login(tester)
+        body = client.post(
+            edit_url(vex),
+            {
+                "act": "picture",
+                "image": SimpleUploadedFile(
+                    "story.txt", b"not a picture", content_type="text/plain"
+                ),
+            },
+            follow=True,
+        ).content.decode()
+
+        assert 'data-message="error"' in body
+        # And the reason is inside that alert, which is what gets read out.
+        reason = body.split('data-message="error"', 1)[1]
+        assert "valid image" in reason
+
+    def test_a_save_that_landed_says_so_the_same_way(
+        self, client, tester, gang, vex, own_storage
+    ):
+        """A background save leaves nothing on screen to say it worked, so
+        the dialog reads the same alerts and repeats the success as a
+        toast."""
+        client.force_login(tester)
+        body = client.post(
+            edit_url(vex),
+            {"act": "picture", "image": png_upload()},
+            follow=True,
+        ).content.decode()
+
+        assert 'data-message="success"' in body
+        assert "Picture saved." in body
+
+    def test_the_dialog_carries_the_place_a_refusal_is_drawn(
+        self, client, tester, gang, vex
+    ):
+        """Drawn empty and hidden by the component, filled by the script.
+        Missing, a refused save would leave the dialog open saying
+        nothing."""
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+
+        assert "data-crop-error" in body
+        assert "data-crop-error-text" in body
+
     def test_the_crop_dialog_is_told_the_servers_own_shape(
         self, client, tester, gang, vex
     ):

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1942,7 +1942,12 @@ GROUPS: list[Group] = [
                     "input is an ordinary file box, and either way the "
                     "server centre-crops every upload to the same shape "
                     "(n26/core/images.py): the dialog chooses, it is not "
-                    "trusted."
+                    "trusted. With submit_on_crop the save runs from the "
+                    "open dialog, and a refusal is drawn into the alert the "
+                    "dialog carries for it — the script reads it off the "
+                    "data-message hook that n26/includes/messages.html "
+                    "stamps on every alert, so a page that renders its "
+                    "messages some other way would leave that alert empty."
                 ),
             ),
             Component(


### PR DESCRIPTION
Follow-up to #2342, which noted this as a gap: the picture save was the one mutating control the busy affordance could not reach, because by the time it ran the dialog had already closed.

## The problem

Confirming a crop posted the picture in the background and closed the dialog on the spot. The page that came back was thrown away except for its picture box — and everything the server said went with it. A picture the server refused left the dialog closed, the picture unchanged, and nothing on screen saying why. A save that worked said nothing either, because the "Picture saved." message had been drained by a page nobody sees.

## The change

- **The dialog stays open until the save lands.** The confirm button wears the busy state while it works, and both controls are shut for the duration, so the save cannot be sent twice and nobody can walk out from under a post in flight.
- **A refusal is read in the dialog**, on the same rectangle, so the answer is to choose again and send again. Leaving instead clears the pick, since nothing was stored and a file left on the input would ride the next save of any other field on the page.
- **A save that landed** closes the dialog, swaps the picture box in place as before, and repeats the server's own words as a toast.
- **Alerts state their level** in `data-message` (`n26/core/templates/n26/includes/messages.html`). That is how a page fetched in the background is read for what the server said rather than drawn; the styling variant beside it is a mapping and would tell a reader nothing.
- **A request that failed, or an answer that made no sense, still falls back to the plain submit** — the same act with a page load. A refusal the server put into words is not that: it has somewhere to be read, and repeating the post would only earn it again.

Nothing changes without JavaScript: the file input is still an ordinary file box with its own Save control, and the server still centre-crops every upload to the same shape whatever the dialog chose.

## Test plan

- [x] `pytest n26` — 4231 passed, 1 xfailed
- [x] Real save on a model's edit page: the dialog stays open with the confirm button working, then closes; the picture box swaps in place and a "Picture saved." toast appears where before there was silence
- [x] Real refusal from the real view (a file that is not a picture): the dialog stays open and shows "Upload a valid image…" in its own alert, with both controls clickable again
- [x] Retry from the same rectangle after a refusal saves and closes
- [x] Leaving after a refusal drops the staged pick and forgets the message, so the next open starts clean
- [x] Gallery page for `<c-n26.picture-input>` renders: props table, demos, and the new notes

Refs #2342