### PR TITLE
feat: convert Variant onto slots and picks

### DIFF
--- a/n26/library/conversion/__init__.py
+++ b/n26/library/conversion/__init__.py
@@ -7,10 +7,12 @@ Each system's ``plan_*`` reads the database and returns a frozen Plan.
 from n26.library.conversion.affiliation import plan_outcast_affiliation
 from n26.library.conversion.base import ConversionRefused, Plan, apply
 from n26.library.conversion.chaos_god import plan_chaos_god
+from n26.library.conversion.variant import plan_variant
 
 SYSTEMS = {
     "outcast_affiliation": plan_outcast_affiliation,
     "chaos_god": plan_chaos_god,
+    "variant": plan_variant,
 }
 
 __all__ = [
@@ -20,4 +22,5 @@ __all__ = [
     "apply",
     "plan_chaos_god",
     "plan_outcast_affiliation",
+    "plan_variant",
 ]

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -454,6 +454,28 @@ class SwapSharedCarrier:
 
 
 @dataclass(frozen=True)
+class ArchivePick:
+    """A stored pick archived in place — the declared ledger change for
+    a printed “None” that an optional slot already says with nothing
+    chosen. Already-archived picks stay archived; this does not revive
+    them. No money, no event: the conversion exception."""
+
+    assignment_id: object
+    gang: str
+    name: str = "None"
+
+    def say(self):
+        return f"archive pick {self.assignment_id} ({self.gang}) — “{self.name}”"
+
+    def perform(self, made):
+        from n26.core.models import Assignment
+
+        pick = Assignment.objects.get(pk=self.assignment_id)
+        if not pick.archived:
+            pick.archive()
+
+
+@dataclass(frozen=True)
 class RewritePick:
     """One stored choice, re-said as a pick: the old kind's column moves
     to ``pickable``, the anchor it already hangs from (``caused_by``)
@@ -532,6 +554,11 @@ class Plan:
     #: True when the system simply is not here — nothing to convert and
     #: nothing wrong: the apply is a clean no-op.
     nothing_here: bool = False
+    #: Choice pairs this conversion treats as unanswered after the write.
+    #: Archiving a printed “None” leaves the same question with nothing
+    #: settled; capture otherwise sees the stored name become "". Each
+    #: pair is ``(kind_label, chosen)``.
+    unanswered_as: tuple = ()
 
     @property
     def ok(self):
@@ -655,6 +682,30 @@ def _one_snapshot():
             )
 
 
+def _canonicalize_unanswered(state, pairs):
+    """Rewrite captured choices so listed ``(kind, chosen)`` pairs read
+    as unanswered. A conversion that archives a printed None in favour
+    of an optional slot uses this rather than weakening ``differences``
+    for every caller."""
+    if not pairs:
+        return state
+    equivalent = set(pairs)
+
+    def choices(rows):
+        return sorted(
+            (kind, "") if (kind, chosen) in equivalent else (kind, chosen)
+            for kind, chosen in rows
+        )
+
+    rewritten = dict(state)
+    rewritten["choices"] = choices(state["choices"])
+    rewritten["models"] = {
+        model_id: {**model, "choices": choices(model["choices"])}
+        for model_id, model in state.get("models", {}).items()
+    }
+    return rewritten
+
+
 def _perform(plan, report):
     from n26.core.capture import differences, gang_state
     from n26.core.models import Gang
@@ -684,7 +735,16 @@ def _perform(plan, report):
             str(gang.pk): gang_state(gang)
             for gang in Gang.objects.filter(pk__in=plan.gang_ids)
         }
-        changed = differences(before, after)
+        changed = differences(
+            {
+                key: _canonicalize_unanswered(state, plan.unanswered_as)
+                for key, state in before.items()
+            },
+            {
+                key: _canonicalize_unanswered(state, plan.unanswered_as)
+                for key, state in after.items()
+            },
+        )
         if changed:
             raise ConversionRefused(
                 f"[{plan.system}] refused — the pages would change:\n  "

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -13,7 +13,11 @@ what any page says. Three stages, the ingest discipline:
   pages say (``n26.core.capture``); after writing it captures again and
   **refuses** — unwinding the whole transaction — on any difference, and
   on any touched gang that no longer reconciles. A conversion that would
-  change what a reader is told never lands.
+  change what a reader is told never lands — except a printed “None”
+  that an optional slot already says with nothing chosen. That exception
+  is named on the plan (``unanswered_as``) so the proof treats the two
+  as equal; apply then checks every planned :class:`ArchivePick` landed
+  by identity, because that proof can no longer see them.
 * A plan whose system is absent (``plan.nothing_here``) applies as a
   no-op, so the migration that ships a conversion is safe on databases
   that never held the system — a fresh environment, a pack without it.
@@ -594,7 +598,8 @@ def apply(plan):
 
     Returns the report lines. Raises :class:`ConversionRefused` — after
     unwinding everything — if the plan carries problems, any affected
-    gang's pages change, or any touched gang stops reconciling.
+    gang's pages change, any planned archive did not land, or any
+    touched gang stops reconciling.
     """
     if plan.problems:
         raise ConversionRefused(
@@ -682,6 +687,34 @@ def _one_snapshot():
             )
 
 
+def _assert_archives_landed(plan):
+    """Every planned ArchivePick must now be an archived row.
+
+    The page proof treats a printed None as unanswered, so it cannot
+    tell a landed archive from a no-op. Check the planned rows by
+    identity instead.
+    """
+    from n26.core.models import Assignment
+
+    wanted = [
+        step.assignment_id for step in plan.steps if isinstance(step, ArchivePick)
+    ]
+    if not wanted:
+        return
+    landed = set(
+        Assignment.objects.filter(pk__in=wanted, archived=True).values_list(
+            "pk", flat=True
+        )
+    )
+    missing = [pk for pk in wanted if pk not in landed]
+    if missing:
+        n = len(missing)
+        raise ConversionRefused(
+            f"[{plan.system}] refused — {n} planned archive"
+            f"{'' if n == 1 else 's'} did not land"
+        )
+
+
 def _canonicalize_unanswered(state, pairs):
     """Rewrite captured choices so listed ``(kind, chosen)`` pairs read
     as unanswered. A conversion that archives a printed None in favour
@@ -729,6 +762,10 @@ def _perform(plan, report):
                 raise ConversionRefused(
                     f"[{plan.system}] failed at “{step.say()}”: {failed}"
                 ) from failed
+        # unanswered_as makes a printed None compare equal to an unanswered
+        # optional slot, so the proof cannot tell a landed archive from a
+        # no-op. The planned rows are checked by identity instead.
+        _assert_archives_landed(plan)
         # Fresh instances: the steps may have moved column-backed facts,
         # and a stale row would compare stale with stale.
         after = {

--- a/n26/library/conversion/variant.py
+++ b/n26/library/conversion/variant.py
@@ -1,0 +1,415 @@
+"""The Variant conversion — one shared offer, optional slot, no None.
+
+Today: one affiliation-labelled offer, label casefold "variant", menu
+Variants: Chaos Corrupted, Genestealer Cult Corrupted, Malstrain
+Corrupted, and "None". The offer is shared across the house gang types
+(and a vestigial Hidden that nothing holds). Chaos Corrupted already
+grants the Chaos God slot.
+
+After: a "Variant" slot type; the three corruptions as pickables
+carrying those same modifiers, moved not copied; one picklist; one
+slot, granted by exactly the offer's carriers as one shared grant;
+every stored corruption pick — live and archived — is re-said as a
+pick; every stored "None" pick is archived. No None pickable. The
+question never nagged, so the slot does not either.
+
+Nothing is deleted. Emptied affiliation rows, the menu, and the
+vestigial Hidden stay where they are. The Hidden is a carrier of the
+one swap, not a second door. Other affiliation-labelled offers
+(Outcast, already slots; Chaos God, already slots; fossils) are other
+systems and are left standing.
+
+The system is found by structure, not by production names: a live
+affiliation-labelled offer whose label casefolds to "variant", carried
+by gang types. A second distinct Variant-labelled offer that is not
+this shared one is a refusal.
+
+Production converts from the maintenance console, once, after the code
+deploys — see :mod:`n26.maintenance`.
+"""
+
+from n26.library.conversion.affiliation import (
+    _affiliations_on,
+    _offers_of_kind,
+    _qualifier_for,
+)
+from n26.library.conversion.base import (
+    ArchivePick,
+    CreatePickable,
+    CreatePicklist,
+    CreateSlot,
+    CreateSlotType,
+    Plan,
+    RewritePick,
+    SwapSharedCarrier,
+    carriers_of,
+    duplicate_names,
+    one_answer_per_question,
+    refuse_if_granted,
+    spread,
+)
+
+SYSTEM = "variant"
+SLOT_TYPE = "Variant"
+SLOT_PLURAL = "Variants"
+SLOT_NAME = "Variant"
+OFFER_LABEL = "variant"
+NONE_NAME = "none"
+PROVEN = 15
+
+
+def _said_carriers(held):
+    """The carriers in preview words, gang types then hiddens."""
+    types = sorted(
+        (row for kind, row in held if kind == "GangType"),
+        key=lambda row: row.name.lower(),
+    )
+    hiddens = sorted(
+        (row for kind, row in held if kind == "Hidden"),
+        key=lambda row: row.name.lower(),
+    )
+    bits = []
+    if types:
+        noun = "gang type" if len(types) == 1 else "gang types"
+        bits.append(noun + " " + ", ".join(f"“{row.name}”" for row in types))
+    if hiddens:
+        noun = "hidden" if len(hiddens) == 1 else "hiddens"
+        bits.append(noun + " " + ", ".join(f"“{row.name}”" for row in hiddens))
+    return "the " + " and the ".join(bits)
+
+
+def _is_none(row):
+    return row.name.casefold() == NONE_NAME
+
+
+def plan_variant():
+    from n26.core.models import Assignment, Gang
+    from n26.library.models import Modifier, Picklist, Slot, SlotType
+    from n26.library.models.pack import default_pack_id
+
+    problems = []
+
+    # Live Variant-labelled offers carried by something. A detached one
+    # is a fossil: carried by nothing, it does nothing on any page, and
+    # it is left where it lies. Offers wearing another label
+    # (Affiliation, Chaos God, Corruption) are other systems.
+    carried = []
+    for modifier in Modifier.objects.filter(
+        offers_choice__isnull=False,
+        offers_choice__of_kind__model="affiliation",
+    ).select_related("offers_choice", "offers_choice__from_section"):
+        if modifier.offers_choice.label.casefold() != OFFER_LABEL:
+            continue
+        held = carriers_of(modifier)
+        if held:
+            carried.append((modifier, held))
+    if not carried:
+        return Plan(system=SYSTEM, nothing_here=True)
+
+    on_types = [
+        (modifier, held)
+        for modifier, held in carried
+        if any(kind == "GangType" for kind, _ in held)
+    ]
+    if not on_types:
+        return Plan(system=SYSTEM, nothing_here=True)
+
+    distinct = []
+    seen = set()
+    for modifier, held in on_types:
+        if modifier.pk in seen:
+            continue
+        seen.add(modifier.pk)
+        distinct.append((modifier, held))
+    if len(distinct) != 1:
+        problems.append(
+            f"{len(distinct)} distinct Variant-labelled offer(s) on gang "
+            "types — expected one shared offer"
+        )
+        return Plan(system=SYSTEM, problems=tuple(problems))
+
+    offer, held = distinct[0]
+    others = [
+        (modifier, other) for modifier, other in carried if modifier.pk != offer.pk
+    ]
+    if others:
+        said = "; ".join(
+            f"“{modifier.name}” carried by "
+            + ", ".join(f"{kind} “{row}”" for kind, row in other)
+            for modifier, other in others
+        )
+        problems.append("a second distinct Variant-labelled offer stands — " + said)
+
+    unexpected = sorted(
+        {kind for kind, _ in held if kind not in ("GangType", "Hidden")}
+    )
+    if unexpected:
+        problems.append(
+            f"“{offer.name}” is also carried by "
+            + ", ".join(unexpected)
+            + " — expected gang types, and optionally a Hidden"
+        )
+
+    for kind, row in held:
+        if kind == "Hidden":
+            refuse_if_granted(row, f"the “{row.name}” hidden", problems)
+
+    section = offer.offers_choice.from_section
+    if section is None:
+        problems.append("the offer names no menu — expected the Variants list")
+        menu_rows = []
+    else:
+        menu_rows = _affiliations_on(section)
+        if not menu_rows:
+            problems.append("the menu offers no Variants to convert")
+
+    twice = duplicate_names(menu_rows)
+    if twice:
+        problems.append("more than one live Variant is called: " + ", ".join(twice))
+
+    nones = [row for row in menu_rows if _is_none(row)]
+    corruptions = [row for row in menu_rows if not _is_none(row)]
+    if section is not None and not corruptions:
+        problems.append("the menu offers no corruptions to convert")
+
+    for row in corruptions:
+        leftover = _offers_of_kind(row, "affiliation", "chaos god")
+        if leftover:
+            problems.append(
+                f"“{row.name}” still offers a Chaos God choice — "
+                "that door converts first"
+            )
+
+    pack = default_pack_id()
+    if SlotType.objects.filter(name__iexact=SLOT_TYPE, pack_id=pack).exists():
+        problems.append(f"a slot type named “{SLOT_TYPE}” already stands")
+
+    picklist_name = section.collection.name if section is not None else SLOT_PLURAL
+    if Picklist.objects.filter(pack_id=pack, name__iexact=picklist_name).exists():
+        problems.append(f"a picklist named “{picklist_name}” already stands")
+    if Slot.objects.filter(pack_id=pack, name__iexact=SLOT_NAME).exists():
+        problems.append(f"a slot named “{SLOT_NAME}” already stands")
+
+    taken_pairs = set()
+    qualifiers = {
+        row.pk: _qualifier_for(row.name, SLOT_TYPE, pack, taken_pairs, problems)
+        for row in corruptions
+    }
+    becoming = {row.pk: row.name for row in corruptions}
+
+    live_picks = list(
+        Assignment.objects.filter(affiliation__in=list(becoming), archived=False)
+        .exclude(removes=True)
+        .select_related("affiliation", "gang_root", "caused_by")
+        .order_by("created")
+    )
+    answers, spares = one_answer_per_question(live_picks)
+    archived_picks = list(
+        Assignment.objects.filter(affiliation__in=list(becoming), archived=True)
+        .exclude(removes=True)
+        .select_related("affiliation", "gang_root", "caused_by")
+        .order_by("created")
+    )
+    none_picks = list(
+        Assignment.objects.filter(affiliation__in=[row.pk for row in nones])
+        .exclude(removes=True)
+        .select_related("affiliation", "gang_root")
+        .order_by("created")
+    )
+
+    type_ids = [row.pk for kind, row in held if kind == "GangType"]
+    hidden_ids = [row.pk for kind, row in held if kind == "Hidden"]
+    type_anchors = set(
+        Assignment.objects.filter(gang_type_id__in=type_ids)
+        .exclude(removes=True)
+        .values_list("pk", flat=True)
+    )
+    hidden_anchors = set(
+        Assignment.objects.filter(hidden_id__in=hidden_ids)
+        .exclude(removes=True)
+        .values_list("pk", flat=True)
+    )
+    door_anchors = type_anchors | hidden_anchors
+    menu_ids = [row.pk for row in menu_rows]
+
+    for pick in [*answers, *archived_picks]:
+        if pick.caused_by_id is None:
+            problems.append(f"pick {pick.pk} has no caused_by to settle against")
+
+    # A live pick of an affiliation the menu does not offer, hanging from
+    # a carrier, would keep its line and lose its question when the
+    # offer is swapped. Refuse rather than strand it.
+    strays = (
+        Assignment.objects.filter(
+            affiliation__isnull=False,
+            archived=False,
+            caused_by_id__in=door_anchors,
+        )
+        .exclude(removes=True)
+        .exclude(affiliation__in=menu_ids)
+        .select_related("affiliation")
+    )
+    for stray in strays:
+        problems.append(
+            f"pick {stray.pk} names “{stray.affiliation.name}”, which the menu "
+            "does not offer — it would lose its question unanswered"
+        )
+
+    if problems:
+        return Plan(system=SYSTEM, problems=tuple(problems))
+
+    slot_label = offer.offers_choice.kind_label
+    sorted_held = sorted(
+        held, key=lambda item: (item[0], item[1].name.lower(), str(item[1].pk))
+    )
+    carriers = tuple((f"library.{kind}", row.pk) for kind, row in sorted_held)
+
+    steps = [
+        CreateSlotType(
+            name=SLOT_TYPE,
+            plural_name=SLOT_PLURAL,
+            allows_repeats=False,
+        ),
+        *[
+            CreatePickable(
+                name=row.name,
+                slot_type=SLOT_TYPE,
+                moved_modifier_ids=tuple(m.pk for m in row.modifiers.all()),
+                moved_from=("library.Affiliation", row.pk),
+                qualifier=qualifiers[row.pk],
+            )
+            for row in corruptions
+        ],
+        CreatePicklist(
+            name=picklist_name,
+            slot_type=SLOT_TYPE,
+            members=tuple(row.name for row in corruptions),
+        ),
+        CreateSlot(
+            name=SLOT_NAME,
+            slot_type=SLOT_TYPE,
+            picklist=picklist_name,
+            label=slot_label,
+            assigned_to="gang",
+            min_picks=0,
+            max_picks=1,
+        ),
+        SwapSharedCarrier(
+            carriers=carriers,
+            carriers_said=_said_carriers(held),
+            drop_modifier_id=offer.pk,
+            drop_modifier_name=offer.name,
+            grant_name=f"Variants: the gang is asked its {SLOT_TYPE}",
+            slot=SLOT_NAME,
+            reach="gang_alone",
+        ),
+    ]
+    steps += [
+        RewritePick(
+            assignment_id=pick.pk,
+            old_column="affiliation",
+            pickable=becoming[pick.affiliation_id],
+            slot=SLOT_NAME,
+            gang=str(pick.gang_root),
+        )
+        for pick in [*answers, *archived_picks]
+    ]
+    steps += [
+        ArchivePick(
+            assignment_id=pick.pk,
+            gang=str(pick.gang_root),
+            name=pick.affiliation.name,
+        )
+        for pick in none_picks
+    ]
+
+    holders = set(
+        Assignment.objects.filter(gang_type_id__in=type_ids, archived=False)
+        .exclude(removes=True)
+        .values_list("gang_root_id", flat=True)
+        .distinct()
+    )
+    holders |= set(
+        Assignment.objects.filter(affiliation_id__in=menu_ids, archived=False)
+        .exclude(removes=True)
+        .values_list("gang_root_id", flat=True)
+        .distinct()
+    )
+    holders.discard(None)
+
+    live_holders = set(
+        Gang.objects.filter(pk__in=holders, archived=False).values_list("pk", flat=True)
+    )
+    answered = {pick.gang_root_id for pick in answers}
+    none_live = {
+        pick.gang_root_id
+        for pick in none_picks
+        if not pick.archived and pick.gang_root_id in live_holders
+    }
+    unanswered = live_holders - answered - none_live
+    archived_rechoice = {
+        pick.gang_root_id
+        for pick in archived_picks
+        if pick.gang_root_id in live_holders
+    }
+
+    per_corruption = [
+        sorted(
+            {pick.gang_root_id for pick in answers if pick.affiliation_id == row.pk},
+            key=str,
+        )
+        for row in corruptions
+    ]
+    chaining_pks = set()
+    granted_slot_ids = []
+    for row in corruptions:
+        for modifier in row.modifiers.all():
+            adds = getattr(modifier, "adds_assignable", None)
+            if adds is not None and getattr(adds, "slot_id", None):
+                chaining_pks.add(row.pk)
+                granted_slot_ids.append(adds.slot_id)
+    chained = []
+    unchained = []
+    if chaining_pks:
+        chained_ids = {
+            pick.gang_root_id for pick in answers if pick.affiliation_id in chaining_pks
+        }
+        god_answered = set()
+        if granted_slot_ids:
+            god_answered = set(
+                Assignment.objects.filter(
+                    chosen_for_slot_id__in=granted_slot_ids,
+                    archived=False,
+                )
+                .exclude(removes=True)
+                .values_list("gang_root_id", flat=True)
+            )
+        chained = sorted(chained_ids & god_answered, key=str)
+        unchained = sorted(chained_ids - god_answered, key=str)
+
+    proven = spread(
+        live_holders,
+        [
+            [pick.gang_root_id for pick in spares],
+            sorted(archived_rechoice, key=str),
+            sorted(none_live, key=str),
+            sorted(unanswered, key=str),
+            chained,
+            unchained,
+            *per_corruption,
+        ],
+        PROVEN,
+    )
+    unanswered_as = tuple((slot_label, row.name) for row in nones)
+    return Plan(
+        system=SYSTEM,
+        steps=tuple(steps),
+        gang_ids=tuple(proven),
+        # Live gangs only: archived ones still have their picks rewritten
+        # and Nones archived, but a stale archived gang must not lock or
+        # refuse the write.
+        holder_ids=tuple(sorted(live_holders, key=str)),
+        reaches=len(live_holders),
+        left_alone=len(spares),
+        unanswered_as=unanswered_as,
+    )

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -114,6 +114,10 @@ class Operation(models.TextChoices):
         "n26_convert_chaos_god",
         "n26: the Chaos Gods become picks",
     )
+    CONVERT_VARIANT = (
+        "n26_convert_variant",
+        "n26: the Variants become picks",
+    )
     SWEEP_ARCHIVED = (
         "n26_sweep_archived",
         "n26: the answers already taken back become picks",
@@ -151,6 +155,7 @@ LOCK_KEYS = {
     Operation.CONVERT_OUTCAST_AFFILIATION: 826_020_608,
     Operation.REPAIR_DOUBLED_REFUNDS: 826_020_609,
     Operation.CONVERT_CHAOS_GOD: 826_020_610,
+    Operation.CONVERT_VARIANT: 826_020_611,
 }
 
 
@@ -519,6 +524,17 @@ def convert_chaos_god(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def convert_variant(backfill_id, **said_by_whoever_enqueued_it):
+    """The Variant conversion, as a task."""
+    _run_conversion(
+        backfill_id,
+        Operation.CONVERT_VARIANT,
+        "variant",
+        **said_by_whoever_enqueued_it,
+    )
+
+
 def _proof_words(plan):
     """What a conversion's page says about its own proof."""
     # Same fallback as Plan.preview — a plan may omit `reaches`.
@@ -606,6 +622,15 @@ def convert_chaos_god_view(request):
         Operation.CONVERT_CHAOS_GOD,
         "chaos_god",
         convert_chaos_god,
+    )
+
+
+def convert_variant_view(request):
+    return _conversion_view(
+        request,
+        Operation.CONVERT_VARIANT,
+        "variant",
+        convert_variant,
     )
 
 
@@ -907,6 +932,26 @@ register_operation(
 
 register_operation(
     MaintenanceOperation(
+        operation=Operation.CONVERT_VARIANT.value,
+        name=Operation.CONVERT_VARIANT.label,
+        added=date(2026, 8, 28),
+        description=(
+            "Move the Variants onto slots and picks: the shared offer on the "
+            "house gang types becomes a grant of an optional Variant slot, "
+            "the three corruptions become pickables (Chaos Corrupted keeps "
+            "its Chaos God grant), every stored corruption pick is re-said "
+            "as a pick, and every stored None is archived so the question "
+            "reads unanswered. Proves a spread of gangs' pages read the "
+            "same and every reached gang still reconciles, or writes nothing."
+        ),
+        view=convert_variant_view,
+        detail_template="admin/maintenance/n26/_convert_detail.html",
+    )
+)
+
+
+register_operation(
+    MaintenanceOperation(
         operation=Operation.DELETE_NAMELESS_GANG_TYPE.value,
         name=Operation.DELETE_NAMELESS_GANG_TYPE.label,
         added=date(2026, 8, 21),
@@ -960,6 +1005,7 @@ task_routes = [
     TaskRoute(delete_nameless_gang_type, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_outcast_affiliation, ack_deadline=600, min_retry_delay=60),
     TaskRoute(convert_chaos_god, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(convert_variant, ack_deadline=600, min_retry_delay=60),
     TaskRoute(propagate_built_ins, ack_deadline=600),
     TaskRoute(sweep_built_in_propagations, schedule="*/5 * * * *"),
     TaskRoute(audit_reconcile),

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -941,7 +941,9 @@ register_operation(
             "the three corruptions become pickables (Chaos Corrupted keeps "
             "its Chaos God grant), every stored corruption pick is re-said "
             "as a pick, and every stored None is archived so the question "
-            "reads unanswered. Proves a spread of gangs' pages read the "
+            "reads unanswered. Cards that print the word None today will "
+            "print nothing after — an optional slot with nothing chosen "
+            "already says that. Proves a spread of gangs' pages read the "
             "same and every reached gang still reconciles, or writes nothing."
         ),
         view=convert_variant_view,

--- a/n26/tests/sandbox/test_conversion_variant.py
+++ b/n26/tests/sandbox/test_conversion_variant.py
@@ -14,8 +14,12 @@ from n26.core.capture import differences, gang_state
 from n26.core.models import Assignment
 from n26.core.reconcile import assert_reconciled
 from n26.library.authoring import attach_modifiers_to
-from n26.library.conversion import apply, plan_variant
-from n26.library.conversion.base import _canonicalize_unanswered, carriers_of
+from n26.library.conversion import ConversionRefused, apply, plan_variant
+from n26.library.conversion.base import (
+    ArchivePick,
+    _canonicalize_unanswered,
+    carriers_of,
+)
 from n26.library.models import Affiliation, Hidden, Modifier, Pickable, Slot
 from n26.tests.sandbox.actions import (
     adds,
@@ -351,6 +355,29 @@ class TestTheApply:
         )
         assert archived.archived
         assert archived.pickable_id is None
+
+    def test_every_planned_archive_lands(self, world):
+        plan = plan_variant()
+        wanted = [
+            step.assignment_id for step in plan.steps if isinstance(step, ArchivePick)
+        ]
+        assert wanted
+
+        apply(plan)
+
+        assert Assignment.objects.filter(pk__in=wanted, archived=True).count() == len(
+            wanted
+        )
+        assert not Assignment.objects.filter(pk__in=wanted, archived=False).exists()
+
+    def test_a_planned_archive_that_did_not_land_is_refused(self, world, monkeypatch):
+        """The page proof treats a printed None as unanswered, so it
+        cannot tell a landed archive from a no-op. Apply still has to
+        see that every planned archive actually archived."""
+        monkeypatch.setattr(ArchivePick, "perform", lambda self, made: None)
+
+        with pytest.raises(ConversionRefused, match="planned archive"):
+            apply(plan_variant())
 
     def test_every_corruption_is_a_pickable_even_if_nobody_picked_it(self, world):
         apply(plan_variant())

--- a/n26/tests/sandbox/test_conversion_variant.py
+++ b/n26/tests/sandbox/test_conversion_variant.py
@@ -1,0 +1,560 @@
+"""The Variant conversion, proven on a prod-shaped world.
+
+One shared offer on the house gang types (and a vestigial Hidden), menu
+of three corruptions plus None. Chaos Corrupted already grants the
+Chaos God slot. After the conversion that is one optional Variant slot,
+the corruptions are pickables with their modifiers moved not copied,
+None is archived, and every page still says the same things — a printed
+None reading as an unanswered optional slot.
+"""
+
+import pytest
+
+from n26.core.capture import differences, gang_state
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.authoring import attach_modifiers_to
+from n26.library.conversion import apply, plan_variant
+from n26.library.conversion.base import _canonicalize_unanswered, carriers_of
+from n26.library.models import Affiliation, Hidden, Modifier, Pickable, Slot
+from n26.tests.sandbox.actions import (
+    adds,
+    choose,
+    create_affiliation,
+    create_collection,
+    create_gang_type,
+    create_hidden,
+    create_pickable,
+    create_picklist,
+    create_rule,
+    create_slot,
+    create_slot_type,
+    create_subtype,
+    found_gang,
+    modifier,
+    offers_choice,
+    remove,
+    removes,
+    section_of,
+    targets_every_model,
+    targets_gang,
+    targets_gang_alone,
+)
+
+pytestmark = pytest.mark.django_db
+
+HOUSE_TYPES = (
+    "Cawdor",
+    "Delaque",
+    "Escher",
+    "Goliath",
+    "Orlock",
+    "Palanite Enforcers",
+    "Van Saar",
+)
+CORRUPTIONS = (
+    "Chaos Corrupted",
+    "Genestealer Cult Corrupted",
+    "Malstrain Corrupted",
+)
+GODS = ("Architect of Fate", "Blood God", "Dark Prince", "Plague Lord")
+
+
+@pytest.fixture
+def prod_shape(default_pack):
+    return build_prod_shape()
+
+
+@pytest.fixture
+def world(prod_shape, owner):
+    return build_world(prod_shape, owner)
+
+
+def build_prod_shape():
+    """The system as production holds it after the Chaos God conversion:
+    a shared Variant offer on the seven house gang types and a vestigial
+    Hidden, three corruptions plus None, Chaos Corrupted granting the
+    Chaos God slot rather than offering a choice."""
+    god_type = create_slot_type(
+        "Chaos God", plural_name="Chaos Gods", allows_repeats=False
+    )
+    gods = {name: create_pickable(name, god_type) for name in GODS}
+    god_slot = create_slot(
+        "Chaos God",
+        god_type,
+        create_picklist("Chaos Gods", god_type, members=[gods[name] for name in GODS]),
+        label="Chaos God",
+        assigned_to="gang",
+        min_picks=0,
+        max_picks=1,
+        qualifier="Chaos Corrupted",
+    )
+
+    brutes = create_subtype("Gang Brute")
+    shared_strip = modifier(
+        "no Brutes or Pets",
+        targets_every_model(),
+        removes(brutes),
+    )
+    affiliations = {}
+    for name in CORRUPTIONS:
+        row = create_affiliation(
+            name,
+            effects=[(targets_every_model(), adds(create_rule(f"{name} mark")))],
+        )
+        attach_modifiers_to(row, [shared_strip])
+        affiliations[name] = row
+    modifier(
+        "Chaos Corrupted: the gang is asked its Chaos God",
+        targets_gang(),
+        adds(god_slot),
+        carried_by=affiliations["Chaos Corrupted"],
+    )
+    none = create_affiliation("None")
+    menu = section_of(
+        create_collection(
+            "Variants",
+            entries=[(affiliations[name], {}) for name in CORRUPTIONS] + [(none, {})],
+        ),
+        "Variants",
+        0,
+        is_default=True,
+    )
+
+    types = {
+        name: create_gang_type(name, starting_credits=2000) for name in HOUSE_TYPES
+    }
+    offer = modifier(
+        "Offer Variants",
+        targets_gang_alone(),
+        offers_choice(Affiliation, from_section=menu, label="Variant"),
+        carried_by=types["Cawdor"],
+    )
+    for name, gang_type in types.items():
+        if name != "Cawdor":
+            attach_modifiers_to(gang_type, [offer])
+    hidden = create_hidden("Variant")
+    attach_modifiers_to(hidden, [offer])
+
+    # Fossils / other systems the conversion must not swap.
+    modifier(
+        "a detached Variant offer",
+        targets_gang(),
+        offers_choice(Affiliation, from_section=menu, label="Variant"),
+    )
+    outcast_hidden = create_hidden("Affiliation")
+    modifier(
+        "Outcasts: the Leader chooses an Affiliation",
+        targets_gang(),
+        offers_choice(Affiliation, label="Affiliation"),
+        carried_by=outcast_hidden,
+    )
+    return types, affiliations, none, god_slot, gods, hidden, offer
+
+
+def build_world(prod_shape, owner):
+    types, affiliations, none, god_slot, gods, hidden, _ = prod_shape
+    escher = types["Escher"]
+    gangs = {
+        "unanswered": found_gang("The Untouched", escher, owner=owner, budget=2000),
+        "none": found_gang("The Ordinary House", escher, owner=owner, budget=2000),
+        "chaos": found_gang("The Unnamed Corrupted", escher, owner=owner, budget=2000),
+        "chaos_god": found_gang("The Bloodied House", escher, owner=owner, budget=2000),
+        "gsc": found_gang("The Cult", escher, owner=owner, budget=2000),
+        "malstrain": found_gang("The Strain", escher, owner=owner, budget=2000),
+        "rechosen": found_gang("The Twice Dedicated", escher, owner=owner, budget=2000),
+    }
+
+    def line(gang):
+        return Assignment.objects.get(gang_type=escher, gang=gang, archived=False)
+
+    choose(line(gangs["none"]), none)
+    choose(line(gangs["chaos"]), affiliations["Chaos Corrupted"])
+    choose(line(gangs["chaos_god"]), affiliations["Chaos Corrupted"])
+    choose(
+        Assignment.objects.get(
+            affiliation=affiliations["Chaos Corrupted"],
+            gang=gangs["chaos_god"],
+            archived=False,
+        ),
+        gods["Blood God"],
+        slot=god_slot,
+    )
+    choose(line(gangs["gsc"]), affiliations["Genestealer Cult Corrupted"])
+    choose(line(gangs["malstrain"]), affiliations["Malstrain Corrupted"])
+    choose(line(gangs["rechosen"]), none)
+    remove(
+        Assignment.objects.get(affiliation=none, gang=gangs["rechosen"], archived=False)
+    )
+    choose(line(gangs["rechosen"]), affiliations["Malstrain Corrupted"])
+    for gang in gangs.values():
+        assert_reconciled(gang)
+    return gangs, hidden, affiliations, none, god_slot
+
+
+def _variant_slot():
+    return Slot.objects.get(name="Variant")
+
+
+class TestThePlan:
+    def test_it_says_everything_it_would_do(self, world):
+        plan = plan_variant()
+
+        assert plan.ok and not plan.nothing_here
+        said = "\n".join(plan.preview())
+        assert "create slot type “Variant”, refusing repeats" in said
+        assert said.count("create pickable") == 3
+        assert "create pickable “Chaos Corrupted”" in said
+        assert "create pickable “Genestealer Cult Corrupted”" in said
+        assert "create pickable “Malstrain Corrupted”" in said
+        assert "create pickable “None”" not in said
+        assert "create slot “Variant”" in said
+        assert "pick landing on the gang" in said
+        assert "shared" in said
+        assert "grant of the “Variant” slot" in said
+        assert "the gang types" in said
+        assert "the hidden “Variant”" in said
+        assert "made_pickable" not in said
+        assert "retire" not in said
+        assert "prove " in said
+        assert "reconcile all" in said
+
+    def test_it_archives_every_none_and_rewrites_the_corruptions(self, world):
+        said = "\n".join(plan_variant().preview())
+        # Live None, archived None on the rechosen gang, four live
+        # corruptions (chaos, chaos_god, gsc, malstrain) plus the
+        # rechosen Malstrain, no archived corruption.
+        assert said.count("archive pick") == 2
+        assert said.count("rewrite pick") >= 5
+
+    def test_an_archived_gang_is_rewritten_but_not_held(self, world):
+        """Archived gangs still have their picks moved, but a stale
+        archived gang must not lock or refuse the whole conversion."""
+        gangs, _, _, _, _ = world
+        gone = gangs["chaos"]
+        gone.archive()
+
+        plan = plan_variant()
+
+        assert gone.pk not in plan.holder_ids
+        apply(plan)
+        pick = Assignment.objects.get(gang=gone, pickable__isnull=False, archived=False)
+        assert pick.pickable.name == "Chaos Corrupted"
+
+    def test_an_archived_gangs_none_is_archived_but_not_held(self, world):
+        gangs, _, _, _, _ = world
+        gone = gangs["none"]
+        gone.archive()
+
+        plan = plan_variant()
+
+        assert gone.pk not in plan.holder_ids
+        apply(plan)
+        none_pick = Assignment.objects.get(gang=gone, affiliation__name="None")
+        assert none_pick.archived
+
+    def test_nothing_here_when_the_system_is_absent(self, default_pack):
+        plan = plan_variant()
+
+        assert plan.nothing_here
+        assert apply(plan) == plan.preview()
+
+
+class TestTheApply:
+    def test_every_page_reads_the_same(self, world):
+        gangs, _, _, _, _ = world
+        before = {key: gang_state(g) for key, g in gangs.items()}
+
+        apply(plan_variant())
+
+        pair = (("Variant", "None"),)
+        for key, gang in gangs.items():
+            after = gang_state(gang)
+            assert (
+                differences(
+                    _canonicalize_unanswered(before[key], pair),
+                    _canonicalize_unanswered(after, pair),
+                )
+                == []
+            )
+            assert_reconciled(gang)
+
+    def test_a_none_gang_captures_equal_to_unanswered(self, world):
+        gangs, _, _, _, _ = world
+        before = gang_state(gangs["none"])
+        assert ("Variant", "None") in before["choices"]
+
+        apply(plan_variant())
+
+        after = gang_state(gangs["none"])
+        assert ("Variant", "") in after["choices"]
+        assert ("Variant", "None") not in after["choices"]
+        assert (
+            differences(
+                _canonicalize_unanswered(before, (("Variant", "None"),)),
+                _canonicalize_unanswered(after, (("Variant", "None"),)),
+            )
+            == []
+        )
+
+    def test_an_unanswered_gang_stays_unanswered(self, world):
+        gangs, _, _, _, _ = world
+        before = gang_state(gangs["unanswered"])
+
+        apply(plan_variant())
+
+        after = gang_state(gangs["unanswered"])
+        assert ("Variant", "") in after["choices"]
+        assert differences(before, after) == []
+
+    def test_a_corruption_pick_lands_on_the_variant_slot(self, world):
+        gangs, _, _, _, _ = world
+
+        apply(plan_variant())
+
+        pick = Assignment.objects.get(
+            gang=gangs["chaos_god"],
+            pickable__name="Chaos Corrupted",
+            archived=False,
+        )
+        assert pick.affiliation_id is None
+        assert pick.chosen_for_slot == _variant_slot()
+        assert pick.miniature_id is None
+        assert pick.chosen_for_id == pick.caused_by_id
+
+    def test_chaos_corrupted_stays_an_affiliation_and_becomes_a_pickable(self, world):
+        apply(plan_variant())
+
+        assert Affiliation.objects.filter(name="Chaos Corrupted").exists()
+        assert Pickable.objects.filter(
+            name="Chaos Corrupted", slot_type__name="Variant"
+        ).exists()
+        assert not Pickable.objects.filter(name="None").exists()
+
+    def test_the_slot_is_labelled_the_way_the_offer_already_was(self, world):
+        apply(plan_variant())
+
+        slot = _variant_slot()
+        assert slot.choice_label == "Variant"
+        assert slot.min_picks == 0
+        assert slot.max_picks == 1
+        assert slot.assigned_to == Slot.WillBeAssignedTo.GANG
+        assert Slot.objects.filter(name="Variant").count() == 1
+
+    def test_the_archived_none_stays_archived(self, world):
+        gangs, _, _, _, _ = world
+
+        apply(plan_variant())
+
+        archived = Assignment.objects.get(
+            gang=gangs["rechosen"], affiliation__name="None"
+        )
+        assert archived.archived
+        assert archived.pickable_id is None
+
+    def test_every_corruption_is_a_pickable_even_if_nobody_picked_it(self, world):
+        apply(plan_variant())
+
+        for name in CORRUPTIONS:
+            assert Pickable.objects.filter(
+                name=name, slot_type__name="Variant"
+            ).exists()
+
+    def test_the_fossils_are_left_standing(self, world):
+        before = Modifier.objects.filter(name="a detached Variant offer").count()
+        apply(plan_variant())
+        assert (
+            Modifier.objects.filter(name="a detached Variant offer").count()
+            == before
+            == 1
+        )
+        assert Modifier.objects.filter(
+            name="Outcasts: the Leader chooses an Affiliation"
+        ).exists()
+
+    def test_an_unanswered_variant_does_not_nag(self, world):
+        gangs, _, _, _, _ = world
+
+        apply(plan_variant())
+
+        state = gang_state(gangs["unanswered"])
+        assert ("Variant", "") in state["choices"]
+        assert all("0 of 1" not in note for note in state["notes"])
+        state = gang_state(gangs["none"])
+        assert ("Variant", "") in state["choices"]
+        assert all("0 of 1" not in note for note in state["notes"])
+
+    def test_the_vestigial_hidden_is_not_a_door(self, world):
+        apply(plan_variant())
+
+        assert Slot.objects.filter(name="Variant").count() == 1
+        assert not Slot.objects.filter(name="Variant", qualifier="Hidden").exists()
+        assert not Slot.objects.filter(name="Variant", qualifier="Variant").exists()
+        hidden = Hidden.objects.get(name="Variant")
+        assert all(
+            getattr(m, "offers_choice", None) is None for m in hidden.modifiers.all()
+        )
+        grants = [
+            m
+            for m in hidden.modifiers.all()
+            if getattr(m, "adds_assignable", None) is not None
+            and m.adds_assignable.slot_id
+        ]
+        assert len(grants) == 1
+        assert grants[0].adds_assignable.slot == _variant_slot()
+
+
+class TestTheBehaviourThatMustSurvive:
+    def test_chaos_corrupted_holds_the_chaos_god_grant(self, world):
+        apply(plan_variant())
+
+        pickable = Pickable.objects.get(name="Chaos Corrupted")
+        grants = [
+            m
+            for m in pickable.modifiers.all()
+            if getattr(m, "adds_assignable", None) is not None
+            and m.adds_assignable.slot_id
+            and m.adds_assignable.slot.slot_type.name == "Chaos God"
+        ]
+        assert len(grants) == 1
+        emptied = Affiliation.objects.get(name="Chaos Corrupted")
+        assert grants[0] not in emptied.modifiers.all()
+
+    def test_un_choosing_variant_retracts_the_god(self, world):
+        gangs, _, _, _, _ = world
+        apply(plan_variant())
+        gang = gangs["chaos_god"]
+        pick = Assignment.objects.get(
+            gang=gang, pickable__name="Chaos Corrupted", archived=False
+        )
+        god = Assignment.objects.get(
+            gang=gang, pickable__slot_type__name="Chaos God", archived=False
+        )
+
+        remove(pick)
+
+        assert not Assignment.objects.filter(pk=god.pk, archived=False).exists()
+        state = gang_state(gang)
+        assert all(kind != "Chaos God" for kind, _ in state["choices"])
+        assert ("Variant", "") in state["choices"]
+        assert_reconciled(gang)
+
+    def test_a_shared_modifier_stays_one_row(self, world):
+        apply(plan_variant())
+
+        shared = Modifier.objects.get(name="no Brutes or Pets")
+        holders = carriers_of(shared)
+        assert {kind for kind, _ in holders} == {"Pickable"}
+        assert {row.name for _, row in holders} == set(CORRUPTIONS)
+
+    def test_the_new_machinery_answers_again(self, world):
+        gangs, _, _, _, _ = world
+        apply(plan_variant())
+        gang = gangs["unanswered"]
+        type_line = Assignment.objects.get(
+            gang_type=gang.gang_type, gang=gang, archived=False
+        )
+
+        choose(
+            type_line,
+            Pickable.objects.get(name="Malstrain Corrupted"),
+            slot=_variant_slot(),
+        )
+
+        state = gang_state(gang)
+        assert ("Variant", "Malstrain Corrupted") in state["choices"]
+        assert_reconciled(gang)
+
+    def test_a_second_run_is_a_clean_no_op(self, world):
+        apply(plan_variant())
+
+        assert plan_variant().nothing_here
+
+
+class TestTheStory:
+    def test_a_corruption_pick_is_reworded_to_variant(self, world):
+        """The story names a pick by its slot type, so a corruption that
+        used to read as an affiliation now reads as a variant."""
+        from n26.core.history import Sub, _kindword
+
+        gangs, _, _, _, _ = world
+        apply(plan_variant())
+
+        pick = Assignment.objects.get(
+            gang=gangs["gsc"], pickable__isnull=False, archived=False
+        )
+        assert _kindword(pick) == "variant"
+        assert Sub(name=pick.pickable.name, kind=_kindword(pick)).detail == "variant"
+
+
+class TestTheRefusals:
+    def test_a_standing_slot_type_is_refused(self, world):
+        create_slot_type("Variant")
+
+        plan = plan_variant()
+
+        assert not plan.ok
+        assert any("already stands" in problem for problem in plan.problems)
+
+    def test_a_differently_cased_slot_type_is_refused(self, world):
+        create_slot_type("VARIANT")
+
+        plan = plan_variant()
+
+        assert not plan.ok
+        assert any("already stands" in problem for problem in plan.problems)
+
+    def test_a_colliding_pickable_is_qualified(self, world):
+        other = create_slot_type("Something Else")
+        create_pickable("Chaos Corrupted", other)
+
+        plan = plan_variant()
+
+        assert plan.ok
+        said = "\n".join(plan.preview())
+        assert "told apart as “Variant”" in said
+
+    def test_a_colliding_qualified_pickable_is_refused(self, world):
+        other = create_slot_type("Something Else")
+        create_pickable("Chaos Corrupted", other)
+        create_pickable("Chaos Corrupted", other, qualifier="Variant")
+
+        plan = plan_variant()
+
+        assert not plan.ok
+        assert any("already stands" in p for p in plan.problems)
+
+    def test_a_second_distinct_variant_offer_is_refused(self, world, prod_shape):
+        types, _, _, _, _, _, _ = prod_shape
+        extra = create_hidden("Another Variant door")
+        modifier(
+            "another Variant offer",
+            targets_gang(),
+            offers_choice(Affiliation, label="Variant"),
+            carried_by=extra,
+        )
+
+        plan = plan_variant()
+
+        assert not plan.ok
+        assert any("second distinct" in p for p in plan.problems)
+
+    def test_an_off_menu_pick_is_refused(self, world, prod_shape):
+        types, _, _, _, _, _, _ = prod_shape
+        gangs, _, _, _, _ = world
+        offmenu = create_affiliation("Something Else Entirely")
+        line = Assignment.objects.get(
+            gang_type=types["Escher"], gang=gangs["unanswered"], archived=False
+        )
+        Assignment.objects.create(
+            affiliation=offmenu,
+            gang=gangs["unanswered"],
+            caused_by=line,
+            chosen_for=line,
+            gang_root=gangs["unanswered"],
+        )
+
+        plan = plan_variant()
+
+        assert not plan.ok
+        assert any("the menu does not offer" in p for p in plan.problems)

--- a/n26/tests/sandbox/test_gang_books.py
+++ b/n26/tests/sandbox/test_gang_books.py
@@ -38,9 +38,13 @@ from n26.library.authoring import (
     create_gang_type,
     create_hidden,
     create_option_group,
+    create_pickable,
+    create_picklist,
     create_power,
     create_profile,
     create_rule,
+    create_slot,
+    create_slot_type,
     create_subtype,
     create_wargear,
     ef_adds,
@@ -58,7 +62,7 @@ from n26.library.authoring import (
     targets_gang,
     targets_model,
 )
-from n26.library.models import Affiliation, Power
+from n26.library.models import Power
 from n26.tests.sandbox.actions import (
     assign,
     buy,
@@ -123,12 +127,47 @@ def chaos_powers(default_pack):
 
 
 @pytest.fixture
-def escher(ranks, default_pack):
+def corruption_choice(default_pack):
+    """A Variant slot whose Chaos Corrupted pickable grants the Chaos
+    God slot — the shape the conversion leaves standing."""
+    variant_type = create_slot_type("Variant", allows_repeats=False)
+    god_type = create_slot_type(
+        "Chaos God", plural_name="Chaos Gods", allows_repeats=False
+    )
+    gods = {
+        name: create_pickable(f"Dedicated: the {name}", god_type)
+        for name in ("Blood God", "Plague Lord", "Dark Prince", "Architect of Fate")
+    }
+    god_slot = create_slot(
+        "Chaos God",
+        god_type,
+        create_picklist("Chaos Gods", god_type, members=list(gods.values())),
+        label="Dedication",
+        assigned_to="gang",
+        min_picks=0,
+        max_picks=1,
+    )
+    corrupted = create_pickable("Chaos Corrupted", variant_type)
+    variant_slot = create_slot(
+        "Variant",
+        variant_type,
+        create_picklist("Variants", variant_type, members=[corrupted]),
+        label="Corruption",
+        assigned_to="gang",
+        min_picks=0,
+        max_picks=1,
+    )
+    return variant_slot, god_slot, corrupted, gods
+
+
+@pytest.fixture
+def escher(ranks, default_pack, corruption_choice):
     """A slim House Escher: its rule, and the founding corruption slot.
 
     The charter Hidden is the gang type's anchor row — founding assigns
     it, so gang-level questions have an assignment to hang picks off.
     """
+    variant_slot, _, _, _ = corruption_choice
     nimble = create_rule("Nimble")
     charter = create_hidden(
         "House Escher charter",
@@ -137,7 +176,7 @@ def escher(ranks, default_pack):
             # "During Gang Creation a player can decide that their gang
             # has been corrupted" — an open question on the gang's own
             # card, chosen for or simply left.
-            (targets_gang(), ef_offers_choice(Affiliation, label="corruption")),
+            (targets_gang(), ef_adds(variant_slot)),
         ],
     )
     gang_type = create_gang_type("Escher")
@@ -147,19 +186,13 @@ def escher(ranks, default_pack):
 
 
 @pytest.fixture
-def chaos_corruption(escher, ranks, chaos_powers, skills_catalogue):
+def chaos_corruption(escher, ranks, chaos_powers, skills_catalogue, corruption_choice):
     """Everything 'Embracing the Chaos Gods' means, hanging off one pick."""
     _, nimble, _ = escher
+    _, god_slot, corruption, gods = corruption_choice
     family, powers = chaos_powers
     _, tiers = skills_catalogue
     wyrd = create_subtype("Wyrd")
-
-    # The Dark Gods are chosen carriers of their own — the dedication is
-    # a chained choice, and each god's battle favour is names-only.
-    gods = {
-        name: create_affiliation(f"Dedicated: the {name}")
-        for name in ("Blood God", "Plague Lord", "Dark Prince", "Architect of Fate")
-    }
 
     # "The Leader can be upgraded to become a Wyrd for +35 credits" — a
     # priced purchasable carrier. Its power pick falls out of the
@@ -184,28 +217,26 @@ def chaos_corruption(escher, ranks, chaos_powers, skills_catalogue):
         "Chaos Corruption Options", entries=[(ascension, {}), (familiar, {})]
     )
 
-    corruption = create_affiliation(
-        "Chaos Corrupted",
-        effects=[
-            # "Members of the gang do not benefit from any of the gang's
-            # special rules" — computed removal; removes always win.
-            (targets_every_model(), ef_removes(nimble)),
-            # The Post-cycle rituals, printed on who may perform them.
-            (
-                targets_every_model(has_subtypes(ranks["leader"])),
-                ef_adds(create_rule("Lead Ritual", annotation="Leader only")),
-            ),
-            (
-                targets_every_model(),
-                ef_adds(create_rule("Ritual Focus", annotation="max one Fighter")),
-            ),
-            # "The gang must select one of the Chaos gods" — what is
-            # chosen asks its own follow-up. Chained by construction.
-            (targets_gang(), ef_offers_choice(Affiliation, label="dedication")),
-            # The corruption-only equipment list, opened for everyone.
-            (targets_every_model(), ef_adds(options)),
-        ],
-    )
+    for scope, effect in [
+        # "Members of the gang do not benefit from any of the gang's
+        # special rules" — computed removal; removes always win.
+        (targets_every_model(), ef_removes(nimble)),
+        # The Post-cycle rituals, printed on who may perform them.
+        (
+            targets_every_model(has_subtypes(ranks["leader"])),
+            ef_adds(create_rule("Lead Ritual", annotation="Leader only")),
+        ),
+        (
+            targets_every_model(),
+            ef_adds(create_rule("Ritual Focus", annotation="max one Fighter")),
+        ),
+        # "The gang must select one of the Chaos gods" — the pick
+        # grants the follow-up, retracted when Variant is un-chosen.
+        (targets_gang(), ef_adds(god_slot)),
+        # The corruption-only equipment list, opened for everyone.
+        (targets_every_model(), ef_adds(options)),
+    ]:
+        modifier(f"Chaos Corrupted: {effect}", scope, effect, attach_to=corruption)
     return corruption, gods, options, powers
 
 
@@ -264,6 +295,8 @@ def ganger_profile(fighter_type, escher, ranks):
 
 class TestChaosCorruption:
     def corrupted_gang(self, escher, chaos_corruption):
+        from n26.library.models import Slot
+
         gang_type, _, charter = escher
         corruption, gods, _, _ = chaos_corruption
         gang = found_gang(
@@ -273,8 +306,8 @@ class TestChaosCorruption:
             budget=1000,
         )
         anchor = Assignment.objects.get(gang=gang, hidden=charter)
-        corrupted = choose(anchor, corruption)
-        choose(corrupted, gods["Blood God"])
+        corrupted = choose(anchor, corruption, slot=Slot.objects.get(name="Variant"))
+        choose(corrupted, gods["Blood God"], slot=Slot.objects.get(name="Chaos God"))
         return gang
 
     def test_the_founding_pick_suppresses_the_house_rules(

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -27,6 +27,7 @@ from n26.maintenance import (
     Operation,
     convert_chaos_god_view,
     convert_outcast_affiliation_view,
+    convert_variant_view,
     delete_nameless_gang_type_view,
 )
 
@@ -392,3 +393,88 @@ class TestTheChaosGodConversion:
         assert Pickable.objects.filter(
             name="Blood God", slot_type__name="Chaos God"
         ).exists()
+
+
+class TestTheVariantConversion:
+    """The repair still on offer: the Variants become picks."""
+
+    def test_its_lock_is_not_shared(self):
+        keys = list(LOCK_KEYS.values())
+        assert len(keys) == len(set(keys))
+        assert (
+            LOCK_KEYS[Operation.CONVERT_VARIANT]
+            != LOCK_KEYS[Operation.CONVERT_CHAOS_GOD]
+        )
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.CONVERT_VARIANT.value in registered
+        found = resolve_operation(Operation.CONVERT_VARIANT.value)
+        assert found.name == Operation.CONVERT_VARIANT.label
+        assert found.view is convert_variant_view
+
+    def test_it_is_not_retired(self):
+        assert Operation.CONVERT_VARIANT not in TestARepairThatHasBeenRun.RETIRED
+        assert resolve_operation(Operation.CONVERT_VARIANT.value).view is not None
+
+    def test_only_a_superuser_may_reach_it(self, client, staffer):
+        client.force_login(staffer)
+
+        response = client.get(reverse("admin:maintenance_n26_convert_variant"))
+
+        assert response.status_code in (302, 403)
+
+    def test_its_page_shows_nothing_to_convert_when_the_system_is_absent(
+        self, client, superuser, default_pack
+    ):
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_convert_variant"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "Nothing to convert" in page
+        assert not Backfill.objects.exists()
+
+    def test_its_page_shows_the_plan_and_writes_nothing(
+        self, client, superuser, default_pack, owner
+    ):
+        from n26.tests.sandbox.test_conversion_variant import (
+            build_prod_shape,
+            build_world,
+        )
+
+        build_world(build_prod_shape(), owner)
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_convert_variant"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "create slot type “Variant”" in page
+        assert not Backfill.objects.exists()
+
+    def test_applying_records_what_it_converted(
+        self, client, superuser, default_pack, owner
+    ):
+        from n26.library.models import Pickable, Slot
+        from n26.tests.sandbox.test_conversion_variant import (
+            build_prod_shape,
+            build_world,
+        )
+
+        build_world(build_prod_shape(), owner)
+        client.force_login(superuser)
+
+        response = client.post(reverse("admin:maintenance_n26_convert_variant"))
+
+        assert response.status_code == 302
+        run = Backfill.objects.get(operation=Operation.CONVERT_VARIANT)
+        assert run.status == Backfill.Status.DONE
+        assert any("applied" in line for line in run.summary["report"])
+        assert Slot.objects.filter(name="Variant").count() == 1
+        assert Pickable.objects.filter(
+            name="Chaos Corrupted", slot_type__name="Variant"
+        ).exists()
+        assert not Pickable.objects.filter(name="None").exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The shared house-gang Variant question — Chaos Corrupted, Genestealer Cult Corrupted, Malstrain Corrupted, or None — moves onto an optional Variant slot and picks. After deploy, a superuser runs this once from the maintenance console, then `audit_reconcile` by hand.

## What changed

House gangs are asked Variant as a slot (`min_picks=0`, `assigned_to=gang`), granted from the same shared modifier the seven gang types already carry. The three corruptions become pickables and keep their payloads, including Chaos Corrupted's Chaos God grant, so un-choosing Variant still retracts the god.

**Stored None picks are archived, and those cards will change.** Today they print the word “None”. After the conversion they print nothing: an optional slot with nothing chosen. The picker already has a None row. That is a deliberate product call, not an accident the proof papered over. `unanswered_as` is what lets capture treat printed None and unanswered as equal for that question only; apply then checks every planned `ArchivePick` landed by identity, because that proof can no longer see those archives.

Affiliation stays. Outcast and Chaos God are not converted again. The vestigial hidden “Variant” is a carrier of that one swap, not a second door.

## How to try it

1. Maintenance console → **n26: the Variants become picks**. GET shows the plan (creates, shared swap, rewrites, how many Nones it archives) and states that cards printing None will print nothing after. POST applies.
2. A house gang on None: the sheet asks Variant with nothing chosen, and does not nag “0 of 1”.
3. A Chaos Corrupted gang is still asked its Chaos God. Un-choose Variant and the god goes with it.
4. Then run the existing `audit_reconcile` operation. Do not nest it on this Backfill.

Retry after a successful flip is `nothing_here`. A standing Variant slot type is a refusal, not a skip.

## Production plan and timing

`plan_variant()` is ok against production. Carriers are exactly the seven house gang types plus the hidden “Variant” (0 live assignments). No Variant slot type yet. Chaos Corrupted already grants the Chaos God slot.

Counts: 189 live None, 19 archived None, 69 live corruptions (36 Chaos / 15 GSC / 18 Malstrain), 34 archived corruptions. Preview archives 208 Nones and rewrites 103 corruption picks. It reaches 1022 live house gangs.

A local rebuild at production’s pick counts, after Chaos God, applied in 68.4s at 39k assignments; reconciling all 1022 gangs is the dominant cost. Production is denser, so expect roughly 2 minutes — comfortable against the 600s ack deadline. The run holds a write lock on those 1022 gangs for that window, so it is better at a quiet time than at peak.

A live Van Saar on None already shows Variant only on the gang sheet (nine models, none of them asked). `gang_alone` is the right grant reach.

Independent capture of all 1022 gangs, without this conversion’s canonicalisation: exactly 208 differ, and only as `('Variant', 'None')` → `('Variant', '')`. 0 reconcile failures. A second run reports `nothing_here`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2894c7a-41e2-407a-b223-ac90a2648c91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2894c7a-41e2-407a-b223-ac90a2648c91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

