### PR TITLE
docs: an apply's duration depends on the gangs it reaches

### DIFF
--- a/.claude/notes/affiliation-conversion-eval.md
+++ b/.claude/notes/affiliation-conversion-eval.md
@@ -300,9 +300,9 @@ God) refuse them.
 
 **Runner.** One write per system: create, move modifiers, swap, rewrite
 every pick, in one transaction, with the reached gangs locked. Prove a
-spread in that transaction and unwind on a diff. `run_batched` walks
-every reached gang afterwards and reconciles — it does not drip the
-switch. No dual-read, no per-gang flag, no dormant slots.
+spread in that transaction and unwind on a diff. Reconcile every reached
+gang in that same transaction. No dual-read, no per-gang flag, no
+dormant slots.
 
 ## Engine work
 
@@ -315,8 +315,8 @@ the behaviour on Malstrain itself).
 
 Put back a small `n26.library.conversion` — frozen plan, typed steps,
 one apply — not the 7,000-line module #2287 deleted. Console operations
-call it through `_run_recorded`, then enqueue `run_batched` for the
-reconcile walk. Capture (`n26.core.capture.gang_state`) is still here.
+call it through `_run_recorded`. Capture
+(`n26.core.capture.gang_state`) is still here.
 
 Authoring already refuses a bare pickable built in. Recipes and
 `concepts.md` still teach Affiliation as the way to author a gang-level

--- a/.claude/notes/affiliation-conversion-plan.md
+++ b/.claude/notes/affiliation-conversion-plan.md
@@ -11,10 +11,12 @@ part that made them slow: **one write per system**, then an operator
 runs `audit_reconcile` afterwards. Do not run the old offer and the
 new slot on the same gang. Do not rewrite picks one gang at a time.
 
-The writes are a few hundred assignment rows. What used to hold the
-transaction for minutes was rendering pages inside it. Do not enqueue
-`run_batched` on the same Backfill — the conversion already marks
-that record DONE. The after-the-fact check is the existing
+The writes are a few hundred assignments and are quick. The reconcile
+walk is the slow part: the apply reconciles every reached gang inside
+the transaction, and each gang needs several queries against a database
+across the network. Duration depends on the gangs a system reaches. Do not
+enqueue `run_batched` on the same Backfill — the conversion already
+marks that record DONE. The after-the-fact check is the existing
 `audit_reconcile` operation, run by hand.
 
 ## Decisions
@@ -33,7 +35,9 @@ that record DONE. The after-the-fact check is the existing
 | Writes | Assignment updates are the sanctioned conversion exception (`n26/core/CLAUDE.md`): no `operation()`, no money, no ledger events. |
 
 If the fork write is not short (seconds, not minutes), stop and look
-again. Do not then invent a per-gang window.
+again. Do not then invent a per-gang window. A fork time is a floor:
+the fork answers over a socket, and production answers over the
+network, so production is slower than the assignment counts suggest.
 
 ## Reusable machinery
 

--- a/n26/library/conversion/base.py
+++ b/n26/library/conversion/base.py
@@ -29,6 +29,19 @@ its assignment names now, so moving an assignment from one kind to
 another rewrites the wording of things that already happened. Every
 conversion must check the history page against a converted assignment
 and keep those words the same — see the note in ``n26/core/CLAUDE.md``.
+
+An apply's duration depends on the gangs it reaches, not on the
+assignments it writes. The write is a few hundred updates and is quick.
+The reconcile walk is the slow part: the apply reconciles every reached
+gang inside the transaction, and each gang needs several queries. In
+production every query crosses the network to the database. A thousand
+gangs take tens of minutes, and all of them stay locked for that time.
+
+Time an apply on a fork of the content mirror before it runs in
+production, and count the gangs the plan reaches. A local time is a
+floor, not a forecast: a local database answers over a socket, and
+production answers over the network. If the apply is not short, stop and
+look again.
 """
 
 import logging
@@ -516,9 +529,8 @@ class Plan:
     steps: tuple = ()
     #: The gangs the apply proves unchanged before committing — a spread
     #: chosen by the system's own plan to hold every shape it comes in,
-    #: not every gang it reaches. Rendering everyone with the transaction
-    #: open is the part that used to take minutes; a few hundred row
-    #: updates do not.
+    #: not every gang it reaches. Capturing a gang's pages is slow, so
+    #: the proof reads a sample.
     gang_ids: tuple = ()
     problems: tuple = ()
     #: How many gangs the change reaches in all, proven or not.


### PR DESCRIPTION
The note on `Plan.gang_ids` named rendering as the slow part of a conversion apply, and dismissed everything else as "a few hundred row updates". That is the wrong model, and it is the reason the Variant conversion (#2347) went to production expected to take about two minutes and held its transaction — and 1,022 gangs — for roughly half an hour.

The real driver is the reconcile walk. The apply reconciles **every** reached gang inside the transaction, each gang needs several queries, and in production every query crosses the network to Cloud SQL. So duration depends on the gangs a system reaches, not on the assignments it writes. A local fork answers over a socket, which is why a local time is a floor rather than a forecast — my fork measurement of 68s under-predicted production by an order of magnitude.

`conversion/base.py` now states both facts where someone planning or reviewing a conversion will meet them.

The two planning notes also disagreed with each other about the runner. `affiliation-conversion-eval.md` said `run_batched` walks the reached gangs and reconciles them *after* the write; `affiliation-conversion-plan.md` reversed that — the reconcile is in the transaction, and the after-the-fact check is `audit_reconcile` run by hand. The code follows the plan. The superseded sentences in the eval note are removed, so the two no longer contradict each other. That contradiction is what made "we don't do these in a single transaction any more" a reasonable thing to believe.

The old wording also broke two house rules from `n26/CLAUDE.md`: it narrated what the code used to do, and it called assignments rows.

Docs only — no behaviour change. Verified `ruff`, `markdownlint`, the money-words vocabulary test, and the affiliation and Chaos God conversion suites (50 passed).
