### PR TITLE
feat: n26_backfill_built_ins tags legacy DEFAULT grants and catches carriers up

### DIFF
--- a/n26/core/backfill_built_ins.py
+++ b/n26/core/backfill_built_ins.py
@@ -25,9 +25,8 @@ settles both, one gang at a time, inside one ``operation(gang)``:
 
    Tagging writes provenance and nothing else — no ledger entry, no
    event, no repin. It changes how a grant is recorded, not what the
-   owner has, which is the one exception ``n26/core/CLAUDE.md`` allows
-   to the rule that player data is written only by an operation's
-   verbs: it moves no money, and the gang is proved to reconcile after.
+   owner has: it moves no money, and the gang is proved to reconcile
+   after.
 
 2. **Catch up.** Every live carrier in the gang is reconciled against
    its sets, so a member added after the hire arrives now, recorded as
@@ -35,9 +34,10 @@ settles both, one gang at a time, inside one ``operation(gang)``:
    gang-hosted carrier — already holds a live copy of the member's
    thing that arrived some other way (bought, rewarded, edited in,
    granted by a modifier), the member is skipped and the carrier named
-   in the outcome: the backfill never creates a duplicate. That is a
-   backfill-only reading; live propagation judges by provenance alone
-   (``n26.core.builtins``).
+   in the outcome: for the carrier's own set members, the backfill
+   never creates a duplicate. That is a backfill-only reading; live
+   propagation judges by provenance alone (``n26.core.builtins``), and
+   so does the reconcile of anything the catch-up itself creates.
 
 Both steps are idempotent, so a gang may be walked again: a second
 pass tags nothing and grants nothing. Archived grants are tagged like
@@ -169,9 +169,12 @@ def _tag_legacy_grants(gang, outcome):
         named = False
         accounted = 0
         for default_set in sets_by_carrier[carrier_id]:
+            # Live members first: a copy bound to an archived member
+            # leaves its live twin unsatisfied, and catch-up would then
+            # grant the duplicate this pairing exists to prevent.
             members = list(
                 default_set.members.filter(**{f"{kind}_id": assignable_id}).order_by(
-                    "pk"
+                    "archived", "pk"
                 )
             )
             if not members:

--- a/n26/core/backfill_built_ins.py
+++ b/n26/core/backfill_built_ins.py
@@ -111,6 +111,17 @@ def catch_up(gang_id):
     outcome = GangOutcome(gang_id=str(gang_id))
     with operation(gang, actor=None) as op:
         _tag_legacy_grants(gang, outcome)
+        # A grant with no cause recorded has no carrier whose sets could
+        # claim it. Counted with the unmatched, so the report explains
+        # every row the preview shows and a rerun's residue reads as
+        # settled rather than silently lingering.
+        outcome.unmatched += (
+            Assignment.objects.filter(
+                gang_root=gang, caused_by__isnull=True, **LEGACY_SHAPE
+            )
+            .filter(_of_kinds(TAGGABLE_KINDS))
+            .count()
+        )
         _catch_up_carriers(op, gang, outcome)
     return outcome
 

--- a/n26/core/backfill_built_ins.py
+++ b/n26/core/backfill_built_ins.py
@@ -191,12 +191,10 @@ def _catch_up_carriers(op, gang, outcome):
         host_gang = carrier.gang if hosted_on_gang else None
         omit = []
         for member in plan_defaults(carrier).missing:
-            if _held_another_way(member, carrier, host_gang):
+            held = _held_another_way(member, carrier, host_gang)
+            if held:
                 omit.append(member.pk)
-                outcome.held_another_way.append(
-                    f"{_name_of(carrier, host_gang)} already holds "
-                    f"{member.assignable} another way"
-                )
+                outcome.held_another_way.append(held)
         result = op.reconcile_defaults(
             carrier,
             gang=host_gang,
@@ -224,29 +222,62 @@ def _carriers_in(gang):
 
 
 def _held_another_way(member, carrier, host_gang):
-    """Whether the carrier's model — or the gang, for a gang-hosted
-    carrier — holds a live copy of the member's thing that no set
-    materialised: bought, rewarded, edited in, or granted by a
-    modifier. Such a copy carries no provenance and a reason other
-    than ``DEFAULT``."""
+    """A sentence saying how the carrier's model — or the gang, for a
+    gang-hosted carrier — already holds the member's thing without a
+    set having materialised it, or None where it does not.
+
+    For most kinds that is a live copy with no provenance and a reason
+    other than ``DEFAULT``: bought, rewarded, edited in, or granted by
+    a modifier. Ammo is read differently: a firing line stacked on a
+    gun with no provenance is held whatever its reason, because a
+    weapon's own free lines and a legacy ammo grant are written in the
+    same shape, and a second line under the same gun is the duplicate
+    this check exists to prevent. The gun is the one the member would
+    land under — its named gun member's live copy for this carrier, or
+    any live gun of that weapon on the host where it names none.
+    """
+    from n26.core.builtins import copies_of
+    from n26.library.models import WeaponProfile
+
     assignable = member.assignable
-    scope = {
-        Assignment.field_for(assignable): assignable,
-        "archived": False,
-        "removes": False,
-        "materialised_from__isnull": True,
-    }
     if host_gang is not None:
-        scope["gang"] = host_gang
+        host = {"gang": host_gang}
     elif carrier.miniature_root_id is not None:
-        scope["miniature_root_id"] = carrier.miniature_root_id
+        host = {"miniature_root_id": carrier.miniature_root_id}
     else:
-        return False
-    return (
-        Assignment.objects.filter(**scope)
+        return None
+    who = _name_of(carrier, host_gang)
+
+    if isinstance(assignable, WeaponProfile):
+        if member.gun_member_id is not None:
+            guns = copies_of(member.gun_member, carrier, include_archived=False)
+        else:
+            guns = Assignment.objects.filter(
+                weapon=assignable.weapon, archived=False, **host
+            )
+        line = Assignment.objects.filter(
+            weapon_profile=assignable,
+            parent__in=guns,
+            archived=False,
+            removes=False,
+            materialised_from__isnull=True,
+        ).first()
+        if line is None:
+            return None
+        return f"{who} already carries {assignable} under its {assignable.weapon}"
+
+    held = (
+        Assignment.objects.filter(
+            archived=False,
+            removes=False,
+            materialised_from__isnull=True,
+            **{Assignment.field_for(assignable): assignable},
+            **host,
+        )
         .exclude(ledger_entry__reason=Reason.DEFAULT)
         .exists()
     )
+    return f"{who} already holds {assignable} another way" if held else None
 
 
 def _name_of(carrier, host_gang):

--- a/n26/core/backfill_built_ins.py
+++ b/n26/core/backfill_built_ins.py
@@ -12,12 +12,16 @@ settles both, one gang at a time, inside one ``operation(gang)``:
    its carrier's sets (``sets_for``: the carrier's built-ins and the
    option sets it took) naming the same assignable — and the pair is
    written onto it. A weapon's own free firing lines are not set
-   members and are left alone. Where a set names the same assignable
-   more than once (twin guns), the carrier's untagged copies are paired
-   to the members newest copy first, one per member, as many as the
-   set has members and provenance does not already account for; a copy
-   left over stays untagged and is counted as ambiguous. A copy whose
-   member is gone stays untagged and is counted.
+   members and are left alone. Sets claim copies one at a time, never
+   pooled — the option sets first, last recorded first, then the
+   built-ins — so that where two sets name the same thing each gets
+   the copies it wrote (``_tag_legacy_grants``). Within a set, where
+   it names the same assignable more than once (twin guns), the
+   carrier's untagged copies are paired to the members newest copy
+   first, one per member, as many as the set has members and
+   provenance does not already account for; a copy left over stays
+   untagged and is counted as ambiguous. A copy whose member is gone
+   stays untagged and is counted.
 
    Tagging writes provenance and nothing else — no ledger entry, no
    event, no repin. It changes how a grant is recorded, not what the
@@ -45,7 +49,7 @@ from dataclasses import dataclass, field
 
 from django.db.models import Count, Q
 
-from n26.core.builtins import plan_defaults, sets_for
+from n26.core.builtins import plan_defaults
 from n26.core.models import Assignment, Gang, LedgerEvent, Reason
 from n26.core.operations import operation
 from n26.library.models.defaults import DEFAULT_ASSIGNABLE_FIELDS
@@ -115,6 +119,21 @@ def catch_up(gang_id):
 
 
 def _tag_legacy_grants(gang, outcome):
+    """Give every legacy grant in the gang its provenance.
+
+    Grants are grouped by carrier and by the thing they name, then
+    each of the carrier's sets claims copies one set at a time — never
+    pooled — because the built-ins and a chosen option set may name
+    the same thing, and pooling their members would pair the copies
+    backwards. The invariant: the pairing written here is the one
+    ``_granted_rows(carrier, set)`` reads for every set. That read
+    takes a set's copies newest first, on the rule that where the
+    built-ins and an option set grant the same thing, the option's copy
+    is the newer one — the built-ins materialise first, then the option
+    sets in the order they were recorded. So the option sets claim
+    first, the one recorded last claiming first from the newest copies,
+    and the built-ins set claims last, from what remains.
+    """
     legacy = (
         Assignment.objects.filter(
             gang_root=gang, caused_by__isnull=False, **LEGACY_SHAPE
@@ -134,34 +153,55 @@ def _tag_legacy_grants(gang, outcome):
     for (carrier_id, kind, assignable_id), copies in groups.items():
         carrier = copies[0].caused_by
         if carrier_id not in sets_by_carrier:
-            sets_by_carrier[carrier_id] = sets_for(carrier)
-        candidates = [
-            member
-            for default_set in sets_by_carrier[carrier_id]
-            for member in default_set.members.filter(**{f"{kind}_id": assignable_id})
-        ]
-        if not candidates:
+            sets_by_carrier[carrier_id] = _sets_in_claiming_order(carrier)
+        remaining = list(copies)
+        named = False
+        accounted = 0
+        for default_set in sets_by_carrier[carrier_id]:
+            members = list(
+                default_set.members.filter(**{f"{kind}_id": assignable_id}).order_by(
+                    "pk"
+                )
+            )
+            if not members:
+                continue
+            named = True
+            # A member already accounted for by a tagged copy — live or
+            # archived — is settled; only the rest may claim a legacy copy.
+            settled = set(
+                Assignment.objects.filter(
+                    materialised_from__in=members, materialised_for=carrier
+                ).values_list("materialised_from_id", flat=True)
+            )
+            accounted += len(settled)
+            open_members = [member for member in members if member.pk not in settled]
+            for copy, member in zip(remaining, open_members, strict=False):
+                copy.materialised_from = member
+                copy.materialised_for = carrier
+                copy.save(
+                    update_fields=["materialised_from", "materialised_for", "modified"]
+                )
+                outcome.tagged += 1
+            remaining = remaining[len(open_members) :]
+        if not named:
             outcome.unmatched += len(copies)
             continue
-        # A member already accounted for by a tagged copy — live or
-        # archived — is settled; only the rest may claim a legacy copy.
-        accounted = set(
-            Assignment.objects.filter(
-                materialised_from__in=candidates, materialised_for=carrier
-            ).values_list("materialised_from_id", flat=True)
-        )
-        open_members = [member for member in candidates if member.pk not in accounted]
-        for copy, member in zip(copies, open_members, strict=False):
-            copy.materialised_from = member
-            copy.materialised_for = carrier
-            copy.save(
-                update_fields=["materialised_from", "materialised_for", "modified"]
-            )
-            outcome.tagged += 1
-        left_over = max(len(copies) - len(open_members), 0)
-        already = min(left_over, len(accounted))
+        already = min(len(remaining), accounted)
         outcome.already += already
-        outcome.ambiguous += left_over - already
+        outcome.ambiguous += len(remaining) - already
+
+
+def _sets_in_claiming_order(carrier):
+    """The carrier's sets, in the order they claim legacy copies: the
+    chosen option sets, last recorded first, then the built-ins. The
+    reverse of the order they materialised in, so that newest-first
+    claiming hands each set the copies it wrote."""
+    chosen = carrier.chosen_options.select_related("default_set").order_by("-pk")
+    ordered = [taken.default_set for taken in chosen]
+    built = getattr(carrier.assignable, "built_ins", None)
+    if built is not None and built.pk not in {s.pk for s in ordered}:
+        ordered.append(built)
+    return ordered
 
 
 def _of_kinds(kinds):

--- a/n26/core/backfill_built_ins.py
+++ b/n26/core/backfill_built_ins.py
@@ -1,0 +1,273 @@
+"""Fighters catch up with the built-ins they were hired without.
+
+Two things went unrecorded before provenance existed. A grant a set
+materialised carried no note of which member it came from or which
+carrier it came for — only the shape it was written in: reason
+``DEFAULT``, caused by the carrier. And a member added to a set after
+a hire never reached the models already hired from it. This module
+settles both, one gang at a time, inside one ``operation(gang)``:
+
+1. **Tag.** Every grant in the gang written in the legacy shape is
+   matched to the member it must have come from — a member of one of
+   its carrier's sets (``sets_for``: the carrier's built-ins and the
+   option sets it took) naming the same assignable — and the pair is
+   written onto it. A weapon's own free firing lines are not set
+   members and are left alone. Where a set names the same assignable
+   more than once (twin guns), the carrier's untagged copies are paired
+   to the members newest copy first, one per member, as many as the
+   set has members and provenance does not already account for; a copy
+   left over stays untagged and is counted as ambiguous. A copy whose
+   member is gone stays untagged and is counted.
+
+   Tagging writes provenance and nothing else — no ledger entry, no
+   event, no repin. It changes how a grant is recorded, not what the
+   owner has, which is the one exception ``n26/core/CLAUDE.md`` allows
+   to the rule that player data is written only by an operation's
+   verbs: it moves no money, and the gang is proved to reconcile after.
+
+2. **Catch up.** Every live carrier in the gang is reconciled against
+   its sets, so a member added after the hire arrives now, recorded as
+   caught up. Where the carrier's model — or the gang, for a
+   gang-hosted carrier — already holds a live copy of the member's
+   thing that arrived some other way (bought, rewarded, edited in,
+   granted by a modifier), the member is skipped and the carrier named
+   in the outcome: the backfill never creates a duplicate. That is a
+   backfill-only reading; live propagation judges by provenance alone
+   (``n26.core.builtins``).
+
+Both steps are idempotent, so a gang may be walked again: a second
+pass tags nothing and grants nothing. Archived grants are tagged like
+live ones, because a grant the owner sold or removed is settled and
+must never be granted again — the tag is what says so.
+"""
+
+from dataclasses import dataclass, field
+
+from django.db.models import Count, Q
+
+from n26.core.builtins import plan_defaults, sets_for
+from n26.core.models import Assignment, Gang, LedgerEvent, Reason
+from n26.core.operations import operation
+from n26.library.models.defaults import DEFAULT_ASSIGNABLE_FIELDS
+
+#: The kinds a legacy grant may be: what a set can name, less a
+#: weapon's firing lines, which are its own free profiles rather than
+#: members of any set.
+TAGGABLE_KINDS = tuple(
+    kind for kind in DEFAULT_ASSIGNABLE_FIELDS if kind != "weapon_profile"
+)
+
+#: Grants written before provenance existed, in the shape that says so.
+LEGACY_SHAPE = {
+    "materialised_from__isnull": True,
+    "ledger_entry__reason": Reason.DEFAULT,
+    "removes": False,
+}
+
+
+@dataclass
+class GangOutcome:
+    """What the backfill did to one gang, in counts, plus the carriers
+    it left holding a member's thing some other way."""
+
+    gang_id: str
+    #: Legacy grants given their provenance.
+    tagged: int = 0
+    #: Legacy grants whose member is already accounted for by a tagged
+    #: copy — a live copy for the pair stood, so no second was tagged.
+    already: int = 0
+    #: Legacy grants with more copies than the set has members.
+    ambiguous: int = 0
+    #: Legacy grants whose member no set of their carrier names.
+    unmatched: int = 0
+    #: Members materialised as caught up.
+    granted: int = 0
+    #: Members reconcile could not place — ammo with no gun.
+    skipped: int = 0
+    #: Sentences, one per member skipped because the carrier's model
+    #: already holds the thing another way.
+    held_another_way: list = field(default_factory=list)
+
+    def counts(self):
+        return {
+            "tagged": self.tagged,
+            "already": self.already,
+            "ambiguous": self.ambiguous,
+            "unmatched": self.unmatched,
+            "granted": self.granted,
+            "skipped": self.skipped,
+            "held_another_way": len(self.held_another_way),
+        }
+
+
+def catch_up(gang_id):
+    """Settle one gang: tag its legacy grants, then catch every live
+    carrier up with its sets. One operation, committing on its own."""
+    gang = Gang.objects.get(pk=gang_id)
+    outcome = GangOutcome(gang_id=str(gang_id))
+    with operation(gang, actor=None) as op:
+        _tag_legacy_grants(gang, outcome)
+        _catch_up_carriers(op, gang, outcome)
+    return outcome
+
+
+# --- tagging -------------------------------------------------------------
+
+
+def _tag_legacy_grants(gang, outcome):
+    legacy = (
+        Assignment.objects.filter(
+            gang_root=gang, caused_by__isnull=False, **LEGACY_SHAPE
+        )
+        .filter(_of_kinds(TAGGABLE_KINDS))
+        .select_related("caused_by")
+        .order_by("-pk")
+    )
+    groups = {}
+    for copy in legacy:
+        kind = _kind_of(copy)
+        groups.setdefault(
+            (copy.caused_by_id, kind, getattr(copy, f"{kind}_id")), []
+        ).append(copy)
+
+    sets_by_carrier = {}
+    for (carrier_id, kind, assignable_id), copies in groups.items():
+        carrier = copies[0].caused_by
+        if carrier_id not in sets_by_carrier:
+            sets_by_carrier[carrier_id] = sets_for(carrier)
+        candidates = [
+            member
+            for default_set in sets_by_carrier[carrier_id]
+            for member in default_set.members.filter(**{f"{kind}_id": assignable_id})
+        ]
+        if not candidates:
+            outcome.unmatched += len(copies)
+            continue
+        # A member already accounted for by a tagged copy — live or
+        # archived — is settled; only the rest may claim a legacy copy.
+        accounted = set(
+            Assignment.objects.filter(
+                materialised_from__in=candidates, materialised_for=carrier
+            ).values_list("materialised_from_id", flat=True)
+        )
+        open_members = [member for member in candidates if member.pk not in accounted]
+        for copy, member in zip(copies, open_members, strict=False):
+            copy.materialised_from = member
+            copy.materialised_for = carrier
+            copy.save(
+                update_fields=["materialised_from", "materialised_for", "modified"]
+            )
+            outcome.tagged += 1
+        left_over = max(len(copies) - len(open_members), 0)
+        already = min(left_over, len(accounted))
+        outcome.already += already
+        outcome.ambiguous += left_over - already
+
+
+def _of_kinds(kinds):
+    holds = Q()
+    for kind in kinds:
+        holds |= Q(**{f"{kind}__isnull": False})
+    return holds
+
+
+def _kind_of(assignment):
+    for kind in TAGGABLE_KINDS:
+        if getattr(assignment, f"{kind}_id") is not None:
+            return kind
+    raise ValueError(f"{assignment} names nothing a set can grant.")
+
+
+# --- catching up ---------------------------------------------------------
+
+
+def _catch_up_carriers(op, gang, outcome):
+    for carrier in _carriers_in(gang):
+        # The founding is gang-hosted and about no model, so its grants
+        # land on the gang — the same split hire makes.
+        hosted_on_gang = (
+            carrier.miniature_root_id is None and carrier.gang_id is not None
+        )
+        host_gang = carrier.gang if hosted_on_gang else None
+        omit = []
+        for member in plan_defaults(carrier).missing:
+            if _held_another_way(member, carrier, host_gang):
+                omit.append(member.pk)
+                outcome.held_another_way.append(
+                    f"{_name_of(carrier, host_gang)} already holds "
+                    f"{member.assignable} another way"
+                )
+        result = op.reconcile_defaults(
+            carrier,
+            gang=host_gang,
+            strict=False,
+            event_kind=LedgerEvent.Kind.CAUGHT_UP,
+            omit=omit,
+        )
+        outcome.granted += len(result.created)
+        outcome.skipped += len(result.skipped) - len(omit)
+
+
+def _carriers_in(gang):
+    """The gang's live carriers: every assignment whose thing has
+    built-ins, and every one that took an option set. A removal is
+    machinery, not a use; an archived carrier is settled history."""
+    holds = Q(chosen_options__isnull=False)
+    for kind in Assignment.ASSIGNABLE_FIELDS:
+        holds |= Q(**{f"{kind}__built_ins__isnull": False})
+    return (
+        Assignment.objects.filter(gang_root=gang, archived=False, removes=False)
+        .filter(holds)
+        .distinct()
+        .order_by("pk")
+    )
+
+
+def _held_another_way(member, carrier, host_gang):
+    """Whether the carrier's model — or the gang, for a gang-hosted
+    carrier — holds a live copy of the member's thing that no set
+    materialised: bought, rewarded, edited in, or granted by a
+    modifier. Such a copy carries no provenance and a reason other
+    than ``DEFAULT``."""
+    assignable = member.assignable
+    scope = {
+        Assignment.field_for(assignable): assignable,
+        "archived": False,
+        "removes": False,
+        "materialised_from__isnull": True,
+    }
+    if host_gang is not None:
+        scope["gang"] = host_gang
+    elif carrier.miniature_root_id is not None:
+        scope["miniature_root_id"] = carrier.miniature_root_id
+    else:
+        return False
+    return (
+        Assignment.objects.filter(**scope)
+        .exclude(ledger_entry__reason=Reason.DEFAULT)
+        .exists()
+    )
+
+
+def _name_of(carrier, host_gang):
+    if host_gang is not None:
+        return f"the gang ({carrier.assignable})"
+    model = carrier.miniature_root
+    return f"{model.name} ({carrier.assignable})" if model else str(carrier)
+
+
+# --- preview -------------------------------------------------------------
+
+
+def legacy_grants_by_kind():
+    """How many grants in unarchived gangs still carry no provenance,
+    by what they name. One query."""
+    counted = Assignment.objects.filter(
+        gang_root__archived=False, **LEGACY_SHAPE
+    ).aggregate(
+        **{
+            kind: Count("pk", filter=Q(**{f"{kind}__isnull": False}))
+            for kind in DEFAULT_ASSIGNABLE_FIELDS
+        }
+    )
+    return {kind: counted[kind] for kind in DEFAULT_ASSIGNABLE_FIELDS}

--- a/n26/core/builtins.py
+++ b/n26/core/builtins.py
@@ -126,7 +126,7 @@ class ReconcileOutcome:
     skipped: list
 
 
-def plan_defaults(carrier, kinds=None, built_ins=True, fresh=()):
+def plan_defaults(carrier, kinds=None, built_ins=True, fresh=(), omit=()):
     """Walk a carrier's sets and say which members lack their copy.
 
     Only live members count — an archived member is a built-in an
@@ -141,10 +141,15 @@ def plan_defaults(carrier, kinds=None, built_ins=True, fresh=()):
     re-gift what an owner parted with — while taking a set is an
     acquisition, and what is bought arrives: the copies a set's earlier
     tenure left archived are history, not a settled grant.
+
+    ``omit`` names members, by primary key, to treat as satisfied
+    whatever provenance says — for a caller that has judged the carrier
+    already holds the thing another way and must not be handed a second.
     """
     if kinds is None:
         kinds = kinds_for(carrier)
     fresh_pks = {default_set.pk for default_set in fresh}
+    omitted = set(omit)
     entries = []
     for default_set in sets_for(carrier, built_ins=built_ins):
         include_archived = default_set.pk not in fresh_pks
@@ -157,9 +162,8 @@ def plan_defaults(carrier, kinds=None, built_ins=True, fresh=()):
             entries.append(
                 MemberPlan(
                     member=member,
-                    satisfied=is_satisfied(
-                        member, carrier, include_archived=include_archived
-                    ),
+                    satisfied=member.pk in omitted
+                    or is_satisfied(member, carrier, include_archived=include_archived),
                 )
             )
     return DefaultsPlan(carrier=carrier, entries=tuple(entries))

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -1161,6 +1161,7 @@ class Operation:
         strict=True,
         fresh=(),
         event_kind=None,
+        omit=(),
         _chain=(),
     ):
         """Create what the carrier's sets say is missing, and nothing else.
@@ -1216,6 +1217,11 @@ class Operation:
         pass says its grants arrived by catch-up, so a reader asking
         why a thing appeared long after the hire gets the answer.
 
+        ``omit`` names members, by primary key, the caller has judged
+        the carrier already holds another way. Each is treated as
+        satisfied and recorded among the skips with that reason, so
+        nothing is created for it and the outcome still says so.
+
         A copy created here is itself an arrival, and a thing with
         built-ins of its own brings them wherever it arrives — a subtype
         granted by a profile brings the counters built into the subtype.
@@ -1240,7 +1246,10 @@ class Operation:
         from n26.library.models import Weapon, WeaponProfile
 
         narrowed = kinds if kinds is not None else kinds_for(carrier)
-        plan = plan_defaults(carrier, kinds=narrowed, built_ins=built_ins, fresh=fresh)
+        omitted = set(omit)
+        plan = plan_defaults(
+            carrier, kinds=narrowed, built_ins=built_ins, fresh=fresh, omit=omitted
+        )
 
         miniature = None if gang is not None else carrier.miniature_root
         if gang is not None:
@@ -1260,10 +1269,14 @@ class Operation:
             entry
             for entry in plan.entries
             if isinstance(entry.member.assignable, WeaponProfile)
+            and entry.member.pk not in omitted
         ]
         for entry in plan.entries:
             member = entry.member
             assignable = member.assignable
+            if member.pk in omitted:
+                skipped.append((entry, f"{assignable} is already held another way."))
+                continue
             if isinstance(assignable, WeaponProfile):
                 continue
             if entry.satisfied:

--- a/n26/core/templates/admin/maintenance/n26/_backfill_built_ins_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_backfill_built_ins_detail.html
@@ -1,0 +1,63 @@
+{% comment %}
+    The summary of one built-ins backfill run, on the Backfill detail
+    page: how far the walk has got, the totals so far, the carriers
+    left holding a member's thing another way, and the gangs that
+    could not be settled. Every gang commits on its own, so the totals
+    of a run still working are what it has already done.
+{% endcomment %}
+<h2>Progress</h2>
+<p>
+    {{ backfill.summary.done|default:0 }} of {{ backfill.summary.total|default:"?" }} gang{{ backfill.summary.total|pluralize }} settled.
+    {% if backfill.summary.attempts %}
+        Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }} since the last batch landed.
+    {% endif %}
+</p>
+{% if backfill.summary.totals %}
+    <h2>Totals</h2>
+    <table class="table">
+        <tr>
+            <th>Legacy grants tagged with their provenance</th>
+            <td>{{ backfill.summary.totals.tagged|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Left untagged: a tagged copy already stood for the member</th>
+            <td>{{ backfill.summary.totals.already|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Left untagged: more copies than the set has members</th>
+            <td>{{ backfill.summary.totals.ambiguous|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Left untagged: no set of the carrier names the thing</th>
+            <td>{{ backfill.summary.totals.unmatched|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Members granted as caught up</th>
+            <td>{{ backfill.summary.totals.granted|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Members skipped: already held another way</th>
+            <td>{{ backfill.summary.totals.held_another_way|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Members skipped: nothing to place them on</th>
+            <td>{{ backfill.summary.totals.skipped|default:0 }}</td>
+        </tr>
+    </table>
+{% endif %}
+{% if backfill.summary.held_another_way %}
+    <h2>Held another way</h2>
+    <ul>
+        {% for line in backfill.summary.held_another_way %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+{% if backfill.summary.failures %}
+    <h2>Gangs that could not be settled</h2>
+    <ul>
+        {% for gang_id, why in backfill.summary.failures.items %}
+            <li>
+                <code>{{ gang_id }}</code>: {{ why }}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/backfill_built_ins.html
+++ b/n26/core/templates/admin/maintenance/n26/backfill_built_ins.html
@@ -1,0 +1,82 @@
+{% extends "admin/base_site.html" %}
+{% comment %}
+The built-ins backfill's console page: the grants still carrying no
+provenance, by kind; how many gangs the run would walk; a run button;
+the recent runs. The exact number of members the run will grant is
+only known by walking every carrier, so the page does not say it.
+Context from backfill_built_ins_view (n26/maintenance.py): title,
+gangs, legacy, legacy_total, apply_url, recent.
+{% endcomment %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    .mt-hint { color: #888; font-size: 0.85em; }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        Walks every unarchived gang. Each built-in grant written before
+        provenance was recorded is tagged with the set member it came from
+        and the carrier it came for; then every live carrier catches up with
+        what its sets say it comes with. A model that already holds a
+        member's thing some other way is skipped and named on the record.
+    </p>
+    <p>
+        {{ gangs }} gang{{ gangs|pluralize }} would be walked, holding {{ legacy_total }} grant{{ legacy_total|pluralize }} still without provenance.
+        How many members are granted is reported by the run.
+    </p>
+    <table class="mt-table">
+        <thead>
+            <tr>
+                <th>Kind</th>
+                <th>Grants without provenance</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for line in legacy %}
+                <tr>
+                    <td>{{ line.kind }}</td>
+                    <td>{{ line.count }}</td>
+                    <td class="mt-hint">{% if not line.taggable %}a weapon's own firing lines — left alone{% endif %}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <form method="post" class="mt-form">
+        {% csrf_token %}
+        <button type="submit" class="button default">Catch every gang up</button>
+    </form>
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "Operation",
+    "backfill_built_ins",
     "delete_nameless_gang_type",
     "repair_doubled_refunds",
     "run_batched",
@@ -146,6 +147,10 @@ class Operation(models.TextChoices):
         "n26_repair_doubled_refunds",
         "n26: the second refund a doubled click wrote is dropped",
     )
+    BACKFILL_BUILT_INS = (
+        "n26_backfill_built_ins",
+        "n26: fighters catch up with the built-ins they were hired without",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -156,6 +161,7 @@ LOCK_KEYS = {
     Operation.REPAIR_DOUBLED_REFUNDS: 826_020_609,
     Operation.CONVERT_CHAOS_GOD: 826_020_610,
     Operation.CONVERT_VARIANT: 826_020_611,
+    Operation.BACKFILL_BUILT_INS: 826_020_612,
 }
 
 
@@ -873,6 +879,120 @@ def audit_reconcile_view(request):
     return render(request, "admin/maintenance/n26/audit.html", context)
 
 
+@task
+def backfill_built_ins(backfill_id, **said_by_whoever_enqueued_it):
+    """Tag every legacy built-in grant with its provenance and catch
+    every live carrier up with its sets, one unarchived gang at a time.
+
+    Batched, because the whole estate is walked and each gang is its
+    own operation, committing on its own. What each gang came to is
+    added to the record's totals as it lands, so a run read part-way
+    still says what it has done so far.
+    """
+    from n26.core.backfill_built_ins import catch_up
+    from n26.core.models import Gang
+
+    record = Backfill.objects.get(pk=backfill_id)
+    totals = dict(record.summary.get("totals", {}))
+    held_another_way = list(record.summary.get("held_another_way", []))
+
+    def do_one(pk):
+        outcome = catch_up(pk)
+        for key, count in outcome.counts().items():
+            totals[key] = int(totals.get(key, 0)) + count
+        held_another_way.extend(outcome.held_another_way)
+        _write(
+            backfill_id,
+            summary_patch={"totals": totals, "held_another_way": held_another_way},
+        )
+
+    run_batched(
+        backfill_id,
+        operation=Operation.BACKFILL_BUILT_INS,
+        what="Built-ins backfill",
+        items=Gang.objects.filter(archived=False),
+        do_one=do_one,
+        again=lambda: backfill_built_ins.enqueue(backfill_id=backfill_id),
+    )
+
+
+def backfill_built_ins_view(request):
+    """Say what would be walked (GET), or record a run and enqueue it.
+
+    The preview is deliberately cheap — one count of the grants still
+    without provenance, by kind, and the number of gangs — because the
+    exact grant count is only known by walking every carrier, which is
+    the run's job, not the page's.
+    """
+    from n26.core.backfill_built_ins import TAGGABLE_KINDS, legacy_grants_by_kind
+    from n26.core.models import Gang
+
+    operation = Operation.BACKFILL_BUILT_INS
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That backfill is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": 0},
+        )
+        backfill_built_ins.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The backfill is running. This page shows what it does."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+    by_kind = legacy_grants_by_kind()
+    context = page_context(
+        request,
+        operation.label,
+        gangs=Gang.objects.filter(archived=False).count(),
+        legacy=[
+            {
+                "kind": kind.replace("_", " "),
+                "count": count,
+                "taggable": kind in TAGGABLE_KINDS,
+            }
+            for kind, count in by_kind.items()
+        ],
+        legacy_total=sum(
+            count for kind, count in by_kind.items() if kind in TAGGABLE_KINDS
+        ),
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+    )
+    return render(request, "admin/maintenance/n26/backfill_built_ins.html", context)
+
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.BACKFILL_BUILT_INS.value,
+        name=Operation.BACKFILL_BUILT_INS.label,
+        added=date(2026, 8, 29),
+        description=(
+            "Walk every unarchived gang. Each built-in grant written before "
+            "provenance was recorded is tagged with the set member it came "
+            "from and the carrier it came for; then every live carrier — "
+            "each model's membership, the gang's founding, a bought mount — "
+            "catches up with what its sets say it comes with, so a member "
+            "added after the hire arrives now, told in the history as "
+            "caught up. A model that already holds a member's thing some "
+            "other way is skipped and named on the record. Tagging moves no "
+            "money; every gang is proved to reconcile."
+        ),
+        view=backfill_built_ins_view,
+        detail_template="admin/maintenance/n26/_backfill_built_ins_detail.html",
+    )
+)
+
+
 register_operation(
     MaintenanceOperation(
         operation=Operation.AUDIT_RECONCILE.value,
@@ -1012,6 +1132,7 @@ task_routes = [
     TaskRoute(sweep_built_in_propagations, schedule="*/5 * * * *"),
     TaskRoute(audit_reconcile),
     TaskRoute(repair_doubled_refunds, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(backfill_built_ins, ack_deadline=600),
 ]
 
 

--- a/n26/tests/sandbox/test_builtin_backfill.py
+++ b/n26/tests/sandbox/test_builtin_backfill.py
@@ -311,6 +311,43 @@ class TestWhatTheOwnerAlreadySettled:
         assert held.get().ledger_entry.reason == Reason.REWARD
         assert settled(gang).rating == rating
 
+    def test_a_legacy_ammo_line_under_the_gun_is_not_granted_twice(
+        self, gang, person_type, gang_type, default_pack, launcher
+    ):
+        """A set's ammo member materialised before provenance existed
+        looks exactly like the gun's own free line — caused by the gun,
+        reason DEFAULT — so tagging leaves it alone; catch-up must still
+        see it under the gun rather than stack a second."""
+        from n26.library.models import WeaponProfile
+
+        smoke = WeaponProfile.objects.create(
+            name="Smoke", weapon=launcher, price=10, position=1
+        )
+        profile = create_profile("Gunner", person_type, gang_type, price=50)
+        gun_member = add_built_in(profile, launcher)
+        ammo_member = add_built_in(profile, smoke, gun_member=gun_member)
+        fighter = hire(gang, profile, "Ana", paid=50)
+        strip_provenance(gang)
+        rating = settled(gang).rating
+
+        record = run_backfill()
+
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["totals"]["granted"] == 0
+        assert record.summary["held_another_way"] == [
+            "Ana (Gunner) already carries Smoke under its Launcher"
+        ]
+        gun = Assignment.objects.get(
+            materialised_from=gun_member, materialised_for=fighter.membership
+        )
+        lines = Assignment.objects.filter(
+            parent=gun, weapon_profile=smoke, archived=False
+        )
+        assert lines.count() == 1
+        assert lines.get().materialised_from_id is None
+        assert not Assignment.objects.filter(materialised_from=ammo_member).exists()
+        assert settled(gang).rating == rating
+
 
 class TestRunningTwice:
     """The walk is idempotent: a second run tags nothing and grants

--- a/n26/tests/sandbox/test_builtin_backfill.py
+++ b/n26/tests/sandbox/test_builtin_backfill.py
@@ -105,6 +105,32 @@ def settled(gang):
     return gang
 
 
+class TestArchivedAndLiveTwinsPairLiveFirst:
+    """Where a set names the same thing through an archived member and a
+    live one, the live member claims the legacy copy — a copy bound to
+    the archived twin would leave the live one unsatisfied, and the
+    catch-up would grant the duplicate the pairing exists to prevent."""
+
+    def test_the_live_member_claims_the_copy_and_nothing_is_granted(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        profile = create_profile("Sergeant", person_type, gang_type, price=50)
+        sharp = create_skill("Sharp Eye")
+        gone = add_built_in(profile, sharp)
+        gone.archived = True
+        gone.save()
+        live = add_built_in(profile, sharp)
+        fighter = hire(gang, profile, "Ana", paid=50)
+        strip_provenance(gang)
+
+        run_backfill()
+
+        copies = Assignment.objects.filter(skill=sharp, miniature_root=fighter)
+        assert copies.count() == 1
+        assert copies.get().materialised_from == live
+        settled(gang)
+
+
 class TestTaggingLegacyGrants:
     """A grant written without provenance is matched to the member it
     came from, and the tag is all that is written."""

--- a/n26/tests/sandbox/test_builtin_backfill.py
+++ b/n26/tests/sandbox/test_builtin_backfill.py
@@ -1,0 +1,370 @@
+"""The built-ins backfill: fighters catch up with what they were hired without.
+
+Grants written before provenance existed carry only their shape — reason
+``DEFAULT``, caused by the carrier — and a member added to a set after a
+hire never reached the models already hired from it. The backfill walks
+every unarchived gang on the batched runner and, per gang, tags each
+legacy grant with the member and carrier it came from, then reconciles
+every live carrier so a later member arrives as caught up. Proven here:
+tagging alone moves no money; a gained member is granted with a
+catch-up event, free as every built-in is; twin guns pair one copy per
+member; a grant whose member is gone is left untagged and counted; the
+gang's founding and an option set tag like any carrier; a sold grant is
+tagged so it is never handed back; a model already holding a member's
+thing another way is skipped and named rather than given a second; a
+second run does nothing; and the console offers the operation without
+writing on GET.
+
+The legacy shape is planted the way it really arose: hire normally, then
+strip the provenance the hire recorded.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from gyrinx.maintenance.models import Backfill
+from gyrinx.maintenance.registry import operations, resolve_operation
+from n26.core.models import Assignment, LedgerEvent, Reason
+from n26.core.reconcile import assert_reconciled
+from n26.library.models import DefaultAssignment
+from n26.maintenance import Operation, backfill_built_ins, backfill_built_ins_view
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    create_profile,
+    create_rule,
+    create_skill,
+    create_weapon,
+    found_gang,
+    hire,
+    hire_with_option,
+    learn,
+    offer_option,
+    sell,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def player():
+    return User.objects.create_user("veteran")
+
+
+@pytest.fixture
+def gang(gang_type, player):
+    return found_gang("The Old Guard", gang_type, owner=player, budget=1000)
+
+
+@pytest.fixture
+def launcher(default_pack):
+    return create_weapon("Launcher", profiles=[("Frag", 0)], price=30)
+
+
+@pytest.fixture
+def ganger(person_type, gang_type, default_pack, launcher):
+    """A profile that comes with a rule and a gun."""
+    profile = create_profile("Ganger", person_type, gang_type, price=50)
+    add_built_in(profile, create_rule("Gang Fighter"))
+    add_built_in(profile, launcher)
+    return profile
+
+
+def strip_provenance(gang):
+    """What every grant looked like before provenance was recorded."""
+    return Assignment.objects.filter(
+        gang_root=gang, materialised_from__isnull=False
+    ).update(materialised_from=None, materialised_for=None)
+
+
+def legacy_grants(gang):
+    return Assignment.objects.filter(
+        gang_root=gang,
+        materialised_from__isnull=True,
+        ledger_entry__reason=Reason.DEFAULT,
+        weapon_profile__isnull=True,
+    )
+
+
+def run_backfill():
+    record = Backfill.objects.create(
+        operation=Operation.BACKFILL_BUILT_INS,
+        status=Backfill.Status.RUNNING,
+        summary={"attempts": 0},
+    )
+    backfill_built_ins.func(backfill_id=str(record.pk))
+    record.refresh_from_db()
+    return record
+
+
+def settled(gang):
+    gang.refresh_from_db()
+    assert_reconciled(gang)
+    return gang
+
+
+class TestTaggingLegacyGrants:
+    """A grant written without provenance is matched to the member it
+    came from, and the tag is all that is written."""
+
+    def test_a_legacy_fighter_whose_set_is_unchanged_is_tagged_and_gains_nothing(
+        self, gang, ganger
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        stripped = strip_provenance(gang)
+        assert stripped == 2
+        rating = settled(gang).rating
+        events = LedgerEvent.objects.filter(gang=gang).count()
+
+        record = run_backfill()
+
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["totals"]["tagged"] == 2
+        assert record.summary["totals"]["granted"] == 0
+        assert record.summary["totals"]["unmatched"] == 0
+        assert not legacy_grants(gang).exists()
+        for member in ganger.built_ins.members.all():
+            assert Assignment.objects.filter(
+                materialised_from=member,
+                materialised_for=fighter.membership,
+                archived=False,
+            ).exists()
+        assert LedgerEvent.objects.filter(gang=gang).count() == events
+        assert settled(gang).rating == rating
+
+    def test_a_member_gained_after_the_hire_arrives_as_caught_up(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        rating = settled(gang).rating
+        knife = create_weapon("Knife", profiles=[("Stab", 0)], price=15)
+        # Propagation is shut, so the member waits for the backfill.
+        member = add_built_in(ganger, knife)
+        assert not Assignment.objects.filter(materialised_from=member).exists()
+
+        record = run_backfill()
+
+        assert record.summary["totals"]["tagged"] == 2
+        assert record.summary["totals"]["granted"] == 1
+        copy = Assignment.objects.get(
+            materialised_from=member, materialised_for=fighter.membership
+        )
+        assert copy.archived is False
+        assert copy.miniature_root_id == fighter.pk
+        assert LedgerEvent.objects.filter(
+            gang=gang, assignment=copy, kind=LedgerEvent.Kind.CAUGHT_UP
+        ).exists()
+        # A built-in is free: the hire's package carries the money, so
+        # what arrives late is worth nothing on its own.
+        assert copy.ledger_entry.rating_contribution == 0
+        assert settled(gang).rating == rating
+
+    def test_twin_guns_pair_one_copy_to_each_member(
+        self, gang, person_type, gang_type, default_pack, launcher
+    ):
+        profile = create_profile("Twin gunner", person_type, gang_type, price=50)
+        first = add_built_in(profile, launcher)
+        second = add_built_in(profile, launcher)
+        fighter = hire(gang, profile, "Ana", paid=50)
+        strip_provenance(gang)
+
+        record = run_backfill()
+
+        assert record.summary["totals"]["tagged"] == 2
+        assert record.summary["totals"]["ambiguous"] == 0
+        assert record.summary["totals"]["granted"] == 0
+        tagged = Assignment.objects.filter(
+            materialised_for=fighter.membership, weapon=launcher
+        )
+        assert sorted(tagged.values_list("materialised_from_id", flat=True)) == sorted(
+            [first.pk, second.pk]
+        )
+        assert (
+            Assignment.objects.filter(
+                miniature_root=fighter, weapon=launcher, archived=False
+            ).count()
+            == 2
+        )
+        settled(gang)
+
+    def test_a_grant_whose_member_is_gone_is_left_untagged_and_counted(
+        self, gang, ganger
+    ):
+        hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        gone = ganger.built_ins.members.get(rule__isnull=False)
+        DefaultAssignment.objects.filter(pk=gone.pk).delete()
+        events = LedgerEvent.objects.filter(gang=gang).count()
+
+        record = run_backfill()
+
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["totals"]["tagged"] == 1
+        assert record.summary["totals"]["unmatched"] == 1
+        assert record.summary["totals"]["granted"] == 0
+        orphan = legacy_grants(gang).get()
+        assert orphan.rule is not None
+        assert orphan.archived is False
+        assert LedgerEvent.objects.filter(gang=gang).count() == events
+        settled(gang)
+
+
+class TestEveryKindOfCarrier:
+    """The gang's founding and an option set materialise the same way a
+    hire does, and are tagged and caught up the same way."""
+
+    def test_the_gang_type_set_tags_and_catches_up_on_the_gang(
+        self, gang_type, player, default_pack
+    ):
+        creed = add_built_in(gang_type, create_rule("House Creed"))
+        gang = found_gang("The Old Guard", gang_type, owner=player, budget=1000)
+        strip_provenance(gang)
+        later = add_built_in(gang_type, create_rule("New Law"))
+
+        record = run_backfill()
+
+        assert record.summary["totals"]["tagged"] == 1
+        assert record.summary["totals"]["granted"] == 1
+        for member in (creed, later):
+            copy = Assignment.objects.get(
+                materialised_from=member, materialised_for=gang.founding
+            )
+            assert copy.gang_id == gang.pk
+            assert copy.miniature_root_id is None
+        settled(gang)
+
+    def test_an_option_sets_members_are_tagged_for_the_carrier_that_took_it(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        profile = create_profile("Chooser", person_type, gang_type, price=100)
+        offer_option(profile, "Plain", thing=create_rule("Plain Style"))
+        fancy = offer_option(profile, "Fancy", thing=create_rule("Fancy Style"))
+        fancy_style = fancy.default_set.members.get()
+        took_it = hire_with_option(gang, profile, "Ana", option=fancy.default_set)
+        went_plain = hire_with_option(gang, profile, "Bea")
+        strip_provenance(gang)
+
+        record = run_backfill()
+
+        assert record.summary["totals"]["granted"] == 0
+        assert record.summary["totals"]["unmatched"] == 0
+        assert Assignment.objects.filter(
+            materialised_from=fancy_style, materialised_for=took_it.membership
+        ).exists()
+        assert not Assignment.objects.filter(
+            materialised_from=fancy_style, materialised_for=went_plain.membership
+        ).exists()
+        assert not legacy_grants(gang).exists()
+        settled(gang)
+
+
+class TestWhatTheOwnerAlreadySettled:
+    """A grant the owner sold is tagged where it lies, so it is never
+    handed back; a thing the model already holds another way is not
+    duplicated, and the carrier is named."""
+
+    def test_a_sold_built_in_is_tagged_and_not_granted_again(
+        self, gang, ganger, launcher
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        gun = Assignment.objects.get(miniature_root=fighter, weapon=launcher)
+        sell(gun)
+        strip_provenance(gang)
+        credits = settled(gang).credits
+
+        record = run_backfill()
+
+        assert record.summary["totals"]["tagged"] == 2
+        assert record.summary["totals"]["granted"] == 0
+        gun.refresh_from_db()
+        assert gun.archived is True
+        assert gun.materialised_for_id == fighter.membership.pk
+        assert not Assignment.objects.filter(
+            miniature_root=fighter, weapon=launcher, archived=False
+        ).exists()
+        assert settled(gang).credits == credits
+
+    def test_a_member_the_model_holds_as_a_reward_is_skipped_and_named(
+        self, gang, ganger, default_pack
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        nerves = create_skill("Nerves of Steel")
+        learn(fighter, nerves)
+        member = add_built_in(ganger, nerves)
+        rating = settled(gang).rating
+
+        record = run_backfill()
+
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["totals"]["granted"] == 0
+        assert record.summary["totals"]["held_another_way"] == 1
+        assert record.summary["held_another_way"] == [
+            "Ana (Ganger) already holds Nerves of Steel another way"
+        ]
+        assert not Assignment.objects.filter(materialised_from=member).exists()
+        held = Assignment.objects.filter(
+            miniature_root=fighter, skill=nerves, archived=False
+        )
+        assert held.count() == 1
+        assert held.get().ledger_entry.reason == Reason.REWARD
+        assert settled(gang).rating == rating
+
+
+class TestRunningTwice:
+    """The walk is idempotent: a second run tags nothing and grants
+    nothing."""
+
+    def test_a_second_run_finds_nothing_to_do(self, gang, ganger, default_pack):
+        hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        add_built_in(ganger, create_rule("Late Addition"))
+        first = run_backfill()
+        assert first.summary["totals"]["tagged"] == 2
+        assert first.summary["totals"]["granted"] == 1
+        assignments = Assignment.objects.filter(gang_root=gang).count()
+        events = LedgerEvent.objects.filter(gang=gang).count()
+
+        second = run_backfill()
+
+        assert second.status == Backfill.Status.DONE
+        assert second.summary["totals"]["tagged"] == 0
+        assert second.summary["totals"]["granted"] == 0
+        assert Assignment.objects.filter(gang_root=gang).count() == assignments
+        assert LedgerEvent.objects.filter(gang=gang).count() == events
+        settled(gang)
+
+
+class TestTheConsoleDoor:
+    """The operation is registered under its label, and its page says
+    what a run would walk without writing anything."""
+
+    @pytest.fixture
+    def superuser(self, db):
+        return User.objects.create_superuser("boss", "boss@example.com", "password")
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.BACKFILL_BUILT_INS.value in registered
+        found = resolve_operation(Operation.BACKFILL_BUILT_INS.value)
+        assert found.name == Operation.BACKFILL_BUILT_INS.label
+        assert found.view is backfill_built_ins_view
+
+    def test_its_page_counts_the_legacy_grants_and_writes_nothing(
+        self, client, superuser, gang, ganger
+    ):
+        hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_backfill_built_ins"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "1 gang would be walked" in page
+        assert "2 grants still without provenance" in page
+        assert "a weapon's own firing lines — left alone" in page
+        assert not Backfill.objects.exists()
+        assert legacy_grants(gang).count() == 2

--- a/n26/tests/sandbox/test_builtin_backfill.py
+++ b/n26/tests/sandbox/test_builtin_backfill.py
@@ -477,3 +477,4 @@ class TestTheConsoleDoor:
         assert "a weapon's own firing lines — left alone" in page
         assert not Backfill.objects.exists()
         assert legacy_grants(gang).count() == 2
+        settled(gang)

--- a/n26/tests/sandbox/test_builtin_backfill.py
+++ b/n26/tests/sandbox/test_builtin_backfill.py
@@ -26,11 +26,13 @@ from django.urls import reverse
 from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import operations, resolve_operation
 from n26.core.models import Assignment, LedgerEvent, Reason
+from n26.core.operations import operation
 from n26.core.reconcile import assert_reconciled
 from n26.library.models import DefaultAssignment
 from n26.maintenance import Operation, backfill_built_ins, backfill_built_ins_view
 from n26.tests.sandbox.actions import (
     add_built_in,
+    create_option_group,
     create_profile,
     create_rule,
     create_skill,
@@ -256,6 +258,76 @@ class TestEveryKindOfCarrier:
             materialised_from=fancy_style, materialised_for=went_plain.membership
         ).exists()
         assert not legacy_grants(gang).exists()
+        settled(gang)
+
+    def test_a_built_in_and_an_option_naming_the_same_gun_each_keep_their_own_copy(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        """The built-ins materialise first, so the older copy is the
+        built-in's and the newer the option's — and dropping the option
+        later must take only its own copy."""
+        autopistol = create_weapon("Autopistol", profiles=[("Standard", 0)], price=10)
+        profile = create_profile("Pistolier", person_type, gang_type, price=50)
+        built_in = add_built_in(profile, autopistol)
+        plain = offer_option(profile, "Plain", thing=create_rule("Plain Style"))
+        twin = offer_option(profile, "Second pistol", thing=autopistol)
+        twin_member = twin.default_set.members.get()
+        fighter = hire_with_option(gang, profile, "Ana", option=twin.default_set)
+        strip_provenance(gang)
+
+        run_backfill()
+
+        older, newer = Assignment.objects.filter(
+            miniature_root=fighter, weapon=autopistol
+        ).order_by("pk")
+        assert older.materialised_from_id == built_in.pk
+        assert newer.materialised_from_id == twin_member.pk
+
+        with operation(gang, actor=gang.owner) as op:
+            op.rechoose(fighter.membership, option=plain.default_set)
+
+        older.refresh_from_db()
+        newer.refresh_from_db()
+        assert older.archived is False
+        assert newer.archived is True
+        settled(gang)
+
+    def test_two_options_naming_the_same_thing_each_unwind_their_own_copy(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        """Two chosen sets naming one thing pair deterministically: the
+        set recorded last claims the newest copy, so each copy leaves
+        with the set that brought it."""
+        grit = create_rule("Grit")
+        profile = create_profile("Stubborn", person_type, gang_type, price=50)
+        first = offer_option(profile, "First grit", thing=grit)
+        extra = create_option_group(profile, "Extra", choose="any")
+        second = offer_option(profile, "Second grit", thing=grit, group=extra)
+        first_member = first.default_set.members.get()
+        second_member = second.default_set.members.get()
+        fighter = hire_with_option(
+            gang, profile, "Ana", option=[first.default_set, second.default_set]
+        )
+        strip_provenance(gang)
+
+        record = run_backfill()
+
+        assert record.summary["totals"]["ambiguous"] == 0
+        older, newer = Assignment.objects.filter(
+            miniature_root=fighter, rule=grit
+        ).order_by("pk")
+        recorded_last = fighter.membership.chosen_options.order_by("-pk").first()
+        assert recorded_last.default_set_id == second.default_set.pk
+        assert older.materialised_from_id == first_member.pk
+        assert newer.materialised_from_id == second_member.pk
+
+        with operation(gang, actor=gang.owner) as op:
+            op.rechoose(fighter.membership, option=[first.default_set])
+
+        older.refresh_from_db()
+        newer.refresh_from_db()
+        assert older.archived is False
+        assert newer.archived is True
         settled(gang)
 
 


### PR DESCRIPTION
Refs #2165 — chunk C7, the retroactive built-ins backfill.

## What this adds

A maintenance operation, **n26: fighters catch up with the built-ins they were hired without** (`n26_backfill_built_ins`), on the batched runner. It walks every unarchived gang, one gang per batch item, each inside one `operation(gang)`:

1. **Tag.** Every assignment with ledger reason `DEFAULT` and no provenance (the shape every built-in grant was written in before provenance existed) is matched to the set member it came from and the carrier it came for, and the pair is written onto it. The carrier is `caused_by`; the candidate members are the carrier's built-ins plus the option sets it took (`builtins.sets_for`), archived members included, naming the same assignable. Where a set names the same thing more than once (twin guns), the carrier's untagged copies are paired to the members newest copy first, one per member, as many as the set has members and existing provenance does not already account for — the same resolution `_granted_rows_without_provenance` uses. A copy left over stays untagged and is counted as ambiguous; a copy whose member is gone stays untagged and is counted. A weapon's own free firing lines are not set members and are left alone. Tagging writes provenance only — no ledger entry, no event, no repin.
2. **Catch up.** Every live carrier in the gang is reconciled (`reconcile_defaults(strict=False, event_kind=CAUGHT_UP)`), so a member added to a set after the hire arrives now, told in the history as caught up. Where the carrier's model — or the gang, for a gang-hosted carrier — already holds a live copy of the member's thing that arrived some other way (bought, rewarded, edited in, modifier-granted: no provenance, reason other than `DEFAULT`), the member is skipped and the carrier named on the record. The backfill never creates a duplicate.

Both steps are idempotent; a second run tags nothing and grants nothing.

## Seam added

`plan_defaults` / `reconcile_defaults` gain `omit=()` — member primary keys treated as satisfied for that call and recorded in the outcome's `skipped` list with a sentence. Every existing call site passes nothing and behaves as before.

## The record

Per-gang outcomes are folded into the `Backfill` summary as it goes: `totals` (tagged / already / ambiguous / unmatched / granted / held_another_way / skipped) and a `held_another_way` list of sentences, alongside the runner's own done / total / cursor / failures. A detail fragment renders them on the record page. The console page shows a cheap preview only — untagged grants by kind in one query, and the number of gangs to walk; the exact grant count is reported by the run.

No migration.

## How to try it

- Sign in as a superuser, open Maintenance, pick the operation, read the counts, click *Catch every gang up*, and watch the record page fill in.
- `pytest n26/tests/sandbox/test_builtin_backfill.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
