### PR TITLE
fix: a several-pick choice says Add, in one size, on the card and in the picker

### DIFF
--- a/n26/core/printing.py
+++ b/n26/core/printing.py
@@ -80,7 +80,7 @@ def detail_groups(card) -> list[DetailGroup]:
         if choice.is_resolved and not choice.is_full:
             # On paper as on screen: a choice with room left says so,
             # because the sheet is read away from the picker.
-            chosen = f"{chosen} (choose)"
+            chosen = f"{chosen} (add)"
         groups.append(DetailGroup(choice.kind_label, chosen))
     for effect in card.effects:
         # "(when taken)" on paper as on screen. A printed card is read away

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -314,12 +314,18 @@ class ChoiceLine:
     #: Whether the choice will take another pick. A choice that holds one
     #: is full the moment it is resolved; one worked at a pick at a time
     #: stays open past its first, and the card keeps offering a way in
-    #: beside what is already held until this says otherwise.
-    is_full: bool = True
+    #: beside what is already held until this says otherwise. Left unsaid,
+    #: it follows the one-pick rule — full once chosen — so a line built
+    #: without a slot behind it, as a sample or a preview is, draws right.
+    is_full: bool | None = None
     #: Whether the choice may hold more than one pick. Decides the word
     #: on the control: a choice of one is chosen, a choice of several has
     #: picks added to it.
     takes_several: bool = False
+
+    def __post_init__(self):
+        if self.is_full is None:
+            object.__setattr__(self, "is_full", self.is_resolved)
 
     @property
     def is_resolved(self):

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -316,8 +316,8 @@ class ChoiceLine:
     #: stays open past its first, and the card keeps offering a way in
     #: beside what is already held until this says otherwise.
     is_full: bool = True
-    #: Whether the choice holds more than one pick. Decides the word on
-    #: the control: a choice of one is chosen, a choice of several has
+    #: Whether the choice may hold more than one pick. Decides the word
+    #: on the control: a choice of one is chosen, a choice of several has
     #: picks added to it.
     takes_several: bool = False
 

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -313,9 +313,13 @@ class ChoiceLine:
     href: str = ""
     #: Whether the choice will take another pick. A choice that holds one
     #: is full the moment it is resolved; one worked at a pick at a time
-    #: stays open past its first, and the card keeps offering Choose
+    #: stays open past its first, and the card keeps offering a way in
     #: beside what is already held until this says otherwise.
     is_full: bool = True
+    #: Whether the choice holds more than one pick. Decides the word on
+    #: the control: a choice of one is chosen, a choice of several has
+    #: picks added to it.
+    takes_several: bool = False
 
     @property
     def is_resolved(self):
@@ -822,6 +826,7 @@ def _choice_line(slot, host):
         kind_label=slot.kind_label,
         chosen=slot.chosen_name,
         is_full=slot.is_full,
+        takes_several=slot.max_picks > 1,
         key=_slot_key(slot, host),
         provenance=Provenance(
             source=slot.source,

--- a/n26/core/render_text.py
+++ b/n26/core/render_text.py
@@ -83,7 +83,7 @@ def render_model_card(card, indent=""):
         # link here. The provenance is deliberately not shown.
         chosen = choice.chosen if choice.is_resolved else "— (not chosen)"
         if choice.is_resolved and not choice.is_full:
-            chosen = f"{chosen} (choose)"
+            chosen = f"{chosen} (add)"
         lines.append(f"{indent}  {choice.kind_label}: {chosen}")
     if card.equipment:
         names = ", ".join(line.name for line in card.equipment)
@@ -135,7 +135,7 @@ def render_gang_sheet(sheet):
     for choice in sheet.choices:
         chosen = choice.chosen if choice.is_resolved else "— (not chosen)"
         if choice.is_resolved and not choice.is_full:
-            chosen = f"{chosen} (choose)"
+            chosen = f"{chosen} (add)"
         lines.append(f"{choice.kind_label}: {chosen}")
     if sheet.stash:
         lines.append(f"Stash — {sheet.stash_rating}cr")

--- a/n26/core/templates/cotton/n26/choice_picks.html
+++ b/n26/core/templates/cotton/n26/choice_picks.html
@@ -61,7 +61,7 @@ that holds one.
                             {% comment %}
                             The act says which option it acts on, for a reader who
                             hears the button rather than seeing the row it sits in:
-                            twenty-six buttons all called "Choose" are twenty-six
+                            twenty-six buttons all called "Add" are twenty-six
                             unlabelled buttons.
                             {% endcomment %}
                             {% if option.control == "remove" or option.control == "both" %}

--- a/n26/core/templates/cotton/n26/choice_picks.html
+++ b/n26/core/templates/cotton/n26/choice_picks.html
@@ -78,7 +78,7 @@ that holds one.
                                              value="{{ option.key }}"
                                              variant="success"
                                              size="sm"
-                                             aria-label="{% if offer.takes_several %}Add{% else %}Choose{% endif %} {{ option.name }}{% if option.control == "both" %} again{% endif %}">{% if offer.takes_several %}Add{% else %}Choose{% endif %}{% if option.control == "both" %} again{% endif %}</c-ui.button>
+                                             aria-label="Add {{ option.name }}{% if option.control == "both" %} again{% endif %}">Add{% if option.control == "both" %} again{% endif %}</c-ui.button>
                             {% endif %}
                         </li>
                     {% endfor %}

--- a/n26/core/templates/cotton/n26/choice_picks.html
+++ b/n26/core/templates/cotton/n26/choice_picks.html
@@ -78,7 +78,7 @@ that holds one.
                                              value="{{ option.key }}"
                                              variant="success"
                                              size="sm"
-                                             aria-label="Choose {{ option.name }}{% if option.control == "both" %} again{% endif %}">Choose{% if option.control == "both" %} again{% endif %}</c-ui.button>
+                                             aria-label="{% if offer.takes_several %}Add{% else %}Choose{% endif %} {{ option.name }}{% if option.control == "both" %} again{% endif %}">{% if offer.takes_several %}Add{% else %}Choose{% endif %}{% if option.control == "both" %} again{% endif %}</c-ui.button>
                             {% endif %}
                         </li>
                     {% endfor %}

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -164,7 +164,7 @@ draw the same thing.
                 {% endcomment %}
                 {% if choice.takes_several and choice.is_resolved and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="ms-2 text-xs">Add</c-n26.link>
                 {% elif choice.takes_several and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="text-xs">Add</c-n26.link>
-                {% elif not choice.is_resolved %}<c-n26.link href="{{ choice.href }}" underline="always">Choose</c-n26.link>{% endif %}
+                {% elif not choice.is_resolved and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always">Choose</c-n26.link>{% endif %}
             </dd>
         {% endfor %}
 

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -156,11 +156,15 @@ draw the same thing.
                 {% endcomment %}
                 {% if choice.is_resolved %}<c-n26.link href="{{ choice.href }}" tone="current">{{ choice.chosen }}</c-n26.link>{% endif %}
                 {% comment %}
-                A choice with room left keeps its Choose beside what it
-                holds — smaller there, so the picks stay the thing read.
+                A choice of one is chosen; a choice of several has picks
+                added to it, and keeps its Add beside what it holds while
+                there is room. The Add is one size whether or not anything
+                is held yet, so the control does not shrink the moment a
+                pick lands.
                 {% endcomment %}
-                {% if choice.is_resolved and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="ms-2 text-xs">Choose</c-n26.link>
-                {% elif not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always">Choose</c-n26.link>{% endif %}
+                {% if choice.takes_several and choice.is_resolved and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="ms-2 text-xs">Add</c-n26.link>
+                {% elif choice.takes_several and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="text-xs">Add</c-n26.link>
+                {% elif not choice.is_resolved %}<c-n26.link href="{{ choice.href }}" underline="always">Choose</c-n26.link>{% endif %}
             </dd>
         {% endfor %}
 

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -299,7 +299,14 @@ def choose(request, pk, slot):
             offer=offer.label,
             picked=picked.name,
         )
-        said = "Removed" if dropped else "Chose"
+        # The confirmation uses the verb the button did: a several-pick
+        # choice has picks added, a choice of one is chosen.
+        if dropped:
+            said = "Removed"
+        elif offer.takes_several:
+            said = "Added"
+        else:
+            said = "Chose"
         messages.success(request, f"{said} {picked.name} — {offer.label}.")
         return redirect(landing)
 

--- a/n26/core/views/choose.py
+++ b/n26/core/views/choose.py
@@ -299,8 +299,9 @@ def choose(request, pk, slot):
             offer=offer.label,
             picked=picked.name,
         )
-        # The confirmation uses the verb the button did: a several-pick
-        # choice has picks added, a choice of one is chosen.
+        # The confirmation says what happened in the choice's own terms: a
+        # several-pick choice has picks added to it, a choice of one is
+        # chosen — whatever the button that sent it was called.
         if dropped:
             said = "Removed"
         elif offer.takes_several:

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1464,8 +1464,10 @@ GROUPS: list[Group] = [
                 notes=(
                     "A flat list of options, one per row: the name, an "
                     "optional muted remark, and a button. Options the choice "
-                    "already holds show a red Remove; the rest show a green "
-                    "Choose. When the choice is full, only what it holds is "
+                    "already holds show a red Remove — and a green Add again, "
+                    "where the slot type allows repeats and there is room; "
+                    "the rest show a green Add. When the choice is full, only "
+                    "what it holds is "
                     "listed. Plain submit buttons and no script: the page "
                     "wraps this in its own form, and only the clicked button "
                     "is sent, so the view knows which option to add or take "

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1418,11 +1418,12 @@ def model_card():
                 ),
             ),
             # A choice worked at a pick at a time, with room left: what it
-            # holds is drawn, and Choose stays beside it until it is full.
+            # holds is drawn, and Add stays beside it until it is full.
             ChoiceLine(
                 kind_label="Lasting Injuries",
                 chosen="Eye Injury, Out Cold",
                 is_full=False,
+                takes_several=True,
                 href="#",
                 provenance=Provenance(
                     source="Ganger", source_kind="profile", computed=True

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -139,7 +139,7 @@ class TestTheChoicePicksPage:
         buttons, so each act says what it acts on."""
         page = reader.get("/n26/design/c/choice-picks/").content.decode()
         assert 'aria-label="Remove Cawdor"' in page
-        assert 'aria-label="Choose Ironhead Squats"' in page
+        assert 'aria-label="Add Ironhead Squats"' in page
 
 
 class TestTheOwnedDialogsPage:

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -371,3 +371,15 @@ class TestTheModelCardsTooltips:
         assert 'role="tooltip"' in page
         assert "From Leader" in page
         assert "Rating, including weapons and wargear" in page
+
+    def test_both_kinds_of_open_choice_draw_their_way_in(self, reader):
+        """The sample carries an open one-pick choice and a several-pick
+        choice with room left. A line built without a slot behind it
+        defaults to the one-pick rule, so the open one must still prompt
+        — a sample that quietly drew nothing would document the wrong
+        thing."""
+        page = reader.get("/n26/design/c/model-card/").content.decode()
+        legacy = page[page.index("Gang Legacy</dt>") :]
+        assert ">Choose</" in legacy[: legacy.index("</dd>")]
+        injuries = page[page.index("Lasting Injuries</dt>") :]
+        assert ">Add</" in injuries[: injuries.index("</dd>")]

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -1773,7 +1773,10 @@ class TestAChoiceThatHoldsSeveral:
         said = button_labels(client.get(picker_href(gang)).content.decode())
 
         assert "Save" in said
-        assert "Add" not in said
+        # Neither verb: a one-pick picker draws radios and a Save, and a
+        # per-option button under either word would mean it was drawn as
+        # the several-pick list by mistake.
+        assert "Add" not in said and "Choose" not in said
         assert_reconciled(gang)
 
 
@@ -2155,6 +2158,18 @@ class TestAChoiceThatAllowsRepeatsOnScreen:
         row = body[body.index("Lasting Injuries</dt>") :]
         assert "Eye Injury, Eye Injury" in row
         assert ">Add</" not in row[: row.index("</dd>")]
+
+    def test_the_confirmation_uses_the_verb_the_button_did(
+        self, client, owner, gang, yolanda, results
+    ):
+        from django.contrib.messages import get_messages
+
+        client.force_login(owner)
+        href, _ = self._href(gang)
+        response = self._post(client, href, results["Eye Injury"])
+
+        said = [str(m) for m in get_messages(response.wsgi_request)]
+        assert any(m.startswith("Added Eye Injury") for m in said), said
 
     def test_a_third_click_on_a_full_choice_is_refused_in_words(
         self, client, owner, gang, yolanda, results

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -1752,7 +1752,7 @@ class TestAChoiceThatHoldsSeveral:
         body = client.get(href).content.decode()
 
         assert "Ironhead Squats" in body
-        assert button_labels(body).count("Choose") == 2
+        assert button_labels(body).count("Add") == 2
         assert_reconciled(gang)
 
     def test_the_page_ends_with_no_save(self, gang, wanderer, client):
@@ -1761,7 +1761,7 @@ class TestAChoiceThatHoldsSeveral:
         said = button_labels(client.get(picker_href(gang)).content.decode())
 
         assert "Save" not in said
-        assert said.count("Choose") == 3
+        assert said.count("Add") == 3
         assert_reconciled(gang)
 
     def test_a_choice_of_one_still_ends_with_save(self, gang, hunter, client, owner):
@@ -1773,7 +1773,7 @@ class TestAChoiceThatHoldsSeveral:
         said = button_labels(client.get(picker_href(gang)).content.decode())
 
         assert "Save" in said
-        assert "Choose" not in said
+        assert "Add" not in said
         assert_reconciled(gang)
 
 
@@ -2109,9 +2109,9 @@ class TestAChoiceThatAllowsRepeatsOnScreen:
 
         body = client.get(href).content.decode()
         assert 'aria-label="Remove Eye Injury"' in body
-        assert 'aria-label="Choose Eye Injury again"' in body
+        assert 'aria-label="Add Eye Injury again"' in body
         # The result not yet held offers only the one way in.
-        assert 'aria-label="Choose Out Cold"' in body
+        assert 'aria-label="Add Out Cold"' in body
         assert 'aria-label="Remove Out Cold"' not in body
 
     def test_the_card_keeps_its_choose_beside_a_held_result(
@@ -2125,7 +2125,7 @@ class TestAChoiceThatAllowsRepeatsOnScreen:
         # The row, not the flash message that also names the choice.
         row = body[body.index("Lasting Injuries</dt>") :]
         assert "Out Cold" in row
-        assert ">Choose</" in row[: row.index("</dd>")]
+        assert ">Add</" in row[: row.index("</dd>")]
 
     def test_and_stops_asking_once_full(self, client, owner, gang, yolanda, results):
         client.force_login(owner)
@@ -2137,7 +2137,7 @@ class TestAChoiceThatAllowsRepeatsOnScreen:
         # The row, not the flash message that also names the choice.
         row = body[body.index("Lasting Injuries</dt>") :]
         assert "Eye Injury, Eye Injury" in row
-        assert ">Choose</" not in row[: row.index("</dd>")]
+        assert ">Add</" not in row[: row.index("</dd>")]
 
     def test_a_third_click_on_a_full_choice_is_refused_in_words(
         self, client, owner, gang, yolanda, results

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -1817,6 +1817,23 @@ class TestAChoiceThatHoldsNone:
         ).exists()
         assert_reconciled(gang)
 
+    def test_the_card_draws_the_row_and_no_way_in(
+        self, gang, asks_nothing, client, owner
+    ):
+        """The row still stands, headed as authored, but nothing on it
+        is clickable: a choice that asks nothing is full from the start,
+        and a link there would lead to a picker with nothing on it."""
+        from django.urls import reverse
+
+        hire(gang, asks_nothing, "Kaustos", paid=100)
+        client.force_login(owner)
+        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+
+        row = body[body.index("Gang Legacy</dt>") :]
+        row = row[: row.index("</dd>")]
+        assert ">Choose</" not in row
+        assert ">Add</" not in row
+
 
 class TestThePickerStaysFlatHoweverLongTheList:
     def test_the_page_reads_flat_as_the_list_grows(


### PR DESCRIPTION
Follow-up to #2350, from reviewing it in the browser.

Two changes to the several-pick control:

- **It says Add, not Choose.** A choice of one is chosen; a choice of several has picks added to it. `ChoiceLine` gains `takes_several` so the card can tell the two apart — the own-row control reads **Add** for a several-pick choice, while a one-pick choice (Gang Legacy) keeps **Choose**. The picker's buttons follow: Add, Add again, Remove. The text and print cards' room-left marker becomes `(add)`.
- **The Add on the card is one size.** It was body-sized when nothing was held and smaller once a pick landed, so the control shrank the moment it was used. It is now the small style in both states — verified at 12px against a 14px body, empty and held.

The Skills and Powers rows keep "Choose skill" / "Choose power" — those are one-pick questions and were not touched.

Three pre-existing tests counted "Choose" buttons on a several-pick picker; they now count "Add". They pin the number of ways in, not the word.

## From review

The first commit dropped the `is_full` guard from the card's Choose branch, so a choice authored with `max_picks=0` — full from the start, resolved never — drew a link to a picker with nothing on it. The guard is back, and a new test pins the card for that shape (only the picker was covered before; the test fails without the guard and passes with it). The choice-picks component's design-system notes and the picker's own comment now say Add.

Then: the flash after clicking Add said "Chose", so the button's verb and its confirmation disagreed — it now says Added. The picks list's `Choose` branch could never run (the list is only ever drawn for a several-pick choice) and is gone. And `ChoiceLine.is_full` defaulted `True`, so a line built without a slot behind it — a gallery sample, a preview — read as full while unresolved and drew no way in; left unsaid it now follows the one-pick rule, full once chosen. A gallery test pins that both an open one-pick choice and a several-pick choice with room prompt.

Every fix from review carries a test that was confirmed to fail without it.

`pytest` on the slots-and-picks, choosing, printing and design-system suites — 198 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
