### PR TITLE
feat: maintenance op to delete empty Affiliation rows

### DIFF
--- a/n26/library/CLAUDE.md
+++ b/n26/library/CLAUDE.md
@@ -118,8 +118,8 @@ steps into that file.** The rules for what goes in it:
 
 - Author-facing language only: the things to create and how to join
   them. No technical internals, no code, no model or field names —
-  the words are the authoring pages' own (affiliation, collection,
-  modifier, *gives*, *offers a choice*).
+  the words are the authoring pages' own (slot type, pickable,
+  collection, modifier, *gives*, *offers a choice*).
 - Clear and simple. Match the register of the modifier option cards in
   `specs.py` — short, concrete, one game example beats a paragraph.
 - A step that is not yet possible says so plainly, in one sentence.

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -474,8 +474,8 @@ def create_hidden(name, effects=(), qualifier="", library_author_help="", **kwar
 def create_affiliation(
     name, effects=(), qualifier="", library_author_help="", **kwargs
 ):
-    """A chosen carrier for where the gang's loyalties lie;
-    ``effects`` are (scope, effect) pairs."""
+    """A leftover chosen-carrier kind. New gang-level choices are a
+    slot type. ``effects`` are (scope, effect) pairs."""
     from n26.library.models import Affiliation
 
     carrier = Affiliation.objects.create(

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -4,9 +4,9 @@ This should give you a solid grounding in how Gyrinx N26 fits together.
 
 If you take nothing else away:
 
-1. **To control who gets a thing, control where it lands — don't look for a per-type switch.** Want it gang-wide? Build it into the gang type, or have a choice whose "will be assigned to" field is "the gang". Want it on one model? Build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on an affiliation or a rule — reach is entirely a consequence of the **host**, so you aim content by choosing its arrival route.
+1. **To control who gets a thing, control where it lands — don't look for a per-type switch.** Want it gang-wide? Build it into the gang type, or have a slot whose pick is assigned to the gang. Want it on one model? Build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on a pickable or a rule — reach is entirely a consequence of the **host**, so you aim content by choosing its arrival route.
 
-2. **Behaviour is always a modifier on a carrier — and modifiers are shared, so edit with care.** A rule, an affiliation, a pickable are just names; everything they do rides them as modifiers (scope + effect, conditions ANDed). Two practical consequences: to make content do something, attach the modifier to the thing that should carry it; and before editing an existing modifier, check its carriers — the change lands everywhere it's attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once and won't undo — author those as one-way doors.
+2. **Behaviour is always a modifier on a carrier — and modifiers are shared, so edit with care.** A rule or a pickable is just a name; everything they do rides them as modifiers (scope + effect, conditions ANDed). Two practical consequences: to make content do something, attach the modifier to the thing that should carry it; and before editing an existing modifier, check its carriers — the change lands everywhere it's attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once and won't undo — author those as one-way doors.
 
 3. **Being in a collection and being offered from a section of it are two separate authoring acts.** Entries and sweeps decide **membership** of the collection; **placement** decides whether a particular category appears. If you narrow a choice "from section: Primary" and the skill's category hasn't been placed into Primary for that fighter, it will not be offered — it's sitting in "Other". So a working "choose a Primary skill" needs both halves authored: the content in the collection, and a placement putting its category in that section for the right models.
 
@@ -14,15 +14,15 @@ If you take nothing else away:
 
 ## Assignment
 
-**An assignment has three components**: *what* is held (an **assignable** — a weapon, a skill, an affiliation…), *who it is assigned to* (the **host**), and *what brought it* (its **cause** — remove the cause and the assignment goes too). Nothing gets onto a card any other way; everything from a hired fighter's profile to a granted rule is one of these assignments.
+**An assignment has three components**: *what* is held (an **assignable** — a weapon, a skill, a pickable…), *who it is assigned to* (the **host**), and *what brought it* (its **cause** — remove the cause and the assignment goes too). Nothing gets onto a card any other way; everything from a hired fighter's profile to a granted rule is one of these assignments.
 
-An **assignable** is typically very simple: a piece of data that, once assigned, can carry modifiers. Sometimes they have extra configuration. Affiliation, Rule and Skill are all assignables.
+An **assignable** is typically very simple: a piece of data that, once assigned, can carry modifiers. Sometimes they have extra configuration. Rule, Skill and a pickable are all assignables.
 
 The **host** is the specific object the assignment sits on: a model, the gang, a parent item (a scope fitted to a gun), or the stash *only*. Host decides *reach*: an assignment hosted on a model is that model's; an assignment hosted on the gang is **broadcast** to every member's card.
 
 The **cause** is then the action that brought a particular assignment into existence, answering "why is this here?" Cause powers one important behaviour: **removal cascades down the cause chain**. Remove an assignment and everything caused by it (and caused by *those*, recursively) goes too. It's also where provenance comes from — the card can say "came with X" because the assignment knows its cause.
 
-A **modifier** is attached to a specific instance of an assignable (e.g. Aranthian Affiliation) which we call the **carrier**, asserting who it reaches (**scope**), and what it does (**effect**). Conditions limit the scope — AND-ed across conditions, any-of within a single condition — to allowlist modifier effects only in certain contexts.
+A **modifier** is attached to a specific instance of an assignable (e.g. the Aranthian pickable) which we call the **carrier**, asserting who it reaches (**scope**), and what it does (**effect**). Conditions limit the scope — AND-ed across conditions, any-of within a single condition — to allowlist modifier effects only in certain contexts.
 
 Modifiers are shared by design: they can attach on any number of specific assignables ("carriers"), and editing the modifier changes it everywhere it is carried.
 
@@ -31,7 +31,7 @@ Effects are split by when they happen:
 - **computed** ones (gives, takes away, changes a stat, adds to a counter, offers a choice, places a category, notes a limit) are re-derived on every read and vanish with their carrier
 - **written** ones (brings a model, moves a counter) run once at arrival and are never undone by removal.
 
-We use **carrier** as a library-side word for one specific piece of *content*, typically because they "carry" a modifier. A power maul carries its "+1 Strength" modifier; the Clan House affiliation carries a choice of affiliation from Clan Houses. Carrier is about authoring — edit the carrier's modifier and it changes everywhere that carrier appears.
+We use **carrier** as a library-side word for one specific piece of *content*, typically because they "carry" a modifier. A power maul carries its "+1 Strength" modifier; the Clan House pickable carries a grant of the house slot. Carrier is about authoring — edit the carrier's modifier and it changes everywhere that carrier appears.
 
 **Bearer** is used to describe the thing being affected by a modifier. The maul's modifier says "+1 Strength *to its bearer*" — whoever holds a *specific* maul, no name attached.
 
@@ -73,13 +73,13 @@ So the relationships after one hire, spelled out:
 
 ## Assignable types
 
-### Affiliation
+### A gang-level choice (slot type)
 
-*Who the gang sides with, chosen once when the gang is created.*
+*Who the gang sides with, which god it follows, which corruption it took — chosen once, as a pick.*
 
-Fields of its own: none. Chosen, not bought: it refuses built-ins (nothing would ever hand over items built into it), arrives free through an offered choice, and leaves when the thing that offered it leaves.
+Do not author a new kind for this. Create a **slot type** (Affiliation, Chaos God, Variant, or a new name), its **pickables**, a **picklist**, and a **slot** assigned to the gang. Grant that slot from a hidden built into the gang type, or from the gang type itself. What the choice does rides the pickable as ordinary modifiers — equipment lists opened to some ranks, a further slot granted while this pick stands.
 
-Its payload is usually access — equipment lists opened to some ranks — so its gives are typically scoped ("to Leaders and Champions") while the affiliation itself rides gang-wide. It may itself offer the next choice (Clan House: "choose one of the six Houses"), which simply computes into another open slot on the gang.
+The slot type's name is the word the card and the history use. The slot's label is the question on one card. See **Slot type** below.
 
 ### Rule (special rule)
 
@@ -169,7 +169,7 @@ Within a collection, when displayed, items are grouped by collection section and
 
 > Draft, for review.
 
-*What is chosen: Gang Legacy is the first, and new ones are authored.*
+*What is chosen: Gang Legacy, Affiliation, Clan House, Chaos God, Variant — and new ones are authored.*
 
 Fields of its own: a **plural** (what several of them are called, so a page can say "Gang Legacies"), and **allows repeats** (whether one holder may pick the same pickable for two slots of this type).
 

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -4,9 +4,9 @@ This should give you a solid grounding in how Gyrinx N26 fits together.
 
 If you take nothing else away:
 
-1. **To control who gets a thing, control where it lands — don't look for a per-type switch.** Want it gang-wide? Build it into the gang type, or have a slot whose pick is assigned to the gang. Want it on one model? Build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on a pickable or a rule — reach is entirely a consequence of the **host**, so you aim content by choosing its arrival route.
+1. **To control who gets a thing, control where it lands — do not look for a per-type switch.** Want it gang-wide? Build it into the gang type, or have a slot whose pick is assigned to the gang. Want it on one model? Build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on a pickable or a rule — reach is entirely a consequence of the **host**, so you aim content by choosing its arrival route.
 
-2. **Behaviour is always a modifier on a carrier — and modifiers are shared, so edit with care.** A rule or a pickable is just a name; everything they do rides them as modifiers (scope + effect, conditions ANDed). Two practical consequences: to make content do something, attach the modifier to the thing that should carry it; and before editing an existing modifier, check its carriers — the change lands everywhere it's attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once and won't undo — author those as one-way doors.
+2. **Behaviour comes from modifiers attached to carriers — and modifiers are shared, so edit with care.** A rule or a pickable starts as a name; its attached modifiers define its behaviour (scope + effect, conditions ANDed). Two practical consequences: attach a modifier to the content it should affect; and before editing an existing modifier, check its carriers, because the change applies everywhere it is attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once and removal will not reverse them.
 
 3. **Being in a collection and being offered from a section of it are two separate authoring acts.** Entries and sweeps decide **membership** of the collection; **placement** decides whether a particular category appears. If you narrow a choice "from section: Primary" and the skill's category hasn't been placed into Primary for that fighter, it will not be offered — it's sitting in "Other". So a working "choose a Primary skill" needs both halves authored: the content in the collection, and a placement putting its category in that section for the right models.
 
@@ -14,9 +14,9 @@ If you take nothing else away:
 
 ## Assignment
 
-**An assignment has three components**: *what* is held (an **assignable** — a weapon, a skill, a pickable…), *who it is assigned to* (the **host**), and *what brought it* (its **cause** — remove the cause and the assignment goes too). Nothing gets onto a card any other way; everything from a hired fighter's profile to a granted rule is one of these assignments.
+**An assignment has three components**: *what* is held (an **assignable** — a weapon, a skill, a pickable…), *who it is assigned to* (the **host**), and the source of the assignment (its **cause**). Removing the cause also removes the assignment. Every item on a card, from a hired fighter's profile to a granted rule, is an assignment.
 
-An **assignable** is typically very simple: a piece of data that, once assigned, can carry modifiers. Sometimes they have extra configuration. Rule, Skill and a pickable are all assignables.
+An **assignable** is typically very simple: a piece of data that, once assigned, can carry modifiers. Sometimes they have extra configuration. Rules, skills and pickables are all assignables.
 
 The **host** is the specific object the assignment sits on: a model, the gang, a parent item (a scope fitted to a gun), or the stash *only*. Host decides *reach*: an assignment hosted on a model is that model's; an assignment hosted on the gang is **broadcast** to every member's card.
 
@@ -75,9 +75,9 @@ So the relationships after one hire, spelled out:
 
 ### A gang-level choice (slot type)
 
-*Who the gang sides with, which god it follows, which corruption it took — chosen once, as a pick.*
+*Who the gang sides with, which god it follows, or which corruption it has — chosen once, as a pick.*
 
-Do not author a new kind for this. Create a **slot type** (Affiliation, Chaos God, Variant, or a new name), its **pickables**, a **picklist**, and a **slot** assigned to the gang. Grant that slot from a hidden built into the gang type, or from the gang type itself. What the choice does rides the pickable as ordinary modifiers — equipment lists opened to some ranks, a further slot granted while this pick stands.
+Do not author a new kind for this. Create a **slot type** (Affiliation, Chaos God, Variant, or a new name), its **pickables**, a **picklist**, and a **slot** assigned to the gang. Grant that slot from a hidden built into the gang type, or from the gang type itself. Attach ordinary modifiers to each pickable to define its effects. For example, a pickable can open equipment lists to some ranks or grant another slot while the pick remains assigned.
 
 The slot type's name is the word the card and the history use. The slot's label is the question on one card. See **Slot type** below.
 

--- a/n26/library/empty_affiliations.py
+++ b/n26/library/empty_affiliations.py
@@ -1,0 +1,601 @@
+"""What the Affiliation conversions left standing, and deleting it.
+
+Moving Outcast Affiliation, Chaos God and Variant onto slots and picks
+left their old machinery behind on purpose: a conversion proves that
+nothing a reader sees moves, and deleting library rows is a different
+job with a different risk. This is that job.
+
+What stands is a library of things nothing uses. The Affiliation kind
+rows the conversions emptied — their modifiers moved onto pickables, so
+each is a name and nothing else. The menus those kinds were chosen
+from, which no question now offers. The fossil offers the conversions
+refused to swap. The vestigial Hidden that granted a slot after the
+shared offer was swapped, that nobody holds and nothing is built with.
+
+**Nothing here may change a page.** That is the whole test, and it is
+what makes deleting safe to do in bulk: if these rows really are unused,
+removing them is invisible, and if any of them is doing something the
+proof says so and the run unwinds.
+
+The slot types named Affiliation, Clan House, Chaos God and Variant —
+and every pickable, picklist and slot of theirs — stay. Those are the
+new system.
+
+Four rules keep the reading honest:
+
+* A kind row that still carries a modifier is doing something, whatever
+  its column says. It is left where it is and named on the page, rather
+  than deleted or made into a refusal.
+* A kind row anything still names cannot be deleted at all. Those
+  answers belong to a conversion that has not run, so this refuses and
+  says which, rather than running before its turn.
+* A menu is deleted only when everything in it names Affiliation and
+  nothing outside what is going asks for it. A menu holding one live
+  entry keeps its shape and loses only the entries.
+* A marker that grants a slot, that nobody holds and nothing is built
+  with, is leftover conversion wiring. The grant stays if anything else
+  carries it — the real doors still need it. Markers a profile is built
+  with are not this.
+
+An effect and its modifier travel together. A modifier here is one
+scope and one effect, so removing the effect would leave a scope
+addressing nobody about nothing; the carrier it hangs on is kept unless
+it too exists solely for what is going.
+"""
+
+from dataclasses import dataclass, field
+
+from django.db import transaction
+
+#: How many gangs the proof draws when nothing being deleted is held —
+#: a spread of pages, so a library-only write is still shown to leave
+#: every shape of gang unmoved.
+PROVEN = 15
+
+#: Slot types the conversions created. They stay forever.
+KEPT_SLOT_TYPE_NAMES = ("Affiliation", "Clan House", "Chaos God", "Variant")
+
+
+class Refused(Exception):
+    """The world is not the one the reading found."""
+
+
+@dataclass(frozen=True)
+class Fossils:
+    """Everything that would go, by kind of row."""
+
+    kind_rows: tuple = ()
+    entries: tuple = ()
+    collections: tuple = ()
+    sections: tuple = ()
+    modifiers: tuple = ()
+    hiddens: tuple = ()
+    said: tuple = ()
+    left_alone: tuple = ()
+    gang_ids: tuple = ()
+    problems: tuple = ()
+    nothing_here: bool = False
+    counts: dict = field(default_factory=dict)
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    def preview(self):
+        if self.nothing_here:
+            return [
+                "nothing to delete — the emptied Affiliation rows have gone already"
+            ]
+        lines = list(self.said)
+        for note in self.left_alone:
+            lines.append(f"leave {note}")
+        lines.append(
+            f"prove {len(self.gang_ids)} gang"
+            f"{'' if len(self.gang_ids) == 1 else 's'} read exactly the same, "
+            "or refuse"
+        )
+        return lines
+
+
+def _kinds():
+    """Affiliation, with the column an assignment names it by.
+
+    Read from the assignment's own registry rather than guessed from the
+    class name.
+    """
+    from django.apps import apps
+
+    from n26.core.models.assignment import ASSIGNABLE_FIELDS
+
+    return [("affiliation", apps.get_model(ASSIGNABLE_FIELDS["affiliation"]))]
+
+
+def _named_by(model, rows):
+    """The menu entries naming these, where a menu can name them at all.
+
+    Found by what a field points at rather than by what it is called:
+    a menu holds only some of the kinds, so asking for a column it does
+    not have would be an error rather than an empty answer.
+    """
+    from n26.library.models import CollectionEntry
+
+    for entry_field in CollectionEntry._meta.get_fields():
+        if not getattr(entry_field, "concrete", False):
+            continue
+        if getattr(entry_field, "related_model", None) is model:
+            return CollectionEntry.objects.filter(**{f"{entry_field.name}__in": rows})
+    return CollectionEntry.objects.none()
+
+
+def _held_carriers(effect):
+    """What carries this effect and is itself held by somebody, in words.
+
+    An effect reaches a page through its carrier, so a carrier nobody
+    holds means the effect is drawn nowhere. Empty when nothing carries
+    it, or when what does is held by no one.
+    """
+    from n26.core.models import Assignment
+    from n26.library.conversion.base import carriers_of
+    from n26.library.models import Modifier
+
+    modifier = Modifier.objects.filter(**{f"{_part_name(effect)}": effect}).first()
+    if modifier is None:
+        return ""
+    said = []
+    for _, carrier in carriers_of(modifier):
+        column = _column_for(type(carrier))
+        if column and Assignment.objects.filter(**{column: carrier}).exists():
+            said.append(str(carrier))
+    return ", ".join(sorted(said))
+
+
+def _part_name(effect):
+    """The field a modifier holds this sort of effect in."""
+    from n26.library.models import Modifier
+
+    for one_to_one in Modifier._meta.get_fields():
+        if not getattr(one_to_one, "concrete", False):
+            continue
+        if getattr(one_to_one, "related_model", None) is type(effect):
+            return one_to_one.name
+    raise ValueError(f"no modifier holds a {type(effect).__name__}")
+
+
+def _anything_naming(row, doomed):
+    """What still names this row once everything going has gone.
+
+    Asked of every model and every field that points here rather than of
+    a list somebody remembered to write. A reverse-relation scan misses
+    everything declared ``related_name="+"``. What is itself being
+    deleted does not count.
+    """
+    from django.apps import apps
+
+    found = []
+    for model in apps.get_models():
+        if model._meta.auto_created:
+            continue
+        for pointing in model._meta.get_fields():
+            if not getattr(pointing, "is_relation", False):
+                continue
+            if not (
+                getattr(pointing, "concrete", False)
+                or getattr(pointing, "many_to_many", False)
+            ):
+                continue
+            if getattr(pointing, "related_model", None) is not type(row):
+                continue
+            here = model.objects.filter(**{pointing.name: row})
+            spared = doomed.get(model, set())
+            if spared:
+                here = here.exclude(pk__in=spared)
+            count = here.count()
+            if count:
+                found.append(f"{count} {model._meta.verbose_name_plural}")
+    return ", ".join(sorted(found))
+
+
+def _column_for(model):
+    """The assignment column naming this kind of thing, if there is one."""
+    from django.apps import apps
+
+    from n26.core.models.assignment import ASSIGNABLE_FIELDS
+
+    for column, label in ASSIGNABLE_FIELDS.items():
+        if apps.get_model(label) is model:
+            return column
+    return ""
+
+
+def _leave_the_new_system(left_alone):
+    """Name the slot types this never touches, if they stand."""
+    from n26.library.models import SlotType
+
+    standing = list(
+        SlotType.objects.filter(name__in=KEPT_SLOT_TYPE_NAMES).order_by("name")
+    )
+    if not standing:
+        left_alone.append(
+            "the slot types named Affiliation, Clan House, Chaos God and "
+            "Variant, and every pickable, picklist and slot of theirs — "
+            "those are the new system, and none stand yet"
+        )
+        return
+    names = ", ".join(f"“{row}”" for row in standing)
+    noun = "slot type" if len(standing) == 1 else "slot types"
+    left_alone.append(
+        f"the {noun} {names} and every pickable, picklist and slot of "
+        "theirs — those are the new system"
+    )
+
+
+def find():
+    """Read what is left of the Affiliation kind. Never writes."""
+    from django.contrib.contenttypes.models import ContentType
+
+    from n26.core.models import Assignment
+    from n26.library.conversion.base import carriers_of
+    from n26.library.models import (
+        AddsAssignable,
+        Collection,
+        CollectionEntry,
+        CollectionSection,
+        Hidden,
+        Modifier,
+        OffersChoice,
+        PlacesCategory,
+        RemovesAssignable,
+    )
+
+    problems = []
+    left_alone = []
+    said = []
+
+    doomed_kinds = []
+    for column, model in _kinds():
+        for row in model.objects.all().order_by("name"):
+            held = Assignment.objects.filter(**{column: row}).count()
+            if held:
+                problems.append(
+                    f"{held} assignment{'' if held == 1 else 's'} still name "
+                    f"“{row}”, so it cannot be deleted yet"
+                )
+                continue
+            carried = row.modifiers.count()
+            if carried:
+                left_alone.append(
+                    f"“{row}” where it is: it still carries "
+                    f"{carried} modifier{'' if carried == 1 else 's'}, so it "
+                    "is doing something whatever its column says"
+                )
+                continue
+            doomed_kinds.append(row)
+
+    if problems:
+        return Fossils(problems=tuple(problems))
+
+    entries = []
+    for _, model in _kinds():
+        here = [row for row in doomed_kinds if isinstance(row, model)]
+        if here:
+            entries += list(_named_by(model, here).select_related("collection"))
+    doomed_entries = {entry.pk for entry in entries}
+
+    kinds = ContentType.objects.filter(
+        app_label="library",
+        model__in=[model._meta.model_name for _, model in _kinds()],
+    )
+    offers = []
+    standing = []
+    for offer in OffersChoice.objects.filter(of_kind__in=kinds).select_related(
+        "from_section"
+    ):
+        carried_by = _held_carriers(offer)
+        if carried_by:
+            standing.append(offer)
+            left_alone.append(
+                f"the offer on “{carried_by}”: somebody holds it, so it is a "
+                "question on a card rather than a fossil"
+            )
+            continue
+        offers.append(offer)
+
+    kept_sections = {
+        offer.from_section_id for offer in standing if offer.from_section_id
+    }
+    collections = []
+    for collection in Collection.objects.filter(
+        pk__in={entry.collection_id for entry in entries}
+    ).order_by("name"):
+        held = set(
+            CollectionEntry.objects.filter(collection=collection).values_list(
+                "pk", flat=True
+            )
+        )
+        if held - doomed_entries:
+            left_alone.append(
+                f"the menu “{collection}”: not everything in it names "
+                "Affiliation, so it loses those entries and keeps its shape"
+            )
+            continue
+        asked_of = set(
+            CollectionSection.objects.filter(collection=collection).values_list(
+                "pk", flat=True
+            )
+        )
+        if asked_of & kept_sections:
+            left_alone.append(
+                f"the menu “{collection}”: an offer somebody holds still asks "
+                "from it, so it keeps its shape"
+            )
+            continue
+        collections.append(collection)
+    sections = list(CollectionSection.objects.filter(collection__in=collections))
+
+    for offer in OffersChoice.objects.filter(from_section__in=sections):
+        if offer not in offers:
+            problems.append(
+                f"“{offer.modifier}” asks for a menu that would go but is "
+                "not an offer of Affiliation, so the menu is not dead"
+            )
+    places = list(PlacesCategory.objects.filter(section__in=sections))
+
+    if problems:
+        return Fossils(problems=tuple(problems))
+
+    modifiers = {
+        row.pk: row
+        for row in Modifier.objects.filter(offers_choice__in=offers)
+        | Modifier.objects.filter(places_category__in=places)
+    }
+
+    hiddens = []
+    for hidden in Hidden.objects.filter(modifiers__in=modifiers.values()).distinct():
+        others = hidden.modifiers.exclude(pk__in=modifiers).count()
+        if others:
+            left_alone.append(
+                f"the marker “{hidden}”: it carries {others} other "
+                f"modifier{'' if others == 1 else 's'}"
+            )
+            continue
+        handers = {
+            naming: set(
+                naming.objects.filter(hidden=hidden).values_list("pk", flat=True)
+            )
+            for naming in (AddsAssignable, RemovesAssignable)
+        }
+        named_by = _anything_naming(hidden, {**handers, Modifier: set(modifiers)})
+        if named_by:
+            left_alone.append(f"the marker “{hidden}”: {named_by} still name it")
+            continue
+        hiddens.append(hidden)
+
+    for row in Modifier.objects.filter(
+        adds_assignable__in=AddsAssignable.objects.filter(hidden__in=hiddens)
+    ) | Modifier.objects.filter(
+        removes_assignable__in=RemovesAssignable.objects.filter(hidden__in=hiddens)
+    ):
+        modifiers[row.pk] = row
+
+    already = {hidden.pk for hidden in hiddens}
+    for hidden in Hidden.objects.order_by("name"):
+        if hidden.pk in already:
+            continue
+        grants = [
+            modifier
+            for modifier in hidden.modifiers.all()
+            if getattr(modifier, "adds_assignable", None) is not None
+            and modifier.adds_assignable.slot_id
+        ]
+        if not grants:
+            continue
+        if Assignment.objects.filter(hidden=hidden).exists():
+            continue
+        named_by = _anything_naming(
+            hidden, {Modifier: {modifier.pk for modifier in hidden.modifiers.all()}}
+        )
+        if named_by:
+            left_alone.append(f"the marker “{hidden}”: {named_by} still name it")
+            continue
+        hiddens.append(hidden)
+        for modifier in hidden.modifiers.all():
+            others = [
+                (kind, row)
+                for kind, row in carriers_of(modifier)
+                if not (kind == "Hidden" and row.pk == hidden.pk)
+            ]
+            if not others:
+                modifiers[modifier.pk] = modifier
+
+    doomed = {
+        type(row): {r.pk for r in doomed_kinds if type(r) is type(row)}
+        for row in doomed_kinds
+    }
+    doomed[CollectionEntry] = doomed_entries
+    doomed[Collection] = {collection.pk for collection in collections}
+    doomed[CollectionSection] = {section.pk for section in sections}
+    doomed[Modifier] = set(modifiers)
+    doomed[Hidden] = {hidden.pk for hidden in hiddens}
+    doomed[OffersChoice] = {offer.pk for offer in offers}
+    doomed[PlacesCategory] = {place.pk for place in places}
+
+    for row in doomed_kinds:
+        named_by = _anything_naming(row, doomed)
+        if named_by:
+            problems.append(
+                f"{named_by} still name “{row}”, so it cannot be deleted yet"
+            )
+    if problems:
+        return Fossils(problems=tuple(problems))
+
+    _leave_the_new_system(left_alone)
+
+    gang_ids = _gangs_to_prove(modifiers.values())
+
+    for row in doomed_kinds:
+        said.append(f"delete the emptied {type(row).__name__.lower()} “{row}”")
+    if entries:
+        said.append(
+            f"delete {len(entries)} menu entr{'y' if len(entries) == 1 else 'ies'} "
+            "naming them"
+        )
+    for collection in collections:
+        said.append(f"delete the menu “{collection}” and its sections")
+    for modifier in sorted(modifiers.values(), key=str):
+        said.append(f"delete the modifier “{modifier}”, which nothing needs")
+    for hidden in hiddens:
+        said.append(f"delete the marker “{hidden}”, which nothing holds")
+
+    if not (doomed_kinds or entries or collections or modifiers or hiddens):
+        return Fossils(nothing_here=True, left_alone=tuple(left_alone))
+
+    return Fossils(
+        kind_rows=tuple((type(row), row.pk) for row in doomed_kinds),
+        entries=tuple(entry.pk for entry in entries),
+        collections=tuple(collection.pk for collection in collections),
+        sections=tuple(section.pk for section in sections),
+        modifiers=tuple(modifiers),
+        hiddens=tuple(hidden.pk for hidden in hiddens),
+        said=tuple(said),
+        left_alone=tuple(left_alone),
+        gang_ids=tuple(gang_ids),
+        counts={
+            "kind rows": len(doomed_kinds),
+            "menu entries": len(entries),
+            "menus": len(collections),
+            "modifiers": len(modifiers),
+            "markers": len(hiddens),
+        },
+    )
+
+
+def _gangs_touched(modifiers):
+    """Every gang a modifier being deleted could reach.
+
+    A modifier hangs on a carrier and reaches a page through whoever
+    holds that carrier. Asked of every kind of carrier rather than a
+    chosen few: a carrier nobody thought of is a gang the proof would
+    not have looked at.
+    """
+    from n26.core.models import Assignment
+    from n26.library.conversion.base import carriers_of
+
+    gangs = set()
+    for modifier in modifiers:
+        for _, carrier in carriers_of(modifier):
+            column = _column_for(type(carrier))
+            if not column:
+                continue
+            gangs |= set(
+                Assignment.objects.filter(**{column: carrier})
+                .values_list("gang_root_id", flat=True)
+                .distinct()
+            )
+    gangs.discard(None)
+    return sorted(gangs, key=str)
+
+
+def _gangs_to_prove(modifiers):
+    """The gangs whose pages are captured: everyone who could notice,
+    then a spread of the rest so a library-only write is still shown
+    to leave ordinary gangs unmoved.
+    """
+    from n26.core.models import Gang
+    from n26.library.conversion.base import spread
+
+    touched = list(_gangs_touched(modifiers))
+    live = list(
+        Gang.objects.filter(archived=False).order_by("pk").values_list("pk", flat=True)
+    )
+    extra = [pk for pk in live if pk not in set(touched)]
+    if len(touched) >= PROVEN:
+        return touched
+    return touched + spread(set(extra), [extra], PROVEN - len(touched))
+
+
+def _delete_parts_of(modifiers):
+    """Delete each modifier's scope and effect, taking it with them."""
+    from n26.library.models import Modifier
+
+    parts = [
+        one_to_one.name
+        for one_to_one in Modifier._meta.get_fields()
+        if getattr(one_to_one, "one_to_one", False)
+        and getattr(one_to_one, "concrete", False)
+    ]
+    for modifier in list(modifiers):
+        for part in parts:
+            held = getattr(modifier, part, None)
+            if held is not None:
+                held.delete()
+
+
+def apply(fossils):
+    """Delete exactly what was read, and prove every page unmoved."""
+    from django.db.models import ProtectedError
+
+    from n26.core.capture import differences, gang_state
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+    from n26.library.conversion.base import ConversionRefused, _one_snapshot
+    from n26.library.models import (
+        Collection,
+        CollectionEntry,
+        CollectionSection,
+        Hidden,
+        Modifier,
+    )
+
+    if fossils.problems:
+        raise Refused("not deleted: " + "; ".join(fossils.problems))
+    if fossils.nothing_here:
+        return list(fossils.preview())
+
+    report = list(fossils.preview())
+    try:
+        with _one_snapshot(), transaction.atomic():
+            gangs = list(Gang.objects.filter(pk__in=fossils.gang_ids))
+            before = {str(gang.pk): gang_state(gang) for gang in gangs}
+
+            # The order is what protects what. An offer names the menu
+            # section it asks from, and a grant names the marker it
+            # hands over, so both have to go before the things they
+            # name — and a modifier owns its scope and its effect, each
+            # of which takes the modifier with it, so what is deleted is
+            # the parts rather than the modifier that would leave them
+            # behind.
+            _delete_parts_of(Modifier.objects.filter(pk__in=fossils.modifiers))
+            CollectionEntry.objects.filter(pk__in=fossils.entries).delete()
+            CollectionSection.objects.filter(pk__in=fossils.sections).delete()
+            Collection.objects.filter(pk__in=fossils.collections).delete()
+            Hidden.objects.filter(pk__in=fossils.hiddens).delete()
+            for model, pk in fossils.kind_rows:
+                model.objects.filter(pk=pk).delete()
+
+            gangs = list(Gang.objects.filter(pk__in=fossils.gang_ids))
+            after = {str(gang.pk): gang_state(gang) for gang in gangs}
+            changed = differences(before, after)
+            if changed:
+                raise Refused(
+                    "refused — what a reader is told would change:\n  "
+                    + "\n  ".join(changed[:10])
+                )
+            for gang in gangs:
+                try:
+                    assert_reconciled(gang)
+                except Exception as failed:
+                    raise Refused(
+                        f"refused — {gang} no longer reconciles: {failed}"
+                    ) from failed
+    except ConversionRefused as refused:
+        raise Refused(str(refused)) from refused
+    except ProtectedError as protected:
+        # The backstop behind the enumerated checks: whatever this names
+        # is a referent nobody listed, and the answer is a refusal in
+        # words rather than a traceback.
+        raise Refused(
+            "refused — something still names what would be deleted: "
+            f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}"
+        ) from protected
+    report.append("deleted; every page reads the same")
+    return report

--- a/n26/library/empty_affiliations.py
+++ b/n26/library/empty_affiliations.py
@@ -29,9 +29,9 @@ Four rules keep the reading honest:
 * A kind row anything still names cannot be deleted at all. Those
   answers belong to a conversion that has not run, so this refuses and
   says which, rather than running before its turn.
-* A menu is deleted only when everything in it names Affiliation and
-  nothing outside what is going asks for it. A menu holding one live
-  entry keeps its shape and loses only the entries.
+* A menu is deleted only when everything in it is going and nothing
+  outside what is going asks for it. A menu holding one live entry
+  keeps its shape and loses only the entries.
 * A marker that grants a slot, that nobody holds and nothing is built
   with, is leftover conversion wiring. The grant stays if anything else
   carries it — the real doors still need it. Markers a profile is built
@@ -314,8 +314,8 @@ def find():
         )
         if held - doomed_entries:
             left_alone.append(
-                f"the menu “{collection}”: not everything in it names "
-                "Affiliation, so it loses those entries and keeps its shape"
+                f"the menu “{collection}”: not everything in it is going, "
+                "so it loses those entries and keeps its shape"
             )
             continue
         asked_of = set(

--- a/n26/library/empty_affiliations.py
+++ b/n26/library/empty_affiliations.py
@@ -88,9 +88,10 @@ class Fossils:
 
     def preview(self):
         if self.nothing_here:
-            return [
-                "nothing to delete — the emptied affiliation rows were already deleted"
-            ]
+            lines = ["nothing selected for deletion"]
+            for note in self.left_alone:
+                lines.append(f"leave {note}")
+            return lines
         lines = list(self.said)
         for note in self.left_alone:
             lines.append(f"leave {note}")

--- a/n26/library/empty_affiliations.py
+++ b/n26/library/empty_affiliations.py
@@ -49,6 +49,7 @@ it too exists solely for what is going.
 
 from dataclasses import dataclass, field
 
+from django.conf import settings
 from django.db import transaction
 
 #: How many gangs the proof draws when nothing being deleted is held —
@@ -88,15 +89,15 @@ class Fossils:
     def preview(self):
         if self.nothing_here:
             return [
-                "nothing to delete — the emptied Affiliation rows have gone already"
+                "nothing to delete — the emptied affiliation rows were already deleted"
             ]
         lines = list(self.said)
         for note in self.left_alone:
             lines.append(f"leave {note}")
         lines.append(
-            f"prove {len(self.gang_ids)} gang"
-            f"{'' if len(self.gang_ids) == 1 else 's'} read exactly the same, "
-            "or refuse"
+            f"check that {len(self.gang_ids)} gang page"
+            f"{'' if len(self.gang_ids) == 1 else 's'} render exactly the same; "
+            "delete nothing if any page changes"
         )
         return lines
 
@@ -127,7 +128,11 @@ def _named_by(model, rows):
         if not getattr(entry_field, "concrete", False):
             continue
         if getattr(entry_field, "related_model", None) is model:
-            return CollectionEntry.objects.filter(**{f"{entry_field.name}__in": rows})
+            return CollectionEntry.objects.filter(
+                **{f"{entry_field.name}__in": rows},
+                pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
+                collection__pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
+            )
     return CollectionEntry.objects.none()
 
 
@@ -195,7 +200,12 @@ def _anything_naming(row, doomed):
                 here = here.exclude(pk__in=spared)
             count = here.count()
             if count:
-                found.append(f"{count} {model._meta.verbose_name_plural}")
+                noun = (
+                    model._meta.verbose_name
+                    if count == 1
+                    else model._meta.verbose_name_plural
+                )
+                found.append(f"{count} {noun}")
     return ", ".join(sorted(found))
 
 
@@ -219,11 +229,6 @@ def _leave_the_new_system(left_alone):
         SlotType.objects.filter(name__in=KEPT_SLOT_TYPE_NAMES).order_by("name")
     )
     if not standing:
-        left_alone.append(
-            "the slot types named Affiliation, Clan House, Chaos God and "
-            "Variant, and every pickable, picklist and slot of theirs — "
-            "those are the new system, and none stand yet"
-        )
         return
     names = ", ".join(f"“{row}”" for row in standing)
     noun = "slot type" if len(standing) == 1 else "slot types"
@@ -257,11 +262,24 @@ def find():
 
     doomed_kinds = []
     for column, model in _kinds():
-        for row in model.objects.all().order_by("name"):
+        outside = model.objects.exclude(
+            pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG
+        ).count()
+        if outside:
+            problems.append(
+                f"{outside} {model._meta.verbose_name}"
+                f"{'' if outside == 1 else 's'} belong"
+                f"{'' if outside != 1 else 's'} to another pack. This deletion "
+                "only removes N26 conversion leftovers"
+            )
+        for row in model.objects.filter(
+            pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG
+        ).order_by("name"):
             held = Assignment.objects.filter(**{column: row}).count()
             if held:
                 problems.append(
-                    f"{held} assignment{'' if held == 1 else 's'} still name "
+                    f"{held} assignment{'' if held == 1 else 's'} still "
+                    f"{'names' if held == 1 else 'name'} "
                     f"“{row}”, so it cannot be deleted yet"
                 )
                 continue
@@ -270,7 +288,7 @@ def find():
                 left_alone.append(
                     f"“{row}” where it is: it still carries "
                     f"{carried} modifier{'' if carried == 1 else 's'}, so it "
-                    "is doing something whatever its column says"
+                    "remains in use"
                 )
                 continue
             doomed_kinds.append(row)
@@ -291,14 +309,38 @@ def find():
     )
     offers = []
     for offer in OffersChoice.objects.filter(of_kind__in=kinds).select_related(
-        "from_section"
+        "from_section", "modifier", "modifier__pack"
     ):
-        carried_by = _held_carriers(offer)
-        if carried_by:
+        try:
+            offer_modifier = offer.modifier
+        except Modifier.DoesNotExist:
             problems.append(
-                f"somebody still holds the Affiliation offer on “{carried_by}”, "
-                "so the old question is still live"
+                f"the affiliation offer {offer.pk} has no modifier. Fix that "
+                "library data before running the deletion"
             )
+            continue
+        if offer_modifier.pack.slug != settings.DEFAULT_CONTENT_PACK_SLUG:
+            problems.append(
+                f"the affiliation offer “{offer_modifier}” belongs to another "
+                "pack. This deletion only removes N26 conversion leftovers"
+            )
+            continue
+        carriers = carriers_of(offer_modifier)
+        if carriers:
+            carried_by = _held_carriers(offer)
+            if carried_by:
+                problems.append(
+                    f"the affiliation offer on “{carried_by}” is still in use. "
+                    "Run the related conversion first"
+                )
+            else:
+                named = ", ".join(
+                    f"{kind} “{row}”" for kind, row in sorted(carriers, key=str)
+                )
+                problems.append(
+                    f"the affiliation offer “{offer_modifier}” remains attached "
+                    f"to {named}. Remove or convert it first"
+                )
             continue
         offers.append(offer)
     if problems:
@@ -306,17 +348,41 @@ def find():
 
     collections = []
     for collection in Collection.objects.filter(
-        pk__in={entry.collection_id for entry in entries}
+        pk__in={entry.collection_id for entry in entries},
+        pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
     ).order_by("name"):
         held = set(
             CollectionEntry.objects.filter(collection=collection).values_list(
                 "pk", flat=True
             )
         )
-        if held - doomed_entries:
+        section_ids = set(
+            CollectionSection.objects.filter(
+                collection=collection,
+                pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
+            ).values_list("pk", flat=True)
+        )
+        named_by = _anything_naming(
+            collection,
+            {
+                CollectionEntry: doomed_entries,
+                CollectionSection: section_ids,
+            },
+        )
+        carried = collection.modifiers.count()
+        if held - doomed_entries or named_by or carried:
+            reasons = []
+            if held - doomed_entries:
+                reasons.append("it also contains entries that will remain")
+            if named_by:
+                reasons.append(f"it is still used by {named_by}")
+            if carried:
+                reasons.append(
+                    f"it carries {carried} modifier{'' if carried == 1 else 's'}"
+                )
             left_alone.append(
-                f"the menu “{collection}”: not everything in it is going, "
-                "so it loses those entries and keeps its shape"
+                f"the menu “{collection}” because {'; '.join(reasons)}. The "
+                "emptied affiliation entries will still be deleted"
             )
             continue
         collections.append(collection)
@@ -324,9 +390,11 @@ def find():
 
     for offer in OffersChoice.objects.filter(from_section__in=sections):
         if offer not in offers:
+            offer_modifier = Modifier.objects.filter(offers_choice=offer).first()
+            label = f"“{offer_modifier}”" if offer_modifier else f"offer {offer.pk}"
             problems.append(
-                f"“{offer.modifier}” asks for a menu that would go but is "
-                "not an offer of Affiliation, so the menu is not dead"
+                f"{label} uses a menu selected for deletion but does not offer "
+                "an affiliation. Keep or update the menu first"
             )
     places = list(PlacesCategory.objects.filter(section__in=sections))
 
@@ -339,8 +407,18 @@ def find():
         | Modifier.objects.filter(places_category__in=places)
     }
 
+    for modifier in modifiers.values():
+        if modifier.pack.slug != settings.DEFAULT_CONTENT_PACK_SLUG:
+            problems.append(
+                f"the modifier “{modifier}” belongs to another pack. This "
+                "deletion only removes N26 conversion leftovers"
+            )
+
     hiddens = []
-    for hidden in Hidden.objects.filter(modifiers__in=modifiers.values()).distinct():
+    for hidden in Hidden.objects.filter(
+        modifiers__in=modifiers.values(),
+        pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
+    ).distinct():
         others = hidden.modifiers.exclude(pk__in=modifiers).count()
         if others:
             left_alone.append(
@@ -348,54 +426,88 @@ def find():
                 f"modifier{'' if others == 1 else 's'}"
             )
             continue
-        handers = {
-            naming: set(
-                naming.objects.filter(hidden=hidden).values_list("pk", flat=True)
-            )
-            for naming in (AddsAssignable, RemovesAssignable)
-        }
+        handers = {AddsAssignable: set(), RemovesAssignable: set()}
+        hander_modifiers = {}
+        for naming in handers:
+            for effect in naming.objects.filter(hidden=hidden):
+                effect_modifier = Modifier.objects.filter(
+                    **{_part_name(effect): effect}
+                ).first()
+                if (
+                    effect_modifier is None
+                    or effect_modifier.pack.slug != settings.DEFAULT_CONTENT_PACK_SLUG
+                    or carriers_of(effect_modifier)
+                ):
+                    continue
+                handers[naming].add(effect.pk)
+                hander_modifiers[effect_modifier.pk] = effect_modifier
         named_by = _anything_naming(hidden, {**handers, Modifier: set(modifiers)})
         if named_by:
-            left_alone.append(f"the marker “{hidden}”: {named_by} still name it")
+            left_alone.append(
+                f"the marker “{hidden}” because it is still used by {named_by}"
+            )
             continue
         hiddens.append(hidden)
+        modifiers.update(hander_modifiers)
 
-    for row in Modifier.objects.filter(
-        adds_assignable__in=AddsAssignable.objects.filter(hidden__in=hiddens)
-    ) | Modifier.objects.filter(
-        removes_assignable__in=RemovesAssignable.objects.filter(hidden__in=hiddens)
-    ):
-        modifiers[row.pk] = row
+    doomed_hidden_ids = {hidden.pk for hidden in hiddens}
+    for modifier in modifiers.values():
+        other_carriers = [
+            (kind, row)
+            for kind, row in carriers_of(modifier)
+            if not (kind == "Hidden" and row.pk in doomed_hidden_ids)
+        ]
+        if other_carriers:
+            named = ", ".join(
+                f"{kind} “{row}”" for kind, row in sorted(other_carriers, key=str)
+            )
+            problems.append(
+                f"the modifier “{modifier}” remains attached to {named}. "
+                "Remove or convert it first"
+            )
+
+    if problems:
+        return Fossils(problems=tuple(problems))
 
     already = {hidden.pk for hidden in hiddens}
-    for hidden in Hidden.objects.order_by("name"):
+    for hidden in Hidden.objects.filter(
+        pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG
+    ).order_by("name"):
         if hidden.pk in already:
             continue
-        grants = [
-            modifier
-            for modifier in hidden.modifiers.all()
-            if getattr(modifier, "adds_assignable", None) is not None
-            and modifier.adds_assignable.slot_id
+        held_modifiers = list(hidden.modifiers.all())
+        if len(held_modifiers) != 1:
+            continue
+        grant = held_modifiers[0]
+        effect = getattr(grant, "adds_assignable", None)
+        if (
+            effect is None
+            or effect.slot_id is None
+            or grant.pack.slug != settings.DEFAULT_CONTENT_PACK_SLUG
+            or effect.slot.slot_type.name != "Variant"
+            or effect.slot.pack.slug != settings.DEFAULT_CONTENT_PACK_SLUG
+            or effect.slot.slot_type.pack.slug != settings.DEFAULT_CONTENT_PACK_SLUG
+        ):
+            continue
+        other_carriers = [
+            (kind, row)
+            for kind, row in carriers_of(grant)
+            if not (kind == "Hidden" and row.pk == hidden.pk)
         ]
-        if not grants:
+        if not any(
+            kind == "GangType" and row.pack.slug == settings.DEFAULT_CONTENT_PACK_SLUG
+            for kind, row in other_carriers
+        ):
             continue
         if Assignment.objects.filter(hidden=hidden).exists():
             continue
-        named_by = _anything_naming(
-            hidden, {Modifier: {modifier.pk for modifier in hidden.modifiers.all()}}
-        )
+        named_by = _anything_naming(hidden, {Modifier: {grant.pk}})
         if named_by:
-            left_alone.append(f"the marker “{hidden}”: {named_by} still name it")
+            left_alone.append(
+                f"the marker “{hidden}” because it is still used by {named_by}"
+            )
             continue
         hiddens.append(hidden)
-        for modifier in hidden.modifiers.all():
-            others = [
-                (kind, row)
-                for kind, row in carriers_of(modifier)
-                if not (kind == "Hidden" and row.pk == hidden.pk)
-            ]
-            if not others:
-                modifiers[modifier.pk] = modifier
 
     doomed = {
         type(row): {r.pk for r in doomed_kinds if type(r) is type(row)}
@@ -413,7 +525,7 @@ def find():
         named_by = _anything_naming(row, doomed)
         if named_by:
             problems.append(
-                f"{named_by} still name “{row}”, so it cannot be deleted yet"
+                f"“{row}” is still used by {named_by}, so it cannot be deleted yet"
             )
     if problems:
         return Fossils(problems=tuple(problems))
@@ -432,9 +544,11 @@ def find():
     for collection in collections:
         said.append(f"delete the menu “{collection}” and its sections")
     for modifier in sorted(modifiers.values(), key=str):
-        said.append(f"delete the modifier “{modifier}”, which nothing needs")
+        said.append(
+            f"delete the modifier “{modifier}” because no remaining row uses it"
+        )
     for hidden in hiddens:
-        said.append(f"delete the marker “{hidden}”, which nothing holds")
+        said.append(f"delete the marker “{hidden}” because no assignment uses it")
 
     if not (doomed_kinds or entries or collections or modifiers or hiddens):
         return Fossils(nothing_here=True, left_alone=tuple(left_alone))
@@ -529,11 +643,13 @@ def _same_deletion_set(left, right):
         and set(left.sections) == set(right.sections)
         and set(left.modifiers) == set(right.modifiers)
         and set(left.hiddens) == set(right.hiddens)
+        and set(left.gang_ids) == set(right.gang_ids)
     )
 
 
 def apply(fossils):
     """Delete exactly what was read, and prove every page unmoved."""
+    from django.db import connection
     from django.db.models import ProtectedError
 
     from n26.core.capture import differences, gang_state
@@ -546,40 +662,91 @@ def apply(fossils):
         CollectionSection,
         Hidden,
         Modifier,
+        OffersChoice,
     )
 
     if fossils.problems:
-        raise Refused("not deleted: " + "; ".join(fossils.problems))
+        raise Refused(
+            "The deletion cannot run because " + "; ".join(fossils.problems) + "."
+        )
     if fossils.nothing_here:
         return list(fossils.preview())
 
     report = list(fossils.preview())
     try:
         with _one_snapshot(), transaction.atomic():
-            # The plan was read before this transaction opened, and a
-            # menu's entries cascade rather than protect — so an entry
-            # added in between would ride a delete down instead of
-            # refusing. The menus are locked first: inserting an entry
-            # takes a key-share lock on its collection, which this
-            # conflicts with. Then the plan is read again, and anything
-            # that moved before the lock refuses.
-            list(
-                Collection.objects.select_for_update()
-                .filter(pk__in=fossils.collections)
+            # An affiliation offer points only at the ContentType, not at an
+            # Affiliation row. Fence writes to the offer table before the
+            # repeatable-read snapshot is established, or a new whole-kind
+            # offer could appear after validation with no answers left for it.
+            if connection.vendor == "postgresql":
+                table = connection.ops.quote_name(OffersChoice._meta.db_table)
+                with connection.cursor() as cursor:
+                    cursor.execute(f"LOCK TABLE {table} IN SHARE MODE")
+            # The plan was read before this transaction opened. Every
+            # row whose relations cascade is locked before the second
+            # reading, so a new entry, modifier attachment, or edited
+            # effect cannot ride the deletion down. Foreign-key checks
+            # take key-share locks on their targets, which these locks
+            # conflict with. Anything that moved before the locks were
+            # taken changes the second reading and refuses.
+            kind_rows = {}
+            for model, pk in fossils.kind_rows:
+                kind_rows.setdefault(model, []).append(pk)
+            for model in sorted(kind_rows, key=lambda item: item._meta.label_lower):
+                list(
+                    model.objects.select_for_update()
+                    .filter(pk__in=kind_rows[model])
+                    .order_by("pk")
+                )
+            for model, pks in (
+                (Collection, fossils.collections),
+                (CollectionSection, fossils.sections),
+                (CollectionEntry, fossils.entries),
+                (Hidden, fossils.hiddens),
+            ):
+                list(
+                    model.objects.select_for_update().filter(pk__in=pks).order_by("pk")
+                )
+            hidden_modifier_ids = Hidden.objects.filter(
+                pk__in=fossils.hiddens
+            ).values_list("modifiers__pk", flat=True)
+            locked_modifiers = list(
+                Modifier.objects.select_for_update()
+                .filter(pk__in={*fossils.modifiers, *hidden_modifier_ids})
                 .order_by("pk")
             )
-            list(
-                CollectionEntry.objects.select_for_update()
-                .filter(pk__in=fossils.entries)
-                .order_by("pk")
-            )
+            modifier_parts = {}
+            for modifier in locked_modifiers:
+                for one_to_one in Modifier._meta.get_fields():
+                    if not (
+                        getattr(one_to_one, "one_to_one", False)
+                        and getattr(one_to_one, "concrete", False)
+                    ):
+                        continue
+                    part_id = getattr(modifier, f"{one_to_one.name}_id")
+                    if part_id is not None:
+                        modifier_parts.setdefault(one_to_one.related_model, []).append(
+                            part_id
+                        )
+            for model in sorted(
+                modifier_parts, key=lambda item: item._meta.label_lower
+            ):
+                list(
+                    model.objects.select_for_update()
+                    .filter(pk__in=modifier_parts[model])
+                    .order_by("pk")
+                )
             now = find()
             if now.problems:
-                raise Refused("not deleted: " + "; ".join(now.problems))
+                raise Refused(
+                    "The deletion cannot run because " + "; ".join(now.problems) + "."
+                )
             if now.nothing_here or not _same_deletion_set(fossils, now):
                 raise Refused(
-                    "not deleted: what stands has changed since the plan "
-                    "was read — read it again"
+                    "The deletion cannot run because the rows selected for deletion "
+                    "have changed since the plan was read. Reload this page to "
+                    "generate a new plan."
                 )
 
             gangs = list(Gang.objects.filter(pk__in=fossils.gang_ids))
@@ -605,15 +772,16 @@ def apply(fossils):
             changed = differences(before, after)
             if changed:
                 raise Refused(
-                    "refused — what a reader is told would change:\n  "
-                    + "\n  ".join(changed[:10])
+                    "The deletion cannot run because a checked gang page would "
+                    "change:\n  " + "\n  ".join(changed[:10])
                 )
             for gang in gangs:
                 try:
                     assert_reconciled(gang)
                 except Exception as failed:
                     raise Refused(
-                        f"refused — {gang} no longer reconciles: {failed}"
+                        "The deletion cannot run because "
+                        f"{gang} no longer reconciles: {failed}."
                     ) from failed
     except ConversionRefused as refused:
         raise Refused(str(refused)) from refused
@@ -622,8 +790,9 @@ def apply(fossils):
         # is a referent nobody listed, and the answer is a refusal in
         # words rather than a traceback.
         raise Refused(
-            "refused — something still names what would be deleted: "
-            f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}"
+            "The deletion cannot run because these rows still refer to a row "
+            "selected for deletion: "
+            f"{sorted(str(obj) for obj in protected.protected_objects)[:5]}."
         ) from protected
-    report.append("deleted; every page reads the same")
+    report.append("Deleted. The checked gang pages render the same.")
     return report

--- a/n26/library/empty_affiliations.py
+++ b/n26/library/empty_affiliations.py
@@ -29,6 +29,10 @@ Four rules keep the reading honest:
 * A kind row anything still names cannot be deleted at all. Those
   answers belong to a conversion that has not run, so this refuses and
   says which, rather than running before its turn.
+* An Affiliation offer somebody still holds is the old question still
+  live on a card. Deleting emptied rows would take the answers out from
+  under it, so this refuses rather than leaving the offer and emptying
+  the menu.
 * A menu is deleted only when everything in it is going and nothing
   outside what is going asks for it. A menu holding one live entry
   keeps its shape and loses only the entries.
@@ -286,23 +290,20 @@ def find():
         model__in=[model._meta.model_name for _, model in _kinds()],
     )
     offers = []
-    standing = []
     for offer in OffersChoice.objects.filter(of_kind__in=kinds).select_related(
         "from_section"
     ):
         carried_by = _held_carriers(offer)
         if carried_by:
-            standing.append(offer)
-            left_alone.append(
-                f"the offer on “{carried_by}”: somebody holds it, so it is a "
-                "question on a card rather than a fossil"
+            problems.append(
+                f"somebody still holds the Affiliation offer on “{carried_by}”, "
+                "so the old question is still live"
             )
             continue
         offers.append(offer)
+    if problems:
+        return Fossils(problems=tuple(problems))
 
-    kept_sections = {
-        offer.from_section_id for offer in standing if offer.from_section_id
-    }
     collections = []
     for collection in Collection.objects.filter(
         pk__in={entry.collection_id for entry in entries}
@@ -316,17 +317,6 @@ def find():
             left_alone.append(
                 f"the menu “{collection}”: not everything in it is going, "
                 "so it loses those entries and keeps its shape"
-            )
-            continue
-        asked_of = set(
-            CollectionSection.objects.filter(collection=collection).values_list(
-                "pk", flat=True
-            )
-        )
-        if asked_of & kept_sections:
-            left_alone.append(
-                f"the menu “{collection}”: an offer somebody holds still asks "
-                "from it, so it keeps its shape"
             )
             continue
         collections.append(collection)
@@ -530,6 +520,18 @@ def _delete_parts_of(modifiers):
                 held.delete()
 
 
+def _same_deletion_set(left, right):
+    """Whether two readings name the same rows to delete."""
+    return (
+        set(left.kind_rows) == set(right.kind_rows)
+        and set(left.entries) == set(right.entries)
+        and set(left.collections) == set(right.collections)
+        and set(left.sections) == set(right.sections)
+        and set(left.modifiers) == set(right.modifiers)
+        and set(left.hiddens) == set(right.hiddens)
+    )
+
+
 def apply(fossils):
     """Delete exactly what was read, and prove every page unmoved."""
     from django.db.models import ProtectedError
@@ -554,6 +556,32 @@ def apply(fossils):
     report = list(fossils.preview())
     try:
         with _one_snapshot(), transaction.atomic():
+            # The plan was read before this transaction opened, and a
+            # menu's entries cascade rather than protect — so an entry
+            # added in between would ride a delete down instead of
+            # refusing. The menus are locked first: inserting an entry
+            # takes a key-share lock on its collection, which this
+            # conflicts with. Then the plan is read again, and anything
+            # that moved before the lock refuses.
+            list(
+                Collection.objects.select_for_update()
+                .filter(pk__in=fossils.collections)
+                .order_by("pk")
+            )
+            list(
+                CollectionEntry.objects.select_for_update()
+                .filter(pk__in=fossils.entries)
+                .order_by("pk")
+            )
+            now = find()
+            if now.problems:
+                raise Refused("not deleted: " + "; ".join(now.problems))
+            if now.nothing_here or not _same_deletion_set(fossils, now):
+                raise Refused(
+                    "not deleted: what stands has changed since the plan "
+                    "was read — read it again"
+                )
+
             gangs = list(Gang.objects.filter(pk__in=fossils.gang_ids))
             before = {str(gang.pk): gang_state(gang) for gang in gangs}
 

--- a/n26/library/forms.py
+++ b/n26/library/forms.py
@@ -512,10 +512,21 @@ class GeneratedForm(forms.Form):
         form rather than only hidden — ``apply_to`` writes the fields the
         form carries, so a submission naming one anyway writes nothing.
         """
-        form = cls(data, files, initial=_initial_from(cls.spec, thing), prefix=prefix)
+        initial = _initial_from(cls.spec, thing)
+        form = cls(data, files, initial=initial, prefix=prefix)
         for name, kind in cls.spec.fields.items():
             if getattr(kind, "fixed", False):
                 form.fields.pop(name, None)
+                continue
+            if not (isinstance(kind, Choice) and name in initial):
+                continue
+            current = str(initial[name])
+            offered = {str(value) for value, _label in form.fields[name].choices}
+            if current not in offered:
+                form.fields[name].choices = [
+                    *form.fields[name].choices,
+                    (current, f"{current.replace('_', ' ')} (retired)"),
+                ]
         return form
 
     def apply_to(self, thing):

--- a/n26/library/models/assignable.py
+++ b/n26/library/models/assignable.py
@@ -920,12 +920,11 @@ class Rule(Content, Assignable):
 
 
 class Affiliation(Content, Assignable):
-    """A leftover chosen-carrier kind. Author a slot type instead.
+    """Affiliations are retired. Use a slot type, pickables, and a grant of
+    that slot for gang-level choices.
 
-    Gang-level choices — who the gang sides with, which god it follows,
-    which corruption it took — are a slot type, its pickables, and a
-    grant of that slot. The leftover rows stay reachable until they are
-    deleted; nothing new is authored here.
+    Existing affiliation rows remain available here until they are
+    deleted.
     """
 
     family = Family.GANG

--- a/n26/library/models/assignable.py
+++ b/n26/library/models/assignable.py
@@ -920,16 +920,12 @@ class Rule(Content, Assignable):
 
 
 class Affiliation(Content, Assignable):
-    """Who the gang sides with, chosen once when the gang is created.
+    """A leftover chosen-carrier kind. Author a slot type instead.
 
-    A chosen carrier: the whole of what it means rides it as ordinary
-    modifiers, and it is its own kind so the card says "Affiliation:".
-    An affiliation's payload is typically *access* —
-    equipment lists opened to some ranks, so its gives are scoped while
-    the affiliation itself rides gang-wide — and an affiliation may
-    itself offer a further choice (Clan House's "choose one of the six
-    Houses"): what is chosen is an ordinary assignment hosted on the
-    gang, so a choice carried on it simply computes into another slot.
+    Gang-level choices — who the gang sides with, which god it follows,
+    which corruption it took — are a slot type, its pickables, and a
+    grant of that slot. The leftover rows stay reachable until they are
+    deleted; nothing new is authored here.
     """
 
     family = Family.GANG

--- a/n26/library/models/modifier.py
+++ b/n26/library/models/modifier.py
@@ -74,6 +74,13 @@ OFFERABLE_KINDS = (
     "subtype",
 )
 
+#: Kinds authors may choose for a new offer. Affiliation remains valid above
+#: only so legacy rows can still be loaded and repaired before the model is
+#: removed; the slot-based replacement is the only authorable route now.
+AUTHORABLE_OFFER_KINDS = tuple(
+    kind for kind in OFFERABLE_KINDS if kind != "affiliation"
+)
+
 EFFECT_FIELDS = (*COMPUTED_EFFECT_FIELDS, *STORED_EFFECT_FIELDS)
 
 #: Which assignable kinds an AddsAssignable/RemovesAssignable can name.

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -11,12 +11,12 @@ Where a step is not yet possible, it says so plainly.
 
 Genestealer Cult, Chaos and Malstrain corruption are one build with
 different contents: a corruption is a choice the gang makes once, and
-everything it does rides the chosen pickable as ordinary modifiers.
+all of its effects come from modifiers attached to the chosen pickable.
 
 ### The choice
 
-A gang-level choice is a **slot type**, not a new kind. The same six
-steps that build a Gang Legacy build this — the pick lands on the gang.
+Use a **slot type** for this gang-level choice. Follow the same six steps
+as a Gang Legacy, assigning the pick to the gang.
 
 1. Create a **slot type** named "Variant" — what is being chosen — and
    give it a plural. Turn *allows repeats* off. Everything below is
@@ -24,8 +24,8 @@ steps that build a Gang Legacy build this — the pick lands on the gang.
 2. Add a **pickable** for each corruption — "Genestealer Cult
    Corrupted", "Chaos Corrupted", "Malstrain Corrupted".
 3. Add a **picklist** named "Variants" holding those three.
-4. Add a **slot** labelled "Variant", taking 0–1 (most gangs never
-   answer), assigned to the gang.
+4. Add a **slot** labelled "Variant", taking 0–1 (most gangs leave it
+   empty), assigned to the gang.
 5. Create a **hidden** if the gang type should carry the question
    without drawing a line of its own, or skip this and attach the grant
    to the gang type directly.
@@ -33,16 +33,16 @@ steps that build a Gang Legacy build this — the pick lands on the gang.
    slot.
 
 Every gang of those types now shows an open "Variant" question on its
-sheet. Most players never make that choice. The ones who do pick one
-pickable, and everything below hangs off that pick.
+sheet. Most players never make that choice. Players who use it make one
+pick. The chosen pickable's modifiers provide the effects described
+below.
 
 ### What a corruption grants
 
-Each of these is a modifier carried by the corruption's pickable.
-Everything a chosen thing brings rides it as modifiers — *gives*,
-*brings a model*, *moves a counter* — and never as built-in items: a
-pickable is chosen, not bought or hired, so nothing would ever hand
-built-in items over.
+Each effect is a modifier carried by the corruption's pickable: *gives*,
+*brings a model*, or *moves a counter*. Do not add these as built-in
+items. Pickables are chosen rather than bought or hired, so built-in
+items would never be assigned.
 
 **New fighters to hire.** Create the profiles — Aberrant, Abominant,
 Helot Cult Witch, Chaos Spawn, Brood Scum. Create a collection listing
@@ -70,10 +70,10 @@ credits, usable by Prospects, carrying *gives* the Extra Arm rule. List
 it in the corruption's collection.
 
 **A god to dedicate to (Chaos).** Create a **slot type** named "Chaos
-God", refusing repeats; a pickable per god; a picklist of the four; and
-a slot labelled "Chaos God", taking 0–1, assigned to the gang. On the
-Chaos Corrupted pickable: targets the gang, *gives* that slot. Anything
-one god means rides that god's pickable the same way.
+God" and turn *allows repeats* off. Add a pickable per god, a picklist of
+the four, and a slot labelled "Chaos God", taking 0–1 and assigned to
+the gang. On the Chaos Corrupted pickable: targets the gang, *gives*
+that slot. Attach each god's effects to that god's pickable.
 
 **Post-cycle actions (Chaos).** Create each action as a **rule**. On the
 pickable: targets the gang, *gives* the rule. They print on the gang's

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -11,33 +11,42 @@ Where a step is not yet possible, it says so plainly.
 
 Genestealer Cult, Chaos and Malstrain corruption are one build with
 different contents: a corruption is a choice the gang makes once, and
-everything it does rides the chosen item as ordinary modifiers.
+everything it does rides the chosen pickable as ordinary modifiers.
 
 ### The choice
 
-1. Create an **affiliation** for each corruption — "Genestealer Cult
-   Corrupted", "Chaos Corrupted", "Malstrain Corrupted".
-2. Create a **collection** named "Corruptions" and switch off *Prices its
-   entries* — it is a menu, not a catalogue. List the three affiliations in it.
-3. Create a **modifier**: targets the gang, *offers a choice* of
-   affiliation from that menu, labelled "Corruption". Attach it to every
-   gang type that can be corrupted.
+A gang-level choice is a **slot type**, not a new kind. The same six
+steps that build a Gang Legacy build this — the pick lands on the gang.
 
-Every gang of those types now shows an open "Corruption" question on its
-sheet. Most players never make that choice. The ones who do pick one affiliation,
-and everything below hangs off that pick.
+1. Create a **slot type** named "Variant" — what is being chosen — and
+   give it a plural. Turn *allows repeats* off. Everything below is
+   built on its page.
+2. Add a **pickable** for each corruption — "Genestealer Cult
+   Corrupted", "Chaos Corrupted", "Malstrain Corrupted".
+3. Add a **picklist** named "Variants" holding those three.
+4. Add a **slot** labelled "Variant", taking 0–1 (most gangs never
+   answer), assigned to the gang.
+5. Create a **hidden** if the gang type should carry the question
+   without drawing a line of its own, or skip this and attach the grant
+   to the gang type directly.
+6. On that hidden or gang type: targets the gang, *gives* the Variant
+   slot.
+
+Every gang of those types now shows an open "Variant" question on its
+sheet. Most players never make that choice. The ones who do pick one
+pickable, and everything below hangs off that pick.
 
 ### What a corruption grants
 
-Each of these is a modifier carried by the corruption's affiliation.
+Each of these is a modifier carried by the corruption's pickable.
 Everything a chosen thing brings rides it as modifiers — *gives*,
-*brings a model*, *moves a counter* — and never as built-in items: an
-affiliation is chosen, not bought or hired, so nothing would ever hand
+*brings a model*, *moves a counter* — and never as built-in items: a
+pickable is chosen, not bought or hired, so nothing would ever hand
 built-in items over.
 
 **New fighters to hire.** Create the profiles — Aberrant, Abominant,
 Helot Cult Witch, Chaos Spawn, Brood Scum. Create a collection listing
-them at their prices. On the affiliation: targets the gang, *gives* the
+them at their prices. On the pickable: targets the gang, *gives* the
 collection.
 
 Once a gang carries that collection, its hire page grows a section named
@@ -53,23 +62,24 @@ corruption's collection at 35 credits. A player buys it for their Leader
 whenever suits — at hire or later; the book's timing is theirs to honour.
 
 **Familiars.** Create the familiar as **wargear**, usable by Leaders and
-Champions, and put it in a collection. On the affiliation: targets models
+Champions, and put it in a collection. On the pickable: targets models
 that are Leaders or Champions, *gives* that collection.
 
 **Extra Arm on Prospects.** Create a **wargear** named "Extra Arm" at 20
 credits, usable by Prospects, carrying *gives* the Extra Arm rule. List
 it in the corruption's collection.
 
-**A god to dedicate to (Chaos).** Create an affiliation per god, and a
-menu collection listing the four. On the Chaos affiliation: targets the
-gang, *offers a choice* from that menu, labelled "Dedicated to". Anything
-one god means rides that god's affiliation the same way.
+**A god to dedicate to (Chaos).** Create a **slot type** named "Chaos
+God", refusing repeats; a pickable per god; a picklist of the four; and
+a slot labelled "Chaos God", taking 0–1, assigned to the gang. On the
+Chaos Corrupted pickable: targets the gang, *gives* that slot. Anything
+one god means rides that god's pickable the same way.
 
 **Post-cycle actions (Chaos).** Create each action as a **rule**. On the
-affiliation: targets the gang, *gives* the rule. They print on the gang's
+pickable: targets the gang, *gives* the rule. They print on the gang's
 card.
 
-**Counts and bans.** Each is one modifier on the affiliation. For "0–2
+**Counts and bans.** Each is one modifier on the pickable. For "0–2
 Aberrants": targets the gang, *notes a limit*, set to 2, naming the
 Aberrant profile — the gang's sheet says nothing until a third one is
 hired, and then it says the roster is over. For "no Brutes, Hangers-on or
@@ -91,7 +101,7 @@ rule that improves their weapons or shifts a characteristic does so from
 there, and only a rule you want printed on each fighter's card as well
 needs a second *gives* aimed at the model. The rules are then granted
 rather than built in, so there is a single thing standing behind the lot.
-On each corruption's affiliation, add *takes something away* naming that
+On each corruption's pickable, add *takes something away* naming that
 hidden item: aimed at the gang, which is where the item sits, and aimed at
 the model too if the fighters' own cards were given rules of their own.
 Everything the hidden item was handing out goes with it, and drop the

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -373,9 +373,9 @@ def _build_registry():
     )
     from n26.library.models.defaults import DEFAULT_ASSIGNABLE_FIELDS
     from n26.library.models.modifier import (
+        AUTHORABLE_OFFER_KINDS,
         COUNTABLE_FIELDS,
         GRANTABLE_FIELDS,
-        OFFERABLE_KINDS,
     )
 
     # What a built-in may be, derived from the DefaultAssignment row
@@ -607,7 +607,7 @@ def _build_registry():
             authoring.ef_offers_choice,
             {
                 "model": Choice(
-                    options=OFFERABLE_KINDS,
+                    options=AUTHORABLE_OFFER_KINDS,
                     coerce=_offerable_kind_to_model,
                     reads=lambda row: row.of_kind.model,
                 ),

--- a/n26/library/templates/authoring/leaf.html
+++ b/n26/library/templates/authoring/leaf.html
@@ -32,9 +32,11 @@ twice in a row.
             </c-ui.breadcrumbs>
         </c-slot>
         <c-slot name="actions">
-            <c-ui.button href="{% url 'authoring-create' kind %}" variant="primary">
-                New {{ verbose_name }}
-            </c-ui.button>
+            {% if not retired %}
+                <c-ui.button href="{% url 'authoring-create' kind %}" variant="primary">
+                    New {{ verbose_name }}
+                </c-ui.button>
+            {% endif %}
         </c-slot>
     </c-n26.page-header>
     {% if kind_help %}

--- a/n26/library/templatetags/authoring_nav.py
+++ b/n26/library/templatetags/authoring_nav.py
@@ -42,7 +42,7 @@ def kinds_switcher(here="", menu_label="Switch kind", named=False):
 
     from n26.core.navigation import Switcher, SwitcherItem
     from n26.library.specs import specs
-    from n26.library.views import LEAF_KINDS, _model_for
+    from n26.library.views import LEAF_KINDS, RETIRED_KINDS, _model_for
 
     items = sorted(
         (
@@ -54,6 +54,7 @@ def kinds_switcher(here="", menu_label="Switch kind", named=False):
                 current=kind == here,
             )
             for kind, verb in LEAF_KINDS.items()
+            if kind not in RETIRED_KINDS
         ),
         key=lambda item: item.label,
     )

--- a/n26/library/templatetags/authoring_nav.py
+++ b/n26/library/templatetags/authoring_nav.py
@@ -54,7 +54,7 @@ def kinds_switcher(here="", menu_label="Switch kind", named=False):
                 current=kind == here,
             )
             for kind, verb in LEAF_KINDS.items()
-            if kind not in RETIRED_KINDS
+            if kind not in RETIRED_KINDS or kind == here
         ),
         key=lambda item: item.label,
     )

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -71,6 +71,14 @@ LEAF_KINDS = {
 }
 
 
+#: Kinds a menu no longer offers. What they said is said by slots and
+#: picks now, and the rows that remain are history: emptied leftovers
+#: waiting to be deleted. They keep their listing and detail pages, so
+#: those rows stay reachable — it is the invitation to make another one
+#: that goes.
+RETIRED_KINDS = frozenset({"affiliation"})
+
+
 #: Kinds whose page is a place you come back to: the thing, and the
 #: parts you add to it over time. ``kind -> the verb that adds a part``.
 def _describe_weapon_profile(profile):
@@ -1105,6 +1113,8 @@ def index(request):
     qualities, the kit, the gang-scale picks."""
     grouped = {family: [] for family in Family}
     for kind, verb_name in LEAF_KINDS.items():
+        if kind in RETIRED_KINDS:
+            continue
         model = _model_for(specs()[verb_name])
         grouped[model.family].append(
             {
@@ -1288,6 +1298,7 @@ def leaf(request, kind):
             # where the act exists: hanging a modifier on a thing that
             # can carry one.
             "bulk_attach": _carries_modifiers(kind),
+            "retired": kind in RETIRED_KINDS,
         },
     )
 
@@ -1387,6 +1398,8 @@ def _selected(rows, pks):
 @staff_member_required
 def create(request, kind):
     """The form that makes one more of a leaf kind, on its own page."""
+    if kind in RETIRED_KINDS:
+        raise Http404(f"No authoring page for {kind!r}")
     spec = _spec_for(kind)
     model = _model_for(spec)
     form_class = generate_form(spec)
@@ -3738,7 +3751,8 @@ def foundations(request):
                     "count": _model_for(specs()[verb]).objects.count(),
                 }
                 for kind, verb in LEAF_KINDS.items()
-                if _model_for(specs()[verb]).family == Family.FOUNDATION
+                if kind not in RETIRED_KINDS
+                and _model_for(specs()[verb]).family == Family.FOUNDATION
             ],
         },
     )

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -942,8 +942,9 @@ EMPTY_AFFILIATION_WORDS = {
         "slots — stay; those are the new system. Because none of what "
         "goes is in use, no page should move at all — and that is what "
         "it proves before committing. It refuses while any assignment "
-        "still names an Affiliation, which belongs to a conversion that "
-        "has not run."
+        "still names an Affiliation, or while anybody still holds an "
+        "Affiliation offer — both belong to a conversion that has not "
+        "run."
     ),
     "nothing_heading": "Nothing to delete",
     "nothing_flash": "There was nothing to delete — the emptied Affiliation rows have gone already.",

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "Operation",
     "backfill_built_ins",
+    "delete_empty_affiliations",
     "delete_nameless_gang_type",
     "rehost_gang_picks",
     "repair_doubled_refunds",
@@ -166,6 +167,10 @@ class Operation(models.TextChoices):
         "n26_repoint_champion_picks",
         "n26: the Champion picks move onto the Champion archetypes",
     )
+    DELETE_EMPTY_AFFILIATIONS = (
+        "n26_delete_empty_affiliations",
+        "n26: the emptied Affiliation rows are deleted",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -180,6 +185,7 @@ LOCK_KEYS = {
     Operation.DROP_DUPLICATE_GRANTS: 826_020_613,
     Operation.REHOST_GANG_PICKS: 826_020_614,
     Operation.REPOINT_CHAMPION_PICKS: 826_020_615,
+    Operation.DELETE_EMPTY_AFFILIATIONS: 826_020_616,
 }
 
 
@@ -859,6 +865,25 @@ def rehost_gang_picks(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def delete_empty_affiliations(backfill_id, **said_by_whoever_enqueued_it):
+    """Delete emptied Affiliation library rows, and record it.
+
+    The runner discipline of a conversion around work that deletes
+    library rows only. Nothing a player holds is touched, which is why
+    what it proves is that no page moves at all.
+    """
+    from n26.library.empty_affiliations import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.DELETE_EMPTY_AFFILIATIONS,
+        "Empty Affiliation deletion",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
 REHOST_WORDS = {
     "noun": "move",
     "intro": (
@@ -901,6 +926,44 @@ def rehost_gang_picks_view(request):
         find,
         rehost_gang_picks,
         REHOST_WORDS,
+    )
+
+
+EMPTY_AFFILIATION_WORDS = {
+    "noun": "deletion",
+    "intro": (
+        "This deletes library rows and nothing a player holds: the "
+        "Affiliation kind rows the conversions emptied, the menus those "
+        "kinds were chosen from, the fossil offers nothing carries, and "
+        "the vestigial Hidden that grants a slot nobody holds. Every row "
+        "it would delete is listed below, along with anything it leaves "
+        "alone and why. The slot types named Affiliation, Clan House, "
+        "Chaos God and Variant — and their pickables, picklists and "
+        "slots — stay; those are the new system. Because none of what "
+        "goes is in use, no page should move at all — and that is what "
+        "it proves before committing. It refuses while any assignment "
+        "still names an Affiliation, which belongs to a conversion that "
+        "has not run."
+    ),
+    "nothing_heading": "Nothing to delete",
+    "nothing_flash": "There was nothing to delete — the emptied Affiliation rows have gone already.",
+    "nothing_words": "The emptied Affiliation rows have gone already.",
+    "refuses_heading": "The deletion refuses",
+    "button": "Delete the emptied Affiliation rows",
+    "confirm": "Delete these library rows? This cannot be undone.",
+}
+
+
+def delete_empty_affiliations_view(request):
+    """Preview the deletion (GET), or record a run and enqueue it."""
+    from n26.library.empty_affiliations import find
+
+    return _deletion_view(
+        request,
+        Operation.DELETE_EMPTY_AFFILIATIONS,
+        find,
+        delete_empty_affiliations,
+        EMPTY_AFFILIATION_WORDS,
     )
 
 
@@ -1440,6 +1503,25 @@ register_operation(
     )
 )
 
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.DELETE_EMPTY_AFFILIATIONS.value,
+        name=Operation.DELETE_EMPTY_AFFILIATIONS.label,
+        added=date(2026, 8, 29),
+        description=(
+            "Delete what the Affiliation conversions left behind: the "
+            "emptied kind rows, the menus nothing offers from, the fossil "
+            "offers, and the vestigial Hidden that nothing holds. All "
+            "library, none of it in use, so it proves that no page moves "
+            "at all. The slot types named Affiliation, Clan House, Chaos "
+            "God and Variant stay. Refuses while any assignment still "
+            "names an Affiliation."
+        ),
+        view=delete_empty_affiliations_view,
+        detail_template="admin/maintenance/n26/_delete_detail.html",
+    )
+)
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a repair holds one
 #: transaction for as long as proving what it touched takes. It is also
@@ -1468,6 +1550,7 @@ task_routes = [
     TaskRoute(drop_duplicate_grants, ack_deadline=600),
     TaskRoute(rehost_gang_picks, ack_deadline=600, min_retry_delay=60),
     TaskRoute(repoint_champion_picks, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(delete_empty_affiliations, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -1517,7 +1517,8 @@ register_operation(
             "The deletion is rolled back if it would change any checked "
             "gang page. The slot types named Affiliation, Clan House, "
             "Chaos God and Variant remain. The deletion cannot run while "
-            "any assignment still names an affiliation."
+            "any assignment still names an affiliation or any affiliation "
+            "offer remains attached to a carrier."
         ),
         view=delete_empty_affiliations_view,
         detail_template="admin/maintenance/n26/_delete_detail.html",

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -945,11 +945,8 @@ EMPTY_AFFILIATION_WORDS = {
         "affiliation offer. Run the related conversion first."
     ),
     "nothing_heading": "Nothing to delete",
-    "nothing_flash": (
-        "There was nothing to delete. The emptied affiliation rows were "
-        "already deleted."
-    ),
-    "nothing_words": "The emptied affiliation rows were already deleted.",
+    "nothing_flash": "There was nothing selected for deletion.",
+    "nothing_words": "No Affiliation leftovers are selected for deletion.",
     "refuses_heading": "The deletion cannot run",
     "button": "Delete the emptied affiliation rows",
     "confirm": "Delete these library rows? This cannot be undone.",

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -169,7 +169,7 @@ class Operation(models.TextChoices):
     )
     DELETE_EMPTY_AFFILIATIONS = (
         "n26_delete_empty_affiliations",
-        "n26: the emptied Affiliation rows are deleted",
+        "n26: the emptied affiliation rows are deleted",
     )
 
 
@@ -746,7 +746,7 @@ def _deletion_view(request, operation, find_fn, task_fn, words):
         if not plan.ok:
             messages.error(
                 request,
-                f"The {words['noun']} refuses: " + "; ".join(plan.problems),
+                f"The {words['noun']} cannot run: " + "; ".join(plan.problems) + ".",
             )
             return HttpResponseRedirect(address)
         backfill = Backfill.objects.create(
@@ -757,7 +757,7 @@ def _deletion_view(request, operation, find_fn, task_fn, words):
         )
         task_fn.enqueue(backfill_id=str(backfill.id))
         messages.success(
-            request, f"The {words['noun']} is running. This page shows what it did."
+            request, f"The {words['noun']} is running. The result will appear below."
         )
         return HttpResponseRedirect(
             reverse("admin:maintenance_backfill_detail", args=[backfill.id])
@@ -932,25 +932,26 @@ def rehost_gang_picks_view(request):
 EMPTY_AFFILIATION_WORDS = {
     "noun": "deletion",
     "intro": (
-        "This deletes library rows and nothing a player holds: the "
-        "Affiliation kind rows the conversions emptied, the menus those "
-        "kinds were chosen from, the fossil offers nothing carries, and "
-        "the vestigial Hidden that grants a slot nobody holds. Every row "
-        "it would delete is listed below, along with anything it leaves "
-        "alone and why. The slot types named Affiliation, Clan House, "
-        "Chaos God and Variant — and their pickables, picklists and "
-        "slots — stay; those are the new system. Because none of what "
-        "goes is in use, no page should move at all — and that is what "
-        "it proves before committing. It refuses while any assignment "
-        "still names an Affiliation, or while anybody still holds an "
-        "Affiliation offer — both belong to a conversion that has not "
-        "run."
+        "This deletes old library rows without changing player data: "
+        "emptied affiliation rows, their menus, unused affiliation "
+        "offers, and unused hidden rows that grant slots. The rows "
+        "selected for deletion are listed below, together with the rows "
+        "that will remain and the reason for keeping them. The slot types "
+        "named Affiliation, Clan House, Chaos God and Variant remain, "
+        "along with their pickables, picklists and slots. Those rows are "
+        "the new system. The deletion is rolled back if it would change "
+        "any checked gang page. The deletion cannot run while any "
+        "assignment still names an affiliation or anyone still holds an "
+        "affiliation offer. Run the related conversion first."
     ),
     "nothing_heading": "Nothing to delete",
-    "nothing_flash": "There was nothing to delete — the emptied Affiliation rows have gone already.",
-    "nothing_words": "The emptied Affiliation rows have gone already.",
-    "refuses_heading": "The deletion refuses",
-    "button": "Delete the emptied Affiliation rows",
+    "nothing_flash": (
+        "There was nothing to delete. The emptied affiliation rows were "
+        "already deleted."
+    ),
+    "nothing_words": "The emptied affiliation rows were already deleted.",
+    "refuses_heading": "The deletion cannot run",
+    "button": "Delete the emptied affiliation rows",
     "confirm": "Delete these library rows? This cannot be undone.",
 }
 
@@ -1510,13 +1511,13 @@ register_operation(
         name=Operation.DELETE_EMPTY_AFFILIATIONS.label,
         added=date(2026, 8, 29),
         description=(
-            "Delete what the Affiliation conversions left behind: the "
-            "emptied kind rows, the menus nothing offers from, the fossil "
-            "offers, and the vestigial Hidden that nothing holds. All "
-            "library, none of it in use, so it proves that no page moves "
-            "at all. The slot types named Affiliation, Clan House, Chaos "
-            "God and Variant stay. Refuses while any assignment still "
-            "names an Affiliation."
+            "Delete the affiliation library rows left after the "
+            "conversions: the emptied kind rows, their menus, unused "
+            "affiliation offers, and unused hidden rows that grant slots. "
+            "The deletion is rolled back if it would change any checked "
+            "gang page. The slot types named Affiliation, Clan House, "
+            "Chaos God and Variant remain. The deletion cannot run while "
+            "any assignment still names an affiliation."
         ),
         view=delete_empty_affiliations_view,
         detail_template="admin/maintenance/n26/_delete_detail.html",

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -150,6 +150,12 @@ class TestAffiliationIsRetiredFromTheMenu:
         assert page.status_code == 200
         assert "Clanless" in page.content.decode()
         assert "/n26/authoring/affiliation/new/" not in listing.content.decode()
+        listing_body = listing.content.decode()
+        assert re.search(
+            r'<a href="/n26/authoring/affiliation/"[^>]*aria-current="page"',
+            listing_body,
+        )
+        assert ">Affiliations</span>" in listing_body
 
 
 class TestTheIndex:

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -4077,7 +4077,7 @@ class TestTheCollectionPage:
         assert Collection.objects.filter(name="House Escher Armoury").exists()
 
     def test_the_affiliation_pick_list_is_buildable_end_to_end(
-        self, author, client, default_pack, gang_type
+        self, author, client, default_pack, gang_type, owner
     ):
         """The whole guide, through the pages: a slot type, its
         pickables, a picklist, a slot granted by a hidden built into the
@@ -4151,9 +4151,6 @@ class TestTheCollectionPage:
         )
         assert aboard.status_code == 302
 
-        from django.contrib.auth.models import User
-
-        owner = User.objects.create_user("outcast-founder")
         gang_type.refresh_from_db()
         gang = found_gang("The Unmade", gang_type, owner=owner)
         line = next(

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -22,7 +22,7 @@ import pytest
 from django.contrib.auth.models import User
 
 from n26.library.specs import specs
-from n26.library.views import LEAF_KINDS
+from n26.library.views import LEAF_KINDS, RETIRED_KINDS
 
 pytestmark = pytest.mark.django_db
 
@@ -86,12 +86,16 @@ class TestTheMenuIsBackedBySpecs:
         response = client.get(f"/n26/authoring/{kind}/")
         assert response.status_code == 200
 
-    @pytest.mark.parametrize("kind", sorted(LEAF_KINDS), ids=str)
+    @pytest.mark.parametrize(
+        "kind", sorted(k for k in LEAF_KINDS if k not in RETIRED_KINDS), ids=str
+    )
     def test_every_kind_has_a_create_page(self, kind, author, client, default_pack):
         response = client.get(f"/n26/authoring/{kind}/new/")
         assert response.status_code == 200
 
-    @pytest.mark.parametrize("kind", sorted(LEAF_KINDS), ids=str)
+    @pytest.mark.parametrize(
+        "kind", sorted(k for k in LEAF_KINDS if k not in RETIRED_KINDS), ids=str
+    )
     def test_no_switch_is_handed_a_value_javascript_cannot_read(
         self, kind, author, client, default_pack
     ):
@@ -120,6 +124,32 @@ class TestTheMenuIsBackedBySpecs:
 
     def test_an_unknown_kind_is_a_404(self, author, client, default_pack):
         assert client.get("/n26/authoring/gadget/").status_code == 404
+
+
+class TestAffiliationIsRetiredFromTheMenu:
+    """What an affiliation said is said by slots and picks. The menu
+    stops inviting another one; leftover rows stay reachable."""
+
+    def test_the_index_offers_none_of_the_retired_kinds(
+        self, author, client, default_pack
+    ):
+        body = client.get("/n26/authoring/").content.decode()
+
+        for kind in RETIRED_KINDS:
+            assert f"/n26/authoring/{kind}/new/" not in body, kind
+
+    def test_a_retired_kinds_page_still_opens(self, author, client, default_pack):
+        from n26.tests.sandbox.actions import create_affiliation
+
+        held = create_affiliation("Clanless")
+
+        listing = client.get("/n26/authoring/affiliation/")
+        page = client.get(f"/n26/authoring/affiliation/{held.pk}/")
+
+        assert listing.status_code == 200
+        assert page.status_code == 200
+        assert "Clanless" in page.content.decode()
+        assert "/n26/authoring/affiliation/new/" not in listing.content.decode()
 
 
 class TestTheIndex:
@@ -886,7 +916,7 @@ class TestFamilies:
         assert positions == sorted(positions)
         # A kind sits under its family.
         assert positions[2] < body.index("wargear")
-        assert positions[3] < body.index("affiliation")
+        assert positions[3] < body.index("gang-type")
 
     def test_the_family_table(self):
         """The grouping as agreed, pinned so it changes deliberately."""
@@ -961,11 +991,16 @@ class TestTheCarriers:
         assert made.library_author_help.startswith("Rides the option set")
         assert not made.modifiers.exists()  # armed by the composer, later
 
-    def test_the_chosen_carrier(self, author, client, default_pack):
-        from n26.library.models import Affiliation
+    def test_the_chosen_carrier_is_no_longer_offered(
+        self, author, client, default_pack
+    ):
+        """A gang-level choice is a slot type now. The Affiliation
+        create page is closed so nobody authors another leftover."""
+        response = client.get("/n26/authoring/affiliation/new/")
+        posted = client.post("/n26/authoring/affiliation/new/", {"name": "Clan House"})
 
-        client.post("/n26/authoring/affiliation/new/", {"name": "Clan House"})
-        assert Affiliation.objects.filter(name="Clan House").exists()
+        assert response.status_code == 404
+        assert posted.status_code == 404
 
 
 @pytest.fixture
@@ -4044,48 +4079,60 @@ class TestTheCollectionPage:
     def test_the_affiliation_pick_list_is_buildable_end_to_end(
         self, author, client, default_pack, gang_type
     ):
-        """The whole guide, through the pages: affiliations, the menu
-        collection with its default section and entries, the hidden
-        carrier armed by the composer, the gang type's built-in — and
-        then a player's picker offering exactly the two answers."""
+        """The whole guide, through the pages: a slot type, its
+        pickables, a picklist, a slot granted by a hidden built into the
+        gang type — and then a player's picker offering exactly the two
+        answers."""
         from n26.core.render import render_gang
-        from n26.library.models import Affiliation, Collection, Hidden
+        from n26.library.models import Hidden, Pickable, Picklist, Slot, SlotType
         from n26.tests.sandbox.actions import found_gang
 
-        # The carriers and the menu, every row through a page.
-        for name in ("Clanless Outcast", "Clan House Outcast"):
-            client.post("/n26/authoring/affiliation/new/", {"name": name})
-        client.post("/n26/authoring/collection/new/", {"name": "Affiliations"})
-        picks = Collection.objects.get(name="Affiliations")
-        page = f"/n26/authoring/collection/{picks.pk}/"
         client.post(
-            page, {"act": "section", "name": "Affiliations", "is_default": "on"}
+            "/n26/authoring/slot-type/new/",
+            {"name": "Affiliation", "plural_name": "Affiliations"},
         )
+        slot_type = SlotType.objects.get(name="Affiliation")
+        page = f"/n26/authoring/slot-type/{slot_type.pk}/"
         for name in ("Clanless Outcast", "Clan House Outcast"):
-            made = client.post(
-                page,
+            made = client.post(page, {"act": "pickable", "name": name, "qualifier": ""})
+            assert made.status_code == 302
+        client.post(page, {"act": "picklist", "name": "Affiliations"})
+        picks = Picklist.objects.get(name="Affiliations")
+        for name in ("Clanless Outcast", "Clan House Outcast"):
+            added = client.post(
+                f"/n26/authoring/picklist/{picks.pk}/",
                 {
-                    "act": "entry",
-                    "thing_kind": "affiliation",
-                    "thing_affiliation": str(Affiliation.objects.get(name=name).pk),
+                    "pickable": str(Pickable.objects.get(name=name).pk),
+                    "label_override": "",
+                    "position": "0",
                 },
             )
-            assert made.status_code == 302
+            assert added.status_code == 302
+        client.post(
+            page,
+            {
+                "act": "slot",
+                "name": "Affiliation",
+                "picklist": str(picks.pk),
+                "label": "Affiliation",
+                "min_picks": "0",
+                "max_picks": "1",
+                "assigned_to": "gang",
+                "position": "0",
+            },
+        )
+        slot = Slot.objects.get(name="Affiliation")
 
-        # The question: a hidden carrier, armed on its own page.
         client.post("/n26/authoring/hidden/new/", {"name": "Affiliation"})
         hidden = Hidden.objects.get(name="Affiliation")
-        section = picks.sections.get()
         composed = client.post(
             f"/n26/authoring/hidden/{hidden.pk}/",
             {
                 "act": "compose",
                 "scope_kind": "targets_gang",
-                "effect_kind": "ef_offers_choice",
-                "what-model": "affiliation",
-                "what-from_section": str(section.pk),
-                "what-label": "affiliation",
-                "what-will_be_assigned_to": "bearer",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "slot",
+                "what-thing_slot": str(slot.pk),
                 "conditions-TOTAL_FORMS": "0",
                 "conditions-INITIAL_FORMS": "0",
                 "conditions-MIN_NUM_FORMS": "0",
@@ -4094,7 +4141,6 @@ class TestTheCollectionPage:
         )
         assert composed.status_code == 302
 
-        # Into the gang type's Comes with, through its page.
         aboard = client.post(
             f"/n26/authoring/gang-type/{gang_type.pk}/",
             {
@@ -4105,17 +4151,15 @@ class TestTheCollectionPage:
         )
         assert aboard.status_code == 302
 
-        # The player's side of the seam: found a gang, click the choice.
         from django.contrib.auth.models import User
 
         owner = User.objects.create_user("outcast-founder")
-        # The page changed the row; this test's instance predates it.
         gang_type.refresh_from_db()
         gang = found_gang("The Unmade", gang_type, owner=owner)
         line = next(
-            slot
-            for slot in render_gang(gang).choices
-            if slot.kind_label == "Affiliation"
+            choice
+            for choice in render_gang(gang).choices
+            if choice.kind_label == "Affiliation"
         )
         client.force_login(owner)
         picker = client.get(f"/n26/gangs/{gang.pk}/choose/{line.key}/").content.decode()

--- a/n26/tests/sandbox/test_empty_affiliations.py
+++ b/n26/tests/sandbox/test_empty_affiliations.py
@@ -310,7 +310,7 @@ class TestWhatItRefuses:
 
         assert fossils.ok
         assert any(
-            f"the menu “{menu}”: not everything in it names Affiliation" in note
+            f"the menu “{menu}”: not everything in it is going" in note
             for note in fossils.left_alone
         )
 

--- a/n26/tests/sandbox/test_empty_affiliations.py
+++ b/n26/tests/sandbox/test_empty_affiliations.py
@@ -272,6 +272,22 @@ class TestDeletingIt:
         assert fossils.nothing_here
         assert fossils.ok
 
+    def test_nothing_to_delete_still_explains_what_remains(self, default_pack):
+        affiliation = create_affiliation("Clanless")
+        modifier(
+            "Clanless: something new",
+            targets_model(),
+            ef_adds(create_skill("Overwatch")),
+            carried_by=affiliation,
+        )
+
+        fossils = find()
+
+        assert fossils.nothing_here
+        preview = "\n".join(fossils.preview())
+        assert "nothing selected for deletion" in preview
+        assert "leave “Clanless” where it is" in preview
+
 
 class TestWhatItRefuses:
     def test_an_affiliation_in_another_pack_is_a_refusal(self, default_pack, homebrew):

--- a/n26/tests/sandbox/test_empty_affiliations.py
+++ b/n26/tests/sandbox/test_empty_affiliations.py
@@ -206,7 +206,7 @@ class TestWhatItWouldDelete:
 
 class TestDeletingIt:
     def test_the_rows_go(self, leftover_world):
-        _, _, menus, vestigial, house = leftover_world
+        gang, _, menus, vestigial, house = leftover_world
         grant = house.modifiers.get()
 
         apply(find())
@@ -223,6 +223,7 @@ class TestDeletingIt:
         assert Modifier.objects.filter(pk=grant.pk).exists()
         assert house.modifiers.filter(pk=grant.pk).exists()
         assert Slot.objects.filter(name="Variant").exists()
+        assert_reconciled(gang)
 
     def test_no_page_moves(self, leftover_world):
         gang, _, _, _, _ = leftover_world

--- a/n26/tests/sandbox/test_empty_affiliations.py
+++ b/n26/tests/sandbox/test_empty_affiliations.py
@@ -19,8 +19,10 @@ from n26.library.models import (
     Affiliation,
     Collection,
     CollectionEntry,
+    CollectionSelector,
     Hidden,
     Modifier,
+    Skill,
     Slot,
 )
 from n26.tests.sandbox.actions import (
@@ -177,7 +179,7 @@ class TestWhatItWouldDelete:
         assert f"delete the menu “{menus['Clan House']}” and its sections" in said
         assert "a whole-kind Affiliation offer" in said
         assert "Corruption" in said
-        assert f"delete the marker “{vestigial}”, which nothing holds" in said
+        assert f"delete the marker “{vestigial}” because no assignment uses it" in said
         assert "those are the new system" in said
         assert fossils.counts["kind rows"] == 8
         assert fossils.counts["menus"] == 4
@@ -202,6 +204,27 @@ class TestWhatItWouldDelete:
         assert "delete the emptied affiliation “Clanless”" not in "\n".join(
             fossils.preview()
         )
+
+    def test_an_unrelated_unused_hidden_is_not_a_conversion_leftover(
+        self, default_pack
+    ):
+        rank = create_slot_type("Rank", plural_name="Ranks", allows_repeats=False)
+        ranks = create_picklist("Ranks", rank)
+        slot = create_slot("Rank", rank, ranks, min_picks=0, max_picks=1)
+        hidden = create_hidden("Future rank")
+        grant = modifier(
+            "offers a rank",
+            targets_model(),
+            ef_adds(slot),
+            carried_by=hidden,
+        )
+
+        fossils = find()
+
+        assert fossils.nothing_here
+        apply(fossils)
+        assert Hidden.objects.filter(pk=hidden.pk).exists()
+        assert Modifier.objects.filter(pk=grant.pk).exists()
 
 
 class TestDeletingIt:
@@ -251,6 +274,17 @@ class TestDeletingIt:
 
 
 class TestWhatItRefuses:
+    def test_an_affiliation_in_another_pack_is_a_refusal(self, default_pack, homebrew):
+        authored = create_affiliation("Homebrew allegiance", pack=homebrew)
+
+        fossils = find()
+
+        assert not fossils.ok
+        assert any("another pack" in problem for problem in fossils.problems)
+        with pytest.raises(Refused):
+            apply(fossils)
+        assert Affiliation.objects.filter(pk=authored.pk).exists()
+
     def test_a_live_assignment_still_naming_an_affiliation_is_a_refusal(
         self, default_pack, person_type, owner
     ):
@@ -274,7 +308,7 @@ class TestWhatItRefuses:
 
         assert not fossils.ok
         assert any(
-            "1 assignment still name “Mutant”" in problem
+            "1 assignment still names “Mutant”" in problem
             for problem in fossils.problems
         )
         with pytest.raises(Refused):
@@ -305,13 +339,32 @@ class TestWhatItRefuses:
 
         assert not fossils.ok
         assert any(
-            "Affiliation offer" in problem and "still live" in problem
+            "affiliation offer" in problem and "still in use" in problem
             for problem in fossils.problems
         )
         with pytest.raises(Refused):
             apply(fossils)
         assert Affiliation.objects.filter(name="Clanless").exists()
         assert_reconciled(gang)
+
+    def test_an_unheld_carrier_keeps_its_affiliation_offer(self, default_pack):
+        create_affiliation("Clanless")
+        carrier = create_subtype("Future specialist")
+        offered = modifier(
+            "offers an affiliation",
+            targets_model(),
+            offers_choice(Affiliation),
+            carried_by=carrier,
+        )
+
+        fossils = find()
+
+        assert not fossils.ok
+        assert any("remains attached" in problem for problem in fossils.problems)
+        with pytest.raises(Refused):
+            apply(fossils)
+        assert Modifier.objects.filter(pk=offered.pk).exists()
+        assert carrier.modifiers.filter(pk=offered.pk).exists()
 
     def test_an_entry_added_after_the_plan_is_a_refusal(self, leftover_world):
         """A menu's entries cascade with it. An entry that arrived
@@ -359,7 +412,8 @@ class TestWhatItRefuses:
 
         assert fossils.ok
         assert any(
-            f"the menu “{menu}”: not everything in it is going" in note
+            f"the menu “{menu}” because it also contains entries that will remain"
+            in note
             for note in fossils.left_alone
         )
 
@@ -367,6 +421,32 @@ class TestWhatItRefuses:
 
         assert Collection.objects.filter(pk=menu.pk).exists()
         assert CollectionEntry.objects.filter(collection=menu).count() == 1
+
+    def test_a_menu_with_a_selector_keeps_its_shape(self, leftover_world):
+        _, _, menus, _, _ = leftover_world
+        menu = menus["Affiliations"]
+        selector = CollectionSelector.of(menu, Skill, pack=menu.pack)
+
+        fossils = find()
+
+        assert fossils.ok
+        assert menu.pk not in fossils.collections
+        apply(fossils)
+        assert Collection.objects.filter(pk=menu.pk).exists()
+        assert CollectionSelector.objects.filter(pk=selector.pk).exists()
+
+    def test_a_modifier_attached_after_the_plan_is_a_refusal(self, leftover_world):
+        gang, _, _, _, _ = leftover_world
+        fossils = find()
+        offered = Modifier.objects.get(name="Corruption")
+        carrier = create_subtype("Future specialist")
+        carrier.modifiers.add(offered)
+
+        with pytest.raises(Refused):
+            apply(fossils)
+
+        assert carrier.modifiers.filter(pk=offered.pk).exists()
+        assert_reconciled(gang)
 
     def test_a_marker_a_profile_comes_with_is_left_alone(self, leftover_world):
         """Nobody holding a marker is not the same as nothing naming it:
@@ -380,7 +460,7 @@ class TestWhatItRefuses:
 
         assert fossils.ok
         assert any(
-            f"the marker “{vestigial}”" in note and "still name it" in note
+            f"the marker “{vestigial}”" in note and "still used by" in note
             for note in fossils.left_alone
         )
 

--- a/n26/tests/sandbox/test_empty_affiliations.py
+++ b/n26/tests/sandbox/test_empty_affiliations.py
@@ -1,0 +1,369 @@
+"""Deleting emptied Affiliation library rows.
+
+A conversion moves a system onto slots and picks and deletes nothing, so
+its old machinery is still there afterwards: kind rows with their
+modifiers moved away, the menu they were chosen from, the fossil offers,
+the vestigial Hidden. None of it reaches a page any more, which is both
+why it can go and how the going is proved — nothing a reader is told may
+move.
+"""
+
+import pytest
+
+from n26.core.capture import gang_state
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.library.authoring import add_section
+from n26.library.empty_affiliations import Refused, apply, find
+from n26.library.models import (
+    Affiliation,
+    Collection,
+    CollectionEntry,
+    Hidden,
+    Modifier,
+    Slot,
+)
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    add_entry,
+    choose,
+    create_affiliation,
+    create_collection,
+    create_default_set,
+    create_gang_type,
+    create_hidden,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_skill,
+    create_slot,
+    create_slot_type,
+    create_subtype,
+    ef_adds,
+    found_gang,
+    hire,
+    modifier,
+    offers_choice,
+    targets_gang,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def build_leftover_world(person_type, owner):
+    """Emptied Affiliation rows, the four menus, two fossil offers, and
+    the vestigial Hidden — the state this deletion runs in, after the
+    conversions have moved the picks.
+    """
+    affiliation = create_slot_type(
+        "Affiliation", plural_name="Affiliations", allows_repeats=False
+    )
+    clan_house = create_slot_type(
+        "Clan House", plural_name="Clan Houses", allows_repeats=False
+    )
+    chaos_god = create_slot_type(
+        "Chaos God", plural_name="Chaos Gods", allows_repeats=False
+    )
+    variant = create_slot_type("Variant", plural_name="Variants", allows_repeats=False)
+    for slot_type, name, members in (
+        (
+            affiliation,
+            "Affiliations",
+            ("Clanless", "Clan House", "Mutant", "Aranthian"),
+        ),
+        (
+            clan_house,
+            "Clan Houses",
+            ("House Cawdor", "House Delaque", "House Escher"),
+        ),
+        (chaos_god, "Chaos Gods", ("Blood God", "Dark Prince")),
+        (
+            variant,
+            "Variants",
+            ("Chaos Corrupted", "Genestealer Cult Corrupted"),
+        ),
+    ):
+        pickables = [create_pickable(member, slot_type) for member in members]
+        create_slot(
+            slot_type.name,
+            slot_type,
+            create_picklist(name, slot_type, members=pickables),
+            assigned_to="gang",
+            min_picks=0,
+            max_picks=1,
+        )
+
+    names = {
+        "Clanless": create_affiliation("Clanless"),
+        "Clan House": create_affiliation("Clan House"),
+        "Mutant": create_affiliation("Mutant"),
+        "Aranthian": create_affiliation("Aranthian"),
+        "House Cawdor": create_affiliation("House Cawdor", qualifier="Affiliation"),
+        "None": create_affiliation("None"),
+        "Chaos Corrupted": create_affiliation("Chaos Corrupted"),
+        "Blood God": create_affiliation("Blood God"),
+    }
+    menus = {
+        "Affiliations": create_collection(
+            "Affiliations",
+            entries=[
+                (names[n], {})
+                for n in ("Clanless", "Clan House", "Mutant", "Aranthian")
+            ],
+        ),
+        "Clan House": create_collection(
+            "Clan House", entries=[(names["House Cawdor"], {})]
+        ),
+        "Variants": create_collection(
+            "Variants",
+            entries=[(names["Chaos Corrupted"], {}), (names["None"], {})],
+        ),
+        "Chaos Gods": create_collection(
+            "Chaos Gods", entries=[(names["Blood God"], {})]
+        ),
+    }
+    affiliations_section = add_section(menus["Affiliations"], "Affiliations")
+    modifier(
+        "a whole-kind Affiliation offer",
+        targets_gang(),
+        offers_choice(Affiliation),
+    )
+    modifier(
+        "Corruption",
+        targets_gang(),
+        offers_choice(
+            Affiliation, from_section=affiliations_section, label="Corruption"
+        ),
+    )
+
+    variant_slot = Slot.objects.get(name="Variant")
+    house = create_gang_type("Cawdor", starting_credits=2000)
+    grant = modifier(
+        "Variants: the gang is asked its Variant",
+        targets_gang(),
+        ef_adds(variant_slot),
+        carried_by=house,
+    )
+    vestigial = create_hidden("Variant")
+    vestigial.modifiers.add(grant)
+
+    profile = create_profile("Cawdor Ganger", person_type, house, price=50)
+    profile.built_ins = create_default_set("Ganger kit")
+    profile.save()
+    gang = found_gang("The Orphans", house, owner=owner, budget=2000)
+    hire(gang, profile, "Vex", paid=50)
+    return gang, names, menus, vestigial, house
+
+
+@pytest.fixture
+def leftover_world(default_pack, person_type, owner):
+    return build_leftover_world(person_type, owner)
+
+
+class TestWhatItWouldDelete:
+    def test_it_names_the_emptied_kinds_the_menus_the_fossils_and_the_hidden(
+        self, leftover_world
+    ):
+        _, names, menus, vestigial, _ = leftover_world
+
+        fossils = find()
+
+        assert fossils.ok and not fossils.nothing_here
+        said = "\n".join(fossils.preview())
+        assert "delete the emptied affiliation “Clanless”" in said
+        assert "delete the emptied affiliation “None”" in said
+        assert f"delete the menu “{menus['Affiliations']}” and its sections" in said
+        assert f"delete the menu “{menus['Clan House']}” and its sections" in said
+        assert "a whole-kind Affiliation offer" in said
+        assert "Corruption" in said
+        assert f"delete the marker “{vestigial}”, which nothing holds" in said
+        assert "those are the new system" in said
+        assert fossils.counts["kind rows"] == 8
+        assert fossils.counts["menus"] == 4
+        assert fossils.counts["markers"] == 1
+
+    def test_a_kind_still_carrying_something_is_left_where_it_is(self, leftover_world):
+        _, names, _, _, _ = leftover_world
+        modifier(
+            "Clanless: something new",
+            targets_model(),
+            ef_adds(create_skill("Overwatch")),
+            carried_by=names["Clanless"],
+        )
+
+        fossils = find()
+
+        assert fossils.ok
+        assert any(
+            "“Clanless” where it is: it still carries 1 modifier" in note
+            for note in fossils.left_alone
+        )
+        assert "delete the emptied affiliation “Clanless”" not in "\n".join(
+            fossils.preview()
+        )
+
+
+class TestDeletingIt:
+    def test_the_rows_go(self, leftover_world):
+        _, _, menus, vestigial, house = leftover_world
+        grant = house.modifiers.get()
+
+        apply(find())
+
+        assert not Affiliation.objects.exists()
+        assert not Collection.objects.filter(
+            pk__in=[menu.pk for menu in menus.values()]
+        ).exists()
+        assert not Modifier.objects.filter(name="Corruption").exists()
+        assert not Modifier.objects.filter(
+            name="a whole-kind Affiliation offer"
+        ).exists()
+        assert not Hidden.objects.filter(pk=vestigial.pk).exists()
+        assert Modifier.objects.filter(pk=grant.pk).exists()
+        assert house.modifiers.filter(pk=grant.pk).exists()
+        assert Slot.objects.filter(name="Variant").exists()
+
+    def test_no_page_moves(self, leftover_world):
+        gang, _, _, _, _ = leftover_world
+        before = gang_state(gang)
+
+        apply(find())
+
+        assert gang_state(gang) == before
+        assert_reconciled(gang)
+
+    def test_a_second_run_finds_nothing(self, leftover_world):
+        apply(find())
+
+        assert find().nothing_here
+
+    def test_a_world_with_no_affiliation_rows_is_nothing_here(self, default_pack):
+        create_slot_type(
+            "Affiliation", plural_name="Affiliations", allows_repeats=False
+        )
+
+        fossils = find()
+
+        assert fossils.nothing_here
+        assert fossils.ok
+
+
+class TestWhatItRefuses:
+    def test_a_live_assignment_still_naming_an_affiliation_is_a_refusal(
+        self, default_pack, person_type, owner
+    ):
+        spec = create_affiliation("Mutant")
+        specialist = create_subtype("Specialist")
+        modifier(
+            "offers an affiliation",
+            targets_model(),
+            offers_choice(Affiliation),
+            carried_by=specialist,
+        )
+        gang_type = create_gang_type("Enforcers", starting_credits=2000)
+        profile = create_profile("Patrol Officer", person_type, gang_type, price=50)
+        profile.built_ins = create_default_set("Officer kit", members=[specialist])
+        profile.save()
+        gang = found_gang("The Watch", gang_type, owner=owner, budget=2000)
+        fighter = hire(gang, profile, "Vex", paid=50)
+        choose(Assignment.objects.get(subtype=specialist, miniature=fighter), spec)
+
+        fossils = find()
+
+        assert not fossils.ok
+        assert any(
+            "1 assignment still name “Mutant”" in problem
+            for problem in fossils.problems
+        )
+        with pytest.raises(Refused):
+            apply(fossils)
+
+    def test_an_archived_assignment_still_naming_an_affiliation_is_a_refusal(
+        self, leftover_world
+    ):
+        """The Variant conversion archives a printed None in place, so
+        the Affiliation column still names it. That is not this to
+        clear."""
+        gang, names, _, _, _ = leftover_world
+        Assignment.objects.create(
+            affiliation=names["None"],
+            gang=gang,
+            gang_root=gang,
+            archived=True,
+        )
+
+        fossils = find()
+
+        assert not fossils.ok
+        assert any(
+            "assignment" in problem and "None" in problem
+            for problem in fossils.problems
+        )
+
+    def test_a_menu_holding_something_live_keeps_its_shape(self, leftover_world):
+        _, _, menus, _, _ = leftover_world
+        menu = menus["Affiliations"]
+        add_entry(menu, create_skill("Nerves"))
+
+        fossils = find()
+
+        assert fossils.ok
+        assert any(
+            f"the menu “{menu}”: not everything in it names Affiliation" in note
+            for note in fossils.left_alone
+        )
+
+        apply(fossils)
+
+        assert Collection.objects.filter(pk=menu.pk).exists()
+        assert CollectionEntry.objects.filter(collection=menu).count() == 1
+
+    def test_a_marker_a_profile_comes_with_is_left_alone(self, leftover_world):
+        """Nobody holding a marker is not the same as nothing naming it:
+        it can be part of what a profile arrives with."""
+        gang, _, _, vestigial, _ = leftover_world
+        from n26.library.models import Profile
+
+        add_built_in(Profile.objects.get(name="Cawdor Ganger"), vestigial)
+
+        fossils = find()
+
+        assert fossils.ok
+        assert any(
+            f"the marker “{vestigial}”" in note and "still name it" in note
+            for note in fossils.left_alone
+        )
+
+        apply(fossils)
+
+        assert Hidden.objects.filter(pk=vestigial.pk).exists()
+        assert gang_state(gang)  # still builds
+
+
+class TestAfterTheConversions:
+    """A leftover world built the way the conversions leave it."""
+
+    def test_after_the_outcast_conversion_the_emptied_rows_can_go(
+        self, default_pack, person_type, owner
+    ):
+        from n26.library.conversion import apply as apply_conversion
+        from n26.library.conversion import plan_outcast_affiliation
+        from n26.tests.sandbox.test_conversion_affiliation import (
+            build_prod_shape,
+            build_world,
+        )
+
+        gangs, _fighters, _hidden = build_world(build_prod_shape(person_type), owner)
+        apply_conversion(plan_outcast_affiliation())
+        before = {name: gang_state(gang) for name, gang in gangs.items()}
+
+        fossils = find()
+        assert fossils.ok and not fossils.nothing_here
+        apply(fossils)
+
+        for name, gang in gangs.items():
+            assert gang_state(gang) == before[name]
+            assert_reconciled(gang)
+        assert find().nothing_here
+        assert not Assignment.objects.filter(affiliation__isnull=False).exists()

--- a/n26/tests/sandbox/test_empty_affiliations.py
+++ b/n26/tests/sandbox/test_empty_affiliations.py
@@ -279,6 +279,54 @@ class TestWhatItRefuses:
         )
         with pytest.raises(Refused):
             apply(fossils)
+        assert_reconciled(gang)
+
+    def test_a_held_affiliation_offer_is_a_refusal(
+        self, default_pack, person_type, owner
+    ):
+        """The old question still on a card is not a fossil. Deleting
+        emptied rows would take its answers with it."""
+        create_affiliation("Clanless")
+        specialist = create_subtype("Specialist")
+        modifier(
+            "offers an affiliation",
+            targets_model(),
+            offers_choice(Affiliation),
+            carried_by=specialist,
+        )
+        gang_type = create_gang_type("Enforcers", starting_credits=2000)
+        profile = create_profile("Patrol Officer", person_type, gang_type, price=50)
+        profile.built_ins = create_default_set("Officer kit", members=[specialist])
+        profile.save()
+        gang = found_gang("The Watch", gang_type, owner=owner, budget=2000)
+        hire(gang, profile, "Vex", paid=50)
+
+        fossils = find()
+
+        assert not fossils.ok
+        assert any(
+            "Affiliation offer" in problem and "still live" in problem
+            for problem in fossils.problems
+        )
+        with pytest.raises(Refused):
+            apply(fossils)
+        assert Affiliation.objects.filter(name="Clanless").exists()
+        assert_reconciled(gang)
+
+    def test_an_entry_added_after_the_plan_is_a_refusal(self, leftover_world):
+        """A menu's entries cascade with it. An entry that arrived
+        after the plan was read must not ride that delete down."""
+        gang, _, menus, _, _ = leftover_world
+        menu = menus["Affiliations"]
+        fossils = find()
+        added = add_entry(menu, create_skill("Nerves"))
+
+        with pytest.raises(Refused, match="changed since the plan"):
+            apply(fossils)
+
+        assert CollectionEntry.objects.filter(pk=added.pk).exists()
+        assert Collection.objects.filter(pk=menu.pk).exists()
+        assert_reconciled(gang)
 
     def test_an_archived_assignment_still_naming_an_affiliation_is_a_refusal(
         self, leftover_world

--- a/n26/tests/sandbox/test_generated_forms.py
+++ b/n26/tests/sandbox/test_generated_forms.py
@@ -150,6 +150,29 @@ class TestGeneratedForms:
             OffersChoice._meta.get_field("from_section").help_text
         )
 
+    def test_a_retired_choice_remains_selected_and_can_be_saved(self, default_pack):
+        from n26.library.models import Affiliation, OffersChoice
+
+        effect = OffersChoice.of(Affiliation, will_be_assigned_to="gang")
+        form_class = generate_form(specs()["ef_offers_choice"])
+
+        opened = form_class.opened_on(effect)
+        assert opened["model"].value() == "affiliation"
+        assert ("affiliation", "affiliation (retired)") in opened.fields[
+            "model"
+        ].choices
+
+        submitted = form_class.opened_on(
+            effect,
+            {
+                "edit-model": "affiliation",
+                "edit-will_be_assigned_to": "gang",
+            },
+        )
+        assert submitted.is_valid(), submitted.errors
+        replacement = submitted.compile()
+        assert replacement.of_kind.model == "affiliation"
+
     def test_a_valid_form_compiles_to_the_verb_call(self, skills_and_powers):
         collection, tiers = skills_and_powers
         create_category("Skills", "Combat")

--- a/n26/tests/sandbox/test_specs.py
+++ b/n26/tests/sandbox/test_specs.py
@@ -181,7 +181,6 @@ class TestHelpIsSourcedNeverWritten:
             for kind in (
                 "power",
                 "skill",
-                "affiliation",
                 "subtype",
             )
         )

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -538,6 +538,7 @@ class TestTheEmptyAffiliationDeletion:
         page = response.content.decode()
         assert response.status_code == 200
         assert "Nothing to delete" in page
+        assert "No Affiliation leftovers are selected for deletion" in page
         assert not Backfill.objects.exists()
 
     def test_its_page_shows_the_plan_and_writes_nothing(

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -28,6 +28,7 @@ from n26.maintenance import (
     convert_chaos_god_view,
     convert_outcast_affiliation_view,
     convert_variant_view,
+    delete_empty_affiliations_view,
     delete_nameless_gang_type_view,
 )
 
@@ -478,3 +479,124 @@ class TestTheVariantConversion:
             name="Chaos Corrupted", slot_type__name="Variant"
         ).exists()
         assert not Pickable.objects.filter(name="None").exists()
+
+
+class TestTheEmptyAffiliationDeletion:
+    """The repair still on offer: emptied Affiliation library rows go."""
+
+    def test_its_lock_is_not_shared(self):
+        keys = list(LOCK_KEYS.values())
+        assert len(keys) == len(set(keys))
+        assert LOCK_KEYS[Operation.DELETE_EMPTY_AFFILIATIONS] == 826_020_614
+        assert (
+            LOCK_KEYS[Operation.DELETE_EMPTY_AFFILIATIONS]
+            != LOCK_KEYS[Operation.BACKFILL_BUILT_INS]
+        )
+        assert (
+            LOCK_KEYS[Operation.DELETE_EMPTY_AFFILIATIONS]
+            != LOCK_KEYS[Operation.DROP_DUPLICATE_GRANTS]
+        )
+        assert Operation.DELETE_EMPTY_AFFILIATIONS.value == (
+            "n26_delete_empty_affiliations"
+        )
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.DELETE_EMPTY_AFFILIATIONS.value in registered
+        found = resolve_operation(Operation.DELETE_EMPTY_AFFILIATIONS.value)
+        assert found.name == Operation.DELETE_EMPTY_AFFILIATIONS.label
+        assert found.view is delete_empty_affiliations_view
+
+    def test_it_is_not_retired(self):
+        assert (
+            Operation.DELETE_EMPTY_AFFILIATIONS not in TestARepairThatHasBeenRun.RETIRED
+        )
+        assert (
+            resolve_operation(Operation.DELETE_EMPTY_AFFILIATIONS.value).view
+            is not None
+        )
+
+    def test_only_a_superuser_may_reach_it(self, client, staffer):
+        client.force_login(staffer)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_delete_empty_affiliations")
+        )
+
+        assert response.status_code in (302, 403)
+
+    def test_its_page_shows_nothing_to_delete_when_the_rows_are_gone(
+        self, client, superuser, default_pack
+    ):
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_delete_empty_affiliations")
+        )
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "Nothing to delete" in page
+        assert not Backfill.objects.exists()
+
+    def test_its_page_shows_the_plan_and_writes_nothing(
+        self, client, superuser, leftover_world
+    ):
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_delete_empty_affiliations")
+        )
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "delete the emptied affiliation" in page
+        assert "those are the new system" in page
+        assert not Backfill.objects.exists()
+
+    def test_applying_records_what_it_deleted(self, client, superuser, leftover_world):
+        from n26.library.models import Affiliation
+
+        client.force_login(superuser)
+
+        response = client.post(
+            reverse("admin:maintenance_n26_delete_empty_affiliations")
+        )
+
+        assert response.status_code == 302
+        run = Backfill.objects.get(operation=Operation.DELETE_EMPTY_AFFILIATIONS)
+        assert run.status == Backfill.Status.DONE
+        assert any("deleted" in line for line in run.summary["report"])
+        assert not Affiliation.objects.exists()
+
+    def test_its_page_refuses_while_an_assignment_still_names_one(
+        self, client, superuser, leftover_world
+    ):
+        from n26.core.models import Assignment
+        from n26.library.models import Affiliation
+
+        gang, names, _, _, _ = leftover_world
+        Assignment.objects.create(
+            affiliation=names["Mutant"],
+            gang=gang,
+            gang_root=gang,
+        )
+        client.force_login(superuser)
+        address = reverse("admin:maintenance_n26_delete_empty_affiliations")
+
+        page = client.get(address).content.decode()
+        posted = client.post(address)
+
+        assert "The deletion refuses" in page
+        assert "assignment" in page and "Mutant" in page
+        assert posted.status_code == 302
+        assert not Backfill.objects.exists()
+        assert Affiliation.objects.filter(pk=names["Mutant"].pk).exists()
+
+
+@pytest.fixture
+def leftover_world(default_pack, person_type, owner):
+    from n26.tests.sandbox.test_empty_affiliations import build_leftover_world
+
+    return build_leftover_world(person_type, owner)

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -558,6 +558,7 @@ class TestTheEmptyAffiliationDeletion:
     def test_applying_records_what_it_deleted(self, client, superuser, leftover_world):
         from n26.library.models import Affiliation
 
+        gang, *_ = leftover_world
         client.force_login(superuser)
 
         response = client.post(
@@ -569,6 +570,7 @@ class TestTheEmptyAffiliationDeletion:
         assert run.status == Backfill.Status.DONE
         assert any("deleted" in line for line in run.summary["report"])
         assert not Affiliation.objects.exists()
+        assert_reconciled(gang)
 
     def test_its_page_refuses_while_an_assignment_still_names_one(
         self, client, superuser, leftover_world

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -487,7 +487,7 @@ class TestTheEmptyAffiliationDeletion:
     def test_its_lock_is_not_shared(self):
         keys = list(LOCK_KEYS.values())
         assert len(keys) == len(set(keys))
-        assert LOCK_KEYS[Operation.DELETE_EMPTY_AFFILIATIONS] == 826_020_614
+        assert LOCK_KEYS[Operation.DELETE_EMPTY_AFFILIATIONS] == 826_020_616
         assert (
             LOCK_KEYS[Operation.DELETE_EMPTY_AFFILIATIONS]
             != LOCK_KEYS[Operation.BACKFILL_BUILT_INS]
@@ -568,7 +568,7 @@ class TestTheEmptyAffiliationDeletion:
         assert response.status_code == 302
         run = Backfill.objects.get(operation=Operation.DELETE_EMPTY_AFFILIATIONS)
         assert run.status == Backfill.Status.DONE
-        assert any("deleted" in line for line in run.summary["report"])
+        assert any("Deleted" in line for line in run.summary["report"])
         assert not Affiliation.objects.exists()
         assert_reconciled(gang)
 
@@ -590,7 +590,7 @@ class TestTheEmptyAffiliationDeletion:
         page = client.get(address).content.decode()
         posted = client.post(address)
 
-        assert "The deletion refuses" in page
+        assert "The deletion cannot run" in page
         assert "assignment" in page and "Mutant" in page
         assert posted.status_code == 302
         assert not Backfill.objects.exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The three Affiliation conversions have run in production. They deliberately leave the old library rows in place. This PR adds the separate, guarded cleanup step, analogous to `DELETE_RETIRED_KINDS` (#2277). It does not rewrite player picks or remove the `Affiliation` model.

## What this does

Adds the console operation `n26_delete_empty_affiliations`, using advisory lock `826_020_615`. The preview is the deletion contract. Apply deletes exactly the planned rows, compares representative gang pages before and after with `gang_state`, and checks each reached gang with `assert_reconciled`. A successful retry reports `nothing_here`.

The plan finds rows by structure, never by fixed IDs:

- emptied N26-pack Affiliation rows;
- N26 collection entries that name those rows, plus a collection and its sections only when nothing else uses them;
- unattached legacy `OffersChoice` effects for Affiliation;
- the precise Variant-conversion Hidden residue: one N26 modifier granting the N26 Variant slot, shared with an N26 gang type, unassigned, and otherwise unreferenced.

The operation refuses without deleting anything when:

- any live or archived assignment still names an Affiliation;
- any Affiliation or Affiliation offer belongs to another content pack;
- an Affiliation offer is still attached to any carrier, whether or not that carrier is currently assigned;
- another row, selector, modifier, surviving entry, or custom-pack section still uses a planned collection or row;
- the plan changes between preview and apply.

Unrelated Hidden slot grants are not candidates. Shared grants survive when only their conversion-residue Hidden is removed. Missing reverse modifier data is reported as a refusal instead of raising during preview.

Apply locks the destructive graph, re-reads the plan inside one transaction, and fences writes to the offer table before establishing its PostgreSQL repeatable-read snapshot. The composer no longer offers Affiliation as a new choice kind, while model validation continues to accept legacy rows until the later model-removal PR.

The Affiliation, Clan House, Chaos God, and Variant slot types, with their pickables, picklists, and slots, remain.

Authoring no longer offers new Affiliation rows: `/n26/authoring/affiliation/new/` returns 404. Existing list and detail pages remain available so leftover rows can be inspected. The recipes and concepts documentation now describes the slot-type replacement.

## Production shape (read-only check on 2026-08-29)

At that check, all three conversion planners reported `nothing_here`, and the four replacement slot types existed.

The remaining legacy data was:

- 18 live N26 Affiliation rows and no archived Affiliation rows; none carried modifiers;
- four structurally discovered menus: Affiliations (4 entries), Clan House (6), Variants (4), and Chaos Gods (4);
- two unattached legacy Affiliation offers: the whole-kind offer and “Corruption”;
- one unassigned Variant Hidden whose grant was shared with the house gang types;
- 210 assignments naming Affiliation rows: 1 live Mutant assignment and 209 archived None assignments.

The operation refused on that 2026-08-29 production check, as intended. Do not apply it until those assignment counts are zero. The preview reports current blockers and writes nothing when any remain.

## What this does not do

- It does not drop `Affiliation`, `Assignment.affiliation`, legacy model validation, or `ASSIGNABLE_FIELDS`. That belongs in a later PR after this operation has run successfully.
- It does not delete the conversion modules; they must still report `nothing_here` on a post-cleanup mirror.
- It does not rewrite, archive, or delete player assignments.
- It does not touch Aranthian Gangers.
- It is not a migration.

## Merge with main

Rebased onto `main` at `d81785259`. Main added `REHOST_GANG_PICKS` with lock `826_020_614` (#2409), so this operation now uses the next lock, `826_020_615`.

## Checked

- `ruff format` and `ruff check` on the changed Python files;
- `git diff --check`;
- focused generated-form, cleanup, specs, and maintenance-console suites: 329 passed;
- complete suite: 9,175 passed, 12 skipped, 1 expected failure.

## How to try it

1. Open `/admin/maintenance/n26-delete-empty-affiliations/` as a superuser. GET previews the exact plan; POST enqueues it.
2. Confirm the preview lists only the intended N26 leftovers and reports any assignments, carriers, pack boundaries, selectors, or other references as blockers.
3. After a successful run, run `audit_reconcile`, re-check the counts below, and refresh the content mirror before starting the later model-removal PR.

```python
print(Affiliation.objects.filter(archived=False).count(), Affiliation.objects.filter(archived=True).count())
print(Assignment.objects.filter(affiliation__isnull=False, archived=False).count(), Assignment.objects.filter(affiliation__isnull=False, archived=True).count())
print(CollectionEntry.objects.filter(affiliation__isnull=False).count())
print(OffersChoice.objects.filter(of_kind__model="affiliation").count())
```

Do not combine this with a pick-rewrite change, and do not run the production cleanup merely by merging this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-349d3553-95ea-4f85-95b9-b1b4e3a56f86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-349d3553-95ea-4f85-95b9-b1b4e3a56f86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
