### PR TITLE
feat: open a campaign's page to its participants and anyone with the link

### DIFF
--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -372,7 +372,7 @@ class JoinCampaignForm(forms.Form):
 
     gang = forms.CharField(
         label="Gang",
-        help_text="Paste the link a player sent you, or the gang's id.",
+        help_text="Paste the link a player sent you, or the gang’s id.",
     )
 
     def clean_gang(self):

--- a/n26/core/models/campaign.py
+++ b/n26/core/models/campaign.py
@@ -11,6 +11,10 @@ class CampaignQuerySet(models.QuerySet):
         they run, and the ones they were asked into and said yes to. An
         invitation still waiting is not one of them — an unanswered question
         belongs with the questions, and a declined one is over.
+
+        Says nothing about archiving: an archived campaign is still one this
+        person is in, so a caller listing campaigns to read must ask for
+        ``archived=False`` itself.
         """
         if user is None or not user.is_authenticated:
             return self.none()

--- a/n26/core/models/campaign.py
+++ b/n26/core/models/campaign.py
@@ -3,6 +3,26 @@ from django.db import models
 from n26.core.models.abstract import Archived, Base, Owned
 
 
+class CampaignQuerySet(models.QuerySet):
+    def involving(self, user):
+        """Every campaign this person arbitrates or has accepted a place in.
+
+        The two halves of what somebody means by their campaigns: the ones
+        they run, and the ones they were asked into and said yes to. An
+        invitation still waiting is not one of them — an unanswered question
+        belongs with the questions, and a declined one is over.
+        """
+        if user is None or not user.is_authenticated:
+            return self.none()
+        return self.filter(
+            models.Q(owner=user)
+            | models.Q(
+                participants__user=user,
+                participants__state=CampaignParticipant.State.ACCEPTED,
+            )
+        ).distinct()
+
+
 class Campaign(Base, Owned, Archived):
     """A run of linked battles, and the gangs playing them.
 
@@ -42,6 +62,8 @@ class Campaign(Base, Owned, Archived):
     #: way out (n26.core.templatetags.richtext), so a tightened allowlist
     #: reaches what was already saved.
     summary = models.TextField(blank=True, default="")
+
+    objects = CampaignQuerySet.as_manager()
 
     class Meta:
         verbose_name = "campaign"

--- a/n26/core/navigation.py
+++ b/n26/core/navigation.py
@@ -179,7 +179,7 @@ def reader_campaigns(request):
         found = list(
             Campaign.objects.involving(user)
             .filter(archived=False)
-            .order_by("name")[:NAV_SIBLINGS]
+            .order_by("name", "pk")[:NAV_SIBLINGS]
         )
     request._n26_reader_campaigns = found
     return found

--- a/n26/core/navigation.py
+++ b/n26/core/navigation.py
@@ -155,8 +155,12 @@ def owned_gangs(request):
     return found
 
 
-def owned_campaigns(request):
+def reader_campaigns(request):
     """The signed-in reader's campaigns, at most ``NAV_SIBLINGS`` of them.
+
+    Both the ones they arbitrate and the ones they play in, because the
+    chevron beside a campaign's name is how somebody gets to another one
+    and a player has no other way through to theirs.
 
     Memoised on the request for the same reason a gang's list is: every
     screen belonging to one campaign offers the others in the bar, and a
@@ -164,7 +168,7 @@ def owned_campaigns(request):
     """
     from n26.core.models import Campaign
 
-    found = getattr(request, "_n26_owned_campaigns", None)
+    found = getattr(request, "_n26_reader_campaigns", None)
     if found is not None:
         return found
 
@@ -173,11 +177,11 @@ def owned_campaigns(request):
         found = []
     else:
         found = list(
-            Campaign.objects.filter(owner=user, archived=False).order_by("name")[
-                :NAV_SIBLINGS
-            ]
+            Campaign.objects.involving(user)
+            .filter(archived=False)
+            .order_by("name")[:NAV_SIBLINGS]
         )
-    request._n26_owned_campaigns = found
+    request._n26_reader_campaigns = found
     return found
 
 
@@ -212,7 +216,7 @@ def campaign_switcher(
         menu_label=menu_label,
         placeholder="Search campaigns",
         empty="No campaigns match",
-        items=with_current([item(row) for row in owned_campaigns(request)], here),
+        items=with_current([item(row) for row in reader_campaigns(request)], here),
     )
 
 

--- a/n26/core/templates/cotton/n26/record_table/campaign_row.html
+++ b/n26/core/templates/cotton/n26/record_table/campaign_row.html
@@ -3,7 +3,7 @@
 
     <c-n26.record-table.campaign-row name="Dust Falls"
                                      href="/n26/campaigns/1/"
-                                     by="alice"
+                                     owner="alice"
                                      action_label="Edit" />
 
 The gang row's twin, on the same grid so the two lists read as the same kind
@@ -18,12 +18,12 @@ options — never appears.
 
   name — the campaign's name, and the row's accessible name.
   href — the campaign's own page.
-  by — the arbitrator's username, drawn after the name. Omitted, nothing is
-    said: a reader running the campaign already knows who runs it.
+  owner — the arbitrator's username, drawn beside the name. Omitted, nothing
+    is said: a reader running the campaign already knows who runs it.
   action_label — the button's word. Empty, there is no button, which is what
     a campaign somebody only plays in offers: the whole row already opens it.
 {% endcomment %}
-<c-vars name="" href="" by="" action_label="Edit" class="" />
+<c-vars name="" href="" owner="" action_label="Edit" class="" />
 
 <div x-data="{ facets: {
         type: '',
@@ -47,7 +47,14 @@ options — never appears.
            class="n26-row-link rounded-control text-base font-semibold text-ink-900 focus-ring dark:text-ink-100">
             {{ name }}
         </a>
-        {% if by %}<span class="text-sm text-muted">arbitrated by {{ by }}</span>{% endif %}
+        {% comment %}
+        Beside the name rather than under it, where the gang row puts its
+        owner. A gang row always has that second line — it carries a type —
+        so every one of them stands the same height; a campaign names an
+        arbitrator only on the rows the reader does not run, and putting it
+        below would leave a list of both sorts ragged.
+        {% endcomment %}
+        {% if owner %}<span class="text-sm text-muted">arbitrated by {{ owner }}</span>{% endif %}
     </div>
 
     {% comment %}

--- a/n26/core/templates/cotton/n26/record_table/campaign_row.html
+++ b/n26/core/templates/cotton/n26/record_table/campaign_row.html
@@ -2,12 +2,14 @@
 <c-n26.record-table.campaign-row> — one campaign in a <c-n26.record-table>.
 
     <c-n26.record-table.campaign-row name="Dust Falls"
-                                     href="/n26/campaigns/1/" />
+                                     href="/n26/campaigns/1/"
+                                     by="alice"
+                                     action_label="Edit" />
 
 The gang row's twin, on the same grid so the two lists read as the same kind
 of page. What differs is what a row has to say: a gang carries a type, a
-colour and a strip of money, where a campaign carries its name and nothing
-else a list can use.
+colour and a strip of money, where a campaign carries its name and, where the
+reader is not the one running it, who is.
 
 It registers the same facets the container's filter reads, so typing in the
 box narrows these rows exactly as it narrows gangs. There is no type here, so
@@ -16,8 +18,12 @@ options — never appears.
 
   name — the campaign's name, and the row's accessible name.
   href — the campaign's own page.
+  by — the arbitrator's username, drawn after the name. Omitted, nothing is
+    said: a reader running the campaign already knows who runs it.
+  action_label — the button's word. Empty, there is no button, which is what
+    a campaign somebody only plays in offers: the whole row already opens it.
 {% endcomment %}
-<c-vars name="" href="" class="" />
+<c-vars name="" href="" by="" action_label="Edit" class="" />
 
 <div x-data="{ facets: {
         type: '',
@@ -41,13 +47,21 @@ options — never appears.
            class="n26-row-link rounded-control text-base font-semibold text-ink-900 focus-ring dark:text-ink-100">
             {{ name }}
         </a>
+        {% if by %}<span class="text-sm text-muted">arbitrated by {{ by }}</span>{% endif %}
     </div>
 
     {% comment %}
     relative, so the button paints above the stretched link rather than under
     it.
     {% endcomment %}
-    <div class="relative col-start-2 row-start-1 flex shrink-0 items-center justify-self-end">
-        <c-ui.button size="sm" variant="default" href="{{ href }}">Edit</c-ui.button>
+    {% comment %}
+    The cell is drawn whether or not it holds a button, and stands as tall as
+    one: a list mixing rows that have a button with rows that do not would
+    otherwise draw them at two different heights.
+    {% endcomment %}
+    <div class="relative col-start-2 row-start-1 flex min-h-8.5 shrink-0 items-center justify-self-end">
+        {% if action_label %}
+            <c-ui.button size="sm" variant="default" href="{{ href }}">{{ action_label }}</c-ui.button>
+        {% endif %}
     </div>
 </div>

--- a/n26/core/templates/cotton/n26/record_table/campaign_row.html
+++ b/n26/core/templates/cotton/n26/record_table/campaign_row.html
@@ -20,10 +20,14 @@ options — never appears.
   href — the campaign's own page.
   owner — the arbitrator's username, drawn beside the name. Omitted, nothing
     is said: a reader running the campaign already knows who runs it.
-  action_label — the button's word. Empty, there is no button, which is what
-    a campaign somebody only plays in offers: the whole row already opens it.
+  action_label — the button's word, and there is no button without one. A
+    campaign somebody only plays in offers none: the whole row already opens
+    it, and there is nothing on the far side for them to change. Left out,
+    a row draws no button — the quiet way round, because a row that grew a
+    control nobody asked for would say the reader may do something they may
+    not.
 {% endcomment %}
-<c-vars name="" href="" owner="" action_label="Edit" class="" />
+<c-vars name="" href="" owner="" action_label="" class="" />
 
 <div x-data="{ facets: {
         type: '',
@@ -35,9 +39,9 @@ options — never appears.
      {% comment %}
      The same fixed tracks as the gang row, minus its middle column: stating
      the widths is what makes separate grids look like one table. One row,
-     because a campaign says only its name — so nothing here may span two, or
-     the grid grows a second row and the name centres in the first while the
-     button centres across both.
+     because everything a campaign says sits on a single line — so nothing
+     here may span two, or the grid grows a second row and the name centres
+     in the first while the button centres across both.
      {% endcomment %}
      class="relative grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 px-1 py-3
             hover:bg-ink-500/5 {{ class }}">
@@ -60,11 +64,12 @@ options — never appears.
     {% comment %}
     relative, so the button paints above the stretched link rather than under
     it.
-    {% endcomment %}
-    {% comment %}
-    The cell is drawn whether or not it holds a button, and stands as tall as
-    one: a list mixing rows that have a button with rows that do not would
-    otherwise draw them at two different heights.
+
+    Drawn whether or not it holds a button, and floored at the height of one
+    — a small button's line plus its padding and border — so a list mixing
+    rows that have a button with rows that do not keeps a single row height.
+    The floor is stated rather than measured, so a change to the button's
+    padding has to be repeated here.
     {% endcomment %}
     <div class="relative col-start-2 row-start-1 flex min-h-8.5 shrink-0 items-center justify-self-end">
         {% if action_label %}

--- a/n26/core/templates/n26/add_gang_to_campaign.html
+++ b/n26/core/templates/n26/add_gang_to_campaign.html
@@ -40,7 +40,7 @@ search across other people's gangs.
         {% csrf_token %}
         <c-n26.form-section title="The gang">
             <c-ui.field label="Gang *"
-                        description="Paste the link a player sent you, or the gang's id."
+                        description="Paste the link a player sent you, or the gang’s id."
                         error="x"
                         :form="form"
                         name="gang"

--- a/n26/core/templates/n26/campaign.html
+++ b/n26/core/templates/n26/campaign.html
@@ -4,12 +4,11 @@
 {% comment %}
 One campaign, to whoever opens it.
 
-Shareable the way a gang sheet is: the arbitrator sends the address round and
-everybody at the table reads the same page. Every control on it is the
-arbitrator's, and a reader who is not one gets none of them — not a disabled
-button, which is a control saying no, but nothing at all. What is left is the
-whole of the campaign: its facts, its people, its gangs, its battles and its
-log.
+The arbitrator sends the address round and everybody at the table reads the
+same page. Every control on it is the arbitrator's, and a reader who is not one
+gets none of them — not a disabled button, which is a control saying no, but
+nothing at all. What is left is the whole of the campaign: its facts, its
+people, its gangs, its battles and its log.
 
 The standing facts sit in <c-n26.detail-list>, the same way a gang sheet
 carries its own — each a small fact that is also something to change.

--- a/n26/core/templates/n26/campaign.html
+++ b/n26/core/templates/n26/campaign.html
@@ -2,7 +2,14 @@
 {% load navigation %}
 {% load richtext %}
 {% comment %}
-One campaign, as its arbitrator sees it.
+One campaign, to whoever opens it.
+
+Shareable the way a gang sheet is: the arbitrator sends the address round and
+everybody at the table reads the same page. Every control on it is the
+arbitrator's, and a reader who is not one gets none of them — not a disabled
+button, which is a control saying no, but nothing at all. What is left is the
+whole of the campaign: its facts, its people, its gangs, its battles and its
+log.
 
 The standing facts sit in <c-n26.detail-list>, the same way a gang sheet
 carries its own — each a small fact that is also something to change.
@@ -43,43 +50,46 @@ reader's other campaigns — the same pattern a gang's screens use.
                     </c-ui.breadcrumbs.item>
                 </c-ui.breadcrumbs>
             </c-slot>
-            {% comment %}
-            Archiving sits behind the second click rather than beside Edit:
-            it is the one control here that takes the campaign away, and a
-            page's own actions should read as the things you came to do.
-            {% endcomment %}
-            <c-slot name="actions">
-                <c-n26.button-group>
-                    {% comment %}
+            {% if yours %}
+                {% comment %}
+                Archiving sits behind the second click rather than beside
+                Edit: it is the one control here that takes the campaign
+                away, and a page's own actions should read as the things
+                you came to do.
+                {% endcomment %}
+                <c-slot name="actions">
+                    <c-n26.button-group>
+                        {% comment %}
                     Default rather than primary, as on the gang sheet: blue
                     is the page's one creative act, and editing what is
                     already here is not it.
-                    {% endcomment %}
-                    <c-ui.button size="sm"
-                                 variant="default"
-                                 href="{% url 'n26-edit-campaign' campaign.pk %}">
-                        Edit
-                    </c-ui.button>
-                    <c-ui.dropdown>
-                        <c-slot name="trigger">
-                            <c-ui.button size="sm" variant="default" aria-label="More actions">
-                                <span class="n26-icon-only gap-0.5">
-                                    <c-n26.icon name="ellipsis-vertical" class="size-4" />
-                                    <c-n26.icon name="chevron-down" class="size-3" stroke_width="2.5" />
-                                </span>
-                            </c-ui.button>
-                        </c-slot>
-                        {% comment %}
+                        {% endcomment %}
+                        <c-ui.button size="sm"
+                                     variant="default"
+                                     href="{% url 'n26-edit-campaign' campaign.pk %}">
+                            Edit
+                        </c-ui.button>
+                        <c-ui.dropdown>
+                            <c-slot name="trigger">
+                                <c-ui.button size="sm" variant="default" aria-label="More actions">
+                                    <span class="n26-icon-only gap-0.5">
+                                        <c-n26.icon name="ellipsis-vertical" class="size-4" />
+                                        <c-n26.icon name="chevron-down" class="size-3" stroke_width="2.5" />
+                                    </span>
+                                </c-ui.button>
+                            </c-slot>
+                            {% comment %}
                         A page that asks, not the act: following this link
                         archives nothing, and the POST it leads to is the
                         only thing that does.
-                        {% endcomment %}
-                        <c-ui.dropdown.item href="{% url 'n26-archive-campaign' campaign.pk %}">
-                            Archive campaign
-                        </c-ui.dropdown.item>
-                    </c-ui.dropdown>
-                </c-n26.button-group>
-            </c-slot>
+                            {% endcomment %}
+                            <c-ui.dropdown.item href="{% url 'n26-archive-campaign' campaign.pk %}">
+                                Archive campaign
+                            </c-ui.dropdown.item>
+                        </c-ui.dropdown>
+                    </c-n26.button-group>
+                </c-slot>
+            {% endif %}
         </c-n26.page-header>
         <c-n26.detail-list>
             <c-n26.detail-list.row label="Gang budget">
@@ -107,11 +117,13 @@ reader's other campaigns — the same pattern a gang's screens use.
         <section class="flex flex-col gap-2">
             <div class="flex items-center justify-between gap-3">
                 <h2 class="text-sm font-medium text-muted">Participants</h2>
-                <c-ui.button size="sm"
-                             variant="primary"
-                             href="{% url 'n26-campaign-add-participant' campaign.pk %}">
-                    Add participants
-                </c-ui.button>
+                {% if yours %}
+                    <c-ui.button size="sm"
+                                 variant="primary"
+                                 href="{% url 'n26-campaign-add-participant' campaign.pk %}">
+                        Add participants
+                    </c-ui.button>
+                {% endif %}
             </div>
             {% if participants %}
                 <ul class="flex flex-col">
@@ -146,11 +158,13 @@ reader's other campaigns — the same pattern a gang's screens use.
         <section class="flex flex-col gap-2">
             <div class="flex items-center justify-between gap-3">
                 <h2 class="text-sm font-medium text-muted">Gangs</h2>
-                <c-ui.button size="sm"
-                             variant="primary"
-                             href="{% url 'n26-campaign-add-gang' campaign.pk %}">
-                    Add gang
-                </c-ui.button>
+                {% if yours %}
+                    <c-ui.button size="sm"
+                                 variant="primary"
+                                 href="{% url 'n26-campaign-add-gang' campaign.pk %}">
+                        Add gang
+                    </c-ui.button>
+                {% endif %}
             </div>
             {% if playing %}
                 <ul class="flex flex-col">
@@ -161,15 +175,17 @@ reader's other campaigns — the same pattern a gang's screens use.
                                 <span class="text-sm text-muted">{{ membership.gang.gang_type }}</span>
                             </div>
                             <span class="shrink-0 text-sm tabular-nums text-muted">{{ membership.gang.rating }}¢</span>
-                            <c-ui.button size="sm"
-                                         variant="ghost"
-                                         href="{% url 'n26-campaign-remove-gang' campaign.pk membership.gang.pk %}"
-                                         aria-label="Remove {{ membership.gang.name }}"
-                                         title="Remove {{ membership.gang.name }}">
-                                <span class="n26-icon-only">
-                                    <c-n26.icon name="x-mark" class="size-4" />
-                                </span>
-                            </c-ui.button>
+                            {% if yours %}
+                                <c-ui.button size="sm"
+                                             variant="ghost"
+                                             href="{% url 'n26-campaign-remove-gang' campaign.pk membership.gang.pk %}"
+                                             aria-label="Remove {{ membership.gang.name }}"
+                                             title="Remove {{ membership.gang.name }}">
+                                    <span class="n26-icon-only">
+                                        <c-n26.icon name="x-mark" class="size-4" />
+                                    </span>
+                                </c-ui.button>
+                            {% endif %}
                         </li>
                     {% endfor %}
                 </ul>
@@ -185,11 +201,13 @@ reader's other campaigns — the same pattern a gang's screens use.
         <section class="flex flex-col gap-2">
             <div class="flex items-center justify-between gap-3">
                 <h2 class="text-sm font-medium text-muted">Battles</h2>
-                <c-ui.button size="sm"
-                             variant="primary"
-                             href="{% url 'n26-campaign-add-battle' campaign.pk %}">
-                    Record battle
-                </c-ui.button>
+                {% if yours %}
+                    <c-ui.button size="sm"
+                                 variant="primary"
+                                 href="{% url 'n26-campaign-add-battle' campaign.pk %}">
+                        Record battle
+                    </c-ui.button>
+                {% endif %}
             </div>
             {% if battles %}
                 <ul class="flex flex-col">
@@ -199,15 +217,17 @@ reader's other campaigns — the same pattern a gang's screens use.
                             <span class="min-w-0 flex-1 text-sm text-muted">
                                 {% for gang in battle.gangs.all %}{% if not forloop.first %}, {% endif %}{{ gang.name }}{% empty %}Nobody named{% endfor %}
                             </span>
-                            <c-ui.button size="sm"
-                                         variant="ghost"
-                                         href="{% url 'n26-campaign-remove-battle' campaign.pk battle.pk %}"
-                                         aria-label="Remove the battle of {{ battle.date|date:'j F Y' }}"
-                                         title="Remove this battle">
-                                <span class="n26-icon-only">
-                                    <c-n26.icon name="x-mark" class="size-4" />
-                                </span>
-                            </c-ui.button>
+                            {% if yours %}
+                                <c-ui.button size="sm"
+                                             variant="ghost"
+                                             href="{% url 'n26-campaign-remove-battle' campaign.pk battle.pk %}"
+                                             aria-label="Remove the battle of {{ battle.date|date:'j F Y' }}"
+                                             title="Remove this battle">
+                                    <span class="n26-icon-only">
+                                        <c-n26.icon name="x-mark" class="size-4" />
+                                    </span>
+                                </c-ui.button>
+                            {% endif %}
                         </li>
                     {% endfor %}
                 </ul>

--- a/n26/core/templates/n26/campaign.html
+++ b/n26/core/templates/n26/campaign.html
@@ -59,9 +59,9 @@ reader's other campaigns — the same pattern a gang's screens use.
                 <c-slot name="actions">
                     <c-n26.button-group>
                         {% comment %}
-                    Default rather than primary, as on the gang sheet: blue
-                    is the page's one creative act, and editing what is
-                    already here is not it.
+                        Default rather than primary, as on the gang sheet:
+                        blue is the page's one creative act, and editing what
+                        is already here is not it.
                         {% endcomment %}
                         <c-ui.button size="sm"
                                      variant="default"
@@ -78,9 +78,9 @@ reader's other campaigns — the same pattern a gang's screens use.
                                 </c-ui.button>
                             </c-slot>
                             {% comment %}
-                        A page that asks, not the act: following this link
-                        archives nothing, and the POST it leads to is the
-                        only thing that does.
+                            A page that asks, not the act: following this
+                            link archives nothing, and the POST it leads to
+                            is the only thing that does.
                             {% endcomment %}
                             <c-ui.dropdown.item href="{% url 'n26-archive-campaign' campaign.pk %}">
                                 Archive campaign

--- a/n26/core/templates/n26/campaigns.html
+++ b/n26/core/templates/n26/campaigns.html
@@ -1,14 +1,16 @@
 {% extends "n26/layouts/base.html" %}
 {% load navigation %}
 {% comment %}
-Every campaign you arbitrate, and the way to set another up.
+Every campaign you are in, and the way to set another up.
 
 The same <c-n26.record-table> the gangs list draws, over a row shaped for a
 campaign: one component and one search, so the two lists cannot come to
 disagree about what a list of things looks like. What differs is the row — a
-gang carries a type and a strip of money, a campaign carries its name alone.
+gang carries a type and a strip of money, a campaign carries its name.
 The budget is a ceiling on what a gang may be worth, which says nothing
-useful about the campaign until you are in it.
+useful about the campaign until you are in it. A campaign somebody only plays
+in says who runs it and offers no button, because the row already opens it and
+there is nothing on the far side of it for them to change.
 
 Setting one up is the page's action, in the header, because a list of
 campaigns is where someone goes when they want one more.
@@ -48,7 +50,10 @@ campaigns is where someone goes when they want one more.
                 {% endif %}
             </c-slot>
             {% for row in campaigns %}
-                <c-n26.record-table.campaign-row name="{{ row.name }}" href="{% url 'n26-campaign' row.pk %}" />
+                <c-n26.record-table.campaign-row name="{{ row.name }}"
+                                                 href="{% url 'n26-campaign' row.pk %}"
+                                                 by="{% if not row.arbitrated %}{{ row.owner.username }}{% endif %}"
+                                                 action_label="{% if row.arbitrated %}Edit{% endif %}" />
             {% endfor %}
         </c-n26.record-table>
         {% comment %}

--- a/n26/core/templates/n26/campaigns.html
+++ b/n26/core/templates/n26/campaigns.html
@@ -52,8 +52,8 @@ campaigns is where someone goes when they want one more.
             {% for row in campaigns %}
                 <c-n26.record-table.campaign-row name="{{ row.name }}"
                                                  href="{% url 'n26-campaign' row.pk %}"
-                                                 by="{% if not row.arbitrated %}{{ row.owner.username }}{% endif %}"
-                                                 action_label="{% if row.arbitrated %}Edit{% endif %}" />
+                                                 owner="{{ row.owner_name }}"
+                                                 action_label="{{ row.action_label }}" />
             {% endfor %}
         </c-n26.record-table>
         {% comment %}

--- a/n26/core/templates/n26/dashboard.html
+++ b/n26/core/templates/n26/dashboard.html
@@ -89,8 +89,8 @@ places — the same pattern a gang's screens use for their siblings.
                     {% for row in campaigns %}
                         <c-n26.record-table.campaign-row name="{{ row.name }}"
                                                          href="{% url 'n26-campaign' row.pk %}"
-                                                         by="{% if not row.arbitrated %}{{ row.owner.username }}{% endif %}"
-                                                         action_label="{% if row.arbitrated %}Edit{% endif %}" />
+                                                         owner="{{ row.owner_name }}"
+                                                         action_label="{{ row.action_label }}" />
                     {% endfor %}
                 </c-n26.record-table>
             </c-slot>

--- a/n26/core/templates/n26/dashboard.html
+++ b/n26/core/templates/n26/dashboard.html
@@ -87,7 +87,10 @@ places — the same pattern a gang's screens use for their siblings.
                         No campaigns yet — <c-n26.link href="{% url 'n26-create-campaign' %}">set one up</c-n26.link>.
                     </c-slot>
                     {% for row in campaigns %}
-                        <c-n26.record-table.campaign-row name="{{ row.name }}" href="{% url 'n26-campaign' row.pk %}" />
+                        <c-n26.record-table.campaign-row name="{{ row.name }}"
+                                                         href="{% url 'n26-campaign' row.pk %}"
+                                                         by="{% if not row.arbitrated %}{{ row.owner.username }}{% endif %}"
+                                                         action_label="{% if row.arbitrated %}Edit{% endif %}" />
                     {% endfor %}
                 </c-n26.record-table>
             </c-slot>

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -12,7 +12,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, redirect, render
 
-from n26.core.views.permissions import _own_campaign_or_404
+from n26.core.views.permissions import _any_campaign_or_404, _own_campaign_or_404
 from n26.flags import CAMPAIGNS, requires_flag
 
 #: How many campaigns a page of the list holds. A row is a name, a budget
@@ -36,7 +36,13 @@ LOG_ON_THE_PAGE = 10
 @requires_flag(CAMPAIGNS)
 @login_required
 def campaigns(request):
-    """Every campaign this reader arbitrates, narrowed by ``?q=``.
+    """Every campaign this reader is in, narrowed by ``?q=``.
+
+    Both kinds together: the campaigns they arbitrate and the ones they
+    were asked into and accepted. Somebody looking for a campaign does not
+    first decide which sort it was, and a page that held only one sort
+    would leave the other reachable by nothing but the invitation that has
+    already been answered.
 
     Drawn by the same table the gangs list uses, so the two pages search the
     same way and count the same way. The matching is the platform's
@@ -51,23 +57,27 @@ def campaigns(request):
     from n26.core.views.gangs import _pages
 
     query = request.GET.get("q", "").strip()
-    listed = Campaign.objects.filter(owner=request.user, archived=False).order_by(
-        "name"
+    listed = (
+        Campaign.objects.involving(request.user)
+        .filter(archived=False)
+        .select_related("owner")
+        .order_by("name")
     )
     found = search_queryset(listed, query, ["name"])
 
     page = Paginator(found, CAMPAIGNS_PER_PAGE).get_page(request.GET.get("page"))
+    rows = campaign_rows(page.object_list, request.user)
     return render(
         request,
         "n26/campaigns.html",
         {
             "invitations": invitations_for(request.user),
-            "campaigns": page.object_list,
+            "campaigns": rows,
             "query": query,
             # How many rows this page carries, for a reader with no script:
             # the live count is Alpine's, and without it the number beside
             # the noun would be blank.
-            "listed": len(page.object_list),
+            "listed": len(rows),
             "total": page.paginator.count,
             # Drawn only where there is more than one, so a short list is a
             # list rather than a list with a pager saying "1 of 1".
@@ -76,6 +86,21 @@ def campaigns(request):
             "page": page,
         },
     )
+
+
+def campaign_rows(campaigns, user):
+    """The listed campaigns, each told whether this reader arbitrates it.
+
+    A list holding both the campaigns somebody runs and the ones they play
+    in has to say which is which, and the row draws its controls from the
+    answer: what an arbitrator may do to a campaign is not what somebody
+    playing in it may. The home page's campaigns tab draws the same rows,
+    off the same helper, so the two cannot come to disagree.
+    """
+    rows = list(campaigns)
+    for row in rows:
+        row.arbitrated = row.owner_id == getattr(user, "id", None)
+    return rows
 
 
 @requires_flag(CAMPAIGNS)
@@ -122,7 +147,14 @@ def create_campaign(request):
 @requires_flag(CAMPAIGNS)
 @login_required
 def campaign(request, pk):
-    """One campaign, as its arbitrator sees it.
+    """One campaign, whoever is reading it.
+
+    Shareable like a gang sheet: an arbitrator can send the address to the
+    table, and everybody who opens it reads the same campaign — the same
+    facts, the same gangs, the same battles, the same log. What the page
+    withholds from a reader who does not arbitrate it is every control,
+    and not a disabled one either: the acts belong to the arbitrator, so
+    for anybody else they are simply not there.
 
     The log reads newest first and is cut to the most recent acts: the page
     is a campaign, not its history, and a log that grew without bound would
@@ -131,7 +163,8 @@ def campaign(request, pk):
     from n26.core.history import campaign_history, campaign_history_size
     from n26.core.models import CampaignMembership
 
-    found = _own_campaign_or_404(request, pk)
+    found = _any_campaign_or_404(pk)
+    yours = found.owner_id == request.user.id
     # Only the acts that will be drawn are built; how many more there are is
     # counted rather than read, so a campaign played for a year opens as
     # quickly as one set up this morning.
@@ -147,6 +180,7 @@ def campaign(request, pk):
         "n26/campaign.html",
         {
             "campaign": found,
+            "yours": yours,
             "participants": _participants(found),
             "playing": playing,
             "battles": battles,

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -57,11 +57,14 @@ def campaigns(request):
     from n26.core.views.gangs import _pages
 
     query = request.GET.get("q", "").strip()
+    # Ordered by name and then by key: two campaigns may share a name now
+    # that the list holds other people's, and tied rows under a name-only
+    # sort are free to swap places from one page to the next.
     listed = (
         Campaign.objects.involving(request.user)
         .filter(archived=False)
         .select_related("owner")
-        .order_by("name")
+        .order_by("name", "pk")
     )
     found = search_queryset(listed, query, ["name"])
 
@@ -88,7 +91,7 @@ def campaigns(request):
     )
 
 
-def campaign_rows(campaigns, user):
+def campaign_rows(listed, user):
     """The listed campaigns, each carrying what its row has to draw.
 
     A list holding both the campaigns somebody runs and the ones they play
@@ -103,7 +106,7 @@ def campaign_rows(campaigns, user):
     arbitrator and offers nothing: the whole row already opens it, and
     there is nothing on the far side for them to change.
     """
-    rows = list(campaigns)
+    rows = list(listed)
     for row in rows:
         arbitrated = row.owner_id == getattr(user, "id", None)
         row.owner_name = "" if arbitrated else row.owner.username
@@ -176,7 +179,7 @@ def campaign(request, pk):
     from n26.core.models import CampaignMembership
 
     found = _any_campaign_or_404(pk)
-    yours = found.owner_id == request.user.id
+    yours = found.owner_id == getattr(request.user, "id", None)
     # Only the acts that will be drawn are built; how many more there are is
     # counted rather than read, so a campaign played for a year opens as
     # quickly as one set up this morning.
@@ -273,8 +276,8 @@ def add_gang(request, pk):
 
     The arbitrator's act, not the gang owner's: a campaign is run by somebody,
     and it is that somebody who says who is in it. Nothing about the gang
-    changes but where it plays, the gang's own history says it happened and
-    who did it, and its owner may leave at any time.
+    changes but where it plays, and the gang's own history says it happened
+    and who did it. Taking a gang back out is the arbitrator's act too.
     """
     from n26.core.forms import JoinCampaignForm
     from n26.core.operations import Refusal, operation

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -89,17 +89,25 @@ def campaigns(request):
 
 
 def campaign_rows(campaigns, user):
-    """The listed campaigns, each told whether this reader arbitrates it.
+    """The listed campaigns, each carrying what its row has to draw.
 
     A list holding both the campaigns somebody runs and the ones they play
-    in has to say which is which, and the row draws its controls from the
-    answer: what an arbitrator may do to a campaign is not what somebody
-    playing in it may. The home page's campaigns tab draws the same rows,
-    off the same helper, so the two cannot come to disagree.
+    in has to say which is which: what an arbitrator may do to a campaign
+    is not what somebody playing in it may. The answer is settled here, as
+    the words the row draws rather than a flag it has to interpret, so the
+    campaigns list and the home page's tab cannot come to disagree about
+    what either sort of row looks like.
+
+    A campaign the reader runs names nobody — they know who runs it — and
+    offers the way in to change it. One they only play in names its
+    arbitrator and offers nothing: the whole row already opens it, and
+    there is nothing on the far side for them to change.
     """
     rows = list(campaigns)
     for row in rows:
-        row.arbitrated = row.owner_id == getattr(user, "id", None)
+        arbitrated = row.owner_id == getattr(user, "id", None)
+        row.owner_name = "" if arbitrated else row.owner.username
+        row.action_label = "Edit" if arbitrated else ""
     return rows
 
 
@@ -149,12 +157,16 @@ def create_campaign(request):
 def campaign(request, pk):
     """One campaign, whoever is reading it.
 
-    Shareable like a gang sheet: an arbitrator can send the address to the
-    table, and everybody who opens it reads the same campaign — the same
-    facts, the same gangs, the same battles, the same log. What the page
-    withholds from a reader who does not arbitrate it is every control,
-    and not a disabled one either: the acts belong to the arbitrator, so
-    for anybody else they are simply not there.
+    An arbitrator can send the address round the table, and everybody who
+    opens it reads the same campaign — the same facts, the same gangs, the
+    same battles, the same log. What the page withholds from a reader who
+    does not arbitrate it is every control, and not a disabled one either:
+    the acts belong to the arbitrator, so for anybody else they are simply
+    not there.
+
+    Who the address reaches is the decorators' answer rather than this
+    one's: signed in, and inside the campaigns feature. A reader outside
+    either is told there is nothing here.
 
     The log reads newest first and is cut to the most recent acts: the page
     is a campaign, not its history, and a log that grew without bound would

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -61,7 +61,7 @@ def dashboard(request):
             Campaign.objects.involving(request.user)
             .filter(archived=False)
             .select_related("owner")
-            .order_by("name"),
+            .order_by("name", "pk"),
             request.user,
         )
         if campaigns_open

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -48,7 +48,7 @@ def dashboard(request):
     edition.
     """
     from n26.core.models import Campaign
-    from n26.core.views.campaigns import invitations_for
+    from n26.core.views.campaigns import campaign_rows, invitations_for
     from n26.flags import CAMPAIGNS, enabled
 
     # The tab is a place this reader can go only where the feature is open to
@@ -57,7 +57,13 @@ def dashboard(request):
     # fetched — a tab with rows nobody may reach would be the worse bug.
     campaigns_open = enabled(CAMPAIGNS, request.user)
     campaigns = (
-        Campaign.objects.filter(owner=request.user, archived=False).order_by("name")
+        campaign_rows(
+            Campaign.objects.involving(request.user)
+            .filter(archived=False)
+            .select_related("owner")
+            .order_by("name"),
+            request.user,
+        )
         if campaigns_open
         else []
     )

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -86,14 +86,38 @@ def _any_gang_or_404(pk):
         raise Http404("No such gang") from None
 
 
+def _any_campaign_or_404(pk):
+    """The campaign, whoever arbitrates it — a table anybody may read.
+
+    A campaign's page is shareable the way a gang sheet is: the address an
+    arbitrator sends round shows the same campaign to whoever opens it.
+    What differs is what the page lets them *do* — every control on it is
+    the arbitrator's, and the page decides that by asking who is reading,
+    never by hiding the campaign.
+
+    Archived campaigns stay out, as archived rosters do: one its arbitrator
+    has put away is not something a link should keep alive. A pk that is
+    not a ULID is a bad URL rather than a server error.
+    """
+    from n26.core.models import Campaign
+
+    try:
+        return get_object_or_404(
+            Campaign.objects.select_related("owner"),
+            pk=pk,
+            archived=False,
+        )
+    except ValidationError:
+        raise Http404("No such campaign") from None
+
+
 def _own_campaign_or_404(request, pk):
     """The campaign, if the viewer is its arbitrator.
 
-    Owner-scoped where a gang sheet is not: a roster is a thing players
-    send each other, while a campaign's own pages are where its arbitrator
-    sets it up. What a player in a campaign gets to see is a different
-    question, answered by a different view when there are players to ask
-    about.
+    Owner-scoped where the page itself is not: reading a campaign is one
+    question and changing it is another, so the screens that set a campaign
+    up ask for its arbitrator by name rather than gating a control on a
+    page anybody may open.
     """
     from n26.core.models import Campaign
 

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -2,11 +2,12 @@
 
 Most scope to the owner and answer a stranger with 404 rather than 403:
 which gangs and fighters exist is not something to be probed for. The
-exception is ``_any_gang_or_404``, which scopes to nobody, because a
-roster is a thing players send each other — owner-scoping is the rule
-for acting on a gang, not for reading one. All of them catch the
-ULIDField refusal, because a pk that is not a ULID is only ever a bad
-link and a 500 is the wrong answer to one.
+exceptions are the two read guards, ``_any_gang_or_404`` and
+``_any_campaign_or_404``: a roster and a campaign are things players
+send each other, so owner-scoping is the rule for acting on one and not
+for reading it. All of them catch the ULIDField refusal, because a pk
+that is not a ULID is only ever a bad link and a 500 is the wrong answer
+to one.
 """
 
 from django.core.exceptions import ValidationError
@@ -87,13 +88,18 @@ def _any_gang_or_404(pk):
 
 
 def _any_campaign_or_404(pk):
-    """The campaign, whoever arbitrates it — a table anybody may read.
+    """The campaign, whoever arbitrates it — a table its players may read.
 
-    A campaign's page is shareable the way a gang sheet is: the address an
-    arbitrator sends round shows the same campaign to whoever opens it.
-    What differs is what the page lets them *do* — every control on it is
-    the arbitrator's, and the page decides that by asking who is reading,
-    never by hiding the campaign.
+    Not owner-scoped: the address an arbitrator sends round shows the same
+    campaign to everybody it reaches, and what differs is what the page
+    lets them *do*. Every control on it is the arbitrator's, and the page
+    decides that by asking who is reading, never by hiding the campaign.
+
+    How far the address reaches is decided above this, not here: the view
+    is gated on the campaigns feature and on being signed in, so a reader
+    outside either gets a 404 whatever this returns. A roster reaches
+    further — anybody at all may read one — and the difference is the
+    gate, not the guard.
 
     Archived campaigns stay out, as archived rosters do: one its arbitrator
     has put away is not something a link should keep alive. A pk that is

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1642,7 +1642,7 @@ GROUPS: list[Group] = [
                     Part(
                         "c-n26.record-table.campaign-row",
                         "n26/record_table/campaign_row.html",
-                        "One campaign: its name, who arbitrates it, and Edit.",
+                        "One campaign: its name, who arbitrates it, and — where the reader runs it — Edit.",
                     ),
                 ),
                 notes=(

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1642,7 +1642,7 @@ GROUPS: list[Group] = [
                     Part(
                         "c-n26.record-table.campaign-row",
                         "n26/record_table/campaign_row.html",
-                        "One campaign: its name, and Edit.",
+                        "One campaign: its name, who arbitrates it, and Edit.",
                     ),
                 ),
                 notes=(

--- a/n26/designsystem/templates/designsystem/demos/record-table/20-campaigns.html
+++ b/n26/designsystem/templates/designsystem/demos/record-table/20-campaigns.html
@@ -1,0 +1,11 @@
+{# title: A list holding two sorts of campaign #}
+{# note: The campaign row's twin cases, which a list mixes freely: the ones a reader arbitrates carry the way in to change them, and the ones they only play in name whoever runs it and carry no button at all — the whole row already opens the campaign, and there is nothing on the far side for them to change. The empty cell is still drawn, so both sorts stand the same height and the names keep one left edge. #}
+{# layout: full #}
+<c-n26.record-table noun="campaigns" singular="campaign">
+    <c-slot name="empty">
+        No campaigns match that. Try a shorter search.
+    </c-slot>
+    <c-n26.record-table.campaign-row name="Dust Falls" href="#" action_label="Edit" />
+    <c-n26.record-table.campaign-row name="Sump Wars" href="#" owner="kesh" />
+    <c-n26.record-table.campaign-row name="The Ash Wastes" href="#" action_label="Edit" />
+</c-n26.record-table>

--- a/n26/designsystem/templates/designsystem/demos/record-table/20-campaigns.html
+++ b/n26/designsystem/templates/designsystem/demos/record-table/20-campaigns.html
@@ -6,6 +6,6 @@
         No campaigns match that. Try a shorter search.
     </c-slot>
     <c-n26.record-table.campaign-row name="Dust Falls" href="#" action_label="Edit" />
-    <c-n26.record-table.campaign-row name="Sump Wars" href="#" owner="kesh" />
+    <c-n26.record-table.campaign-row name="Sump Wars" href="#" owner="kesh" action_label="" />
     <c-n26.record-table.campaign-row name="The Ash Wastes" href="#" action_label="Edit" />
 </c-n26.record-table>

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -236,8 +236,9 @@ class TestSettingOneUp:
 
 
 class TestSomebodyElsesCampaign:
-    """Owner-scoped, and answered with 404 rather than 403 — the same way
-    every other page holding player data answers a stranger."""
+    """The page reads for anybody holding the address; the screens that
+    change it are the arbitrator's, and answer a stranger with 404 rather
+    than 403 — the same way every other page holding player data does."""
 
     @pytest.fixture
     def theirs(self):
@@ -245,7 +246,30 @@ class TestSomebodyElsesCampaign:
             name="Not Yours", owner=User.objects.create_user("someone-else")
         )
 
-    def test_it_is_not_readable(self, client, arbitrator, theirs, open_to_everyone):
+    def test_it_is_readable(self, client, arbitrator, theirs, open_to_everyone):
+        response = client.get(f"/n26/campaigns/{theirs.pk}/")
+        assert response.status_code == 200
+        assert "Not Yours" in response.content.decode()
+
+    def test_it_offers_no_controls(self, client, arbitrator, theirs, open_to_everyone):
+        """Not a disabled button but nothing at all, so every address that
+        would refuse this reader is absent from what they are given."""
+        drawn = client.get(f"/n26/campaigns/{theirs.pk}/").content.decode()
+        for address in (
+            f"/n26/campaigns/{theirs.pk}/edit/",
+            f"/n26/campaigns/{theirs.pk}/archive/",
+            f"/n26/campaigns/{theirs.pk}/participants/add/",
+            f"/n26/campaigns/{theirs.pk}/gangs/add/",
+            f"/n26/campaigns/{theirs.pk}/battles/new/",
+        ):
+            assert address not in drawn
+
+    def test_an_archived_one_is_gone(
+        self, client, arbitrator, theirs, open_to_everyone
+    ):
+        """A link does not keep alive what its arbitrator has put away."""
+        theirs.archived = True
+        theirs.save()
         assert client.get(f"/n26/campaigns/{theirs.pk}/").status_code == 404
 
     def test_it_is_not_editable(self, client, arbitrator, theirs, open_to_everyone):
@@ -868,6 +892,78 @@ class TestAnsweringAnInvitation:
             ).status_code
             == 404
         )
+
+
+class TestWhatAParticipantSees:
+    """Accepting puts the campaign among the reader's own, because the
+    invitation it arrived on is answered and gone: without this a player
+    who said yes has nothing left pointing at the campaign."""
+
+    @pytest.fixture
+    def theirs(self, arbitrator):
+        from n26.core.campaigns import campaign_operation
+
+        owner = User.objects.create_user("kesh")
+        campaign = Campaign.objects.create(name="Sump Wars", owner=owner)
+        with campaign_operation(campaign, actor=owner) as act:
+            act.invite(arbitrator)
+        return campaign
+
+    def accept(self, client, campaign):
+        client.post(f"/n26/campaigns/{campaign.pk}/invitation/", {"answer": "accept"})
+
+    def test_the_list_holds_it_once_accepted(self, client, theirs, open_to_everyone):
+        self.accept(client, theirs)
+        response = client.get("/n26/campaigns/")
+        assert [row.pk for row in response.context["campaigns"]] == [theirs.pk]
+
+    def test_the_home_page_holds_it_too(self, client, theirs, open_to_everyone):
+        self.accept(client, theirs)
+        response = client.get("/n26/")
+        assert [row.pk for row in response.context["campaigns"]] == [theirs.pk]
+
+    def test_the_row_names_who_runs_it_and_offers_nothing(
+        self, client, theirs, open_to_everyone
+    ):
+        self.accept(client, theirs)
+        drawn = client.get("/n26/campaigns/").content.decode()
+        assert "arbitrated by kesh" in drawn
+        assert f"/n26/campaigns/{theirs.pk}/edit/" not in drawn
+
+    def test_a_question_still_waiting_is_not_one_of_their_campaigns(
+        self, client, theirs, open_to_everyone
+    ):
+        """It is drawn on the page as an invitation, which is a different
+        thing from being in the campaign."""
+        assert list(client.get("/n26/campaigns/").context["campaigns"]) == []
+
+    def test_declining_leaves_it_out(self, client, theirs, open_to_everyone):
+        client.post(f"/n26/campaigns/{theirs.pk}/invitation/", {"answer": "decline"})
+        assert list(client.get("/n26/campaigns/").context["campaigns"]) == []
+
+    def test_the_bar_offers_it(self, client, theirs, open_to_everyone):
+        """The chevron beside a campaign's name is how somebody reaches
+        another of theirs, and a player has no other way through."""
+        from n26.core.navigation import reader_campaigns
+
+        self.accept(client, theirs)
+        response = client.get(f"/n26/campaigns/{theirs.pk}/")
+        assert [row.pk for row in reader_campaigns(response.wsgi_request)] == [
+            theirs.pk
+        ]
+
+    def test_they_read_the_log(self, client, theirs, arbitrator, open_to_everyone):
+        """Everybody who can open the page can read what has happened."""
+        self.accept(client, theirs)
+        response = client.get(f"/n26/campaigns/{theirs.pk}/")
+        assert response.context["acts"]
+
+    def test_the_arbitrator_still_gets_the_controls(
+        self, client, campaign, open_to_everyone
+    ):
+        drawn = client.get(f"/n26/campaigns/{campaign.pk}/").content.decode()
+        assert f"/n26/campaigns/{campaign.pk}/edit/" in drawn
+        assert f"/n26/campaigns/{campaign.pk}/participants/add/" in drawn
 
 
 class TestNothingTypedIntoAnAddressIsAServerError:

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -127,7 +127,9 @@ class TestTheDashboardTab:
         assert "Dust Falls" in body
         assert "/n26/campaigns/new/" in body
 
-    def test_it_shows_only_the_readers_own(self, client, arbitrator, open_to_everyone):
+    def test_it_leaves_out_a_campaign_the_reader_has_no_place_in(
+        self, client, arbitrator, open_to_everyone
+    ):
         Campaign.objects.create(
             name="Not Yours", owner=User.objects.create_user("someone-else")
         )
@@ -286,6 +288,7 @@ class TestSomebodyElsesCampaign:
         assert theirs.archived is False
 
     def test_it_is_not_listed(self, client, arbitrator, theirs, open_to_everyone):
+        """Readable at its own address, but not one of the reader's own."""
         assert "Not Yours" not in client.get("/n26/campaigns/").content.decode()
 
 
@@ -940,6 +943,22 @@ class TestWhatAParticipantSees:
     def test_declining_leaves_it_out(self, client, theirs, open_to_everyone):
         client.post(f"/n26/campaigns/{theirs.pk}/invitation/", {"answer": "decline"})
         assert list(client.get("/n26/campaigns/").context["campaigns"]) == []
+
+    def test_searching_finds_it(self, client, theirs, open_to_everyone):
+        """The list is a join across participants and is deduplicated, so a
+        search over it has to survive both."""
+        self.accept(client, theirs)
+        response = client.get("/n26/campaigns/", {"q": "Sump"})
+        assert [row.pk for row in response.context["campaigns"]] == [theirs.pk]
+
+    def test_searching_for_something_else_finds_nothing(
+        self, client, theirs, open_to_everyone
+    ):
+        self.accept(client, theirs)
+        assert (
+            list(client.get("/n26/campaigns/", {"q": "Ashfall"}).context["campaigns"])
+            == []
+        )
 
     def test_the_bar_offers_it(self, client, theirs, open_to_everyone):
         """The chevron beside a campaign's name is how somebody reaches


### PR DESCRIPTION
A campaign's page was owner-scoped, so everybody except its arbitrator got a 404 — the people actually playing in one had nowhere to read it. It now opens for everyone at the table, and what differs is what the page lets them do.

- **Reading.** The campaign page opens for its arbitrator and for anybody else holding the address, so long as they are signed in and the campaigns feature is open to them. An anonymous visitor still gets a 404: that is the feature flag's answer, not the page's, and it is why this is not quite a gang sheet, which anybody may read signed in or not. Archived campaigns stay 404 for everyone, as archived rosters do.
- **Controls.** Edit, Archive, Add participants, Add gang, Record battle and the two removals are drawn only for the arbitrator — not as disabled buttons, but not at all. The screens behind them are unchanged and still answer a stranger with 404.
- **Finding it.** Accepting an invitation now puts the campaign among the reader's own. It had to: the invitation it arrived on is answered and gone, which previously left a player who said yes with nothing pointing at the campaign. `Campaign.objects.involving(user)` is the single query behind that, and the campaigns list, the home page's tab and the bar's switcher all read through it. Those three order by name and then by key, because names collide across owners once the list holds other people's campaigns.
- **The row.** A campaign somebody only plays in names its arbitrator and carries no button. The action cell is drawn either way so a list mixing both sorts keeps one row height, and the button's label is never assumed — a row draws one only when asked, so it cannot grow a control its reader may not use.

The log is visible to everybody who can open the page.

## How to try it

With two accounts, one arbitrating a campaign and the other an accepted participant:

- `/n26/campaigns/<id>/` — the same page for both; only the arbitrator sees any controls
- `/n26/campaigns/` — the participant's list now holds the campaign, labelled with who runs it and with no Edit button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZEooSg8dnNJ2T4oqexpJY