### PR TITLE
feat: a roll table's own page says whether its bands cover the die

### DIFF
--- a/n26/core/browse.py
+++ b/n26/core/browse.py
@@ -764,7 +764,9 @@ def offered_by(slot, computed, terms=EQUIPMENT_LIST):
             # that holds it. Bandless rows gather at the end.
             from django.db.models import F
 
-            members = members.order_by(F("roll_low").asc(nulls_last=True), "position")
+            members = members.order_by(
+                F("roll_low").asc(nulls_last=True), "position", "pickable__name"
+            )
         return [
             Listed(thing=member.pickable, name=member.label, band=member.band)
             # One query for the whole list: the wording is the member's

--- a/n26/core/browse.py
+++ b/n26/core/browse.py
@@ -114,6 +114,10 @@ class Listed:
 
     thing: object
     name: str
+    #: The band of rolls that lands on this row, as a roll table prints
+    #: it — "51", "21-26" — or nothing on an ordinary list. A player who
+    #: rolled on the physical table finds their result by this.
+    band: str = ""
 
 
 @dataclass(frozen=True)
@@ -753,12 +757,20 @@ def offered_by(slot, computed, terms=EQUIPMENT_LIST):
     and an owner may still hand over something off it.
     """
     if slot.slot is not None:
+        members = slot.slot.picklist.members.select_related("pickable")
+        if slot.slot.picklist.dice:
+            # A roll table is read by the roll, so its picker comes in
+            # roll order — a player who rolled 24 scans for the band
+            # that holds it. Bandless rows gather at the end.
+            from django.db.models import F
+
+            members = members.order_by(F("roll_low").asc(nulls_last=True), "position")
         return [
-            Listed(thing=member.pickable, name=member.label)
+            Listed(thing=member.pickable, name=member.label, band=member.band)
             # One query for the whole list: the wording is the member's
             # and the identity is the pickable's, so a list of thirty
             # pickables must not be thirty fetches.
-            for member in slot.slot.picklist.members.select_related("pickable")
+            for member in members
         ]
     offer = slot.offer
     section = getattr(offer, "from_section", None) if offer is not None else None

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -341,6 +341,10 @@ class Choosable:
     #: a bare key is ambiguous across the assignable tables.
     key: str
     name: str
+    #: The band of rolls that lands on this option, where the list behind
+    #: the choice is a roll table — "51", "21-26" — or nothing. Drawn
+    #: ahead of the name so a player finds their roll by scanning.
+    band: str = ""
     thing: object = None
     #: True for a thing the surface opens on already marked: what a slot
     #: already holds, or — where a list is ticked rather than picked — one
@@ -950,7 +954,13 @@ def build_choice_offer(slot, computed):
             control = "remove"
         options.append(
             _choosable(
-                thing, current, taken=taken, name=name, held=held, control=control
+                thing,
+                current,
+                taken=taken,
+                name=name,
+                held=held,
+                control=control,
+                band=getattr(item, "band", ""),
             )
         )
 
@@ -1058,7 +1068,15 @@ def option_key(thing):
 
 
 def _choosable(
-    thing, current, notes=(), held=(), granted=None, taken=None, name=None, control=""
+    thing,
+    current,
+    notes=(),
+    held=(),
+    granted=None,
+    taken=None,
+    name=None,
+    control="",
+    band="",
 ):
     key = option_key(thing)
     granted_by = (granted or {}).get(key, "")
@@ -1067,6 +1085,7 @@ def _choosable(
         # The wording a list gives a pickable, where it gives it one. The
         # thing's own name everywhere else, and on every other surface.
         name=name or str(thing),
+        band=band,
         thing=thing,
         is_current=(current is not None and thing == current)
         or key in held

--- a/n26/core/templates/cotton/n26/choice_picks.html
+++ b/n26/core/templates/cotton/n26/choice_picks.html
@@ -48,6 +48,12 @@ that holds one.
                 <ul class="divide-y divide-box-border border-y border-box-border">
                     {% for option in group.options %}
                         <li class="flex items-center gap-3 py-2">
+                            {% comment %}
+                            On a roll table the band leads the row, in a fixed
+                            column, so a player who rolled on the physical
+                            table finds their result by scanning the numbers.
+                            {% endcomment %}
+                            {% if option.band %}<span class="w-12 shrink-0 text-right tabular-nums text-muted">{{ option.band }}</span>{% endif %}
                             <span class="min-w-0 flex-1">
                                 <span class="block text-ink-900 dark:text-ink-100">{{ option.name }}</span>
                                 {% comment %}

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -17,6 +17,11 @@ thing twice, a line apart.
         hundred rows costs the page the same as a kind with three.
         {% endcomment %}
         <c-slot name="trailing">
+            {% if table_href %}
+                <c-ui.button variant="primary" :outlined="True" size="sm" href="{{ table_href }}">
+                    Roll table
+                </c-ui.button>
+            {% endif %}
             {% siblings_switcher kind thing as siblings_ %}
             <c-n26.quick-switcher.of :switcher="siblings_" hotkey="r" />
         </c-slot>

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -17,11 +17,6 @@ thing twice, a line apart.
         hundred rows costs the page the same as a kind with three.
         {% endcomment %}
         <c-slot name="trailing">
-            {% if table_href %}
-                <c-ui.button variant="primary" :outlined="True" size="sm" href="{{ table_href }}">
-                    Roll table
-                </c-ui.button>
-            {% endif %}
             {% siblings_switcher kind thing as siblings_ %}
             <c-n26.quick-switcher.of :switcher="siblings_" hotkey="r" />
         </c-slot>

--- a/n26/library/templates/authoring/picklist_table.html
+++ b/n26/library/templates/authoring/picklist_table.html
@@ -28,7 +28,7 @@
                 {% endif %}
             </p>
         </c-n26.prose>
-        {% if coverage.covered == coverage.total and not doubled_said %}
+        {% if coverage.covered == coverage.total and not doubled_said and not coverage.bandless %}
             <c-ui.alert variant="success" class="mt-4">
                 {{ coverage.covered }} of {{ coverage.total }} rolls covered.
             </c-ui.alert>

--- a/n26/library/templates/authoring/picklist_table.html
+++ b/n26/library/templates/authoring/picklist_table.html
@@ -1,0 +1,86 @@
+{% extends "authoring/base.html" %}
+{% block head_title %}
+    {{ picklist }} — table
+{% endblock head_title %}
+{% block content %}
+    <c-n26.page-header title="{{ picklist }}">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Content library</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' 'picklist' %}">Picklists</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-detail' 'picklist' picklist.pk %}">
+                    {{ picklist }}
+                </c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    Table
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+    </c-n26.page-header>
+    {% if coverage %}
+        <c-n26.prose class="mt-2">
+            <p>
+                Rolled on a {{ picklist.get_dice_display }} — a roll picks
+                {% if picklist.roll_selects == "threshold" %}
+                    every row at or below it.
+                {% else %}
+                    the one row it lands in.
+                {% endif %}
+            </p>
+        </c-n26.prose>
+        {% if coverage.covered == coverage.total and not doubled_said %}
+            <c-ui.alert variant="success" class="mt-4">
+                {{ coverage.covered }} of {{ coverage.total }} rolls covered.
+            </c-ui.alert>
+        {% else %}
+            <c-ui.alert variant="warning" class="mt-4">
+                {{ coverage.covered }} of {{ coverage.total }} rolls covered{% if unclaimed_said %} — {{ unclaimed_said }} unclaimed{% endif %}.
+                {% for roll, results in doubled_said %}
+                    <br />
+                    {{ roll }} is claimed by more than one result — {{ results }}.
+                {% endfor %}
+                {% for member in coverage.bandless %}
+                    <br />
+                    {{ member.label }} has no band, so no roll lands on it.
+                {% endfor %}
+            </c-ui.alert>
+        {% endif %}
+    {% endif %}
+    <c-n26.form-section title="Results" class="mt-8">
+        {% if members %}
+            <c-ui.table>
+                <tbody>
+                    {% for member in members %}
+                        <tr>
+                            <td class="w-16 text-right tabular-nums text-muted">{{ member.band }}</td>
+                            <td>
+                                <c-n26.link href="{% url 'authoring-detail' 'pickable' member.pickable.pk %}">{{ member.label }}</c-n26.link>
+                            </td>
+                            <td class="text-right">
+                                <c-n26.link href="{% url 'authoring-picklist-member-remove' member.pk %}"
+                                            tone="muted"
+                                            underline="always"
+                                            class="text-xs">Remove</c-n26.link>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </c-ui.table>
+        {% else %}
+            <c-ui.description>
+                Nothing on this list yet.
+            </c-ui.description>
+        {% endif %}
+    </c-n26.form-section>
+    <c-n26.form-section title="Add a result" class="mt-8">
+        <form method="post">
+            {% csrf_token %}
+            {% include "authoring/_form.html" %}
+            <div class="mt-4">
+                <c-ui.button type="submit" variant="success">
+                    Add result
+                </c-ui.button>
+            </div>
+        </form>
+    </c-n26.form-section>
+{% endblock content %}

--- a/n26/library/test_slots.py
+++ b/n26/library/test_slots.py
@@ -419,6 +419,77 @@ class TestARollTable:
         assert legacies.roll_selects == ""
 
 
+class TestCoverage:
+    """Whether a table's bands claim its die: gaps and overlaps make a
+    table unrollable, and neither can be seen one row at a time — which
+    is what the table page exists to show."""
+
+    @pytest.fixture
+    def injury(self, default_pack):
+        return create_slot_type("Lasting Injury", allows_repeats=True)
+
+    @pytest.fixture
+    def table(self, injury):
+        return create_picklist(
+            "Lasting Injury Table", injury, dice="d66", roll_selects="band"
+        )
+
+    def add(self, table, injury, name, low, high=None):
+        return add_picklist_member(
+            table, create_pickable(name, injury), roll_low=low, roll_high=high
+        )
+
+    def test_a_band_counts_only_rolls_the_die_can_produce(self, table, injury):
+        """ "31-46" on a D66 is twelve rolls, not sixteen: 37 through 40
+        can never come up."""
+        from n26.library.views import coverage
+
+        self.add(table, injury, "Grievous Wound", 31, 46)
+        said = coverage(table)
+        assert said.total == 36
+        assert said.covered == 12
+
+    def test_unclaimed_rolls_are_named(self, table, injury):
+        from n26.library.views import coverage
+
+        self.add(table, injury, "Out Cold", 21, 26)
+        said = coverage(table)
+        assert 11 in said.unclaimed and 66 in said.unclaimed
+        assert 22 not in said.unclaimed
+        assert 37 not in said.unclaimed
+
+    def test_a_roll_claimed_twice_names_both_results(self, table, injury):
+        from n26.library.views import coverage
+
+        self.add(table, injury, "Eye Injury", 51)
+        self.add(table, injury, "Hand Injury", 51, 52)
+        said = coverage(table)
+        assert [m.label for m in dict(said.doubled)[51]] == [
+            "Eye Injury",
+            "Hand Injury",
+        ]
+        assert 52 not in dict(said.doubled)
+
+    def test_a_complete_table_reports_itself_whole(self, injury):
+        from n26.library.views import coverage
+
+        table = create_picklist("Whole", injury, dice="d6", roll_selects="band")
+        self.add(table, injury, "Low", 1, 3)
+        self.add(table, injury, "High", 4, 6)
+        said = coverage(table)
+        assert said.covered == said.total == 6
+        assert said.unclaimed == []
+        assert said.doubled == []
+
+    def test_a_bandless_result_claims_nothing_and_is_named(self, table, injury):
+        from n26.library.views import coverage
+
+        add_picklist_member(table, create_pickable("Lesson Learnt", injury))
+        said = coverage(table)
+        assert [m.label for m in said.bandless] == ["Lesson Learnt"]
+        assert said.covered == 0
+
+
 class TestWhatEachDieCanRoll:
     """The rolls a table has to cover, per die. D66 is the one worth
     stating: it is two D6 read as tens and units, so 37 through 40 can

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -16,7 +16,7 @@ The composer and the preview pane hang off this same skeleton later
 import inspect
 import re
 from collections import Counter
-from dataclasses import replace
+from dataclasses import dataclass, replace
 
 from django import forms
 from django.contrib import messages
@@ -1737,6 +1737,13 @@ def detail(request, kind, pk):
             "verbose_name": model._meta.verbose_name,
             "verbose_name_plural": model._meta.verbose_name_plural,
             "edit_form": edit_form,
+            # A roll table's gaps and overlaps live on a page of their
+            # own; an ordinary picklist has no such page to offer.
+            "table_href": (
+                reverse("authoring-picklist-table", args=[thing.pk])
+                if kind == "picklist" and thing.dice
+                else ""
+            ),
             "statline_cells": statline_edit.cells() if statline_edit else None,
             "part_sections": drawn,
             "hire_options": hire_options,
@@ -3977,3 +3984,117 @@ def _rows(model, kind=None):
         )
     hint = LEAF_LISTING_HINTS.get(kind)
     return hint(rows) if hint else rows
+
+
+@dataclass(frozen=True)
+class Coverage:
+    """Whether a roll table's bands claim its die.
+
+    Gaps and overlaps make a table unrollable, and neither is a fact
+    about any one row — only the whole table can say. ``covered`` counts
+    rolls claimed by at least one result; a roll claimed twice is
+    covered and doubled both.
+    """
+
+    #: Every roll the die can produce.
+    total: int
+    #: How many of them at least one band claims.
+    covered: int
+    #: The rolls no band claims, in roll order.
+    unclaimed: list
+    #: ``(roll, members)`` for every roll more than one band claims.
+    doubled: list
+    #: Results with no band at all: on the list, never rolled.
+    bandless: list
+
+
+def coverage(picklist):
+    """The table's bands checked against its die, as :class:`Coverage`.
+
+    Pure over the rows it is handed, so a page can say "34 of 36 rolls
+    covered; 23 and 24 unclaimed" and a test can assert it without
+    rendering anything. A band may span rolls the die cannot produce —
+    "31-46" on a D66 — and such rolls count for nothing: the check walks
+    the die's own rolls, never the band's arithmetic.
+    """
+    from n26.library.models import Dice
+
+    rolls = Dice.rolls(picklist.dice)
+    # One query however long the table: a member's label falls back to
+    # its pickable's name, and the page prints every label it is handed.
+    members = list(picklist.members.select_related("pickable"))
+    claimed = {}
+    for member in members:
+        if member.roll_low is None:
+            continue
+        for roll in rolls:
+            if member.roll_low <= roll <= member.roll_high:
+                claimed.setdefault(roll, []).append(member)
+    return Coverage(
+        total=len(rolls),
+        covered=len(claimed),
+        unclaimed=[roll for roll in rolls if roll not in claimed],
+        doubled=[(roll, who) for roll, who in claimed.items() if len(who) > 1],
+        bandless=[member for member in members if member.roll_low is None],
+    )
+
+
+@staff_member_required
+def picklist_table(request, pk):
+    """One roll table, whole: its rows in roll order, and whether its
+    bands cover the die.
+
+    The picklist's own page adds and removes members one at a time; this
+    page exists for the fact no single row carries — a gap or an overlap
+    in the table. The add-a-row form is the detail page's own, handed
+    the picklist so its picker offers this slot type's pickables and
+    nothing else. An ordinary list opens here too, drawn without the
+    coverage it has no die to check against.
+    """
+    from django.db.models import F
+
+    from n26.library.models import Picklist
+
+    picklist = get_object_or_404(Picklist, pk=pk)
+    spec = specs()["add_picklist_member"]
+    form_class = generate_form(spec)
+
+    if request.method == "POST":
+        form = form_class(request.POST, carrier=picklist)
+        if form.is_valid():
+            try:
+                with transaction.atomic():
+                    member = spec.verb(picklist, **form.verb_data())
+            except ValidationError as refused:
+                form.add_error(None, refused)
+            else:
+                messages.success(request, f"Added {member.label}.")
+                return redirect("authoring-picklist-table", pk=pk)
+    else:
+        form = form_class(carrier=picklist)
+
+    members = picklist.members.select_related("pickable").order_by(
+        F("roll_low").asc(nulls_last=True), "position", "pickable__name"
+    )
+    said = coverage(picklist) if picklist.dice else None
+    doubled_said = (
+        [
+            (roll, ", ".join(member.label for member in who))
+            for roll, who in said.doubled
+        ]
+        if said
+        else []
+    )
+    unclaimed_said = ", ".join(str(roll) for roll in said.unclaimed) if said else ""
+    return render(
+        request,
+        "authoring/picklist_table.html",
+        {
+            "picklist": picklist,
+            "members": members,
+            "coverage": said,
+            "unclaimed_said": unclaimed_said,
+            "doubled_said": doubled_said,
+            "form": form,
+        },
+    )

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -161,6 +161,31 @@ def _describe_picklist_member(member):
     return label, notes
 
 
+def _roll_table_summary(picklist):
+    """What the members section says under its heading, for a roll table.
+
+    The one fact worth a glance before opening the table page: how much
+    of the die the bands claim. An ordinary picklist says nothing here.
+    """
+    if not picklist.dice:
+        return ""
+    said = coverage(picklist)
+    words = [
+        f"Rolled on a {picklist.get_dice_display()}.",
+        f"{said.covered} of {said.total} rolls covered"
+        + (
+            f"; {', '.join(str(roll) for roll in said.unclaimed)} unclaimed"
+            if said.unclaimed
+            else ""
+        )
+        + ".",
+    ]
+    if said.doubled:
+        rolls = ", ".join(str(roll) for roll, _ in said.doubled)
+        words.append(f"Claimed by more than one result: {rolls}.")
+    return " ".join(words)
+
+
 def _weapon_parts(parts):
     """What ``_describe_weapon_profile`` reads, loaded for every line at
     once — unhinted, each profile fetches its weapon, its statline's
@@ -306,29 +331,33 @@ DETAIL_KINDS = {
         "statline": False,
         "describe": _describe_picklist_member,
         "parts_hint": lambda parts: parts.select_related("pickable"),
-        # A roll table's gaps and overlaps are facts about the whole
-        # list, so they get a page of their own; an ordinary picklist
-        # has no die to check and no such page.
-        "door": lambda picklist: (
+        # A roll table's results only mean anything with their bands and
+        # the coverage check, so they are worked on the table page — this
+        # section names the shape, says how covered it is, and sends an
+        # author there. An ordinary picklist keeps its form here.
+        "adds": lambda picklist: (
             reverse("authoring-picklist-table", args=[picklist.pk])
             if picklist.dice
             else ""
         ),
-        "door_label": "Roll table",
+        "parts_label": lambda picklist: "roll table" if picklist.dice else "pickables",
         # The row is the listing, but the name on it is the pickable's,
         # and the pickable's page is where what it does is written.
         "opens": lambda member: reverse(
             "authoring-detail", args=["pickable", member.pickable_id]
         ),
-        "parts_label": "pickables",
         # The part model's own name is accurate and nothing an author
-        # says; what they are adding is one more pickable to choose from.
-        "part_name": "pickable",
-        "parts_description": (
-            "A list of pickables for a particular slot type, in the order "
-            "a player reads them. Taking one off changes only what is "
-            "offered next: the pickable itself stays in the library, and "
-            "anyone who already made a pick keeps it."
+        # says; what they are adding is one more pickable to choose from —
+        # or, on a roll table, one more result at its band.
+        "part_name": lambda picklist: "result" if picklist.dice else "pickable",
+        "parts_description": lambda picklist: (
+            _roll_table_summary(picklist)
+            or (
+                "A list of pickables for a particular slot type, in the order "
+                "a player reads them. Taking one off changes only what is "
+                "offered next: the pickable itself stays in the library, and "
+                "anyone who already made a pick keeps it."
+            )
         ),
         "nothing_yet": (
             "No pickables yet — a choice drawing on this list has nothing to offer."
@@ -1566,10 +1595,23 @@ def detail(request, kind, pk):
 
     composer = None
     act = request.POST.get("act", "")
+
+    def adds_elsewhere(one):
+        """Where this section's parts are added, or nothing — a route
+        name for every row of the kind, a callable deciding row by row."""
+        where = one.get("adds")
+        if callable(where):
+            return where(thing)
+        return reverse(where, args=[thing.pk]) if where else ""
+
     # A section whose add form lives elsewhere has no form here to post
     # to, so it is not a candidate however the act reads.
     posted_to = next(
-        (one for one in sections if one.get("act", "") == act and not one.get("adds")),
+        (
+            one
+            for one in sections
+            if one.get("act", "") == act and not adds_elsewhere(one)
+        ),
         None,
     )
     if (
@@ -1624,7 +1666,7 @@ def detail(request, kind, pk):
         part_model = _model_for(part_spec)
         # A section that adds its parts elsewhere draws a way there
         # instead of a form, so neither form is built at all.
-        elsewhere = section.get("adds")
+        elsewhere = adds_elsewhere(section)
         form_class = None if elsewhere else generate_form(part_spec)
         statline_class = (
             statline_form_for(thing.statline_type)
@@ -1683,7 +1725,11 @@ def detail(request, kind, pk):
             )
         arrange = section.get("arrange")
         parts = arrange(pairs) if arrange else [drawn for _part, drawn in pairs]
-        part_name = str(section.get("part_name", part_model._meta.verbose_name))
+
+        def worded(value):
+            return value(thing) if callable(value) else value
+
+        part_name = str(worded(section.get("part_name", part_model._meta.verbose_name)))
         drawn.append(
             {
                 "act": section.get("act", ""),
@@ -1692,10 +1738,10 @@ def detail(request, kind, pk):
                 # than written beside each name, so a kind renamed on its
                 # model never leaves the heading ungrammatical.
                 "part_article": _article_for(part_name),
-                "part_verbose_name_plural": section.get(
-                    "parts_label", part_model._meta.verbose_name_plural
+                "part_verbose_name_plural": worded(
+                    section.get("parts_label", part_model._meta.verbose_name_plural)
                 ),
-                "parts_description": section.get("parts_description", ""),
+                "parts_description": worded(section.get("parts_description", "")),
                 "nothing_yet": section.get("nothing_yet", ""),
                 # Said beside the add form, so an author knows how far
                 # the addition travels before committing it. Only the
@@ -1713,7 +1759,7 @@ def detail(request, kind, pk):
                 "statline_form": statline_form,
                 # Blank for a section adding its parts in a form here;
                 # the page then draws that form rather than a way out.
-                "add_url": reverse(elsewhere, args=[thing.pk]) if elsewhere else "",
+                "add_url": elsewhere or "",
                 # A further way in for parts the form cannot offer —
                 # blank for every section that has none.
                 "door_url": section.get("door", lambda thing: "")(thing),
@@ -4058,6 +4104,8 @@ def picklist_table(request, pk):
     from n26.library.models import Picklist
 
     picklist = get_object_or_404(Picklist, pk=pk)
+    if not picklist.dice:
+        return redirect("authoring-detail", kind="picklist", pk=pk)
     spec = specs()["add_picklist_member"]
     form_class = generate_form(spec)
 

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -183,6 +183,9 @@ def _roll_table_summary(picklist):
     if said.doubled:
         rolls = ", ".join(str(roll) for roll, _ in said.doubled)
         words.append(f"Claimed by more than one result: {rolls}.")
+    if said.bandless:
+        names = ", ".join(member.label for member in said.bandless)
+        words.append(f"No band, so never rolled: {names}.")
     return " ".join(words)
 
 
@@ -4056,21 +4059,24 @@ class Coverage:
     bandless: list
 
 
-def coverage(picklist):
+def coverage(picklist, members=None):
     """The table's bands checked against its die, as :class:`Coverage`.
 
     Pure over the rows it is handed, so a page can say "34 of 36 rolls
     covered; 23 and 24 unclaimed" and a test can assert it without
     rendering anything. A band may span rolls the die cannot produce —
     "31-46" on a D66 — and such rolls count for nothing: the check walks
-    the die's own rolls, never the band's arithmetic.
+    the die's own rolls, never the band's arithmetic. A caller that has
+    already fetched the members hands them over rather than paying for
+    the same rows twice.
     """
     from n26.library.models import Dice
 
     rolls = Dice.rolls(picklist.dice)
-    # One query however long the table: a member's label falls back to
-    # its pickable's name, and the page prints every label it is handed.
-    members = list(picklist.members.select_related("pickable"))
+    if members is None:
+        # One query however long the table: a member's label falls back
+        # to its pickable's name, and every label it holds is printed.
+        members = list(picklist.members.select_related("pickable"))
     claimed = {}
     for member in members:
         if member.roll_low is None:
@@ -4082,7 +4088,8 @@ def coverage(picklist):
         total=len(rolls),
         covered=len(claimed),
         unclaimed=[roll for roll in rolls if roll not in claimed],
-        doubled=[(roll, who) for roll, who in claimed.items() if len(who) > 1],
+        # In roll order, as everything about a table is read.
+        doubled=sorted((roll, who) for roll, who in claimed.items() if len(who) > 1),
         bandless=[member for member in members if member.roll_low is None],
     )
 
@@ -4096,8 +4103,8 @@ def picklist_table(request, pk):
     page exists for the fact no single row carries — a gap or an overlap
     in the table. The add-a-row form is the detail page's own, handed
     the picklist so its picker offers this slot type's pickables and
-    nothing else. An ordinary list opens here too, drawn without the
-    coverage it has no die to check against.
+    nothing else. An ordinary list has no table to show, so its address
+    here leads back to its own page.
     """
     from django.db.models import F
 
@@ -4123,10 +4130,12 @@ def picklist_table(request, pk):
     else:
         form = form_class(carrier=picklist)
 
-    members = picklist.members.select_related("pickable").order_by(
-        F("roll_low").asc(nulls_last=True), "position", "pickable__name"
+    members = list(
+        picklist.members.select_related("pickable").order_by(
+            F("roll_low").asc(nulls_last=True), "position", "pickable__name"
+        )
     )
-    said = coverage(picklist) if picklist.dice else None
+    said = coverage(picklist, members)
     doubled_said = (
         [
             (roll, ", ".join(member.label for member in who))

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -306,6 +306,15 @@ DETAIL_KINDS = {
         "statline": False,
         "describe": _describe_picklist_member,
         "parts_hint": lambda parts: parts.select_related("pickable"),
+        # A roll table's gaps and overlaps are facts about the whole
+        # list, so they get a page of their own; an ordinary picklist
+        # has no die to check and no such page.
+        "door": lambda picklist: (
+            reverse("authoring-picklist-table", args=[picklist.pk])
+            if picklist.dice
+            else ""
+        ),
+        "door_label": "Roll table",
         # The row is the listing, but the name on it is the pickable's,
         # and the pickable's page is where what it does is written.
         "opens": lambda member: reverse(
@@ -1737,13 +1746,6 @@ def detail(request, kind, pk):
             "verbose_name": model._meta.verbose_name,
             "verbose_name_plural": model._meta.verbose_name_plural,
             "edit_form": edit_form,
-            # A roll table's gaps and overlaps live on a page of their
-            # own; an ordinary picklist has no such page to offer.
-            "table_href": (
-                reverse("authoring-picklist-table", args=[thing.pk])
-                if kind == "picklist" and thing.dice
-                else ""
-            ),
             "statline_cells": statline_edit.cells() if statline_edit else None,
             "part_sections": drawn,
             "hire_options": hire_options,

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -1564,6 +1564,17 @@ class TestAPicklistsOwnPage:
         assert response.status_code == 302
         assert Picklist.objects.get(pk=table.pk).name == "Lasting Injuries"
 
+    def test_a_roll_table_links_to_its_table_page(self, author, client, legacy):
+        from n26.library.authoring import create_picklist
+
+        table = create_picklist("Injuries", legacy, dice="d66", roll_selects="band")
+        body = client.get(f"/n26/authoring/picklist/{table.pk}/").content.decode()
+        assert f'href="/n26/authoring/picklists/{table.pk}/table/"' in body
+
+        plain = create_picklist("Plain", legacy)
+        body = client.get(f"/n26/authoring/picklist/{plain.pk}/").content.decode()
+        assert "/table/" not in body
+
     def test_a_band_on_a_list_with_no_dice_is_refused_on_the_page(
         self, author, client, legacy
     ):
@@ -1612,6 +1623,148 @@ class TestAPicklistsOwnPage:
         assert not PicklistMember.objects.exists()
         # The pickable itself is untouched — only what the list offers changed.
         assert Pickable.objects.filter(name="Cawdor").exists()
+
+
+class TestARollTablesOwnPage:
+    """The table as the book prints it, and whether it can be rolled at
+    all: gaps and overlaps are facts about the whole table, invisible one
+    row at a time, so they get a page that sees all the rows at once."""
+
+    @pytest.fixture
+    def table(self, legacy):
+        from n26.library.authoring import (
+            add_picklist_member,
+            create_pickable,
+            create_picklist,
+        )
+
+        from_bands = [
+            ("Out Cold", 21, 26),
+            ("Lesson Learnt", 11, 11),
+            ("Grievous Wound", 31, 46),
+        ]
+        table = create_picklist("Injuries", legacy, dice="d66", roll_selects="band")
+        for name, low, high in from_bands:
+            add_picklist_member(
+                table, create_pickable(name, legacy), roll_low=low, roll_high=high
+            )
+        return table
+
+    def url(self, table):
+        from django.urls import reverse
+
+        return reverse("authoring-picklist-table", args=[table.pk])
+
+    def test_the_address_resolves_ahead_of_the_kind_catch_all(
+        self, author, client, table
+    ):
+        assert self.url(table) == f"/n26/authoring/picklists/{table.pk}/table/"
+        assert client.get(self.url(table)).status_code == 200
+
+    def test_the_rows_come_in_roll_order_with_their_bands(self, author, client, table):
+        body = client.get(self.url(table)).content.decode()
+        assert body.index("Lesson Learnt") < body.index("Out Cold")
+        assert body.index("Out Cold") < body.index("Grievous Wound")
+        assert "21-26" in body
+
+    def test_it_says_what_is_unclaimed(self, author, client, table):
+        body = client.get(self.url(table)).content.decode()
+        assert "19 of 36 rolls covered" in body
+        assert "12" in body and "61" in body
+
+    def test_it_says_when_a_roll_is_claimed_twice(self, author, client, table, legacy):
+        from n26.library.authoring import add_picklist_member, create_pickable
+
+        add_picklist_member(
+            table, create_pickable("Also Out Cold", legacy), roll_low=26
+        )
+        body = client.get(self.url(table)).content.decode()
+        assert "claimed by more than one result" in body
+        assert "Also Out Cold" in body
+
+    def test_a_whole_table_says_so(self, author, client, legacy):
+        from n26.library.authoring import (
+            add_picklist_member,
+            create_pickable,
+            create_picklist,
+        )
+
+        whole = create_picklist("Whole", legacy, dice="d6", roll_selects="band")
+        add_picklist_member(
+            whole, create_pickable("All of it", legacy), roll_low=1, roll_high=6
+        )
+        body = client.get(self.url(whole)).content.decode()
+        assert "6 of 6 rolls covered" in body
+
+    def test_a_row_is_added_from_the_page_with_its_band(
+        self, author, client, table, legacy
+    ):
+        from n26.library.authoring import create_pickable
+        from n26.library.models import PicklistMember
+
+        eye = create_pickable("Eye Injury", legacy)
+        client.post(
+            self.url(table),
+            {
+                "pickable": str(eye.pk),
+                "label_override": "",
+                "position": "9",
+                "roll_low": "51",
+                "roll_high": "51",
+            },
+        )
+        assert PicklistMember.objects.get(pickable=eye).band == "51"
+
+    def test_the_picker_offers_only_this_slot_types_pickables(
+        self, author, client, table, affiliation
+    ):
+        """The add-a-row form is handed the picklist, so its picker is
+        narrowed the way the detail page's is — not the whole library."""
+        from n26.library.models import Pickable
+
+        elsewhere = Pickable.objects.get(name="Clanless")
+        body = client.get(self.url(table)).content.decode()
+        assert f'value="{elsewhere.pk}"' not in body
+        assert f'value="{Pickable.objects.get(name="Cawdor").pk}"' in body
+
+    def test_a_list_that_is_no_roll_table_shows_rows_and_no_coverage(
+        self, author, client, legacy
+    ):
+        from n26.library.authoring import create_picklist
+
+        plain = create_picklist("Plain", legacy)
+        body = client.get(self.url(plain)).content.decode()
+        assert "rolls covered" not in body
+
+    def test_the_page_is_the_staff_s(self, client, db, legacy, table):
+        from django.contrib.auth.models import User
+
+        client.force_login(User.objects.create_user("player"))
+        response = client.get(self.url(table))
+        assert response.status_code == 302
+        assert "login" in response["Location"]
+
+    def test_the_page_reads_flat_as_the_table_grows(
+        self, author, client, legacy, table
+    ):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from n26.library.authoring import add_picklist_member, create_pickable
+
+        def grow(indices):
+            for index in indices:
+                add_picklist_member(
+                    table, create_pickable(f"Result {index}", legacy), roll_low=51
+                )
+
+        grow(range(2))
+        with CaptureQueriesContext(connection) as few:
+            assert client.get(self.url(table)).status_code == 200
+        grow(range(2, 12))
+        with CaptureQueriesContext(connection) as more:
+            assert client.get(self.url(table)).status_code == 200
+        assert len(more) <= len(few)
 
 
 class TestKindHelp:

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -1426,32 +1426,26 @@ class TestAPicklistsOwnPage:
 
         assert [member.label for member in houses.members.all()] == ["Cawdor", "Escher"]
 
-    def test_the_add_form_offers_a_band_and_stores_what_it_is_given(
+    def test_a_roll_tables_results_are_worked_on_the_table_page(
         self, author, client, legacy
     ):
-        """A roll table's rows carry bands, so the form that adds a row
-        asks for one. A picklist that is not a table shows the fields
-        blank rather than hiding them."""
-        from n26.library.authoring import create_pickable, create_picklist
-        from n26.library.models import PicklistMember
+        """A result only means anything with its band and the coverage
+        check, so a roll table's detail page offers no member form — the
+        section says what the table is and sends an author to its page.
+        An ordinary picklist keeps its form, band fields included."""
+        from n26.library.authoring import create_picklist
 
         table = create_picklist("Injuries", legacy, dice="d66", roll_selects="band")
-        hobbled = create_pickable("Hobbled", legacy)
-
         body = client.get(f"/n26/authoring/picklist/{table.pk}/").content.decode()
-        assert 'name="roll_low"' in body and 'name="roll_high"' in body
+        assert "Roll table" in body
+        assert "0 of 36 rolls covered" in body
+        assert 'name="pickable"' not in body
+        assert f'href="/n26/authoring/picklists/{table.pk}/table/"' in body
 
-        client.post(
-            f"/n26/authoring/picklist/{table.pk}/",
-            {
-                "pickable": str(hobbled.pk),
-                "label_override": "",
-                "position": "0",
-                "roll_low": "53",
-                "roll_high": "53",
-            },
-        )
-        assert PicklistMember.objects.get(pickable=hobbled).band == "53"
+        plain = create_picklist("Plain", legacy)
+        body = client.get(f"/n26/authoring/picklist/{plain.pk}/").content.decode()
+        assert 'name="pickable"' in body
+        assert 'name="roll_low"' in body and 'name="roll_high"' in body
 
     def test_a_roll_tables_page_leads_each_row_with_its_band(
         self, author, client, legacy
@@ -1727,14 +1721,17 @@ class TestARollTablesOwnPage:
         assert f'value="{elsewhere.pk}"' not in body
         assert f'value="{Pickable.objects.get(name="Cawdor").pk}"' in body
 
-    def test_a_list_that_is_no_roll_table_shows_rows_and_no_coverage(
+    def test_an_ordinary_lists_table_address_leads_back_to_its_page(
         self, author, client, legacy
     ):
+        """An ordinary picklist is worked on its detail page; it has no
+        table to show, so the address does not pretend otherwise."""
         from n26.library.authoring import create_picklist
 
         plain = create_picklist("Plain", legacy)
-        body = client.get(self.url(plain)).content.decode()
-        assert "rolls covered" not in body
+        response = client.get(self.url(plain))
+        assert response.status_code == 302
+        assert response["Location"] == f"/n26/authoring/picklist/{plain.pk}/"
 
     def test_the_page_is_the_staff_s(self, client, db, legacy, table):
         from django.contrib.auth.models import User

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -1690,6 +1690,26 @@ class TestARollTablesOwnPage:
         body = client.get(self.url(whole)).content.decode()
         assert "6 of 6 rolls covered" in body
 
+    def test_a_bandless_result_keeps_a_covered_table_out_of_the_clear(
+        self, author, client, legacy
+    ):
+        """Every roll may be claimed and a result still unreachable: a
+        row with no band is on the list and never rolled, which is as
+        much a fault as a gap."""
+        from n26.library.authoring import (
+            add_picklist_member,
+            create_pickable,
+            create_picklist,
+        )
+
+        table = create_picklist("Whole", legacy, dice="d6", roll_selects="band")
+        add_picklist_member(
+            table, create_pickable("All of it", legacy), roll_low=1, roll_high=6
+        )
+        add_picklist_member(table, create_pickable("Unrollable", legacy))
+        body = client.get(self.url(table)).content.decode()
+        assert "Unrollable has no band, so no roll lands on it" in body
+
     def test_a_row_is_added_from_the_page_with_its_band(
         self, author, client, table, legacy
     ):

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -1838,6 +1838,84 @@ class TestAChoiceThatHoldsNone:
         assert ">Add</" not in row
 
 
+class TestARollTableInThePicker:
+    """A player who rolled on the physical table finds their result by
+    the roll: the picker leads each option with its band and lists them
+    in roll order. An ordinary list draws exactly as it always has."""
+
+    @pytest.fixture
+    def injury(self, default_pack):
+        return create_slot_type("Lasting Injury", allows_repeats=True)
+
+    @pytest.fixture
+    def results(self, injury):
+        # Added out of roll order, so order on screen is the table's.
+        return [
+            create_pickable("Eye Injury", injury),
+            create_pickable("Lesson Learnt", injury),
+            create_pickable("Out Cold", injury),
+        ]
+
+    @pytest.fixture
+    def yolanda(self, gang, person_type, gang_type, injury, results):
+        table = create_picklist(
+            "Lasting Injury Table", injury, dice="d66", roll_selects="band"
+        )
+        for pickable, (low, high) in zip(
+            results, [(51, 51), (11, 11), (21, 26)], strict=True
+        ):
+            add_picklist_member(table, pickable, roll_low=low, roll_high=high)
+        slot = create_slot(
+            "Lasting Injury",
+            injury,
+            table,
+            label="Lasting Injuries",
+            min_picks=0,
+            max_picks=3,
+        )
+        profile = create_profile("Ganger", person_type, gang_type, price=50)
+        add_built_in(profile, slot)
+        return hire(gang, profile, "Yolanda", paid=50)
+
+    def offer_for(self, miniature):
+        _, computed = card_of(miniature)
+        slot = next(s for s in computed.choices if s.kind_label == "Lasting Injuries")
+        return build_choice_offer(slot, computed)
+
+    def test_each_option_carries_its_band_in_roll_order(self, yolanda):
+        offer = self.offer_for(yolanda)
+        rows = [(o.band, o.name) for g in offer.groups for o in g.options]
+        assert rows == [
+            ("11", "Lesson Learnt"),
+            ("21-26", "Out Cold"),
+            ("51", "Eye Injury"),
+        ]
+
+    def test_an_ordinary_list_carries_no_bands(self, gang, hunter, houses):
+        sev = hire(gang, hunter, "Sev", paid=100)
+        _, computed = card_of(sev)
+        offer = build_choice_offer(next(iter(choices_of(sev))), computed)
+        assert all(o.band == "" for g in offer.groups for o in g.options)
+
+    def test_the_page_leads_each_row_with_the_band(self, client, owner, gang, yolanda):
+
+        from n26.core.views.choose import link_slots
+
+        client.force_login(owner)
+        sheet = render_gang(gang)
+        link_slots(gang, sheet, *sheet.models)
+        href = next(
+            line.href
+            for card in sheet.models
+            for line in card.questions
+            if line.kind_label == "Lasting Injuries"
+        )
+        body = client.get(href).content.decode()
+        assert "21-26" in body
+        # The band sits just ahead of its result's name on the row.
+        assert ">11<" in body[: body.index("Lesson Learnt")][-300:]
+
+
 class TestThePickerStaysFlatHoweverLongTheList:
     def test_the_page_reads_flat_as_the_list_grows(
         self, gang, hunter, legacy, legacies, client, owner, django_assert_num_queries

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -1882,7 +1882,7 @@ class TestARollTableInThePicker:
         slot = next(s for s in computed.choices if s.kind_label == "Lasting Injuries")
         return build_choice_offer(slot, computed)
 
-    def test_each_option_carries_its_band_in_roll_order(self, yolanda):
+    def test_each_option_carries_its_band_in_roll_order(self, gang, yolanda):
         offer = self.offer_for(yolanda)
         rows = [(o.band, o.name) for g in offer.groups for o in g.options]
         assert rows == [
@@ -1890,12 +1890,14 @@ class TestARollTableInThePicker:
             ("21-26", "Out Cold"),
             ("51", "Eye Injury"),
         ]
+        assert_reconciled(gang)
 
     def test_an_ordinary_list_carries_no_bands(self, gang, hunter, houses):
         sev = hire(gang, hunter, "Sev", paid=100)
         _, computed = card_of(sev)
         offer = build_choice_offer(next(iter(choices_of(sev))), computed)
         assert all(o.band == "" for g in offer.groups for o in g.options)
+        assert_reconciled(gang)
 
     def test_the_page_leads_each_row_with_the_band(self, client, owner, gang, yolanda):
 
@@ -1914,6 +1916,7 @@ class TestARollTableInThePicker:
         assert "21-26" in body
         # The band sits just ahead of its result's name on the row.
         assert ">11<" in body[: body.index("Lesson Learnt")][-300:]
+        assert_reconciled(gang)
 
 
 class TestThePickerStaysFlatHoweverLongTheList:

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -257,6 +257,14 @@ urlpatterns = [
         authoring_views.picklist_member_remove,
         name="authoring-picklist-member-remove",
     ),
+    # A literal address, so it matches ahead of the kind catch-all: a
+    # roll table's gaps and overlaps are facts about the whole list, and
+    # the picklist's own page shows only one row at a time.
+    path(
+        "authoring/picklists/<str:pk>/table/",
+        authoring_views.picklist_table,
+        name="authoring-picklist-table",
+    ),
     # A firing line belongs to its weapon rather than being an authored
     # kind of its own — there is no listing of every profile in the
     # library, and no making one apart from the weapon it fires — so


### PR DESCRIPTION
Third PR towards #2293. Builds on the roll-band fields from #2352: the roll-table page, and bands in the player's picker.

## The table page — `/n26/authoring/picklists/<pk>/table/` (staff)

A gap or an overlap makes a table unrollable, and neither is a fact about any one row — only the whole table can say. The page shows:

- the die and how a roll picks ("Rolled on a D66 — a roll picks the one row it lands in")
- every result in roll order, band leading (`21-26  Out Cold`), each linking to its pickable and carrying its Remove
- **coverage** — a green "36 of 36 rolls covered", or a warning naming what's wrong: "35 of 36 rolls covered — 51 unclaimed", "61 is claimed by more than one result — Captured, Critical Injury", and any bandless result
- the add-a-result form, handed the picklist so its picker offers this slot type's pickables and nothing else

`coverage()` is a pure function over the rows it is handed, so tests assert on it without rendering. It walks the die's own rolls — so "31-46" on a D66 claims 12 rolls, never 16.

## The detail page knows what it is

A result only means anything with its band and the coverage check, so a roll table's detail page does not offer the generic member form. Its members section is headed **Roll table**, says under the heading how covered the die is — unclaimed and doubled rolls named — and a primary **Add result** button leads to the table page, where results are worked. An ordinary picklist keeps today's flow untouched, and its table address redirects back to its own page.

Mechanically: a parts section's `adds`, labels and description may now be decided row by row (a callable takes the thing), which is how one kind changes shape when its `dice` is set.

## Bands in the player's picker

A player who rolled on the physical table finds their result by the roll: the picker leads each option with its band, in roll order (bandless rows gather at the end). `Listed` and `Choosable` carry the band; an ordinary list draws exactly as before, no band column.

All states verified in the browser: the gap warning, the double-claim warning, the green whole-table state, adding a result from the page (watching 35-of-36 become 36-of-36), and the banded player picker.

## Tests

24 new: the coverage arithmetic colocated in `test_slots.py` (the D66 12-not-16 case pinned; unclaimed, doubled and bandless each named); the page in `test_authoring_views.py` (URL resolves ahead of the kind catch-all, roll order, both warnings, the whole-table state, add-from-page, the narrowed picker, staff gate, flat queries — which caught `coverage()` fetching labels one query per member); the picker in `test_slots_and_picks.py` (bands in roll order on the structure and the page, an ordinary list unchanged).

`pytest n26/` — 4413 passed, 1 xfailed. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
