### PR TITLE
feat: warn on built_in_remove that removal leaves assignments in place

### DIFF
--- a/n26/core/propagation.py
+++ b/n26/core/propagation.py
@@ -219,6 +219,21 @@ def reach_of_new_built_ins(holder):
     )
 
 
+def standing_copies_of(member):
+    """The live copies of one set member, and the gangs holding them.
+
+    What taking the member off the set leaves behind: nothing retracts
+    an assignment, so every one of these stays exactly where it is.
+    Counted by provenance — a copy naming this member — so an owner's
+    own copy of the same thing is not counted among them.
+    """
+    return _reach(
+        Assignment.objects.filter(
+            materialised_from=member, archived=False, removes=False
+        )
+    )
+
+
 def _reach(carriers):
     # An archived gang is skipped by the pass, so its uses are outside
     # the reach; a carrier belonging to no gang likewise.

--- a/n26/core/propagation.py
+++ b/n26/core/propagation.py
@@ -219,13 +219,14 @@ def reach_of_new_built_ins(holder):
     )
 
 
-def standing_copies_of(member):
-    """The live copies of one set member, and the gangs holding them.
+def assignments_naming(member):
+    """The live assignments materialised from one set member, and the
+    gangs holding them.
 
     What taking the member off the set leaves behind: nothing retracts
     an assignment, so every one of these stays exactly where it is.
-    Counted by provenance — a copy naming this member — so an owner's
-    own copy of the same thing is not counted among them.
+    Counted by provenance, so an owner's own copy of the same thing is
+    not counted among them.
     """
     return _reach(
         Assignment.objects.filter(

--- a/n26/library/templates/authoring/built_in_remove.html
+++ b/n26/library/templates/authoring/built_in_remove.html
@@ -55,15 +55,13 @@ name runs the button off the end of the page.
             {{ label }} stays in the library and on everything else that names it.
             What goes is this one line of {{ set_name }}.
         </c-ui.alert>
-        {% if kept %}
+        {% if kept_sentence %}
             <c-ui.alert variant="warning"
                         title="This does not take it off anything that already has it">
-                {{ kept }} standing cop{{ kept|pluralize:"y,ies" }} of {{ label }}
-                {% if kept_gangs > 1 %}across {{ kept_gangs }} gangs{% else %}in one gang{% endif %}
-                keep{{ kept|pluralize:"s," }} it. A built-in <em>added</em> here reaches
+                {{ kept_sentence }} A built-in <em>added</em> here reaches
                 everything already holding the set; one taken off does not,
-                because nothing retracts an assignment. To take these away,
-                remove them one at a time where they stand.
+                because nothing retracts an assignment. To take them away,
+                remove them one at a time where they are.
             </c-ui.alert>
         {% endif %}
         {% if shared %}

--- a/n26/library/templates/authoring/built_in_remove.html
+++ b/n26/library/templates/authoring/built_in_remove.html
@@ -46,12 +46,26 @@ name runs the button off the end of the page.
         What is true, and only what is true. The membership goes and
         nothing puts it back; the thing named is untouched, and so is
         anything already carrying it — built-ins are given at the moment
-        of acquiring, and nothing retracts an assignment.
+        of acquiring, and nothing retracts an assignment. The count of
+        what keeps it is said plainly rather than left as small print,
+        because adding and removing are not mirror images and an author
+        who has watched an addition travel will expect a removal to.
         {% endcomment %}
         <c-ui.alert variant="info" title="The {{ kind_name }} is not deleted">
             {{ label }} stays in the library and on everything else that names it.
             What goes is this one line of {{ set_name }}.
         </c-ui.alert>
+        {% if kept %}
+            <c-ui.alert variant="warning"
+                        title="This does not take it off anything that already has it">
+                {{ kept }} standing cop{{ kept|pluralize:"y,ies" }} of {{ label }}
+                {% if kept_gangs > 1 %}across {{ kept_gangs }} gangs{% else %}in one gang{% endif %}
+                keep{{ kept|pluralize:"s," }} it. A built-in <em>added</em> here reaches
+                everything already holding the set; one taken off does not,
+                because nothing retracts an assignment. To take these away,
+                remove them one at a time where they stand.
+            </c-ui.alert>
+        {% endif %}
         {% if shared %}
             <c-ui.alert variant="warning" title="More than one thing comes with this set">
                 Everything below shares {{ set_name }}, so all of them stop
@@ -91,8 +105,7 @@ name runs the button off the end of the page.
                 which is bought, and the sentence has to be true of both.
                 {% endcomment %}
                 <c-ui.description>
-                    Only what is acquired from here on. Anything already holding
-                    {{ label }} was given it at the moment it was acquired and keeps it.
+                    Only what is acquired from here on.
                 </c-ui.description>
             </c-n26.form-section>
         {% else %}

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -715,6 +715,20 @@ def _reach_said(reach, adding):
     )
 
 
+def _kept_sentence(reach, label):
+    """What taking a built-in off a set leaves behind, in a sentence.
+
+    Counts the assignments naming the member: every one of them stays
+    exactly where it is, whatever the set says from here on.
+    """
+    if reach.uses == 0:
+        return ""
+    times = "once" if reach.uses == 1 else f"{reach.uses} times"
+    where = "in one gang" if reach.gangs == 1 else f"across {reach.gangs} gangs"
+    stays = "That assignment stays" if reach.uses == 1 else "Those assignments stay"
+    return f"{label} is already assigned {times}, {where}. {stays}."
+
+
 def _built_in_reach_said(thing):
     """The reach sentence for a thing's own built-ins: the set it has,
     or — before a first built-in founds one — the set it would get,
@@ -2015,7 +2029,7 @@ def built_in_remove(request, pk):
     ammo lines with it. GET asks and changes nothing; the POST from
     this page is the act.
     """
-    from n26.core.propagation import standing_copies_of
+    from n26.core.propagation import assignments_naming
     from n26.library import authoring
     from n26.library.models import DefaultAssignment
 
@@ -2043,15 +2057,15 @@ def built_in_remove(request, pk):
         return redirect(back)
 
     riders = member.dependent_members.select_related("weapon_profile__weapon")
-    standing = standing_copies_of(member)
+    label = _label_for(member.assignable)
+    kept = assignments_naming(member)
     return render(
         request,
         "authoring/built_in_remove.html",
         {
             "thing": member,
-            "label": _label_for(member.assignable),
-            "kept": standing.uses,
-            "kept_gangs": standing.gangs,
+            "label": label,
+            "kept_sentence": _kept_sentence(kept, label),
             "kind_name": str(member.assignable._meta.verbose_name),
             "set_name": member.default_set.name,
             "holders": holders,

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -2015,6 +2015,7 @@ def built_in_remove(request, pk):
     ammo lines with it. GET asks and changes nothing; the POST from
     this page is the act.
     """
+    from n26.core.propagation import standing_copies_of
     from n26.library import authoring
     from n26.library.models import DefaultAssignment
 
@@ -2042,12 +2043,15 @@ def built_in_remove(request, pk):
         return redirect(back)
 
     riders = member.dependent_members.select_related("weapon_profile__weapon")
+    standing = standing_copies_of(member)
     return render(
         request,
         "authoring/built_in_remove.html",
         {
             "thing": member,
             "label": _label_for(member.assignable),
+            "kept": standing.uses,
+            "kept_gangs": standing.gangs,
             "kind_name": str(member.assignable._meta.verbose_name),
             "set_name": member.default_set.name,
             "holders": holders,

--- a/n26/tests/sandbox/test_builtin_reach_preview.py
+++ b/n26/tests/sandbox/test_builtin_reach_preview.py
@@ -406,8 +406,8 @@ class TestRemovalSaysWhatKeepsIt:
         response = client.get(reverse("authoring-built-in-remove", args=[member.pk]))
 
         page = response.content.decode()
-        assert "2 standing copies" in page
-        assert "in one gang" in page
+        assert "Gang Fighter is already assigned 2 times, in one gang." in page
+        assert "Those assignments stay." in page
         assert "does not take it off anything that already has it" in page
 
     def test_a_member_nothing_holds_says_nothing_about_keeping(
@@ -417,4 +417,4 @@ class TestRemovalSaysWhatKeepsIt:
 
         response = client.get(reverse("authoring-built-in-remove", args=[member.pk]))
 
-        assert "standing cop" not in response.content.decode()
+        assert "is already assigned" not in response.content.decode()

--- a/n26/tests/sandbox/test_builtin_reach_preview.py
+++ b/n26/tests/sandbox/test_builtin_reach_preview.py
@@ -388,3 +388,33 @@ class TestTheIngestPreviewSaysIt:
         page = client.get(PREVIEW_URL)
 
         assert page.context["preview"]["reach_said"] == ""
+
+
+class TestRemovalSaysWhatKeepsIt:
+    """Taking a built-in off a set does not take it off anything that
+    already has it, and the page says so with the count — an author who
+    has watched an addition travel would otherwise expect the reverse."""
+
+    def test_the_page_counts_the_copies_that_keep_it(
+        self, client, author, player, gang_type, ganger
+    ):
+        gang = found_gang("The Old Guard", gang_type, owner=player, budget=1000)
+        hire(gang, ganger, "Ana", paid=50)
+        hire(gang, ganger, "Bea", paid=50)
+        member = ganger.built_ins.members.get(rule__isnull=False)
+
+        response = client.get(reverse("authoring-built-in-remove", args=[member.pk]))
+
+        page = response.content.decode()
+        assert "2 standing copies" in page
+        assert "in one gang" in page
+        assert "does not take it off anything that already has it" in page
+
+    def test_a_member_nothing_holds_says_nothing_about_keeping(
+        self, client, author, ganger
+    ):
+        member = ganger.built_ins.members.get(rule__isnull=False)
+
+        response = client.get(reverse("authoring-built-in-remove", args=[member.pk]))
+
+        assert "standing cop" not in response.content.decode()


### PR DESCRIPTION
Part of #2165. This replaces the planned removal-propagation chunk (C6): rather than building a way to retract built-ins from fighters who already have them, `built_in_remove` now says plainly that it will not, with the count. If authors ask for the real thing, we build it then.

`add_default_member` files a propagation task, so a built-in added to a set reaches every fighter already holding that set within seconds. `remove_default_member` does no such thing — it archives the membership and stops there, because no assignment is ever retracted. An author who has just watched an addition travel has no reason to expect the reverse, and `authoring/built_in_remove.html` said so only in a `c-ui.description` under the holders table, with no number in it.

The page now carries a warning above that table:

> **This does not take it off anything that already has it**
> Gang Fighter is already assigned 2 times, in one gang. Those assignments stay. A built-in *added* here reaches everything already holding the set; one taken off does not, because nothing retracts an assignment. To take them away, remove them one at a time where they are.

`assignments_naming(member)` in `n26/core/propagation.py` counts the live `Assignment` rows whose `materialised_from` is the member, and the gangs they sit in. It returns the same `Reach` dataclass `reach_of()` returns on the adding side, through the same `_reach()` aggregate, so the add and remove pages count alike. `_kept_sentence()` in `n26/library/views.py` builds the wording beside `_reach_said()`, which does the same job for additions.

Two tests in `n26/tests/sandbox/test_builtin_reach_preview.py`: a member two hired fighters hold names the count and the gang; a member nothing holds produces no warning at all.

The two author-side refusals that were also in C6's scope — `stop_offering` refusing while materialised copies stand, and emptying a priced option set — remain unbuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
