### PR TITLE
feat: n26 equip page offers Fit to a weapon on a loose accessory row

### DIFF
--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -436,11 +436,13 @@ def copy_row(copy, refunds=True):
             else None
         ),
         more=(
-            # First, and only where the content asks anything: the acts
-            # that leave the fighter holding what they held, so they read
-            # before the ways of parting with it. Fitting is named for
-            # what it does rather than called a move, because Reassign is
-            # about which fighter holds a thing and this one is not.
+            # First, the acts that leave the fighter holding what they
+            # held, so they read before the ways of parting with it —
+            # each drawn only where it has an answer: options where the
+            # content asks anything, fitting where a loose accessory has
+            # a gun to go on. Fitting is named for what it does rather
+            # than called a move, because Reassign is about which fighter
+            # holds a thing and this one is not.
             *(
                 (Action("Change options", LINK, copy.rechoose_href, SECONDARY),)
                 if copy.rechoose_href

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -436,12 +436,19 @@ def copy_row(copy, refunds=True):
             else None
         ),
         more=(
-            # First, and only where the content asks anything: the one act
-            # here that leaves the fighter holding what they held, so it
-            # reads before the ways of parting with it.
+            # First, and only where the content asks anything: the acts
+            # that leave the fighter holding what they held, so they read
+            # before the ways of parting with it. Fitting is named for
+            # what it does rather than called a move, because Reassign is
+            # about which fighter holds a thing and this one is not.
             *(
                 (Action("Change options", LINK, copy.rechoose_href, SECONDARY),)
                 if copy.rechoose_href
+                else ()
+            ),
+            *(
+                (Action("Fit to a weapon", LINK, copy.fit_href, SECONDARY),)
+                if copy.fit_href
                 else ()
             ),
             Action("Reassign", LINK, copy.reassign_href, SECONDARY),

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -48,7 +48,7 @@ class EquipHost:
 
 #: URL parameters that can open one assignment dialog. Their order is the
 #: precedence when an address names more than one.
-DIALOGS = ("sell", "reassign", "refund", "remove", "accessorise", "rechoose")
+DIALOGS = ("sell", "reassign", "fit", "refund", "remove", "accessorise", "rechoose")
 
 
 def with_query(url, **params):
@@ -144,6 +144,10 @@ class OwnedThing:
     #: an accessory hangs off the gun it changes, so nothing else on a
     #: card is somewhere to fit one.
     accessorise_href: str = ""
+    #: Where to go to bolt this onto one of the guns the fighter is
+    #: carrying — the other end of the same act. Only a loose accessory
+    #: has one, and only where there is a gun to put it on.
+    fit_href: str = ""
     #: Where to go to take this with different options. Only something
     #: whose content offers a choice has one: everything else would be a
     #: click onto a panel with nothing to pick.
@@ -232,6 +236,29 @@ def _parts_of(node, at):
     return tuple(parts)
 
 
+def weapons_on(host: EquipHost):
+    """The guns this host is carrying — everywhere an accessory could go.
+
+    A root the host holds in its own right, rather than anything nested
+    under one: a weapon's own firing line is the weapon, and a gun bolted
+    to a mount belongs to whatever is holding it. The accessory question
+    is asked of exactly this set, so the two directions agree about what
+    counts as a gun on this card.
+
+    No queries — the card is already built.
+    """
+    from n26.library.models import Weapon
+
+    return tuple(
+        node
+        for node in host.roots
+        if node.assignment is not None
+        and not node.suppressed
+        and not node.broadcast
+        and isinstance(node.assignable, Weapon)
+    )
+
+
 def possessions(host: EquipHost):
     """Everything this host carries, keyed the way a catalogue keys its rows.
 
@@ -242,7 +269,14 @@ def possessions(host: EquipHost):
     confirmations open over it and Cancel returns to it, so the list they
     were reading is still the list underneath.
     """
-    from n26.library.models import Weapon
+    from n26.library.models import Weapon, WeaponAccessory
+
+    # Whether this card has anywhere to fit an accessory, asked once for
+    # the whole of it. A fighter carrying no gun is offered no fitting:
+    # a screen must not ask a question its answer refuses. The stash is
+    # never asked — its accessories are fitted from the gang sheet,
+    # where the guns of the whole roster are in reach.
+    fittable = not host.is_stash and bool(weapons_on(host))
 
     index = {}
     for node in host.roots:
@@ -271,6 +305,11 @@ def possessions(host: EquipHost):
                 accessorise_href=(
                     with_query(at, accessorise=pk)
                     if isinstance(node.assignable, Weapon)
+                    else ""
+                ),
+                fit_href=(
+                    with_query(at, fit=pk)
+                    if fittable and isinstance(node.assignable, WeaponAccessory)
                     else ""
                 ),
                 rechoose_href=(

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -3,16 +3,20 @@
 
     <c-n26.owned-dialog :dialog="dialog">{% csrf_token %}</c-n26.owned-dialog>
 
-Five questions in one panel — sell, move, refund, remove, accessorise — since
-the difference between them is a sentence and, for three of them, one control.
-Which is being asked, along with the figures, the roster and the accessories
-that fit, arrives in `dialog` from n26.core.views.owned. The panel itself is
-<c-n26.dialog>, where the open-state rules are written down.
+Six questions in one panel — sell, move, fit, refund, remove, accessorise —
+since the difference between them is a sentence and, for four of them, one
+control. Which is being asked, along with the figures, the roster, the guns
+and the accessories that fit, arrives in `dialog` from n26.core.views.owned.
+The panel itself is <c-n26.dialog>, where the open-state rules are written
+down.
 
 Only the clicked submit is sent, so a move is told apart by `to=stash`
-arriving. Two of the five can end up with nothing to submit: a move with nobody
-else on the roster posts a hidden to=stash and draws no select, and
-accessorise draws no submit when nothing in the library fits the weapon.
+arriving. Move and fit are one act with one address, asked as two questions:
+which model holds a thing is not the same question as which gun it is bolted
+to. Three of the six can end up with nothing to submit: a move with nobody
+else on the roster posts a hidden to=stash and draws no select, a fit draws
+no submit where the card carries no gun, and accessorise draws none when
+nothing in the library fits the weapon.
 
 Accessorise is also the one an equip page draws for every weapon on it rather
 than only for the one the URL names, so those panels are passed open="" and an
@@ -68,6 +72,13 @@ itself.
             You will be charged or refunded the difference.
         {% elif dialog.kind == "reassign" %}
             Moving it does not change its rating.
+        {% elif dialog.kind == "fit" %}
+            {% if dialog.weapons %}
+                Fitting it does not change its rating. Its effects land on that
+                gun and no other the fighter is carrying.
+            {% else %}
+                There is no weapon here to fit it to.
+            {% endif %}
         {% elif dialog.kind == "refund" %}
             {{ dialog.sum }} It and anything attached to it are removed from the
             gang, undoing the purchase.
@@ -138,7 +149,7 @@ itself.
         </c-n26.radio-cards>
     {% endif %}
 
-    {% if dialog.kind == "reassign" %}
+    {% if dialog.kind == "reassign" or dialog.kind == "fit" %}
         {% if dialog.weapons %}
             <input type="hidden" name="to" value="weapon">
             <c-ui.field label="Weapon" for="reassign-weapon">
@@ -150,6 +161,13 @@ itself.
                     {% endfor %}
                 </c-ui.select.native>
             </c-ui.field>
+        {% elif dialog.kind == "fit" %}
+            {% comment %}
+            Nothing to fit it to, so nothing to submit: the panel says so in
+            its lead and the way out is the only control it needs. The
+            destinations below belong to the move and would send this
+            somewhere it was never asked to go.
+            {% endcomment %}
         {% elif dialog.models %}
             {% comment %}
             No placeholder option: the first name on the roster is selected

--- a/n26/core/templates/n26/includes/equip_update.html
+++ b/n26/core/templates/n26/includes/equip_update.html
@@ -10,21 +10,27 @@ without any call site changing. Messages are not among them: they ride the
 HX-Trigger response header and are shown as toasts, because a page that is
 not re-rendered draws no alert block.
 
-The row is the ordinary one — the same include the catalogue draws — so a
+A row is the ordinary one — the same include the catalogue draws — so a
 row delivered by an update and a row drawn with the page cannot come to look
 different. It replaces the row of its own key, which is why buying a first
 copy or selling a last one can deliver a row of a different shape entirely:
 what is held is a state of its row.
 
-Where the screen no longer has a row for the key, the row is removed
+Usually one row, sometimes two: fitting an accessory to a gun empties the
+accessory's row and fills the gun's, and a screen that redrew one of them
+would still be showing the click as half done.
+
+Where the screen no longer has a row for a key, the row is removed
 instead. A listing always keeps a row; a screen showing only what is held
 loses the row along with the last copy.
 {% endcomment %}
-{% if row %}
-    {% include "n26/includes/equip_row.html" with redrawn=True %}
-{% else %}
-    <div id="{{ row_key|row_dom_id }}" hx-swap-oob="delete"></div>
-{% endif %}
+{% for row_key, row in rows %}
+    {% if row %}
+        {% include "n26/includes/equip_row.html" with redrawn=True %}
+    {% else %}
+        <div id="{{ row_key|row_dom_id }}" hx-swap-oob="delete"></div>
+    {% endif %}
+{% endfor %}
 {% comment %}
 The money, and not the model count beside it. An act on kit never changes
 how many models the gang fields, and the count opens onto a tally whose own

--- a/n26/core/templates/n26/includes/equip_update.html
+++ b/n26/core/templates/n26/includes/equip_update.html
@@ -16,9 +16,8 @@ different. It replaces the row of its own key, which is why buying a first
 copy or selling a last one can deliver a row of a different shape entirely:
 what is held is a state of its row.
 
-Usually one row, sometimes two: fitting an accessory to a gun empties the
-accessory's row and fills the gun's, and a screen that redrew one of them
-would still be showing the click as half done.
+Usually one row, sometimes two — which acts change a second one is
+n26.core.views.equip.render_update's business, not this template's.
 
 Where the screen no longer has a row for a key, the row is removed
 instead. A listing always keeps a row; a screen showing only what is held

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -955,6 +955,23 @@ class TestFittingOneTheFighterIsCarrying:
         assert dialog["weapons"] == []
         assert dialog["submit_label"] == ""
 
+    def test_the_panel_with_no_gun_to_offer_carries_no_destination(
+        self, client, tester, fighter, loose
+    ):
+        """Rendered rather than read off the dialog: the destinations are
+        one if/elif chain, and a fitting that fell through to its end
+        would carry the move's hidden stash field — a panel asking to fit
+        something, quietly posting a move instead."""
+        client.force_login(tester)
+
+        response = client.get(
+            reverse("n26-equip", args=[fighter.pk]), {"fit": str(loose.pk)}
+        )
+
+        body = response.content.decode()
+        assert "Fit Telescopic sight to a weapon" in body
+        assert 'name="to"' not in body
+
     def test_only_an_accessory_is_asked_the_question(self, fighter, gun, sword, loose):
         """A gun's own address would otherwise open a picker holding that
         same gun, and fitting a thing to itself is not an act."""
@@ -1012,9 +1029,8 @@ class TestFittingOneTheFighterIsCarrying:
     def test_the_screen_is_told_about_both_rows_it_changed(
         self, client, tester, fighter, gun, loose
     ):
-        """The accessory leaves a row of its own and arrives under the
-        gun, so a screen redrawing one of the two would be showing the
-        click as half done."""
+        """Both keys are delivered: the gun's row redrawn with the sight
+        under it, and the accessory's own row answered for."""
         from n26.core.owned import thing_key
 
         client.force_login(tester)
@@ -1035,10 +1051,10 @@ class TestFittingOneTheFighterIsCarrying:
         gun_row = body.split(f'data-row="{thing_key(gun.assignable)}"', 1)[1]
         gun_row = gun_row.split("n26-accessorise-host", 1)[0]
         assert "Telescopic sight" in gun_row
-        # Nothing holds it any more, so its own row goes rather than
-        # standing there offering to fit it a second time. One string,
-        # because an id and a delete asserted apart are both satisfied by
-        # a response carrying only the first row.
+        # This listing does not sell the sight, so with nothing holding it
+        # the screen has no row for it at all and the update says to take
+        # it away. One string, because an id and a delete asserted apart
+        # are both satisfied by a response carrying only the first row.
         gone = row_dom_id(thing_key(loose.assignable))
         assert f'id="{gone}" hx-swap-oob="delete"' in body
 

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -860,6 +860,137 @@ class TestFittingOneBackOntoAGun:
         assert "is part of" in response.content.decode()
 
 
+class TestFittingOneTheFighterIsCarrying:
+    """An accessory bought on a model's own equip page is loose on the
+    card until somebody bolts it to something. The question is the one the
+    stash asks, narrowed to the guns that model is carrying — and it is
+    asked on its own, so Reassign goes on meaning which model holds it."""
+
+    @pytest.fixture
+    def loose(self, gang, tester, fighter, sight):
+        with operation(gang, actor=tester) as op:
+            return op.buy(fighter, thing=sight)
+
+    @staticmethod
+    def dialog(fighter, **query):
+        from django.test import RequestFactory
+
+        from n26.core.card import build_card
+        from n26.core.owned import EquipHost
+        from n26.core.views.owned import owned_dialog
+
+        request = RequestFactory().get(AT, query)
+        host = EquipHost.fighter(fighter.gang, build_card(fighter), fighter, AT)
+        return owned_dialog(request, host)
+
+    @staticmethod
+    def copy_of(fighter, assignment):
+        from n26.core.card import build_card
+        from n26.core.owned import owned_things, thing_key
+
+        held = owned_things(build_card(fighter), AT)
+        (copy,) = held[thing_key(assignment.assignable)]
+        return copy
+
+    def test_a_loose_accessory_offers_the_fitting(self, fighter, gun, loose):
+        assert self.copy_of(fighter, loose).fit_href == f"{AT}&fit={loose.pk}"
+
+    def test_a_fighter_with_no_gun_is_offered_nowhere_to_fit_it(self, fighter, loose):
+        """A screen must not ask a question its answer refuses."""
+        assert self.copy_of(fighter, loose).fit_href == ""
+
+    def test_nothing_but_an_accessory_offers_it(self, fighter, gun, sword, loose):
+        assert self.copy_of(fighter, gun).fit_href == ""
+        assert self.copy_of(fighter, sword).fit_href == ""
+
+    def test_the_question_offers_the_guns_this_model_is_carrying(
+        self, gang, tester, fighter, other, gun, loose, stash
+    ):
+        """Somebody else's gun and the gang's spare are both places this
+        could end up, and neither is on the screen the question was asked
+        from."""
+        from n26.library.authoring import create_weapon
+
+        with operation(gang, actor=tester) as op:
+            op.buy(other, thing=create_weapon("Autogun", price=20, profiles=[("", 0)]))
+            op.buy(stash, thing=create_weapon("Stub gun", price=5, profiles=[("", 0)]))
+
+        dialog = self.dialog(fighter, fit=str(loose.pk))
+
+        assert dialog["title"] == "Fit Telescopic sight to a weapon"
+        assert dialog["weapons"] == [{"pk": str(gun.pk), "label": "Lasgun"}]
+
+    def test_the_question_is_answered_by_the_move_that_does_it(
+        self, fighter, gun, loose
+    ):
+        dialog = self.dialog(fighter, fit=str(loose.pk))
+
+        assert dialog["action"] == reverse("n26-reassign", args=[loose.pk])
+        assert dialog["submit_label"] == "Fit"
+
+    def test_a_hand_made_address_with_no_gun_to_name_draws_no_submit(
+        self, fighter, loose
+    ):
+        dialog = self.dialog(fighter, fit=str(loose.pk))
+
+        assert dialog["weapons"] == []
+        assert dialog["submit_label"] == ""
+
+    def test_a_click_bolts_it_onto_the_named_gun(
+        self, client, tester, gang, fighter, gun, loose
+    ):
+        client.force_login(tester)
+        gang.refresh_from_db()
+        before = gang.credits
+
+        response = client.post(
+            url("n26-reassign", loose), {"to": "weapon", "weapon": str(gun.pk)}
+        )
+
+        assert response.status_code == 302
+        loose.refresh_from_db()
+        assert loose.parent_id == gun.pk
+        assert loose.miniature_root_id == fighter.pk
+        gang.refresh_from_db()
+        # A move never re-prices, and nothing is charged for one.
+        assert gang.credits == before
+        assert_reconciled(gang)
+
+    def test_the_click_lands_back_on_the_fighters_equip_page(
+        self, client, tester, fighter, gun, loose
+    ):
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", loose), {"to": "weapon", "weapon": str(gun.pk)}
+        )
+        assert response.url.startswith(reverse("n26-equip", args=[fighter.pk]))
+
+    def test_the_screen_is_told_about_both_rows_it_changed(
+        self, client, tester, fighter, gun, loose
+    ):
+        """The accessory leaves a row of its own and arrives under the
+        gun, so a screen redrawing one of the two would be showing the
+        click as half done."""
+        from n26.core.owned import thing_key
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", loose),
+            {"to": "weapon", "weapon": str(gun.pk)},
+            headers={"HX-Request": "true"},
+        )
+
+        body = response.content.decode()
+        assert f'data-row="{thing_key(gun.assignable)}"' in body
+        assert "Telescopic sight" in body
+        # Nothing holds it any more, so its own row goes rather than
+        # standing there offering to fit it a second time.
+        from n26.core.templatetags.listing import row_dom_id
+
+        assert row_dom_id(thing_key(loose.assignable)) in body
+        assert 'hx-swap-oob="delete"' in body
+
+
 @pytest.fixture
 def house_list(gang, tester):
     thing = create_wargear("Knife", price=10)

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -846,6 +846,25 @@ class TestFittingOneBackOntoAGun:
         assert stashed.parent_id is None
         assert_reconciled(gang)
 
+    def test_the_gun_it_lands_on_is_not_a_row_of_the_screen_it_left(
+        self, client, tester, gang, fighter, gun, stashed
+    ):
+        """The stash screen holds no row for a fighter's gun, and an
+        update naming one would tell the page to remove a row that is not
+        there."""
+        from n26.core.owned import thing_key
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", stashed),
+            {"to": "weapon", "weapon": str(gun.pk)},
+            headers={"HX-Request": "true"},
+        )
+
+        assert (
+            f'data-row="{thing_key(gun.assignable)}"' not in response.content.decode()
+        )
+
     def test_a_firing_line_is_refused_in_words(self, client, tester, gang, gun, stash):
         """The listing offers no control for this, so a click that reaches
         it is hand-made — and it is answered with a sentence rather than a
@@ -936,6 +955,31 @@ class TestFittingOneTheFighterIsCarrying:
         assert dialog["weapons"] == []
         assert dialog["submit_label"] == ""
 
+    def test_only_an_accessory_is_asked_the_question(self, fighter, gun, sword, loose):
+        """A gun's own address would otherwise open a picker holding that
+        same gun, and fitting a thing to itself is not an act."""
+        assert self.dialog(fighter, fit=str(gun.pk)) is None
+        assert self.dialog(fighter, fit=str(sword.pk)) is None
+
+    def test_a_hand_made_click_naming_its_own_weapon_is_answered_in_words(
+        self, client, tester, gang, gun
+    ):
+        """Nothing draws this address for a gun, so a click that arrives
+        is hand-made — and it gets a sentence rather than a traceback."""
+        client.force_login(tester)
+
+        response = client.post(
+            url("n26-reassign", gun),
+            {"to": "weapon", "weapon": str(gun.pk)},
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert "There is nowhere to move" in response.content.decode()
+        gun.refresh_from_db()
+        assert gun.parent_id is None
+        assert_reconciled(gang)
+
     def test_a_click_bolts_it_onto_the_named_gun(
         self, client, tester, gang, fighter, gun, loose
     ):
@@ -980,15 +1024,23 @@ class TestFittingOneTheFighterIsCarrying:
             headers={"HX-Request": "true"},
         )
 
-        body = response.content.decode()
-        assert f'data-row="{thing_key(gun.assignable)}"' in body
-        assert "Telescopic sight" in body
-        # Nothing holds it any more, so its own row goes rather than
-        # standing there offering to fit it a second time.
         from n26.core.templatetags.listing import row_dom_id
 
-        assert row_dom_id(thing_key(loose.assignable)) in body
-        assert 'hx-swap-oob="delete"' in body
+        body = response.content.decode()
+        assert f'data-row="{thing_key(gun.assignable)}"' in body
+        # Inside the gun's row rather than anywhere in the response: the
+        # update also re-delivers every accessory panel, and the panel
+        # for this gun offers the sight by name whether or not the second
+        # row was drawn at all.
+        gun_row = body.split(f'data-row="{thing_key(gun.assignable)}"', 1)[1]
+        gun_row = gun_row.split("n26-accessorise-host", 1)[0]
+        assert "Telescopic sight" in gun_row
+        # Nothing holds it any more, so its own row goes rather than
+        # standing there offering to fit it a second time. One string,
+        # because an id and a delete asserted apart are both satisfied by
+        # a response carrying only the first row.
+        gone = row_dom_id(thing_key(loose.assignable))
+        assert f'id="{gone}" hx-swap-oob="delete"' in body
 
 
 @pytest.fixture

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -455,6 +455,7 @@ def render_update(
     expanded_key="",
     at="",
     closed=False,
+    also="",
 ):
     """The partial update for one act on an equip screen.
 
@@ -471,6 +472,12 @@ def render_update(
     ``closed`` marks an act submitted from a confirmation panel; the
     update then also empties the dialog host, closing the panel.
 
+    ``also`` is a second key the same act changed — fitting an accessory
+    to a gun empties one row and fills another — drawn exactly as the
+    first is. It must name a row of this screen: a key belonging to some
+    other screen would be delivered as an instruction to remove a row
+    that is not there.
+
     The screen is derived again rather than reused from the request,
     because the act changed the state this update reports on. That costs
     the same fixed handful of queries as a plain visit.
@@ -486,39 +493,52 @@ def render_update(
 
     screen = _screen(gang, miniature=miniature, list_param=list_param)
     host = screen.host(at)
-    copies = possessions(host).get(key)
+    held = possessions(host)
     refunds = not gang.credits_unlimited
-    expanded = key == expanded_key
 
-    if screen.view is None:
-        # A screen showing only what is held draws a row for each thing
-        # held and for nothing else, so parting with the last copy takes
-        # the row away rather than turning it back into an offer.
-        row = (
-            owned_row_manage_only(key, copies, refunds=refunds, expanded=expanded)
-            if copies
-            else None
-        )
-    else:
+    def row_for(row_key):
+        copies = held.get(row_key)
+        expanded = row_key == expanded_key
+        if screen.view is None:
+            # A screen showing only what is held draws a row for each
+            # thing held and for nothing else, so parting with the last
+            # copy takes the row away rather than turning it back into an
+            # offer.
+            return (
+                owned_row_manage_only(
+                    row_key, copies, refunds=refunds, expanded=expanded
+                )
+                if copies
+                else None
+            )
         line = next(
-            (line for line in screen.view.all_lines() if _thing_key(line.thing) == key),
+            (
+                line
+                for line in screen.view.all_lines()
+                if _thing_key(line.thing) == row_key
+            ),
             None,
         )
         if line is None:
             # The listing does not sell it, so the screen never had a row
             # for it and there is nothing to redraw.
-            row = None
-        else:
-            row = listing_row(line)
-            if copies:
-                row = owned_row(row, copies, refunds=refunds, expanded=expanded)
+            return None
+        row = listing_row(line)
+        return (
+            owned_row(row, copies, refunds=refunds, expanded=expanded)
+            if copies
+            else row
+        )
+
+    rows = [(key, row_for(key))]
+    if also and also != key:
+        rows.append((also, row_for(also)))
 
     response = render(
         request,
         "n26/includes/equip_update.html",
         {
-            "row": row,
-            "row_key": key,
+            "rows": rows,
             "gang": gang,
             # The strip this delivers replaces the one on the page, so it
             # is drawn with what that one had: without this the Trade

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -560,10 +560,9 @@ def _acted(request, touched, gang, back, also=""):
     n26/core/static/n26/htmx_support.js) — so the update draws the row
     in the state the reader left it.
 
-    ``also`` is a second row the same act changed, on the same screen:
-    fitting an accessory to a gun empties the accessory's row and fills
-    the gun's, and a screen redrawing one of the two would still be
-    showing the click as half done.
+    ``also`` is a second row on the same screen that the act changed as
+    well; :func:`n26.core.views.equip.render_update` says when there is
+    one.
     """
     from n26.core.views.equip import render_update
 

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -34,8 +34,11 @@ The acts are deliberately distinct, and the ledger says which happened:
     sales at two prices.
 ``reassign``
     A move to another model, to the stash, or onto a weapon. No money,
-    and no re-pricing. The last of the three is how a stashed accessory
-    is fitted to a gun: the same act, one level down the chain.
+    and no re-pricing. The last of the three is how an accessory is
+    fitted to a gun: the same act, one level down the chain. It is asked
+    as a question of its own — ``?fit=`` rather than ``?reassign=`` —
+    because which model holds a thing and which gun it is bolted to are
+    not one question, however much they are one act.
 ``refund``
     Undoing the purchase: every credit that was paid comes back. The amount
     paid and the rating part company at the first discount, which is why
@@ -64,6 +67,7 @@ from n26.core.owned import (
     EquipHost,
     is_possession,
     thing_key,
+    weapons_on,
     with_query,
 )
 from n26.core.views.htmx import is_htmx, no_update
@@ -206,13 +210,20 @@ def _asked(request):
     return None, None
 
 
+#: The act a question submits to, where that is not the question's own
+#: name. Fitting an accessory to a gun is asked on its own, because
+#: Reassign is about which model holds a thing and this is not, and it is
+#: answered by the move that does it.
+ROUTES = {"fit": "reassign"}
+
+
 def _panel(request, assignment, kind, at):
     """What every one of these dialogs says, whatever it is asking."""
     return {
         "kind": kind,
         "name": str(assignment.assignable),
         "cancel_url": at,
-        "action": reverse(f"n26-{kind}", args=[assignment.pk]),
+        "action": reverse(f"n26-{ROUTES.get(kind, kind)}", args=[assignment.pk]),
         "list": request.GET.get("list", ""),
         # Which section tab the reader had open, carried through the
         # click so the answer lands where the question was asked. The
@@ -237,17 +248,8 @@ def accessorise_dialogs(request, host: EquipHost):
     carrying six guns asks the database exactly what a screen carrying one
     does — and a screen carrying none asks nothing.
     """
-    from n26.library.models import Weapon
-
     kind, named = _asked(request)
-    weapons = [
-        node
-        for node in host.roots
-        if node.assignment is not None
-        and not node.suppressed
-        and not node.broadcast
-        and isinstance(node.assignable, Weapon)
-    ]
+    weapons = weapons_on(host)
     if not weapons:
         return []
 
@@ -399,6 +401,20 @@ def owned_dialog(request, host: EquipHost):
             "submit_variant": "primary",
         }
 
+    if kind == "fit":
+        # Every gun on the card, and not only the ones the accessory was
+        # written for: what fits what is information rather than a gate,
+        # and an owner may bolt anything to anything.
+        weapons = weapons_on(host)
+        return dialog | {
+            "title": f"Fit {name} to a weapon",
+            "weapons": [
+                {"pk": str(node.assignment.pk), "label": node.name} for node in weapons
+            ],
+            "submit_label": "Fit" if weapons else "",
+            "submit_variant": "primary",
+        }
+
     if kind == "rechoose":
         # The same controls the row for sale draws, starting on what this
         # copy took rather than on what a buyer would be handed. What a
@@ -524,7 +540,7 @@ def _unchanged(request, back):
     return no_update(request)
 
 
-def _acted(request, touched, gang, back):
+def _acted(request, touched, gang, back, also=""):
     """The response for an act that changed a row.
 
     With htmx: the partial update for the row, with the confirmation
@@ -536,6 +552,11 @@ def _acted(request, touched, gang, back):
     and every htmx request carries it along (see
     n26/core/static/n26/htmx_support.js) — so the update draws the row
     in the state the reader left it.
+
+    ``also`` is a second row the same act changed, on the same screen:
+    fitting an accessory to a gun empties the accessory's row and fills
+    the gun's, and a screen redrawing one of the two would still be
+    showing the click as half done.
     """
     from n26.core.views.equip import render_update
 
@@ -551,6 +572,7 @@ def _acted(request, touched, gang, back):
         expanded_key=request.POST.get("owned", "")[:200],
         at=back,
         closed=True,
+        also=also,
     )
     response["HX-Replace-Url"] = back
     return response
@@ -686,6 +708,13 @@ def reassign_assignment(request, pk):
         messages.error(request, f"There is nowhere to move {name} to.")
         return _unchanged(request, back)
 
+    # Fitting takes the thing out of a row of its own and draws it under
+    # the gun instead, so two rows on the screen change. The gun's row
+    # counts only where the reader is looking at it: a stash fit reaches
+    # a gun on somebody's card, and that is not the screen this answers.
+    landed = _row_behind(destination) if isinstance(destination, Assignment) else None
+    also = landed.key if landed and landed.miniature == touched.miniature else ""
+
     try:
         with operation(gang, actor=request.user) as op:
             op.move(assignment, destination)
@@ -710,7 +739,7 @@ def reassign_assignment(request, pk):
         messages.success(request, f"Fitted {name} to {destination.assignable}.")
     else:
         messages.success(request, f"Moved {name} to {destination.name}.")
-    return _acted(request, touched, gang, back)
+    return _acted(request, touched, gang, back, also=also)
 
 
 @login_required

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -402,6 +402,13 @@ def owned_dialog(request, host: EquipHost):
         }
 
     if kind == "fit":
+        # An accessory is the only thing bolted onto anything, so a URL
+        # naming something else draws no dialog at all. Without this a
+        # gun's own address opens a picker holding that same gun, whose
+        # answer would be attaching it to itself — a screen must not ask
+        # a question its answer refuses.
+        if assignment.weapon_accessory_id is None:
+            return None
         # Every gun on the card, and not only the ones the accessory was
         # written for: what fits what is information rather than a gate,
         # and an owner may bolt anything to anything.
@@ -691,6 +698,12 @@ def reassign_assignment(request, pk):
                     archived=False,
                 )
                 .exclude(weapon=None)
+                # Nothing hangs off itself. The operation says so too, but
+                # it says it by raising rather than refusing, so a
+                # hand-made click naming its own weapon is answered here
+                # with the same sentence as any other impossible
+                # destination.
+                .exclude(pk=assignment.pk)
                 .first()
             )
         except ValidationError:

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -2092,7 +2092,7 @@ def carried():
     """
     from n26.core.owned import OwnedPart, OwnedThing, thing_key
 
-    def copy(name, rating, index=0, parts=(), chosen=()):
+    def copy(name, rating, index=0, parts=(), chosen=(), fit_href=""):
         stock = _stock(name)
         pk = f"{stock.pk}-{index}"
         return thing_key(stock), OwnedThing(
@@ -2105,6 +2105,7 @@ def carried():
             reassign_href="#",
             refund_href="#",
             remove_href="#",
+            fit_href=fit_href,
             chosen=chosen,
         )
 
@@ -2131,6 +2132,9 @@ def carried():
             125,
             chosen=("Ridge-runner harpoon", "Ridge-runner spikes"),
         ),
+        # An accessory nothing is holding yet, so its row is the one that
+        # offers to bolt it onto one of the guns above.
+        copy("Infra-sight", 40, fit_href="#"),
     ):
         held.setdefault(key, []).append(thing)
     return held
@@ -2181,6 +2185,30 @@ def owned_context():
         # handed over. The two figures differ here on purpose — this gun
         # was haggled down, which is the case that makes the distinction
         # visible at all.
+        # The guns the card is carrying, which is the whole of what a
+        # fitting may name — and the same question with none to offer,
+        # since a card carrying no gun is the state that draws no submit.
+        "owned_fit_dialog": {
+            **named,
+            "kind": "fit",
+            "name": "Infra-sight",
+            "title": "Fit Infra-sight to a weapon",
+            "weapons": [
+                {"pk": "meltagun", "label": "Meltagun"},
+                {"pk": "stub-gun", "label": "Stub gun"},
+            ],
+            "submit_label": "Fit",
+            "submit_variant": "primary",
+        },
+        "owned_fit_nothing_dialog": {
+            **named,
+            "kind": "fit",
+            "name": "Infra-sight",
+            "title": "Fit Infra-sight to a weapon",
+            "weapons": [],
+            "submit_label": "",
+            "submit_variant": "primary",
+        },
         "owned_refund_dialog": {
             **named,
             "kind": "refund",

--- a/n26/designsystem/templates/designsystem/demos/owned-dialog/35-fitting.html
+++ b/n26/designsystem/templates/designsystem/demos/owned-dialog/35-fitting.html
@@ -1,0 +1,4 @@
+{# title: Bolting an accessory onto a gun #}
+{# note: Asked apart from the move, because which model holds a thing and which gun it hangs off are two questions. The select offers the guns that model is carrying, all of them: what fits what shortens a list elsewhere and settles nothing here. #}
+{# layout: full #}
+<c-n26.owned-dialog :dialog="owned_fit_dialog" modal="" />

--- a/n26/designsystem/templates/designsystem/demos/owned-dialog/37-fitting-with-no-gun.html
+++ b/n26/designsystem/templates/designsystem/demos/owned-dialog/37-fitting-with-no-gun.html
@@ -1,0 +1,4 @@
+{# title: Bolting one onto a gun, with no gun to hold it #}
+{# note: A card carrying nothing to fit it to draws the sentence and the way out, and no commit — the one control in a panel that must always mean something. No row offers this state; it is here because an address can still ask for it. #}
+{# layout: full #}
+<c-n26.owned-dialog :dialog="owned_fit_nothing_dialog" modal="" />


### PR DESCRIPTION
Buying a weapon accessory on a model's own equip page left you with no way to put it on a gun. The row offered **Reassign**, which asks which *model* should hold the thing — not which gun it bolts to. The only way to fit one was to buy it into the gang's stash instead, where the same act appeared as **Fit to a weapon** and reached every gun in the gang.

## Summary

- A loose accessory's row on a model's equip page now carries **Fit to a weapon**, next to Reassign, opening a picker of the guns that model is carrying. A model carrying no gun is offered no control at all.
- It is a question of its own (`?fit=<assignment>`), so Reassign goes on meaning what it means everywhere else. The click is answered by the existing reassign route with `to=weapon` — the same move the stash already used — so there is no new write path, no new address, and no money involved.
- The picker offers every gun the model carries rather than only the ones the accessory was written for, matching how the rest of the app treats fitting: information, not a gate.
- `render_update` in `n26/core/views/equip.py` can now redraw two rows in one partial update. Fitting empties the accessory's row and fills the gun's, and redrawing only one of them left the screen showing the click as half done.
- The stash's own behaviour is unchanged.

`weapons_on()` in `n26/core/owned.py` is the single reading of "the guns on this card"; the Add-accessory question now shares it, so the two directions agree about what counts as a gun.

## Test plan

- [x] `pytest -n auto` — 8830 passed, 12 skipped
- [x] Nine new tests in `n26/core/test_views_owned.py`: the control appears only for a loose accessory on a model that carries a gun, the picker excludes another model's guns and the stash's, the panel submits to the reassign address, the click re-parents without charging, and the partial update names both changed rows
- [x] Browser pass on a real gang: the menu entry, the picker listing the model's own gun, and the fit landing in place with a toast

Closes #2362