### PR TITLE
feat: microcopy skill, copywriter agent, and check_microcopy.py warnings

### DIFF
--- a/.agents/skills/microcopy/SKILL.md
+++ b/.agents/skills/microcopy/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: microcopy
+description: >
+  Rules for writing user- and author-facing strings: template text, button
+  labels, headings, empty states, form labels and help_text, messages.*,
+  validation errors, model verbose_name and docstrings shown in authoring
+  pages, emails, notifications, and admin/maintenance screens. Load this
+  skill BEFORE writing or editing any such string, and when reviewing a
+  diff that touches one. This is the canonical home of the project's word
+  bans and copy anti-patterns.
+---
+
+# Microcopy
+
+The reader is mid-task and will not give the words a second read. Every string
+must hand over its meaning in one pass: the real noun, the plain verb, the
+concrete fact. Anything that makes the reader decode — cleverness, metaphor,
+personification, compression, drama — taxes them to make the writing look
+good. Spend nothing of the reader's attention on the writing itself.
+
+A wordy-but-plain sentence beats a short-but-clever one. "That is not one of
+the things available to pick." is fine. "Nought asks for nothing." is not.
+
+## Scope
+
+Every string a person reads in the product, whoever they are:
+
+- Template text, headings, button labels, tooltips, empty states, table headers
+- Python-side strings: `messages.success/error/info`, form `label` and
+  `help_text`, `verbose_name`, choices labels, validation errors
+- Model help text (in `n26/library` the model field is the only legal home for
+  help text) and model docstrings — library docstrings render on the authoring
+  pages, so they are product copy
+- Emails and notifications
+- Admin and maintenance screens (staff are readers too)
+
+Not in scope: commit titles and PR descriptions (see
+`.github/COMMIT_STYLE.md`), code comments, log lines.
+
+## Base rules
+
+**Sentences.** One idea per sentence. Active voice. Instructions are
+imperative ("Upload one first."). Short, common words: use, not utilise;
+about, not approximately; help, not assist.
+
+**Address the reader as "you".** "You can change this later."
+
+**Contractions are fine, negatives are not.** "you'll" is fine; always spell
+out "do not", "cannot", "will not" — a missed negative changes the meaning.
+
+**Full stop on messages.** Every message, confirmation, and help-text sentence
+ends with one: "Battle recorded." Never an exclamation mark, anywhere.
+
+**Sentence case, lowercase domain nouns.** gang, fighter, campaign, battle,
+weapon, territory are common nouns: "Delete gang", "Add a gang to this
+campaign". Capitalise only true proper nouns (Necromunda, Gyrinx, Patreon).
+This supersedes the old n23 rule that title-cased domain nouns; changed n23
+strings follow this rule too (fix on touch — do not sweep untouched copy).
+
+**Buttons: bare verb where the object is obvious.** "Save", "Add", "Remove"
+when the screen leaves no doubt; verb + object when it could be ambiguous
+("Add fighter"). A `success` button ends a form; a `primary` button starts
+one (see `n26/CLAUDE.md`).
+
+**Name the specific noun when the code knows it.** "That weapon is not one of
+the options here." Generic wording ("thing", "item") only when the type
+genuinely varies at that call site.
+
+**Success messages state the fact.** "Battle recorded." "Sold Bolt pistol for
+45¢." Never "successfully", never "has been Xed!".
+
+**Refusals state the rule.** "Only the campaign owner can edit this battle."
+— the reader learns who can, not just that they cannot. Never bare jargon
+("Invalid flow parameters.") and never apology ("We are sorry, but…").
+
+**Empty states say what is absent and what fills it.** "No sheets uploaded
+yet. Upload one first." "No gangs in this campaign yet." The "yet" marks a
+normal starting state, not an error.
+
+**Help text: the fact first, detail after.** Fragments are fine: "Optional —
+you can name them later." "The gang's story. Shown on the lore page, never
+printed."
+
+**No "please", no emoji.** Icons come from the icon system; emoji never appear
+in product strings. Em-dashes are house punctuation and are allowed — but not
+as a way to bolt on a dramatic aside.
+
+**British spelling** in prose and our own names (colour, organise); names that
+mirror CSS or a package API keep that API's spelling.
+
+## Anti-patterns
+
+These are the failure modes of "clever" copy. Each has appeared in this
+codebase; the before strings below are real.
+
+### Personification
+
+The app, the rules, a number, a collection, or code never asks, knows,
+refuses, wants, sells, or decides. Say what happens or what the reader can do.
+
+| Wrong | Right |
+| --- | --- |
+| The conversion refuses: … | The conversion cannot run: … |
+| Fighter or Vehicle — the rules know no other Type. | Type is Fighter or Vehicle. |
+| How many picks expected. Nought asks for nothing. | How many picks to ask for. 0 means none. |
+| This collection sells lasguns. | This collection contains lasguns. |
+
+### Saying what isn't
+
+Negation riddles and drama in place of the plain fact. State what is true, or
+what the reader can and cannot do, directly.
+
+| Wrong | Right |
+| --- | --- |
+| There is no way back from here | You cannot undo this |
+| …the rules know no other Type. | Type is Fighter or Vehicle. |
+
+### Quaint vocabulary
+
+Archaic, literary, or twee word choices. Use the ordinary word.
+
+| Wrong | Right |
+| --- | --- |
+| Nobody by that name. | No users match that name. |
+| {name} had already gone. | {name} was already removed. |
+| Nought | 0 |
+
+### Over-compression
+
+Dropped words that force the reader to decode. The test is one-pass
+comprehension, not length: "Ties fall back to name." is fine (the meaning
+arrives whole); "How many picks expected." is not (expected by whom? decode
+required). When in doubt, put the words back.
+
+### Marketing-speak and AI tells
+
+The feature is described, never sold. Ban outright: "successfully", trailing
+"!", "Get started", "Ready to…" headings, "powerful", "seamless", "robust",
+"leverage", "unlock", "delve", "We are sorry". Also the shapes: false
+antithesis ("It's not X, it's Y"), staccato triads ("Clear. Simple. Done."),
+rule-of-three adjective padding.
+
+## Word bans
+
+These govern product copy, UI strings, and identifiers. They do not apply to
+commit titles (see `.github/COMMIT_STYLE.md`). This list is the canonical
+record — other files that mention "noun bans recorded elsewhere" mean this one.
+
+| Banned | Use instead | Why |
+| --- | --- | --- |
+| cost | price (what a surface asks now) or rating (what a purchase added to the gang's worth) | The two numbers part company at the first discount. n26-wide; a test enforces it (`n26/tests/sandbox/test_money_words.py`). |
+| row (for an assignment) | assignment | "Row" is presentation, not the thing. |
+| shelf, shop | section, category, or the boring relational name | Commerce metaphors invent a noun the domain does not have. |
+| till | the real name of the payment point | Same. Also never "till" for "until". |
+| sells (a collection or the trading post) | contains, includes | A collection represents membership; it is not a merchant. |
+| sow | create | |
+| pressed | clicked | |
+| obligation, debt | name the mechanism that tracks what is owed | Banned in the built-ins programme wording. |
+| answer | pick or choose (see below) | Speech metaphor. |
+| spoken, said (in identifiers) | name the mechanism | Speech metaphors hide what the code does. |
+| SKU | assignable | |
+| Get started, successfully, "!" | state the fact | See anti-patterns. |
+
+**pick vs choose are precise domain verbs, never interchanged:** *pick* is the
+option-groups verb (picking from a picklist's options); *choose* is the
+offers-a-choice verb (resolving a choice an offer puts on a card). Player
+copy keeps the distinction.
+
+Beyond this table, use the words in `n26/design/glossary.md` and
+`n26/library/concepts.md` (maintainer's checkout only — if absent, follow this
+file and the models' own vocabulary). A term in neither is a design
+conversation, not a naming choice. Never invent a noun.
+
+## Calibration corpus
+
+Strings that pass, verbatim from the codebase — match this register:
+
+- "Battle recorded."
+- "Nothing changed."
+- "You can change this later."
+- "Leave blank to spend as much as you like."
+- "That item is not on this list."
+- "Say whether you are accepting or declining."
+- "No gangs in this campaign yet."
+- "Paste the link a player sent you, or the gang's id."
+- "Where it sits in the list. Ties fall back to name."
+- "Only the campaign owner can edit this battle."
+
+## Cold read
+
+Before finishing, read every new or changed string as a stranger mid-task who
+will read it exactly once. If any phrase draws attention to itself — a smile,
+a nice turn, a pause to decode — rewrite it until there is nothing to notice.
+
+`scripts/check_microcopy.py` warns (never blocks) about the greppable subset
+of these rules; run it over changed files, or let the PostToolUse hook do it.
+For a full pass over a diff, run the **copywriter** agent
+(`.claude/agents/copywriter.md`).

--- a/.agents/skills/microcopy/SKILL.md
+++ b/.agents/skills/microcopy/SKILL.md
@@ -35,7 +35,10 @@ Every string a person reads in the product, whoever they are:
 - Admin and maintenance screens (staff are readers too)
 
 Not in scope: commit titles and PR descriptions (see
-`.github/COMMIT_STYLE.md`), code comments, log lines.
+`.github/COMMIT_STYLE.md`), code comments, log lines, and the human-written
+marketing sections (the signed-out landing pitch on the homepage). Marketing
+copy is the maintainer's voice — do not rewrite it to these rules, and do not
+imitate it in app copy.
 
 ## Base rules
 

--- a/.agents/skills/microcopy/SKILL.md
+++ b/.agents/skills/microcopy/SKILL.md
@@ -136,7 +136,7 @@ required). When in doubt, put the words back.
 
 The feature is described, never sold. Ban outright: "successfully", trailing
 "!", "Get started", "Ready to…" headings, "powerful", "seamless", "robust",
-"leverage", "unlock", "delve", "We are sorry". Also the shapes: false
+"leverage", "unlock", "delve", "Oops", "We are sorry". Also the shapes: false
 antithesis ("It's not X, it's Y"), staccato triads ("Clear. Simple. Done."),
 rule-of-three adjective padding.
 

--- a/.agents/skills/microcopy/SKILL.md
+++ b/.agents/skills/microcopy/SKILL.md
@@ -69,9 +69,10 @@ genuinely varies at that call site.
 **Success messages state the fact.** "Battle recorded." "Sold Bolt pistol for
 45¢." Never "successfully", never "has been Xed!".
 
-**Refusals state the rule.** "Only the campaign owner can edit this battle."
-— the reader learns who can, not just that they cannot. Never bare jargon
-("Invalid flow parameters.") and never apology ("We are sorry, but…").
+**Refusals say no, then the rule.** "You cannot edit this battle. Only the
+battle's owner or a campaign admin can." — the reader hears the refusal and
+learns who can. Never bare jargon ("Invalid flow parameters.") and never
+apology ("We are sorry, but…").
 
 **Empty states say what is absent and what fills it.** "No sheets uploaded
 yet. Upload one first." "No gangs in this campaign yet." The "yet" marks a
@@ -184,7 +185,7 @@ Strings that pass, verbatim from the codebase — match this register:
 - "No gangs in this campaign yet."
 - "Paste the link a player sent you, or the gang's id."
 - "Where it sits in the list. Ties fall back to name."
-- "Only the campaign owner can edit this battle."
+- "You cannot edit this battle. Only the battle's owner or a campaign admin can."
 
 ## Cold read
 

--- a/.claude/agents/copywriter.md
+++ b/.claude/agents/copywriter.md
@@ -1,0 +1,60 @@
+---
+name: copywriter
+description: >
+  Reviews and rewrites user- and author-facing strings in a diff so the
+  microcopy matches the project's style (plain, explicit, one-pass
+  comprehension — see .claude/skills/microcopy/SKILL.md). Use PROACTIVELY
+  whenever a task added or changed user-facing strings (templates, form
+  labels/help_text, messages.*, model help text or library docstrings,
+  emails, admin screens), as a pre-push step when the diff touches such
+  strings, or on demand for a copy pass over any file or branch. Examples:
+  after building a new form or page ("run the copywriter over the diff");
+  before pushing a UI PR; or "review the copy in n26/core/forms.py".
+tools: Glob, Grep, LS, Read, Edit, Bash
+model: sonnet
+color: cyan
+---
+
+You are the project's copywriter. Your one job: make every user- and
+author-facing string in the given scope match the microcopy style. You do not
+review logic, structure, or markup — only the words a person reads.
+
+First, read `.claude/skills/microcopy/SKILL.md` in full. It is the authority:
+the credo (the reader does zero work), the base rules, the four anti-patterns
+(personification, saying what isn't, quaint vocabulary, over-compression), the
+marketing/AI-tell list, and the word-ban table. Judge every string against it.
+
+## Scope
+
+By default, review the branch diff (`git diff main...HEAD` plus uncommitted
+changes). The caller may name files or a different range instead. Within that
+scope, find every string a person reads: template text and component props
+(`title=`, `label=`, `submit_label=`, `lead=`, `empty=`, `placeholder=`),
+form `label`/`help_text`, `messages.*` calls, `verbose_name`, choices labels,
+validation errors, model `help_text`, library model docstrings, email and
+notification copy, admin/maintenance screens.
+
+Only strings the diff added or changed are in scope for edits. Neighbouring
+legacy copy is fix-on-touch: mention it in the report if it is badly off-style,
+but do not rewrite lines the diff did not touch unless the caller asked for a
+whole-file pass.
+
+## Method
+
+1. Collect the in-scope strings with file:line references.
+2. For each, do the cold read: a stranger mid-task reads it exactly once.
+   Does the meaning arrive in one pass? Does any phrase draw attention to
+   itself? Does it hit a ban or an anti-pattern?
+3. Rewrite offenders in place with Edit. Keep rewrites minimal — change the
+   words, never the surrounding markup, interpolation variables, or logic.
+   A rewrite must state the same fact; if the right wording depends on a
+   product decision you cannot see, flag it instead of guessing.
+4. Run `python3 scripts/check_microcopy.py <changed files>` at the end and
+   act on any remaining warnings (or explain why one is a false positive).
+
+## Report
+
+End with a table of every change: file:line, the string before, the string
+after, and which rule applied. List separately: strings you flagged but did
+not change (with the open question), and off-style legacy copy you noticed
+but left alone. If everything already passed, say so in one line.

--- a/.claude/agents/copywriter.md
+++ b/.claude/agents/copywriter.md
@@ -3,7 +3,7 @@ name: copywriter
 description: >
   Reviews and rewrites user- and author-facing strings in a diff so the
   microcopy matches the project's style (plain, explicit, one-pass
-  comprehension — see .claude/skills/microcopy/SKILL.md). Use PROACTIVELY
+  comprehension — see .agents/skills/microcopy/SKILL.md). Use PROACTIVELY
   whenever a task added or changed user-facing strings (templates, form
   labels/help_text, messages.*, model help text or library docstrings,
   emails, admin screens), as a pre-push step when the diff touches such
@@ -19,7 +19,7 @@ You are the project's copywriter. Your one job: make every user- and
 author-facing string in the given scope match the microcopy style. You do not
 review logic, structure, or markup — only the words a person reads.
 
-First, read `.claude/skills/microcopy/SKILL.md` in full. It is the authority:
+First, read `.agents/skills/microcopy/SKILL.md` in full. It is the authority:
 the credo (the reader does zero work), the base rules, the four anti-patterns
 (personification, saying what isn't, quaint vocabulary, over-compression), the
 marketing/AI-tell list, and the word-ban table. Judge every string against it.
@@ -49,8 +49,11 @@ whole-file pass.
    words, never the surrounding markup, interpolation variables, or logic.
    A rewrite must state the same fact; if the right wording depends on a
    product decision you cannot see, flag it instead of guessing.
-4. Run `python3 scripts/check_microcopy.py <changed files>` at the end and
-   act on any remaining warnings (or explain why one is a false positive).
+4. Run `python3 scripts/check_microcopy.py <changed files>` at the end.
+   Every remaining warning gets one of three verdicts in your report: fixed,
+   a false positive (say why), or legacy copy on lines the diff did not
+   touch — which is out of scope and stays as it is. Never sweep a file to
+   silence the checker.
 
 ## Report
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/scripts/check_microcopy.py --hook"
+          }
+        ]
+      }
     ]
   },
   "env": {

--- a/.github/COMMIT_STYLE.md
+++ b/.github/COMMIT_STYLE.md
@@ -70,7 +70,7 @@ the thing it happened to goes unnamed. Keep the effect, add the subject.
 
 `CLAUDE.md` asks you to describe changes by their user-visible effect and to
 avoid internal shorthand. The microcopy rules
-(`.claude/skills/microcopy/SKILL.md`) ban particular nouns in product copy
+(`.agents/skills/microcopy/SKILL.md`) ban particular nouns in product copy
 ("shelf", "shop", "row" for an assignment, and others).
 
 **None of that means "avoid naming the thing."** Avoiding internal shorthand

--- a/.github/COMMIT_STYLE.md
+++ b/.github/COMMIT_STYLE.md
@@ -69,7 +69,8 @@ the thing it happened to goes unnamed. Keep the effect, add the subject.
 ## A note on our other language rules
 
 `CLAUDE.md` asks you to describe changes by their user-visible effect and to
-avoid internal shorthand. Various notes ban particular nouns in product copy
+avoid internal shorthand. The microcopy rules
+(`.claude/skills/microcopy/SKILL.md`) ban particular nouns in product copy
 ("shelf", "shop", "row" for an assignment, and others).
 
 **None of that means "avoid naming the thing."** Avoiding internal shorthand

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,27 @@ for the specifics.
 `safe_rich_text` filter for sanitising. Always validate redirect targets from user
 input with `safe_redirect` / `get_return_url` (`gyrinx/http.py`).
 
+**Microcopy is plain, explicit, and invisible.** The canonical rules are in
+`.claude/skills/microcopy/SKILL.md`. For any new or changed user-facing string
+(template text, button labels, form labels/help text, `messages.*`, emails,
+admin screens), flag:
+
+- "successfully", trailing exclamation marks, "Get started", "Ready to…",
+  marketing adjectives ("powerful", "seamless", "robust") — success messages
+  state the fact ("Battle recorded."), refusals state the rule ("Only the
+  campaign owner can edit this battle.").
+- Cleverness of any kind: personification (the app, the rules, or a number
+  never asks, knows, refuses, or sells), negation riddles ("the rules know no
+  other Type" — say "Type is Fighter or Vehicle."), quaint vocabulary
+  ("nought", "had already gone"), and compression the reader must decode.
+  Plain and slightly wordy beats short and clever.
+- Title Case in labels — sentence case throughout, domain nouns lowercase
+  ("Add gang", not "Add Gang"); only true proper nouns capitalised.
+- Banned words in product copy: "cost" in n26 (price vs rating), "row" for an
+  assignment, "shelf"/"shop"/"till", a collection that "sells" its contents
+  (it contains them), "pressed" (say clicked), "obligation"/"debt", "answer"
+  (pick and choose are distinct domain verbs), "please", emoji.
+
 **The fighter list is the hot query path.** Adding a FK or M2M to `ListFighter`
 means updating `ListFighterQuerySet.with_related_data()` and the query-count
 snapshot at `n23/core/tests/fixtures/performance_view_queries.json`. Missing a

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ for the specifics.
 input with `safe_redirect` / `get_return_url` (`gyrinx/http.py`).
 
 **Microcopy is plain, explicit, and invisible.** The canonical rules are in
-`.claude/skills/microcopy/SKILL.md`. For any new or changed user-facing string
+`.agents/skills/microcopy/SKILL.md`. For any new or changed user-facing string
 (template text, button labels, form labels/help text, `messages.*`, emails,
 admin screens), flag:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,9 @@ for the specifics.
 input with `safe_redirect` / `get_return_url` (`gyrinx/http.py`).
 
 **Microcopy is plain, explicit, and invisible.** The canonical rules are in
-`.agents/skills/microcopy/SKILL.md`. For any new or changed user-facing string
+`.agents/skills/microcopy/SKILL.md`. The human-written marketing sections
+(the signed-out landing pitch on the homepage) are exempt — that is the
+maintainer's voice, not microcopy. For any new or changed user-facing string
 (template text, button labels, form labels/help text, `messages.*`, emails,
 admin screens), flag:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   [n23/core/templates/CLAUDE.md](n23/core/templates/CLAUDE.md) for the call-site
   traps — several of them fail *silently*.
 - Mobile-first design
+- **Microcopy: load the `microcopy` skill before writing any user- or
+  author-facing string** (template text, labels, help_text, `messages.*`,
+  emails, admin screens). Plain, explicit, one-pass comprehension; no
+  cleverness, no personification, no marketing-speak. The skill
+  (`.claude/skills/microcopy/SKILL.md`) is the canonical home of the word
+  bans. A warn-only hook (`scripts/check_microcopy.py`) flags the greppable
+  subset after each edit; the **copywriter** agent does the full pass.
 - Look up model definitions before use - don't assume field names
 - Always validate redirect URLs with `safe_redirect`
 
@@ -141,6 +148,8 @@ in the workflow.
   layers, and documenting dependencies.
 - **code-architect** — Designs feature architectures by analyzing existing patterns and providing implementation
   blueprints with component designs, data flows, and build sequences.
+- **copywriter** — Reviews and rewrites user-facing strings in a diff against the microcopy rules. Run it
+  proactively after any task that added or changed such strings, and as a pre-push step on UI PRs.
 - **code-reviewer** — Reviews code for bugs, security vulnerabilities, and convention adherence using confidence-based
   filtering (only reports high-confidence issues).
 
@@ -160,6 +169,8 @@ in the workflow.
 Skills are loaded automatically by agents that need them. They can also be referenced directly:
 
 - **gyrinx-conventions** — Canonical architectural patterns for the project (views, handlers, models, templates, tests)
+- **microcopy** — Rules for user- and author-facing strings: the credo, base rules, anti-patterns, and the
+  canonical word-ban list. Load before writing or editing any such string.
 - **code-analysis-lenses** — Four structured lenses for evaluating code quality
 - **edit-github-discussion** — Workflow for editing GitHub Discussions via GraphQL API
 - **trace-analysis** — Guide for analyzing OpenTelemetry trace files
@@ -277,7 +288,8 @@ Keep the fully technical version for commit messages and code comments.
 **Commit and PR titles have their own rules — see
 [.github/COMMIT_STYLE.md](.github/COMMIT_STYLE.md).** Read that file rather than
 copying the phrasing of recent commits; the log has drifted before. Note that the
-noun bans recorded elsewhere (no "shelf", no "shop", no "row" for an assignment)
+noun bans in [.claude/skills/microcopy/SKILL.md](.claude/skills/microcopy/SKILL.md)
+(no "shelf", no "shop", no "row" for an assignment, and others)
 govern product copy, UI strings and identifiers — they do not apply to commit
 titles, which should freely name model classes, functions and flags.
 
@@ -304,7 +316,10 @@ titles, which should freely name model classes, functions and flags.
 2. Run tests: `pytest -n auto`
 3. Fix any failing tests
 4. Consider running the **code-simplifier** agent on changed files for a quality check
-5. Commit and push changes
+5. If the diff added or changed user-facing strings, run the **copywriter** agent
+   over it (also run it proactively right after finishing UI work — don't wait
+   for push time)
+6. Commit and push changes
 
 - Manually test changes through the running app (dev server + browser) before
   shipping — skip only when the change is trivial

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   author-facing string** (template text, labels, help_text, `messages.*`,
   emails, admin screens). Plain, explicit, one-pass comprehension; no
   cleverness, no personification, no marketing-speak. The skill
-  (`.claude/skills/microcopy/SKILL.md`) is the canonical home of the word
+  (`.agents/skills/microcopy/SKILL.md`) is the canonical home of the word
   bans. A warn-only hook (`scripts/check_microcopy.py`) flags the greppable
   subset after each edit; the **copywriter** agent does the full pass.
 - Look up model definitions before use - don't assume field names
@@ -288,7 +288,7 @@ Keep the fully technical version for commit messages and code comments.
 **Commit and PR titles have their own rules — see
 [.github/COMMIT_STYLE.md](.github/COMMIT_STYLE.md).** Read that file rather than
 copying the phrasing of recent commits; the log has drifted before. Note that the
-noun bans in [.claude/skills/microcopy/SKILL.md](.claude/skills/microcopy/SKILL.md)
+noun bans in [.agents/skills/microcopy/SKILL.md](.agents/skills/microcopy/SKILL.md)
 (no "shelf", no "shop", no "row" for an assignment, and others)
 govern product copy, UI strings and identifiers — they do not apply to commit
 titles, which should freely name model classes, functions and flags.

--- a/n23/core/templates/CLAUDE.md
+++ b/n23/core/templates/CLAUDE.md
@@ -80,37 +80,14 @@ the gate, fix the call site.
 
 ## Microcopy Guidelines
 
-### Casing
+The canonical rules live in the `microcopy` skill
+(`.claude/skills/microcopy/SKILL.md`) — load it before writing or editing any
+user-facing string. Two notes specific to this tree:
 
-Use sentence case for UI text. Title case proper nouns only.
-
-**Proper nouns (title case):**
-
-- Campaign
-- Action
-- Asset
-- Gang
-- Fighter
-- Territory
-- Resource
-
-**Linking words (lowercase):**
-
-- from, to, and, or, the, a, an, in, on, for, with
-
-### Examples
-
-| Correct | Incorrect |
-|---------|-----------|
-| Copy from another Campaign | Copy From Another Campaign |
-| Add a Gang to this Campaign | Add A Gang To This Campaign |
-| Assets and Resources | Assets And Resources |
-| Copy to Campaign | Copy To Campaign |
-| Create new Asset | Create New Asset |
-
-### Button Labels
-
-- Use action verbs: "Add", "Create", "Copy", "Remove"
-- Keep labels concise: "Next", "Cancel", "Save"
-- Arrow icons go after text for forward actions: "Next →"
-- Arrow icons go before text for back actions: "← Back"
+- **Casing: sentence case throughout, domain nouns lowercase.** "Add a gang to
+  this campaign", not "Add a Gang to this Campaign". An older rule here
+  title-cased domain nouns (Gang, Campaign, Asset…) and much existing n23 copy
+  still follows it; the lowercase rule wins for any string you add or touch.
+  Do not sweep untouched copy.
+- Arrow icons go after text for forward actions ("Next →") and before text for
+  back actions ("← Back").

--- a/n23/core/templates/CLAUDE.md
+++ b/n23/core/templates/CLAUDE.md
@@ -81,7 +81,7 @@ the gate, fix the call site.
 ## Microcopy Guidelines
 
 The canonical rules live in the `microcopy` skill
-(`.claude/skills/microcopy/SKILL.md`) — load it before writing or editing any
+(`.agents/skills/microcopy/SKILL.md`) — load it before writing or editing any
 user-facing string. Two notes specific to this tree:
 
 - **Casing: sentence case throughout, domain nouns lowercase.** "Add a gang to

--- a/scripts/check_microcopy.py
+++ b/scripts/check_microcopy.py
@@ -286,8 +286,8 @@ def main():
 
     if findings:
         out = sys.stderr if hook_mode else sys.stdout
-        print("Microcopy warnings (advisory — judge each in context;", file=out)
-        print("rules: .agents/skills/microcopy/SKILL.md):", file=out)
+        print("Microcopy warnings — advisory; judge each in context.", file=out)
+        print("Rules: .agents/skills/microcopy/SKILL.md", file=out)
         for f in findings:
             print("  " + f, file=out)
         if hook_mode:

--- a/scripts/check_microcopy.py
+++ b/scripts/check_microcopy.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Warn about off-style microcopy. Never blocks.
+
+The full rules live in .claude/skills/microcopy/SKILL.md; this script catches
+the greppable subset — banned words, "successfully", exclamation marks in
+strings, Title Case button labels — and prints warnings so the writer can
+judge each one. Warn-only by design: copy calls need human judgement, and a
+matched word can be legitimate in context (a rulebook name, a test asserting
+the old string).
+
+    scripts/check_microcopy.py FILE [FILE...]   # scan named files
+    scripts/check_microcopy.py --diff           # scan files changed vs main
+    scripts/check_microcopy.py --hook           # PostToolUse hook: JSON on stdin
+
+Exit codes: 0 always in CLI modes. In --hook mode, exit 2 when there are
+findings so the agent that made the edit sees them as feedback (the edit
+itself is not undone or blocked).
+"""
+
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# (regex, hint). Case-insensitive. Applied to template lines, and to .py lines
+# that contain a string literal.
+WORD_RULES = [
+    (r"\bsuccessfully\b", 'state the fact instead: "Battle recorded."'),
+    (r"\bnought\b", 'quaint — write "0"'),
+    (
+        r"\bshel(f|ves)\b",
+        "commerce metaphor — say section, category, or the relational name",
+    ),
+    (
+        r"\bshops?\b",
+        "commerce metaphor — say section, category, or the relational name",
+    ),
+    (r"\btill\b", 'banned — name the payment point; never "till" for "until"'),
+    (r"\bsow(s|n|ing)?\b", 'say "create"'),
+    (r"\bpressed\b", '"clicked", not "pressed"'),
+    (r"\bobligations?\b", "banned — name the mechanism that tracks what is owed"),
+    (r"\bdebts?\b", "banned — name the mechanism that tracks what is owed"),
+    (r"\bsells\b", "a collection contains/includes things; it is not a merchant"),
+    (
+        r"\banswers?\b",
+        'speech metaphor — use "pick" or "choose" (they differ; see the skill)',
+    ),
+    (r"\bSKU\b", 'say "assignable"'),
+    (r"\bseamless(ly)?\b", "marketing-speak — describe, never sell"),
+    (r"\bpowerful\b", "marketing-speak — describe, never sell"),
+    (r"\brobust\b", "marketing-speak — describe, never sell"),
+    (r"\bleverage\b", 'say "use"'),
+    (r"\bdelve\b", "AI tell — use a plain verb"),
+    (r"\bget started\b", "onboarding cliché — name the first action instead"),
+    (r"\bwe are sorry\b|\bwe're sorry\b", "no apologies — state the rule or the fact"),
+    (r"\boops\b", "no drama — state what happened"),
+    (r"\bplease\b", 'drop "please" — instructions are imperative'),
+]
+
+# "cost" is price-vs-rating confusion; the ban is n26-wide (test_money_words
+# enforces models — this catches copy).
+N26_WORD_RULES = [
+    (r"\bcosts?\b", "banned in n26 — price (asked now) or rating (added to worth)"),
+]
+
+# An exclamation mark ending a sentence in copy. Must not match `!=`,
+# `!important`, `<!--`, or Tailwind important suffixes (`py-0!`,
+# `bg-ink-200!`, `font-bold!` — a digit or a hyphenated utility before the
+# mark).
+BANG = re.compile(r"(?<![-\w])[A-Za-z]{2,}!(?=[\"'<\s]|$)")
+
+# Title Case after a leading verb in template text: ">Add Fighter<". Second
+# capitalised word must not be a proper noun or an initialism.
+TITLE_CASE = re.compile(
+    r">\s*(Add|New|Create|Edit|Delete|Remove|Save|Copy|Update|Confirm|Change|"
+    r"Select|Send|View|Manage|Assign|Archive|Upload|Record) ([A-Z][a-z]+)"
+)
+PROPER_NOUNS = {"Necromunda", "Gyrinx", "Patreon", "Discord", "Google", "Bootstrap"}
+
+EXCLUDE_PARTS = (
+    "/migrations/",
+    "/tests/",
+    "/test_",
+    "/node_modules/",
+    "/.venv/",
+    "/rule-reference/",
+    "/static/",
+    # This script and its docs quote the banned words on purpose.
+    "/scripts/",
+    "/.claude/",
+)
+
+PY_STRING_LINE = re.compile(r"""["']""")
+
+
+def scan_file(path: pathlib.Path) -> list[str]:
+    rel = path.resolve()
+    try:
+        rel = rel.relative_to(ROOT)
+    except ValueError:
+        pass
+    rel_str = "/" + str(rel)
+    if any(part in rel_str for part in EXCLUDE_PARTS):
+        return []
+    if path.suffix not in (".html", ".py", ".txt"):
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError, UnicodeDecodeError:
+        return []
+
+    is_template = path.suffix in (".html", ".txt")
+    rules = list(WORD_RULES)
+    if str(rel).startswith("n26/"):
+        rules += N26_WORD_RULES
+    compiled = [(re.compile(rx, re.IGNORECASE), hint) for rx, hint in rules]
+
+    findings = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not is_template and not PY_STRING_LINE.search(line):
+            continue
+        for rx, hint in compiled:
+            m = rx.search(line)
+            if m:
+                findings.append(f"{rel}:{lineno}: “{m.group(0)}” — {hint}")
+        if BANG.search(line) and "<!--" not in line:
+            findings.append(
+                f"{rel}:{lineno}: exclamation mark in copy — end with a full stop"
+            )
+        if is_template:
+            m = TITLE_CASE.search(line)
+            if m and m.group(2) not in PROPER_NOUNS:
+                findings.append(
+                    f"{rel}:{lineno}: “{m.group(1)} {m.group(2)}” — sentence case: “{m.group(1)} {m.group(2).lower()}”"
+                )
+    return findings
+
+
+def changed_files() -> list[pathlib.Path]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "main...HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=False,
+    ).stdout
+    out += subprocess.run(
+        ["git", "diff", "--name-only", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=False,
+    ).stdout
+    return [ROOT / line for line in dict.fromkeys(out.splitlines()) if line]
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    hook_mode = "--hook" in argv
+
+    if hook_mode:
+        try:
+            payload = json.load(sys.stdin)
+        except json.JSONDecodeError, OSError:
+            return 0
+        file_path = (payload.get("tool_input") or {}).get("file_path")
+        paths = [pathlib.Path(file_path)] if file_path else []
+    elif "--diff" in argv:
+        paths = changed_files()
+    else:
+        paths = [pathlib.Path(a) for a in argv]
+        if not paths:
+            print(__doc__)
+            return 0
+
+    findings = []
+    for path in paths:
+        if path.is_file():
+            findings += scan_file(path)
+
+    if findings:
+        out = sys.stderr if hook_mode else sys.stdout
+        print("Microcopy warnings (advisory — judge each in context;", file=out)
+        print("rules: .claude/skills/microcopy/SKILL.md):", file=out)
+        for f in findings:
+            print(f"  {f}", file=out)
+        if hook_mode:
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_microcopy.py
+++ b/scripts/check_microcopy.py
@@ -1,32 +1,42 @@
 #!/usr/bin/env python3
 """Warn about off-style microcopy. Never blocks.
 
-The full rules live in .claude/skills/microcopy/SKILL.md; this script catches
+The full rules live in .agents/skills/microcopy/SKILL.md; this script catches
 the greppable subset — banned words, "successfully", exclamation marks in
-strings, Title Case button labels — and prints warnings so the writer can
-judge each one. Warn-only by design: copy calls need human judgement, and a
-matched word can be legitimate in context (a rulebook name, a test asserting
-the old string).
+copy, Title Case button labels — and prints warnings so the writer can judge
+each one. Warn-only by design: copy calls need human judgement, and a matched
+word can be legitimate in context (a rulebook name, a test asserting the old
+string).
 
     scripts/check_microcopy.py FILE [FILE...]   # scan named files
-    scripts/check_microcopy.py --diff           # scan files changed vs main
+    scripts/check_microcopy.py --diff           # files changed vs main + untracked
     scripts/check_microcopy.py --hook           # PostToolUse hook: JSON on stdin
 
 Exit codes: 0 always in CLI modes. In --hook mode, exit 2 when there are
 findings so the agent that made the edit sees them as feedback (the edit
-itself is not undone or blocked).
+itself is not undone or blocked). Hook mode scans only the text the edit
+introduced, so pre-existing warnings in a legacy file do not repeat on every
+edit — existing copy is fix-on-touch, and sweeping it is the skill's call,
+not this script's.
+
+The word list is maintained by hand against the SKILL.md ban table; when a
+ban is added there, add it here too. This file must stay parseable by old
+Pythons (no 3.14-only syntax): the PostToolUse hook runs it with whatever
+`python3` is on PATH, which outside the venv can be the system 3.9.
 """
 
+import io
 import json
 import pathlib
 import re
-import subprocess
+import subprocess  # nosec B404 — runs only fixed git commands to list changed files
 import sys
+import tokenize
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-# (regex, hint). Case-insensitive. Applied to template lines, and to .py lines
-# that contain a string literal.
+# (regex, hint). Case-insensitive. Applied to template lines and, in .py
+# files, to string literals (docstrings included) via tokenize.
 WORD_RULES = [
     (r"\bsuccessfully\b", 'state the fact instead: "Battle recorded."'),
     (r"\bnought\b", 'quaint — write "0"'),
@@ -53,8 +63,10 @@ WORD_RULES = [
     (r"\bpowerful\b", "marketing-speak — describe, never sell"),
     (r"\brobust\b", "marketing-speak — describe, never sell"),
     (r"\bleverage\b", 'say "use"'),
+    (r"\bunlock(s|ed|ing)?\b", "marketing-speak — say what becomes available"),
     (r"\bdelve\b", "AI tell — use a plain verb"),
     (r"\bget started\b", "onboarding cliché — name the first action instead"),
+    (r"\bready to\b", "hype heading — name the thing shown instead"),
     (r"\bwe are sorry\b|\bwe're sorry\b", "no apologies — state the rule or the fact"),
     (r"\boops\b", "no drama — state what happened"),
     (r"\bplease\b", 'drop "please" — instructions are imperative'),
@@ -68,9 +80,13 @@ N26_WORD_RULES = [
 
 # An exclamation mark ending a sentence in copy. Must not match `!=`,
 # `!important`, `<!--`, or Tailwind important suffixes (`py-0!`,
-# `bg-ink-200!`, `font-bold!` — a digit or a hyphenated utility before the
-# mark).
+# `font-bold!`); class attribute values are blanked before this runs, which
+# also covers single-word utilities (`hidden!`).
 BANG = re.compile(r"(?<![-\w])[A-Za-z]{2,}!(?=[\"'<\s]|$)")
+
+# class="..." values carry no copy and are where Tailwind's `!` suffixes and
+# utility words live — blank them before scanning a template line.
+CLASS_ATTR = re.compile(r"""\bclass=("[^"]*"|'[^']*')""")
 
 # Title Case after a leading verb in template text: ">Add Fighter<". Second
 # capitalised word must not be a proper noun or an initialism.
@@ -80,113 +96,200 @@ TITLE_CASE = re.compile(
 )
 PROPER_NOUNS = {"Necromunda", "Gyrinx", "Patreon", "Discord", "Google", "Bootstrap"}
 
-EXCLUDE_PARTS = (
-    "/migrations/",
-    "/tests/",
-    "/test_",
-    "/node_modules/",
-    "/.venv/",
-    "/rule-reference/",
-    "/static/",
-    # This script and its docs quote the banned words on purpose.
-    "/scripts/",
-    "/.claude/",
-)
+# Directory names whose subtrees hold no product copy, matched against path
+# segments (never substrings). scripts/ and the agent trees quote the banned
+# words on purpose.
+EXCLUDE_DIRS = {
+    "migrations",
+    "tests",
+    "node_modules",
+    ".venv",
+    "rule-reference",
+    "static",
+    "scripts",
+    ".claude",
+    ".agents",
+}
 
-PY_STRING_LINE = re.compile(r"""["']""")
 
+def repo_relative_parts(path):
+    """Path segments relative to the repo tree, wherever the file lives.
 
-def scan_file(path: pathlib.Path) -> list[str]:
-    rel = path.resolve()
+    A file under another checkout or worktree still gets sensible segments:
+    everything up to and including `worktrees/<name>` is dropped, so the
+    n26-only rules and the directory exclusions see `n26/...` either way.
+    """
+    resolved = path.resolve()
     try:
-        rel = rel.relative_to(ROOT)
+        return resolved.relative_to(ROOT).parts
     except ValueError:
-        pass
-    rel_str = "/" + str(rel)
-    if any(part in rel_str for part in EXCLUDE_PARTS):
-        return []
-    if path.suffix not in (".html", ".py", ".txt"):
-        return []
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError, UnicodeDecodeError:
-        return []
+        parts = resolved.parts
+        if "worktrees" in parts:
+            idx = parts.index("worktrees")
+            return parts[idx + 2 :]
+        return parts
 
-    is_template = path.suffix in (".html", ".txt")
+
+def scan_text(text, label, parts, is_template):
     rules = list(WORD_RULES)
-    if str(rel).startswith("n26/"):
+    if parts and parts[0] == "n26":
         rules += N26_WORD_RULES
     compiled = [(re.compile(rx, re.IGNORECASE), hint) for rx, hint in rules]
 
     findings = []
     for lineno, line in enumerate(text.splitlines(), start=1):
-        if not is_template and not PY_STRING_LINE.search(line):
-            continue
+        scannable = CLASS_ATTR.sub('class=""', line) if is_template else line
         for rx, hint in compiled:
-            m = rx.search(line)
+            m = rx.search(scannable)
             if m:
-                findings.append(f"{rel}:{lineno}: “{m.group(0)}” — {hint}")
-        if BANG.search(line) and "<!--" not in line:
+                word = m.group(0)
+                findings.append(f"{label}:{lineno}: “{word}” — {hint}")
+        if BANG.search(scannable) and "<!--" not in line:
             findings.append(
-                f"{rel}:{lineno}: exclamation mark in copy — end with a full stop"
+                f"{label}:{lineno}: exclamation mark in copy — end with a full stop"
             )
         if is_template:
             m = TITLE_CASE.search(line)
             if m and m.group(2) not in PROPER_NOUNS:
+                verb, noun = m.group(1), m.group(2)
                 findings.append(
-                    f"{rel}:{lineno}: “{m.group(1)} {m.group(2)}” — sentence case: “{m.group(1)} {m.group(2).lower()}”"
+                    f"{label}:{lineno}: “{verb} {noun}” — "
+                    f"sentence case: “{verb} {noun.lower()}”"
                 )
     return findings
 
 
-def changed_files() -> list[pathlib.Path]:
-    out = subprocess.run(
+def python_strings(text):
+    """(start_line, string_source) for every string literal, docstrings and
+    f-string text included. Comments and code never reach the word rules this
+    way. f-strings tokenize as FSTRING_MIDDLE chunks on Python 3.12+; on
+    older Pythons they arrive as plain STRING tokens."""
+    string_types = {tokenize.STRING, getattr(tokenize, "FSTRING_MIDDLE", -1)}
+    tokenize_errors = (tokenize.TokenError, IndentationError, SyntaxError)
+    out = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+            if tok.type in string_types:
+                out.append((tok.start[0], tok.string))
+    except tokenize_errors:
+        return None
+    return out
+
+
+def scan_file(path):
+    parts = repo_relative_parts(path)
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return []
+    if any(part.startswith("test_") for part in parts):
+        return []
+    if path.suffix not in (".html", ".py", ".txt"):
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    except UnicodeDecodeError:
+        return []
+
+    label = "/".join(parts)
+    if path.suffix in (".html", ".txt"):
+        return scan_text(text, label, parts, is_template=True)
+
+    strings = python_strings(text)
+    if strings is None:
+        return scan_text(text, label, parts, is_template=False)
+    findings = []
+    for start_line, source in strings:
+        for f in scan_text(source, label, parts, is_template=False):
+            _, lineno, rest = f.split(":", 2)
+            real_line = start_line + int(lineno) - 1
+            findings.append(f"{label}:{real_line}:{rest}")
+    return findings
+
+
+def hook_findings(payload):
+    """Scan only the text this edit introduced, so warnings are about the
+    change, never the file's backlog."""
+    tool_input = payload.get("tool_input") or {}
+    file_path = tool_input.get("file_path")
+    if not file_path:
+        return []
+    path = pathlib.Path(file_path)
+    if path.suffix not in (".html", ".py", ".txt"):
+        return []
+    parts = repo_relative_parts(path)
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return []
+    if any(part.startswith("test_") for part in parts):
+        return []
+
+    texts = []
+    if "content" in tool_input:
+        texts.append(tool_input["content"])
+    if "new_string" in tool_input:
+        texts.append(tool_input["new_string"])
+    for edit in tool_input.get("edits") or []:
+        if isinstance(edit, dict) and edit.get("new_string"):
+            texts.append(edit["new_string"])
+
+    label = "/".join(parts) + " (this edit)"
+    is_template = path.suffix in (".html", ".txt")
+    findings = []
+    for text in texts:
+        for f in scan_text(text, label, parts, is_template):
+            findings.append(f)
+    return findings
+
+
+def changed_files():
+    names = []
+    for args in (
         ["git", "diff", "--name-only", "main...HEAD"],
-        capture_output=True,
-        text=True,
-        cwd=ROOT,
-        check=False,
-    ).stdout
-    out += subprocess.run(
         ["git", "diff", "--name-only", "HEAD"],
-        capture_output=True,
-        text=True,
-        cwd=ROOT,
-        check=False,
-    ).stdout
-    return [ROOT / line for line in dict.fromkeys(out.splitlines()) if line]
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    ):
+        result = subprocess.run(  # nosec B607 — fixed argv; git resolved from PATH like every repo tool
+            args, capture_output=True, text=True, cwd=str(ROOT), check=False
+        )
+        names.extend(result.stdout.splitlines())
+    seen = []
+    for name in names:
+        if name and name not in seen:
+            seen.append(name)
+    return [ROOT / name for name in seen]
 
 
-def main() -> int:
+def main():
     argv = sys.argv[1:]
     hook_mode = "--hook" in argv
 
     if hook_mode:
         try:
             payload = json.load(sys.stdin)
-        except json.JSONDecodeError, OSError:
+        except ValueError:
             return 0
-        file_path = (payload.get("tool_input") or {}).get("file_path")
-        paths = [pathlib.Path(file_path)] if file_path else []
-    elif "--diff" in argv:
-        paths = changed_files()
+        except OSError:
+            return 0
+        findings = hook_findings(payload)
     else:
-        paths = [pathlib.Path(a) for a in argv]
-        if not paths:
-            print(__doc__)
-            return 0
-
-    findings = []
-    for path in paths:
-        if path.is_file():
-            findings += scan_file(path)
+        if "--diff" in argv:
+            paths = changed_files()
+        else:
+            paths = [pathlib.Path(a) for a in argv]
+            if not paths:
+                print(__doc__)
+                return 0
+        findings = []
+        for path in paths:
+            if path.is_file():
+                findings += scan_file(path)
 
     if findings:
         out = sys.stderr if hook_mode else sys.stdout
         print("Microcopy warnings (advisory — judge each in context;", file=out)
-        print("rules: .claude/skills/microcopy/SKILL.md):", file=out)
+        print("rules: .agents/skills/microcopy/SKILL.md):", file=out)
         for f in findings:
-            print(f"  {f}", file=out)
+            print("  " + f, file=out)
         if hook_mode:
             return 2
     return 0


### PR DESCRIPTION
## Summary

- `.claude/skills/microcopy/SKILL.md` is now the canonical home of the microcopy style: the credo (the reader does zero work — plain, explicit, one-pass comprehension), base rules (sentence case with lowercase domain nouns, full stops on messages, success messages state the fact, refusals state the rule), four named anti-patterns (personification, saying what isn't, quaint vocabulary, over-compression), the marketing/AI-tell list, and the word-ban table ("cost" in n26, "row" for an assignment, "shelf"/"shop"/"till", a collection that "sells", "pressed", "obligation"/"debt", "answer", and others). `CLAUDE.md` and `.github/COMMIT_STYLE.md` previously deferred to noun bans "recorded elsewhere" that existed in no tracked file; both now point here.
- `.claude/agents/copywriter.md` — an agent that reviews and rewrites the user-facing strings in a diff against the skill. `CLAUDE.md` tells agents to run it proactively after UI work and as a Before Push step.
- `scripts/check_microcopy.py` — a warn-only checker for the greppable subset (banned words, "successfully", exclamation marks in copy, Title Case labels). Wired as a PostToolUse hook in `.claude/settings.json` so any agent that writes an off-style string sees the warning immediately; also runs by hand (`--diff` or file args). It never blocks — copy needs judgement.
- `.github/copilot-instructions.md` gains a microcopy section so bot review flags the same patterns.
- `n23/core/templates/CLAUDE.md`: the old title-case-domain-nouns rule is replaced by the n26 lowercase rule ("Add a gang to this campaign"), applied fix-on-touch.

## Test plan

- [x] `scripts/check_microcopy.py` flags the known offenders (n23 "successfully!" messages, "Get started", "powerful", Title Case buttons, "Nought" in `n26/library/models/slots.py`) and stays quiet on Tailwind `!` suffixes and its own source
- [x] Hook mode reads PostToolUse JSON and exits 2 with findings on stderr, 0 otherwise
- [x] `.claude/settings.json` still parses; pre-commit passes

## Next steps

A follow-up PR rewrites the existing offenders the survey found (n23 message strings, landing-page copy, and the n26 strings the new anti-patterns name).