### PR TITLE
feat: draw counters on the model card and tally them on the edit page

### DIFF
--- a/.claude/notes/n26-counters-plan.md
+++ b/.claude/notes/n26-counters-plan.md
@@ -1,0 +1,155 @@
+# n26: drawing and editing counters
+
+## The bug that started this
+
+A Spyre Hunt Master hired into a new gang gets `Kill Count` and `Glitch Count`
+as built-in grants from their subtype, alongside `XP`. The grants land
+correctly — prod shows all three as live assignments with `CounterValue` rows —
+but the card draws none of them.
+
+`model_card()` in `n26/core/render.py` drops every counter that is not XP:
+
+```python
+elif isinstance(thing, Counter):
+    if thing.name.casefold() == XP_COUNTER.casefold():
+        counted_xp = _counter_value(node)
+```
+
+Anything else falls out of the loop with nowhere to go — `ModelCard` has no
+field for it. `test_a_counter_is_not_drawn_as_a_piece_of_equipment` locks in
+"a counter is not equipment" but never asks for a counter line instead.
+
+Counters *do* draw on the gang sheet (`GangSheet.counters`, from
+`counter_readings(gang_card)`), but that reads gang-hosted counters only, so a
+model's never reach it.
+
+Second gap behind the first: nothing can change a counter by hand. `op.tally`
+has exactly one non-test caller — a Tally modifier firing off an assignment
+(`n26/library/models/modifier.py`). No view, no route. XP included: there is
+today no way to give a fighter XP.
+
+Prod holds three counters in total: `XP`, `Kill Count`, `Glitch Count`.
+
+## The rules these serve
+
+From The Book of Desolation p28 (Spyre Hunting Party).
+
+**Kill Count** is a currency, not a score. "In addition to gaining XP, each time
+a Spyrer takes an enemy fighter Out of Action, increase the Spyrer's Kill Count
+by one." It accrues off the same event as XP and is spent on a separate track.
+
+**Suit Evolution** is a post-battle action. With Kill Count at 4 or more, reduce
+it by 4 and take one of: clear all glitches (Glitch Count to zero, and remove
+the negatives the glitches caused), or roll D6 on the Power Boost table, apply
+it, and raise the fighter's credits value. Repeatable while Kill Count is still
+at least 4 — so a good battle might drain 8 or 12 in one sequence.
+
+**Power Boost (D6)**: 1 Combat Neuroware (+1 WS or BS, max 2+, +20cr); 2
+Heightened Reactions (+1 I, max 2+, +10cr); 3 Improved Motive Power (+1 M, max
+8", +10cr); 4 Thickened Armour (+1 save, max 2+, +15cr); 5-6 Hunting Rig
+Augmentation (one weapon or wargear +1 Augmentation level, +1 more if a
+characteristic would exceed its max, +20cr). Any roll that would push a
+characteristic past its maximum becomes Hunting Rig Augmentation instead.
+
+**Glitch Count** is a death clock. A Spyrer taken Out of Action rolls D66 on
+Spyrer Hunting Rig Glitches rather than the Lasting Injury table. Results 41-64
+each read: Convalescence, +1 Glitch Count, and one penalty (a characteristic
+down, a weapon's Ammo or AP worsened, an Augmentation level lost). 11 gains D3
+XP and no glitch; 12-36 carry no glitch; 54 adds a standing risk; 65 rolls D3
+more times; 66 kills outright.
+
+The kill switch: during Purchase Advancements, if Glitch Count is higher than
+Toughness the rig shuts down and the fighter is deleted with all their
+equipment. Vicious, because result 64 lowers Toughness — a bad run moves the
+threshold down while pushing the count up. That is why the number has to be
+legible on the card.
+
+**What it means here.** Both counters persist across battles and move in both
+directions. Clearing the glitch *penalties* is not a counter act — those are
+stat edits and lasting effects modelled elsewhere; Suit Evolution only zeroes
+the count. Every act that moves either belongs to a post-battle sequence n26
+does not have yet, so hand-editing on the model's own page is the right shape
+for now.
+
+## Scope
+
+Settled with Tom, 2026-08-31.
+
+- Draw counters everywhere a card draws: gang sheet, fighter-edit page, print
+  sheet, text sheet.
+- Controls **only on the fighter-edit page** (`/n26/fighters/<pk>/edit/`). No
+  controls on the gang sheet: doing this rapidly is a bulk-update feature later,
+  and the sheet's rule that its controls live in the actions slot stands.
+- **XP is editable**, through the same control on the same page. It is the
+  gap people feel first, and it will be bulk-editable later too.
+- The card there already draws in `edit` mode — the same switch that brings out
+  Equip and the Choose buttons — so the controls need no new mode.
+
+Deferred: the dialog (arbitrary change, a note, reset-to-zero), bulk update, and
+the `3/4` threshold reading that `CounterAtLeast` would make possible.
+
+## Design
+
+**XP keeps its statline cell, and gets a line only where it can be moved.**
+The cell shows `61/79` including the target, which a counter line has no way to
+show. The line earns its place by being the control, so on a screen that offers
+none — the gang sheet, a print sheet, a hire preview — it would say 61 twice and
+is left out. `ModelCard.counter_lines` is that rule, in one place, read by the
+card template, the print columns and the text sheet alike; `counters` holds them
+all. Every other counter has no cell and draws either way.
+
+The alternative — an action slot inside `c-n26.statline` — costs more and buys
+less now that the controls are not on the sheet, and that component draws
+hundreds of times per sheet and is shared with print.
+
+**Order.** XP first, then the rest in the order the card holds them. The lines
+sit at the top of the card's `<dl>`, under the statline strip and adjacent to
+the XP cell above them, so every tally the model keeps reads as one block.
+
+**No act that will be refused.** `op.tally` floors at zero, so the `-` is not
+drawn at zero.
+
+**One route, signed change.** `assignments/<str:pk>/tally/`, matching the
+assignment-keyed verbs already in `n26/core/views/owned.py`. A signed `change`
+means the bulk-update feature later posts to the same place.
+
+```
+ -- Fighter edit page ----------------------------------------------------------
+| XP             61  ( - ) ( + )                                               |
+| Kill Count      3  ( - ) ( + )                                               |
+| Glitch Count    0        ( + )       <- no minus at zero                      |
+| Skills         Nerves of Steel, Overwatch          [Choose skill] [pencil]    |
+| Gear           Spyre Hunting Rig                            [Equip]           |
+
+ -- Gang sheet, print, text sheet ----------------------------------------------
+| XP stays in its cell alone                                                    |
+| Kill Count      3                                                             |
+| Glitch Count    0                                                             |
+```
+
+## Build
+
+Built, in this order.
+
+1. **Draw.** `CounterLine` in `n26/core/render.py`; `ModelCard.counters` and the
+   `counter_lines` property; filled in `model_card()` where the `Counter` branch
+   dropped non-XP counters. XP goes in the list *and* keeps filling `counted_xp`.
+   The loop already skips `broadcast` nodes, so the gang's own counters do not
+   leak onto a member's card.
+2. **Card.** A line per counter at the top of the `<dl>` in
+   `cotton/n26/model_card/body.html`, controls in a new
+   `cotton/n26/counter_controls.html` drawn only where the line has an href.
+3. **Print and text.** `detail_groups` in `n26/core/printing.py` and the model
+   block in `n26/core/render_text.py`, both reading `counter_lines`.
+4. **Route.** `assignments/<str:pk>/tally/` -> `n26-tally` in
+   `n26/core/views/owned.py`: `_own_assignment_or_404`, 404 for anything that is
+   not a `Counter`, signed `change`, `op.tally`, analytics, message, and a `back`
+   through `_safe_redirect`. `link_counters` fills the hrefs, called from
+   `edit_fighter` and nowhere else.
+5. **History.** `op.tally` writes the movement and where it landed into the
+   note; `_movement` in `n26/core/history.py` turns it into words, and `TALLIED`
+   joins `_NOTE_IS_MACHINERY` so the sentence does not print twice.
+6. **Gallery.** Counters on the sample card in `n26/designsystem/sampledata.py`
+   and a `Part` for the controls, so `/n26/design/c/model-card/` shows them.
+7. **Tests.** `TestWhatTheCardShows` and a new `TestMovingACounterByHand` in
+   `n26/tests/sandbox/test_counters.py`.

--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -443,6 +443,23 @@ def _one_act(e, row, viewer, alive):
     )
 
 
+def _movement(note):
+    """What a tally moved, as words: "— +1, now 4".
+
+    ``Operation.tally`` writes the movement and where it landed in front
+    of whatever reason the caller gave. An event from before it did —
+    or one whose note is only a reason — has no movement to state, and
+    says its reason alone.
+    """
+    movement, _, reason = note.partition(":")
+    change, arrow, standing = movement.partition(" → ")
+    if not arrow:
+        return (Span(f" — {note}"),) if note else ()
+    said = f" — {change}, now {standing}"
+    reason = reason.strip()
+    return (Span(f"{said} ({reason})"),) if reason else (Span(said),)
+
+
 def _tell(e, row, alive):
     """The sentence for one event, and which filter bucket it sits in.
 
@@ -515,7 +532,12 @@ def _tell(e, row, alive):
         case Kind.MOVED:
             return (Span("moved "), thing), "kit"
         case Kind.TALLIED:
-            return (Span("changed "), thing, *_for(model, at, "on")), "model"
+            return (
+                Span("changed "),
+                thing,
+                *_for(model, at, "on"),
+                *_movement(e.note),
+            ), "model"
         case Kind.RENAMED:
             was, _, now = e.note.rpartition(" → ")
             # About no model, so about the gang: the same act one level up.
@@ -607,9 +629,14 @@ def _for(model, at, word="for"):
 
 #: Kinds whose note is a record for the code rather than words for a
 #: reader — the figure a visit brought, the word that says one closed,
-#: the rank a fighter went as. The sentence has already said all three,
-#: and printing the note under it puts bookkeeping on the page.
-_NOTE_IS_MACHINERY = {Kind.TRADE_POINTS_SET, Kind.VISITED_TRADING_POST}
+#: the rank a fighter went as, what a tally moved and why. The sentence
+#: has already said all of them, and printing the note under it puts
+#: bookkeeping on the page.
+_NOTE_IS_MACHINERY = {
+    Kind.TRADE_POINTS_SET,
+    Kind.VISITED_TRADING_POST,
+    Kind.TALLIED,
+}
 
 
 def _shown_note(e):

--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -447,17 +447,16 @@ def _movement(note):
     """What a tally moved, as words: "— +1, now 4".
 
     ``Operation.tally`` writes the movement and where it landed in front
-    of whatever reason the caller gave. An event from before it did —
-    or one whose note is only a reason — has no movement to state, and
-    says its reason alone.
+    of whatever reason the caller gave. A note carrying only a reason,
+    or none at all, has no movement to state and gives its reason alone.
     """
     movement, _, reason = note.partition(":")
     change, arrow, standing = movement.partition(" → ")
     if not arrow:
         return (Span(f" — {note}"),) if note else ()
-    said = f" — {change}, now {standing}"
+    moved = f" — {change}, now {standing}"
     reason = reason.strip()
-    return (Span(f"{said} ({reason})"),) if reason else (Span(said),)
+    return (Span(f"{moved} ({reason})"),) if reason else (Span(moved),)
 
 
 def _tell(e, row, alive):

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -218,6 +218,26 @@ class NotOnOffer(Refusal):
 _UNASKED = object()
 
 
+def _movement_note(moved, reason):
+    """A tally's note: what moved, then why, inside the column's width.
+
+    The movement is the half that has to survive — an audit reads the
+    number, and the reason is the reader's own words about it — so a
+    reason too long to fit is what gives way. A caller can hand over a
+    great deal more than the column holds: an assignable's name and its
+    annotation are 200 characters each, and a rule that tallies passes
+    the pair of them as its reason.
+    """
+    from n26.core.models import LedgerEvent
+
+    if not reason:
+        return moved
+    room = LedgerEvent._meta.get_field("note").max_length - len(moved) - len(": ")
+    if len(reason) > room:
+        reason = reason[: max(0, room - 1)] + "…"
+    return f"{moved}: {reason}"
+
+
 class Operation:
     """Collects what it touched, so the boundary knows what to repin."""
 
@@ -1737,7 +1757,7 @@ class Operation:
         self.event(
             assignment,
             LedgerEvent.Kind.TALLIED,
-            note=f"{moved}: {note}" if note else moved,
+            note=_movement_note(moved, note),
         )
         return held.value
 

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -1719,14 +1719,26 @@ class Operation:
 
         ``change`` is signed; the value floors at zero. Every change is a
         ledger event, so the history of a Kill Count reads like the
-        history of anything else the gang owns.
+        history of anything else the gang owns — and carries what moved
+        and where it landed, which is what a reader auditing a number is
+        looking for. ``note`` is why, where the caller knows.
         """
         from n26.core.models import CounterValue, LedgerEvent
 
         held, _ = CounterValue.objects.get_or_create(assignment=assignment)
+        before = held.value
         held.value = max(0, held.value + change)
         held.save(update_fields=["value", "modified"])
-        self.event(assignment, LedgerEvent.Kind.TALLIED, note=note)
+        # What moved and where it landed, so the history can be read
+        # against the number on the card. The movement recorded is the
+        # one that happened rather than the one asked for: a subtraction
+        # that would go below zero stops at zero.
+        moved = f"{held.value - before:+d} → {held.value}"
+        self.event(
+            assignment,
+            LedgerEvent.Kind.TALLIED,
+            note=f"{moved}: {note}" if note else moved,
+        )
         return held.value
 
     def move(self, assignment, to, note=""):

--- a/n26/core/printing.py
+++ b/n26/core/printing.py
@@ -65,8 +65,15 @@ def detail_groups(card) -> list[DetailGroup]:
     hand, and the row spends space a reader needs for what the model can
     do. The screen card leaves it out for the same reason and sends a
     reader to Equip instead — this is the last surface that printed it.
+
+    The counters a model keeps lead, as they do on screen. Which of them
+    print is ``ModelCard.counter_lines``' decision: nothing on paper can
+    be changed, so an XP that has a cell in the statline above does not
+    draw a line here as well.
     """
     groups = []
+    for counter in card.counter_lines:
+        groups.append(DetailGroup(counter.name, str(counter.value)))
     if card.skills:
         groups.append(DetailGroup("Skills", ", ".join(s.name for s in card.skills)))
     if card.rules:

--- a/n26/core/printing.py
+++ b/n26/core/printing.py
@@ -66,14 +66,18 @@ def detail_groups(card) -> list[DetailGroup]:
     do. The screen card leaves it out for the same reason and sends a
     reader to Equip instead — this is the last surface that printed it.
 
-    The counters a model keeps lead, as they do on screen. Which of them
-    print is ``ModelCard.counter_lines``' decision: nothing on paper can
-    be changed, so an XP that has a cell in the statline above does not
-    draw a line here as well.
+    The counters a model keeps lead, as they do on screen — bar XP, which
+    has a cell in the statline above and would be saying the same number
+    twice. Nothing on paper can be changed, so the line XP draws on the
+    screen it is edited from has nothing to do here.
     """
     groups = []
     for counter in card.counter_lines:
-        groups.append(DetailGroup(counter.name, str(counter.value)))
+        # XP is in the statline above, with its target beside it. Skipped
+        # here rather than left to counter_lines, which keeps XP for a
+        # card whose lines can be moved — nothing on paper can be.
+        if not counter.is_xp:
+            groups.append(DetailGroup(counter.name, str(counter.value)))
     if card.skills:
         groups.append(DetailGroup("Skills", ", ".join(s.name for s in card.skills)))
     if card.rules:

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -128,6 +128,11 @@ class CounterLine:
     value: int
     assignment_id: str = ""
     href: str = ""
+    #: Whether this is the XP counter, decided where the counter itself is
+    #: to hand rather than re-derived from ``name`` — which is what a
+    #: reader sees, and carries the counter's annotation with it, so an
+    #: annotated XP would stop being recognised as XP.
+    is_xp: bool = False
 
 
 @dataclass
@@ -613,11 +618,7 @@ class ModelCard:
         hire preview — it would say the same number twice and is left
         out. Every other counter has no cell and draws either way.
         """
-        return [
-            line
-            for line in self.counters
-            if line.href or line.name.casefold() != XP_COUNTER.casefold()
-        ]
+        return [line for line in self.counters if line.href or not line.is_xp]
 
 
 @dataclass
@@ -1358,6 +1359,7 @@ def card_to_model_card(
             # tally moves — because the cell carries the target beside it
             # and a line has no room for one.
             standing = _counter_value(node)
+            is_xp = thing.name.casefold() == XP_COUNTER.casefold()
             counters.append(
                 CounterLine(
                     name=node.name,
@@ -1365,9 +1367,10 @@ def card_to_model_card(
                     assignment_id=(
                         str(node.assignment.pk) if node.assignment is not None else ""
                     ),
+                    is_xp=is_xp,
                 )
             )
-            if thing.name.casefold() == XP_COUNTER.casefold():
+            if is_xp:
                 counted_xp = standing
         elif node.is_profile:
             # A Legacy profile rides the card but is not drawn from: it is
@@ -1472,9 +1475,7 @@ def card_to_model_card(
         owned_by=owned_by,
         # XP first, then the rest in the order the card holds them: it is
         # the one every model keeps and the one a reader looks for.
-        counters=sorted(
-            counters, key=lambda line: line.name.casefold() != XP_COUNTER.casefold()
-        ),
+        counters=sorted(counters, key=lambda line: not line.is_xp),
         xp=xp if counted_xp is None else counted_xp,
         xp_target=xp_target,
     )

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -109,6 +109,28 @@ class AssignableLine:
 
 
 @dataclass
+class CounterLine:
+    """One counter a model keeps, drawn on its card.
+
+    A counter is a running number rather than a possession, so it draws
+    its own line and never appears among the kit — but it *is* an
+    assignment underneath, and ``assignment_id`` is what a control that
+    changes it posts to. Empty where the card depicts nobody (a hire
+    preview, a gallery sample).
+
+    ``href`` is where a change is posted, filled in by whoever knows the
+    URL space — like a choice's own href, and empty by default. A line
+    with none draws as a fact with nothing to click, which is what a
+    gang sheet, a print sheet and a hire preview all want.
+    """
+
+    name: str
+    value: int
+    assignment_id: str = ""
+    href: str = ""
+
+
+@dataclass
 class StatCell:
     """One characteristic on a card."""
 
@@ -475,6 +497,9 @@ class ModelCard:
     #: Collections this model can browse — equipment lists, trading posts.
     #: Access to buy from, not things owned; drawn apart from equipment.
     collections: list[AssignableLine] = field(default_factory=list)
+    #: The running numbers this model keeps — XP, a Spyrer's Kill Count.
+    #: Every one of them, XP included; ``counter_lines`` is what to draw.
+    counters: list[CounterLine] = field(default_factory=list)
     choices: list[ChoiceLine] = field(default_factory=list)
     #: Open questions filed into the card's own rows, kept apart from
     #: the general run. They are drawn in the Skills and Powers rows,
@@ -576,6 +601,23 @@ class ModelCard:
     def xp_display(self):
         """``13/19``, or ``13/–`` until ranks tell us the target."""
         return f"{self.xp}/{self.xp_target if self.xp_target is not None else '–'}"
+
+    @property
+    def counter_lines(self):
+        """The counters to draw — every one, bar an XP nobody can move.
+
+        XP has a cell in the statline already, and the cell is the better
+        reading: it carries the target beside the value. The line earns
+        its place only by being where the number is changed, so on a
+        screen that offers no control — a gang sheet, a print sheet, a
+        hire preview — it would say the same number twice and is left
+        out. Every other counter has no cell and draws either way.
+        """
+        return [
+            line
+            for line in self.counters
+            if line.href or line.name.casefold() != XP_COUNTER.casefold()
+        ]
 
 
 @dataclass
@@ -1168,6 +1210,7 @@ def card_to_model_card(
         "collections": [],
     }
     counted_xp = None
+    counters = []
 
     # A node chosen for a choice is drawn as that choice's row, not as a
     # loose piece of equipment as well. Questions filed to a row are the
@@ -1309,11 +1352,23 @@ def card_to_model_card(
             weapons.append(weapon_line(node, [node]))
         elif isinstance(thing, Counter):
             # A counter is a running number, not a possession, so it is
-            # never drawn as a piece of kit. XP has a cell of its own on
-            # the card and fills it from the counter's value — the value a
-            # hire opens at its printed Starting XP and every tally moves.
+            # never drawn as a piece of kit: it draws a line of its own.
+            # XP has a cell as well, and fills it from the same value —
+            # the value a hire opens at its printed Starting XP and every
+            # tally moves — because the cell carries the target beside it
+            # and a line has no room for one.
+            standing = _counter_value(node)
+            counters.append(
+                CounterLine(
+                    name=node.name,
+                    value=standing,
+                    assignment_id=(
+                        str(node.assignment.pk) if node.assignment is not None else ""
+                    ),
+                )
+            )
             if thing.name.casefold() == XP_COUNTER.casefold():
-                counted_xp = _counter_value(node)
+                counted_xp = standing
         elif node.is_profile:
             # A Legacy profile rides the card but is not drawn from: it is
             # not equipment either, so it falls off here until Legacy gets
@@ -1415,6 +1470,11 @@ def card_to_model_card(
             [*limit_notes(card, computed), *choice_notes(computed)] if computed else []
         ),
         owned_by=owned_by,
+        # XP first, then the rest in the order the card holds them: it is
+        # the one every model keeps and the one a reader looks for.
+        counters=sorted(
+            counters, key=lambda line: line.name.casefold() != XP_COUNTER.casefold()
+        ),
         xp=xp if counted_xp is None else counted_xp,
         xp_target=xp_target,
     )

--- a/n26/core/render_text.py
+++ b/n26/core/render_text.py
@@ -36,6 +36,10 @@ def render_model_card(card, indent=""):
         *render_statline(card.statline, indent=indent + "  "),
         f"{indent}  XP: {card.xp_display}",
     ]
+    # XP has its own line above, with the target on it, and so is not
+    # among these — see ModelCard.counter_lines.
+    for counter in card.counter_lines:
+        lines.append(f"{indent}  {counter.name}: {counter.value}")
     if card.weapons:
         lines.append(f"{indent}  Weapons:")
         for weapon in card.weapons:

--- a/n26/core/render_text.py
+++ b/n26/core/render_text.py
@@ -36,10 +36,13 @@ def render_model_card(card, indent=""):
         *render_statline(card.statline, indent=indent + "  "),
         f"{indent}  XP: {card.xp_display}",
     ]
-    # XP has its own line above, with the target on it, and so is not
-    # among these — see ModelCard.counter_lines.
+    # XP has its own line above, with the target on it. Skipped by name
+    # rather than left to counter_lines, which keeps XP for a card whose
+    # lines can be moved — nothing here can be, whatever the card was
+    # built for.
     for counter in card.counter_lines:
-        lines.append(f"{indent}  {counter.name}: {counter.value}")
+        if not counter.is_xp:
+            lines.append(f"{indent}  {counter.name}: {counter.value}")
     if card.weapons:
         lines.append(f"{indent}  Weapons:")
         for weapon in card.weapons:

--- a/n26/core/templates/cotton/n26/counter_controls.html
+++ b/n26/core/templates/cotton/n26/counter_controls.html
@@ -5,14 +5,13 @@
 
 Drawn beside the number on a card's counter line, and only where the line
 carries an address: a card that depicts nobody, a print sheet and the gang
-sheet all draw the number alone. Changing a counter quickly is a bulk act and
-belongs to a screen built for it; this is the single-model control on the
+sheet all draw the number alone. This is the single-model control, on the
 model's own page.
 
 One form, two buttons: each submits the same address with its own signed
-`change`, so the pair works with no script and posts what the bulk act will
-post later. Minus is not drawn at zero — the value floors there, so the
-control would be offering something that cannot happen.
+`change`, so the pair works with no script. Minus is not drawn at zero — the
+value floors there, so the control would be offering something that cannot
+happen.
 
   :counter — a n26.render.CounterLine.
 {% endcomment %}

--- a/n26/core/templates/cotton/n26/counter_controls.html
+++ b/n26/core/templates/cotton/n26/counter_controls.html
@@ -1,0 +1,44 @@
+{% comment %}
+<c-n26.counter-controls> — the way to move one counter up or down by one.
+
+    <c-n26.counter-controls :counter="counter" />
+
+Drawn beside the number on a card's counter line, and only where the line
+carries an address: a card that depicts nobody, a print sheet and the gang
+sheet all draw the number alone. Changing a counter quickly is a bulk act and
+belongs to a screen built for it; this is the single-model control on the
+model's own page.
+
+One form, two buttons: each submits the same address with its own signed
+`change`, so the pair works with no script and posts what the bulk act will
+post later. Minus is not drawn at zero — the value floors there, so the
+control would be offering something that cannot happen.
+
+  :counter — a n26.render.CounterLine.
+{% endcomment %}
+<c-vars :counter="None" />
+
+<form method="post" action="{{ counter.href }}" class="ms-1 inline-flex items-center gap-1 align-middle">
+    {% csrf_token %}
+    <input type="hidden" name="back" value="{{ request.get_full_path }}">
+    {% if counter.value %}
+        <c-ui.button type="submit"
+                     name="change"
+                     value="-1"
+                     size="xs"
+                     variant="default"
+                     class="py-0!"
+                     aria-label="Take one off {{ counter.name }}">
+            <span aria-hidden="true">&minus;</span>
+        </c-ui.button>
+    {% endif %}
+    <c-ui.button type="submit"
+                 name="change"
+                 value="1"
+                 size="xs"
+                 variant="default"
+                 class="py-0!"
+                 aria-label="Add one to {{ counter.name }}">
+        <span aria-hidden="true">+</span>
+    </c-ui.button>
+</form>

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -25,6 +25,28 @@ draw the same thing.
     the same line as the value.
     {% endcomment %}
     <dl class="grid grid-cols-[auto_1fr] items-baseline gap-x-5 gap-y-2 border-t border-box-border px-4 py-3 text-sm">
+        {% comment %}
+        The running numbers, above the rows that say what the model is and
+        carries: they sit under the statline strip, next to the XP cell in
+        it, so every tally reads as one block.
+
+        A line changes where it has an address and is a settled number
+        everywhere else, so the gang sheet, a print sheet and a hire
+        preview all draw the same block with nothing to click. Which
+        lines those are is ModelCard.counter_lines' decision, not this
+        template's — an XP nobody can move is the cell above and nothing
+        here.
+        {% endcomment %}
+        {% for counter in card.counter_lines %}
+            <dt class="font-semibold text-ink-900 dark:text-ink-100">{{ counter.name }}</dt>
+            <dd class="min-w-0 tabular-nums text-ink-900 dark:text-ink-100">
+                {{ counter.value }}
+                {% if counter.href %}
+                    <c-n26.counter-controls :counter="counter" />
+                {% endif %}
+            </dd>
+        {% endfor %}
+
         <dt class="font-semibold text-ink-900 dark:text-ink-100">Skills</dt>
         <dd class="min-w-0 text-ink-900 dark:text-ink-100">
             <c-n26.assignable-lines :lines="card.skills" :ratings="False" />

--- a/n26/core/views/__init__.py
+++ b/n26/core/views/__init__.py
@@ -55,6 +55,7 @@ from n26.core.views.owned import (
     refund_assignment,
     remove_assignment,
     sell_assignment,
+    tally_counter,
 )
 from n26.core.views.printing import print_gang, print_setup
 
@@ -102,4 +103,5 @@ __all__ = [
     "remove_assignment",
     "rename_fighter",
     "sell_assignment",
+    "tally_counter",
 ]

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -554,10 +554,9 @@ def edit_fighter(request, pk):
     )
     if card is None:
         raise Http404("No such model")
-    # Only here. A counter is drawn wherever a card is, and moved on the
-    # model's own page: doing it quickly, for a whole roster after a
-    # battle, is a screen built for that and not a control the gang
-    # sheet grows.
+    # Only here. A counter is drawn wherever a card is; the model's own
+    # page is the one place it is moved, so this is the one place the
+    # lines are given addresses.
     link_counters(card)
 
     subtype_edits, subtype_more, subtype_edits_dirty = _edits_offer(

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -311,6 +311,7 @@ def edit_fighter(request, pk):
     from n26.core.views.gangs import _fighter_named
     from n26.core.views.htmx import is_htmx, stay_or_redirect
     from n26.core.views.learn import apply_ticks, link_skills, skills_offer
+    from n26.core.views.owned import link_counters
 
     miniature = _own_miniature_or_404(request, pk)
     gang = miniature.membership.gang
@@ -553,6 +554,11 @@ def edit_fighter(request, pk):
     )
     if card is None:
         raise Http404("No such model")
+    # Only here. A counter is drawn wherever a card is, and moved on the
+    # model's own page: doing it quickly, for a whole roster after a
+    # battle, is a screen built for that and not a control the gang
+    # sheet grows.
+    link_counters(card)
 
     subtype_edits, subtype_more, subtype_edits_dirty = _edits_offer(
         own, computed, "subtype", "Subtypes"

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -73,6 +73,24 @@ from n26.core.owned import (
 from n26.core.views.htmx import is_htmx, no_update
 from n26.core.views.permissions import _own_assignment_or_404, _safe_redirect
 
+#: The largest step this address will take, either way. The control posts
+#: one; the bulk act that comes later will post a handful.
+MOST_A_TALLY_MOVES = 1000
+
+
+def link_counters(card):
+    """Point every counter line on this card at what changes it.
+
+    Costs no queries: the line already carries the assignment behind it,
+    and this only turns it into a URL. A line with none keeps an empty
+    href and draws as a number with nothing to click — which is right
+    for a card depicting nobody, and for every screen that shows a
+    counter without offering to move it.
+    """
+    for line in card.counters:
+        if line.assignment_id:
+            line.href = reverse("n26-tally", args=[line.assignment_id])
+
 
 def _possession_or_404(request, pk):
     """One of the viewer's own assignments, and one these acts are *about*.
@@ -995,3 +1013,68 @@ def refund_assignment(request, pk):
     )
     messages.success(request, f"Refunded {name} — {paid}¢ back.")
     return _acted(request, touched, gang, back)
+
+
+@login_required
+@require_POST
+def tally_counter(request, pk):
+    """Move one counter up or down.
+
+    ``change`` is signed and the value floors at zero, both of which are
+    ``Operation.tally``'s — so a stale control that offers a subtraction
+    a later reader has already made impossible takes the value to zero
+    rather than below it.
+
+    The same address serves a model's counter and the gang's own: what
+    is being changed is the assignment, and who is carrying it is its
+    business. Only counters, though — every other assignment has verbs
+    of its own, and none of them is a running number.
+
+    Written a step at a time on purpose. The rulebook's own acts move
+    these by more (a Spyrer spends four Kill Count on Suit Evolution),
+    and doing that in one go — with a note saying why — is the dialog
+    this control makes room for rather than replaces.
+    """
+    from n26.analytics import EventVerb, N26Noun, record
+    from n26.core.operations import Refusal, operation
+    from n26.library.models import Counter
+
+    assignment = _own_assignment_or_404(request, pk)
+    if not isinstance(assignment.assignable, Counter):
+        raise Http404("Not a counter")
+    gang = assignment.gang_root
+    miniature = assignment.miniature_root
+    name = str(assignment.assignable)
+    back = request.POST.get("back", "")[:500]
+    here = reverse("n26-gang", args=[gang.pk])
+
+    try:
+        change = int(request.POST.get("change", ""))
+    except ValueError:
+        raise Http404("Not a change to make") from None
+    if abs(change) > MOST_A_TALLY_MOVES:
+        # A counter's value is a database integer, and a number past what
+        # one holds would be a 500 rather than a refusal. Nothing offers
+        # a step anywhere near this, so it is a bound and not a rule.
+        raise Http404("Not a change to make")
+
+    try:
+        with operation(gang, actor=request.user) as op:
+            standing = op.tally(assignment, change)
+    except Refusal as refusal:
+        messages.error(request, str(refusal))
+        return _safe_redirect(request, back, here)
+
+    record(
+        request,
+        N26Noun.ASSIGNMENT,
+        EventVerb.UPDATE,
+        assignment,
+        gang_id=str(gang.pk),
+        miniature_id=str(miniature.pk) if miniature else None,
+        thing=name,
+        action="tally",
+        change=change,
+    )
+    messages.success(request, f"{name} is now {standing}.")
+    return _safe_redirect(request, back, here)

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -1,6 +1,6 @@
 """What a fighter already owns — selling it, handing it on, taking it off.
 
-Six acts, six addresses, one shape each: a POST names the assignment
+Seven acts, seven addresses, one shape each: a POST names the assignment
 in its path, an ``operation`` writes it, and the reader lands back where
 they clicked. They are addressed by *assignment* rather than by
 fighter, because that is what they are about — a weapon on a fighter, a
@@ -73,8 +73,8 @@ from n26.core.owned import (
 from n26.core.views.htmx import is_htmx, no_update
 from n26.core.views.permissions import _own_assignment_or_404, _safe_redirect
 
-#: The largest step this address will take, either way. The control posts
-#: one; the bulk act that comes later will post a handful.
+#: The largest step this address will take, either way. Far above any
+#: step a control offers, and far below what the column holds.
 MOST_A_TALLY_MOVES = 1000
 
 
@@ -1030,10 +1030,9 @@ def tally_counter(request, pk):
     business. Only counters, though — every other assignment has verbs
     of its own, and none of them is a running number.
 
-    Written a step at a time on purpose. The rulebook's own acts move
-    these by more (a Spyrer spends four Kill Count on Suit Evolution),
-    and doing that in one go — with a note saying why — is the dialog
-    this control makes room for rather than replaces.
+    A step at a time. The rulebook's own acts move these by more — a
+    Spyrer spends four Kill Count on Suit Evolution — and ``change``
+    being signed and free is what lets one address serve both.
     """
     from n26.analytics import EventVerb, N26Noun, record
     from n26.core.operations import Refusal, operation
@@ -1052,10 +1051,12 @@ def tally_counter(request, pk):
         change = int(request.POST.get("change", ""))
     except ValueError:
         raise Http404("Not a change to make") from None
-    if abs(change) > MOST_A_TALLY_MOVES:
-        # A counter's value is a database integer, and a number past what
-        # one holds would be a 500 rather than a refusal. Nothing offers
-        # a step anywhere near this, so it is a bound and not a rule.
+    if not change or abs(change) > MOST_A_TALLY_MOVES:
+        # Zero moves nothing, and writing an event to say so fills a
+        # gang's history with rows that record nothing happening. The
+        # bound beside it is because a counter's value is a database
+        # integer: a number past what one holds would be a 500 rather
+        # than a refusal, and no control offers a step anywhere near it.
         raise Http404("Not a change to make")
 
     try:

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1868,7 +1868,10 @@ GROUPS: list[Group] = [
                     "settled, an open one being information rather than an error. "
                     "Every control is drawn from an href on the structure, so a "
                     "print sheet and a hire preview draw none of them without "
-                    "asking. A stored model's card is three segmented tabs — Card, "
+                    "asking — the counter lines included, which draw as settled "
+                    "numbers wherever nobody may move them. XP is both a line "
+                    "and a cell in the statline: the cell carries the target "
+                    "beside it, the line is where the number is changed. A stored model's card is three segmented tabs — Card, "
                     "then Lore and Notes, the sections a player writes; a card with "
                     "no id (a preview, a picker option) draws the body plain. "
                     "Two modes: gang, the sheet's — dense, with the open "
@@ -1907,6 +1910,13 @@ GROUPS: list[Group] = [
                         "c-n26.model-card.prose",
                         "n26/model_card/prose.html",
                         "A written section of a card: the Lore and Notes panels.",
+                    ),
+                    Part(
+                        "c-n26.counter-controls",
+                        "n26/counter_controls.html",
+                        "The pair that moves one counter a step either way. "
+                        "Drawn only where the line carries an address, and "
+                        "without the minus at zero.",
                     ),
                 ),
             ),

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -34,6 +34,7 @@ from n26.core.render import (
     ChoiceOffer,
     Choosable,
     ChoosableGroup,
+    CounterLine,
     EffectLine,
     GangSheet,
     ModelCard,
@@ -1513,6 +1514,19 @@ def model_card():
             ),
         ],
         owned_by="tom",
+        # The running numbers. XP is here as well as in the statline's own
+        # cell: the cell carries the target beside it, and the line is
+        # where the number is changed. A line with an href grows the pair
+        # of controls; without one it is a settled number, which is what
+        # the gang sheet and a print sheet draw. The addresses here go
+        # nowhere, as every href in this gallery does.
+        counters=[
+            CounterLine(name="XP", value=61, assignment_id="xp", href="#"),
+            CounterLine(name="Kill Count", value=3, assignment_id="kills", href="#"),
+            # At zero, so the demo shows that the minus is not drawn: the
+            # value floors there and the control would offer nothing.
+            CounterLine(name="Glitch Count", value=0, assignment_id="glitch", href="#"),
+        ],
         xp=61,
         xp_target=79,
     )

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1514,18 +1514,18 @@ def model_card():
             ),
         ],
         owned_by="tom",
-        # The running numbers. XP is here as well as in the statline's own
-        # cell: the cell carries the target beside it, and the line is
-        # where the number is changed. A line with an href grows the pair
-        # of controls; without one it is a settled number, which is what
-        # the gang sheet and a print sheet draw. The addresses here go
-        # nowhere, as every href in this gallery does.
+        # The running numbers, as every card but one draws them: settled
+        # values with nothing to click. XP keeps no line here — it has a
+        # cell in the statline with its target beside it, and the line
+        # exists only to be the control. model_card_editable() is the
+        # card that carries the addresses.
         counters=[
-            CounterLine(name="XP", value=61, assignment_id="xp", href="#"),
-            CounterLine(name="Kill Count", value=3, assignment_id="kills", href="#"),
-            # At zero, so the demo shows that the minus is not drawn: the
-            # value floors there and the control would offer nothing.
-            CounterLine(name="Glitch Count", value=0, assignment_id="glitch", href="#"),
+            CounterLine(name="XP", value=61, assignment_id="xp", is_xp=True),
+            CounterLine(name="Kill Count", value=3, assignment_id="kills"),
+            # At zero, so the editable card shows that the minus is not
+            # drawn: the value floors there and the control would offer
+            # nothing.
+            CounterLine(name="Glitch Count", value=0, assignment_id="glitch"),
         ],
         xp=61,
         xp_target=79,
@@ -1954,6 +1954,21 @@ CARD_IMAGE = (
 def model_card_written():
     """The sample card with its picture and its Lore and Notes tabs filled."""
     return replace(model_card(), notes=CARD_NOTES, lore=CARD_LORE, image_url=CARD_IMAGE)
+
+
+def model_card_editable():
+    """The sample card as the model's own page draws it: its counters
+    carry addresses, so the lines grow their controls and XP joins them.
+
+    A card of its own rather than a flag on the base one, because the
+    base card is what the gang sheet, the hire previews and the print
+    specimens are all built from, and none of those may offer to change
+    a number. The addresses go nowhere, as every href in this gallery
+    does.
+    """
+    card = replace(model_card())
+    card.counters = [replace(line, href="#") for line in card.counters]
+    return card
 
 
 def gang_sheet_context():

--- a/n26/designsystem/templates/designsystem/demos/model-card/50-edit.html
+++ b/n26/designsystem/templates/designsystem/demos/model-card/50-edit.html
@@ -1,6 +1,6 @@
 {# title: Edit mode #}
-{# note: mode="edit" is the model's own page: the choice buttons the gang sheet holds back come out, and the Gear row and the Weapons header each carry the way to the Equip tab. Same card and same data as the sheet draws. #}
+{# note: mode="edit" is the model's own page: the choice buttons the gang sheet holds back come out, and the Gear row and the Weapons header each carry the way to the Equip tab. The counter lines carry addresses here and nowhere else, so this is the only card that offers to move a number — and the only one XP draws a line on, since the statline cell above already says 61/79. Glitch Count sits at zero and draws no minus. #}
 {# layout: full #}
 <div class="max-w-2xl">
-    <c-n26.model-card :card="model_card" mode="edit" equip_href="#equip" />
+    <c-n26.model-card :card="model_card_editable" mode="edit" equip_href="#equip" />
 </div>

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -348,7 +348,7 @@ class TestTheShellStillDraws:
         assert "Choose one, or none" in page
 
 
-class TestTheGallerysCounterLines:
+class TestCounterLinesInTheGallery:
     """Only one sample card offers to move a number.
 
     The base sample is what the gang sheet's sample, the hire previews

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -348,6 +348,43 @@ class TestTheShellStillDraws:
         assert "Choose one, or none" in page
 
 
+class TestTheGallerysCounterLines:
+    """Only one sample card offers to move a number.
+
+    The base sample is what the gang sheet's sample, the hire previews
+    and the print specimens are all built from, so an address on its
+    counters would put a pair of buttons on every one of them — screens
+    that never carry the control in the app. It would also give XP a
+    line beside the statline cell that already holds it, which is the
+    doubled reading the card exists to avoid.
+    """
+
+    def test_the_base_sample_offers_nothing_to_click(self):
+        from n26.designsystem import sampledata
+
+        assert all(not line.href for line in sampledata.model_card().counter_lines)
+
+    def test_the_base_sample_keeps_xp_to_its_cell(self):
+        from n26.designsystem import sampledata
+
+        assert not [
+            line for line in sampledata.model_card().counter_lines if line.is_xp
+        ]
+
+    def test_the_gang_sheets_members_offer_nothing_either(self):
+        from n26.designsystem import sampledata
+
+        member = sampledata.gang_sheet().models[0]
+        assert all(not line.href for line in member.counter_lines)
+
+    def test_the_editable_sample_carries_every_line_and_its_address(self):
+        from n26.designsystem import sampledata
+
+        lines = sampledata.model_card_editable().counter_lines
+        assert [line.name for line in lines] == ["XP", "Kill Count", "Glitch Count"]
+        assert all(line.href for line in lines)
+
+
 class TestTheModelCardsTooltips:
     """The card's tooltips are real components, never a native title —
     which shows only under a mouse and never on touch."""

--- a/n26/designsystem/views.py
+++ b/n26/designsystem/views.py
@@ -95,6 +95,7 @@ def component(request, slug):
             "rich_text_form": rich_text_form,
             "unsafe_html": UNSAFE_HTML,
             "model_card": sampledata.model_card(),
+            "model_card_editable": sampledata.model_card_editable(),
             "model_card_written": sampledata.model_card_written(),
             "needs_rich_text": needs_rich_text,
             # The icon gallery renders the registry rather than a written-out
@@ -191,6 +192,7 @@ def view_preview(request, slug):
             "component": found,
             "demo_template": found.demos[0].template_name,
             "model_card": sampledata.model_card(),
+            "model_card_editable": sampledata.model_card_editable(),
             "model_card_written": sampledata.model_card_written(),
             # The same test the component page makes: a view whose demo
             # draws an editor brings TinyMCE with it, and only then.

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -43,7 +43,7 @@ def xp(db):
 
 @pytest.fixture
 def kills(db):
-    """A Spyrer's second counter — the one the card drew nowhere."""
+    """A second counter, so a card has to keep more than one."""
     return create_counter("Kill Count")
 
 
@@ -77,7 +77,11 @@ def queen(make_profile, xp, gang_type):
 
 
 def xp_row(miniature):
-    return Assignment.objects.get(miniature=miniature, counter__isnull=False)
+    return Assignment.objects.get(miniature=miniature, counter__name="XP")
+
+
+def kill_row(miniature):
+    return Assignment.objects.get(miniature=miniature, counter__name="Kill Count")
 
 
 def drawn(miniature):
@@ -134,14 +138,18 @@ class TestWhatTheCardShows:
 
         assert [line.name for line in drawn(yolanda)[0].equipment] == []
 
-    def test_a_counter_draws_a_line_of_its_own(self, gang, queen):
-        """The bug this class was written for, in its second half: a
-        Spyrer's Kill Count was granted, stored and tallied, and appeared
-        on no card at all."""
+    def test_a_counter_draws_a_line_of_its_own(self, gang, queen, kills):
+        """Every counter a model keeps is a line on their card. A
+        Spyrer's Kill Count is granted, stored and tallied like any
+        other, and reads on the card like any other."""
+        from n26.tests.sandbox.actions import assign
+
         yolanda = hire_with_option(gang, queen, "Yolanda")
+        assign(kills, miniature=yolanda)
 
         assert [(line.name, line.value) for line in drawn(yolanda)[0].counters] == [
-            ("XP", 61)
+            ("XP", 61),
+            ("Kill Count", 0),
         ]
 
     def test_the_line_follows_the_tally(self, gang, queen):
@@ -200,9 +208,9 @@ class TestWhatTheCardShows:
 class TestMovingACounterByHand:
     """The control on the model's own page, and the address behind it.
 
-    Nothing could change a counter before this: ``tally`` had one caller,
-    a rule firing off an assignment. XP included — a fighter could earn
-    none, and a Spyrer's Kill Count could only be watched.
+    A counter is drawn wherever a card is and moved in one place. The
+    same address serves XP, a Spyrer's Kill Count and the gang's own
+    tallies, because what it names is the assignment.
     """
 
     def address(self, miniature):
@@ -314,6 +322,26 @@ class TestMovingACounterByHand:
 
         assert response.status_code == 404
 
+    def test_a_step_of_nothing_is_not_an_act(self, client, gang, queen):
+        """It would write a ledger event recording that nothing
+        happened. No control offers it; a crafted post is refused."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        response = client.post(self.address(yolanda), {"change": "0"})
+
+        assert response.status_code == 404
+        assert not xp_row(yolanda).ledger_events.filter(kind="tallied").exists()
+
+    def test_a_step_past_what_the_column_holds_is_refused(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        response = client.post(self.address(yolanda), {"change": "99999999999"})
+
+        assert response.status_code == 404
+        assert xp_row(yolanda).counter_value.value == 61
+
     def test_a_change_that_is_not_a_number_is_no_address_at_all(
         self, client, gang, queen
     ):
@@ -324,6 +352,108 @@ class TestMovingACounterByHand:
 
         assert response.status_code == 404
         assert xp_row(yolanda).counter_value.value == 61
+
+
+class TestTheOtherSurfaces:
+    """Print and text draw the same counters the screen card draws.
+
+    Both read ``counter_lines``, so neither can disagree with the card
+    about which counters a model keeps — nor about XP, which has a cell
+    in the statline on all three and draws a line on none of them.
+    """
+
+    def test_the_text_card_lists_them(self, gang, queen, kills):
+        from n26.core.render_text import render_model_card
+        from n26.tests.sandbox.actions import assign
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        assign(kills, miniature=yolanda)
+        tally(kill_row(yolanda), +3)
+
+        assert "Kill Count: 3" in "\n".join(render_model_card(drawn(yolanda)[0]))
+
+    def test_the_text_card_keeps_xp_to_its_own_line(self, gang, queen):
+        from n26.core.render_text import render_model_card
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+
+        told = render_model_card(drawn(yolanda)[0])
+        assert len([line for line in told if "XP" in line]) == 1
+
+    def test_the_print_sheet_leads_with_them(self, gang, queen, kills):
+        from n26.core.printing import detail_groups
+        from n26.tests.sandbox.actions import assign
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        assign(kills, miniature=yolanda)
+
+        groups = detail_groups(drawn(yolanda)[0])
+        assert (groups[0].label, groups[0].text) == ("Kill Count", "0")
+
+    def test_the_print_sheet_says_xp_once(self, gang, queen):
+        """It has a cell in the statline above, and a card somebody cuts
+        out has no room to say a number twice."""
+        from n26.core.printing import detail_groups
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+
+        assert not [
+            group for group in detail_groups(drawn(yolanda)[0]) if group.label == "XP"
+        ]
+
+
+class TestWhatTheHistorySays:
+    """A tally drawn as a sentence: what moved, and where it landed.
+
+    The number on the card is the only thing a reader can check the log
+    against, so the log has to state it.
+    """
+
+    def told(self, gang):
+        from n26.core import history
+
+        return [
+            "".join(span.text for span in act.spans)
+            for act in history.build(gang, viewer=gang.owner)
+        ]
+
+    def test_it_says_what_moved_and_where_it_landed(self, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), +5)
+
+        assert any(
+            "changed XP" in told and "+5, now 66" in told for told in self.told(gang)
+        )
+
+    def test_a_step_that_hit_the_floor_says_where_it_stopped(self, gang, queen):
+        """The movement stated is the one that happened, not the one
+        asked for."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), -100)
+
+        assert any("-61, now 0" in told for told in self.told(gang))
+
+    def test_what_caused_it_rides_along(self, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), +5, note="won a battle")
+
+        assert any("(won a battle)" in told for told in self.told(gang))
+
+    def test_the_note_is_not_printed_under_the_sentence_as_well(self, gang, queen):
+        """The sentence already holds both halves of it."""
+        from n26.core import history
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), +5, note="won a battle")
+
+        # Spans carry their own spacing, so the phrase only reads whole
+        # once they are joined.
+        tallied = [
+            act
+            for act in history.build(gang, viewer=gang.owner)
+            if "changed XP" in "".join(span.text for span in act.spans)
+        ]
+        assert tallied and all(not act.note for act in tallied)
 
 
 class TestEffectsHangOffValues:
@@ -414,9 +544,8 @@ class TestARuleThatMovesACounter:
         assign(leader_mark, miniature=yolanda)
 
         event = xp_row(yolanda).ledger_events.filter(kind="tallied").latest("created")
-        # What moved and where it landed, then what caused it: a reader
-        # auditing the number wants both, and the source alone answers
-        # only half of it.
+        # What moved and where it landed, then what caused it. A reader
+        # auditing the number needs both halves.
         assert event.note == "+0 → 61: Chosen Leader"
 
     def test_add_and_subtract_move_it_relative(self, gang, xp, make_profile):

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -11,6 +11,7 @@ one ledger event per change.
 
 import pytest
 from django.contrib.auth.models import User
+from django.urls import reverse
 
 from n26.core.card import build_card, build_modifier_index
 from n26.core.effects import compute
@@ -38,6 +39,12 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def xp(db):
     return create_counter("XP")
+
+
+@pytest.fixture
+def kills(db):
+    """A Spyrer's second counter — the one the card drew nowhere."""
+    return create_counter("Kill Count")
 
 
 @pytest.fixture
@@ -126,6 +133,197 @@ class TestWhatTheCardShows:
         yolanda = hire_with_option(gang, queen, "Yolanda")
 
         assert [line.name for line in drawn(yolanda)[0].equipment] == []
+
+    def test_a_counter_draws_a_line_of_its_own(self, gang, queen):
+        """The bug this class was written for, in its second half: a
+        Spyrer's Kill Count was granted, stored and tallied, and appeared
+        on no card at all."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+
+        assert [(line.name, line.value) for line in drawn(yolanda)[0].counters] == [
+            ("XP", 61)
+        ]
+
+    def test_the_line_follows_the_tally(self, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), +5)
+
+        assert drawn(yolanda)[0].counters[0].value == 66
+
+    def test_xp_leads_however_the_card_holds_them(self, gang, queen, kills):
+        """XP first: it is the one every model keeps and the one a
+        reader looks for."""
+        from n26.tests.sandbox.actions import assign
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        assign(kills, miniature=yolanda)
+
+        assert [line.name for line in drawn(yolanda)[0].counters] == [
+            "XP",
+            "Kill Count",
+        ]
+
+    def test_a_line_carries_the_assignment_behind_it(self, gang, queen):
+        """What a control posts to. A card built from library alone has
+        none, which is how it says there is nothing here to change."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+
+        assert drawn(yolanda)[0].counters[0].assignment_id == str(xp_row(yolanda).pk)
+
+    def test_a_line_has_no_address_until_somebody_gives_it_one(self, gang, queen):
+        """Every control is drawn from an href, and nothing here fills
+        one: a gang sheet and a print sheet draw settled numbers."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+
+        assert drawn(yolanda)[0].counters[0].href == ""
+
+    def test_an_xp_nobody_can_move_is_the_cell_and_not_a_line(self, gang, queen, kills):
+        """XP has a cell with its target in it. The line earns its place
+        by being where the number is changed, so where nothing can be
+        changed it would only say 61 twice."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        from n26.tests.sandbox.actions import assign
+
+        assign(kills, miniature=yolanda)
+        card = drawn(yolanda)[0]
+
+        assert [line.name for line in card.counter_lines] == ["Kill Count"]
+
+    def test_it_is_a_line_again_once_it_can_be_moved(self, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        card = drawn(yolanda)[0]
+        card.counters[0].href = "/somewhere/"
+
+        assert [line.name for line in card.counter_lines] == ["XP"]
+
+
+class TestMovingACounterByHand:
+    """The control on the model's own page, and the address behind it.
+
+    Nothing could change a counter before this: ``tally`` had one caller,
+    a rule firing off an assignment. XP included — a fighter could earn
+    none, and a Spyrer's Kill Count could only be watched.
+    """
+
+    def address(self, miniature):
+        """Where this model's XP is moved from."""
+        row = Assignment.objects.get(miniature=miniature, counter__name="XP")
+        return reverse("n26-tally", args=[row.pk])
+
+    def test_the_models_own_page_offers_the_control(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.get(reverse("n26-edit-fighter", args=[yolanda.pk]))
+
+        assert self.address(yolanda) in page.content.decode()
+
+    def test_the_gang_sheet_does_not(self, client, gang, queen, kills):
+        """Changing these quickly, for a roster at a time after a battle,
+        is a screen built for it — not a control the sheet grows."""
+        from n26.tests.sandbox.actions import assign
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        counted = assign(kills, miniature=yolanda)
+        client.force_login(gang.owner)
+
+        page = client.get(reverse("n26-gang", args=[gang.pk]))
+
+        drawn_there = page.content.decode()
+        # The number is on the sheet; the way to change it is not.
+        assert "Kill Count" in drawn_there
+        assert reverse("n26-tally", args=[counted.pk]) not in drawn_there
+
+    def test_a_step_up_moves_it(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        client.post(self.address(yolanda), {"change": "1"})
+
+        assert xp_row(yolanda).counter_value.value == 62
+
+    def test_a_step_down_moves_it_back(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        client.post(self.address(yolanda), {"change": "-1"})
+
+        assert xp_row(yolanda).counter_value.value == 60
+
+    def test_it_floors_at_zero(self, client, gang, queen):
+        """The floor is ``tally``'s own, so a control that has gone
+        stale takes the value to zero rather than below it."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), -61)
+        client.force_login(gang.owner)
+
+        client.post(self.address(yolanda), {"change": "-1"})
+
+        assert xp_row(yolanda).counter_value.value == 0
+
+    def test_the_change_is_a_ledger_event(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        client.post(self.address(yolanda), {"change": "1"})
+
+        event = xp_row(yolanda).ledger_events.filter(kind="tallied").latest("created")
+        assert event.note == "+1 → 62"
+
+    def test_it_returns_to_the_page_the_click_came_from(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        back = reverse("n26-edit-fighter", args=[yolanda.pk])
+        client.force_login(gang.owner)
+
+        response = client.post(self.address(yolanda), {"change": "1", "back": back})
+
+        assert response.status_code == 302
+        assert response["Location"] == back
+
+    def test_it_will_not_be_sent_somewhere_else(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        response = client.post(
+            self.address(yolanda), {"change": "1", "back": "https://elsewhere.test/"}
+        )
+
+        assert response["Location"] == reverse("n26-gang", args=[gang.pk])
+
+    def test_somebody_elses_counter_is_not_theirs_to_move(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(User.objects.create_user("interloper"))
+
+        response = client.post(self.address(yolanda), {"change": "1"})
+
+        assert response.status_code == 404
+        assert xp_row(yolanda).counter_value.value == 61
+
+    def test_only_counters_are_tallied(self, client, gang, queen):
+        """Every other assignment has verbs of its own, and none of them
+        is a running number."""
+        from n26.tests.sandbox.actions import assign
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        not_a_counter = assign(create_rule("Bonded to the Rig"), miniature=yolanda)
+        client.force_login(gang.owner)
+
+        response = client.post(
+            reverse("n26-tally", args=[not_a_counter.pk]), {"change": "1"}
+        )
+
+        assert response.status_code == 404
+
+    def test_a_change_that_is_not_a_number_is_no_address_at_all(
+        self, client, gang, queen
+    ):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        response = client.post(self.address(yolanda), {"change": "lots"})
+
+        assert response.status_code == 404
+        assert xp_row(yolanda).counter_value.value == 61
 
 
 class TestEffectsHangOffValues:
@@ -216,7 +414,10 @@ class TestARuleThatMovesACounter:
         assign(leader_mark, miniature=yolanda)
 
         event = xp_row(yolanda).ledger_events.filter(kind="tallied").latest("created")
-        assert event.note == "Chosen Leader"
+        # What moved and where it landed, then what caused it: a reader
+        # auditing the number wants both, and the source alone answers
+        # only half of it.
+        assert event.note == "+0 → 61: Chosen Leader"
 
     def test_add_and_subtract_move_it_relative(self, gang, xp, make_profile):
         from n26.tests.sandbox.actions import (

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -444,6 +444,20 @@ class TestTheOtherSurfaces:
             group for group in detail_groups(drawn(yolanda)[0]) if group.label == "XP"
         ]
 
+    def test_neither_repeats_xp_for_a_card_that_could_be_edited(self, gang, queen):
+        """Paper and text carry no controls, so the line XP draws on the
+        screen it is edited from has nothing to do on either."""
+        from n26.core.printing import detail_groups
+        from n26.core.render_text import render_model_card
+        from n26.core.views.owned import link_counters
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        card = drawn(yolanda)[0]
+        link_counters(card)
+
+        assert not [group for group in detail_groups(card) if group.label == "XP"]
+        assert len([line for line in render_model_card(card) if "XP" in line]) == 1
+
 
 class TestWhatTheHistorySays:
     """A tally drawn as a sentence: what moved, and where it landed.

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -354,6 +354,49 @@ class TestMovingACounterByHand:
         assert xp_row(yolanda).counter_value.value == 61
 
 
+class TestTheNoteFitsTheColumn:
+    """A tally's note is a fixed-width column, and a caller can hand over
+    more than it holds.
+
+    A rule that tallies passes the thing carrying it as the reason, and
+    an assignable's name and annotation are 200 characters each — so a
+    reason can arrive at over 400 into a column of 255. The movement is
+    the half an audit reads, so it is the reason that gives way.
+    """
+
+    def note_of(self, miniature):
+        return (
+            xp_row(miniature)
+            .ledger_events.filter(kind="tallied")
+            .latest("created")
+            .note
+        )
+
+    def test_a_long_reason_is_cut_to_fit(self, gang, queen):
+        from n26.core.models import LedgerEvent
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), +1, note="x" * 400)
+
+        held = self.note_of(yolanda)
+        assert len(held) <= LedgerEvent._meta.get_field("note").max_length
+        assert held.startswith("+1 → 62: xxx")
+        assert held.endswith("…")
+
+    def test_the_movement_survives_it(self, gang, queen):
+        """What the number did is what the log is for."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), -1, note="y" * 400)
+
+        assert self.note_of(yolanda).startswith("-1 → 60: ")
+
+    def test_a_reason_that_fits_is_left_alone(self, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        tally(xp_row(yolanda), +1, note="won a battle")
+
+        assert self.note_of(yolanda) == "+1 → 62: won a battle"
+
+
 class TestTheOtherSurfaces:
     """Print and text draw the same counters the screen card draws.
 

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -153,6 +153,13 @@ urlpatterns = [
         views.rechoose_assignment,
         name="n26-rechoose",
     ),
+    # A counter moved by hand. Addressed by the assignment like the acts
+    # above, so one route serves a model's tallies and the gang's.
+    path(
+        "assignments/<str:pk>/tally/",
+        views.tally_counter,
+        name="n26-tally",
+    ),
     path("gangs/<str:pk>/print/setup/", views.print_setup, name="n26-print-setup"),
     path("gangs/<str:pk>/print/", views.print_gang, name="n26-print"),
     path("design/", include("n26.designsystem.urls")),


### PR DESCRIPTION
A Spyre Hunt Master hired into a new gang gets Kill Count and Glitch Count as
built-in grants from their subtype, alongside XP. The grants land correctly and
the values are stored, but no card has ever drawn either of them.

Two gaps, one behind the other:

- `card_to_model_card` dropped every counter that was not XP, and `ModelCard`
  had no field to put one in. Counters appeared only on the gang's own sheet,
  which reads gang-hosted counters, so a model's never reached a screen.
- Nothing could change one by hand. `Operation.tally` had a single caller — a
  Tally modifier firing off an assignment — with no view and no route behind it.
  XP included: there was no way to give a fighter experience.

## What this adds

Every counter a model keeps now draws a line on their card: gang sheet, the
model's own page, print sheet and text sheet.

On the model's Edit page each line grows a minus and a plus. The minus is not
drawn at zero, because the value floors there and the control would be offering
something that cannot happen. The controls ride the card's existing `edit` mode,
the same switch that brings out Equip and the Choose buttons, so the gang sheet
keeps its own rule that its controls live in the actions slot. Changing these
quickly for a whole roster after a battle is a bulk screen for later; this is
the single-model control.

XP is worth calling out. It keeps its statline cell, which carries the target
beside the value, and draws a line only where that line can be moved.
`ModelCard.counter_lines` is that one rule, read by the card template, the print
columns and the text sheet alike, so XP never appears twice on a surface that
cannot change it.

The ledger already recorded a tally; it now records what moved and where it
landed, so the gang history reads "changed Kill Count on <fighter> — +1, now 4"
rather than naming the counter with no number at all. `TALLIED` joins
`_NOTE_IS_MACHINERY` so the sentence is not printed twice.

The route is `assignments/<pk>/tally/`, addressed by the assignment like `sell`,
`refund` and `remove` — so one address serves a model's counters and the gang's,
and the bulk act later posts the same signed change to it. It is bounded at
±1000 so a crafted POST cannot overflow the column into a 500.

## The rules behind it

From The Book of Desolation p28. Kill Count is a currency, not a score: it goes
up by one each time a Spyrer takes an enemy out of action, and Suit Evolution
spends four of it post-battle, repeatably, to either clear the rig's glitches or
roll on the Power Boost table. Glitch Count is a death clock — most results on
the Hunting Rig Glitches table add one, and if it ever exceeds the fighter's
Toughness the rig shuts down and the fighter is deleted. Which is why the number
has to be legible on the card: one of the glitch results lowers Toughness, so a
bad run moves the threshold down while pushing the count up.

Both persist across battles and move in both directions, and every act that
moves them belongs to a post-battle sequence n26 does not have yet — so
hand-editing on the model's own page is the right shape for now.

The full write-up, including the rules as read, is in
`.claude/notes/n26-counters-plan.md`.

## Deferred

The dialog (an arbitrary change, a note, reset-to-zero — what Suit Evolution
actually wants), the bulk screen, and the `3/4` threshold reading that
`CounterAtLeast` would make possible.

## How to try it

Open any Spyrer's Edit page — the card's top rows are XP, Kill Count and Glitch
Count, each with a minus and a plus. Click a few, then look at the gang's
history page. The gang sheet shows the same numbers with nothing to click.
`/n26/design/c/model-card/` shows the lines in the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcfaept4eVpfxrt15jmPdB
