### PR TITLE
chore: CODEOWNERS leaves the dependency manifests unowned so Dependabot PRs merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,10 +32,14 @@ jobs:
 
       # Enabling auto-merge is not sufficient on its own: the default branch
       # requires an approving review, so every Dependabot PR parks at
-      # REVIEW_REQUIRED until a human approves it. That is what let eight PRs
-      # pile up — auto-merge was armed on all of them and fired the moment they
-      # were approved. Approving here (as the App, never GITHUB_TOKEN) closes
-      # the loop. Gated to minor/patch, same as the merge below, so majors still
+      # REVIEW_REQUIRED until one lands. This supplies it, as the App and never
+      # GITHUB_TOKEN.
+      #
+      # It only clears the requirement because the files Dependabot touches have
+      # no code owner (see CODEOWNERS). An App cannot be named as a code owner,
+      # and a ruleset bypass does not reach auto-merge, so on an owned path this
+      # approval would count towards the review total and still leave the PR
+      # parked. Gated to minor/patch, same as the merge below, so majors still
       # get a human.
       - name: Approve
         if: >-

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,18 @@
 *   @tgvashworth
+
+# Dependency manifests and lockfiles have no code owner.
+#
+# A path listed without an owner clears ownership for it, and the code-owner
+# rule only asks for review from owners of the files a PR actually changes.
+# Dependabot PRs touch nothing but these files, so there is no owner to ask and
+# the rule is satisfied. The automerge app's approval supplies the required
+# review, CI still has to pass, and the PR merges itself.
+#
+# Anything Dependabot cannot reach stays owned above, so ordinary PRs are
+# unaffected. See .github/workflows/dependabot-auto-merge.yml.
+/package.json
+/package-lock.json
+/pyproject.toml
+/uv.lock
+/.pre-commit-config.yaml
+/Dockerfile


### PR DESCRIPTION
Dependabot's PRs pass CI and get approved by the automerge app, then sit there. Three did this week; the pattern goes back to July, and each batch has been cleared by hand.

The default branch requires a code-owner review, and `CODEOWNERS` was `* @tgvashworth` — one owner for every path. So GitHub kept a review request open against a human on every Dependabot PR, and `reviewDecision` stayed `REVIEW_REQUIRED`. Auto-merge was armed the whole time and simply had nothing to fire on. The bot's approval did count towards the required review total; it just could never be the code-owner one.

## What this changes

The code-owner rule only asks for review from owners of the files a PR actually changes. Listing Dependabot's six manifests without an owner leaves nothing to ask for, so the app's approval satisfies the review requirement on its own and auto-merge completes the PR.

The six are the full set Dependabot touches across the npm, uv, pre-commit and docker ecosystems: `package.json`, `package-lock.json`, `pyproject.toml`, `uv.lock`, `.pre-commit-config.yaml`, `Dockerfile`.

`.github/workflows/` is deliberately **not** in that list. Dependabot's github-actions group edits workflow files, and those are worth a human look, so action bumps will still wait for an approval. Say the word if you'd rather they flowed too.

Nothing else is affected — everything outside those six paths stays owned, so ordinary PRs need code-owner review exactly as before. Required status checks are untouched: `test`, `ci-checks` and `fresh-database` still have to pass, and majors still get a human because the workflow only approves minor and patch updates.

## Two routes that don't work

Worth recording, since both look plausible:

- **Naming the app as a code owner.** GitHub's CODEOWNERS validator rejects every spelling — `@gyrinx-automerge`, `@gyrinx-automerge[bot]`, `@dependabot`, `@dependabot[bot]` — with *"make sure @… exists and has write access"*. Only real users and teams are eligible.
- **A ruleset bypass.** Dependabot was given an `always` bypass on the review ruleset and it changed nothing. Auto-merge reads the PR's own review state and doesn't consult anyone's bypass. Tested properly: with auto-merge armed, a required check was re-run so it went green *after* arming — the exact event auto-merge exists to act on — and the PR sat unmerged.

## How to check it worked

After this merges, re-run any required check on #2355 (or just wait for the next Dependabot PR). It should approve, go green and merge without anyone touching it.

Two bits of cleanup follow from this and aren't included here: ruleset `21936547` ("Default (Reviews, no CODEOWNERS)") and Dependabot's bypass on `8061211` were added while diagnosing this and are now redundant. Happy to strip both once this is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMS2fdsQkUgwwtTsC1o52A
