### PR TITLE
feat: offer every skill set on the n26 fighter edit page, in two tabs

### DIFF
--- a/n26/core/static/n26/htmx_support.js
+++ b/n26/core/static/n26/htmx_support.js
@@ -1,7 +1,7 @@
 /*
  * Client glue for htmx partial updates. The server side of the pattern is
- * documented in n26/core/views/htmx.py; this file holds the three pieces
- * the browser needs.
+ * documented in n26/core/views/htmx.py; this file holds the pieces the
+ * browser needs.
  */
 
 /*
@@ -68,7 +68,33 @@ document.body.addEventListener("htmx:configRequest", function (event) {
 });
 
 /*
- * 3. Toasts from the HX-Trigger header.
+ * 3. <noscript> arriving in a swapped fragment.
+ *
+ * A page's own parser has scripting enabled, so a <noscript>'s contents are
+ * text and nothing in them applies. htmx builds a response with innerHTML,
+ * where the parser has scripting disabled — and there the same contents are
+ * parsed as real elements. Everything written for a reader with no script
+ * then comes alive on a page that has one: a <style> revealing the boxes a
+ * picker keeps hidden until they are chosen, a plain list drawing a second
+ * copy of a menu's rows.
+ *
+ * Emptying them leaves the swapped copy as the page's own parser would have
+ * left it. A reader with no script runs none of this and keeps the fallback.
+ */
+function n26EmptyNoscript(event) {
+    var swapped = event.target;
+    if (!swapped || !swapped.querySelectorAll) return;
+    if (swapped.tagName === "NOSCRIPT") swapped.replaceChildren();
+    var found = swapped.querySelectorAll("noscript");
+    for (var index = 0; index < found.length; index++) {
+        found[index].replaceChildren();
+    }
+}
+document.body.addEventListener("htmx:afterSwap", n26EmptyNoscript);
+document.body.addEventListener("htmx:oobAfterSwap", n26EmptyNoscript);
+
+/*
+ * 4. Toasts from the HX-Trigger header.
  *
  * A partial response carries the server's queued messages in its
  * HX-Trigger header as one n26-toasts event holding the whole list. htmx

--- a/n26/core/templates/cotton/n26/pick_list/index.html
+++ b/n26/core/templates/cotton/n26/pick_list/index.html
@@ -48,9 +48,24 @@ disabled saying why — as <c-n26.tick-list> draws them. A disabled box submits
 nothing, so whatever applies the difference must leave those out rather than
 read their silence as a clearing.
 
+  --- one list, or a list under headings ---
+
+Left alone, the offer's groups are drawn as one run of boxes: a list of
+subtypes is a list of subtypes, and a heading over each would be the same word
+down the page. Set `grouped` where the groups are the point — skill sets, each
+sitting in a tier — and each is drawn under its own name, the way
+<c-n26.tick-list> draws them. The addable boxes stay together at the foot under
+a heading of their own, since which set a thing came from is what the panel's
+search was for.
+
   :offer — a n26.render.ChoiceOffer: what the thing has, and anything the owner
     has touched. Always drawn, so a row saying "taken away by you" stays where
     it can be put back.
+  :grouped — draw each of the offer's groups under its own name and caption.
+    Off by default, for a list whose one group needs no heading.
+  added_label — the heading over the boxes that came from the panel, when
+    `grouped`. Left out, they sit under the last group as if they had always
+    been there.
   :addable — the rest of the library, as n26.render.Choosable options. Each is
     a box that appears once ticked, and a row in the panel until it is.
   name — the input name every box submits under.
@@ -64,6 +79,8 @@ read their silence as a clearing.
         name="thing"
         add_label="Add"
         placeholder="Search"
+        :grouped="False"
+        added_label=""
         actions=""
         class="" />
 
@@ -76,14 +93,19 @@ Save can say whether anything moved.
      x-data="{
          picked: [],
          opened: [],
+         added: [],
          init() {
              this.picked = Array.from(
                  this.$root.querySelectorAll('input[type=checkbox]:checked')
              ).map(box => box.value);
              this.opened = [...this.picked];
+             this.added = Array.from(
+                 this.$root.querySelectorAll('.n26-addable input[type=checkbox]')
+             ).map(box => box.value);
          },
          isPicked(key) { return this.picked.includes(key) },
          pick(key) { if (!this.isPicked(key)) this.picked.push(key) },
+         get anyAdded() { return this.picked.some(key => this.added.includes(key)) },
          get dirty() {
              return this.picked.length !== this.opened.length
                  || this.picked.some(key => !this.opened.includes(key));
@@ -92,27 +114,71 @@ Save can say whether anything moved.
      @quick-switcher-choose="pick($event.detail.value)"
      class="{{ class }}">
     <noscript>
-        <style>.n26-addable { display: flex !important; }</style>
+        <style>
+            .n26-addable { display: flex !important; }
+            .n26-addable-group { display: block !important; }
+        </style>
     </noscript>
-    <div class="flex flex-col">
+    <div class="{% if grouped %}space-y-4{% else %}flex flex-col{% endif %}">
         {% for group in offer.groups %}
-            {% for option in group.options %}
-                <c-n26.pick-list.box :option="option" name="{{ name }}" />
-            {% endfor %}
+            {% if grouped %}
+                {% comment %}
+                A fieldset per heading, as <c-n26.tick-list> draws one: the
+                heading is what the boxes under it have in common, and the
+                caption says which tier it sits in.
+                {% endcomment %}
+                <fieldset>
+                    <legend class="mb-1 block text-base font-semibold text-ink-900 dark:text-ink-100">
+                        {{ group.name }}
+                        {% if group.caption %}<span class="text-sm font-normal text-muted">{{ group.caption }}</span>{% endif %}
+                    </legend>
+                    <div class="flex flex-col">
+                        {% for option in group.options %}
+                            <c-n26.pick-list.box :option="option" name="{{ name }}" />
+                        {% endfor %}
+                    </div>
+                </fieldset>
+            {% else %}
+                {% for option in group.options %}
+                    <c-n26.pick-list.box :option="option" name="{{ name }}" />
+                {% endfor %}
+            {% endif %}
         {% endfor %}
         {% comment %}
         Hidden until ticked, and hidden by a style rather than by x-show alone
         so a hundred boxes do not flash up before Alpine folds them away. The
         noscript rule above puts them back for a reader with no script, for
         whom this list is the only way to add anything.
+
+        Under a heading of their own where the list is grouped, so a box that
+        arrives from the panel is not read as belonging to the last group. The
+        heading goes with them: it is drawn while any of them is ticked, and a
+        reader with no script sees it over the rest of the library.
         {% endcomment %}
-        {% for option in addable %}
-            <c-n26.pick-list.box :option="option"
-                                 name="{{ name }}"
-                                 class="n26-addable"
-                                 style="display: none"
-                                 x-show="isPicked('{{ option.key }}')" />
-        {% endfor %}
+        {% if grouped and added_label and addable %}
+            <fieldset class="n26-addable-group" style="display: none" x-show="anyAdded">
+                <legend class="mb-1 block text-base font-semibold text-ink-900 dark:text-ink-100">
+                    {{ added_label }}
+                </legend>
+                <div class="flex flex-col">
+                    {% for option in addable %}
+                        <c-n26.pick-list.box :option="option"
+                                             name="{{ name }}"
+                                             class="n26-addable"
+                                             style="display: none"
+                                             x-show="isPicked('{{ option.key }}')" />
+                    {% endfor %}
+                </div>
+            </fieldset>
+        {% else %}
+            {% for option in addable %}
+                <c-n26.pick-list.box :option="option"
+                                     name="{{ name }}"
+                                     class="n26-addable"
+                                     style="display: none"
+                                     x-show="isPicked('{{ option.key }}')" />
+            {% endfor %}
+        {% endif %}
     </div>
     {% if addable %}
         {% comment %}

--- a/n26/core/templates/cotton/n26/tab_links.html
+++ b/n26/core/templates/cotton/n26/tab_links.html
@@ -40,10 +40,11 @@ wider than the page.
     opt in: it needs the ids the answer replaces, and the answer must set
     HX-Replace-Url so the address still says which tab is open. See
     n26/core/views/htmx.py. Off by default, and without script or on a page
-    that has not opted in the same links navigate as usual. Below the sm
-    breakpoint the other tabs sit in the switcher's menu, whose rows are plain
-    links: that width changes tab by loading the page, which is the same
-    address and the same result.
+    that has not opted in the same links navigate as usual. A click holding a
+    modifier is left to the browser, so a tab still opens in a new window.
+    Below the sm breakpoint the other tabs sit in the switcher's menu, whose
+    rows are plain links: that width changes tab by loading the page, which
+    is the same address and the same result.
   busy — a CSS selector. While the chosen tab's page loads, that element's
     contents give way to a small centred spinner, so a click on a strip whose
     pages take seconds to build is seen to have landed. Modified clicks are
@@ -93,7 +94,13 @@ wider than the page.
         <c-slot name="full">
             {% for tab in tabs %}
                 <a href="{{ tab.href }}"
-                   {% if htmx and not tab.current %}hx-get="{{ tab.href }}" hx-swap="none"{% endif %}
+                   {% comment %}
+                   A modified click is left to the browser, so a tab still
+                   opens in a new window or tab. htmx cancels an anchor's
+                   own navigation whatever key is held, and only spares a
+                   boosted one, so the keys are named on the trigger.
+                   {% endcomment %}
+                   {% if htmx and not tab.current %}hx-get="{{ tab.href }}" hx-swap="none" hx-trigger="click[!ctrlKey&amp;&amp;!metaKey&amp;&amp;!shiftKey&amp;&amp;!altKey]"{% endif %}
                    {% if tab.title and tab.title != tab.label %}title="{{ tab.title }}"{% endif %}
                    {% if tab.current %}aria-current="page"{% endif %}
                    class="flex min-h-11 max-w-full items-center border-b-2 px-3 text-sm no-underline focus-ring

--- a/n26/core/templates/cotton/n26/tab_links.html
+++ b/n26/core/templates/cotton/n26/tab_links.html
@@ -35,6 +35,15 @@ wider than the page.
   eagerness — when to start. "moderate" (the default) waits for hover or
     touch-down; "immediate" starts as soon as the page settles, buying the most
     head start on pages that may never be opened.
+  htmx — draw the tabs as htmx controls as well as links, for a page that
+    answers an htmx GET with the part of itself the tab changes. The page must
+    opt in: it needs the ids the answer replaces, and the answer must set
+    HX-Replace-Url so the address still says which tab is open. See
+    n26/core/views/htmx.py. Off by default, and without script or on a page
+    that has not opted in the same links navigate as usual. Below the sm
+    breakpoint the other tabs sit in the switcher's menu, whose rows are plain
+    links: that width changes tab by loading the page, which is the same
+    address and the same result.
   busy — a CSS selector. While the chosen tab's page loads, that element's
     contents give way to a small centred spinner, so a click on a strip whose
     pages take seconds to build is seen to have landed. Modified clicks are
@@ -43,7 +52,7 @@ wider than the page.
     back, since it returns exactly as it was left. Off by default; without
     script the links still navigate, just without the feedback.
 {% endcomment %}
-<c-vars :tabs="[]" label="" speculate="" eagerness="moderate" busy="" class="" />
+<c-vars :tabs="[]" label="" speculate="" eagerness="moderate" busy="" :htmx="False" class="" />
 
 <nav {{ attrs }}
      aria-label="{{ label }}"
@@ -84,6 +93,7 @@ wider than the page.
         <c-slot name="full">
             {% for tab in tabs %}
                 <a href="{{ tab.href }}"
+                   {% if htmx and not tab.current %}hx-get="{{ tab.href }}" hx-swap="none"{% endif %}
                    {% if tab.title and tab.title != tab.label %}title="{{ tab.title }}"{% endif %}
                    {% if tab.current %}aria-current="page"{% endif %}
                    class="flex min-h-11 max-w-full items-center border-b-2 px-3 text-sm no-underline focus-ring

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -233,30 +233,18 @@ is named by the page's own heading directly below.
             {% endif %}
         </c-slot>
         {% comment %}
-        Everything this model's grid puts within reach, ticked where they
-        have it. Ticking selects and clearing takes away, in one click and
-        one operation — which is why Save is green here as it is above.
-        What a rule grants is fixed: it is theirs while the thing granting
-        it stands, and no click on this page could take it away.
+        Every skill and power the library holds for a model, ticked where
+        they have it, under the set it belongs to. Ticking selects and
+        clearing takes away, in one click and one operation — which is why
+        Save is green here as it is above. What a rule grants is fixed: it
+        is theirs while the thing granting it stands, and no click on this
+        page could take it away.
 
-        The square is drawn only where there is something to tick. A model
-        nobody has graded reaches no set, and their card's Skills row still
-        leads to the screen that says so.
+        A file of its own because a tab click is answered with the box
+        alone — see n26/includes/skills_box.html.
         {% endcomment %}
         <c-slot name="skills">
-            {% if skills %}
-                <form method="post" action="{{ edit_url }}">
-                    {% csrf_token %}
-                    <input type="hidden" name="act" value="skills">
-                    <p class="mb-3 text-sm text-ink-500 dark:text-ink-400">Edit the model's skills &amp; powers</p>
-                    <c-n26.tick-list :offer="skills" name="skills" />
-                    <div class="mt-3 flex justify-end">
-                        <c-ui.button type="submit" variant="success" size="sm">
-                            Save skills
-                        </c-ui.button>
-                    </div>
-                </form>
-            {% endif %}
+            {% include "n26/includes/skills_box.html" %}
         </c-slot>
         {% comment %}
         The same boxes an author types a statline into, filled with what

--- a/n26/core/templates/n26/includes/skills_box.html
+++ b/n26/core/templates/n26/includes/skills_box.html
@@ -1,0 +1,57 @@
+{% comment %}
+The skills and powers a model holds, as boxes to tick, and the two listings
+they can be read in: the sets somebody placed for this model, and every set
+the library holds.
+
+Drawn by the model's own page, and handed back on its own when a tab is
+clicked with script running — which is why it is a file rather than markup in
+the page: one definition, so a tab click cannot draw a different box from the
+one a reload draws. `oob` is set only on the second of those, where htmx has
+to be told which element on the standing page this replaces.
+
+Both listings offer the same things — the panel on the first searches the sets
+the second lists — so which tab a save was made from decides nothing. The form
+says which one only so the reader is put back where they were.
+
+Nothing at all where there is nothing to tick, because the square around this
+is drawn only if there is something in it: a library holding no set for a
+model to take from is not worth a heading over an empty box.
+{% endcomment %}
+{% if skills %}
+    <div id="n26-skills-box" {% if oob %}hx-swap-oob="true"{% endif %}>
+        <c-n26.tab-links label="Which sets" :tabs="skills_tabs" :htmx="True" class="mb-3" />
+        <form method="post" action="{{ edit_url }}">
+            {% csrf_token %}
+            <input type="hidden" name="act" value="skills">
+            <input type="hidden" name="tab" value="{{ skills_tab }}">
+            {% if skills.is_empty %}
+                {% comment %}
+                No placement names a set for this model. The library is still
+                theirs to take from, so the panel below stays and the other
+                tab lists every set.
+                {% endcomment %}
+                <p class="mb-3 text-sm text-ink-500 dark:text-ink-400">
+                    No skill set has been put in a tier for {{ miniature.name }}.
+                    Every set is on the All sets tab, and the search below reaches them too.
+                </p>
+            {% else %}
+                <p class="mb-3 text-sm text-ink-500 dark:text-ink-400">Edit the model's skills &amp; powers</p>
+            {% endif %}
+            <c-n26.pick-list :offer="skills"
+                             :addable="skills_more"
+                             name="skills"
+                             :grouped="True"
+                             added_label="From other sets"
+                             add_label="Add a skill"
+                             placeholder="Search skills and powers">
+                <c-slot name="actions">
+                    <div class="flex justify-end">
+                        <c-ui.button type="submit" variant="success" size="sm" ::disabled="!dirty">
+                            Save skills
+                        </c-ui.button>
+                    </div>
+                </c-slot>
+            </c-n26.pick-list>
+        </form>
+    </div>
+{% endif %}

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -2147,6 +2147,21 @@ class TestTheWiringEveryActLeansOn:
         assert 'addEventListener("n26-toasts"' in js
         assert "detail.value" in js
 
+    def test_a_swapped_in_noscript_is_emptied(self):
+        """A page's own parser treats a <noscript>'s contents as text, so
+        nothing in them applies. htmx builds a response with innerHTML,
+        where the parser has scripting disabled and those same contents
+        become real elements — a <style> written for a reader with no
+        script then comes alive on a page that has one, revealing every
+        box a picker keeps hidden and drawing a second copy of a menu's
+        rows."""
+        js = _support_js()
+
+        assert 'addEventListener("htmx:afterSwap"' in js
+        assert 'addEventListener("htmx:oobAfterSwap"' in js
+        assert 'querySelectorAll("noscript")' in js
+        assert "replaceChildren()" in js
+
     @pytest.mark.parametrize("host_id", ["n26-dialog-host", "n26-accessorise-host"])
     def test_the_page_holds_every_element_an_update_replaces(
         self, client, tester, fighter, gun_list, host_id

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -167,6 +167,49 @@ def _edits_offer(own, computed, field, heading):
     return held, rest, bool(state.own_adds or state.removed)
 
 
+#: How the skills box's two listings are named in the address.
+OWN_SETS, ALL_SETS = "their-sets", "all-sets"
+
+
+def _skills_tabs(miniature, current):
+    """The two ways the skills box lists a model's sets.
+
+    Their own first, because it is the everyday answer: the handful of
+    sets somebody wrote a placement for, which is what a reader came to
+    settle. The whole library is a tab away rather than the default,
+    since it holds every set the content has and the two that are theirs
+    would be lost among them.
+
+    Both addresses render the whole page on a plain visit, so a tab is
+    somewhere a link can point and a reload comes back to.
+    """
+    here = reverse("n26-edit-fighter", args=[miniature.pk])
+    return [
+        {
+            "label": "Their sets",
+            "href": f"{here}?skills={OWN_SETS}",
+            "current": current == OWN_SETS,
+        },
+        {
+            "label": "All sets",
+            "href": f"{here}?skills={ALL_SETS}",
+            "current": current == ALL_SETS,
+        },
+    ]
+
+
+def _skills_here(request, miniature):
+    """Where a skills save goes back to: the tab it was made from.
+
+    The form carries which listing drew it, so settling the boxes leaves
+    the reader looking at the same ones. A form naming no tab, or one
+    this page does not draw, lands on the page's own default.
+    """
+    here = reverse("n26-edit-fighter", args=[miniature.pk])
+    tab = request.POST.get("tab")
+    return f"{here}?skills={tab}" if tab in (OWN_SETS, ALL_SETS) else here
+
+
 def _apply_edits(op, miniature, own, computed, field, ticked):
     """Make what the card shows match what was ticked, and say what moved.
 
@@ -258,8 +301,8 @@ def edit_fighter(request, pk):
     from n26.core.render import render_gang, roster, summarise_roster
     from n26.core.views.choose import link_slots
     from n26.core.views.gangs import _fighter_named
-    from n26.core.views.htmx import stay_or_redirect
-    from n26.core.views.learn import apply_ticks, link_skills, ticked_offer
+    from n26.core.views.htmx import is_htmx, stay_or_redirect
+    from n26.core.views.learn import apply_ticks, link_skills, skills_offer
 
     miniature = _own_miniature_or_404(request, pk)
     gang = miniature.membership.gang
@@ -294,7 +337,7 @@ def edit_fighter(request, pk):
                 )
         except Refusal as refusal:
             messages.error(request, str(refusal))
-            return redirect("n26-edit-fighter", pk=miniature.pk)
+            return redirect(_skills_here(request, miniature))
         record(
             request,
             N26Noun.MODEL,
@@ -317,7 +360,7 @@ def edit_fighter(request, pk):
             request,
             f"{miniature.name} {' and '.join(moved)}." if moved else "Skills saved.",
         )
-        return redirect("n26-edit-fighter", pk=miniature.pk)
+        return redirect(_skills_here(request, miniature))
     elif request.method == "POST" and request.POST.get("act") in EDITABLE_KINDS:
         field = EDITABLE_KINDS[request.POST["act"]]
         own = build_card(miniature)
@@ -450,6 +493,50 @@ def edit_fighter(request, pk):
     if statline_edit is None and statline_class is not None:
         statline_edit = statline_class.opened_on(miniature)
 
+    # The model's own card, computed: the boxes need the assignments and
+    # the grants behind what the card shows, which the sheet does not
+    # carry. A fixed reading, however much this model knows.
+    own = build_card(miniature)
+    index = build_modifier_index([node.assignable for node in own.all_nodes()])
+    computed = compute(own, index)
+    skills = skills_offer(own, computed)
+    asked = request.GET.get("skills")
+    # A model no placement names has nothing under the first heading, so
+    # the box opens on the listing holding every set. An address naming a
+    # tab is obeyed either way: the first one saying so is a real answer.
+    tab = (
+        asked
+        if asked in (OWN_SETS, ALL_SETS)
+        else (ALL_SETS if skills.own.is_empty else OWN_SETS)
+    )
+    skills_box = {
+        "miniature": miniature,
+        "edit_url": reverse("n26-edit-fighter", args=[miniature.pk]),
+        # Nothing rather than an empty box: a library with no set for a
+        # model to take anything from is not worth asking about. Which of
+        # the two listings is empty is the box's own business, and it says
+        # so under its own heading.
+        "skills": None
+        if skills.everything.is_empty
+        else (skills.own if tab == OWN_SETS else skills.everything),
+        # The panel searches what the drawn listing leaves out, which on
+        # the listing holding every set is nothing.
+        "skills_more": skills.rest if tab == OWN_SETS else [],
+        "skills_tab": tab,
+        "skills_tabs": _skills_tabs(miniature, tab),
+    }
+
+    # A tab clicked with script running is answered with the box alone,
+    # before the gang sheet is built: changing which sets are listed
+    # changes nothing else on the page, and the address still says which
+    # tab is open so a reload draws the same screen.
+    if request.method == "GET" and asked and is_htmx(request):
+        answer = render(
+            request, "n26/includes/skills_box.html", {**skills_box, "oob": True}
+        )
+        answer["HX-Replace-Url"] = request.get_full_path()
+        return answer
+
     sheet = render_gang(gang)
     link_slots(gang, sheet, *sheet.models)
     link_skills(*sheet.models)
@@ -459,13 +546,6 @@ def edit_fighter(request, pk):
     if card is None:
         raise Http404("No such model")
 
-    # The model's own card again, computed: the sheet hands back what to
-    # draw, and the tick list needs the assignments and the grants behind it.
-    # A fixed reading, however much this model knows.
-    own = build_card(miniature)
-    index = build_modifier_index([node.assignable for node in own.all_nodes()])
-    computed = compute(own, index)
-    skills = ticked_offer(own, computed)
     subtype_edits, subtype_more, subtype_edits_dirty = _edits_offer(
         own, computed, "subtype", "Subtypes"
     )
@@ -497,15 +577,13 @@ def edit_fighter(request, pk):
             # bound form is display logic, and the component that draws
             # them has no business knowing what a form looks like.
             "statline_cells": statline_edit.cells() if statline_edit else None,
-            # Nothing rather than an empty box: a model whose grid reaches
-            # no set has nothing to tick, and a heading over a blank
-            # square would read as a list that failed to load. The card's
-            # own Skills row still leads to the screen that says why.
-            "skills": None if skills.is_empty else skills,
-            # The same rule for the edits box: a library offering no
-            # subtypes and no rules is not asked about either. Each
-            # section carries its own Reset, drawn only while the owner
-            # has edits of that kind to undo.
+            # Which sets are listed, which tab is open, and what the
+            # panel searches — the same box the tab click is answered
+            # with, so the two cannot draw different things.
+            **skills_box,
+            # A library offering no subtypes and no rules draws no edits
+            # box at all. Each section carries its own Reset, drawn only
+            # while the owner has edits of that kind to undo.
             "subtype_edits": subtype_edits,
             "subtype_more": subtype_more,
             "subtype_edits_dirty": subtype_edits_dirty,
@@ -513,7 +591,6 @@ def edit_fighter(request, pk):
             "rule_more": rule_more,
             "rule_edits_dirty": rule_edits_dirty,
             "renaming": _fighter_named(request, gang, "rename"),
-            "edit_url": reverse("n26-edit-fighter", args=[miniature.pk]),
             # The crop spec the picture box stamps onto the browser's
             # dialog — handed from the same constants the server crops
             # with, so the two cannot disagree.

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -204,10 +204,18 @@ def _skills_here(request, miniature):
     The form carries which listing drew it, so settling the boxes leaves
     the reader looking at the same ones. A form naming no tab, or one
     this page does not draw, lands on the page's own default.
+
+    What was posted chooses between addresses; it never becomes part of
+    one. Every address here is built from this page's own route and one
+    of its two constants, so no value a form carries can reach the
+    reader's browser as somewhere to go.
     """
     here = reverse("n26-edit-fighter", args=[miniature.pk])
-    tab = request.POST.get("tab")
-    return f"{here}?skills={tab}" if tab in (OWN_SETS, ALL_SETS) else here
+    asked = request.POST.get("tab")
+    for tab in (OWN_SETS, ALL_SETS):
+        if asked == tab:
+            return f"{here}?skills={tab}"
+    return here
 
 
 def _apply_edits(op, miniature, own, computed, field, ticked):

--- a/n26/core/views/learn.py
+++ b/n26/core/views/learn.py
@@ -40,16 +40,17 @@ thing at a time and the other settles the whole list at once, and the
 two draw different lists: this screen keeps to the fighter's own
 placements, while the edit page offers every set the library holds.
 
-That is a difference of *reach*, not of rules. Both write the same
-assignment, and neither can do anything to a model the other could not.
-What separates them is who is reading. This screen is the fighter's own
-view — theirs, tier by tier, one click at a time — and offering every
-set here would bury the two that are actually theirs under every set
-that is not. The edit page is where an owner settles what a model is,
-beside the boxes for their subtypes and special rules, and there the
-answer to "may I take a skill from another house's tree" is yes: the
-game allows it, and a skill already held from such a set could be
-cleared nowhere else.
+The difference is in what each offers, not in what either may write:
+both make the same assignment, at no price and caused by nothing, and a
+skill selected on one is indistinguishable from the same skill selected
+on the other. What separates them is who is reading. This screen is the
+fighter's own view — theirs, tier by tier, one click at a time — and
+offering every set here would bury the two that are actually theirs
+under every set that is not. The edit page is where an owner settles
+what a model is, beside the boxes for their subtypes and special rules,
+and there the answer to "may I take a skill from another house's tree"
+is yes: the game allows it, and a skill already held from such a set can
+be cleared nowhere else.
 """
 
 import dataclasses

--- a/n26/core/views/learn.py
+++ b/n26/core/views/learn.py
@@ -34,11 +34,22 @@ stays a standing selection and the question stays open. Otherwise the
 card would keep asking beside a skill the owner just picked from the
 list, and a later Choose would hand out a second starting skill.
 
-The same listing is offered a second way, as a box to tick on the
-fighter's own edit page (``ticked_offer`` and ``apply_ticks``). One
-screen selects a thing at a time and the other settles the whole list at
-once, but both read the same grid through the same browse: two ways of
-saying it, never two ideas of what a fighter may have.
+A listing is offered a second way, as a box to tick on the fighter's own
+edit page (``skills_offer`` and ``apply_ticks``). One screen selects a
+thing at a time and the other settles the whole list at once, and the
+two draw different lists: this screen keeps to the fighter's own
+placements, while the edit page offers every set the library holds.
+
+That is a difference of *reach*, not of rules. Both write the same
+assignment, and neither can do anything to a model the other could not.
+What separates them is who is reading. This screen is the fighter's own
+view — theirs, tier by tier, one click at a time — and offering every
+set here would bury the two that are actually theirs under every set
+that is not. The edit page is where an owner settles what a model is,
+beside the boxes for their subtypes and special rules, and there the
+answer to "may I take a skill from another house's tree" is yes: the
+game allows it, and a skill already held from such a set could be
+cleared nowhere else.
 """
 
 import dataclasses
@@ -104,60 +115,121 @@ def _grants_on(computed):
     }
 
 
-def ticked_offer(card, computed):
-    """What this model may hold, as a list to tick rather than to click.
+@dataclasses.dataclass(frozen=True)
+class SkillsOffer:
+    """One derivation, in the three shapes the edit page draws it in.
 
-    The skills screen's own listing: the same browse of the same
-    collections, resectioned by the same placements and narrowed to the
-    same tiers, so the two surfaces cannot come to disagree about what is
-    theirs. Skills and powers alike — a tier holds whatever the content
-    swept into it, and a family of powers a fighter's grid places is as
-    much theirs as a skill set is.
-
-    The tiers are the ones their grid names, which for the published
-    lists is Primary and Secondary; the unplaced fallback stays off,
-    because another house's sets are not this fighter's. A tier their
-    grid reaches nothing in simply has no heading.
-
-    Ticked where the model already holds the thing, by any route. What a
-    modifier grants says what grants it and is fixed: no assignment is
-    behind it, so there is nothing a click here could take away.
+    ``everything`` is the whole of it and the only one a save is applied
+    against. ``own`` and ``rest`` are the same options partitioned for
+    reading, so which tab a click came from can never decide what it is
+    allowed to do.
     """
-    from n26.core.access import learnable_for
+
+    #: Every set, grouped, tier by tier — the All sets tab.
+    everything: object
+    #: The sets this model's placements name, plus any they already hold
+    #: something in, so a skill from elsewhere can be cleared without
+    #: going looking for it.
+    own: object
+    #: The other sets' options, flat, for the panel that searches them.
+    rest: list
+
+
+def _sets_on_offer(card, computed):
+    """Every set a model could hold something from, one group each, said
+    with whether their placements name the tier it sits in.
+
+    The browse and the resectioning are the skills screen's own, minus
+    the one call that screen makes and this one does not: it narrows to
+    the tiers the placements name, and so drops the fallback the rest of
+    the library gathers under. Keeping the fallback is the whole of what
+    widens this surface, and it costs nothing — ``regrouped_by_placement``
+    has already put those categories there.
+
+    Built a section at a time so each group knows which tier it came
+    from. A one-section view is not tiered and ``offer_from_view`` writes
+    no caption for it, so the caption is put back here where the whole
+    listing spans more than one — the reader is being told Primary from
+    Secondary, and that is a fact about the listing rather than about the
+    slice it is being built in.
+    """
+    from n26.core.access import model_collections
     from n26.core.browse import (
         EQUIPMENT_LIST,
         browse,
-        narrow,
         placements_for,
         regrouped_by_placement,
         usability_for,
         with_use_notes,
     )
-    from n26.core.render import ChoiceOffer, offer_from_view
+    from n26.core.render import offer_from_view
 
     held = _rows_on(card)
     granted = _grants_on(computed)
-    groups = []
-    for collection in learnable_for(computed):
+    found = []
+    for collection in model_collections():
         placements = placements_for(computed, collection)
-        listed = narrow(
-            with_use_notes(
-                regrouped_by_placement(
-                    browse(collection, EQUIPMENT_LIST),
-                    placements,
-                    fallback=collection.default_section(),
-                    name=str(collection),
-                ),
-                usability_for(computed),
+        placed = {placement.section.name for placement in placements.values()}
+        listed = with_use_notes(
+            regrouped_by_placement(
+                browse(collection, EQUIPMENT_LIST),
+                placements,
+                fallback=collection.default_section(),
+                name=str(collection),
             ),
-            sections=[placement.section.name for placement in placements.values()],
+            usability_for(computed),
         )
-        groups.extend(
-            offer_from_view(
-                listed, label=str(collection), held=held, granted=granted
-            ).groups
-        )
-    return ChoiceOffer(label="", groups=groups)
+        tiered = len(listed.sections) > 1
+        for section in listed.sections:
+            offer = offer_from_view(
+                dataclasses.replace(listed, sections=[section]),
+                label=str(collection),
+                held=held,
+                granted=granted,
+            )
+            for group in offer.groups:
+                if tiered:
+                    group.caption = section.name
+                found.append((section.name in placed, group))
+    return found
+
+
+def skills_offer(card, computed):
+    """What this model may hold, as a list to tick rather than to click.
+
+    Every set the library holds for a model, skills and powers alike —
+    not only the ones their placements reach. A set nobody placed for
+    them is still a set the game has, and an owner reaching for one is
+    doing something the rules allow; the placements say which are
+    *theirs*, which is worth drawing, and not much more.
+
+    So the tiers are drawn as the placements name them, and everything
+    unplaced keeps the heading the browse filed it under — the
+    collection's own default section, or "Other" last of all.
+
+    Ticked where the model already holds the thing, by any route. What a
+    modifier grants says what grants it and is fixed: no assignment is
+    behind it, so there is nothing a click here could take away.
+
+    The partition is a reading aid, never a permission: a set the model
+    holds something in is drawn among their own so it can be cleared
+    where they will look for it, and everything else is on the same
+    listing one tab or one search away.
+    """
+    from n26.core.render import ChoiceOffer
+
+    own, rest, every = [], [], []
+    for placed, group in _sets_on_offer(card, computed):
+        every.append(group)
+        if placed or any(option.is_current for option in group.options):
+            own.append(group)
+        else:
+            rest.extend(group.options)
+    return SkillsOffer(
+        everything=ChoiceOffer(label="", groups=every),
+        own=ChoiceOffer(label="", groups=own),
+        rest=rest,
+    )
 
 
 def _offered_keys(slot, computed):
@@ -244,9 +316,12 @@ def apply_ticks(op, miniature, card, computed, ticked):
 
     The listing is derived again here rather than trusted from the page,
     so a stale form or a hand-made click can only name things that are on
-    the list now. Nothing off the list is touched: a skill selected from a
-    set the grid has since stopped reaching keeps its assignment, because it is
-    not being offered and so cannot have been cleared.
+    the list now. That listing is the whole of it, never the half a tab
+    is showing: both tabs draw the same options and the panel searches
+    the rest of them, so which one a save came from settles nothing and
+    is not asked. What follows is that a form submitted from a page
+    drawn long ago clears whatever has been selected since, across the
+    whole library rather than one corner of it.
 
     A newly ticked thing is selected — free, and caused by nothing, the
     same write the skills screen makes — unless the card is still asking
@@ -262,7 +337,7 @@ def apply_ticks(op, miniature, card, computed, ticked):
     fixed box submits nothing and reading its silence as a clearing
     would take away the assignment of anything a modifier also grants.
     """
-    offer = ticked_offer(card, computed)
+    offer = skills_offer(card, computed).everything
     rows = _rows_on(card)
     granted = _grants_on(computed)
     questions = _open_questions(computed)

--- a/n26/core/views/learn.py
+++ b/n26/core/views/learn.py
@@ -140,12 +140,17 @@ def _sets_on_offer(card, computed):
     """Every set a model could hold something from, one group each, said
     with whether their placements name the tier it sits in.
 
-    The browse and the resectioning are the skills screen's own, minus
-    the one call that screen makes and this one does not: it narrows to
-    the tiers the placements name, and so drops the fallback the rest of
-    the library gathers under. Keeping the fallback is the whole of what
-    widens this surface, and it costs nothing — ``regrouped_by_placement``
-    has already put those categories there.
+    Every collection holding what a model is, resectioned by their
+    placements and kept whole: the fallback tier the unplaced gather
+    under stays on the listing, because a set nobody placed for them is
+    still a set they may take from.
+
+    That is not free. A screen keeping to the placements browses only
+    the collections those reach; this one browses all of them, and each
+    is a fixed handful of queries — so a model placed into one of two
+    collections pays for the second as well. The price buys the panel
+    that searches what the first tab does not draw, which has to know
+    the whole library to offer it.
 
     Built a section at a time so each group knows which tier it came
     from. A one-section view is not tiered and ``offer_from_view`` writes
@@ -158,12 +163,14 @@ def _sets_on_offer(card, computed):
     from n26.core.browse import (
         EQUIPMENT_LIST,
         browse,
+        narrow,
         placements_for,
         regrouped_by_placement,
         usability_for,
         with_use_notes,
     )
     from n26.core.render import offer_from_view
+    from n26.library.models import Power, Skill
 
     held = _rows_on(card)
     granted = _grants_on(computed)
@@ -173,7 +180,13 @@ def _sets_on_offer(card, computed):
         placed = {placement.section.name for placement in placements.values()}
         listed = with_use_notes(
             regrouped_by_placement(
-                browse(collection, EQUIPMENT_LIST),
+                # Skills and powers, and nothing else a model can be.
+                # Subtypes are of the same family and a collection may
+                # perfectly well hold them, but they are the edits box's
+                # to settle: were one on this list, a save that did not
+                # tick it would take it away — by the wrong write, and
+                # from a box the owner was not looking at.
+                narrow(browse(collection, EQUIPMENT_LIST), kinds=(Skill, Power)),
                 placements,
                 fallback=collection.default_section(),
                 name=str(collection),

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1497,7 +1497,11 @@ GROUPS: list[Group] = [
                     "option that works. Save is disabled until the ticked set "
                     "differs from the one the page opened with: the actions "
                     "slot renders inside this component's scope, which is what "
-                    'lets a caller bind ::disabled="!dirty" on its own button.'
+                    'lets a caller bind ::disabled="!dirty" on its own button. '
+                    "Left alone the groups are drawn as one run of boxes, since "
+                    "a heading over each would be the same word down the page; "
+                    "`grouped` draws each under its own name and tier where the "
+                    "groups are the point, as c-n26.tick-list does."
                 ),
                 parts=(
                     Part(

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -830,6 +830,9 @@ def context():
         # the library its panel offers.
         "pick_list_held": pick_list_held(),
         "pick_list_addable": pick_list_addable(),
+        # The same control where the groups are the point: skill sets,
+        # each sitting in a tier.
+        "pick_list_grouped": pick_list_grouped(),
         "editable_statline": editable_statline(),
         # A profile nobody has typed a statline for yet, and one where a
         # value was refused: the two states the editor has that a card
@@ -1023,6 +1026,43 @@ def pick_list_held():
                     ),
                 ],
             )
+        ],
+    )
+
+
+def pick_list_grouped():
+    """The same control where the headings carry meaning: two skill sets,
+    each saying which tier it sits in, one of them holding a skill a rule
+    gives that no click can clear."""
+    return ChoiceOffer(
+        label="",
+        groups=[
+            ChoosableGroup(
+                name="Agility",
+                caption="Primary",
+                options=[
+                    Choosable(key="library.skill:1", name="Catfall", is_current=True),
+                    Choosable(key="library.skill:2", name="Clamber"),
+                    Choosable(
+                        key="library.skill:3",
+                        name="Dodge",
+                        is_current=True,
+                        granted_by="Keen-eyed",
+                    ),
+                ],
+            ),
+            ChoosableGroup(
+                name="Savant",
+                caption="Secondary",
+                options=[
+                    Choosable(key="library.skill:4", name="Connected"),
+                    Choosable(
+                        key="library.skill:5",
+                        name="Fixer",
+                        detail="usable by Leaders only",
+                    ),
+                ],
+            ),
         ],
     )
 

--- a/n26/designsystem/templates/designsystem/demos/pick-list/20-grouped.html
+++ b/n26/designsystem/templates/designsystem/demos/pick-list/20-grouped.html
@@ -1,0 +1,20 @@
+{# title: Under its headings #}
+{# note: Where the groups carry meaning — skill sets, each in a tier — `grouped` draws each under its own name, the way c-n26.tick-list does. What the panel adds lands under a heading of its own, since which set a thing came from is what the search was for; that heading appears with the first box ticked from it. #}
+{# layout: col #}
+<form>
+    <c-n26.pick-list :offer="pick_list_grouped"
+                     :addable="pick_list_addable"
+                     name="skills"
+                     :grouped="True"
+                     added_label="From other sets"
+                     add_label="Add a skill"
+                     placeholder="Search skills">
+        <c-slot name="actions">
+            <div class="flex items-center justify-end gap-2">
+                <c-ui.button type="submit" variant="success" size="sm" ::disabled="!dirty">
+                    Save skills
+                </c-ui.button>
+            </div>
+        </c-slot>
+    </c-n26.pick-list>
+</form>

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -162,7 +162,8 @@ Within a collection, when displayed, items are grouped by collection section and
 
 - Membership is entries and sweeps — *placement* has nothing to do with whether a *thing is in the collection*.
 - Where it appears: when a fighter's view of a collection is built, everything unplaced falls into the collection's own default section (part of its schema, so its name and position are content too), or a code-level "Other", drawn last. So browsing Skills & Powers, an unplaced set ("category") is there, under Other.
-- But narrowing excludes it: a Primary-narrowed picker (e.g. used by the "offers a choice" modifier, by setting that the choice comes "from section") only shows categories *placed* within that section. An unplaced skill category lives in Other, not Primary, so it isn't offered. Same for the skills square on the edit page: that surface is the *fighter's* view — their placements — so a collection that hasn't been placed for them isn't shown.
+- But narrowing excludes it: a Primary-narrowed picker (e.g. used by the "offers a choice" modifier, by setting that the choice comes "from section") only shows categories *placed* within that section. An unplaced skill category lives in Other, not Primary, so it isn't offered. The fighter's own skills screen narrows this way too: it is the *fighter's* view, so a set nobody placed for them isn't on it.
+- The skills square on the edit page does not narrow. It draws every set the library holds, under two tabs: the sets a fighter's placements name (plus any they already hold something in) and, a click away, all of them. The placements sort that listing rather than shorten it — an owner settling what a model *is* may take a skill from any set, and a skill already held from an unplaced set could be removed nowhere else.
 
 ### Slot type
 

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -508,6 +508,32 @@ class TestTheRestOfTheLibrary:
         assert response.status_code == 302
         assert response["Location"] == at_tab(yolanda, ALL_SETS)
 
+    def test_a_subtype_in_a_collection_is_not_on_the_listing(
+        self, client, player, gang, yolanda, sets, tiers, catalogue, library
+    ):
+        """A subtype is the same family as a skill, so a collection may
+        hold one and this box would otherwise offer it — and a save that
+        left it unticked would take it away, by the write that archives
+        a selection rather than the one that records an owner's edit,
+        and from a box whose heading says skills.
+
+        What a model is belongs to the edits box beside this one, so
+        only skills and powers are on the list here.
+        """
+        from n26.library.authoring import add_entry
+
+        badge = create_subtype("Hardened")
+        add_entry(catalogue, badge)
+        assign(badge, miniature=yolanda)
+        client.force_login(player)
+
+        assert "Hardened" not in named(offer_on(client, yolanda, ALL_SETS))
+
+        post_skills(client, yolanda, tab=ALL_SETS)
+
+        assert "Hardened" in [line.name for line in card_for(yolanda).subtypes]
+        assert_reconciled(gang)
+
     def test_a_stranger_cannot_reach_the_wider_listing_either(
         self, client, yolanda, library
     ):
@@ -982,13 +1008,15 @@ class TestTheQueryBudget:
     """The square is read with the model's own card, so a fighter who
     knows everything costs what one who knows nothing costs."""
 
-    def test_the_wider_listing_costs_what_their_own_costs(
+    def test_which_tab_is_open_costs_nothing(
         self, client, player, yolanda, sets, library
     ):
-        """Both are the same browse of the same collections. The
-        narrower one is that browse with its unplaced tier dropped,
-        which is a filter over rows already in hand rather than another
-        question to the database."""
+        """One derivation serves both listings, so the tab only picks
+        which of its shapes reaches the template.
+
+        This says nothing about what the widening itself costs — the
+        listing below is what pins that.
+        """
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
@@ -1003,6 +1031,31 @@ class TestTheQueryBudget:
         measure(OWN_SETS)
         theirs = measure(OWN_SETS)
         assert measure(ALL_SETS) == theirs
+
+    def test_the_listing_costs_the_same_however_big_the_library(
+        self, client, player, yolanda, sets, library
+    ):
+        """What a collection holds is asked in a fixed number of
+        queries, so widening the offer to every set is paid per
+        collection and never per skill. A library that doubles asks
+        the database exactly as much.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        client.force_login(player)
+
+        def measure():
+            with CaptureQueriesContext(connection) as captured:
+                assert client.get(at_tab(yolanda, ALL_SETS)).status_code == 200
+            return len(captured.captured_queries)
+
+        measure()
+        small = measure()
+        for index in range(2, 30):
+            create_skill(f"Trick {index}", category=sets["brawn"], position=index)
+
+        assert measure() == small
 
     def test_the_page_costs_the_same_however_much_she_knows(
         self, client, player, gang, yolanda, sets, library

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -1,16 +1,20 @@
 """Ticking a model's skills and powers on their own page.
 
 The skills screen selects one thing at a time, at its own address. This is
-the same list as a box on the model's edit page: everything their grid
-puts within reach, ticked where they have it, settled in one click.
+a box on the model's edit page instead: every skill and power the library
+holds, ticked where they have it, settled in one click.
 
 The rules this file pins:
 
-* **The grid is the list.** The square draws the fighter's own view of
-  the collections their placements reach, tier by tier — the same browse
-  the skills screen makes, so the two cannot come to disagree about what
-  is theirs. A set nobody placed for them is not on it, and neither is
-  the tier the unplaced fall into.
+* **The placements sort the list; they do not shorten it.** Two tabs
+  draw the same options. The first holds the sets somebody placed in a
+  tier for this model, plus any set they already hold something in, so
+  what is theirs is what they see; the second holds every set the
+  library has. A panel on the first searches what it leaves out, so
+  both listings reach the whole library and which tab a save came from
+  settles nothing.
+* **What is offered can be taken away.** A skill from a set nobody
+  placed can be cleared, which is only true because it is on the list.
 * **Skills and powers alike.** A tier holds whatever the content swept
   into it, so a family of powers placed for a fighter ticks like a skill
   set does.
@@ -37,6 +41,7 @@ from n26.core.effects import compute
 from n26.core.models import Assignment, LedgerEntry
 from n26.core.reconcile import assert_reconciled
 from n26.core.render import build_model_card
+from n26.core.views.edit import ALL_SETS, OWN_SETS
 from n26.library.models import Power, Skill
 from n26.tests.sandbox.actions import (
     adds,
@@ -181,23 +186,32 @@ def box(page, thing):
     return match.group(0)
 
 
-def offer_on(client, miniature):
-    return client.get(edit_url(miniature)).context["skills"]
+def at_tab(miniature, tab=""):
+    return edit_url(miniature) + (f"?skills={tab}" if tab else "")
+
+
+def offer_on(client, miniature, tab=""):
+    """The listing the box draws, on whichever tab the address names."""
+    return client.get(at_tab(miniature, tab)).context["skills"]
+
+
+def more_on(client, miniature, tab=""):
+    """What the panel searches: the sets the drawn listing leaves out."""
+    return client.get(at_tab(miniature, tab)).context["skills_more"]
 
 
 def named(offer):
     return {option.name for group in offer.groups for option in group.options}
 
 
-def post_skills(client, miniature, *ticked, follow=False):
+def post_skills(client, miniature, *ticked, follow=False, tab=""):
     """Save the skills form as a browser sends it: the act, and one entry
     per ticked box. Boxes left alone send nothing, which is the whole of
     how a browser says a thing was cleared."""
-    return client.post(
-        edit_url(miniature),
-        {"act": "skills", "skills": [key_of(thing) for thing in ticked]},
-        follow=follow,
-    )
+    sent = {"act": "skills", "skills": [key_of(thing) for thing in ticked]}
+    if tab:
+        sent["tab"] = tab
+    return client.post(edit_url(miniature), sent, follow=follow)
 
 
 def card_for(miniature):
@@ -277,17 +291,31 @@ class TestWhatTheSquareShows:
         assert "checked" in box(page, library["skills"]["Catfall"])
         assert "checked" not in box(page, library["skills"]["Dodge"])
 
-    def test_a_model_nobody_graded_is_not_asked(
-        self, client, player, gang, gridless, catalogue
+    def test_a_model_no_placement_names_is_asked_about_every_set(
+        self, client, player, gang, gridless, catalogue, library
     ):
-        """No grid, no sets within reach — and a heading over an empty
-        square would read as a list that failed to load."""
+        """Nobody has put a set in a tier for them. That is a gap in the
+        content, not a rule about the model: the library is still theirs
+        to take from, so the box opens on the listing holding every set
+        and says why the other one is bare."""
         nobody = hire_with_option(gang, gridless, "Nobody")
         client.force_login(player)
         response = client.get(edit_url(nobody))
 
-        assert response.context["skills"] is None
-        assert "Save skills" not in response.content.decode()
+        assert response.context["skills_tab"] == ALL_SETS
+        assert "Bull Charge" in named(response.context["skills"])
+        assert "Save skills" in response.content.decode()
+
+    def test_their_own_listing_says_when_no_set_is_theirs(
+        self, client, player, gang, gridless, catalogue, library
+    ):
+        """Asked for the listing that is empty, the box draws it empty
+        and says so, rather than sending the reader somewhere else."""
+        nobody = hire_with_option(gang, gridless, "Nobody")
+        client.force_login(player)
+        page = client.get(at_tab(nobody, OWN_SETS)).content.decode()
+
+        assert "No skill set has been put in a tier for Nobody." in page
 
     def test_a_granted_skill_is_drawn_ticked_and_fixed(
         self, client, player, yolanda, sets, library
@@ -357,6 +385,134 @@ class TestWhatTheSquareShows:
     def test_somebody_elses_model_has_no_page(self, client, yolanda, catalogue):
         client.force_login(User.objects.create_user("stranger"))
         assert client.get(edit_url(yolanda)).status_code == 404
+
+
+# --- The sets that are not theirs ------------------------------------------
+
+
+class TestTheRestOfTheLibrary:
+    """Every set is reachable from the box, one tab or one search away."""
+
+    def test_the_other_tab_lists_the_sets_nobody_placed(
+        self, client, player, yolanda, library
+    ):
+        """Brawn is nobody's here, so it is not among her own sets — but
+        it is a set the game has, and the second listing holds it."""
+        client.force_login(player)
+
+        assert "Bull Charge" not in named(offer_on(client, yolanda, OWN_SETS))
+        assert "Bull Charge" in named(offer_on(client, yolanda, ALL_SETS))
+
+    def test_the_other_tab_keeps_the_sets_that_are_theirs(
+        self, client, player, yolanda, library
+    ):
+        """The wider listing is the whole library, not the remainder of
+        it: a reader who switches tabs to find one skill does not lose
+        sight of what the model already has."""
+        client.force_login(player)
+        offer = offer_on(client, yolanda, ALL_SETS)
+
+        assert {"Catfall", "Connected", "Bull Charge"} <= named(offer)
+
+    def test_each_set_says_its_tier_on_the_wider_listing(
+        self, client, player, yolanda, sets, tiers, library
+    ):
+        """A set nobody placed is filed under the collection's own
+        default tier, and says so, so the reader can tell the two that
+        are theirs from the rest without counting headings."""
+        client.force_login(player)
+        tier = {
+            group.name: group.caption
+            for group in offer_on(client, yolanda, ALL_SETS).groups
+        }
+
+        assert tier["Agility"] == "Primary"
+        assert tier["Savant"] == "Secondary"
+        assert tier["Brawn"] == "Other"
+
+    def test_the_panel_searches_what_their_own_listing_leaves_out(
+        self, client, player, yolanda, library
+    ):
+        """The first tab is not a dead end: the sets it does not draw
+        are the ones its search offers, so a skill can be added without
+        leaving it."""
+        client.force_login(player)
+        offered = {option.name for option in more_on(client, yolanda, OWN_SETS)}
+
+        assert "Bull Charge" in offered
+        assert "Catfall" not in offered
+
+    def test_the_wider_listing_needs_no_panel(self, client, player, yolanda, library):
+        """Everything is already a box there, and a search offering what
+        is drawn a few lines above would be a second way to do the same
+        thing."""
+        client.force_login(player)
+
+        assert more_on(client, yolanda, ALL_SETS) == []
+
+    def test_a_skill_from_another_set_can_be_selected(
+        self, client, player, gang, yolanda, library
+    ):
+        """The whole of the ask: a skill nobody placed for her, ticked
+        and saved from the page she was already on."""
+        client.force_login(player)
+        post_skills(client, yolanda, library["skills"]["Bull Charge"], tab=ALL_SETS)
+
+        assert held_by(yolanda) == ["Bull Charge"]
+        assert_reconciled(gang)
+
+    def test_a_skill_from_another_set_can_be_cleared_again(
+        self, client, player, gang, yolanda, library
+    ):
+        """And the other half of it, which the narrower listing could
+        not do at all: what was selected can be taken away."""
+        learn(yolanda, library["skills"]["Bull Charge"])
+        client.force_login(player)
+        post_skills(client, yolanda, tab=ALL_SETS)
+
+        assert held_by(yolanda) == []
+        assert_reconciled(gang)
+
+    def test_a_set_they_hold_something_in_is_drawn_among_their_own(
+        self, client, player, yolanda, library
+    ):
+        """Held, so it is theirs whatever the placements say — and it is
+        drawn where they will look for it rather than a tab away, since
+        the reader wanting to clear it is looking at what she has."""
+        learn(yolanda, library["skills"]["Bull Charge"])
+        client.force_login(player)
+        offer = offer_on(client, yolanda, OWN_SETS)
+
+        assert "Brawn" in [group.name for group in offer.groups]
+        assert "Bull Charge" in named(offer)
+
+    def test_a_held_set_is_not_offered_twice(self, client, player, yolanda, library):
+        """Drawn among their own, it is off the panel: a box and a
+        search row for the same skill would be two controls settling one
+        thing."""
+        learn(yolanda, library["skills"]["Bull Charge"])
+        client.force_login(player)
+        offered = {option.name for option in more_on(client, yolanda, OWN_SETS)}
+
+        assert "Bull Charge" not in offered
+        assert "Terrify (Double)" in offered
+
+    def test_a_save_comes_back_to_the_tab_it_was_made_from(
+        self, client, player, yolanda, library
+    ):
+        client.force_login(player)
+        response = post_skills(
+            client, yolanda, library["skills"]["Bull Charge"], tab=ALL_SETS
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == at_tab(yolanda, ALL_SETS)
+
+    def test_a_stranger_cannot_reach_the_wider_listing_either(
+        self, client, yolanda, library
+    ):
+        client.force_login(User.objects.create_user("interloper"))
+        assert client.get(at_tab(yolanda, ALL_SETS)).status_code == 404
 
 
 # --- The click -------------------------------------------------------------
@@ -460,22 +616,29 @@ class TestSavingTheSquare:
         assert_reconciled(gang)
 
     def test_a_click_naming_something_off_the_list_writes_nothing(
-        self, client, player, gang, yolanda, library
+        self, client, player, gang, yolanda, wyrd, library
     ):
-        """Brawn is nobody's here, so it is not on her square — and the
-        click is answered by the list rather than by the ledger."""
+        """The listing holds what the collection sweeps, which here is
+        skills and powers. A click naming anything else — a subtype — is
+        answered by the list rather than by the ledger."""
         client.force_login(player)
-        post_skills(client, yolanda, library["skills"]["Bull Charge"])
+        post_skills(client, yolanda, wyrd)
 
         assert held_by(yolanda) == []
         assert_reconciled(gang)
 
-    def test_a_skill_from_a_set_no_longer_reached_is_left_alone(
+    def test_a_power_from_a_set_nothing_places_can_be_cleared(
         self, client, player, gang, gang_sister, wyrd, library
     ):
-        """What is not offered cannot have been cleared. A power selected
-        while a subtype revealed the family keeps its row once the subtype
-        goes: an earned thing is nobody's consequence."""
+        """Every set is on the listing, so a power selected while a
+        subtype placed its family is still offered once the subtype
+        goes — and what is offered can be taken away.
+
+        The price of that is on show here: an empty save clears it, the
+        way an empty save clears whatever it does not name. A stale form
+        therefore reaches the whole library rather than one corner of
+        it, which is what being able to remove a skill nobody placed
+        costs."""
         from n26.tests.sandbox.actions import remove
 
         thalia = hire_with_option(gang, gang_sister, "Thalia")
@@ -484,9 +647,11 @@ class TestSavingTheSquare:
         remove(badge)
 
         client.force_login(player)
+        assert "Terrify (Double)" in named(offer_on(client, thalia))
+
         post_skills(client, thalia)
 
-        assert held_by(thalia) == ["Terrify (Double)"]
+        assert held_by(thalia) == []
         assert_reconciled(gang)
 
     def test_the_page_says_what_moved(self, client, player, yolanda, library):
@@ -711,9 +876,131 @@ class TestAnOpenStartingSkill:
         assert "Catfall" in held_by(leader_yolanda)
 
 
+class TestSwitchingTabs:
+    """Which sets are listed is in the address, so a reload draws the
+    same screen and a link points at one. With script the click is
+    answered with the box alone; without it, with the page."""
+
+    HTMX = {"HX-Request": "true"}
+
+    def test_the_address_says_which_listing_is_open(
+        self, client, player, yolanda, library
+    ):
+        client.force_login(player)
+        page = client.get(at_tab(yolanda, ALL_SETS))
+
+        assert page.status_code == 200
+        assert page.context["skills_tab"] == ALL_SETS
+        assert "<html" in page.content.decode()
+
+    def test_an_address_naming_no_listing_opens_their_own(
+        self, client, player, yolanda, library
+    ):
+        client.force_login(player)
+        assert client.get(edit_url(yolanda)).context["skills_tab"] == OWN_SETS
+
+    def test_an_address_naming_nonsense_opens_their_own(
+        self, client, player, yolanda, library
+    ):
+        """A hand-typed address settles on the everyday listing rather
+        than drawing nothing."""
+        client.force_login(player)
+        page = client.get(edit_url(yolanda) + "?skills=whatever")
+
+        assert page.status_code == 200
+        assert page.context["skills_tab"] == OWN_SETS
+
+    def test_a_tab_clicked_with_script_is_answered_with_the_box(
+        self, client, player, yolanda, library
+    ):
+        """Changing which sets are listed changes nothing else on the
+        page, so nothing else is sent — and the answer says which
+        element it replaces, because a click on a link targets none."""
+        client.force_login(player)
+        answer = client.get(at_tab(yolanda, ALL_SETS), headers=self.HTMX)
+        body = answer.content.decode()
+
+        assert answer.status_code == 200
+        assert "<html" not in body
+        assert 'id="n26-skills-box"' in body
+        assert 'hx-swap-oob="true"' in body
+        assert "Bull Charge" in body
+
+    def test_the_answer_moves_the_address_to_the_tab_it_opened(
+        self, client, player, yolanda, library
+    ):
+        """Replaced rather than pushed: a tab is not somewhere to go
+        back to, but a reload must draw what is on screen."""
+        client.force_login(player)
+        answer = client.get(at_tab(yolanda, ALL_SETS), headers=self.HTMX)
+
+        assert answer["HX-Replace-Url"] == at_tab(yolanda, ALL_SETS)
+
+    def test_the_page_itself_is_never_answered_with_a_fragment(
+        self, client, player, yolanda, library
+    ):
+        """Only a tab click is: the box is handed back for the act that
+        changes it, and a page asked for as a whole is drawn whole
+        however it was asked for."""
+        client.force_login(player)
+        body = client.get(edit_url(yolanda), headers=self.HTMX).content.decode()
+
+        assert "<html" in body
+
+    def test_the_same_address_without_script_draws_the_whole_page(
+        self, client, player, yolanda, library
+    ):
+        client.force_login(player)
+        body = client.get(at_tab(yolanda, ALL_SETS)).content.decode()
+
+        assert "<html" in body
+        assert 'id="n26-skills-box"' in body
+        assert "Bull Charge" in body
+
+    def test_the_tabs_are_links_that_script_turns_into_clicks(
+        self, client, player, yolanda, library
+    ):
+        """An ordinary href, so the tab works with no script and can be
+        opened in another window; the htmx attribute beside it is what
+        makes the click stay on the page."""
+        client.force_login(player)
+        body = client.get(edit_url(yolanda)).content.decode()
+
+        assert f'href="{at_tab(yolanda, ALL_SETS)}"' in body
+        assert f'hx-get="{at_tab(yolanda, ALL_SETS)}"' in body
+
+    def test_the_form_says_which_listing_drew_it(
+        self, client, player, yolanda, library
+    ):
+        client.force_login(player)
+        body = client.get(at_tab(yolanda, ALL_SETS)).content.decode()
+
+        assert f'name="tab" value="{ALL_SETS}"' in body
+
+
 class TestTheQueryBudget:
     """The square is read with the model's own card, so a fighter who
     knows everything costs what one who knows nothing costs."""
+
+    def test_the_wider_listing_costs_what_their_own_costs(
+        self, client, player, yolanda, sets, library
+    ):
+        """Both are the same browse of the same collections. The
+        narrower one is that browse with its unplaced tier dropped,
+        which is a filter over rows already in hand rather than another
+        question to the database."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        client.force_login(player)
+
+        def measure(tab):
+            with CaptureQueriesContext(connection) as captured:
+                assert client.get(at_tab(yolanda, tab)).status_code == 200
+            return len(captured.captured_queries)
+
+        measure(OWN_SETS)
+        assert measure(ALL_SETS) == measure(OWN_SETS)
 
     def test_the_page_costs_the_same_however_much_she_knows(
         self, client, player, gang, yolanda, sets, library

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -999,8 +999,10 @@ class TestTheQueryBudget:
                 assert client.get(at_tab(yolanda, tab)).status_code == 200
             return len(captured.captured_queries)
 
+        # The first reading pays one-time caches that no later one does.
         measure(OWN_SETS)
-        assert measure(ALL_SETS) == measure(OWN_SETS)
+        theirs = measure(OWN_SETS)
+        assert measure(ALL_SETS) == theirs
 
     def test_the_page_costs_the_same_however_much_she_knows(
         self, client, player, gang, yolanda, sets, library


### PR DESCRIPTION
Closes #2304. Closes #2224.

## What a player gets

The Skills & Powers box on a fighter's edit page only ever listed the skill sets that fighter's profile and subtypes place — in practice Primary and Secondary. Anything else was unreachable: you could not add a skill from another house's tree, and if a fighter already held one, you could not take it away either, from anywhere in the app.

The box now offers the whole library, under two tabs:

- **Their sets** — the sets something places for this model, plus any set they already hold a skill from, with an "Add a skill" search over everything else.
- **All sets** — every set the content has, each under its own name and tier.

A model that nothing places a set for used to get no box at all. It now gets one, opened on the wider tab.

## What changed underneath

`skills_offer` browses every model-facing collection and skips the `narrow()` to the placed sections — that call was the whole restriction, since the browse already files unplaced categories under the collection's own default tier.

Both tabs offer the same things, because the first tab's search panel covers what its listing leaves out. So the code that applies a save needs no idea which tab it came from, and stays a single path.

**What it costs.** Not nothing, and an earlier draft of this description claimed otherwise. A screen that keeps to a model's placements browses only the collections those reach; this one browses all of them, each a fixed handful of queries. Measured against the real library — two model-facing collections — a fighter placed into one pays **twelve extra queries** for the second, on every edit-page GET and skills save. That price buys the search panel, which has to know the whole library to offer it. The count is fixed per collection and flat in the number of skills, and there's a test pinning that; the tab you're on costs nothing either way.

**One deliberate loss.** Previously a skill from a set nothing placed was safe from a stale form, because it was not on the list and so could not be cleared. Now it is on the list, so an empty save clears it like anything else. That is the direct price of being able to remove such a skill at all, and there is a test saying so in as many words.

**Subtypes stay out of it.** A subtype is the same family as a skill, so a collection may hold one and this listing would have offered it — and since `apply_ticks` treats the listing as its authority, a save that left it unticked would have taken the subtype away, by the wrong write and from a box headed "skills". No collection holds a subtype today, so it never fired, but the guarantee lived in the content rather than the code. The browse is now narrowed to skills and powers.

## #2224 folded in

The box moves from the old plain checkbox list to `c-n26.pick-list`, matching the Subtypes and Special rules boxes beside it: searchable panel, and Save greyed until something actually moves. That was not a drop-in — pick-list drew no group headings, and a skill list without its set names is unreadable — so pick-list gains a `grouped` var and draws the same fieldset-and-legend headings the old list had. Skills added from the search panel appear under a heading of their own.

## A latent htmx bug this turned up

htmx builds responses with `innerHTML`, where the HTML parser has scripting disabled. In that mode a `<noscript>`'s contents are parsed as **real elements** rather than text — so on the first tab switch, the stylesheet that keeps a picker's unchosen boxes hidden came alive and revealed the entire library, and a menu's no-script fallback drew a second copy of its rows. `htmx_support.js` now empties any `<noscript>` in a swapped fragment. This would have bitten any future swapped fragment containing one.

## Known and not fixed here

- Switching tabs discards unsaved ticks, the same way following any tab link would. No worse than a plain page load, but no warning either.
- `?skills=` and `?rename=` clobber each other: opening the rename dialog resets the tab, and vice versa. Both links build a query string from scratch.
- Whether a set is "theirs" is decided by section *name*. Safe with today's content, but if a placed tier were ever also marked the collection's default section, the whole library would land on the first tab.
- The second model-facing collection is gang-specific content, and now lists on every model's edit page under All sets. Consistent with "offer every set", but worth a conscious yes. Relatedly, a few power sets appear twice there because both collections sweep the same rows — same option key, so saves dedupe.

## How to try it

Open any fighter's edit page and look at Skills & Powers.

- Switch between **Their sets** and **All sets** — the page does not reload, and the address updates so a refresh or a link comes back to the same tab. With JavaScript off the same links work as ordinary page loads.
- Use **Add a skill** to search for a skill from a set that is not theirs, tick it, and Save. Its set then appears among their own sets, where you can untick it and Save to take it away again.
- The design gallery page for the component is at `/n26/design/c/pick-list/`, which now has a grouped demo.

## Testing

Whole repo green. Verified in a browser against real content: both tabs, the tier captions, the htmx swap in both directions, the search panel, adding a skill from an unplaced set, and removing it again.