### PR TITLE
test: the Lasting Injury and Lasting Damage tables as the executable spec

### DIFF
--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -234,3 +234,40 @@ clicks Choose and lands on an empty page. The reverse is a real setup
 rather than a mistake: place the family and offer nothing, and the model
 may select powers from it whenever they like, but was never handed the
 founding one.
+
+## The Lasting Injury and Lasting Damage tables
+
+> Draft, for review.
+
+A model taken out of action rolls on one of the book's two D66 tables
+and keeps the result for good. Each table is a slot type of its own —
+two, not one, so a fighter can never be handed vehicle damage — and
+the app never rolls: the dice are the table's, and a player adds the
+result they rolled.
+
+1. Create a **slot type** per table: "Lasting Injury" (plural "Lasting
+   Injuries") and "Lasting Damage". Set *allows repeats* on both — a
+   second Eye Injury is a second Eye Injury.
+2. Create a **picklist** per slot type, and give it its **dice** (D66)
+   and how a roll finds its result (the one row the roll lands in).
+   That makes it a roll table, and its page grows a table view.
+3. On the **roll table page**, add each result at its band — "21-26"
+   as readily as "51" — until the page says every roll is covered. It
+   names any roll left unclaimed, any roll claimed twice, and any
+   result with no band, because none of those can be seen one row at
+   a time. Five results sit on both tables at the same rolls; a pack
+   holds one pickable per name, so give the damage twins a qualifier
+   (players never see it).
+4. On each result that worsens a characteristic, attach a **modifier**:
+   targets the model, worsens that characteristic by one. A result that
+   changes no number needs nothing — the card says the model has it,
+   and the rest is played at the table.
+5. Create a **slot** per table, labelled with the plural, expecting no
+   picks and holding plenty. Build it into each fighter or vehicle
+   entry, so every model carries its empty row from the moment it is
+   hired.
+
+The player's picker then lists the results in roll order with their
+bands leading, so someone who rolled 24 scans to "21-26" and adds Out
+Cold.
+\n

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -252,7 +252,7 @@ result they rolled.
    roll covered. (Five results sit on both tables at the same rolls; a
    pack holds one pickable per name, so the damage twins arrive with a
    qualifier, which players never see.)
-2. Standard content carries names and numbers only, so finish the six
+2. Standard content carries names and numbers only, so finish the ten
    results that worsen a characteristic by hand: on each, attach a
    **modifier** — targets the model, worsens that characteristic by
    one. A result that changes no number needs nothing — the card says

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -245,26 +245,20 @@ two, not one, so a fighter can never be handed vehicle damage — and
 the app never rolls: the dice are the table's, and a player adds the
 result they rolled.
 
-1. Create a **slot type** per table: "Lasting Injury" (plural "Lasting
-   Injuries") and "Lasting Damage". Set *allows repeats* on both — a
-   second Eye Injury is a second Eye Injury.
-2. Create a **picklist** per slot type, and give it its **dice** (D66)
-   and how a roll finds its result (the one row the roll lands in).
-   That makes it a roll table, and its page grows a table view.
-3. On the **roll table page**, add each result at its band — "21-26"
-   as readily as "51" — until the page says every roll is covered. It
-   names any roll left unclaimed, any roll claimed twice, and any
-   result with no band, because none of those can be seen one row at
-   a time. Five results sit on both tables at the same rolls; a pack
-   holds one pickable per name, so give the damage twins a qualifier
-   (players never see it).
-4. On each result that worsens a characteristic, attach a **modifier**:
-   targets the model, worsens that characteristic by one. A result that
-   changes no number needs nothing — the card says the model has it,
-   and the rest is played at the table.
-5. Create a **slot** per table, labelled with the plural, expecting no
-   picks and holding plenty. Build it into each fighter or vehicle
-   entry, so every model carries its empty row from the moment it is
+1. On **Foundations**, create the **lasting effect tables**. One press
+   makes both tables whole: a slot type each with *allows repeats* set —
+   a second Eye Injury is a second Eye Injury — every result at its
+   band, and a standing choice each. Each table's own page shows every
+   roll covered. (Five results sit on both tables at the same rolls; a
+   pack holds one pickable per name, so the damage twins arrive with a
+   qualifier, which players never see.)
+2. Standard content carries names and numbers only, so finish the six
+   results that worsen a characteristic by hand: on each, attach a
+   **modifier** — targets the model, worsens that characteristic by
+   one. A result that changes no number needs nothing — the card says
+   the model has it, and the rest is played at the table.
+3. Build each table's choice into the matching fighter or vehicle
+   entries, so every model carries its empty row from the moment it is
    hired.
 
 The player's picker then lists the results in roll order with their

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -264,4 +264,3 @@ result they rolled.
 The player's picker then lists the results in roll order with their
 bands leading, so someone who rolled 24 scans to "21-26" and adds Out
 Cold.
-\n

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -520,7 +520,7 @@ def _check_subtypes():
 #: The two lasting-effect tables (core rules: the Lasting Injury and
 #: Lasting Damage tables), as ``(band low, band high, result)``. Names
 #: and bands only — what a result *does* is a modifier, which seeds
-#: never write, so the six characteristic results are finished by hand.
+#: never write, so the ten characteristic results are finished by hand.
 LASTING_INJURY_TABLE = [
     (11, 11, "Lesson Learnt"),
     (12, 12, "Eternal Enmity"),
@@ -660,7 +660,7 @@ STANDARD_CONTENT = {
             help=(
                 "The Lasting Injury and Lasting Damage tables as D66 roll "
                 "tables — a slot type, results at their bands, and a "
-                "standing choice each. Names and bands only: the six "
+                "standing choice each. Names and bands only: the ten "
                 "results that worsen a characteristic still need their "
                 "modifiers attached, and the choices built into entries."
             ),

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -517,6 +517,117 @@ def _check_subtypes():
     return _count(Subtype, name__in=names), len(names)
 
 
+#: The two lasting-effect tables (core rules: the Lasting Injury and
+#: Lasting Damage tables), as ``(band low, band high, result)``. Names
+#: and bands only — what a result *does* is a modifier, which seeds
+#: never write, so the six characteristic results are finished by hand.
+LASTING_INJURY_TABLE = [
+    (11, 11, "Lesson Learnt"),
+    (12, 12, "Eternal Enmity"),
+    (13, 13, "Bitter Enmity"),
+    (14, 14, "Personal Enmity"),
+    (15, 15, "Horrid Scars"),
+    (16, 16, "Impressive Scars"),
+    (21, 26, "Out Cold"),
+    (31, 46, "Grievous Wound"),
+    (51, 51, "Eye Injury"),
+    (52, 52, "Hand Injury"),
+    (53, 53, "Hobbled"),
+    (54, 54, "Spinal Injury"),
+    (55, 55, "Enfeebled"),
+    (56, 56, "Head Injury"),
+    (61, 62, "Captured"),
+    (63, 65, "Critical Injury"),
+    (66, 66, "Memorable Death"),
+]
+
+LASTING_DAMAGE_TABLE = [
+    (11, 11, "Lesson Learnt"),
+    (12, 12, "Eternal Enmity"),
+    (13, 13, "Bitter Enmity"),
+    (14, 14, "Personal Enmity"),
+    (15, 16, "Percussive Repair"),
+    (21, 26, "Superficial Damage"),
+    (31, 46, "Major Damage"),
+    (51, 52, "Busted Sights"),
+    (53, 53, "Drive System Fault"),
+    (54, 54, "Buckled Frame"),
+    (55, 56, "Engine Fracture"),
+    (61, 62, "Captured"),
+    (63, 65, "Critical Damage"),
+    (66, 66, "Catastrophic Explosion!"),
+]
+
+#: On both tables at the same rolls. A pack holds one pickable per name,
+#: so the damage twin of each carries a qualifier — author-facing only,
+#: never a player's word.
+SHARED_LASTING_RESULTS = {
+    "Lesson Learnt",
+    "Eternal Enmity",
+    "Bitter Enmity",
+    "Personal Enmity",
+    "Captured",
+}
+
+#: (slot type, plural, rows, the damage twins' qualifier)
+LASTING_EFFECT_TABLES = [
+    ("Lasting Injury", "Lasting Injuries", LASTING_INJURY_TABLE, ""),
+    ("Lasting Damage", "Lasting Damage", LASTING_DAMAGE_TABLE, "vehicle"),
+]
+
+
+def _create_lasting_effect_tables():
+    from n26.library.models import Pickable, Picklist, PicklistMember, Slot, SlotType
+
+    for name, plural, rows, twin_qualifier in LASTING_EFFECT_TABLES:
+        slot_type, _ = SlotType.objects.get_or_create(
+            name=name,
+            defaults={"plural_name": plural, "allows_repeats": True},
+        )
+        table, _ = Picklist.objects.get_or_create(
+            name=f"{name} Table",
+            slot_type=slot_type,
+            defaults={"dice": "d66", "roll_selects": "band"},
+        )
+        for position, (low, high, result) in enumerate(rows):
+            qualifier = twin_qualifier if result in SHARED_LASTING_RESULTS else ""
+            pickable, _ = Pickable.objects.get_or_create(
+                name=result,
+                slot_type=slot_type,
+                defaults={"qualifier": qualifier},
+            )
+            PicklistMember.objects.get_or_create(
+                picklist=table,
+                pickable=pickable,
+                defaults={
+                    "roll_low": low,
+                    "roll_high": high,
+                    "position": position,
+                },
+            )
+        Slot.objects.get_or_create(
+            name=name,
+            slot_type=slot_type,
+            defaults={
+                "picklist": table,
+                "label": plural,
+                "min_picks": 0,
+                "max_picks": 20,
+            },
+        )
+
+
+def _check_lasting_effect_tables():
+    from n26.library.models import PicklistMember
+
+    total = sum(len(rows) for _, _, rows, _ in LASTING_EFFECT_TABLES)
+    present = _count(
+        PicklistMember,
+        picklist__name__in=[f"{name} Table" for name, _, _, _ in LASTING_EFFECT_TABLES],
+    )
+    return present, total
+
+
 STANDARD_CONTENT = {
     item.key: item
     for item in [
@@ -542,6 +653,19 @@ STANDARD_CONTENT = {
             ),
             check=_check_weapon_characteristics,
             create=_create_weapon_characteristics,
+        ),
+        StandardContent(
+            key="lasting-effect-tables",
+            name="Lasting effect tables",
+            help=(
+                "The Lasting Injury and Lasting Damage tables as D66 roll "
+                "tables — a slot type, results at their bands, and a "
+                "standing choice each. Names and bands only: the six "
+                "results that worsen a characteristic still need their "
+                "modifiers attached, and the choices built into entries."
+            ),
+            check=_check_lasting_effect_tables,
+            create=_create_lasting_effect_tables,
         ),
         StandardContent(
             key="core-subtypes",

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -576,26 +576,48 @@ LASTING_EFFECT_TABLES = [
 ]
 
 
+def _lasting_row(model, name, qualifier, slot_type, defaults):
+    """One pickable or slot, matched the way its uniqueness is defined:
+    per pack on lowercased name and qualifier, not per slot type. An
+    exact-key lookup scoped to the slot type would miss a row that
+    differs only in case or belongs to another type, then trip the
+    unique constraint trying to insert its double."""
+    row = model.objects.filter(name__iexact=name, qualifier__iexact=qualifier).first()
+    if row is None:
+        return model.objects.create(
+            name=name, qualifier=qualifier, slot_type=slot_type, **defaults
+        )
+    if row.slot_type_id != slot_type.pk:
+        raise RuntimeError(
+            f'A {model._meta.verbose_name} named "{name}" already belongs '
+            f'to the "{row.slot_type}" slot type, so the "{slot_type}" '
+            f"table cannot claim the name."
+        )
+    return row
+
+
 def _create_lasting_effect_tables():
     from n26.library.models import Pickable, Picklist, PicklistMember, Slot, SlotType
 
     for name, plural, rows, twin_qualifier in LASTING_EFFECT_TABLES:
-        slot_type, _ = SlotType.objects.get_or_create(
-            name=name,
-            defaults={"plural_name": plural, "allows_repeats": True},
-        )
-        table, _ = Picklist.objects.get_or_create(
-            name=f"{name} Table",
-            slot_type=slot_type,
-            defaults={"dice": "d66", "roll_selects": "band"},
-        )
+        slot_type = SlotType.objects.filter(name__iexact=name).first()
+        if slot_type is None:
+            slot_type = SlotType.objects.create(
+                name=name, plural_name=plural, allows_repeats=True
+            )
+        table = Picklist.objects.filter(
+            slot_type=slot_type, name__iexact=f"{name} Table"
+        ).first()
+        if table is None:
+            table = Picklist.objects.create(
+                name=f"{name} Table",
+                slot_type=slot_type,
+                dice="d66",
+                roll_selects="band",
+            )
         for position, (low, high, result) in enumerate(rows):
             qualifier = twin_qualifier if result in SHARED_LASTING_RESULTS else ""
-            pickable, _ = Pickable.objects.get_or_create(
-                name=result,
-                slot_type=slot_type,
-                defaults={"qualifier": qualifier},
-            )
+            pickable = _lasting_row(Pickable, result, qualifier, slot_type, {})
             PicklistMember.objects.get_or_create(
                 picklist=table,
                 pickable=pickable,
@@ -605,27 +627,27 @@ def _create_lasting_effect_tables():
                     "position": position,
                 },
             )
-        Slot.objects.get_or_create(
-            name=name,
-            slot_type=slot_type,
-            defaults={
-                "picklist": table,
-                "label": plural,
-                "min_picks": 0,
-                "max_picks": 20,
-            },
+        _lasting_row(
+            Slot,
+            name,
+            "",
+            slot_type,
+            {"picklist": table, "label": plural, "min_picks": 0, "max_picks": 20},
         )
 
 
 def _check_lasting_effect_tables():
-    from n26.library.models import PicklistMember
+    from n26.library.models import PicklistMember, Slot, SlotType
 
-    total = sum(len(rows) for _, _, rows, _ in LASTING_EFFECT_TABLES)
-    present = _count(
+    names = [name for name, _, _, _ in LASTING_EFFECT_TABLES]
+    members = sum(len(rows) for _, _, rows, _ in LASTING_EFFECT_TABLES)
+    present = _count(SlotType, name__in=names)
+    present += _count(
         PicklistMember,
-        picklist__name__in=[f"{name} Table" for name, _, _, _ in LASTING_EFFECT_TABLES],
+        picklist__name__in=[f"{name} Table" for name in names],
     )
-    return present, total
+    present += _count(Slot, name__in=names)
+    return present, len(names) + members + len(names)
 
 
 STANDARD_CONTENT = {

--- a/n26/tests/sandbox/test_lasting_effects.py
+++ b/n26/tests/sandbox/test_lasting_effects.py
@@ -1,0 +1,291 @@
+"""The Lasting Injury and Lasting Damage tables, built as they ship.
+
+The executable spec for the rulebook's two lasting-effect tables (core
+rules: resolving hits and injuries): each is a slot type, a roll table
+of pickables with their bands, and a standing choice built into a
+profile. Names and bands only, never the book's wording; the six
+results that change a characteristic carry an ordinary modifier.
+
+Two slot types rather than one, so a fighter can never be handed
+vehicle damage — the choice's own type check refuses it. Five names
+appear on both tables at the same rolls; they are separate pickables,
+because a pickable belongs to one slot type — and the damage twins
+carry the qualifier "vehicle", because a pack holds one pickable per
+name and the qualifier is the author-facing way to tell twins apart.
+"""
+
+import pytest
+
+from n26.core.card import build_card, build_modifier_index
+from n26.core.effects import compute
+from n26.core.reconcile import assert_reconciled
+from n26.library.views import coverage
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    add_picklist_member,
+    changes_stat,
+    choose,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_slot,
+    create_slot_type,
+    found_gang,
+    hire,
+    modifier,
+    remove,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+# (band low, band high, result, characteristic worsened or None).
+# A result with no characteristic is a name and a band: what it does is
+# played at the table, and the card only has to say the model has it.
+LASTING_INJURY_TABLE = [
+    (11, 11, "Lesson Learnt", None),
+    (12, 12, "Eternal Enmity", None),
+    (13, 13, "Bitter Enmity", None),
+    (14, 14, "Personal Enmity", None),
+    (15, 15, "Horrid Scars", None),
+    (16, 16, "Impressive Scars", None),
+    (21, 26, "Out Cold", None),
+    (31, 46, "Grievous Wound", None),
+    (51, 51, "Eye Injury", "BS"),
+    (52, 52, "Hand Injury", "WS"),
+    (53, 53, "Hobbled", "M"),
+    (54, 54, "Spinal Injury", "S"),
+    (55, 55, "Enfeebled", "T"),
+    (56, 56, "Head Injury", "Ld"),
+    (61, 62, "Captured", None),
+    (63, 65, "Critical Injury", None),
+    (66, 66, "Memorable Death", None),
+]
+
+LASTING_DAMAGE_TABLE = [
+    (11, 11, "Lesson Learnt", None),
+    (12, 12, "Eternal Enmity", None),
+    (13, 13, "Bitter Enmity", None),
+    (14, 14, "Personal Enmity", None),
+    (15, 16, "Percussive Repair", None),
+    (21, 26, "Superficial Damage", None),
+    (31, 46, "Major Damage", None),
+    (51, 52, "Busted Sights", "BS"),
+    (53, 53, "Drive System Fault", "M"),
+    (54, 54, "Buckled Frame", "T"),
+    (55, 56, "Engine Fracture", "W"),
+    (61, 62, "Captured", None),
+    (63, 65, "Critical Damage", None),
+    (66, 66, "Catastrophic Explosion!", None),
+]
+
+
+#: On both tables at the same rolls. One pickable per name per pack, so
+#: the damage twin of each carries a qualifier.
+SHARED_RESULTS = {
+    "Lesson Learnt",
+    "Eternal Enmity",
+    "Bitter Enmity",
+    "Personal Enmity",
+    "Captured",
+}
+
+
+def build_table(name, plural, rows, stats, twin_qualifier=""):
+    """One lasting-effect table, whole, through the authoring verbs."""
+    slot_type = create_slot_type(name, plural_name=plural, allows_repeats=True)
+    table = create_picklist(f"{name} Table", slot_type, dice="d66", roll_selects="band")
+    for low, high, result, worsens in rows:
+        qualifier = twin_qualifier if result in SHARED_RESULTS else ""
+        pickable = create_pickable(result, slot_type, qualifier=qualifier)
+        add_picklist_member(table, pickable, roll_low=low, roll_high=high)
+        if worsens:
+            modifier(
+                f"{result}: worsens {worsens}",
+                targets_model(),
+                changes_stat(stats[worsens], "worsen", 1),
+                carried_by=pickable,
+            )
+    slot = create_slot(name, slot_type, table, label=plural, min_picks=0, max_picks=20)
+    return slot_type, table, slot
+
+
+@pytest.fixture
+def injuries(default_pack, fighter_stats):
+    return build_table(
+        "Lasting Injury", "Lasting Injuries", LASTING_INJURY_TABLE, fighter_stats
+    )
+
+
+@pytest.fixture
+def damage(default_pack, fighter_stats):
+    return build_table(
+        "Lasting Damage",
+        "Lasting Damage",
+        LASTING_DAMAGE_TABLE,
+        fighter_stats,
+        twin_qualifier="vehicle",
+    )
+
+
+@pytest.fixture
+def gang(gang_type, db):
+    from django.contrib.auth.models import User
+
+    owner = User.objects.create_user("player")
+    return found_gang("The Scar Crossing", gang_type, owner=owner, budget=1000)
+
+
+@pytest.fixture
+def yolanda(gang, gang_type, fighter_type, injuries):
+    _, _, slot = injuries
+    profile = create_profile("Ganger", fighter_type, gang_type, price=50)
+    add_built_in(profile, slot)
+    return hire(gang, profile, "Yolanda", paid=50)
+
+
+@pytest.fixture
+def rig(gang, gang_type, vehicle_type, damage):
+    _, _, slot = damage
+    profile = create_profile("Cargo Rig", vehicle_type, gang_type, price=100)
+    add_built_in(profile, slot)
+    return hire(gang, profile, "The Rig", paid=100)
+
+
+def computed_for(miniature):
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return compute(card, index)
+
+
+def choice_of(miniature, label):
+    return next(
+        slot for slot in computed_for(miniature).choices if slot.kind_label == label
+    )
+
+
+def result_named(table, name):
+    return next(m.pickable for m in table.members.all() if m.pickable.name == name)
+
+
+class TestTheTablesAsAuthored:
+    """Both tables cover their die exactly, with nothing doubled and
+    nothing unrollable — pinned so a band changes deliberately."""
+
+    def test_the_injury_table_is_whole(self, injuries):
+        _, table, _ = injuries
+        said = coverage(table)
+        assert said.covered == said.total == 36
+        assert said.unclaimed == []
+        assert said.doubled == []
+        assert said.bandless == []
+
+    def test_the_damage_table_is_whole(self, damage):
+        _, table, _ = damage
+        said = coverage(table)
+        assert said.covered == said.total == 36
+        assert said.unclaimed == []
+        assert said.doubled == []
+        assert said.bandless == []
+
+    def test_the_shared_names_are_separate_results_per_table(self, injuries, damage):
+        """Lesson Learnt, the three Enmities and Captured sit on both
+        tables at the same rolls — as two pickables each, because a
+        pickable belongs to one slot type."""
+        from n26.library.models import Pickable
+
+        for name in (
+            "Lesson Learnt",
+            "Eternal Enmity",
+            "Bitter Enmity",
+            "Personal Enmity",
+            "Captured",
+        ):
+            types = {p.slot_type.name for p in Pickable.objects.filter(name=name)}
+            assert types == {"Lasting Injury", "Lasting Damage"}, name
+
+
+class TestAFighterIsHurt:
+    def test_the_card_asks_under_the_tables_own_word(self, yolanda, rig):
+        assert choice_of(yolanda, "Lasting Injuries") is not None
+        assert choice_of(rig, "Lasting Damage") is not None
+        assert not any(
+            slot.kind_label == "Lasting Damage"
+            for slot in computed_for(yolanda).choices
+        )
+
+    def test_an_eye_injury_worsens_the_ballistic_skill(self, gang, yolanda, injuries):
+        _, table, _ = injuries
+        slot = choice_of(yolanda, "Lasting Injuries")
+        choose(slot.anchor.assignment, result_named(table, "Eye Injury"))
+
+        changes = [
+            c for c in computed_for(yolanda).stat_changes if c.source == "Eye Injury"
+        ]
+        assert len(changes) == 1
+        assert_reconciled(gang)
+
+    def test_a_result_that_changes_nothing_is_still_on_the_card(
+        self, gang, yolanda, injuries
+    ):
+        _, table, _ = injuries
+        slot = choice_of(yolanda, "Lasting Injuries")
+        choose(slot.anchor.assignment, result_named(table, "Out Cold"))
+
+        slot = choice_of(yolanda, "Lasting Injuries")
+        assert [p.assignable.name for p in slot.picks] == ["Out Cold"]
+        assert_reconciled(gang)
+
+    def test_the_same_injury_twice_stands_and_stacks(self, gang, yolanda, injuries):
+        _, table, _ = injuries
+        eye = result_named(table, "Eye Injury")
+        for _ in range(2):
+            slot = choice_of(yolanda, "Lasting Injuries")
+            choose(slot.anchor.assignment, eye)
+
+        changes = [
+            c for c in computed_for(yolanda).stat_changes if c.source == "Eye Injury"
+        ]
+        assert len(changes) == 2
+        assert_reconciled(gang)
+
+    def test_removing_the_slot_takes_the_injuries_and_their_effects(
+        self, gang, yolanda, injuries
+    ):
+        _, table, _ = injuries
+        slot = choice_of(yolanda, "Lasting Injuries")
+        choose(slot.anchor.assignment, result_named(table, "Eye Injury"))
+
+        remove(choice_of(yolanda, "Lasting Injuries").anchor.assignment)
+
+        computed = computed_for(yolanda)
+        assert not any(s.kind_label == "Lasting Injuries" for s in computed.choices)
+        assert not any(c.source == "Eye Injury" for c in computed.stat_changes)
+        assert_reconciled(gang)
+
+
+class TestAVehicleIsHit:
+    def test_busted_sights_worsen_the_ballistic_skill(self, gang, rig, damage):
+        _, table, _ = damage
+        slot = choice_of(rig, "Lasting Damage")
+        choose(slot.anchor.assignment, result_named(table, "Busted Sights"))
+
+        changes = [
+            c for c in computed_for(rig).stat_changes if c.source == "Busted Sights"
+        ]
+        assert len(changes) == 1
+        assert_reconciled(gang)
+
+    def test_a_fighter_cannot_be_handed_vehicle_damage(
+        self, gang, yolanda, rig, damage
+    ):
+        """The two tables share a card row's shape, never their results:
+        the choice's own type check is what stands between a fighter and
+        a Busted Sights."""
+        from n26.core.operations import Refusal
+
+        _, table, _ = damage
+        slot = choice_of(yolanda, "Lasting Injuries")
+        with pytest.raises(Refusal):
+            choose(slot.anchor.assignment, result_named(table, "Busted Sights"))
+        assert_reconciled(gang)

--- a/n26/tests/sandbox/test_lasting_effects.py
+++ b/n26/tests/sandbox/test_lasting_effects.py
@@ -129,6 +129,29 @@ class TestTheTablesAsSeeded:
         assert said.doubled == []
         assert said.bandless == []
 
+    def test_running_the_seed_again_creates_nothing(self, tables):
+        from n26.library.models import Pickable, PicklistMember, Slot, SlotType
+
+        kinds = (SlotType, Pickable, PicklistMember, Slot)
+        counts = {kind: kind.objects.count() for kind in kinds}
+        STANDARD_CONTENT["lasting-effect-tables"].create()
+        assert counts == {kind: kind.objects.count() for kind in kinds}
+
+        present, total = STANDARD_CONTENT["lasting-effect-tables"].check()
+        assert present == total
+
+    def test_a_name_owned_by_another_slot_type_is_refused_in_words(self, default_pack):
+        """A pack holds one pickable per name and qualifier, whichever
+        slot type it belongs to — so a name already claimed elsewhere
+        stops the seed with an explanation, never a bare constraint."""
+        from n26.library.authoring import create_pickable, create_slot_type
+
+        other = create_slot_type("Gang Legacy", plural_name="Gang Legacies")
+        create_pickable("Captured", other)
+
+        with pytest.raises(RuntimeError, match="Captured"):
+            STANDARD_CONTENT["lasting-effect-tables"].create()
+
     def test_the_shared_names_are_separate_results_per_table(self, tables):
         """Lesson Learnt, the three Enmities and Captured sit on both
         tables at the same rolls — as two pickables each, because a

--- a/n26/tests/sandbox/test_lasting_effects.py
+++ b/n26/tests/sandbox/test_lasting_effects.py
@@ -1,10 +1,12 @@
 """The Lasting Injury and Lasting Damage tables, built as they ship.
 
 The executable spec for the rulebook's two lasting-effect tables (core
-rules: resolving hits and injuries): each is a slot type, a roll table
-of pickables with their bands, and a standing choice built into a
-profile. Names and bands only, never the book's wording; the six
-results that change a characteristic carry an ordinary modifier.
+rules: resolving hits and injuries). The tables themselves — two slot
+types, a D66 roll table of results at their bands, a standing choice
+each — are a Foundations seed, created here exactly as the button
+creates them. Seeds write names and numbers only, so what the six
+characteristic results *do* is attached afterwards as ordinary
+modifiers, the way an author finishes the tables by hand.
 
 Two slot types rather than one, so a fighter can never be handed
 vehicle damage — the choice's own type check refuses it. Five names
@@ -19,17 +21,16 @@ import pytest
 from n26.core.card import build_card, build_modifier_index
 from n26.core.effects import compute
 from n26.core.reconcile import assert_reconciled
+from n26.library.standard_content import (
+    LASTING_EFFECT_TABLES,
+    STANDARD_CONTENT,
+)
 from n26.library.views import coverage
 from n26.tests.sandbox.actions import (
     add_built_in,
-    add_picklist_member,
     changes_stat,
     choose,
-    create_pickable,
-    create_picklist,
     create_profile,
-    create_slot,
-    create_slot_type,
     found_gang,
     hire,
     modifier,
@@ -39,93 +40,43 @@ from n26.tests.sandbox.actions import (
 
 pytestmark = pytest.mark.django_db
 
-# (band low, band high, result, characteristic worsened or None).
-# A result with no characteristic is a name and a band: what it does is
-# played at the table, and the card only has to say the model has it.
-LASTING_INJURY_TABLE = [
-    (11, 11, "Lesson Learnt", None),
-    (12, 12, "Eternal Enmity", None),
-    (13, 13, "Bitter Enmity", None),
-    (14, 14, "Personal Enmity", None),
-    (15, 15, "Horrid Scars", None),
-    (16, 16, "Impressive Scars", None),
-    (21, 26, "Out Cold", None),
-    (31, 46, "Grievous Wound", None),
-    (51, 51, "Eye Injury", "BS"),
-    (52, 52, "Hand Injury", "WS"),
-    (53, 53, "Hobbled", "M"),
-    (54, 54, "Spinal Injury", "S"),
-    (55, 55, "Enfeebled", "T"),
-    (56, 56, "Head Injury", "Ld"),
-    (61, 62, "Captured", None),
-    (63, 65, "Critical Injury", None),
-    (66, 66, "Memorable Death", None),
-]
-
-LASTING_DAMAGE_TABLE = [
-    (11, 11, "Lesson Learnt", None),
-    (12, 12, "Eternal Enmity", None),
-    (13, 13, "Bitter Enmity", None),
-    (14, 14, "Personal Enmity", None),
-    (15, 16, "Percussive Repair", None),
-    (21, 26, "Superficial Damage", None),
-    (31, 46, "Major Damage", None),
-    (51, 52, "Busted Sights", "BS"),
-    (53, 53, "Drive System Fault", "M"),
-    (54, 54, "Buckled Frame", "T"),
-    (55, 56, "Engine Fracture", "W"),
-    (61, 62, "Captured", None),
-    (63, 65, "Critical Damage", None),
-    (66, 66, "Catastrophic Explosion!", None),
-]
-
-
-#: On both tables at the same rolls. One pickable per name per pack, so
-#: the damage twin of each carries a qualifier.
-SHARED_RESULTS = {
-    "Lesson Learnt",
-    "Eternal Enmity",
-    "Bitter Enmity",
-    "Personal Enmity",
-    "Captured",
+#: What the six characteristic results worsen, by one. The seed cannot
+#: write these — a modifier is behaviour, not a name — so they are the
+#: hand-authored half of the tables.
+WORSENS = {
+    "Eye Injury": "BS",
+    "Hand Injury": "WS",
+    "Hobbled": "M",
+    "Spinal Injury": "S",
+    "Enfeebled": "T",
+    "Head Injury": "Ld",
+    "Busted Sights": "BS",
+    "Drive System Fault": "M",
+    "Buckled Frame": "T",
+    "Engine Fracture": "W",
 }
 
 
-def build_table(name, plural, rows, stats, twin_qualifier=""):
-    """One lasting-effect table, whole, through the authoring verbs."""
-    slot_type = create_slot_type(name, plural_name=plural, allows_repeats=True)
-    table = create_picklist(f"{name} Table", slot_type, dice="d66", roll_selects="band")
-    for low, high, result, worsens in rows:
-        qualifier = twin_qualifier if result in SHARED_RESULTS else ""
-        pickable = create_pickable(result, slot_type, qualifier=qualifier)
-        add_picklist_member(table, pickable, roll_low=low, roll_high=high)
-        if worsens:
-            modifier(
-                f"{result}: worsens {worsens}",
-                targets_model(),
-                changes_stat(stats[worsens], "worsen", 1),
-                carried_by=pickable,
-            )
-    slot = create_slot(name, slot_type, table, label=plural, min_picks=0, max_picks=20)
-    return slot_type, table, slot
-
-
 @pytest.fixture
-def injuries(default_pack, fighter_stats):
-    return build_table(
-        "Lasting Injury", "Lasting Injuries", LASTING_INJURY_TABLE, fighter_stats
-    )
+def tables(default_pack, fighter_stats):
+    """The seed, then the hand-finishing: the shipped path, whole."""
+    from n26.library.models import Pickable, Picklist, Slot
 
-
-@pytest.fixture
-def damage(default_pack, fighter_stats):
-    return build_table(
-        "Lasting Damage",
-        "Lasting Damage",
-        LASTING_DAMAGE_TABLE,
-        fighter_stats,
-        twin_qualifier="vehicle",
-    )
+    STANDARD_CONTENT["lasting-effect-tables"].create()
+    for result, short in WORSENS.items():
+        modifier(
+            f"{result}: worsens {short}",
+            targets_model(),
+            changes_stat(fighter_stats[short], "worsen", 1),
+            carried_by=Pickable.objects.get(name=result),
+        )
+    return {
+        name: {
+            "table": Picklist.objects.get(name=f"{name} Table"),
+            "slot": Slot.objects.get(name=name),
+        }
+        for name, _, _, _ in LASTING_EFFECT_TABLES
+    }
 
 
 @pytest.fixture
@@ -137,18 +88,16 @@ def gang(gang_type, db):
 
 
 @pytest.fixture
-def yolanda(gang, gang_type, fighter_type, injuries):
-    _, _, slot = injuries
+def yolanda(gang, gang_type, fighter_type, tables):
     profile = create_profile("Ganger", fighter_type, gang_type, price=50)
-    add_built_in(profile, slot)
+    add_built_in(profile, tables["Lasting Injury"]["slot"])
     return hire(gang, profile, "Yolanda", paid=50)
 
 
 @pytest.fixture
-def rig(gang, gang_type, vehicle_type, damage):
-    _, _, slot = damage
+def rig(gang, gang_type, vehicle_type, tables):
     profile = create_profile("Cargo Rig", vehicle_type, gang_type, price=100)
-    add_built_in(profile, slot)
+    add_built_in(profile, tables["Lasting Damage"]["slot"])
     return hire(gang, profile, "The Rig", paid=100)
 
 
@@ -168,39 +117,26 @@ def result_named(table, name):
     return next(m.pickable for m in table.members.all() if m.pickable.name == name)
 
 
-class TestTheTablesAsAuthored:
+class TestTheTablesAsSeeded:
     """Both tables cover their die exactly, with nothing doubled and
     nothing unrollable — pinned so a band changes deliberately."""
 
-    def test_the_injury_table_is_whole(self, injuries):
-        _, table, _ = injuries
-        said = coverage(table)
+    @pytest.mark.parametrize("name", [n for n, _, _, _ in LASTING_EFFECT_TABLES])
+    def test_the_table_is_whole(self, tables, name):
+        said = coverage(tables[name]["table"])
         assert said.covered == said.total == 36
         assert said.unclaimed == []
         assert said.doubled == []
         assert said.bandless == []
 
-    def test_the_damage_table_is_whole(self, damage):
-        _, table, _ = damage
-        said = coverage(table)
-        assert said.covered == said.total == 36
-        assert said.unclaimed == []
-        assert said.doubled == []
-        assert said.bandless == []
-
-    def test_the_shared_names_are_separate_results_per_table(self, injuries, damage):
+    def test_the_shared_names_are_separate_results_per_table(self, tables):
         """Lesson Learnt, the three Enmities and Captured sit on both
         tables at the same rolls — as two pickables each, because a
         pickable belongs to one slot type."""
         from n26.library.models import Pickable
+        from n26.library.standard_content import SHARED_LASTING_RESULTS
 
-        for name in (
-            "Lesson Learnt",
-            "Eternal Enmity",
-            "Bitter Enmity",
-            "Personal Enmity",
-            "Captured",
-        ):
+        for name in SHARED_LASTING_RESULTS:
             types = {p.slot_type.name for p in Pickable.objects.filter(name=name)}
             assert types == {"Lasting Injury", "Lasting Damage"}, name
 
@@ -214,8 +150,8 @@ class TestAFighterIsHurt:
             for slot in computed_for(yolanda).choices
         )
 
-    def test_an_eye_injury_worsens_the_ballistic_skill(self, gang, yolanda, injuries):
-        _, table, _ = injuries
+    def test_an_eye_injury_worsens_the_ballistic_skill(self, gang, yolanda, tables):
+        table = tables["Lasting Injury"]["table"]
         slot = choice_of(yolanda, "Lasting Injuries")
         choose(slot.anchor.assignment, result_named(table, "Eye Injury"))
 
@@ -226,9 +162,9 @@ class TestAFighterIsHurt:
         assert_reconciled(gang)
 
     def test_a_result_that_changes_nothing_is_still_on_the_card(
-        self, gang, yolanda, injuries
+        self, gang, yolanda, tables
     ):
-        _, table, _ = injuries
+        table = tables["Lasting Injury"]["table"]
         slot = choice_of(yolanda, "Lasting Injuries")
         choose(slot.anchor.assignment, result_named(table, "Out Cold"))
 
@@ -236,9 +172,8 @@ class TestAFighterIsHurt:
         assert [p.assignable.name for p in slot.picks] == ["Out Cold"]
         assert_reconciled(gang)
 
-    def test_the_same_injury_twice_stands_and_stacks(self, gang, yolanda, injuries):
-        _, table, _ = injuries
-        eye = result_named(table, "Eye Injury")
+    def test_the_same_injury_twice_stands_and_stacks(self, gang, yolanda, tables):
+        eye = result_named(tables["Lasting Injury"]["table"], "Eye Injury")
         for _ in range(2):
             slot = choice_of(yolanda, "Lasting Injuries")
             choose(slot.anchor.assignment, eye)
@@ -250,9 +185,9 @@ class TestAFighterIsHurt:
         assert_reconciled(gang)
 
     def test_removing_the_slot_takes_the_injuries_and_their_effects(
-        self, gang, yolanda, injuries
+        self, gang, yolanda, tables
     ):
-        _, table, _ = injuries
+        table = tables["Lasting Injury"]["table"]
         slot = choice_of(yolanda, "Lasting Injuries")
         choose(slot.anchor.assignment, result_named(table, "Eye Injury"))
 
@@ -265,8 +200,8 @@ class TestAFighterIsHurt:
 
 
 class TestAVehicleIsHit:
-    def test_busted_sights_worsen_the_ballistic_skill(self, gang, rig, damage):
-        _, table, _ = damage
+    def test_busted_sights_worsen_the_ballistic_skill(self, gang, rig, tables):
+        table = tables["Lasting Damage"]["table"]
         slot = choice_of(rig, "Lasting Damage")
         choose(slot.anchor.assignment, result_named(table, "Busted Sights"))
 
@@ -277,14 +212,14 @@ class TestAVehicleIsHit:
         assert_reconciled(gang)
 
     def test_a_fighter_cannot_be_handed_vehicle_damage(
-        self, gang, yolanda, rig, damage
+        self, gang, yolanda, rig, tables
     ):
         """The two tables share a card row's shape, never their results:
         the choice's own type check is what stands between a fighter and
         a Busted Sights."""
         from n26.core.operations import Refusal
 
-        _, table, _ = damage
+        table = tables["Lasting Damage"]["table"]
         slot = choice_of(yolanda, "Lasting Injuries")
         with pytest.raises(Refusal):
             choose(slot.anchor.assignment, result_named(table, "Busted Sights"))

--- a/n26/tests/sandbox/test_lasting_effects.py
+++ b/n26/tests/sandbox/test_lasting_effects.py
@@ -4,7 +4,7 @@ The executable spec for the rulebook's two lasting-effect tables (core
 rules: resolving hits and injuries). The tables themselves — two slot
 types, a D66 roll table of results at their bands, a standing choice
 each — are a Foundations seed, created here exactly as the button
-creates them. Seeds write names and numbers only, so what the six
+creates them. Seeds write names and numbers only, so what the ten
 characteristic results *do* is attached afterwards as ordinary
 modifiers, the way an author finishes the tables by hand.
 
@@ -40,7 +40,7 @@ from n26.tests.sandbox.actions import (
 
 pytestmark = pytest.mark.django_db
 
-#: What the six characteristic results worsen, by one. The seed cannot
+#: What the ten characteristic results worsen, by one. The seed cannot
 #: write these — a modifier is behaviour, not a name — so they are the
 #: hand-authored half of the tables.
 WORSENS = {


### PR DESCRIPTION
Fourth PR towards #2293: the two lasting-effect tables as content — a Foundations seed, the executable spec, and the author-facing recipe. No migrations.

## The Foundations button

One press creates both tables whole and idempotently: a slot type each (repeats allowed), every result at its band, a D66 picklist per table, and a standing choice each. The seed's help says plainly what remains by hand — seeds carry names and numbers only, so the ten characteristic results (six injuries, four damage) still need their worsen-by-one modifiers attached, and the choices built into entries. Production setup is: press the button, attach ten modifiers, build two choices in.

## The executable spec — `n26/tests/sandbox/test_lasting_effects.py`

Builds the tables through the seed itself and layers the modifiers on as an author would, so what it proves is the shipped path. Names and bands only, never the book's wording. It pins:

- **coverage at 36 of 36 for each table** — nothing unclaimed, nothing doubled, nothing bandless — so a band changes deliberately
- the ten characteristic results carrying their worsen-by-one modifiers (injuries: BS, WS, M, S, T, Ld; damage: BS, M, T, W)
- a fighter's card asking under **Lasting Injuries**, a vehicle's under **Lasting Damage**, and never each other's
- an Eye Injury worsening BS; the same injury twice standing and stacking; a result with no modifier still on the card; removing the slot taking every injury and its effects
- **a fighter cannot be handed vehicle damage** — the choice's own type check refuses it, message and all

## One thing the spec surfaced

The plan said the five shared results (Lesson Learnt, the three Enmities, Captured) are "separate pickables per table — do not share". They are — but a pack holds **one pickable per name**, so the plain version collides. The qualifier is the designed escape (author-facing, never player-visible): the damage twins carry `qualifier="vehicle"`. The recipe tells authors the same.

## The recipe

`recipes.md` gains "The Lasting Injury and Lasting Damage tables": three steps in the authoring pages' own words — press the Foundations button, attach the ten modifiers, build each table's choice into the matching entries. It states plainly that the app never rolls.

## From review

The seed's lookups were keyed on name and slot type, but a pickable or slot is unique per pack on lowercased name and qualifier — so a row that existed under another slot type (or in a different case) would be missed and then re-inserted into the constraint, aborting the seed as a bare `IntegrityError`. Rows are now matched the way the constraint compares them, and a name already claimed by another slot type stops the seed with an explanation; both behaviours are pinned in the spec, along with running the seed twice creating nothing. The Foundations status check now counts the slot type and standing-choice rows too, not just the table entries, so a run that died before attaching the choices reads incomplete rather than complete. And a stray literal `\n` is gone from the end of the rendered recipe page.

**Not here:** the standing slot on every real profile — and until that step, no card shows the row: the seed creates the tables and their choices, but a model only carries the choice once its profile has the slot built in. Building it into every profile propagates to every existing gang through the live propagation machinery, so it is its own change, previewed through the maintenance console and sized against production counts first.

`pytest n26/` — 4429 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
