### PR TITLE
feat: n26_drop_duplicate_grants drops the second copy a catch-up pass granted

### DIFF
--- a/n26/core/backfill_built_ins.py
+++ b/n26/core/backfill_built_ins.py
@@ -345,11 +345,14 @@ def _name_of(carrier, host_gang):
 
 
 def legacy_grants_by_kind():
-    """How many grants in unarchived gangs still carry no provenance,
-    by what they name. One query."""
-    counted = Assignment.objects.filter(
-        gang_root__archived=False, **LEGACY_SHAPE
-    ).aggregate(
+    """How many grants still carry no provenance, by what they name.
+    One query.
+
+    Archived gangs are counted with the rest: an archived gang is one
+    its owner may bring back, and a gang whose grants were never tagged
+    comes back holding kit nothing can account for.
+    """
+    counted = Assignment.objects.filter(**LEGACY_SHAPE).aggregate(
         **{
             kind: Count("pk", filter=Q(**{f"{kind}__isnull": False}))
             for kind in DEFAULT_ASSIGNABLE_FIELDS

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -1,0 +1,210 @@
+"""Dropping the second copy a catch-up pass granted.
+
+A pass decides whether a carrier already holds a member by provenance
+alone: a copy naming the member and the carrier. Grants written before
+provenance existed name nothing, so to a pass they were invisible — it
+looked at a model that plainly held the thing, found no copy naming the
+member, and granted another. Every such pass over a set left the model
+holding the thing twice: the owner's original, and a fresh grant told in
+the history as caught up.
+
+A duplicate is recognised by its shape rather than by when it happened:
+one copy carrying provenance and a catch-up event, beside a copy of the
+same thing on the same host with no provenance at all. Nothing else has
+that shape. Two members of a set naming one thing leave two copies that
+both carry provenance; a thing an owner bought or was rewarded leaves a
+copy whose reason is not ``default``; a hire's own grant carries no
+catch-up event.
+
+The repair keeps the owner's copy and drops the pass's, then writes the
+dropped copy's provenance onto the survivor — the state the estate would
+have been in had every grant been tagged before any pass ran. Deleting
+is right where archiving is not: an archived copy reads as something the
+owner parted with, and they never had this one. What the dropped copy
+caused goes with it, which is how a duplicated subtype's own built-ins
+leave too; the next pass grants them once, against the survivor.
+
+Nothing here moves money. Every copy dropped is a free grant whose entry
+pins zero and whose events carry no deltas, so the books fold exactly as
+they did — proved per gang, as every repair here proves it.
+"""
+
+from dataclasses import dataclass, field
+
+from n26.core.models import Assignment, LedgerEvent, Reason
+from n26.core.models.assignment import ASSIGNABLE_FIELDS
+
+#: Grants written before provenance was recorded, in the shape that says
+#: so. A removal is machinery rather than a grant and never counts.
+UNTAGGED = {
+    "materialised_from__isnull": True,
+    "ledger_entry__reason": Reason.DEFAULT,
+    "removes": False,
+    "archived": False,
+}
+
+
+@dataclass
+class GangOutcome:
+    """What the repair did to one gang."""
+
+    gang_id: str
+    #: Duplicate grants deleted.
+    dropped: int = 0
+    #: Owner's copies given the dropped copy's provenance.
+    retagged: int = 0
+    #: Assignments that went with a dropped copy because it caused them.
+    swept: int = 0
+    #: Sentences, one per group left alone because dropping it would
+    #: destroy a tally somebody had kept.
+    kept_a_tally: list = field(default_factory=list)
+
+    def counts(self):
+        return {
+            "dropped": self.dropped,
+            "retagged": self.retagged,
+            "swept": self.swept,
+            "kept_a_tally": len(self.kept_a_tally),
+        }
+
+
+def _host_of(assignment):
+    """What the copy hangs on: its model, or the gang where it has none."""
+    if assignment.miniature_root_id is not None:
+        return ("miniature", assignment.miniature_root_id)
+    if assignment.stash_root_id is not None:
+        return ("stash", assignment.stash_root_id)
+    return ("gang", assignment.gang_root_id)
+
+
+def _kind_of(assignment):
+    for field_name in ASSIGNABLE_FIELDS:
+        if getattr(assignment, f"{field_name}_id", None) is not None:
+            return (field_name, getattr(assignment, f"{field_name}_id"))
+    return None
+
+
+def _tally_under(assignment):
+    """The highest counter value on the copy or anything it caused, or
+    None where nothing under it counts anything."""
+    values = [
+        row.counter_value.value
+        for row in [assignment, *assignment.caused.all()]
+        if getattr(row, "counter_value", None) is not None
+    ]
+    return max(values) if values else None
+
+
+def duplicates_in(gang):
+    """The pairs this gang carries: a caught-up grant beside an owner's
+    untagged copy of the same thing on the same host."""
+    caught_up = set(
+        LedgerEvent.objects.filter(
+            kind=LedgerEvent.Kind.CAUGHT_UP, gang=gang
+        ).values_list("assignment_id", flat=True)
+    )
+    if not caught_up:
+        return []
+
+    live = list(
+        Assignment.objects.filter(
+            gang_root=gang, archived=False, removes=False
+        ).select_related("ledger_entry")
+    )
+    by_place = {}
+    for copy in live:
+        kind = _kind_of(copy)
+        if kind is None:
+            continue
+        by_place.setdefault((_host_of(copy), kind), []).append(copy)
+
+    pairs = []
+    for copies in by_place.values():
+        if len(copies) < 2:
+            continue
+        granted = [
+            copy
+            for copy in copies
+            if copy.pk in caught_up and copy.materialised_from_id is not None
+        ]
+        owners = [
+            copy
+            for copy in copies
+            if copy.materialised_from_id is None
+            and getattr(copy, "ledger_entry", None) is not None
+            and copy.ledger_entry.reason == Reason.DEFAULT
+        ]
+        # Pairs only, deliberately: a group with more caught-up grants
+        # than owner's copies has as many duplicates as there are copies
+        # to keep, and the rest are grants standing on their own.
+        for grant, owner in zip(
+            sorted(granted, key=lambda copy: copy.pk), owners, strict=False
+        ):
+            pairs.append((grant, owner))
+    return pairs
+
+
+def de_duplicate(gang_id):
+    """Settle one gang: drop each duplicated grant and hand its
+    provenance to the copy the owner already had."""
+    from django.db import transaction
+
+    from n26.core.models import Gang
+    from n26.core.reconcile import assert_reconciled
+
+    gang = Gang.objects.get(pk=gang_id)
+    outcome = GangOutcome(gang_id=str(gang_id))
+    with transaction.atomic():
+        for grant, owner in duplicates_in(gang):
+            tally = _tally_under(grant)
+            if tally:
+                outcome.kept_a_tally.append(
+                    f"{grant.assignable} on {grant.miniature_root or gang} "
+                    f"counts {tally}, so its duplicate stands."
+                )
+                continue
+            swept = grant.caused.count()
+            member_id = grant.materialised_from_id
+            carrier_id = grant.materialised_for_id
+            grant.delete()
+            owner.materialised_from_id = member_id
+            owner.materialised_for_id = carrier_id
+            owner.save(
+                update_fields=["materialised_from", "materialised_for", "modified"]
+            )
+            outcome.dropped += 1
+            outcome.retagged += 1
+            outcome.swept += swept
+        if outcome.dropped:
+            gang.refresh_from_db()
+            assert_reconciled(gang)
+    return outcome
+
+
+def duplicate_grants_by_kind():
+    """How many caught-up grants sit beside an owner's untagged copy of
+    the same thing, by what they name — the console's preview."""
+    from collections import Counter
+
+    counted = Counter()
+    caught_up = set(
+        LedgerEvent.objects.filter(kind=LedgerEvent.Kind.CAUGHT_UP).values_list(
+            "assignment_id", flat=True
+        )
+    )
+    untagged = {}
+    for copy in Assignment.objects.filter(**UNTAGGED).select_related("ledger_entry"):
+        kind = _kind_of(copy)
+        if kind is not None:
+            untagged.setdefault((_host_of(copy), kind), []).append(copy.pk)
+    for copy in Assignment.objects.filter(
+        pk__in=caught_up, archived=False, removes=False
+    ):
+        kind = _kind_of(copy)
+        if kind is None:
+            continue
+        waiting = untagged.get((_host_of(copy), kind))
+        if waiting:
+            waiting.pop()
+            counted[kind[0]] += 1
+    return dict(counted)

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -84,6 +84,18 @@ def _kind_of(assignment):
     return None
 
 
+def _goes_with(assignment):
+    """Everything the database takes with the copy: what it caused, and
+    what names it as the carrier it materialised for. Both cascade."""
+    return set(
+        Assignment.objects.filter(caused_by=assignment).values_list("pk", flat=True)
+    ) | set(
+        Assignment.objects.filter(materialised_for=assignment).values_list(
+            "pk", flat=True
+        )
+    )
+
+
 def _tally_under(assignment):
     """The highest counter value on the copy or anything it caused, or
     None where nothing under it counts anything."""
@@ -138,11 +150,14 @@ def duplicates_in(gang, only_miniature_id=None):
             and getattr(copy, "ledger_entry", None) is not None
             and copy.ledger_entry.reason == Reason.DEFAULT
         ]
-        # Pairs only, deliberately: a group with more caught-up grants
-        # than owner's copies has as many duplicates as there are copies
-        # to keep, and the rest are grants standing on their own.
+        # Oldest against oldest, so the same reading twice pairs the same
+        # copies. Pairs only, deliberately: a group with more caught-up
+        # grants than owner's copies has as many duplicates as there are
+        # copies to keep, and the rest are grants standing on their own.
         for grant, owner in zip(
-            sorted(granted, key=lambda copy: copy.pk), owners, strict=False
+            sorted(granted, key=lambda copy: copy.pk),
+            sorted(owners, key=lambda copy: copy.pk),
+            strict=False,
         ):
             pairs.append((grant, owner))
     return pairs
@@ -171,7 +186,7 @@ def de_duplicate(gang_id, only_miniature_id=None):
                     f"counts {tally}, so its duplicate stands."
                 )
                 continue
-            swept = grant.caused.count()
+            swept = len(_goes_with(grant))
             member_id = grant.materialised_from_id
             carrier_id = grant.materialised_for_id
             grant.delete()
@@ -222,9 +237,11 @@ def what_one_model_carries(miniature):
     """The duplicates standing on one model, as sentences — what a
     single-model run would drop, read before running it."""
     lines = []
+    if miniature.membership_id is None:
+        return lines
     for grant, _owner in duplicates_in(miniature.membership.gang_root, miniature.pk):
         tally = _tally_under(grant)
-        swept = grant.caused.count()
+        swept = len(_goes_with(grant))
         if tally:
             lines.append(
                 f"{grant.assignable}: the duplicate counts {tally}, so it stands."

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -145,6 +145,54 @@ def _tally_under(assignment, goes_with=None):
     return max(values, default=None)
 
 
+def _verdict(grant, owner, gang=None):
+    """What the repair would do with one pair, as (action, sentence).
+
+    The single reading behind both the run and the page that previews
+    it, so the page can never describe something the run would not do.
+    """
+    goes_with = _goes_with(grant)
+    where = grant.miniature_root or gang or "the gang"
+    if _money_under(grant, goes_with):
+        return (
+            "stands",
+            f"{grant.assignable} on {where} brought something that was paid "
+            f"for, so its duplicate stands.",
+        )
+    tally = _tally_under(grant, goes_with)
+    if tally and not _can_carry(grant, owner, goes_with):
+        return (
+            "stands",
+            f"{grant.assignable} on {where} counts {tally} where the copy "
+            f"already held has no place for it, so its duplicate stands.",
+        )
+    brought = (
+        f", and the {len(goes_with)} thing{'' if len(goes_with) == 1 else 's'} "
+        f"it brought"
+        if goes_with
+        else ""
+    )
+    counted = f" It counts {tally}, which moves across." if tally else ""
+    return (
+        "drops",
+        f"{grant.assignable}: the caught-up copy goes{brought}, and the copy "
+        f"already held takes its provenance.{counted}",
+    )
+
+
+def _can_carry(grant, owner, goes_with):
+    """Whether a tally on the duplicate has a twin to move to."""
+    from n26.core.models import CounterValue
+
+    if grant.counter_id is None or owner.counter_id != grant.counter_id:
+        return False
+    # Something beneath the duplicate counts as well, and that has
+    # nowhere to go.
+    return not CounterValue.objects.filter(
+        assignment_id__in=goes_with, value__gt=0
+    ).exists()
+
+
 def _carry_the_tally(grant, owner, tally, goes_with):
     """Move a tally from the duplicate onto the copy that stays, where
     there is somewhere for it to go.
@@ -158,11 +206,7 @@ def _carry_the_tally(grant, owner, tally, goes_with):
 
     if not tally:
         return True
-    if grant.counter_id is None or owner.counter_id != grant.counter_id:
-        return False
-    if CounterValue.objects.filter(assignment_id__in=goes_with, value__gt=0).exists():
-        # Something beneath the duplicate counts as well, and that has
-        # nowhere to go.
+    if not _can_carry(grant, owner, goes_with):
         return False
     standing, _ = CounterValue.objects.get_or_create(assignment=owner)
     if standing.value < tally:
@@ -321,27 +365,12 @@ def duplicate_grants_by_kind():
 
 
 def what_one_model_carries(miniature):
-    """The duplicates standing on one model, as sentences — what a
-    single-model run would drop, read before running it."""
-    lines = []
+    """The duplicates standing on one model, as sentences — exactly what
+    a single-model run would do, read before running it."""
     if miniature.membership_id is None:
-        return lines
-    for grant, _owner in duplicates_in(miniature.membership.gang_root, miniature.pk):
-        goes_with = _goes_with(grant)
-        tally = _tally_under(grant, goes_with)
-        swept = len(goes_with)
-        if tally:
-            lines.append(
-                f"{grant.assignable}: the duplicate counts {tally}, so it stands."
-            )
-            continue
-        brought = (
-            f", and the {swept} thing{'' if swept == 1 else 's'} it brought"
-            if swept
-            else ""
-        )
-        lines.append(
-            f"{grant.assignable}: the caught-up copy goes{brought}, and the "
-            f"copy already held takes its provenance."
-        )
-    return lines
+        return []
+    gang = miniature.membership.gang_root
+    return [
+        _verdict(grant, owner, gang)[1]
+        for grant, owner in duplicates_in(gang, miniature.pk)
+    ]

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -31,6 +31,8 @@ they did — proved per gang, as every repair here proves it.
 
 from dataclasses import dataclass, field
 
+from django.db.models import Q
+
 from n26.core.models import Assignment, LedgerEvent, Reason
 from n26.core.models.assignment import ASSIGNABLE_FIELDS
 
@@ -85,26 +87,42 @@ def _kind_of(assignment):
 
 
 def _goes_with(assignment):
-    """Everything the database takes with the copy: what it caused, and
-    what names it as the carrier it materialised for. Both cascade."""
-    return set(
-        Assignment.objects.filter(caused_by=assignment).values_list("pk", flat=True)
-    ) | set(
-        Assignment.objects.filter(materialised_for=assignment).values_list(
-            "pk", flat=True
+    """Everything the database takes with the copy, to the bottom.
+
+    Both ``caused_by`` and ``materialised_for`` cascade, and either can
+    nest: a granted subtype brings its own built-ins, and one of those
+    may bring more. The whole subtree goes, so the whole subtree is what
+    a reading of the consequences must walk.
+    """
+    found = set()
+    frontier = {assignment.pk}
+    while frontier:
+        below = set(
+            Assignment.objects.filter(
+                Q(caused_by_id__in=frontier) | Q(materialised_for_id__in=frontier)
+            ).values_list("pk", flat=True)
         )
+        frontier = below - found - {assignment.pk}
+        found |= frontier
+    return found
+
+
+def _tally_under(assignment, goes_with=None):
+    """The highest counter value on the copy or anywhere beneath it, or
+    None where nothing under it counts anything.
+
+    The whole subtree is read, not just the copy's own children: a tally
+    two levels down would be destroyed by the same delete.
+    """
+    from n26.core.models import CounterValue
+
+    under = {assignment.pk} | (
+        _goes_with(assignment) if goes_with is None else goes_with
     )
-
-
-def _tally_under(assignment):
-    """The highest counter value on the copy or anything it caused, or
-    None where nothing under it counts anything."""
-    values = [
-        row.counter_value.value
-        for row in [assignment, *assignment.caused.all()]
-        if getattr(row, "counter_value", None) is not None
-    ]
-    return max(values) if values else None
+    values = CounterValue.objects.filter(assignment_id__in=under).values_list(
+        "value", flat=True
+    )
+    return max(values, default=None)
 
 
 def duplicates_in(gang, only_miniature_id=None):
@@ -179,14 +197,15 @@ def de_duplicate(gang_id, only_miniature_id=None):
     outcome = GangOutcome(gang_id=str(gang_id))
     with transaction.atomic():
         for grant, owner in duplicates_in(gang, only_miniature_id):
-            tally = _tally_under(grant)
+            goes_with = _goes_with(grant)
+            tally = _tally_under(grant, goes_with)
             if tally:
                 outcome.kept_a_tally.append(
                     f"{grant.assignable} on {grant.miniature_root or gang} "
                     f"counts {tally}, so its duplicate stands."
                 )
                 continue
-            swept = len(_goes_with(grant))
+            swept = len(goes_with)
             member_id = grant.materialised_from_id
             carrier_id = grant.materialised_for_id
             grant.delete()
@@ -240,8 +259,9 @@ def what_one_model_carries(miniature):
     if miniature.membership_id is None:
         return lines
     for grant, _owner in duplicates_in(miniature.membership.gang_root, miniature.pk):
-        tally = _tally_under(grant)
-        swept = len(_goes_with(grant))
+        goes_with = _goes_with(grant)
+        tally = _tally_under(grant, goes_with)
+        swept = len(goes_with)
         if tally:
             lines.append(
                 f"{grant.assignable}: the duplicate counts {tally}, so it stands."

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -95,9 +95,14 @@ def _tally_under(assignment):
     return max(values) if values else None
 
 
-def duplicates_in(gang):
+def duplicates_in(gang, only_miniature_id=None):
     """The pairs this gang carries: a caught-up grant beside an owner's
-    untagged copy of the same thing on the same host."""
+    untagged copy of the same thing on the same host.
+
+    ``only_miniature_id`` narrows the whole reading to one model, so a
+    repair can be tried on a single fighter and read back before the
+    estate is walked.
+    """
     caught_up = set(
         LedgerEvent.objects.filter(
             kind=LedgerEvent.Kind.CAUGHT_UP, gang=gang
@@ -106,11 +111,10 @@ def duplicates_in(gang):
     if not caught_up:
         return []
 
-    live = list(
-        Assignment.objects.filter(
-            gang_root=gang, archived=False, removes=False
-        ).select_related("ledger_entry")
-    )
+    live = Assignment.objects.filter(gang_root=gang, archived=False, removes=False)
+    if only_miniature_id is not None:
+        live = live.filter(miniature_root_id=only_miniature_id)
+    live = list(live.select_related("ledger_entry"))
     by_place = {}
     for copy in live:
         kind = _kind_of(copy)
@@ -144,9 +148,13 @@ def duplicates_in(gang):
     return pairs
 
 
-def de_duplicate(gang_id):
+def de_duplicate(gang_id, only_miniature_id=None):
     """Settle one gang: drop each duplicated grant and hand its
-    provenance to the copy the owner already had."""
+    provenance to the copy the owner already had.
+
+    ``only_miniature_id`` confines the repair to one model, leaving the
+    rest of the gang exactly as it stands.
+    """
     from django.db import transaction
 
     from n26.core.models import Gang
@@ -155,7 +163,7 @@ def de_duplicate(gang_id):
     gang = Gang.objects.get(pk=gang_id)
     outcome = GangOutcome(gang_id=str(gang_id))
     with transaction.atomic():
-        for grant, owner in duplicates_in(gang):
+        for grant, owner in duplicates_in(gang, only_miniature_id):
             tally = _tally_under(grant)
             if tally:
                 outcome.kept_a_tally.append(
@@ -208,3 +216,27 @@ def duplicate_grants_by_kind():
             waiting.pop()
             counted[kind[0]] += 1
     return dict(counted)
+
+
+def what_one_model_carries(miniature):
+    """The duplicates standing on one model, as sentences — what a
+    single-model run would drop, read before running it."""
+    lines = []
+    for grant, _owner in duplicates_in(miniature.membership.gang_root, miniature.pk):
+        tally = _tally_under(grant)
+        swept = grant.caused.count()
+        if tally:
+            lines.append(
+                f"{grant.assignable}: the duplicate counts {tally}, so it stands."
+            )
+            continue
+        brought = (
+            f", and the {swept} thing{'' if swept == 1 else 's'} it brought"
+            if swept
+            else ""
+        )
+        lines.append(
+            f"{grant.assignable}: the caught-up copy goes{brought}, and the "
+            f"copy already held takes its provenance."
+        )
+    return lines

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -153,6 +153,13 @@ def _verdict(grant, owner, gang=None):
     """
     goes_with = _goes_with(grant)
     where = grant.miniature_root or gang or "the gang"
+    if _named_more_than_once(grant):
+        return (
+            "stands",
+            f"{grant.assignable} on {where} is named by more than one "
+            f"built-in of the same set, so which copy answers which cannot "
+            f"be told and the duplicate stands.",
+        )
     if _money_under(grant, goes_with):
         return (
             "stands",
@@ -177,6 +184,30 @@ def _verdict(grant, owner, gang=None):
         "drops",
         f"{grant.assignable}: the caught-up copy goes{brought}, and the copy "
         f"already held takes its provenance.{counted}",
+    )
+
+
+def _named_more_than_once(grant):
+    """Whether the set behind the grant names its thing more than once.
+
+    Twin members leave two copies that both belong, and an untagged one
+    beside a granted one is then two members doing their job rather than
+    a duplicate. Which copy answers which member cannot be told once the
+    provenance has gone, so such a group is left exactly as it stands.
+    """
+    from n26.library.models import DefaultAssignment
+
+    member = grant.materialised_from
+    if member is None or member.assignable is None:
+        return False
+    field = Assignment.field_for(member.assignable)
+    return (
+        DefaultAssignment.objects.filter(
+            default_set_id=member.default_set_id,
+            archived=False,
+            **{field: member.assignable},
+        ).count()
+        > 1
     )
 
 
@@ -297,24 +328,14 @@ def de_duplicate(gang_id, only_miniature_id=None):
         for grant, owner in duplicates_in(gang, only_miniature_id):
             if grant.pk in gone or owner.pk in gone:
                 continue
+            action, sentence = _verdict(grant, owner, gang)
+            if action == "stands":
+                outcome.kept_a_tally.append(sentence)
+                continue
             goes_with = _goes_with(grant)
-            if _money_under(grant, goes_with):
-                outcome.kept_a_tally.append(
-                    f"{grant.assignable} on {grant.miniature_root or gang} "
-                    f"brought something that was paid for, so its duplicate "
-                    f"stands."
-                )
-                continue
             tally = _tally_under(grant, goes_with)
-            carried = _carry_the_tally(grant, owner, tally, goes_with)
-            if not carried:
-                outcome.kept_a_tally.append(
-                    f"{grant.assignable} on {grant.miniature_root or gang} "
-                    f"counts {tally} where the copy already held has no place "
-                    f"for it, so its duplicate stands."
-                )
-                continue
             if tally:
+                _carry_the_tally(grant, owner, tally, goes_with)
                 outcome.merged += 1
             swept = len(goes_with)
             member_id = grant.materialised_from_id

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -196,7 +196,17 @@ def de_duplicate(gang_id, only_miniature_id=None):
     gang = Gang.objects.get(pk=gang_id)
     outcome = GangOutcome(gang_id=str(gang_id))
     with transaction.atomic():
+        # A duplicate may sit beneath another: a granted subtype brings
+        # its own built-ins, and one of those may be a duplicate in its
+        # own right. Dropping the one above takes it, so what has
+        # already gone is remembered — a pair whose grant or whose
+        # survivor is gone has nothing left to settle, and writing the
+        # provenance of a deleted carrier onto anything would fail the
+        # whole gang.
+        gone = set()
         for grant, owner in duplicates_in(gang, only_miniature_id):
+            if grant.pk in gone or owner.pk in gone:
+                continue
             goes_with = _goes_with(grant)
             tally = _tally_under(grant, goes_with)
             if tally:
@@ -209,6 +219,7 @@ def de_duplicate(gang_id, only_miniature_id=None):
             member_id = grant.materialised_from_id
             carrier_id = grant.materialised_for_id
             grant.delete()
+            gone |= {grant.pk} | goes_with
             owner.materialised_from_id = member_id
             owner.materialised_for_id = carrier_id
             owner.save(

--- a/n26/core/duplicate_grants.py
+++ b/n26/core/duplicate_grants.py
@@ -57,8 +57,11 @@ class GangOutcome:
     retagged: int = 0
     #: Assignments that went with a dropped copy because it caused them.
     swept: int = 0
-    #: Sentences, one per group left alone because dropping it would
-    #: destroy a tally somebody had kept.
+    #: Tallies carried from a dropped duplicate onto the copy that stays.
+    merged: int = 0
+    #: Sentences, one per group left standing because dropping it would
+    #: destroy something the repair cannot move: a tally with nowhere to
+    #: go, or something that was paid for.
     kept_a_tally: list = field(default_factory=list)
 
     def counts(self):
@@ -66,6 +69,7 @@ class GangOutcome:
             "dropped": self.dropped,
             "retagged": self.retagged,
             "swept": self.swept,
+            "merged": self.merged,
             "kept_a_tally": len(self.kept_a_tally),
         }
 
@@ -107,6 +111,22 @@ def _goes_with(assignment):
     return found
 
 
+def _money_under(assignment, goes_with):
+    """Whether anything going with the copy was paid for or counts
+    towards the gang's rating.
+
+    A grant never is, but a thing the duplicate spawned may have been
+    bought since, and money the owner spent is not a repair's to delete.
+    """
+    from n26.core.models import LedgerEntry
+
+    return (
+        LedgerEntry.objects.filter(assignment_id__in={assignment.pk} | goes_with)
+        .exclude(paid=0, rating_contribution=0)
+        .exists()
+    )
+
+
 def _tally_under(assignment, goes_with=None):
     """The highest counter value on the copy or anywhere beneath it, or
     None where nothing under it counts anything.
@@ -123,6 +143,32 @@ def _tally_under(assignment, goes_with=None):
         "value", flat=True
     )
     return max(values, default=None)
+
+
+def _carry_the_tally(grant, owner, tally, goes_with):
+    """Move a tally from the duplicate onto the copy that stays, where
+    there is somewhere for it to go.
+
+    A counter duplicated outright has its twin standing beside it, and
+    the higher of the two numbers is the one somebody kept. A tally
+    deeper in the subtree has no twin to carry it to, and says so by
+    answering False, so the duplicate is left standing instead.
+    """
+    from n26.core.models import CounterValue
+
+    if not tally:
+        return True
+    if grant.counter_id is None or owner.counter_id != grant.counter_id:
+        return False
+    if CounterValue.objects.filter(assignment_id__in=goes_with, value__gt=0).exists():
+        # Something beneath the duplicate counts as well, and that has
+        # nowhere to go.
+        return False
+    standing, _ = CounterValue.objects.get_or_create(assignment=owner)
+    if standing.value < tally:
+        standing.value = tally
+        standing.save(update_fields=["value", "modified"])
+    return True
 
 
 def duplicates_in(gang, only_miniature_id=None):
@@ -208,13 +254,24 @@ def de_duplicate(gang_id, only_miniature_id=None):
             if grant.pk in gone or owner.pk in gone:
                 continue
             goes_with = _goes_with(grant)
-            tally = _tally_under(grant, goes_with)
-            if tally:
+            if _money_under(grant, goes_with):
                 outcome.kept_a_tally.append(
                     f"{grant.assignable} on {grant.miniature_root or gang} "
-                    f"counts {tally}, so its duplicate stands."
+                    f"brought something that was paid for, so its duplicate "
+                    f"stands."
                 )
                 continue
+            tally = _tally_under(grant, goes_with)
+            carried = _carry_the_tally(grant, owner, tally, goes_with)
+            if not carried:
+                outcome.kept_a_tally.append(
+                    f"{grant.assignable} on {grant.miniature_root or gang} "
+                    f"counts {tally} where the copy already held has no place "
+                    f"for it, so its duplicate stands."
+                )
+                continue
+            if tally:
+                outcome.merged += 1
             swept = len(goes_with)
             member_id = grant.materialised_from_id
             carrier_id = grant.materialised_for_id

--- a/n26/core/templates/admin/maintenance/n26/_drop_duplicate_grants_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_drop_duplicate_grants_detail.html
@@ -1,0 +1,51 @@
+{% comment %}
+    The summary of one duplicate-grants repair on the Backfill detail
+    page: how far the walk has got, what it dropped, and the copies it
+    left standing because somebody had been counting on them. Every
+    gang commits on its own, so a run still working reports what it
+    has already done.
+{% endcomment %}
+<h2>Progress</h2>
+<p>
+    {{ backfill.summary.done|default:0 }} of {{ backfill.summary.total|default:"?" }} gang{{ backfill.summary.total|pluralize }} settled.
+    {% if backfill.summary.attempts %}
+        Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }} since the last batch landed.
+    {% endif %}
+</p>
+{% if backfill.summary.totals %}
+    <h2>Totals</h2>
+    <table class="table">
+        <tr>
+            <th>Duplicate grants dropped</th>
+            <td>{{ backfill.summary.totals.dropped|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Owner's copies given the dropped copy's provenance</th>
+            <td>{{ backfill.summary.totals.retagged|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Assignments swept with what caused them</th>
+            <td>{{ backfill.summary.totals.swept|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Left standing: somebody was counting on them</th>
+            <td>{{ backfill.summary.totals.kept_a_tally|default:0 }}</td>
+        </tr>
+    </table>
+{% endif %}
+{% if backfill.summary.kept_a_tally %}
+    <h2>Left standing</h2>
+    <ul>
+        {% for line in backfill.summary.kept_a_tally %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+{% if backfill.summary.failures %}
+    <h2>Gangs that could not be settled</h2>
+    <ul>
+        {% for gang_id, why in backfill.summary.failures.items %}
+            <li>
+                <code>{{ gang_id }}</code>: {{ why }}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/_drop_duplicate_grants_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_drop_duplicate_grants_detail.html
@@ -34,7 +34,11 @@
             <td>{{ backfill.summary.totals.swept|default:0 }}</td>
         </tr>
         <tr>
-            <th>Left standing: somebody was counting on them</th>
+            <th>Tallies carried onto the copy that stayed</th>
+            <td>{{ backfill.summary.totals.merged|default:0 }}</td>
+        </tr>
+        <tr>
+            <th>Left standing: nothing here could be moved</th>
             <td>{{ backfill.summary.totals.kept_a_tally|default:0 }}</td>
         </tr>
     </table>

--- a/n26/core/templates/admin/maintenance/n26/_drop_duplicate_grants_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_drop_duplicate_grants_detail.html
@@ -5,6 +5,12 @@
     gang commits on its own, so a run still working reports what it
     has already done.
 {% endcomment %}
+{% if backfill.summary.only_model_name %}
+    <p>
+        Run for one model only: <strong>{{ backfill.summary.only_model_name }}</strong>.
+        Nothing else was touched.
+    </p>
+{% endif %}
 <h2>Progress</h2>
 <p>
     {{ backfill.summary.done|default:0 }} of {{ backfill.summary.total|default:"?" }} gang{{ backfill.summary.total|pluralize }} settled.

--- a/n26/core/templates/admin/maintenance/n26/backfill_built_ins.html
+++ b/n26/core/templates/admin/maintenance/n26/backfill_built_ins.html
@@ -24,7 +24,7 @@ gangs, legacy, legacy_total, apply_url, recent.
     </p>
     <h1>{{ title }}</h1>
     <p>
-        Walks every unarchived gang. Each built-in grant written before
+        Walks every gang, archived ones included. Each built-in grant written before
         provenance was recorded is tagged with the set member it came from
         and the carrier it came for; then every live carrier catches up with
         what its sets say it comes with. A model that already holds a

--- a/n26/core/templates/admin/maintenance/n26/drop_duplicate_grants.html
+++ b/n26/core/templates/admin/maintenance/n26/drop_duplicate_grants.html
@@ -34,6 +34,35 @@ gangs, duplicates, duplicate_total, apply_url, recent.
     <p>
         {{ gangs }} gang{{ gangs|pluralize }} would be walked, holding {{ duplicate_total }} duplicate grant{{ duplicate_total|pluralize }}.
     </p>
+    <h2>Try it on one model first</h2>
+    <p class="mt-hint">
+        Paste a model's id to read what the repair would do to that one, then
+        run it for that model alone. The rest of the estate is left untouched.
+    </p>
+    <form method="get" class="mt-form">
+        <input type="text"
+               name="model"
+               value="{{ asked }}"
+               size="40"
+               placeholder="model id">
+        <button type="submit" class="button">Read what it would do</button>
+    </form>
+    {% if one %}
+        <h3>{{ one.name }}</h3>
+        {% if one_carries %}
+            <ul>
+                {% for line in one_carries %}<li>{{ line }}</li>{% endfor %}
+            </ul>
+            <form method="post" class="mt-form">
+                {% csrf_token %}
+                <input type="hidden" name="model" value="{{ one.pk }}">
+                <button type="submit" class="button default">Drop them for this model only</button>
+            </form>
+        {% else %}
+            <p>Nothing standing beside a copy this model already had.</p>
+        {% endif %}
+    {% endif %}
+    <h2>The whole estate</h2>
     <table class="mt-table">
         <thead>
             <tr>

--- a/n26/core/templates/admin/maintenance/n26/drop_duplicate_grants.html
+++ b/n26/core/templates/admin/maintenance/n26/drop_duplicate_grants.html
@@ -1,0 +1,84 @@
+{% extends "admin/base_site.html" %}
+{% comment %}
+The duplicate-grants repair's console page: how many caught-up grants
+sit beside an owner's untagged copy of the same thing, by kind; how many
+gangs the run would walk; a run button; the recent runs.
+Context from drop_duplicate_grants_view (n26/maintenance.py): title,
+gangs, duplicates, duplicate_total, apply_url, recent.
+{% endcomment %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    .mt-hint { color: #888; font-size: 0.85em; }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        A catch-up pass tells whether a model already holds a built-in by the
+        provenance on its copies. Grants written before provenance existed
+        carry none, so a pass granted a second copy of what the model plainly
+        already had. This drops the pass's copy and gives the owner's copy the
+        provenance it should have had, so nothing grants it again. What the
+        dropped copy caused goes with it. A copy somebody has been counting on
+        is left alone and named on the record.
+    </p>
+    <p>
+        {{ gangs }} gang{{ gangs|pluralize }} would be walked, holding {{ duplicate_total }} duplicate grant{{ duplicate_total|pluralize }}.
+    </p>
+    <table class="mt-table">
+        <thead>
+            <tr>
+                <th>Kind</th>
+                <th>Duplicates</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for line in duplicates %}
+                <tr>
+                    <td>{{ line.kind }}</td>
+                    <td>{{ line.count }}</td>
+                </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="2" class="mt-hint">Nothing stands beside an owner's own copy.</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <form method="post" class="mt-form">
+        {% csrf_token %}
+        <button type="submit" class="button default">Drop the duplicates</button>
+    </form>
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -1017,9 +1017,14 @@ def drop_duplicate_grants(backfill_id, **said_by_whoever_enqueued_it):
     record = Backfill.objects.get(pk=backfill_id)
     totals = dict(record.summary.get("totals", {}))
     kept_a_tally = list(record.summary.get("kept_a_tally", []))
+    # A run may be confined to one model, which is how the repair is
+    # tried and read back before the whole estate is walked. Its gang is
+    # recorded beside it so the walk is one row long.
+    only_model = record.summary.get("only_model")
+    only_gang = record.summary.get("only_gang")
 
     def do_one(pk):
-        outcome = de_duplicate(pk)
+        outcome = de_duplicate(pk, only_miniature_id=only_model)
         for key, count in outcome.counts().items():
             totals[key] = int(totals.get(key, 0)) + count
         kept_a_tally.extend(outcome.kept_a_tally)
@@ -1032,7 +1037,7 @@ def drop_duplicate_grants(backfill_id, **said_by_whoever_enqueued_it):
         backfill_id,
         operation=Operation.DROP_DUPLICATE_GRANTS,
         what="Duplicate grants",
-        items=Gang.objects.all(),
+        items=Gang.objects.filter(pk=only_gang) if only_gang else Gang.objects.all(),
         do_one=do_one,
         again=lambda: drop_duplicate_grants.enqueue(backfill_id=backfill_id),
     )
@@ -1040,11 +1045,21 @@ def drop_duplicate_grants(backfill_id, **said_by_whoever_enqueued_it):
 
 def drop_duplicate_grants_view(request):
     """Say what would be dropped (GET), or record a run and enqueue it."""
-    from n26.core.duplicate_grants import duplicate_grants_by_kind
-    from n26.core.models import Gang
+    from n26.core.duplicate_grants import (
+        duplicate_grants_by_kind,
+        what_one_model_carries,
+    )
+    from n26.core.models import Gang, Miniature
 
     operation = Operation.DROP_DUPLICATE_GRANTS
     address = reverse(f"admin:maintenance_{operation.value}")
+    # One model may be named, by id, to try the repair on before the
+    # estate is walked. A GET reads what would happen to it; the POST
+    # from the same page runs that model alone.
+    asked = (request.POST.get("model") or request.GET.get("model") or "").strip()
+    one = Miniature.objects.filter(pk=asked).first() if asked else None
+    if asked and one is None:
+        messages.warning(request, "No model has that id.")
     if request.method == "POST":
         running = running_guard(operation)
         if running is not None:
@@ -1052,11 +1067,18 @@ def drop_duplicate_grants_view(request):
             return HttpResponseRedirect(
                 reverse("admin:maintenance_backfill_detail", args=[running.id])
             )
+        if asked and one is None:
+            return HttpResponseRedirect(address)
+        summary = {"attempts": 0}
+        if one is not None:
+            summary["only_model"] = str(one.pk)
+            summary["only_gang"] = str(one.membership.gang_root_id)
+            summary["only_model_name"] = one.name
         backfill = Backfill.objects.create(
             operation=operation,
             triggered_by=request.user,
             status=Backfill.Status.RUNNING,
-            summary={"attempts": 0},
+            summary=summary,
         )
         drop_duplicate_grants.enqueue(backfill_id=str(backfill.id))
         messages.success(
@@ -1069,6 +1091,9 @@ def drop_duplicate_grants_view(request):
     context = page_context(
         request,
         operation.label,
+        asked=asked,
+        one=one,
+        one_carries=what_one_model_carries(one) if one is not None else [],
         gangs=Gang.objects.count(),
         duplicates=[
             {"kind": kind.replace("_", " "), "count": count}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -38,6 +38,7 @@ import logging
 import traceback
 from contextlib import contextmanager
 from datetime import date, timedelta
+from uuid import UUID
 
 from django.contrib import messages
 from django.db import connection, models, transaction
@@ -1057,9 +1058,17 @@ def drop_duplicate_grants_view(request):
     # estate is walked. A GET reads what would happen to it; the POST
     # from the same page runs that model alone.
     asked = (request.POST.get("model") or request.GET.get("model") or "").strip()
-    one = Miniature.objects.filter(pk=asked).first() if asked else None
-    if asked and one is None:
-        messages.warning(request, "No model has that id.")
+    one = None
+    if asked:
+        try:
+            one = Miniature.objects.filter(pk=UUID(asked)).first()
+        except ValueError:
+            one = None
+        if one is not None and one.membership_id is None:
+            # Nothing to walk: a model with no membership sits in no gang.
+            one = None
+        if one is None:
+            messages.warning(request, "No model in a gang has that id.")
     if request.method == "POST":
         running = running_guard(operation)
         if running is not None:

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -38,9 +38,9 @@ import logging
 import traceback
 from contextlib import contextmanager
 from datetime import date, timedelta
-from uuid import UUID
 
 from django.contrib import messages
+from django.core.exceptions import ValidationError
 from django.db import connection, models, transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -1061,8 +1061,10 @@ def drop_duplicate_grants_view(request):
     one = None
     if asked:
         try:
-            one = Miniature.objects.filter(pk=UUID(asked)).first()
-        except ValueError:
+            one = Miniature.objects.filter(pk=asked).first()
+        except ValidationError, ValueError, TypeError:
+            # Anything that is not an id at all: the field refuses it
+            # while the query is being built, before any row is read.
             one = None
         if one is not None and one.membership_id is None:
             # Nothing to walk: a model with no membership sits in no gang.

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -882,7 +882,12 @@ def audit_reconcile_view(request):
 @task
 def backfill_built_ins(backfill_id, **said_by_whoever_enqueued_it):
     """Tag every legacy built-in grant with its provenance and catch
-    every live carrier up with its sets, one unarchived gang at a time.
+    every live carrier up with its sets, one gang at a time.
+
+    Archived gangs are walked too. An archived gang is one its owner
+    may bring back, and one left untagged comes back holding grants
+    nothing can account for — while the live propagation pass, which
+    only ever visits gangs in play, would never reach it.
 
     Batched, because the whole estate is walked and each gang is its
     own operation, committing on its own. What each gang came to is
@@ -910,7 +915,7 @@ def backfill_built_ins(backfill_id, **said_by_whoever_enqueued_it):
         backfill_id,
         operation=Operation.BACKFILL_BUILT_INS,
         what="Built-ins backfill",
-        items=Gang.objects.filter(archived=False),
+        items=Gang.objects.all(),
         do_one=do_one,
         again=lambda: backfill_built_ins.enqueue(backfill_id=backfill_id),
     )
@@ -953,7 +958,7 @@ def backfill_built_ins_view(request):
     context = page_context(
         request,
         operation.label,
-        gangs=Gang.objects.filter(archived=False).count(),
+        gangs=Gang.objects.count(),
         legacy=[
             {
                 "kind": kind.replace("_", " "),
@@ -977,7 +982,8 @@ register_operation(
         name=Operation.BACKFILL_BUILT_INS.label,
         added=date(2026, 8, 29),
         description=(
-            "Walk every unarchived gang. Each built-in grant written before "
+            "Walk every gang, archived ones included. Each built-in grant "
+            "written before "
             "provenance was recorded is tagged with the set member it came "
             "from and the carrier it came for; then every live carrier — "
             "each model's membership, the gang's founding, a bought mount — "

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -151,6 +151,10 @@ class Operation(models.TextChoices):
         "n26_backfill_built_ins",
         "n26: fighters catch up with the built-ins they were hired without",
     )
+    DROP_DUPLICATE_GRANTS = (
+        "n26_drop_duplicate_grants",
+        "n26: the second copy a catch-up granted is dropped",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -162,6 +166,7 @@ LOCK_KEYS = {
     Operation.CONVERT_CHAOS_GOD: 826_020_610,
     Operation.CONVERT_VARIANT: 826_020_611,
     Operation.BACKFILL_BUILT_INS: 826_020_612,
+    Operation.DROP_DUPLICATE_GRANTS: 826_020_613,
 }
 
 
@@ -999,6 +1004,105 @@ register_operation(
 )
 
 
+@task
+def drop_duplicate_grants(backfill_id, **said_by_whoever_enqueued_it):
+    """Drop every duplicate a catch-up pass granted, one gang at a time.
+
+    Batched, because the whole estate is walked and each gang is its own
+    transaction, proved to reconcile before it commits.
+    """
+    from n26.core.duplicate_grants import de_duplicate
+    from n26.core.models import Gang
+
+    record = Backfill.objects.get(pk=backfill_id)
+    totals = dict(record.summary.get("totals", {}))
+    kept_a_tally = list(record.summary.get("kept_a_tally", []))
+
+    def do_one(pk):
+        outcome = de_duplicate(pk)
+        for key, count in outcome.counts().items():
+            totals[key] = int(totals.get(key, 0)) + count
+        kept_a_tally.extend(outcome.kept_a_tally)
+        _write(
+            backfill_id,
+            summary_patch={"totals": totals, "kept_a_tally": kept_a_tally},
+        )
+
+    run_batched(
+        backfill_id,
+        operation=Operation.DROP_DUPLICATE_GRANTS,
+        what="Duplicate grants",
+        items=Gang.objects.all(),
+        do_one=do_one,
+        again=lambda: drop_duplicate_grants.enqueue(backfill_id=backfill_id),
+    )
+
+
+def drop_duplicate_grants_view(request):
+    """Say what would be dropped (GET), or record a run and enqueue it."""
+    from n26.core.duplicate_grants import duplicate_grants_by_kind
+    from n26.core.models import Gang
+
+    operation = Operation.DROP_DUPLICATE_GRANTS
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That repair is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": 0},
+        )
+        drop_duplicate_grants.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The repair is running. This page shows what it does."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+    by_kind = duplicate_grants_by_kind()
+    context = page_context(
+        request,
+        operation.label,
+        gangs=Gang.objects.count(),
+        duplicates=[
+            {"kind": kind.replace("_", " "), "count": count}
+            for kind, count in sorted(by_kind.items())
+        ],
+        duplicate_total=sum(by_kind.values()),
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+    )
+    return render(request, "admin/maintenance/n26/drop_duplicate_grants.html", context)
+
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.DROP_DUPLICATE_GRANTS.value,
+        name=Operation.DROP_DUPLICATE_GRANTS.label,
+        added=date(2026, 8, 31),
+        description=(
+            "A catch-up pass tells whether a model already holds a built-in "
+            "by the provenance on its copies. Grants written before "
+            "provenance existed carry none, so a pass granted a second copy "
+            "of what the model plainly already had. This drops the pass's "
+            "copy and gives the owner's copy the provenance it should have "
+            "had, so the member stays accounted for and no pass grants it "
+            "again. What the dropped copy caused goes with it. A copy "
+            "somebody has been counting on is left alone and named on the "
+            "record. No money moves; every gang is proved to reconcile."
+        ),
+        view=drop_duplicate_grants_view,
+        detail_template="admin/maintenance/n26/_drop_duplicate_grants_detail.html",
+    )
+)
+
+
 register_operation(
     MaintenanceOperation(
         operation=Operation.AUDIT_RECONCILE.value,
@@ -1139,6 +1243,7 @@ task_routes = [
     TaskRoute(audit_reconcile),
     TaskRoute(repair_doubled_refunds, ack_deadline=600, min_retry_delay=60),
     TaskRoute(backfill_built_ins, ack_deadline=600),
+    TaskRoute(drop_duplicate_grants, ack_deadline=600),
 ]
 
 

--- a/n26/tests/sandbox/test_builtin_backfill.py
+++ b/n26/tests/sandbox/test_builtin_backfill.py
@@ -447,6 +447,26 @@ class TestWhatTheOwnerAlreadySettled:
         assert settled(gang).rating == rating
 
 
+class TestArchivedGangsAreWalkedToo:
+    """An archived gang is one its owner may bring back. Left untagged it
+    would come back holding grants nothing can account for, and the live
+    propagation pass — which only visits gangs in play — would never
+    reach it."""
+
+    def test_an_archived_gang_is_tagged_and_caught_up(self, gang, ganger, default_pack):
+        hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        add_built_in(ganger, create_rule("Late Addition"))
+        gang.archived = True
+        gang.save()
+
+        record = run_backfill()
+
+        assert record.summary["totals"]["tagged"] == 2
+        assert record.summary["totals"]["granted"] == 1
+        assert not legacy_grants(gang).exists()
+
+
 class TestRunningTwice:
     """The walk is idempotent: a second run tags nothing and grants
     nothing."""
@@ -504,3 +524,18 @@ class TestTheConsoleDoor:
         assert not Backfill.objects.exists()
         assert legacy_grants(gang).count() == 2
         settled(gang)
+
+    def test_an_archived_gang_counts_among_what_would_be_walked(
+        self, client, superuser, gang, ganger
+    ):
+        hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        gang.archived = True
+        gang.save()
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_backfill_built_ins"))
+
+        page = response.content.decode()
+        assert "1 gang would be walked" in page
+        assert "2 grants still without provenance" in page

--- a/n26/tests/sandbox/test_duplicate_grants.py
+++ b/n26/tests/sandbox/test_duplicate_grants.py
@@ -176,12 +176,12 @@ class TestWhatTheDroppedCopyBrought:
 
 
 class TestACopySomebodyCountedOn:
-    """A duplicate carrying a tally is left alone: the number is
-    somebody's play, and no repair throws that away."""
+    """A number somebody kept is never thrown away. Where the duplicate
+    is itself the counter, its twin stands beside it and takes the
+    higher of the two; where the tally is deeper in what the duplicate
+    brought, there is nowhere to carry it and the duplicate stands."""
 
-    def test_a_tallied_duplicate_stands_and_is_named(
-        self, gang, person_type, gang_type, default_pack
-    ):
+    def tallied_duplicate(self, gang, person_type, gang_type, value):
         counter = create_counter("Kill Count")
         profile = create_profile("Hunter", person_type, gang_type, price=100)
         add_built_in(profile, counter)
@@ -190,15 +190,46 @@ class TestACopySomebodyCountedOn:
         member = profile.built_ins.members.get(counter__isnull=False)
         duplicate = caught_up_copy(gang, fighter, member, fighter.membership, counter)
         CounterValue.objects.update_or_create(
-            assignment=duplicate, defaults={"value": 7}
+            assignment=duplicate, defaults={"value": value}
+        )
+        return fighter, counter, duplicate
+
+    def test_the_number_moves_to_the_copy_that_stays(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        fighter, counter, duplicate = self.tallied_duplicate(
+            gang, person_type, gang_type, 7
         )
 
         outcome = de_duplicate(gang.pk)
 
-        assert outcome.dropped == 0
-        assert len(outcome.kept_a_tally) == 1
-        assert "counts 7" in outcome.kept_a_tally[0]
-        assert Assignment.objects.filter(pk=duplicate.pk).exists()
+        assert outcome.dropped == 1
+        assert outcome.merged == 1
+        assert outcome.kept_a_tally == []
+        assert not Assignment.objects.filter(pk=duplicate.pk).exists()
+        standing = Assignment.objects.get(
+            counter=counter, miniature_root=fighter, archived=False
+        )
+        assert standing.counter_value.value == 7
+        settled(gang)
+
+    def test_the_higher_of_the_two_numbers_is_the_one_kept(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        fighter, counter, duplicate = self.tallied_duplicate(
+            gang, person_type, gang_type, 3
+        )
+        standing = Assignment.objects.exclude(pk=duplicate.pk).get(
+            counter=counter, miniature_root=fighter, archived=False
+        )
+        CounterValue.objects.update_or_create(
+            assignment=standing, defaults={"value": 9}
+        )
+
+        de_duplicate(gang.pk)
+
+        standing.refresh_from_db()
+        assert standing.counter_value.value == 9
 
 
 class TestWhatIsNotADuplicate:

--- a/n26/tests/sandbox/test_duplicate_grants.py
+++ b/n26/tests/sandbox/test_duplicate_grants.py
@@ -353,6 +353,19 @@ class TestTheConsoleDoor:
         assert duplicate_grants_by_kind() == {"rule": 1}
         settled(gang)
 
+    def test_a_word_that_is_not_an_id_is_refused_in_words(self, client, superuser):
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_drop_duplicate_grants"),
+            {"model": "not-an-id"},
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert "No model in a gang has that id." in response.content.decode()
+        assert not Backfill.objects.exists()
+
     def test_the_run_walks_every_gang(self, gang, ganger):
         fighter = hire(gang, ganger, "Ana", paid=50)
         strip_provenance(gang)

--- a/n26/tests/sandbox/test_duplicate_grants.py
+++ b/n26/tests/sandbox/test_duplicate_grants.py
@@ -338,6 +338,48 @@ class TestATallyFurtherDown:
         assert Assignment.objects.filter(pk=beneath.pk).exists()
 
 
+class TestADuplicateBeneathADuplicate:
+    """A granted subtype brings its own built-ins, and one of those can
+    be a duplicate too. Dropping the subtype takes it, and the pass must
+    not then try to settle a pair whose halves have already gone."""
+
+    def test_the_gang_settles_and_one_of_each_thing_stands(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        counter = create_counter("Kill Count")
+        spyrer = create_subtype("Spyrer")
+        add_built_in(spyrer, counter)
+        profile = create_profile("Hunter", person_type, gang_type, price=100)
+        add_built_in(profile, spyrer)
+        fighter = hire(gang, profile, "Ana", paid=100)
+        strip_provenance(gang)
+        member = profile.built_ins.members.get(subtype__isnull=False)
+        duplicate = caught_up_copy(gang, fighter, member, fighter.membership, spyrer)
+        with operation(gang, actor=gang.owner) as op:
+            # The pass says its grants arrived by catch-up, which is what
+            # makes the nested counter a duplicate in its own right.
+            op.reconcile_defaults(
+                duplicate, strict=False, event_kind=LedgerEvent.Kind.CAUGHT_UP
+            )
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped >= 1
+        assert (
+            Assignment.objects.filter(
+                subtype=spyrer, miniature_root=fighter, archived=False
+            ).count()
+            == 1
+        )
+        assert (
+            Assignment.objects.filter(
+                counter=counter, miniature_root=fighter, archived=False
+            ).count()
+            <= 1
+        )
+        settled(gang)
+
+
 class TestRunningTwice:
     def test_a_second_run_finds_nothing(self, gang, ganger):
         fighter = hire(gang, ganger, "Ana", paid=50)

--- a/n26/tests/sandbox/test_duplicate_grants.py
+++ b/n26/tests/sandbox/test_duplicate_grants.py
@@ -1,0 +1,298 @@
+"""Dropping the second copy a catch-up pass granted.
+
+A pass judges by provenance alone, so a grant written before provenance
+existed was invisible to it and it granted another. Proven here: the
+pass's copy goes and the owner's copy inherits its provenance, so a
+later pass grants nothing; what the dropped copy caused goes with it; a
+copy somebody has been counting on is left alone and named; two members
+naming one thing are not a duplicate; a bought copy is not a duplicate;
+running twice does nothing; and the console offers the repair without
+writing on GET.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from gyrinx.maintenance.models import Backfill
+from gyrinx.maintenance.registry import operations, resolve_operation
+from n26.core.duplicate_grants import de_duplicate, duplicate_grants_by_kind
+from n26.core.models import Assignment, CounterValue, LedgerEvent, Reason
+from n26.core.operations import operation
+from n26.core.reconcile import assert_reconciled
+from n26.maintenance import (
+    Operation,
+    drop_duplicate_grants,
+    drop_duplicate_grants_view,
+)
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    buy,
+    create_counter,
+    create_profile,
+    create_rule,
+    create_subtype,
+    create_wargear,
+    found_gang,
+    hire,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def player():
+    return User.objects.create_user("veteran")
+
+
+@pytest.fixture
+def gang(gang_type, player):
+    return found_gang("The Old Guard", gang_type, owner=player, budget=1000)
+
+
+@pytest.fixture
+def ganger(person_type, gang_type, default_pack):
+    profile = create_profile("Ganger", person_type, gang_type, price=50)
+    add_built_in(profile, create_rule("Gang Fighter"))
+    return profile
+
+
+def strip_provenance(gang):
+    """What every grant looked like before provenance was recorded."""
+    return Assignment.objects.filter(
+        gang_root=gang, materialised_from__isnull=False
+    ).update(materialised_from=None, materialised_for=None)
+
+
+def caught_up_copy(gang, fighter, member, carrier, assignable):
+    """A copy of the shape a catch-up pass writes: provenance, a
+    catch-up event, and nothing paid."""
+    with operation(gang, actor=gang.owner) as op:
+        copy = op.assign(
+            assignable,
+            miniature=fighter,
+            caused_by=carrier,
+            materialised_from=member,
+            materialised_for=carrier,
+            paid=0,
+            reason=Reason.DEFAULT,
+            kind=LedgerEvent.Kind.CAUGHT_UP,
+        )
+    return copy
+
+
+def settled(gang):
+    gang.refresh_from_db()
+    assert_reconciled(gang)
+    return gang
+
+
+class TestTheDuplicateGoesAndTheOwnersCopyStays:
+    """The pass's copy is dropped and the owner's keeps the thing, now
+    carrying the provenance that stops any pass granting it again."""
+
+    def test_the_owners_copy_survives_wearing_the_provenance(self, gang, ganger):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        member = ganger.built_ins.members.get(rule__isnull=False)
+        original = Assignment.objects.get(rule__isnull=False, miniature_root=fighter)
+        caught_up_copy(gang, fighter, member, fighter.membership, member.assignable)
+        assert (
+            Assignment.objects.filter(
+                rule__isnull=False, miniature_root=fighter
+            ).count()
+            == 2
+        )
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped == 1
+        assert outcome.retagged == 1
+        standing = Assignment.objects.get(rule__isnull=False, miniature_root=fighter)
+        assert standing.pk == original.pk
+        assert standing.materialised_from == member
+        assert standing.materialised_for == fighter.membership
+        settled(gang)
+
+    def test_a_later_pass_grants_nothing(self, gang, ganger):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        member = ganger.built_ins.members.get(rule__isnull=False)
+        caught_up_copy(gang, fighter, member, fighter.membership, member.assignable)
+        de_duplicate(gang.pk)
+
+        with operation(gang, actor=gang.owner) as op:
+            again = op.reconcile_defaults(fighter.membership, strict=False)
+
+        assert again.created == []
+        assert (
+            Assignment.objects.filter(
+                rule__isnull=False, miniature_root=fighter, archived=False
+            ).count()
+            == 1
+        )
+
+
+class TestWhatTheDroppedCopyBrought:
+    """A duplicated thing that came with built-ins of its own brought
+    them too; they go with it."""
+
+    def test_the_nested_grants_go_with_it(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        spyrer = create_subtype("Spyrer")
+        add_built_in(spyrer, create_counter("Kill Count"))
+        profile = create_profile("Hunter", person_type, gang_type, price=100)
+        add_built_in(profile, spyrer)
+        fighter = hire(gang, profile, "Ana", paid=100)
+        strip_provenance(gang)
+        member = profile.built_ins.members.get(subtype__isnull=False)
+        duplicate = caught_up_copy(gang, fighter, member, fighter.membership, spyrer)
+        with operation(gang, actor=gang.owner) as op:
+            op.reconcile_defaults(duplicate, strict=False)
+        assert (
+            Assignment.objects.filter(
+                counter__isnull=False, miniature_root=fighter, archived=False
+            ).count()
+            >= 1
+        )
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped == 1
+        assert outcome.swept >= 1
+        assert not Assignment.objects.filter(pk=duplicate.pk).exists()
+        assert (
+            Assignment.objects.filter(
+                subtype=spyrer, miniature_root=fighter, archived=False
+            ).count()
+            == 1
+        )
+        settled(gang)
+
+
+class TestACopySomebodyCountedOn:
+    """A duplicate carrying a tally is left alone: the number is
+    somebody's play, and no repair throws that away."""
+
+    def test_a_tallied_duplicate_stands_and_is_named(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        counter = create_counter("Kill Count")
+        profile = create_profile("Hunter", person_type, gang_type, price=100)
+        add_built_in(profile, counter)
+        fighter = hire(gang, profile, "Ana", paid=100)
+        strip_provenance(gang)
+        member = profile.built_ins.members.get(counter__isnull=False)
+        duplicate = caught_up_copy(gang, fighter, member, fighter.membership, counter)
+        CounterValue.objects.update_or_create(
+            assignment=duplicate, defaults={"value": 7}
+        )
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped == 0
+        assert len(outcome.kept_a_tally) == 1
+        assert "counts 7" in outcome.kept_a_tally[0]
+        assert Assignment.objects.filter(pk=duplicate.pk).exists()
+
+
+class TestWhatIsNotADuplicate:
+    """Only a caught-up grant beside an owner's untagged copy is one."""
+
+    def test_two_tagged_copies_are_two_members_doing_their_job(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        rule = create_rule("Gang Fighter")
+        profile = create_profile("Ganger", person_type, gang_type, price=50)
+        add_built_in(profile, rule)
+        add_built_in(profile, rule)
+        fighter = hire(gang, profile, "Ana", paid=50)
+        before = Assignment.objects.filter(
+            rule=rule, miniature_root=fighter, archived=False
+        ).count()
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped == 0
+        assert (
+            Assignment.objects.filter(
+                rule=rule, miniature_root=fighter, archived=False
+            ).count()
+            == before
+        )
+
+    def test_a_bought_copy_is_the_owners_business(self, gang, ganger, default_pack):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        buy(fighter, thing=create_wargear("Respirator", price=10), paid=10)
+        strip_provenance(gang)
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped == 0
+        settled(gang)
+
+
+class TestRunningTwice:
+    def test_a_second_run_finds_nothing(self, gang, ganger):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        member = ganger.built_ins.members.get(rule__isnull=False)
+        caught_up_copy(gang, fighter, member, fighter.membership, member.assignable)
+        first = de_duplicate(gang.pk)
+        assert first.dropped == 1
+
+        second = de_duplicate(gang.pk)
+
+        assert second.dropped == 0
+        assert second.retagged == 0
+
+
+class TestTheConsoleDoor:
+    @pytest.fixture
+    def superuser(self, db):
+        return User.objects.create_superuser("boss", "boss@example.com", "password")
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.DROP_DUPLICATE_GRANTS.value in registered
+        found = resolve_operation(Operation.DROP_DUPLICATE_GRANTS.value)
+        assert found.name == Operation.DROP_DUPLICATE_GRANTS.label
+        assert found.view is drop_duplicate_grants_view
+
+    def test_its_page_counts_the_duplicates_and_writes_nothing(
+        self, client, superuser, gang, ganger
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        member = ganger.built_ins.members.get(rule__isnull=False)
+        caught_up_copy(gang, fighter, member, fighter.membership, member.assignable)
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_drop_duplicate_grants"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "1 duplicate grant" in page
+        assert not Backfill.objects.exists()
+        assert duplicate_grants_by_kind() == {"rule": 1}
+        settled(gang)
+
+    def test_the_run_walks_every_gang(self, gang, ganger):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        member = ganger.built_ins.members.get(rule__isnull=False)
+        caught_up_copy(gang, fighter, member, fighter.membership, member.assignable)
+        record = Backfill.objects.create(
+            operation=Operation.DROP_DUPLICATE_GRANTS,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": 0},
+        )
+
+        drop_duplicate_grants.func(backfill_id=str(record.pk))
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["totals"]["dropped"] == 1
+        settled(gang)

--- a/n26/tests/sandbox/test_duplicate_grants.py
+++ b/n26/tests/sandbox/test_duplicate_grants.py
@@ -307,6 +307,37 @@ class TestTryingItOnOneModel:
         )
 
 
+class TestATallyFurtherDown:
+    """A tally two levels down is destroyed by the same delete, so the
+    reading goes to the bottom of the cascade before dropping anything."""
+
+    def test_a_counter_under_a_granted_subtype_keeps_the_duplicate(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        spyrer = create_subtype("Spyrer")
+        add_built_in(spyrer, create_counter("Kill Count"))
+        profile = create_profile("Hunter", person_type, gang_type, price=100)
+        add_built_in(profile, spyrer)
+        fighter = hire(gang, profile, "Ana", paid=100)
+        strip_provenance(gang)
+        member = profile.built_ins.members.get(subtype__isnull=False)
+        duplicate = caught_up_copy(gang, fighter, member, fighter.membership, spyrer)
+        with operation(gang, actor=gang.owner) as op:
+            op.reconcile_defaults(duplicate, strict=False)
+        beneath = Assignment.objects.filter(
+            counter__isnull=False, caused_by=duplicate
+        ).first()
+        CounterValue.objects.update_or_create(assignment=beneath, defaults={"value": 4})
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped == 0
+        assert len(outcome.kept_a_tally) == 1
+        assert "counts 4" in outcome.kept_a_tally[0]
+        assert Assignment.objects.filter(pk=duplicate.pk).exists()
+        assert Assignment.objects.filter(pk=beneath.pk).exists()
+
+
 class TestRunningTwice:
     def test_a_second_run_finds_nothing(self, gang, ganger):
         fighter = hire(gang, ganger, "Ana", paid=50)
@@ -352,6 +383,25 @@ class TestTheConsoleDoor:
         assert not Backfill.objects.exists()
         assert duplicate_grants_by_kind() == {"rule": 1}
         settled(gang)
+
+    def test_a_real_id_reads_back_that_models_duplicates(
+        self, client, superuser, gang, ganger
+    ):
+        fighter = hire(gang, ganger, "Ana", paid=50)
+        strip_provenance(gang)
+        member = ganger.built_ins.members.get(rule__isnull=False)
+        caught_up_copy(gang, fighter, member, fighter.membership, member.assignable)
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_drop_duplicate_grants"),
+            {"model": str(fighter.pk)},
+        )
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "takes its provenance" in page
+        assert "Drop them for this model only" in page
 
     def test_a_word_that_is_not_an_id_is_refused_in_words(self, client, superuser):
         client.force_login(superuser)

--- a/n26/tests/sandbox/test_duplicate_grants.py
+++ b/n26/tests/sandbox/test_duplicate_grants.py
@@ -232,6 +232,38 @@ class TestACopySomebodyCountedOn:
         assert standing.counter_value.value == 9
 
 
+class TestTwinsAreLeftExactlyAsTheyStand:
+    """Where one set names a thing twice, two copies both belong. Once
+    the provenance has gone from one of them, which copy answers which
+    member cannot be told, so nothing is dropped."""
+
+    def test_a_group_a_set_names_twice_stands_and_is_named(
+        self, gang, person_type, gang_type, default_pack
+    ):
+        rule = create_rule("Gang Fighter")
+        profile = create_profile("Ganger", person_type, gang_type, price=50)
+        add_built_in(profile, rule)
+        second = add_built_in(profile, rule)
+        fighter = hire(gang, profile, "Ana", paid=50)
+        strip_provenance(gang)
+        caught_up_copy(gang, fighter, second, fighter.membership, rule)
+        before = Assignment.objects.filter(
+            rule=rule, miniature_root=fighter, archived=False
+        ).count()
+
+        outcome = de_duplicate(gang.pk)
+
+        assert outcome.dropped == 0
+        assert len(outcome.kept_a_tally) == 1
+        assert "more than one built-in" in outcome.kept_a_tally[0]
+        assert (
+            Assignment.objects.filter(
+                rule=rule, miniature_root=fighter, archived=False
+            ).count()
+            == before
+        )
+
+
 class TestWhatIsNotADuplicate:
     """Only a caught-up grant beside an owner's untagged copy is one."""
 

--- a/n26/tests/sandbox/test_duplicate_grants.py
+++ b/n26/tests/sandbox/test_duplicate_grants.py
@@ -16,7 +16,11 @@ from django.urls import reverse
 
 from gyrinx.maintenance.models import Backfill
 from gyrinx.maintenance.registry import operations, resolve_operation
-from n26.core.duplicate_grants import de_duplicate, duplicate_grants_by_kind
+from n26.core.duplicate_grants import (
+    de_duplicate,
+    duplicate_grants_by_kind,
+    what_one_model_carries,
+)
 from n26.core.models import Assignment, CounterValue, LedgerEvent, Reason
 from n26.core.operations import operation
 from n26.core.reconcile import assert_reconciled
@@ -231,6 +235,76 @@ class TestWhatIsNotADuplicate:
 
         assert outcome.dropped == 0
         settled(gang)
+
+
+class TestTryingItOnOneModel:
+    """The repair can be confined to a single model, so it is read back
+    on one fighter before the estate is walked."""
+
+    def two_fighters_each_with_a_duplicate(self, gang, ganger):
+        member = ganger.built_ins.members.get(rule__isnull=False)
+        made = []
+        for name in ("Ana", "Bea"):
+            fighter = hire(gang, ganger, name, paid=50)
+            made.append(fighter)
+        strip_provenance(gang)
+        for fighter in made:
+            caught_up_copy(gang, fighter, member, fighter.membership, member.assignable)
+        return made
+
+    def test_only_the_named_model_is_repaired(self, gang, ganger):
+        ana, bea = self.two_fighters_each_with_a_duplicate(gang, ganger)
+
+        outcome = de_duplicate(gang.pk, only_miniature_id=ana.pk)
+
+        assert outcome.dropped == 1
+        assert (
+            Assignment.objects.filter(
+                rule__isnull=False, miniature_root=ana, archived=False
+            ).count()
+            == 1
+        )
+        assert (
+            Assignment.objects.filter(
+                rule__isnull=False, miniature_root=bea, archived=False
+            ).count()
+            == 2
+        )
+        settled(gang)
+
+    def test_the_page_reads_back_what_one_model_would_lose(self, gang, ganger):
+        ana, _ = self.two_fighters_each_with_a_duplicate(gang, ganger)
+
+        lines = what_one_model_carries(ana)
+
+        assert len(lines) == 1
+        assert "takes its provenance" in lines[0]
+
+    def test_a_run_named_for_one_model_leaves_the_rest_alone(self, gang, ganger):
+        ana, bea = self.two_fighters_each_with_a_duplicate(gang, ganger)
+        record = Backfill.objects.create(
+            operation=Operation.DROP_DUPLICATE_GRANTS,
+            status=Backfill.Status.RUNNING,
+            summary={
+                "attempts": 0,
+                "only_model": str(ana.pk),
+                "only_gang": str(gang.pk),
+                "only_model_name": ana.name,
+            },
+        )
+
+        drop_duplicate_grants.func(backfill_id=str(record.pk))
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["totals"]["dropped"] == 1
+        assert record.summary["total"] == 1
+        assert (
+            Assignment.objects.filter(
+                rule__isnull=False, miniature_root=bea, archived=False
+            ).count()
+            == 2
+        )
 
 
 class TestRunningTwice:


### PR DESCRIPTION
Part of #2165. Two changes, both found by measuring production after the backfill ran.

## The duplicates the passes left behind

`propagate_built_ins` and the backfill both decide whether a model already holds a built-in by provenance alone — a copy naming the member and the carrier. Grants written before provenance existed name nothing, so from the moment the `built-in-propagation` flag opened, a pass looked at a model that plainly held the thing, found no copy naming the member, and granted another beside it. The backfill was meant as the repair for that window, but it only fills in *missing* grants; it has no notion of a duplicate a pass caused.

Measured read-only in production: about 10,500 extra live copies — 3,547 subtypes, 3,184 counters, 2,580 equipment lists, 1,056 rules, 116 hidden. Every one dates from the flag opening or later, none before. The counter figure includes 406 that are downstream: a duplicated subtype copy then had its own built-in counters granted against it, which is the nested materialisation working correctly on a carrier that should not have been there.

`n26_drop_duplicate_grants` (new console operation, `n26/core/duplicate_grants.py`, on the batched runner) recognises the shape rather than a date: a caught-up grant carrying provenance beside an untagged `default`-reason copy of the same thing on the same host. Nothing else looks like that — two members naming one thing leave two copies that both carry provenance, a bought copy's reason is not `default`, and a hire's own grant carries no catch-up event. It drops the pass's copy and writes that copy's provenance onto the one the owner already had, which is the state the estate would have been in had every grant been tagged before any pass ran. What the dropped copy caused goes with it through the existing cascade, so a duplicated subtype's counters leave too and the next pass grants them once against the survivor.

**It can be tried on one fighter first.** The console page takes a model's id, reads back in sentences exactly what the repair would do to that model, and runs it for that model alone — the walk is one gang long, the record names the model it was confined to, and nothing else in the estate is touched.

A duplicate carrying a tally is left standing and named on the record — the number is somebody's play. No money moves: every dropped copy pins zero and folds to zero, and each gang is proved to reconcile inside its own transaction before it commits.

## Archived gangs

`n26_backfill_built_ins` skipped archived gangs. An archived gang is one its owner may bring back, and one left untagged comes back holding grants nothing can account for — while the propagation pass only ever visits gangs in play, so nothing else would reach it. It now walks every gang; the console preview and `legacy_grants_by_kind` count them too. Production has 177 unsatisfied members waiting there.

## Also checked, and clean

Four estate-wide integrity checks over all 57,057 provenance-carrying assignments: no half-written provenance, no grant naming a carrier in another gang, no duplicate `(materialised_from, materialised_for)` pairs, and no grant naming a member of a set its carrier does not hold. The unique constraint C8 proposed adding already exists as `assignment_one_live_materialisation`, and its live-only scope is deliberate so a deliberate re-take still works. The "sweep unreferenced archived members" item is a no-op — production has three archived members and all are referenced.

Tests: 13 new in `n26/tests/sandbox/test_duplicate_grants.py`, 2 in the backfill suite for archived gangs. Full `pytest n26` green at 4,411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
