### PR TITLE
fix: default pack fighter equipment list costs to Trading Post price

### DIFF
--- a/n23/core/templates/core/pack/pack_fighter_equipment_list_gear_add.html
+++ b/n23/core/templates/core/pack/pack_fighter_equipment_list_gear_add.html
@@ -71,7 +71,7 @@
                                             <td>
                                                 <input type="number"
                                                        name="cost_{{ item.id }}"
-                                                       value="0"
+                                                       value="{{ item.cost_int }}"
                                                        min="0"
                                                        class="form-control form-control-sm text-center p-0 w-em-5">
                                             </td>

--- a/n23/core/templates/core/pack/pack_fighter_equipment_list_weapons_add.html
+++ b/n23/core/templates/core/pack/pack_fighter_equipment_list_weapons_add.html
@@ -85,7 +85,7 @@
                                                 <td>
                                                     <input type="number"
                                                            name="cost_{{ weapon.equipment.id }}"
-                                                           value="0"
+                                                           value="{{ weapon.equipment.cost_int }}"
                                                            min="0"
                                                            class="form-control form-control-sm text-center p-0 w-em-5">
                                                 </td>
@@ -115,7 +115,7 @@
                                                 <td rowspan="{% if profile.traitline_cached|length > 0 %}2{% else %}1{% endif %}">
                                                     <input type="number"
                                                            name="cost_{{ weapon.equipment.id }}"
-                                                           value="0"
+                                                           value="{{ weapon.equipment.cost_int }}"
                                                            min="0"
                                                            class="form-control form-control-sm text-center p-0 w-em-5">
                                                 </td>
@@ -146,7 +146,7 @@
                                             <td rowspan="{% if profile.traitline_cached|length > 0 %}2{% else %}1{% endif %}">
                                                 <input type="number"
                                                        name="profile_cost_{{ profile.id }}"
-                                                       value="0"
+                                                       value="{{ profile.cost }}"
                                                        min="0"
                                                        class="form-control form-control-sm text-center p-0 w-em-5">
                                             </td>

--- a/n23/core/tests/test_views_pack_equipment_list.py
+++ b/n23/core/tests/test_views_pack_equipment_list.py
@@ -1,5 +1,7 @@
 """Tests for pack fighter equipment list views."""
 
+import re
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -290,6 +292,36 @@ def test_add_equipment_list_weapon_get(
 
 
 @pytest.mark.django_db
+def test_add_equipment_list_weapon_get_defaults_cost_to_trading_post_price(
+    client, group_user, pack, pack_fighter, base_weapon, weapon_with_profiles
+):
+    """Cost inputs prefill with the Trading Post price, not zero."""
+    fighter, pack_item = pack_fighter
+    non_standard = ContentWeaponProfile.objects.get(
+        equipment=weapon_with_profiles, cost__gt=0
+    )
+    client.force_login(group_user)
+    url = reverse(
+        "core:pack-fighter-equipment-list-weapon-add", args=(pack.id, pack_item.id)
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert re.search(
+        rf'name="cost_{re.escape(str(base_weapon.pk))}"\s+value="15"',
+        html,
+    )
+    assert re.search(
+        rf'name="cost_{re.escape(str(weapon_with_profiles.pk))}"\s+value="35"',
+        html,
+    )
+    assert re.search(
+        rf'name="profile_cost_{re.escape(str(non_standard.pk))}"\s+value="15"',
+        html,
+    )
+
+
+@pytest.mark.django_db
 def test_add_equipment_list_weapon_post(
     client, group_user, pack, pack_fighter, base_weapon
 ):
@@ -423,6 +455,25 @@ def test_add_equipment_list_gear_get(client, group_user, pack, pack_fighter, bas
     assert response.status_code == 200
     assert b"Configure equipment list" in response.content
     assert b"Mesh Armour" in response.content
+
+
+@pytest.mark.django_db
+def test_add_equipment_list_gear_get_defaults_cost_to_trading_post_price(
+    client, group_user, pack, pack_fighter, base_gear
+):
+    """Cost inputs prefill with the Trading Post price, not zero."""
+    fighter, pack_item = pack_fighter
+    client.force_login(group_user)
+    url = reverse(
+        "core:pack-fighter-equipment-list-gear-add", args=(pack.id, pack_item.id)
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert re.search(
+        rf'name="cost_{re.escape(str(base_gear.pk))}"\s+value="15"',
+        html,
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When adding weapons or gear to a content-pack fighter's equipment list, the cost fields defaulted to 0. They now prefill with the item's Trading Post price (and extra weapon profiles with that profile's cost), matching the accessory add page.

Zero-cost items still show 0 and still warn before submit.

[Weapon add page with Trading Post costs prefilled](https://cursor.com/agents/bc-add1acf6-97d5-5b38-9e7c-417ec47ad143/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweapons_table_trading_post_costs.png)
[Gear add page with Trading Post costs prefilled](https://cursor.com/agents/bc-add1acf6-97d5-5b38-9e7c-417ec47ad143/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgear_table_trading_post_costs.png)
[Equipment list after add keeps those prices](https://cursor.com/agents/bc-add1acf6-97d5-5b38-9e7c-417ec47ad143/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fequipment_list_section_saved_costs.png)

**How to try it**
1. Open a content pack fighter and go to Equipment, then add weapons or gear.
2. Cost inputs should show the Trading Post price instead of 0.
3. You can still override any cost before adding.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQL2G836V/p1787884374508759?thread_ts=1787884374.508759&cid=C0BQL2G836V)

<div><a href="https://cursor.com/agents/bc-add1acf6-97d5-5b38-9e7c-417ec47ad143?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-add1acf6-97d5-5b38-9e7c-417ec47ad143&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

