### PR TITLE
refactor: rechoose and member removal read provenance alone, ammo excepted

### DIFF
--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -1096,34 +1096,31 @@ class Operation:
         members included, because a copy an author's removal left
         standing still leaves when its set is no longer taken.
 
-        Copies with no recorded provenance are found by the shape they
-        were written in, below.
+        Ammo is the one kind provenance does not cover, and its copies
+        are found by the shape they were written in, below.
         """
         from n26.core.builtins import copies_of_set
 
         tagged = list(copies_of_set(default_set, carrier))
         rows = [copy for copy in tagged if not copy.archived]
-        rows.extend(self._granted_rows_without_provenance(carrier, default_set, tagged))
+        rows.extend(self._ammo_rows_without_provenance(carrier, default_set, tagged))
         return rows
 
-    def _granted_rows_without_provenance(self, carrier, default_set, tagged):
-        """The set's grants among assignments with no provenance recorded.
+    def _ammo_rows_without_provenance(self, carrier, default_set, tagged):
+        """The set's ammo grants among lines with no provenance recorded.
 
-        Most of a set's members landed caused by the carrier itself; an
-        ammo member landed caused by its weapon's own assignment, wherever
-        that weapon came from. Where the built-ins grant the same
-        assignable as the set, the set's copy is the newer one — the
-        built-ins materialise first — so the newest live match is taken,
-        as many as the set granted and provenance has not already
-        accounted for.
+        A granted firing line is written in the same shape as a weapon's
+        own free lines, so it is the one kind of grant never tagged with
+        provenance and the one kind still read by shape: the newest live
+        line on the host, caused by a gun, as many as the set granted and
+        provenance has not already accounted for. Every other kind
+        answers by provenance alone — an untagged copy of anything else
+        is the owner's own business and is never seized.
 
-        The accounting is deliberately cautious both ways. Every tagged
-        copy counts, archived included: a grant the owner parted with is
-        settled, not something to seize a look-alike for. And only live
-        members count: an archived member may never have materialised
-        for this carrier, and hunting for its copy would seize whatever
-        untagged assignment happens to match — worse than leaving a
-        stray copy standing.
+        Every tagged copy counts against the wanted number, archived
+        included: a grant the owner parted with is settled, not something
+        to seize a look-alike for. And only live members count: an
+        archived member may never have materialised for this carrier.
         """
         from n26.core.models import Reason
         from n26.library.models import WeaponProfile
@@ -1131,9 +1128,8 @@ class Operation:
         wanted = {}
         for member in default_set.members.filter(archived=False):
             assignable = member.assignable
-            if assignable is None:
-                continue
-            wanted[assignable] = wanted.get(assignable, 0) + 1
+            if isinstance(assignable, WeaponProfile):
+                wanted[assignable] = wanted.get(assignable, 0) + 1
         for copy in tagged:
             if copy.assignable in wanted:
                 wanted[copy.assignable] -= 1
@@ -1142,20 +1138,16 @@ class Operation:
         for assignable, count in wanted.items():
             if count <= 0:
                 continue
-            scope = {
-                Assignment.field_for(assignable): assignable,
-                "archived": False,
-                "materialised_from__isnull": True,
-                "ledger_entry__reason": Reason.DEFAULT,
-                "gang_root": carrier.gang_root,
-                "miniature_root": carrier.miniature_root,
-            }
-            matches = Assignment.objects.filter(**scope)
-            if isinstance(assignable, WeaponProfile):
+            matches = Assignment.objects.filter(
+                weapon_profile=assignable,
+                archived=False,
+                materialised_from__isnull=True,
+                ledger_entry__reason=Reason.DEFAULT,
+                gang_root=carrier.gang_root,
+                miniature_root=carrier.miniature_root,
                 # Granted ammo is caused by its gun, not by the carrier.
-                matches = matches.exclude(caused_by=None)
-            else:
-                matches = matches.filter(caused_by=carrier)
+                caused_by__isnull=False,
+            )
             rows.extend(matches.order_by("-pk")[:count])
         return rows
 

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -1122,24 +1122,25 @@ def remove_default_member(member):
 def _something_materialised(member):
     """Whether any copy in any gang came from this membership.
 
-    A copy carrying provenance names it outright. A copy with no
-    recorded link cannot say which membership it satisfies, so any
-    free-granted copy of the same thing counts instead — deliberately
-    loose evidence: archiving too readily leaves one hidden row, while
-    deleting too readily destroys the only row a link repair could
-    anchor those copies to.
+    Provenance answers outright for every kind the estate tags. Ammo is
+    the one kind outside that regime — a granted firing line is written
+    in the same shape as a weapon's own free lines and never carries
+    provenance — so for a weapon-profile member any free-granted line of
+    the same profile still counts, and the member is archived rather
+    than deleted so those lines keep their anchor.
     """
     from n26.core.models import Assignment, Reason
+    from n26.library.models import WeaponProfile
 
     if Assignment.objects.filter(materialised_from=member).exists():
         return True
     assignable = member.assignable
-    if assignable is None:
+    if not isinstance(assignable, WeaponProfile):
         return False
     return Assignment.objects.filter(
         materialised_from__isnull=True,
         ledger_entry__reason=Reason.DEFAULT,
-        **{Assignment.field_for(assignable): assignable},
+        weapon_profile=assignable,
     ).exists()
 
 

--- a/n26/tests/sandbox/test_builtins_archival.py
+++ b/n26/tests/sandbox/test_builtins_archival.py
@@ -108,10 +108,11 @@ class TestRemovingABuiltIn:
         ]
         assert_reconciled(gang)
 
-    def test_a_copy_with_no_link_still_keeps_the_membership(self, gang, ganger):
-        """A copy carrying no provenance link cannot name its membership,
-        so a free-granted copy of the same thing keeps it archived rather
-        than deleted — the row is what a link repair anchors to."""
+    def test_a_copy_with_no_link_no_longer_keeps_the_membership(self, gang, ganger):
+        """Provenance answers for every kind the estate tags, so a copy
+        stripped of its link reads as the owner's own and the membership
+        goes completely — only ammo, which is never tagged, still keeps
+        its member archived on the strength of an unlinked line."""
         hire(gang, ganger, "Ana", paid=50)
         member = member_named(ganger, "Stub gun")
         for row in Assignment.objects.filter(materialised_from=member):
@@ -121,8 +122,7 @@ class TestRemovingABuiltIn:
 
         remove_default_member(member)
 
-        member.refresh_from_db()
-        assert member.archived is True
+        assert not DefaultAssignment.objects.filter(pk=member.pk).exists()
         assert_reconciled(gang)
 
     def test_a_member_nothing_materialised_from_goes_completely(self, ganger):
@@ -348,10 +348,11 @@ class TestRechooseFindsGrantsByProvenance:
         assert sword.materialised_for_id == fighter.membership.pk
         assert_reconciled(gang)
 
-    def test_copies_without_provenance_leave_too(self, gang, chooser):
+    def test_copies_without_provenance_are_the_owners_and_stay(self, gang, chooser):
+        """An unlinked copy of anything but ammo is never seized: the
+        unwind takes only what provenance names, so a copy stripped of
+        its link stays with the owner when the set is chosen away."""
         fighter = hire_with_option(gang, chooser, "Ana")
-        # Wiped to stand in for copies that carry no provenance link,
-        # which the unwind must still find by their written shape.
         for row in Assignment.objects.filter(
             miniature_root=fighter, materialised_from__isnull=False
         ):
@@ -361,7 +362,7 @@ class TestRechooseFindsGrantsByProvenance:
 
         self.rechoose(gang, fighter, self.sets_of(chooser)["Fancy kit"])
 
-        assert weapon_names(fighter) == ["Sword"]
+        assert weapon_names(fighter) == ["Knife", "Sword"]
         assert_reconciled(gang)
 
     def test_an_archived_members_copy_still_leaves_with_its_set(self, gang, chooser):


### PR DESCRIPTION
Closes out #2165's final chunk. The estate is fully tagged — the backfill wrote provenance onto every legacy grant and the duplicate repair retagged what the passes had doubled — so the code that hunted untagged copies by their written shape is retired.

`_granted_rows_without_provenance` narrows to `_ammo_rows_without_provenance`. A granted firing line is written in the same shape as a weapon's own free lines and is never tagged, so ammo keeps the reading by shape; for every other kind, an untagged copy is the owner's own business and a rechoose never seizes it. Production's rechoose-reachable untagged rows are exactly three ammo lines (the deliberate held-another-way cases), which the narrowed reading still covers.

`_something_materialised` in `n26/library/authoring.py` likewise answers by provenance for every kind but ammo: removing a member whose only match is an unlinked copy now deletes the member rather than archiving a row no repair will ever anchor to. Ammo members keep the archive path so unlinked firing lines keep their anchor.

Two tests in `test_builtins_archival.py` pinned the old shape-hunting behaviour by wiping provenance; they are restated to pin the new contract (an unlinked non-ammo copy stays with the owner on rechoose; its member goes completely on removal).

Of the chunk's original list: the unique constraint already exists (`assignment_one_live_materialisation`, live-only by design), and the archived-member sweep is a no-op (three archived members in production, all referenced).

Full `pytest n26`: 4,527 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01491jPBkwQ8ok6UivFW3f2E
