### PR TITLE
feat: move a counter over htmx and take back the model card alone

### DIFF
--- a/.claude/notes/issue-2371-counter-htmx-plan.md
+++ b/.claude/notes/issue-2371-counter-htmx-plan.md
@@ -1,0 +1,83 @@
+# n26 #2371: move a counter in place, without reloading the page
+
+Fast-follow to #2367, which put `−`/`+` on a model's counter lines on the
+fighter-edit page. Each click is a plain form post and a full page reload —
+right for shipping, wrong for the screen people click these on repeatedly
+after a battle.
+
+## Three findings that shape it
+
+**The TinyMCE trap does not exist.** #2371 was filed warning that a card swap
+would rebuild the Notes and Lore editors and throw away typing. It would not:
+in `cotton/n26/view/model_edit.html` the model card and those boxes are
+*siblings* in one grid, not nested. Swapping the whole card touches no editor.
+
+That inverts the design. Rather than surgically replacing one counter line,
+replace **the whole card** — simpler, and more correct: it redraws the
+statline, the Rules row and the choice rows, which are exactly what a
+threshold crossing changes.
+
+**Thresholds are theoretical today.** `CounterAtLeast` has zero rows in prod
+(checked). No authored content hangs an effect off a counter value yet, though
+the machinery is built and tested and Power Boost content will use it. So this
+does not have to solve threshold redraws — it has to not be wrong when they
+land, which a card-level swap gives for free.
+
+**htmx 2.0.4 does not read `event.submitter`.** The bundled htmx
+(`n26/designsystem/static/designsystem/vendor/htmx.min.js`) contains no
+submitter handling. The control today is one form with two submit buttons told
+apart by `name="change" value="±1"`: native submission includes the clicked
+button, htmx does not. Over htmx that posts no `change` and the view 404s on
+every click, silently. `c-n26.dialog` puts `hx-post` on the `<form>` and never
+meets this, because its dialogs have one button whose meaning is in the URL.
+
+## Design
+
+**Two forms, one per direction**, each carrying a hidden `change`. Identical
+with and without scripting, needs no submitter support, and avoids the
+double-submit that `hx-post` on a button inside a submitting form invites. The
+cost is a second CSRF token.
+
+**One host, one swap.** A host element with a stable id wraps the card in
+`model_edit.html`, drawn always so the gallery demo and the real page agree.
+`tally_counter` answers an htmx request with that card alone, carrying
+`hx-swap-oob`. The `back` field the control already posts is the address the
+redrawn card rebuilds its Equip and Choose hrefs from, and `link_counters` runs
+again so the new card keeps its own controls.
+
+**No toast on success.** The number visibly moves, so a toast per click is
+noise when someone taps `+` five times. The success message is queued only on
+the non-htmx path; a refusal still toasts, because a click that did nothing has
+to say why. A deliberate departure from the equip screens, where the changed
+row is far from the button that changed it.
+
+**Nothing else swaps.** A tally writes no ledger entry, so rating, credits and
+wealth do not move — the same reasoning `equip_update.html` gives for leaving
+the model count alone.
+
+## Build
+
+1. `cotton/n26/counter_controls.html` — two forms, hidden `change`, and an
+   `htmx` prop putting `hx-post`/`hx-swap="none"` on each, as `c-n26.dialog`
+   does.
+2. `cotton/n26/view/model_edit.html` — the host element around the card.
+3. `n26/fighter_edit.html` — opt in with `:htmx="True"`. The only page that
+   may, being the only one that holds the host.
+4. `n26/core/views/edit.py` — `render_card_update(request, miniature, at)`:
+   derive the sheet again, pick the member, link its slots, skills and
+   counters, render the card into an out-of-band include, `with_toasts`.
+5. `n26/core/views/owned.py` — `tally_counter` calls it when `is_htmx` and the
+   counter sits on a miniature; a gang-hosted counter and a reader with no
+   script keep the redirect.
+6. Tests: the htmx response carries the host id and the new value; the plain
+   path still redirects; a refusal answers `no_update` and says why; and a
+   guard that the page opting in holds every id the response addresses.
+
+## Left out
+
+The sibling **Skills & Powers** and **Subtypes & Rules** boxes read their
+offers from the same derivation, so a future threshold crossing could leave
+them stale until the next full load. Deliberately not swapped: they are forms
+the reader may be part-way through, and clobbering half-ticked boxes is worse
+than a stale offer. Unreachable today. Revisit when the first `CounterAtLeast`
+content is authored.

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -122,12 +122,19 @@ class CounterLine:
     URL space — like a choice's own href, and empty by default. A line
     with none draws as a fact with nothing to click, which is what a
     gang sheet, a print sheet and a hire preview all want.
+
+    ``back`` is the screen the control belongs to, carried so a reader
+    with no scripting lands on it rather than on the address the act
+    posts to. Filled in beside the href, because the same caller knows
+    both — and it cannot be read off the request, which for a card
+    redrawn after an act is the act's own address.
     """
 
     name: str
     value: int
     assignment_id: str = ""
     href: str = ""
+    back: str = ""
     #: Whether this is the XP counter, decided where the counter itself is
     #: to hand rather than re-derived from ``name`` — which is what a
     #: reader sees, and carries the counter's annotation with it, so an

--- a/n26/core/templates/cotton/n26/counter_controls.html
+++ b/n26/core/templates/cotton/n26/counter_controls.html
@@ -19,6 +19,10 @@ card alone. Only a screen holding the card's host may set it — see
 n26/core/templates/cotton/n26/view/model_edit.html. It stays an ordinary form
 to an ordinary address, so without JavaScript the whole page is served.
 
+The screen to return to rides on the line rather than being read off the
+request: a card redrawn after an act is rendered under that act's address, and
+a control built from it would send the next reader to a POST-only endpoint.
+
 Minus is not drawn at zero — the value floors there, so the control would be
 offering something that cannot happen.
 
@@ -34,7 +38,7 @@ offering something that cannot happen.
               {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none"{% endif %}
               class="inline">
             {% csrf_token %}
-            <input type="hidden" name="back" value="{{ request.get_full_path }}">
+            <input type="hidden" name="back" value="{{ counter.back }}">
             <input type="hidden" name="change" value="-1">
             <c-ui.button type="submit"
                          size="xs"
@@ -50,7 +54,7 @@ offering something that cannot happen.
           {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none"{% endif %}
           class="inline">
         {% csrf_token %}
-        <input type="hidden" name="back" value="{{ request.get_full_path }}">
+        <input type="hidden" name="back" value="{{ counter.back }}">
         <input type="hidden" name="change" value="1">
         <c-ui.button type="submit"
                      size="xs"

--- a/n26/core/templates/cotton/n26/counter_controls.html
+++ b/n26/core/templates/cotton/n26/counter_controls.html
@@ -1,43 +1,63 @@
 {% comment %}
 <c-n26.counter-controls> — the way to move one counter up or down by one.
 
-    <c-n26.counter-controls :counter="counter" />
+    <c-n26.counter-controls :counter="counter" :htmx="True" />
 
 Drawn beside the number on a card's counter line, and only where the line
 carries an address: a card that depicts nobody, a print sheet and the gang
 sheet all draw the number alone. This is the single-model control, on the
 model's own page.
 
-One form, two buttons: each submits the same address with its own signed
-`change`, so the pair works with no script. Minus is not drawn at zero — the
-value floors there, so the control would be offering something that cannot
-happen.
+A form each way rather than one form with two buttons. The value has to reach
+the server, and htmx does not read a form's submitter — so a single form
+posting over htmx would carry no `change` at all and be refused, while working
+perfectly without scripting. Two forms carry it in a field, which both paths
+read the same way.
+
+With htmx set, the act posts through htmx and the server sends back the model
+card alone. Only a screen holding the card's host may set it — see
+n26/core/templates/cotton/n26/view/model_edit.html. It stays an ordinary form
+to an ordinary address, so without JavaScript the whole page is served.
+
+Minus is not drawn at zero — the value floors there, so the control would be
+offering something that cannot happen.
 
   :counter — a n26.render.CounterLine.
+  :htmx — post through htmx and take back only what changed.
 {% endcomment %}
-<c-vars :counter="None" />
+<c-vars :counter="None" :htmx="False" />
 
-<form method="post" action="{{ counter.href }}" class="ms-1 inline-flex items-center gap-1 align-middle">
-    {% csrf_token %}
-    <input type="hidden" name="back" value="{{ request.get_full_path }}">
+<span class="ms-1 inline-flex items-center gap-1 align-middle">
     {% if counter.value %}
+        <form method="post"
+              action="{{ counter.href }}"
+              {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none"{% endif %}
+              class="inline">
+            {% csrf_token %}
+            <input type="hidden" name="back" value="{{ request.get_full_path }}">
+            <input type="hidden" name="change" value="-1">
+            <c-ui.button type="submit"
+                         size="xs"
+                         variant="default"
+                         class="py-0!"
+                         aria-label="Take one off {{ counter.name }}">
+                <span aria-hidden="true">&minus;</span>
+            </c-ui.button>
+        </form>
+    {% endif %}
+    <form method="post"
+          action="{{ counter.href }}"
+          {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none"{% endif %}
+          class="inline">
+        {% csrf_token %}
+        <input type="hidden" name="back" value="{{ request.get_full_path }}">
+        <input type="hidden" name="change" value="1">
         <c-ui.button type="submit"
-                     name="change"
-                     value="-1"
                      size="xs"
                      variant="default"
                      class="py-0!"
-                     aria-label="Take one off {{ counter.name }}">
-            <span aria-hidden="true">&minus;</span>
+                     aria-label="Add one to {{ counter.name }}">
+            <span aria-hidden="true">+</span>
         </c-ui.button>
-    {% endif %}
-    <c-ui.button type="submit"
-                 name="change"
-                 value="1"
-                 size="xs"
-                 variant="default"
-                 class="py-0!"
-                 aria-label="Add one to {{ counter.name }}">
-        <span aria-hidden="true">+</span>
-    </c-ui.button>
-</form>
+    </form>
+</span>

--- a/n26/core/templates/cotton/n26/counter_controls.html
+++ b/n26/core/templates/cotton/n26/counter_controls.html
@@ -8,11 +8,14 @@ carries an address: a card that depicts nobody, a print sheet and the gang
 sheet all draw the number alone. This is the single-model control, on the
 model's own page.
 
-A form each way rather than one form with two buttons. The value has to reach
-the server, and htmx does not read a form's submitter — so a single form
-posting over htmx would carry no `change` at all and be refused, while working
-perfectly without scripting. Two forms carry it in a field, which both paths
-read the same way.
+A form each way, because the value has to reach the server in a field: htmx
+does not read a form's submitter, so a single form with two buttons would post
+no `change` at all.
+
+`hx-sync` queues them against the document rather than letting them overlap.
+Each form disables only its own submit while it is in flight, so without this
+a quick reader could have two tallies running at once and the card would paint
+whichever answer arrived last, not the one that is true.
 
 With htmx set, the act posts through htmx and the server sends back the model
 card alone. Only a screen holding the card's host may set it — see
@@ -35,7 +38,7 @@ offering something that cannot happen.
     {% if counter.value %}
         <form method="post"
               action="{{ counter.href }}"
-              {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none"{% endif %}
+              {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none" hx-sync="body:queue all"{% endif %}
               class="inline">
             {% csrf_token %}
             <input type="hidden" name="back" value="{{ counter.back }}">
@@ -51,7 +54,7 @@ offering something that cannot happen.
     {% endif %}
     <form method="post"
           action="{{ counter.href }}"
-          {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none"{% endif %}
+          {% if htmx %}hx-post="{{ counter.href }}" hx-swap="none" hx-sync="body:queue all"{% endif %}
           class="inline">
         {% csrf_token %}
         <input type="hidden" name="back" value="{{ counter.back }}">

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -8,8 +8,12 @@ draw the same thing.
   card — the n26.render.ModelCard.
   mode — as <c-n26.model-card> takes it; the mode-only regions read it.
   equip_href — where the Gear and Weapons rows send an owner, or empty.
+  htmx — passed to the counter controls, and set only by a screen holding the
+    card's host. Threaded rather than read from context, as equip_href is:
+    a control that posts over htmx on a page with nowhere to put the answer
+    would run the act and change nothing on screen.
 {% endcomment %}
-<c-vars :card="None" mode="gang" equip_href="" />
+<c-vars :card="None" mode="gang" equip_href="" :htmx="False" />
 
     {% comment %}
     The statline carries the type line and the XP pair in the columns its
@@ -42,7 +46,7 @@ draw the same thing.
             <dd class="min-w-0 tabular-nums text-ink-900 dark:text-ink-100">
                 {{ counter.value }}
                 {% if counter.href %}
-                    <c-n26.counter-controls :counter="counter" />
+                    <c-n26.counter-controls :counter="counter" :htmx="htmx" />
                 {% endif %}
             </dd>
         {% endfor %}

--- a/n26/core/templates/cotton/n26/model_card/index.html
+++ b/n26/core/templates/cotton/n26/model_card/index.html
@@ -32,6 +32,7 @@ control by the actions opens it.
     :card="None"
     mode="gang"
     equip_href=""
+    :htmx="False"
     notes_href=""
     lore_href=""
     actions=""
@@ -108,7 +109,7 @@ control by the actions opens it.
         <div class="n26-card-tabs">
             <c-ui.tabs variant="segmented" size="sm" :fill="True">
                 <c-ui.tabs.tab name="Card">
-                    <c-n26.model-card.body :card="card" mode="{{ mode }}" equip_href="{{ equip_href }}" />
+                    <c-n26.model-card.body :card="card" mode="{{ mode }}" equip_href="{{ equip_href }}" :htmx="htmx" />
                 </c-ui.tabs.tab>
                 {% comment %}
                 The dot marks a tab with something behind it; without one,
@@ -129,6 +130,6 @@ control by the actions opens it.
             </c-ui.tabs>
         </div>
     {% else %}
-        <c-n26.model-card.body :card="card" mode="{{ mode }}" equip_href="{{ equip_href }}" />
+        <c-n26.model-card.body :card="card" mode="{{ mode }}" equip_href="{{ equip_href }}" :htmx="htmx" />
     {% endif %}
 </c-ui.card>

--- a/n26/core/templates/cotton/n26/view/model_edit.html
+++ b/n26/core/templates/cotton/n26/view/model_edit.html
@@ -30,6 +30,8 @@ sits and what its heading says.
     grid reaches no set is not asked rather than shown an empty list.
   statline — the characteristics form. Without it, nothing is drawn. Full width
     under the grid, so its boxes line up with the card's own strip.
+  htmx — set by a screen that draws this view for a real model, so the card's
+    own controls post through htmx and take back the card alone.
 {% endcomment %}
 <c-vars
     :miniature="None"
@@ -45,6 +47,7 @@ sits and what its heading says.
     edits=""
     skills=""
     statline=""
+    :htmx="False"
     class=""
 />
 
@@ -67,11 +70,24 @@ sits and what its heading says.
     {% endcomment %}
     <div class="grid auto-rows-min grid-cols-1 gap-4 md:grid-cols-2">
         {% url 'n26-equip' miniature.pk as equip_href_ %}
-        <c-n26.model-card :card="card" mode="edit" equip_href="{{ equip_href_ }}">
-            {% if name_action.strip %}
-                <c-slot name="name_action">{{ name_action }}</c-slot>
-            {% endif %}
-        </c-n26.model-card>
+        {% comment %}
+        The card sits in a host of its own so an act on it can send back the
+        card alone. Drawn whether or not anything posts over htmx, so the
+        gallery's card and this page's are the same element — and so an
+        update addressed to this id always lands somewhere. The editors
+        beside it are the card's siblings, not its children, which is what
+        lets the whole card be replaced without rebuilding them.
+        {% endcomment %}
+        <div id="n26-model-card-host">
+            <c-n26.model-card :card="card"
+                              mode="edit"
+                              equip_href="{{ equip_href_ }}"
+                              :htmx="htmx">
+                {% if name_action.strip %}
+                    <c-slot name="name_action">{{ name_action }}</c-slot>
+                {% endif %}
+            </c-n26.model-card>
+        </div>
 
         <c-ui.card>
             <c-slot name="header">

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -34,7 +34,7 @@ is named by the page's own heading directly below.
     {% include 'n26/_nav.html' with here='gangs' %}
 {% endblock %}
 {% block content %}
-    <c-n26.view.model-edit :miniature="miniature" :card="card" lead="{{ role }}">
+    <c-n26.view.model-edit :miniature="miniature" :card="card" lead="{{ role }}" :htmx="True">
         {% comment %}
         The heading offers the gang's other models — every row this same
         screen for them. Not what the bar offers, which is the reader's
@@ -72,16 +72,7 @@ is named by the page's own heading directly below.
         for Edit.
         {% endcomment %}
         <c-slot name="name_action">
-            <c-ui.button variant="ghost"
-                         size="xs"
-                         class="ms-1 -mt-0.5 px-1! align-middle"
-                         href="?rename={{ miniature.pk }}"
-                         aria-label="Rename {{ miniature.name }}"
-                         title="Rename">
-                <span class="n26-icon-only">
-                    <c-n26.icon name="pencil" class="size-3.5 text-ink-500 dark:text-ink-400" />
-                </span>
-            </c-ui.button>
+            {% include "n26/includes/model_name_action.html" %}
         </c-slot>
         {% comment %}
         Save is a success button because it ends the form; the outlined

--- a/n26/core/templates/n26/includes/model_card_update.html
+++ b/n26/core/templates/n26/includes/model_card_update.html
@@ -1,12 +1,7 @@
 {% comment %}
 The partial update for an act on a model's card — rendered by
-n26.core.views.edit.render_card_update, never included by a page.
-
-Nothing here is targeted by the click that caused it. The card carries
-hx-swap-oob and the id of the host it replaces, so what an act updates is
-decided here rather than at the control. Messages are not among them: they
-ride the HX-Trigger response header as toasts, because a page that is not
-re-rendered draws no alert block.
+n26.core.views.edit.render_card_update, never included by a page. The pattern
+these responses follow is documented in n26/core/views/htmx.py.
 
 The whole card, not the line that changed. Redrawing all of it is what keeps
 a tally honest where a value crosses a threshold: an effect conditioned on a

--- a/n26/core/templates/n26/includes/model_card_update.html
+++ b/n26/core/templates/n26/includes/model_card_update.html
@@ -1,0 +1,24 @@
+{% comment %}
+The partial update for an act on a model's card — rendered by
+n26.core.views.edit.render_card_update, never included by a page.
+
+Nothing here is targeted by the click that caused it. The card carries
+hx-swap-oob and the id of the host it replaces, so what an act updates is
+decided here rather than at the control. Messages are not among them: they
+ride the HX-Trigger response header as toasts, because a page that is not
+re-rendered draws no alert block.
+
+The whole card, not the line that changed. Redrawing all of it is what keeps
+a tally honest where a value crosses a threshold: an effect conditioned on a
+counter can confer a rule, reveal a choice or shift a characteristic, and
+every one of those is drawn on this card. The boxes a player writes in sit
+beside the card rather than inside it, so replacing it leaves their editors
+alone.
+{% endcomment %}
+<div id="n26-model-card-host" hx-swap-oob="true">
+    <c-n26.model-card :card="card" mode="edit" equip_href="{{ equip_href }}" :htmx="True">
+        <c-slot name="name_action">
+            {% include "n26/includes/model_name_action.html" %}
+        </c-slot>
+    </c-n26.model-card>
+</div>

--- a/n26/core/templates/n26/includes/model_name_action.html
+++ b/n26/core/templates/n26/includes/model_name_action.html
@@ -1,0 +1,18 @@
+{% comment %}
+The way to rename a model, drawn beside their name on the card. Shared
+between the page and the partial update an act on the card sends back, so a
+redrawn card cannot come back without it.
+
+The address is the page's own with ?rename= on it: opening the question is
+server state, so it survives a reload and can be sent to somebody.
+{% endcomment %}
+<c-ui.button variant="ghost"
+             size="xs"
+             class="ms-1 -mt-0.5 px-1! align-middle"
+             href="?rename={{ miniature.pk }}"
+             aria-label="Rename {{ miniature.name }}"
+             title="Rename">
+    <span class="n26-icon-only">
+        <c-n26.icon name="pencil" class="size-3.5 text-ink-500 dark:text-ink-400" />
+    </span>
+</c-ui.button>

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -263,6 +263,58 @@ def _apply_edits(op, miniature, own, computed, field, ticked):
 
 
 @login_required
+def render_card_update(request, miniature, at):
+    """The partial update for an act on one model's card.
+
+    The whole card, rather than the part that changed. An effect
+    conditioned on a counter's value can confer a rule, reveal a choice
+    or shift a characteristic the moment the value crosses, and all of
+    those are drawn on this card — redrawing it entire is what keeps the
+    screen honest without this having to work out which of them moved.
+
+    The boxes a player writes in are the card's siblings rather than its
+    children, so replacing the card leaves their editors standing and
+    whatever is typed in them with it.
+
+    ``at`` is the address the act came from, and every control on the
+    redrawn card is built from it: a card rendered without one hands back
+    a rename that leads nowhere.
+
+    The gang is derived again rather than reused, because the act changed
+    what this reports on. That costs what a plain visit costs.
+    """
+    from n26.core.render import render_gang
+    from n26.core.views.choose import link_slots
+    from n26.core.views.htmx import with_toasts
+    from n26.core.views.learn import link_skills
+    from n26.core.views.owned import link_counters
+
+    gang = miniature.membership.gang
+    sheet = render_gang(gang)
+    link_slots(gang, sheet, *sheet.models)
+    link_skills(*sheet.models)
+    card = next(
+        (member for member in sheet.models if member.id == str(miniature.pk)), None
+    )
+    if card is None:
+        raise Http404("No such model")
+    link_counters(card)
+
+    response = render(
+        request,
+        "n26/includes/model_card_update.html",
+        {
+            "card": card,
+            "miniature": miniature,
+            "equip_href": reverse("n26-equip", args=[miniature.pk]),
+            # The card is drawn on the page this act came from, so its
+            # controls are addressed from there.
+            "at": at,
+        },
+    )
+    return with_toasts(request, response)
+
+
 def edit_fighter(request, pk):
     """One model, whole: their card with its edit affordances, the
     characteristics they can set by hand, and the notes box.

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -262,7 +262,6 @@ def _apply_edits(op, miniature, own, computed, field, ticked):
     return added, taken, restored
 
 
-@login_required
 def render_card_update(request, miniature, at):
     """The partial update for an act on one model's card.
 
@@ -315,6 +314,7 @@ def render_card_update(request, miniature, at):
     return with_toasts(request, response)
 
 
+@login_required
 def edit_fighter(request, pk):
     """One model, whole: their card with its edit affordances, the
     characteristics they can set by hand, and the notes box.

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -265,38 +265,35 @@ def _apply_edits(op, miniature, own, computed, field, ticked):
 def render_card_update(request, miniature, at):
     """The partial update for an act on one model's card.
 
-    The whole card, rather than the part that changed. An effect
-    conditioned on a counter's value can confer a rule, reveal a choice
-    or shift a characteristic the moment the value crosses, and all of
-    those are drawn on this card — redrawing it entire is what keeps the
-    screen honest without this having to work out which of them moved.
+    Why the whole card is sent back rather than the part that moved is
+    the template's own comment.
 
-    The boxes a player writes in are the card's siblings rather than its
-    children, so replacing the card leaves their editors standing and
-    whatever is typed in them with it.
+    ``at`` is the screen the act came from, and reaches the counter
+    controls as the address they return to. Nothing else needs it: the
+    rename is relative and the browser resolves it against whatever page
+    it lands on.
 
-    ``at`` is the address the act came from, and every control on the
-    redrawn card is built from it: a card rendered without one hands back
-    a rename that leads nowhere.
-
-    The gang is derived again rather than reused, because the act changed
-    what this reports on. That costs what a plain visit costs.
+    The model is read again rather than trusted from the request, because
+    the act changed what this reports on — and read the way the page
+    itself reads it, from this one model rather than from the gang
+    around it, so an act costs what the page costs and not more.
     """
-    from n26.core.render import render_gang
+    from n26.core.access import model_collections
+    from n26.core.card import build_card, build_modifier_index
+    from n26.core.effects import compute
+    from n26.core.render import build_model_card
     from n26.core.views.choose import link_slots
     from n26.core.views.htmx import with_toasts
     from n26.core.views.learn import link_skills
     from n26.core.views.owned import link_counters
 
     gang = miniature.membership.gang
-    sheet = render_gang(gang)
-    link_slots(gang, sheet, *sheet.models)
-    link_skills(*sheet.models)
-    card = next(
-        (member for member in sheet.models if member.id == str(miniature.pk)), None
-    )
-    if card is None:
-        raise Http404("No such model")
+    own = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in own.all_nodes()])
+    computed = compute(own, index)
+    card = build_model_card(miniature, card=own, computed=computed)
+    link_slots(gang, card)
+    link_skills(card, among=model_collections())
     link_counters(card, back=at)
 
     response = render(

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -297,7 +297,7 @@ def render_card_update(request, miniature, at):
     )
     if card is None:
         raise Http404("No such model")
-    link_counters(card)
+    link_counters(card, back=at)
 
     response = render(
         request,
@@ -306,9 +306,6 @@ def render_card_update(request, miniature, at):
             "card": card,
             "miniature": miniature,
             "equip_href": reverse("n26-equip", args=[miniature.pk]),
-            # The card is drawn on the page this act came from, so its
-            # controls are addressed from there.
-            "at": at,
         },
     )
     return with_toasts(request, response)
@@ -614,7 +611,7 @@ def edit_fighter(request, pk):
     # Only here. A counter is drawn wherever a card is; the model's own
     # page is the one place it is moved, so this is the one place the
     # lines are given addresses.
-    link_counters(card)
+    link_counters(card, back=request.get_full_path())
 
     subtype_edits, subtype_more, subtype_edits_dirty = _edits_offer(
         own, computed, "subtype", "Subtypes"

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -78,7 +78,7 @@ from n26.core.views.permissions import _own_assignment_or_404, _safe_redirect
 MOST_A_TALLY_MOVES = 1000
 
 
-def link_counters(card):
+def link_counters(card, back=""):
     """Point every counter line on this card at what changes it.
 
     Costs no queries: the line already carries the assignment behind it,
@@ -86,10 +86,17 @@ def link_counters(card):
     href and draws as a number with nothing to click — which is right
     for a card depicting nobody, and for every screen that shows a
     counter without offering to move it.
+
+    ``back`` is the screen the card is drawn on, which the controls carry
+    so a reader with no scripting lands there. It is passed rather than
+    read off the request because a card redrawn after an act is rendered
+    under that act's own address, and a control sent back carrying it
+    would return the next reader to a POST-only endpoint.
     """
     for line in card.counters:
         if line.assignment_id:
             line.href = reverse("n26-tally", args=[line.assignment_id])
+            line.back = back
 
 
 def _possession_or_404(request, pk):

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -1036,6 +1036,7 @@ def tally_counter(request, pk):
     """
     from n26.analytics import EventVerb, N26Noun, record
     from n26.core.operations import Refusal, operation
+    from n26.core.views.edit import render_card_update
     from n26.library.models import Counter
 
     assignment = _own_assignment_or_404(request, pk)
@@ -1064,6 +1065,10 @@ def tally_counter(request, pk):
             standing = op.tally(assignment, change)
     except Refusal as refusal:
         messages.error(request, str(refusal))
+        if is_htmx(request):
+            # Nothing moved, so nothing on the page is redrawn; the
+            # refusal reaches the reader as a toast and that is all.
+            return no_update(request)
         return _safe_redirect(request, back, here)
 
     record(
@@ -1077,5 +1082,10 @@ def tally_counter(request, pk):
         action="tally",
         change=change,
     )
+    if miniature is not None and is_htmx(request):
+        # No message: the number on the card moves where the reader is
+        # looking, and a toast for every step of a tally somebody is
+        # working through is noise. A refusal still speaks, above.
+        return render_card_update(request, miniature, back or here)
     messages.success(request, f"{name} is now {standing}.")
     return _safe_redirect(request, back, here)

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -1090,9 +1090,14 @@ def tally_counter(request, pk):
         change=change,
     )
     if miniature is not None and is_htmx(request):
-        # No message: the number on the card moves where the reader is
-        # looking, and a toast for every step of a tally somebody is
-        # working through is noise. A refusal still speaks, above.
-        return render_card_update(request, miniature, back or here)
+        # No message queued: the number on the card moves where the
+        # reader is looking, and a toast for every step of a tally
+        # somebody is working through is noise. A refusal is the one
+        # thing they cannot see, and it is queued where it is raised.
+        return render_card_update(
+            request,
+            miniature,
+            back or reverse("n26-edit-fighter", args=[miniature.pk]),
+        )
     messages.success(request, f"{name} is now {standing}.")
     return _safe_redirect(request, back, here)

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -396,6 +396,33 @@ class TestMovingOneWithoutReloading:
 
         assert self.address(yolanda) in page.content.decode()
 
+    def test_the_card_it_sends_back_returns_to_the_page_not_the_act(
+        self, client, gang, queen
+    ):
+        """The redrawn card is rendered under the act's own address. A
+        control built from that would send a reader with no scripting to
+        a POST-only endpoint, so the screen to return to rides on the
+        line instead."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        page = reverse("n26-edit-fighter", args=[yolanda.pk])
+        client.force_login(gang.owner)
+
+        drawn = client.post(
+            self.address(yolanda), {"change": "1", "back": page}, **self.HTMX
+        ).content.decode()
+
+        assert f'name="back" value="{page}"' in drawn
+        assert f'name="back" value="{self.address(yolanda)}"' not in drawn
+
+    def test_the_page_itself_returns_to_itself(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        page = reverse("n26-edit-fighter", args=[yolanda.pk])
+        client.force_login(gang.owner)
+
+        drawn = client.get(page).content.decode()
+
+        assert f'name="back" value="{page}"' in drawn
+
     def test_a_refusal_redraws_nothing_and_says_why(self, client, gang, queen):
         yolanda = hire_with_option(gang, queen, "Yolanda")
         client.force_login(gang.owner)

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -354,6 +354,100 @@ class TestMovingACounterByHand:
         assert xp_row(yolanda).counter_value.value == 61
 
 
+class TestMovingOneWithoutReloading:
+    """Over htmx the act sends back the card and nothing else.
+
+    Without scripting the same control is an ordinary form post and the
+    whole page is served, so nothing here works only one way.
+    """
+
+    HTMX = {"HTTP_HX_REQUEST": "true"}
+
+    def address(self, miniature):
+        row = Assignment.objects.get(miniature=miniature, counter__name="XP")
+        return reverse("n26-tally", args=[row.pk])
+
+    def test_it_sends_back_the_card_addressed_to_its_host(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.post(self.address(yolanda), {"change": "1"}, **self.HTMX)
+
+        drawn = page.content.decode()
+        assert page.status_code == 200
+        assert 'id="n26-model-card-host"' in drawn
+        assert 'hx-swap-oob="true"' in drawn
+
+    def test_the_card_it_sends_back_carries_the_new_value(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.post(self.address(yolanda), {"change": "1"}, **self.HTMX)
+
+        assert "62" in page.content.decode()
+
+    def test_the_card_it_sends_back_can_be_acted_on_again(self, client, gang, queen):
+        """A redrawn card whose controls had lost their addresses would
+        move once and then go quiet."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.post(self.address(yolanda), {"change": "1"}, **self.HTMX)
+
+        assert self.address(yolanda) in page.content.decode()
+
+    def test_a_refusal_redraws_nothing_and_says_why(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.post(self.address(yolanda), {"change": "0"}, **self.HTMX)
+
+        # A step of nothing is no address at all, htmx or not.
+        assert page.status_code == 404
+
+    def test_without_htmx_the_same_act_is_a_redirect(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        back = reverse("n26-edit-fighter", args=[yolanda.pk])
+        client.force_login(gang.owner)
+
+        page = client.post(self.address(yolanda), {"change": "1", "back": back})
+
+        assert page.status_code == 302
+        assert page["Location"] == back
+
+    def test_the_page_holds_the_host_the_update_addresses(self, client, gang, queen):
+        """htmx drops an out-of-band element whose id is missing from the
+        page, silently — so opting in and holding the host have to travel
+        together."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.get(reverse("n26-edit-fighter", args=[yolanda.pk]))
+
+        assert 'id="n26-model-card-host"' in page.content.decode()
+
+    def test_the_controls_on_that_page_post_through_htmx(self, client, gang, queen):
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.get(reverse("n26-edit-fighter", args=[yolanda.pk]))
+
+        assert f'hx-post="{self.address(yolanda)}"' in page.content.decode()
+
+    def test_each_direction_carries_its_own_change(self, client, gang, queen):
+        """htmx does not read a form's submitter, so the value cannot ride
+        on the button that was clicked."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        drawn = client.get(
+            reverse("n26-edit-fighter", args=[yolanda.pk])
+        ).content.decode()
+
+        assert 'name="change" value="1"' in drawn
+        assert 'name="change" value="-1"' in drawn
+
+
 class TestTheNoteFitsTheColumn:
     """A tally's note is a fixed-width column, and a caller can hand over
     more than it holds.

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -386,6 +386,16 @@ class TestMovingOneWithoutReloading:
 
         assert "62" in page.content.decode()
 
+    def test_the_card_it_sends_back_still_carries_the_rename(self, client, gang, queen):
+        """It is drawn from the page rather than the card, so a redrawn
+        card is exactly where it could go missing."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        page = client.post(self.address(yolanda), {"change": "1"}, **self.HTMX)
+
+        assert f"?rename={yolanda.pk}" in page.content.decode()
+
     def test_the_card_it_sends_back_can_be_acted_on_again(self, client, gang, queen):
         """A redrawn card whose controls had lost their addresses would
         move once and then go quiet."""
@@ -424,12 +434,29 @@ class TestMovingOneWithoutReloading:
         assert f'name="back" value="{page}"' in drawn
 
     def test_a_refusal_redraws_nothing_and_says_why(self, client, gang, queen):
+        """The card is not redrawn for an act that did not happen; the
+        reason reaches the reader as a toast, which is the only channel
+        into a page that is not re-rendered."""
+        from unittest.mock import patch
+
+        from n26.core.operations import Operation, Refusal
+
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+        client.force_login(gang.owner)
+
+        with patch.object(Operation, "tally", side_effect=Refusal("No.")):
+            page = client.post(self.address(yolanda), {"change": "1"}, **self.HTMX)
+
+        assert page.status_code == 204
+        assert "No." in page["HX-Trigger"]
+        assert xp_row(yolanda).counter_value.value == 61
+
+    def test_a_zero_step_is_turned_away_over_htmx_too(self, client, gang, queen):
         yolanda = hire_with_option(gang, queen, "Yolanda")
         client.force_login(gang.owner)
 
         page = client.post(self.address(yolanda), {"change": "0"}, **self.HTMX)
 
-        # A step of nothing is no address at all, htmx or not.
         assert page.status_code == 404
 
     def test_without_htmx_the_same_act_is_a_redirect(self, client, gang, queen):
@@ -443,9 +470,9 @@ class TestMovingOneWithoutReloading:
         assert page["Location"] == back
 
     def test_the_page_is_not_open_to_a_signed_out_reader(self, client, gang, queen):
-        """A guard worth a test of its own: the helper that renders the
-        card update sits directly above the view, and an insertion in
-        that gap would take the view's decorator with it."""
+        """The view is guarded, and the guard is a decorator with a
+        helper directly above it — a place where anything inserted
+        carries the guard off with it."""
         yolanda = hire_with_option(gang, queen, "Yolanda")
 
         page = client.get(reverse("n26-edit-fighter", args=[yolanda.pk]))

--- a/n26/tests/sandbox/test_counters.py
+++ b/n26/tests/sandbox/test_counters.py
@@ -415,6 +415,17 @@ class TestMovingOneWithoutReloading:
         assert page.status_code == 302
         assert page["Location"] == back
 
+    def test_the_page_is_not_open_to_a_signed_out_reader(self, client, gang, queen):
+        """A guard worth a test of its own: the helper that renders the
+        card update sits directly above the view, and an insertion in
+        that gap would take the view's decorator with it."""
+        yolanda = hire_with_option(gang, queen, "Yolanda")
+
+        page = client.get(reverse("n26-edit-fighter", args=[yolanda.pk]))
+
+        assert page.status_code == 302
+        assert "/accounts/login/" in page["Location"]
+
     def test_the_page_holds_the_host_the_update_addresses(self, client, gang, queen):
         """htmx drops an out-of-band element whose id is missing from the
         page, silently — so opting in and holding the host have to travel


### PR DESCRIPTION
Closes #2371. Fast-follow to #2367, which put `−`/`+` on a model's counter
lines on the fighter-edit page.

Each click was a form post and a full page reload — on the screen people click
these on repeatedly after a battle. The act now posts through htmx and the
answer is the model card, carrying the id of the host it replaces. Without
scripting it is the same form to the same address and the whole page is served.

## Three things the code decided

**The card entire, not the line that moved.** #2371 was filed assuming a card
swap would rebuild the Notes and Lore editors and lose whatever is typed in
them. It does not: in `cotton/n26/view/model_edit.html` the card and those
boxes are *siblings* in one grid, not nested. That inverts the design in our
favour — replacing the whole card also redraws the statline, the Rules row and
the choice rows, which are exactly what an effect conditioned on a counter's
value changes when it crosses. No per-line bookkeeping, and correct in advance
of content that needs it.

Proven rather than assumed: a browser pass typed into the Notes editor, clicked
`+` three times, and found the value moved 3 → 6 with **zero full page loads**
and the unsaved typing still there.

**A form each way, rather than one form with two buttons.** htmx 2.0.4 has no
`event.submitter` handling, so the value could not ride on the button that was
clicked: the single-form shape would have posted no `change` at all over htmx
and been refused on every click, while working perfectly with scripting off. A
hidden field carries it, which both paths read the same way. This is the one
that would have cost an afternoon to find.

**No message on the way back.** The number moves where the reader is looking,
and a toast for every step of a tally somebody is working through is noise. A
refusal still speaks, because a click that did nothing has to say why. A
deliberate departure from the equip screens, where the row that changed is far
from the button that changed it.

Also: the rename beside the model's name moves into an include the page and the
update share, so a redrawn card cannot come back without it.

## Left alone

The Skills & Powers and Subtypes & Rules boxes read their offers from the same
derivation, so a future threshold crossing could leave them stale until the next
full load. Deliberately not swapped — they are forms the reader may be part-way
through, and clobbering half-ticked boxes is worse than a stale offer. Nothing
in prod hangs an effect off a counter value today (`CounterAtLeast` has no rows),
so this is unreachable; worth revisiting when the first such content is authored.

## How to try it

Open a Spyrer's Edit page and click `+` on Kill Count a few times. The number
moves in place, the page does not reload, and anything typed in the Notes or
Lore box survives. Turn JavaScript off and the same buttons still work, as full
page posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcfaept4eVpfxrt15jmPdB
