### PR TITLE
perf: draw the model edit page from one model's derivation, not the gang's

### DIFF
--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -419,3 +419,49 @@ class TestRenamingFromHere:
             reverse("n26-rename-fighter", args=[vex.pk]), {"name": "Karn"}
         )
         assert response.url == reverse("n26-gang", args=[gang.pk])
+
+
+class TestTheQueryBudget:
+    """One model's page asks about one model.
+
+    The count is pinned so it changes deliberately, and measured against
+    a roster to hold the shape of it: what this page draws is a fact
+    about the model in the address, so the rest of the gang costs
+    nothing. A page that walks the roster to find one card reads the
+    same and passes every other test here.
+
+    Measured after one warm request. The first request of a session
+    writes its own row and reads the site, which would pin the session
+    machinery alongside the page.
+    """
+
+    def measure(self, client, url):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        assert client.get(url).status_code == 200
+        with CaptureQueriesContext(connection) as captured:
+            assert client.get(url).status_code == 200
+        return len(captured.captured_queries)
+
+    def crowd(self, gang, tester, make_profile, make_statline, how_many):
+        """Fill the gang out, so a count that follows the roster shows."""
+        from n26.core.operations import operation
+
+        profile = make_profile("Juve", price=0)
+        make_statline(profile)
+        for n in range(how_many):
+            with operation(gang, actor=tester) as op:
+                op.hire(profile, f"Extra {n}")
+
+    def test_the_page_costs_a_fixed_number(self, client, tester, gang, vex):
+        client.force_login(tester)
+        assert self.measure(client, edit_url(vex)) == 39
+
+    def test_the_rest_of_the_gang_costs_nothing(
+        self, client, tester, gang, vex, make_profile, make_statline
+    ):
+        client.force_login(tester)
+        alone = self.measure(client, edit_url(vex))
+        self.crowd(gang, tester, make_profile, make_statline, 12)
+        assert self.measure(client, edit_url(vex)) == alone

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.http import Http404
 from django.shortcuts import redirect, render
 from django.urls import reverse
 
@@ -268,9 +267,11 @@ def edit_fighter(request, pk):
     """One model, whole: their card with its edit affordances, the
     characteristics they can set by hand, and the notes box.
 
-    The card is rendered off the same gang derivation the sheet uses —
-    one call, fixed queries — and the member picked out of it, so this
-    page and the sheet cannot disagree about what the model is. The
+    One derivation of one model serves the whole page: the card, the
+    skills listing and the edits boxes are all read off it, so they
+    cannot disagree about what the model is. That reading carries the
+    gang's own assignments, which is how what the gang grants reaches
+    the card without the rest of the roster being computed for it. The
     card draws in ``edit`` mode: the choice controls the sheet hides
     are offered here, outlined, and the Gear and Weapons rows carry the
     way to the Equip tab.
@@ -296,6 +297,7 @@ def edit_fighter(request, pk):
     and the complaint under them; anything saved lands back here.
     """
     from n26.analytics import EventVerb, N26Noun, record
+    from n26.core.access import model_collections
     from n26.core.card import build_card, build_modifier_index
     from n26.core.effects import compute
     from n26.core.forms import (
@@ -306,7 +308,7 @@ def edit_fighter(request, pk):
     )
     from n26.core.images import MAX_PX, PORTRAIT
     from n26.core.operations import Refusal, operation
-    from n26.core.render import render_gang, roster, summarise_roster
+    from n26.core.render import build_model_card, roster, summarise_roster
     from n26.core.views.choose import link_slots
     from n26.core.views.gangs import _fighter_named
     from n26.core.views.htmx import is_htmx, stay_or_redirect
@@ -502,13 +504,16 @@ def edit_fighter(request, pk):
     if statline_edit is None and statline_class is not None:
         statline_edit = statline_class.opened_on(miniature)
 
-    # The model's own card, computed: the boxes need the assignments and
-    # the grants behind what the card shows, which the sheet does not
-    # carry. A fixed reading, however much this model knows.
-    own = build_card(miniature)
+    # This model, read once: the card drawn below, the skills listing and
+    # the edits boxes all come off it. A fixed number of queries, however
+    # much this model holds and however large the gang around it.
+    own = build_card(miniature, with_statlines=True)
     index = build_modifier_index([node.assignable for node in own.all_nodes()])
     computed = compute(own, index)
-    skills = skills_offer(own, computed)
+    # Asked once and used twice: the listing reads these collections, and
+    # so does the card's Skills control.
+    sets = model_collections()
+    skills = skills_offer(own, computed, sets)
     asked = request.GET.get("skills")
     # A model no placement names has nothing under the first heading, so
     # the box opens on the listing holding every set. An address naming a
@@ -536,9 +541,9 @@ def edit_fighter(request, pk):
     }
 
     # A tab clicked with script running is answered with the box alone,
-    # before the gang sheet is built: changing which sets are listed
-    # changes nothing else on the page, and the address still says which
-    # tab is open so a reload draws the same screen.
+    # before the card is drawn: changing which sets are listed changes
+    # nothing else on the page, and the address still says which tab is
+    # open so a reload draws the same screen.
     if request.method == "GET" and asked and is_htmx(request):
         answer = render(
             request, "n26/includes/skills_box.html", {**skills_box, "oob": True}
@@ -546,14 +551,14 @@ def edit_fighter(request, pk):
         answer["HX-Replace-Url"] = request.get_full_path()
         return answer
 
-    sheet = render_gang(gang)
-    link_slots(gang, sheet, *sheet.models)
-    link_skills(*sheet.models)
-    card = next(
-        (member for member in sheet.models if member.id == str(miniature.pk)), None
-    )
-    if card is None:
-        raise Http404("No such model")
+    # Drawn from the reading already in hand. A card is a fact about one
+    # model — what it holds, what modifiers make of that — so the gang is
+    # asked for only what the gang alone can answer, which on this page is
+    # the roster tally below. The card's own build carries the gang's
+    # assignments already, so what the gang grants still reaches it.
+    card = build_model_card(miniature, card=own, computed=computed)
+    link_slots(gang, card)
+    link_skills(card, among=sets)
     # Only here. A counter is drawn wherever a card is; the model's own
     # page is the one place it is moved, so this is the one place the
     # lines are given addresses.

--- a/n26/core/views/learn.py
+++ b/n26/core/views/learn.py
@@ -63,7 +63,7 @@ from django.urls import reverse
 from n26.core.views.permissions import _own_miniature_or_404
 
 
-def link_skills(*cards):
+def link_skills(*cards, among=None):
     """Point every card's Skills control at this fighter's skills screen.
 
     One query for a whole roster, and none per card: which collections
@@ -71,10 +71,17 @@ def link_skills(*cards):
     which collections its own grid reaches. A card depicting nobody — a
     hire preview, a gallery sample — keeps an empty href and draws no
     control, which is what a print sheet wants too.
+
+    ``among`` is that answer, where the caller has already asked for it —
+    a page drawing a listing of the same collections has, and asking
+    twice on one request would be the same query twice.
     """
     from n26.core.access import model_collections
 
-    learnable = {str(collection.pk) for collection in model_collections()}
+    learnable = {
+        str(collection.pk)
+        for collection in (model_collections() if among is None else among)
+    }
     for card in cards:
         if card.id and set(card.placed_in) & learnable:
             card.learn_href = reverse("n26-learn", args=[card.id])
@@ -136,7 +143,7 @@ class SkillsOffer:
     rest: list
 
 
-def _sets_on_offer(card, computed):
+def _sets_on_offer(card, computed, among=None):
     """Every set a model could hold something from, one group each, said
     with whether their placements name the tier it sits in.
 
@@ -175,7 +182,7 @@ def _sets_on_offer(card, computed):
     held = _rows_on(card)
     granted = _grants_on(computed)
     found = []
-    for collection in model_collections():
+    for collection in model_collections() if among is None else among:
         placements = placements_for(computed, collection)
         placed = {placement.section.name for placement in placements.values()}
         listed = with_use_notes(
@@ -208,7 +215,7 @@ def _sets_on_offer(card, computed):
     return found
 
 
-def skills_offer(card, computed):
+def skills_offer(card, computed, among=None):
     """What this model may hold, as a list to tick rather than to click.
 
     Every set the library holds for a model, skills and powers alike —
@@ -229,11 +236,15 @@ def skills_offer(card, computed):
     holds something in is drawn among their own so it can be cleared
     where they will look for it, and everything else is on the same
     listing one tab or one search away.
+
+    ``among`` is the collections to read, for a caller that has already
+    asked which they are — the same answer :func:`link_skills` wants,
+    and one query rather than two where a page needs both.
     """
     from n26.core.render import ChoiceOffer
 
     own, rest, every = [], [], []
-    for placed, group in _sets_on_offer(card, computed):
+    for placed, group in _sets_on_offer(card, computed, among):
         every.append(group)
         if placed or any(option.is_current for option in group.options):
             own.append(group)


### PR DESCRIPTION
The n26 fighter edit page was building the entire gang to draw one model's
card, and building that model a second time for the boxes underneath it.

**141 queries → 95. SQL time 155ms → 48ms. Whole request 303ms → 161ms.**
Measured against the content mirror with production's template caching on.

## What was happening

The page called `render_gang(gang)` — which builds every member's card, the
gang card, the stash, and one modifier index over all of it — and then picked
one member out of the result. Separately, it called `build_card(miniature)` and
built a second modifier index, because the skills and edits boxes need the
assignments and grants behind the card. So the same model was derived twice,
and the rest of the roster was derived for nothing.

`link_skills` and `skills_offer` also both called `model_collections()` — the
same query twice on one page, which that function's own docstring anticipates
by leaving the timing to its caller.

## What it does now

One derivation of one model, shared by the card, the skills listing and the
edits boxes. `build_model_card` takes the card and computed reading already in
hand; `link_slots`, `link_skills` and `link_counters` take the card rather than
a sheet. Both collection readers take the answer the page asked for once.

The model's own build already carries the gang's assignments, which is how what
the gang grants still reaches the card — `GangCard.acquired` settles lazily
where `compute_gang` used to set it.

## Verifying it draws the same card

The gang path runs `compute_gang` before each member; the single path does not.
Rather than reason about whether that matters, I built a population and
compared: **261 profiles hired across all 20 gang types**, plus the existing
roster, each model's card built both ways and compared field by field —
every `ModelCard` field plus eleven derived readings the templates draw.

**278 of 278 identical.** The same population also shows that asking for
statlines, which the single build now does, changes nothing about what the
skills and edits boxes offer.

## Tests

A budget test pins the count, and more usefully pins the shape: filling the
gang out costs this page nothing. That is the property a future walk of the
roster would break while passing every other test in the file.

Full suite green.

## Not done here

- `skills_offer` is 24 of the remaining 95, browsing every model-facing
  collection. In the published content one of those two collections sweeps
  every power and the other sweeps three of the same ones, so its eleven
  queries add nothing to the listing. Deduplicating overlapping collections
  would change what is displayed, so it is a product question rather than an
  optimisation.
- `roster()` and the navigation's fighter switcher each list the gang's models,
  about 7ms apiece. They want different columns, so sharing them is not free.