### PR TITLE
fix: keep commas beside granted skills and give Choose its own line on the model card

### DIFF
--- a/n26/core/templates/cotton/n26/assignable_lines.html
+++ b/n26/core/templates/cotton/n26/assignable_lines.html
@@ -26,4 +26,13 @@ The whole run sits in {% spaceless %}, and every piece — a plain name, the
 rating, the comma — is its own <span>: a granted line's tooltip is a sizeable
 component with line breaks of its own, and without this its trailing
 whitespace lands beside the next comma as a visible gap before the mark.
-{% endcomment %}<c-vars :lines="None" :ratings="True" />{% spaceless %}{% if lines %}{% for line in lines %}{% if line.provenance.computed %}<c-ui.tooltip size="sm"><span class="cursor-help underline decoration-dotted underline-offset-2">{{ line.name }}<span class="sr-only"> ({% if line.provenance.source %}from {{ line.provenance.source }}{% else %}granted{% endif %})</span></span><c-slot name="content">{% if line.provenance.source %}From {{ line.provenance.source }}{% if line.provenance.source_kind %} ({{ line.provenance.source_kind }}){% endif %}{% else %}Granted, not printed{% endif %}</c-slot></c-ui.tooltip>{% else %}<span>{{ line.name }}</span>{% endif %}{% if ratings and line.rating %}<span>&nbsp;<span class="tabular-nums">{{ line.rating }}¢</span></span>{% endif %}{% if not forloop.last %}<span>,&nbsp;</span>{% endif %}{% endfor %}{% else %}&mdash;{% endif %}{% endspaceless %}
+
+A granted line's tooltip trigger is an inline-block, and a line may break on
+either side of one however the text around it reads — so a comma sitting after
+the trigger can be carried to the start of the next line alone. Its comma and
+rating go inside the trigger instead, where nothing breaks; the space after
+that comma is a non-breaking one, because a breaking space at the end of an
+inline-block collapses and the names would run together. A plain name's comma
+needs none of this — text never breaks before a comma — and the plain space
+after it is what lets a long run wrap between names.
+{% endcomment %}<c-vars :lines="None" :ratings="True" />{% spaceless %}{% if lines %}{% for line in lines %}{% if line.provenance.computed %}<c-ui.tooltip size="sm"><span class="cursor-help underline decoration-dotted underline-offset-2">{{ line.name }}<span class="sr-only"> ({% if line.provenance.source %}from {{ line.provenance.source }}{% else %}granted{% endif %})</span></span>{% if ratings and line.rating %}<span>&nbsp;<span class="tabular-nums">{{ line.rating }}¢</span></span>{% endif %}{% if not forloop.last %}<span>,&nbsp;</span>{% endif %}<c-slot name="content">{% if line.provenance.source %}From {{ line.provenance.source }}{% if line.provenance.source_kind %} ({{ line.provenance.source_kind }}){% endif %}{% else %}Granted, not printed{% endif %}</c-slot></c-ui.tooltip>{% else %}<span>{{ line.name }}</span>{% if ratings and line.rating %}<span>&nbsp;<span class="tabular-nums">{{ line.rating }}¢</span></span>{% endif %}{% if not forloop.last %}<span>, </span>{% endif %}{% endif %}{% endfor %}{% else %}&mdash;{% endif %}{% endspaceless %}

--- a/n26/core/templates/cotton/n26/assignable_lines.html
+++ b/n26/core/templates/cotton/n26/assignable_lines.html
@@ -25,7 +25,7 @@ With no lines at all it draws an em dash.
 The whole run sits in {% spaceless %}, and every piece — a plain name, the
 rating, the comma — is its own <span>: a granted line's tooltip is a sizeable
 component with line breaks of its own, and without this its trailing
-whitespace lands beside the next comma as a visible gap before the mark.
+whitespace lands beside the next name as a visible gap.
 
 A granted line's tooltip trigger is an inline-block, and a line may break on
 either side of one however the text around it reads — so a comma sitting after

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -54,7 +54,7 @@ draw the same thing.
             An open skill question is drawn in the Skills row, on a line of its
             own under the skills the model already has — not among the choice
             rows below, and not in the flow of the list, where wrapping would
-            fold it into the names. The gang sheet says it as a quiet link and
+            fold it into the names. The gang sheet draws it as a quiet link and
             only the model's own page grows a button; the way to the skills
             screen is edit mode's alone.
             {% endcomment %}
@@ -117,7 +117,8 @@ draw the same thing.
 
         {% comment %}
         Powers are a kind of their own and keep a row of their own, drawn as
-        the Skills row is: one list, and open questions beside it.
+        the Skills row is: one list, and open questions on a line of their
+        own beneath it.
         {% endcomment %}
         {% if card.powers or card.power_choices %}
             <dt class="font-semibold text-ink-900 dark:text-ink-100">Powers</dt>

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -51,18 +51,20 @@ draw the same thing.
         <dd class="min-w-0 text-ink-900 dark:text-ink-100">
             <c-n26.assignable-lines :lines="card.skills" :ratings="False" />
             {% comment %}
-            An open skill question is drawn beside the skills the model already
-            has, not among the choice rows below. The gang sheet says it as a
-            quiet link and only the model's own page grows a button; the way to
-            the skills screen is edit mode's alone.
+            An open skill question is drawn in the Skills row, on a line of its
+            own under the skills the model already has — not among the choice
+            rows below, and not in the flow of the list, where wrapping would
+            fold it into the names. The gang sheet says it as a quiet link and
+            only the model's own page grows a button; the way to the skills
+            screen is edit mode's alone.
             {% endcomment %}
             <c-n26.model-card.mode when="gang view">
                 {% if card.skill_choices %}
-                    <span class="ms-1 inline-flex flex-wrap items-center gap-2 align-middle">
+                    <div class="mt-1 flex flex-wrap items-center gap-2">
                         {% for choice in card.skill_choices %}
                             <c-n26.link href="{{ choice.href }}" tone="muted" underline="always" class="text-xs">Choose {{ choice.kind_label|lower }}</c-n26.link>
                         {% endfor %}
-                    </span>
+                    </div>
                 {% endif %}
             </c-n26.model-card.mode>
             {% comment %}
@@ -72,7 +74,7 @@ draw the same thing.
             {% endcomment %}
             <c-n26.model-card.mode when="edit">
                 {% if card.skill_choices or card.learn_href %}
-                    <span class="ms-1 inline-flex flex-wrap items-center gap-1 align-middle">
+                    <div class="mt-1 flex flex-wrap items-center gap-1">
                         {% for choice in card.skill_choices %}
                             {% if choice.href %}
                                 <c-ui.button size="xs" variant="primary" :outlined="True" class="py-0!" href="{{ choice.href }}">
@@ -97,7 +99,7 @@ draw the same thing.
                                 <c-slot name="content">Select a skill</c-slot>
                             </c-ui.tooltip>
                         {% endif %}
-                    </span>
+                    </div>
                 {% endif %}
             </c-n26.model-card.mode>
         </dd>
@@ -123,16 +125,16 @@ draw the same thing.
                 <c-n26.assignable-lines :lines="card.powers" :ratings="False" />
                 <c-n26.model-card.mode when="gang view">
                     {% if card.power_choices %}
-                        <span class="ms-1 inline-flex flex-wrap items-center gap-2 align-middle">
+                        <div class="mt-1 flex flex-wrap items-center gap-2">
                             {% for choice in card.power_choices %}
                                 <c-n26.link href="{{ choice.href }}" tone="muted" underline="always" class="text-xs">Choose {{ choice.kind_label|lower }}</c-n26.link>
                             {% endfor %}
-                        </span>
+                        </div>
                     {% endif %}
                 </c-n26.model-card.mode>
                 <c-n26.model-card.mode when="edit">
                     {% if card.power_choices %}
-                        <span class="ms-1 inline-flex flex-wrap items-center gap-1 align-middle">
+                        <div class="mt-1 flex flex-wrap items-center gap-1">
                             {% for choice in card.power_choices %}
                                 {% if choice.href %}
                                     <c-ui.button size="xs" variant="primary" :outlined="True" class="py-0!" href="{{ choice.href }}">
@@ -142,7 +144,7 @@ draw the same thing.
                                     <c-n26.link>Choose {{ choice.kind_label|lower }}</c-n26.link>
                                 {% endif %}
                             {% endfor %}
-                        </span>
+                        </div>
                     {% endif %}
                 </c-n26.model-card.mode>
             </dd>

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1861,6 +1861,17 @@ STASH = [
             computed=True, source="Ash Wastes Nomads", source_kind="gang type"
         ),
     ),
+    # Granted AND rated: the one shape where a price is drawn inside the
+    # tooltip's trigger, beside the dotted-underlined name. The gallery must
+    # hold a specimen or that arm of assignable-lines is drawn nowhere.
+    StashLine(
+        name="Blindsnake pouch",
+        rating=60,
+        kind="wargear",
+        provenance=Provenance(
+            computed=True, source="Ash Wastes Nomads", source_kind="gang type"
+        ),
+    ),
     # Deliberately out of kind order. regroup starts a new group whenever the key
     # changes rather than gathering equal keys, so a stash arriving in any order
     # is the case the component's dictsort exists for.

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -345,7 +345,10 @@ class TestWhatTheSquareShows:
         """A granted skill's name sits inside a tooltip component that
         carries line breaks of its own; the run joining it to the next
         skill must swallow those, not let one land beside the comma as a
-        visible gap before the mark."""
+        visible gap before the mark. The two separators differ on
+        purpose: a granted skill's comma rides inside its tooltip
+        trigger with a non-breaking space, and a plain skill's comma is
+        followed by a breaking one so the run can wrap between names."""
         keen = create_subtype("Keen-eyed")
         modifier(
             "Keen-eyed knows how to fall",
@@ -355,14 +358,18 @@ class TestWhatTheSquareShows:
         )
         assign(keen, miniature=yolanda)
         learn(yolanda, library["skills"]["Connected"])
+        learn(yolanda, library["skills"]["Dodge"])
         client.force_login(player)
         page = client.get(edit_url(yolanda)).content.decode()
 
         start = page.index(">Skills<")
         row = page[start : page.index(">Gear<", start)]
         assert " ," not in row
+        # Catfall (granted) sorts first: its comma is the trigger's own.
         assert ",&nbsp;" in row
-        assert "Catfall" in row and "Connected" in row
+        # Connected (plain) is next: its comma allows a wrap after it.
+        assert "<span>, </span>" in row
+        assert "Catfall" in row and "Connected" in row and "Dodge" in row
 
     def test_a_restricted_skill_keeps_its_place_with_a_note(
         self, client, player, yolanda, library


### PR DESCRIPTION
## Summary

- The n26 model card's Skills row could wrap with a comma stranded at the start of a line ("Inspiring` / `, Juggernaut"). A granted skill's tooltip trigger is an inline-block, and a line may break on either side of one — so the separator after it broke away alone. In `n26/core/templates/cotton/n26/assignable_lines.html` the comma (and rating, where drawn) now sit inside the trigger, where nothing breaks.
- Plain-name separators now use a breaking space after the comma, so a long run of one-word skills wraps between names rather than only inside multi-word ones.
- The "Choose primary skill" / "Choose power" links and buttons move out of the list's flow onto a line of their own under the Skills and Powers rows in `n26/core/templates/cotton/n26/model_card/body.html`, in both gang/view and edit modes.

## Test plan

- [x] `pytest n26` — full suite green, including the pinned-separator test in `n26/tests/sandbox/test_editing_skills.py`
- [x] Browser pass on the gallery page `/n26/design/c/model-card/`: desktop, narrowed card (forced wrapping — commas stay glued to names, no orphans), and edit mode (Choose + pencil buttons on their own line)