### PR TITLE
fix: stop htmx-redrawn equip rows printing the update's rows list

### DIFF
--- a/n26/core/templates/cotton/n26/collection_picker/item.html
+++ b/n26/core/templates/cotton/n26/collection_picker/item.html
@@ -46,6 +46,14 @@ everything else is shrink-0, so the actions stay put and stay hittable.
     properties. The row's slots render inside it, so this is how price_control
     and the rows slot share anything; an x-data inside a slot would put them in
     sibling scopes that cannot see each other.
+
+Every slot is declared below as well as described here, and must stay that way.
+A slot a component draws but never declares is not empty when nobody fills it:
+the name falls through to whatever the rendering page holds under that
+spelling. This row is drawn by the partial update as well as by the page, and
+that update walks a context variable called `rows` while an owned row fills no
+`rows` slot — so the undeclared name printed the update's own list of rows
+inside the row it had just delivered.
 {% endcomment %}
 <c-vars
     name=""
@@ -62,6 +70,11 @@ everything else is shrink-0, so the actions stay put and stay hittable.
     row_key=""
     :redrawn="False"
     class=""
+    icon=""
+    meta=""
+    actions=""
+    details=""
+    rows=""
 />
 
 <div x-data="{ facets: {

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1962,6 +1962,26 @@ class TestBuyingWithoutRebuildingThePage:
         # An owned row offers another of the same underneath the copies.
         assert "Buy another" in body
 
+    def test_the_row_draws_nothing_of_the_answer_it_travelled_in(
+        self, client, tester, fighter, house_list
+    ):
+        """A row is built by the same component whether the page or an
+        update drew it, and a component may only draw what it was given.
+        The update hands the template its list of rows to walk; a row
+        that reaches past its own arguments for a name of that spelling
+        prints the list itself into the reader's screen."""
+        from n26.library.models import Wargear
+
+        client.force_login(tester)
+        body = self.asked(
+            client, fighter, house_list, Wargear.objects.get(name="Knife")
+        ).content.decode()
+
+        # The row itself arrived, and none of the list it arrived in.
+        assert 'data-row="library.wargear:' in body
+        assert "OwnedRow(" not in body
+        assert "OwnedCopyRow(" not in body
+
     def test_every_part_of_the_answer_says_what_it_stands_in_for(
         self, client, tester, fighter, house_list
     ):


### PR DESCRIPTION
## What was wrong

Buying a weapon on an n26 equip screen redrew that row through htmx and printed a wall of Python inside it — the update's own list of `(key, OwnedRow(...))` pairs, repr and all, where the row's contents should be. Reported from production.

## Why

`<c-n26.collection-picker.item>` draws a `rows` slot (`{% if rows %}{{ rows }}{% endif %}`) but never declared it in `<c-vars>`. A slot a cotton component draws without declaring is not empty when nobody fills it — the name falls through to whatever the rendering page holds under that spelling.

`render_update` passes its list of rows to walk as `rows`, and `equip_owned_line.html` fills no `rows` slot, so the row printed the list it had travelled in. Only the htmx partial carries a context variable of that name, which is why the full page render was always fine and this only showed after a buy, sell, or refund.

This is a repeat of a known failure mode in this codebase — the same class previously exposed an undeclared `action` slot on the site banner.

## The fix

Declares every slot the component draws — `rows`, `details`, `actions`, `icon`, `meta` — so an unfilled one is empty rather than the page's own variable. Adds a note in the component's own docs saying the declarations must stay in step with what it draws.

A static sweep for the same leak across every cotton component, against every context key the equip views set, found no others.

## Tests

New test in `TestBuyingWithoutRebuildingThePage` asserts a redrawn row contains no `OwnedRow(`/`OwnedCopyRow(` repr while still delivering the row itself. It fails on `main` and passes here. `n26/core/test_views_equip.py` is green: 122 passed.

## How to try it

On a fighter's equip screen, buy a weapon. The row should come back showing the count and "Buy another", with no Python in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7tJ2UNK4brRTD9bBVk7qR