### PR TITLE
feat: pick a gang from the campaign's table instead of pasting its id

### DIFF
--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -378,8 +378,8 @@ class BringGangForm(forms.Form):
         # on a page holding no picker — where Django's own wording would
         # tell the reader to select a valid choice from nothing.
         error_messages={
-            "invalid_choice": "That gang is not one this campaign can take.",
-            "required": "Choose a gang to add.",
+            "invalid_choice": "That gang is not on this list.",
+            "required": "Select a gang to add.",
         },
     )
 

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -371,7 +371,17 @@ class BringGangForm(forms.Form):
     anything.
     """
 
-    gang = forms.ModelChoiceField(queryset=None, label="Gang")
+    gang = forms.ModelChoiceField(
+        queryset=None,
+        label="Gang",
+        # Reachable only by naming a gang the list did not offer, and drawn
+        # on a page holding no picker — where Django's own wording would
+        # tell the reader to select a valid choice from nothing.
+        error_messages={
+            "invalid_choice": "That gang is not one this campaign can take.",
+            "required": "Choose a gang to add.",
+        },
+    )
 
     def __init__(self, *args, gangs, **kwargs):
         super().__init__(*args, **kwargs)

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -7,7 +7,6 @@ gang types are the library's own.
 """
 
 from django import forms
-from django.core.exceptions import ValidationError
 
 from n26.core.widgets import RichText
 from n26.library.models import GangType
@@ -363,71 +362,20 @@ class CampaignForm(forms.Form):
 
 
 class BringGangForm(forms.Form):
-    """One of the reader's own gangs, to bring into a campaign.
+    """A gang from a campaign's table, to put into it.
 
-    A picker rather than the arbitrator's paste field: these are the
-    reader's own gangs, so there is a list to offer and no address to ask
-    for. Gangs already playing somewhere are left out — a gang plays one
-    campaign at a time, and offering one that would be refused is worse
-    than not offering it.
+    The screen draws the list itself, so what the reader is told about it
+    is written there. What this holds is the check: whichever gang comes
+    back must be one the screen was entitled to offer, which is why
+    ``gangs`` has no default — a queryset built without one would accept
+    anything.
     """
 
-    #: The screen draws the picker itself, so what the reader is told about
-    #: it is written there. A help_text here would say nothing to anybody.
-    #: ``owner`` has no default: a queryset built without one would filter
-    #: on a null owner and offer gangs belonging to nobody.
     gang = forms.ModelChoiceField(queryset=None, label="Gang")
 
-    def __init__(self, *args, owner, **kwargs):
-        from n26.core.models import CampaignMembership, Gang
-
+    def __init__(self, *args, gangs, **kwargs):
         super().__init__(*args, **kwargs)
-        # Named by key rather than excluded across the relation: an
-        # exclude() reaching through campaign_memberships would test the
-        # outer join's own NULLs and throw away every gang that has never
-        # been in a campaign — which is most of the ones worth offering.
-        playing = CampaignMembership.objects.filter(left__isnull=True).values("gang")
-        self.fields["gang"].queryset = (
-            Gang.objects.filter(owner=owner, archived=False)
-            .exclude(pk__in=playing)
-            .order_by("name")
-        )
-
-
-class JoinCampaignForm(forms.Form):
-    """Putting a gang into a campaign, named by its address.
-
-    An arbitrator takes the link a player sent them and pastes it in. That is
-    how a roster already travels between people here — a gang sheet opens for
-    anybody holding its address — so it asks for nothing a player has not
-    already chosen to hand over, and needs no way to search other people's
-    gangs.
-    """
-
-    gang = forms.CharField(
-        label="Gang",
-        help_text="Paste the link a player sent you, or the gang's id.",
-    )
-
-    def clean_gang(self):
-        """The gang itself, read out of whatever was pasted.
-
-        A full address, a path, or a bare id all name the same gang, and a
-        reader who pasted their address bar should not have to tidy it.
-        """
-        from n26.core.models import Gang
-
-        given = self.cleaned_data["gang"].strip().rstrip("/")
-        named = given.rpartition("/")[2]
-        try:
-            found = Gang.objects.filter(pk=named, archived=False).first()
-        except ValidationError, ValueError:
-            found = None
-        if found is None:
-            raise forms.ValidationError(
-                "No gang with that address. Check the link and try again."
-            )
-        return found
+        self.fields["gang"].queryset = gangs
 
 
 class BattleForm(forms.Form):

--- a/n26/core/templates/n26/add_gang_to_campaign.html
+++ b/n26/core/templates/n26/add_gang_to_campaign.html
@@ -52,7 +52,7 @@ a reader who cannot find one is told where it went.
         {% if nothing_to_offer %}
             <c-ui.alert variant="info" title="No gangs yet">
                 {% if arbitrating %}
-                    Nobody at this campaign's table has a gang.
+                    No one at this campaign's table has a gang yet.
                 {% else %}
                     You have no gangs to add.
                     <c-n26.link href="{% url 'n26-create-gang' %}">Create one</c-n26.link>

--- a/n26/core/templates/n26/add_gang_to_campaign.html
+++ b/n26/core/templates/n26/add_gang_to_campaign.html
@@ -1,16 +1,18 @@
 {% extends "n26/layouts/base.html" %}
 {% load navigation %}
 {% comment %}
-Putting a gang into a campaign, read two ways.
+Putting a gang into a campaign, picked from the ones at its table.
 
-A player at the table picks from their own gangs, because those are theirs to
-list. The arbitrator pastes an address instead: a gang sheet opens for anybody
-holding its address, so a player choosing to send one is already how a roster
-travels here — the paste is the consent, and no screen has to offer a search
-across other people's gangs.
+The arbitrator draws on every gang belonging to somebody who has accepted a
+place, and their own; a player draws on their own. One list serves both, and a
+control disappears where it has nothing to narrow — one player's gangs need no
+question about which player.
 
-One control, so the page is the heading, the field and the buttons. Anything
-between them restates what the heading has said.
+Newest first, by the last thing the ledger recorded against each gang: the one
+somebody is looking for is nearly always the one they were last working on.
+
+Gangs already in a campaign are hidden to start with rather than left out, so
+a reader who cannot find one is told where it went.
 {% endcomment %}
 {% block head_title %}Add a gang to {{ campaign.name }}{% endblock head_title %}
 {% block nav_switcher %}
@@ -24,7 +26,6 @@ between them restates what the heading has said.
     <c-n26.form-page action="{% url 'n26-campaign-add-gang' campaign.pk %}"
                      title="Add a gang to {{ campaign.name }}"
                      :form="form"
-                     submit_label="{% if not nothing_to_bring %}Add gang{% endif %}"
                      cancel_url="{% url 'n26-campaign' campaign.pk %}">
         <c-slot name="breadcrumb">
             <c-ui.breadcrumbs>
@@ -41,63 +42,124 @@ between them restates what the heading has said.
             </c-ui.breadcrumbs>
         </c-slot>
         {% csrf_token %}
-        <c-n26.form-section>
-            {% if arbitrating %}
-                <c-ui.field label="Gang *"
-                            description="Paste the link a player sent you, or the gang's id."
-                            error="x"
-                            :form="form"
-                            name="gang"
-                            for="join-gang">
-                    <c-ui.input id="join-gang"
-                                name="gang"
-                                autocomplete="off"
-                                :required="True"
-                                value="{{ form.gang.value|default:'' }}" />
-                </c-ui.field>
-            {% elif nothing_to_bring %}
-                {% comment %}
-                Which of the two reasons decides what the reader does next, so
-                the page says which rather than covering both and leaving them
-                to work it out.
-                {% endcomment %}
-                {% if every_gang_busy %}
-                    <c-ui.alert variant="info" title="Every gang of yours is in a campaign">
-                        A gang plays one campaign at a time, so none of yours
-                        can join this one.
-                    </c-ui.alert>
+        {% if nothing_to_offer %}
+            <c-ui.alert variant="info" title="No gangs yet">
+                {% if arbitrating %}
+                    Nobody at this campaign's table has a gang.
                 {% else %}
-                    <c-ui.alert variant="info" title="No gangs yet">
-                        You have no gangs to add.
-                        <c-n26.link href="{% url 'n26-create-gang' %}">Create one</c-n26.link>
-                        first.
-                    </c-ui.alert>
+                    You have no gangs to add.
+                    <c-n26.link href="{% url 'n26-create-gang' %}">Create one</c-n26.link>
+                    first.
                 {% endif %}
-            {% else %}
-                <c-ui.field label="Gang *"
-                            description="Your gangs that are not already in a campaign.{% if campaign.budget is not None %} The campaign's budget is {{ campaign.budget }}¢, and a bigger gang can still join.{% endif %}"
-                            error="x"
-                            :form="form"
-                            name="gang"
-                            for="join-gang">
-                    {% comment %}
-                    The kit's own placeholder draws the blank option, disabled
-                    and selected. A hand-written one is neither, so a reader
-                    can pick the blank back and submit an empty form.
-                    {% endcomment %}
-                    <c-ui.select.native name="gang"
-                                        id="join-gang"
-                                        placeholder="Select one"
-                                        :required="True"
-                                        value="{{ form.gang.value|default:'' }}">
-                        {% for option in gang_options %}
-                            <c-ui.select.option value="{{ option.value }}" :selected="option.selected">
-                                {{ option.label }}
-                            </c-ui.select.option>
-                        {% endfor %}
-                    </c-ui.select.native>
-                </c-ui.field>
-            {% endif %}
-        </c-n26.form-section>
+            </c-ui.alert>
+        {% else %}
+            {% comment %}
+            One scope over the whole list: rows register what can be asked of
+            them and redraw themselves, and the count is written once per
+            change by an effect rather than read from a getter — Alpine caches
+            no getter, so one walked per row goes quadratic as the list grows.
+            {% endcomment %}
+            {% comment %}
+            The filter menu keeps its own selection and cannot reach in here,
+            so it reports by name and this listens under the same one.
+            {% endcomment %}
+            <div x-data="{
+                     rows: [],
+                     query: '',
+                     people: null,
+                     minWealth: 0,
+                     maxWealth: {{ wealth_ceiling }},
+                     hidePlaying: true,
+                     shown: 0,
+                     register(facets) { this.rows.push(facets) },
+                     matches(facets) {
+                         if (this.hidePlaying &amp;&amp; facets.playing) return false;
+                         if (this.people !== null &amp;&amp; !this.people.includes(facets.owner)) return false;
+                         if (facets.wealth &lt; this.minWealth) return false;
+                         if (facets.wealth &gt; this.maxWealth) return false;
+                         const q = this.query.trim().toLowerCase();
+                         return !q || facets.search.includes(q);
+                     },
+                 }"
+                 x-effect="shown = rows.filter(f =&gt; matches(f)).length"
+                 @filter-apply.window="if ($event.detail.name === 'player') people = $event.detail.values"
+                 class="flex flex-col gap-3">
+                <div class="flex flex-wrap items-center gap-2">
+                    <c-n26.search-bar :live="True"
+                                      :nested="True"
+                                      model="query"
+                                      placeholder="Search gangs"
+                                      class="min-w-0 flex-1" />
+                    {% if people %}
+                        <c-n26.filter-menu label="Player" name="player" :options="people" />
+                    {% endif %}
+                    {% if wealth_ceiling %}
+                        <c-n26.range-menu label="Wealth"
+                                          model_min="minWealth"
+                                          model_max="maxWealth"
+                                          min="0"
+                                          max="{{ wealth_ceiling }}"
+                                          step="50"
+                                          suffix="¢"
+                                          at_max_label="Any" />
+                    {% endif %}
+                </div>
+                <label class="flex items-center gap-2 text-sm text-muted">
+                    <input type="checkbox"
+                           x-model="hidePlaying"
+                           class="rounded-sm accent-[var(--color-accent)]" />
+                    Hide gangs already in a campaign
+                </label>
+                <p class="text-sm text-muted">
+                    <span class="font-semibold text-ink-900 tabular-nums dark:text-ink-100"
+                          x-text="shown">{{ free_gangs }}</span>
+                    of {{ gangs|length }} gang{{ gangs|length|pluralize }}
+                </p>
+                <ul class="flex flex-col">
+                    {% for gang in gangs %}
+                        <li x-data="{ facets: {
+                                    owner: {{ gang.owner|json_dumps }},
+                                    wealth: {{ gang.wealth }},
+                                    playing: {{ gang.playing|yesno:'true,false' }},
+                                    search: {{ gang.name|lower|json_dumps }},
+                                } }"
+                            x-init="register(facets)"
+                            x-show="matches(facets)"
+                            x-cloak
+                            class="flex items-center gap-3 border-b border-box-border/50 py-2 last:border-b-0">
+                            <div class="min-w-0 flex-1">
+                                <span class="text-base font-semibold text-ink-900 dark:text-ink-100">{{ gang.name }}</span>
+                                {% if arbitrating %}<span class="text-sm text-muted">{{ gang.owner }}</span>{% endif %}
+                            </div>
+                            {% if gang.playing %}
+                                <c-ui.badge color="ink" size="sm" class="shrink-0">
+                                    In a campaign
+                                </c-ui.badge>
+                            {% endif %}
+                            <span class="shrink-0 text-sm tabular-nums text-muted">{{ gang.wealth }}¢</span>
+                            {% comment %}
+                            One button per row rather than a picker and a
+                            submit below it: the act is adding this gang, and
+                            splitting it into choosing and confirming asks
+                            twice for one answer.
+                            {% endcomment %}
+                            {% if not gang.playing %}
+                                <c-ui.button type="submit"
+                                             name="gang"
+                                             value="{{ gang.pk }}"
+                                             size="sm"
+                                             variant="success"
+                                             class="shrink-0">
+                                    Add
+                                </c-ui.button>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+                <p x-show="shown === 0"
+                   x-cloak
+                   class="py-6 text-center text-sm text-muted">No gangs match that.</p>
+            </div>
+        {% endif %}
     </c-n26.form-page>
 {% endblock content %}

--- a/n26/core/templates/n26/add_gang_to_campaign.html
+++ b/n26/core/templates/n26/add_gang_to_campaign.html
@@ -84,12 +84,13 @@ a reader who cannot find one is told where it went.
                  x-effect="shown = rows.filter(f =&gt; matches(f)).length"
                  @filter-apply.window="if ($event.detail.name === 'player') people = $event.detail.values"
                  class="flex flex-col gap-3">
-                <div class="flex flex-wrap items-center gap-2">
-                    <c-n26.search-bar :live="True"
-                                      :nested="True"
-                                      model="query"
-                                      placeholder="Search gangs"
-                                      class="min-w-0 flex-1" />
+                {% comment %}
+                The search on its own line and the filters in a bar below it,
+                as the equipment catalogue lays out the same pair. A row of
+                filters is a row of actions, which is what action-bar is.
+                {% endcomment %}
+                <c-n26.search-bar :live="True" :nested="True" model="query" placeholder="Search gangs" />
+                <c-n26.action-bar>
                     {% if people %}
                         <c-n26.filter-menu label="Player" name="player" :options="people" />
                     {% endif %}
@@ -103,13 +104,25 @@ a reader who cannot find one is told where it went.
                                           suffix="¢"
                                           at_max_label="Any" />
                     {% endif %}
-                </div>
-                <label class="flex items-center gap-2 text-sm text-muted">
-                    <input type="checkbox"
-                           x-model="hidePlaying"
-                           class="rounded-sm accent-[var(--color-accent)]" />
-                    Hide gangs already in a campaign
-                </label>
+                    {% comment %}
+                    checkedChange, not change: the switch holds its state in
+                    its own scope and writes its hidden checkbox through
+                    x-model, and a checkbox set from script fires no change
+                    event, so a @change here would never run. The name is
+                    written with a dash and camel-cased back, the only
+                    spelling that reaches the dispatched name — an attribute
+                    is lowercased by the parser, and the modifier joins
+                    dash-separated words rather than restoring case.
+
+                    The event says the switch turned over and carries no
+                    state, and the box it writes is still on its old value
+                    when this runs, so the flag is turned over to match
+                    rather than read back.
+                    {% endcomment %}
+                    <c-n26.toggle label="Hide gangs already in a campaign"
+                                  :checked="True"
+                                  @checked-change.camel="hidePlaying = !hidePlaying" />
+                </c-n26.action-bar>
                 <p class="text-sm text-muted">
                     <span class="font-semibold text-ink-900 tabular-nums dark:text-ink-100"
                           x-text="shown">{{ free_gangs }}</span>

--- a/n26/core/templates/n26/add_gang_to_campaign.html
+++ b/n26/core/templates/n26/add_gang_to_campaign.html
@@ -96,14 +96,21 @@ a reader who cannot find one is told where it went.
                 as the equipment catalogue lays out the same pair. A row of
                 filters is a row of actions, which is what action-bar is.
                 {% endcomment %}
+                {% comment %}
+                Enter in the search box would otherwise add a gang. The list
+                sits inside the page's form, every control above it is a
+                plain button, and the footer draws no submit — so the form's
+                default button is the first row's Add, hidden or not.
+                {% endcomment %}
                 <c-n26.search-bar :live="True"
                                   :nested="True"
                                   model="query"
                                   placeholder="Search gangs"
+                                  @keydown.enter.prevent=""
                                   class="n26-gang-filters" />
                 <c-n26.action-bar class="n26-gang-filters">
-                    {% if people %}
-                        <c-n26.filter-menu label="Player" name="player" :options="people" />
+                    {% if player_options %}
+                        <c-n26.filter-menu label="Player" name="player" :options="player_options" />
                     {% endif %}
                     {% if wealth_ceiling %}
                         <c-n26.range-menu label="Wealth"
@@ -116,22 +123,23 @@ a reader who cannot find one is told where it went.
                                           at_max_label="Any" />
                     {% endif %}
                     {% comment %}
-                    checkedChange, not change: the switch holds its state in
-                    its own scope and writes its hidden checkbox through
-                    x-model, and a checkbox set from script fires no change
-                    event, so a @change here would never run. The name is
-                    written with a dash and camel-cased back, the only
-                    spelling that reaches the dispatched name — an attribute
-                    is lowercased by the parser, and the modifier joins
-                    dash-separated words rather than restoring case.
+                    The switch can be worked two ways and each says so
+                    differently. Its button calls the factory, which moves
+                    the switch and dispatches checkedChange without writing
+                    the hidden box until afterwards — so that path is a turn
+                    over, not a value to read. Clicking the label is the
+                    browser working the box directly: it fires an ordinary
+                    change and never reaches the factory, so nothing is
+                    dispatched and the box already holds the answer.
 
-                    The event says the switch turned over and carries no
-                    state, and the box it writes is still on its old value
-                    when this runs, so the flag is turned over to match
-                    rather than read back.
+                    Listening for one alone leaves the switch and the list
+                    disagreeing. The dashed spelling with the camel modifier
+                    is what matches a dispatched checkedChange, an attribute
+                    being lowercased by the parser.
                     {% endcomment %}
                     <c-n26.toggle label="Hide gangs already in a campaign"
                                   :checked="True"
+                                  @change="hidePlaying = $event.target.checked"
                                   @checked-change.camel="hidePlaying = !hidePlaying" />
                 </c-n26.action-bar>
                 {% comment %}
@@ -167,7 +175,7 @@ a reader who cannot find one is told where it went.
                                     owner: {{ gang.owner|json_dumps }},
                                     wealth: {{ gang.wealth }},
                                     playing: {{ gang.playing|yesno:'true,false' }},
-                                    search: {{ gang.name|lower|json_dumps }},
+                                    search: {{ gang.search|json_dumps }},
                                 } }"
                             x-init="register(facets)"
                             x-show="matches(facets)"
@@ -177,10 +185,18 @@ a reader who cannot find one is told where it went.
                                 <span class="text-base font-semibold text-ink-900 dark:text-ink-100">{{ gang.name }}</span>
                                 {% if arbitrating %}<span class="text-sm text-muted">{{ gang.owner }}</span>{% endif %}
                             </div>
+                            {% comment %}
+                            The badge is wrapped rather than given a class:
+                            it declares none, so one passed in is written
+                            before its own and the browser keeps the first,
+                            dropping every style it came with.
+                            {% endcomment %}
                             {% if gang.playing %}
-                                <c-ui.badge color="ink" size="sm" class="shrink-0">
-                                    In a campaign
-                                </c-ui.badge>
+                                <span class="shrink-0">
+                                    <c-ui.badge color="ink" size="sm">
+                                        In a campaign
+                                    </c-ui.badge>
+                                </span>
                             {% endif %}
                             <span class="shrink-0 text-sm tabular-nums text-muted">{{ gang.wealth }}¢</span>
                             {% comment %}

--- a/n26/core/templates/n26/add_gang_to_campaign.html
+++ b/n26/core/templates/n26/add_gang_to_campaign.html
@@ -42,6 +42,13 @@ a reader who cannot find one is told where it went.
             </c-ui.breadcrumbs>
         </c-slot>
         {% csrf_token %}
+        {% comment %}
+        The list submits by its own buttons and draws no widget for the field,
+        so the field's own error has nowhere else to appear. It is reachable
+        only by sending a key the list did not offer, and a page that answered
+        that by redrawing itself and saying nothing would look broken.
+        {% endcomment %}
+        <c-ui.error name="gang" :form="form" />
         {% if nothing_to_offer %}
             <c-ui.alert variant="info" title="No gangs yet">
                 {% if arbitrating %}
@@ -89,8 +96,12 @@ a reader who cannot find one is told where it went.
                 as the equipment catalogue lays out the same pair. A row of
                 filters is a row of actions, which is what action-bar is.
                 {% endcomment %}
-                <c-n26.search-bar :live="True" :nested="True" model="query" placeholder="Search gangs" />
-                <c-n26.action-bar>
+                <c-n26.search-bar :live="True"
+                                  :nested="True"
+                                  model="query"
+                                  placeholder="Search gangs"
+                                  class="n26-gang-filters" />
+                <c-n26.action-bar class="n26-gang-filters">
                     {% if people %}
                         <c-n26.filter-menu label="Player" name="player" :options="people" />
                     {% endif %}
@@ -123,12 +134,34 @@ a reader who cannot find one is told where it went.
                                   :checked="True"
                                   @checked-change.camel="hidePlaying = !hidePlaying" />
                 </c-n26.action-bar>
+                {% comment %}
+                The written figure is every gang, which is what a reader with
+                no script is looking at; Alpine writes the narrowed count over
+                it as soon as it runs.
+                {% endcomment %}
                 <p class="text-sm text-muted">
                     <span class="font-semibold text-ink-900 tabular-nums dark:text-ink-100"
-                          x-text="shown">{{ free_gangs }}</span>
+                          x-text="shown">{{ gangs|length }}</span>
                     of {{ gangs|length }} gang{{ gangs|length|pluralize }}
                 </p>
-                <ul class="flex flex-col">
+                {% comment %}
+                Every row is cloaked so the list does not flash unfiltered
+                before Alpine narrows it, and [x-cloak] hides for good where
+                no script arrives to take it off. Without script there is no
+                narrowing to wait for, so the rows are shown and the controls
+                above them — which do nothing on their own — are not.
+                {% endcomment %}
+                <noscript>
+                    <style>
+                        .n26-gang-picker > li[x-cloak] {
+                            display: flex !important;
+                        }
+                        .n26-gang-filters {
+                            display: none !important;
+                        }
+                    </style>
+                </noscript>
+                <ul class="n26-gang-picker flex flex-col">
                     {% for gang in gangs %}
                         <li x-data="{ facets: {
                                     owner: {{ gang.owner|json_dumps }},

--- a/n26/core/templates/n26/campaign.html
+++ b/n26/core/templates/n26/campaign.html
@@ -185,10 +185,18 @@ reader's other campaigns — the same pattern a gang's screens use.
                             page, and one colour cannot mean two things on
                             one screen.
                             {% endcomment %}
+                            {% comment %}
+                            Wrapped rather than given a class: the badge
+                            declares none, so one passed in is written before
+                            its own and the browser keeps the first, dropping
+                            every style it came with.
+                            {% endcomment %}
                             {% if membership.over_budget %}
-                                <c-ui.badge color="amber" size="sm" class="shrink-0">
-                                    Over budget
-                                </c-ui.badge>
+                                <span class="shrink-0">
+                                    <c-ui.badge color="amber" size="sm">
+                                        Over budget
+                                    </c-ui.badge>
+                                </span>
                             {% endif %}
                             {% comment %}
                             Wealth, which is what the mark beside it is

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -305,12 +305,13 @@ def _addable_gangs(campaign, reader, arbitrating):
     were last working on. A gang nothing has happened to yet sorts last
     rather than first, where a null would put it.
     """
-    from django.db.models import Exists, F, Max, OuterRef
+    from django.db.models import Exists, F, OuterRef, Subquery
 
     from n26.core.models import (
         CampaignMembership,
         CampaignParticipant,
         Gang,
+        LedgerEvent,
     )
 
     if arbitrating:
@@ -327,7 +328,15 @@ def _addable_gangs(campaign, reader, arbitrating):
         Gang.objects.filter(owner_id__in=owners, archived=False)
         .select_related("owner", "stash")
         .annotate(
-            last_touched=Max("ledger_events__created"),
+            # The newest event of this gang's own, read one at a time rather
+            # than aggregated: a Max over the join groups every event
+            # belonging to every gang on the page to produce one sort key
+            # each, where this seeks the gang's own newest and stops.
+            last_touched=Subquery(
+                LedgerEvent.objects.filter(gang=OuterRef("pk"))
+                .order_by("-created")
+                .values("created")[:1]
+            ),
             playing_now=Exists(
                 CampaignMembership.objects.filter(
                     gang=OuterRef("pk"), left__isnull=True
@@ -398,15 +407,18 @@ def add_gang(request, pk):
         {
             "pk": str(row.pk),
             "name": row.name,
-            "owner": row.owner.username if row.owner else "",
+            "owner": row.owner.username,
             "wealth": row.wealth,
+            # The arbitrator's rows draw the owner, so a search that did not
+            # reach it would find nothing for a name the reader can see.
+            "search": f"{row.name} {row.owner.username}".lower(),
             "playing": row.playing_now,
         }
         for row in offering
     ]
     # Only where there is somebody to tell apart: a list of one person's
     # gangs is not narrowed by asking which person.
-    people = sorted({row["owner"] for row in gangs if row["owner"]})
+    players = sorted({row["owner"] for row in gangs})
     return render(
         request,
         "n26/add_gang_to_campaign.html",
@@ -415,8 +427,8 @@ def add_gang(request, pk):
             "campaign": found,
             "arbitrating": arbitrating,
             "gangs": gangs,
-            "people": [{"value": name, "label": name} for name in people]
-            if len(people) > 1
+            "player_options": [{"value": name, "label": name} for name in players]
+            if len(players) > 1
             else [],
             # The ends of the wealth filter, which are also its off positions.
             "wealth_ceiling": max([row["wealth"] for row in gangs], default=0),

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -292,26 +292,69 @@ def archive_campaign(request, pk):
     return render(request, "n26/archive_campaign.html", {"campaign": found})
 
 
+def _addable_gangs(campaign, reader, arbitrating):
+    """The gangs this reader may put into this campaign, newest first.
+
+    The arbitrator draws on everybody at the table — the people who have
+    accepted a place, and themselves — because a campaign's gangs come
+    from its players and asking for an address is asking somebody to
+    fetch one. A player draws on their own and nobody else's.
+
+    Ordered by the last thing that happened to each, which is the ledger's
+    to answer: the gang somebody is picking is nearly always the one they
+    were last working on. A gang nothing has happened to yet sorts last
+    rather than first, where a null would put it.
+    """
+    from django.db.models import Exists, F, Max, OuterRef
+
+    from n26.core.models import (
+        CampaignMembership,
+        CampaignParticipant,
+        Gang,
+    )
+
+    if arbitrating:
+        owners = set(
+            CampaignParticipant.objects.filter(
+                campaign=campaign, state=CampaignParticipant.State.ACCEPTED
+            ).values_list("user_id", flat=True)
+        )
+        owners.add(campaign.owner_id)
+    else:
+        owners = {reader.pk}
+
+    return (
+        Gang.objects.filter(owner_id__in=owners, archived=False)
+        .select_related("owner", "stash")
+        .annotate(
+            last_touched=Max("ledger_events__created"),
+            playing_now=Exists(
+                CampaignMembership.objects.filter(
+                    gang=OuterRef("pk"), left__isnull=True
+                )
+            ),
+        )
+        .order_by(F("last_touched").desc(nulls_last=True), "name")
+    )
+
+
 @requires_flag(CAMPAIGNS)
 @login_required
 def add_gang(request, pk):
-    """Put a gang into this campaign — the same address, read two ways.
+    """Put a gang into this campaign, chosen from the ones at its table.
 
-    A player at the table brings one of their own, chosen from a list, and
-    the campaign's budget is the entry condition they have to meet. The
-    arbitrator brings anybody's, named by the address they were sent, and
-    may seat a gang worth more than the budget: they set that number, so
-    they are the one who may go past it.
+    The arbitrator sees every gang belonging to somebody who has accepted
+    a place, and their own; a player sees their own. Both pick from a list
+    rather than naming an address, and the same list decides what the POST
+    will accept — a gang the screen would not offer is not one it takes.
 
     Nothing about the gang changes but where it plays, and the gang's own
-    history says it happened and who did it. Taking a gang back out is the
-    arbitrator's act.
+    history says it happened and who did it.
     """
     from django.http import Http404
 
     from n26.core.campaigns import over_budget
-    from n26.core.forms import BringGangForm, JoinCampaignForm
-    from n26.core.models import Gang
+    from n26.core.forms import BringGangForm
     from n26.core.operations import Refusal, operation
 
     found = _any_campaign_or_404(pk)
@@ -319,13 +362,10 @@ def add_gang(request, pk):
     if not arbitrating and not _plays_in(found, request.user):
         raise Http404("No such campaign")
 
-    def build(data=None):
-        if arbitrating:
-            return JoinCampaignForm(data)
-        return BringGangForm(data, owner=request.user)
+    offering = _addable_gangs(found, request.user, arbitrating)
 
     if request.method == "POST":
-        form = build(request.POST)
+        form = BringGangForm(request.POST, gangs=offering)
         if form.is_valid():
             gang = form.cleaned_data["gang"]
             try:
@@ -350,22 +390,23 @@ def add_gang(request, pk):
                     )
                 return redirect("n26-campaign", pk=found.pk)
     else:
-        form = build()
+        form = BringGangForm(gangs=offering)
 
-    # The options are built here because a component attribute takes a
-    # variable and not an expression: a comparison written at the call site
-    # would evaluate to nothing and every option would draw unselected.
-    options = []
-    if not arbitrating:
-        chosen = str(form["gang"].value() or "")
-        options = [
-            {"value": str(row.pk), "label": row.name, "selected": str(row.pk) == chosen}
-            for row in form.fields["gang"].queryset
-        ]
-
-    # A player with nothing to bring is told so, rather than shown a picker
-    # with nothing in it.
-    nothing_to_bring = not arbitrating and not options
+    # Drawn here rather than in the template, which cannot ask a gang what
+    # it is worth without a query per row.
+    gangs = [
+        {
+            "pk": str(row.pk),
+            "name": row.name,
+            "owner": row.owner.username if row.owner else "",
+            "wealth": row.wealth,
+            "playing": row.playing_now,
+        }
+        for row in offering
+    ]
+    # Only where there is somebody to tell apart: a list of one person's
+    # gangs is not narrowed by asking which person.
+    people = sorted({row["owner"] for row in gangs if row["owner"]})
     return render(
         request,
         "n26/add_gang_to_campaign.html",
@@ -373,12 +414,15 @@ def add_gang(request, pk):
             "form": form,
             "campaign": found,
             "arbitrating": arbitrating,
-            "gang_options": options,
-            "nothing_to_bring": nothing_to_bring,
-            # Which of the two reasons the picker is empty: owning no gangs
-            # and owning only gangs already playing lead somewhere different.
-            "every_gang_busy": nothing_to_bring
-            and Gang.objects.filter(owner=request.user, archived=False).exists(),
+            "gangs": gangs,
+            "free_gangs": sum(1 for row in gangs if not row["playing"]),
+            "people": [{"value": name, "label": name} for name in people]
+            if len(people) > 1
+            else [],
+            # The ends of the wealth filter, which are also its off positions.
+            "wealth_ceiling": max([row["wealth"] for row in gangs], default=0),
+            "nothing_to_offer": not gangs,
+            "owns_a_gang": bool(gangs),
         },
     )
 

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -415,14 +415,12 @@ def add_gang(request, pk):
             "campaign": found,
             "arbitrating": arbitrating,
             "gangs": gangs,
-            "free_gangs": sum(1 for row in gangs if not row["playing"]),
             "people": [{"value": name, "label": name} for name in people]
             if len(people) > 1
             else [],
             # The ends of the wealth filter, which are also its off positions.
             "wealth_ceiling": max([row["wealth"] for row in gangs], default=0),
             "nothing_to_offer": not gangs,
-            "owns_a_gang": bool(gangs),
         },
     )
 

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -431,7 +431,7 @@ def add_gang(request, pk):
             if len(players) > 1
             else [],
             # The ends of the wealth filter, which are also its off positions.
-            "wealth_ceiling": max([row["wealth"] for row in gangs], default=0),
+            "wealth_ceiling": max((row["wealth"] for row in gangs), default=0),
             "nothing_to_offer": not gangs,
         },
     )

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -669,8 +669,9 @@ class TestBattlesOnTheCampaignsPage:
         """A picker over every gang there is would let an arbitrator record a
         battle between gangs that were never in the campaign."""
         elsewhere = Campaign.objects.create(name="Sump City", owner=arbitrator)
-        # Seated there too: what is under test is the second join being
-        # refused, not who the other campaign would have offered.
+        # Seating the owner is only how the gang gets into the other
+        # campaign; what is under test is which gangs the battle picker
+        # offers afterwards.
         seat(elsewhere, gang.owner)
         client.post(f"/n26/campaigns/{elsewhere.pk}/gangs/add/", {"gang": str(gang.pk)})
 
@@ -1101,7 +1102,7 @@ class TestAPlayerBringingTheirOwnGang:
         # Still listed, because a reader who cannot find a gang is better
         # told where it went — and hidden to start with by the filter.
         assert [row["playing"] for row in response.context["gangs"]] == [True]
-        assert response.context["free_gangs"] == 0
+        assert not any(row["playing"] is False for row in response.context["gangs"])
 
     def test_a_reader_with_no_gangs_is_sent_to_make_one(
         self, client, theirs, open_to_everyone
@@ -1340,7 +1341,7 @@ class TestTheArbitratorsOwnAddGangScreen:
         client.post(f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(rich.pk)})
         response = client.get(f"/n26/campaigns/{campaign.pk}/gangs/add/")
         assert [row["playing"] for row in response.context["gangs"]] == [True]
-        assert response.context["free_gangs"] == 0
+        assert not any(row["playing"] is False for row in response.context["gangs"])
 
     def test_a_gang_over_the_budget_joins_and_is_marked(
         self, client, campaign, rich, arbitrator, open_to_everyone

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -1293,6 +1293,41 @@ class TestTheRollsQueryCount:
         assert len(three_gangs) == len(one_gang)
 
 
+class TestTheAddGangScreensQueryCount:
+    """Every row reads its owner and its stash, so two select_related terms
+    are all that keep the list flat. Nothing else would notice them going."""
+
+    def test_it_does_not_grow_with_the_gangs(
+        self, client, arbitrator, campaign, gang_type, make_profile, open_to_everyone
+    ):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        def seat_a_gang_owner(name):
+            player = User.objects.create_user(name)
+            seat(campaign, player)
+            gang = found_gang(f"Gang of {name}", gang_type, owner=player)
+            hire(gang, make_profile(f"Fighter {name}"), "Yolanda", paid=55)
+            assign(
+                create_wargear(f"Crate {name}", price=25),
+                stash=gang.stash,
+                paid=25,
+            )
+
+        address = f"/n26/campaigns/{campaign.pk}/gangs/add/"
+        seat_a_gang_owner("one")
+        client.get(address)
+        with CaptureQueriesContext(connection) as few:
+            client.get(address)
+
+        seat_a_gang_owner("two")
+        seat_a_gang_owner("three")
+        with CaptureQueriesContext(connection) as many:
+            client.get(address)
+
+        assert len(many) == len(few)
+
+
 class TestTheArbitratorsOwnAddGangScreen:
     """The same list a player sees, over everybody at the table."""
 

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -53,6 +53,20 @@ def campaign(arbitrator):
     return Campaign.objects.create(name="Dust Falls", owner=arbitrator, budget=1000)
 
 
+def seat(campaign, user):
+    """Put somebody at the campaign's table.
+
+    The add-a-gang screen offers the gangs of people who have accepted a
+    place, so a test wanting a gang addable has to seat its owner first.
+    """
+    from n26.core.campaigns import campaign_operation
+
+    with campaign_operation(campaign, actor=campaign.owner) as act:
+        act.invite(user)
+    with campaign_operation(campaign, actor=user) as act:
+        act.answer_invitation(user, accepted=True)
+
+
 #: Every address this feature adds that opens on an empty campaign, so a new
 #: one cannot skip the gate below. The screens for taking something out need
 #: a row to name, and are gated in their own tests.
@@ -480,11 +494,12 @@ class TestTheLogOnTheCampaignsPage:
 
 
 class TestTheRollOfGangs:
-    """Who is playing, added by the link a player sent."""
+    """Who is playing, added from the gangs at the campaign's table."""
 
     @pytest.fixture
-    def gang(self, gang_type):
+    def gang(self, gang_type, campaign):
         player = User.objects.create_user("player")
+        seat(campaign, player)
         return found_gang("The Ashen Choir", gang_type, owner=player)
 
     def page(self, client, campaign):
@@ -497,7 +512,7 @@ class TestTheRollOfGangs:
         assert "Gangs" in drawn
         assert "No gangs yet." in drawn
 
-    def test_a_gang_is_added_by_its_id(self, client, campaign, gang, open_to_everyone):
+    def test_a_gang_is_added_by_its_key(self, client, campaign, gang, open_to_everyone):
         response = client.post(
             f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(gang.pk)}
         )
@@ -505,17 +520,6 @@ class TestTheRollOfGangs:
         assert CampaignMembership.objects.filter(
             campaign=campaign, gang=gang, left__isnull=True
         ).exists()
-
-    def test_a_gang_is_added_by_the_link_a_player_sent(
-        self, client, campaign, gang, open_to_everyone
-    ):
-        """A pasted address names the same gang as a bare id — a reader who
-        pasted their address bar should not have to tidy it."""
-        client.post(
-            f"/n26/campaigns/{campaign.pk}/gangs/add/",
-            {"gang": f"http://example.test/n26/gangs/{gang.pk}/"},
-        )
-        assert CampaignMembership.objects.filter(campaign=campaign, gang=gang).exists()
 
     def test_the_roll_draws_the_gang(self, client, campaign, gang, open_to_everyone):
         client.post(f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(gang.pk)})
@@ -527,20 +531,34 @@ class TestTheRollOfGangs:
         client.post(f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(gang.pk)})
         assert "added the gang to Dust Falls" in self.page(client, campaign)
 
-    def test_an_address_naming_nothing_is_refused_in_words(
-        self, client, campaign, open_to_everyone
-    ):
+    def test_a_key_naming_nothing_is_refused(self, client, campaign, open_to_everyone):
         response = client.post(
             f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": "not-a-gang"}
         )
         assert response.status_code == 200
-        assert "No gang with that address" in response.content.decode()
         assert not CampaignMembership.objects.exists()
+
+    def test_a_gang_belonging_to_nobody_at_the_table_is_refused(
+        self, client, campaign, gang_type, open_to_everyone
+    ):
+        """The screen offers the gangs of people who have accepted a place,
+        and the POST takes only what the screen would offer."""
+        outsider = found_gang(
+            "Not Invited", gang_type, owner=User.objects.create_user("outsider")
+        )
+        response = client.post(
+            f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(outsider.pk)}
+        )
+        assert response.status_code == 200
+        assert not CampaignMembership.objects.filter(gang=outsider).exists()
 
     def test_a_gang_already_playing_elsewhere_is_refused_in_words(
         self, client, campaign, gang, arbitrator, open_to_everyone
     ):
         elsewhere = Campaign.objects.create(name="Sump City", owner=arbitrator)
+        # Seated there too: what is under test is the second join being
+        # refused, not who the other campaign would have offered.
+        seat(elsewhere, gang.owner)
         client.post(f"/n26/campaigns/{elsewhere.pk}/gangs/add/", {"gang": str(gang.pk)})
 
         response = client.post(
@@ -607,8 +625,9 @@ class TestTheRollOfGangs:
 
 class TestBattlesOnTheCampaignsPage:
     @pytest.fixture
-    def gang(self, gang_type):
+    def gang(self, gang_type, campaign):
         player = User.objects.create_user("player")
+        seat(campaign, player)
         return found_gang("The Ashen Choir", gang_type, owner=player)
 
     def page(self, client, campaign):
@@ -650,6 +669,9 @@ class TestBattlesOnTheCampaignsPage:
         """A picker over every gang there is would let an arbitrator record a
         battle between gangs that were never in the campaign."""
         elsewhere = Campaign.objects.create(name="Sump City", owner=arbitrator)
+        # Seated there too: what is under test is the second join being
+        # refused, not who the other campaign would have offered.
+        seat(elsewhere, gang.owner)
         client.post(f"/n26/campaigns/{elsewhere.pk}/gangs/add/", {"gang": str(gang.pk)})
 
         drawn = client.get(
@@ -718,8 +740,9 @@ class TestTheCampaignInTheBar:
     answers 200."""
 
     @pytest.fixture
-    def gang(self, gang_type):
+    def gang(self, gang_type, campaign):
         player = User.objects.create_user("player")
+        seat(campaign, player)
         return found_gang("The Ashen Choir", gang_type, owner=player)
 
     def screens(self, campaign, gang, battle):
@@ -1038,7 +1061,16 @@ class TestAPlayerBringingTheirOwnGang:
         response = client.get(f"/n26/campaigns/{theirs.pk}/gangs/add/")
         assert response.status_code == 200
         assert response.context["arbitrating"] is False
-        assert [row["label"] for row in response.context["gang_options"]] == ["My Own"]
+        assert [row["name"] for row in response.context["gangs"]] == ["My Own"]
+
+    def test_they_are_offered_nobody_elses(
+        self, client, theirs, mine, gang_type, open_to_everyone
+    ):
+        """The arbitrator draws on the whole table; a player draws on their
+        own and is not shown what anybody else has."""
+        found_gang("Not Mine", gang_type, owner=theirs.owner)
+        response = client.get(f"/n26/campaigns/{theirs.pk}/gangs/add/")
+        assert [row["name"] for row in response.context["gangs"]] == ["My Own"]
 
     def test_they_can_bring_it(self, client, theirs, mine, open_to_everyone):
         client.post(f"/n26/campaigns/{theirs.pk}/gangs/add/", {"gang": str(mine.pk)})
@@ -1066,28 +1098,16 @@ class TestAPlayerBringingTheirOwnGang:
         offering something that gets refused."""
         client.post(f"/n26/campaigns/{theirs.pk}/gangs/add/", {"gang": str(mine.pk)})
         response = client.get(f"/n26/campaigns/{theirs.pk}/gangs/add/")
-        assert response.context["gang_options"] == []
-        assert response.context["nothing_to_bring"] is True
-
-    def test_a_reader_whose_gangs_are_all_busy_is_told_which(
-        self, client, theirs, mine, open_to_everyone
-    ):
-        client.post(f"/n26/campaigns/{theirs.pk}/gangs/add/", {"gang": str(mine.pk)})
-        response = client.get(f"/n26/campaigns/{theirs.pk}/gangs/add/")
-        assert response.context["every_gang_busy"] is True
-        drawn = response.content.decode()
-        assert "Every gang of yours is in a campaign" in drawn
-        # Nothing to submit, so nothing offering to.
-        assert "Add gang</" not in drawn
+        # Still listed, because a reader who cannot find a gang is better
+        # told where it went — and hidden to start with by the filter.
+        assert [row["playing"] for row in response.context["gangs"]] == [True]
+        assert response.context["free_gangs"] == 0
 
     def test_a_reader_with_no_gangs_is_sent_to_make_one(
         self, client, theirs, open_to_everyone
     ):
-        """No gang and a busy gang are different problems with different
-        next steps, so the page says which one this is."""
         response = client.get(f"/n26/campaigns/{theirs.pk}/gangs/add/")
-        assert response.context["nothing_to_bring"] is True
-        assert response.context["every_gang_busy"] is False
+        assert response.context["nothing_to_offer"] is True
         drawn = response.content.decode()
         assert "No gangs yet" in drawn
         assert "/n26/gangs/new/" in drawn
@@ -1208,7 +1228,7 @@ class TestAPlayerBringingTheirOwnGang:
         self.accept_and_bring(client, theirs, mine)
         client.post(f"/n26/campaigns/{theirs.pk}/gangs/{mine.pk}/remove/")
         response = client.get(f"/n26/campaigns/{theirs.pk}/gangs/add/")
-        assert [row["label"] for row in response.context["gang_options"]] == ["My Own"]
+        assert [row["playing"] for row in response.context["gangs"]] == [False]
 
     def test_they_cannot_take_out_somebody_elses(
         self, client, theirs, mine, gang_type, arbitrator, open_to_everyone
@@ -1273,37 +1293,64 @@ class TestTheRollsQueryCount:
 
 
 class TestTheArbitratorsOwnAddGangScreen:
-    def test_they_still_paste_an_address(self, client, campaign, open_to_everyone):
+    """The same list a player sees, over everybody at the table."""
+
+    @pytest.fixture
+    def rich(self, campaign, gang_type, make_profile):
+        player = User.objects.create_user("player")
+        seat(campaign, player)
+        gang = found_gang("Too Rich", gang_type, owner=player)
+        hire(gang, make_profile("Escher Ganger"), "Yolanda", paid=55)
+        return gang
+
+    def test_it_offers_the_gangs_of_everybody_seated(
+        self, client, campaign, rich, gang_type, arbitrator, open_to_everyone
+    ):
+        mine = found_gang("The Arbitrator's Own", gang_type, owner=arbitrator)
+        outsider = found_gang(
+            "Not Invited", gang_type, owner=User.objects.create_user("outsider")
+        )
+
         response = client.get(f"/n26/campaigns/{campaign.pk}/gangs/add/")
         assert response.context["arbitrating"] is True
-        assert response.context["gang_options"] == []
+        offered = {row["name"] for row in response.context["gangs"]}
+        assert offered == {"Too Rich", mine.name}
+        assert outsider.name not in offered
 
-    def test_they_may_seat_a_gang_over_the_budget(
-        self, client, arbitrator, campaign, gang_type, make_profile, open_to_everyone
+    def test_the_newest_touched_gang_comes_first(
+        self, client, campaign, rich, gang_type, make_profile, open_to_everyone
     ):
-        """They set the number, so they are the one who may go past it."""
+        """Ordered by the ledger, because the gang somebody is looking for
+        is nearly always the one they were last working on."""
+        older = found_gang("Long Untouched", gang_type, owner=rich.owner)
+        hire(older, make_profile("Escher Juve"), "Nadia", paid=25)
+        hire(rich, make_profile("Escher Champ"), "Vala", paid=80)
+
+        response = client.get(f"/n26/campaigns/{campaign.pk}/gangs/add/")
+        assert [row["name"] for row in response.context["gangs"]][:2] == [
+            "Too Rich",
+            "Long Untouched",
+        ]
+
+    def test_it_says_which_gangs_are_already_playing(
+        self, client, campaign, rich, arbitrator, open_to_everyone
+    ):
+        """Hidden by the filter to start with, but listed — a reader who
+        cannot find a gang should be told where it went."""
+        client.post(f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(rich.pk)})
+        response = client.get(f"/n26/campaigns/{campaign.pk}/gangs/add/")
+        assert [row["playing"] for row in response.context["gangs"]] == [True]
+        assert response.context["free_gangs"] == 0
+
+    def test_a_gang_over_the_budget_joins_and_is_marked(
+        self, client, campaign, rich, arbitrator, open_to_everyone
+    ):
         campaign.budget = 0
         campaign.save()
-        rich = found_gang(
-            "Too Rich", gang_type, owner=User.objects.create_user("player")
-        )
-        hire(rich, make_profile("Escher Ganger"), "Yolanda", paid=55)
-
         client.post(f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(rich.pk)})
         assert CampaignMembership.objects.filter(
             campaign=campaign, gang=rich, left__isnull=True
         ).exists()
-
-    def test_the_roll_marks_a_gang_over_the_budget(
-        self, client, arbitrator, campaign, gang_type, make_profile, open_to_everyone
-    ):
-        campaign.budget = 0
-        campaign.save()
-        rich = found_gang(
-            "Too Rich", gang_type, owner=User.objects.create_user("player")
-        )
-        hire(rich, make_profile("Escher Ganger"), "Yolanda", paid=55)
-        client.post(f"/n26/campaigns/{campaign.pk}/gangs/add/", {"gang": str(rich.pk)})
 
         response = client.get(f"/n26/campaigns/{campaign.pk}/")
         assert [row.over_budget for row in response.context["playing"]] == [True]


### PR DESCRIPTION
`add_gang` asked for a gang's address, so an arbitrator had to get one from the player before they could act. It now lists the gangs belonging to people who have accepted a place, plus the arbitrator's own, each row carrying an Add button — no pasting, and no separate step between choosing and confirming.

## Order

By the last thing the ledger recorded against each gang (`Max("ledger_events__created")`), because the gang somebody is looking for is nearly always the one they were last working on. A gang nothing has happened to yet sorts last rather than where a null would put it.

## Filters

All three narrow rows already on the page, which is the sanctioned use of Alpine here:

- **Player** — `c-n26.filter-menu`, the checkbox dropdown with All / None. Drawn only where there is more than one person to tell apart, so a player looking at their own gangs is not asked which player.
- **Wealth** — `c-n26.range-menu`, the same control the hire page uses for price.
- **Hide gangs already in a campaign** — ticked to start with. Unticking shows them marked "In a campaign" and carrying no Add button, since `Operation.join_campaign` refuses a second campaign. A reader who cannot find a gang is told where it went rather than left guessing.

The count is written once per change by an `x-effect` rather than read from a getter — Alpine caches no getter, and one walked per row goes quadratic as the list grows.

## What the POST accepts

`_addable_gangs()` builds the list, and `BringGangForm` validates against that same queryset, so a gang the screen would not offer is not one it takes.

**This narrows the arbitrator**, and it is the one thing worth a second look: a gang belonging to nobody at the table can no longer be added at all, where the address field would take any gang there was. The workflow becomes invite the player, then add their gang. Eighteen tests failed on this, several of which were using the paste purely as setup.

`JoinCampaignForm` and its address parsing are deleted.

## How to try it

- `/n26/campaigns/<id>/gangs/add/` as the arbitrator — every seated player's gangs, with the Player filter
- the same address as a player — your own gangs, no Player filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZEooSg8dnNJ2T4oqexpJY