### PR TITLE
docs: CLAUDE.md and agent files follow the microcopy audit

### DIFF
--- a/.claude/agents/code-architect.md
+++ b/.claude/agents/code-architect.md
@@ -1,12 +1,12 @@
 ---
 name: code-architect
-description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
+description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
 model: sonnet
 color: green
 ---
 
-You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.
+You are a software architect. You study the codebase, decide on one approach, and produce an implementation blueprint.
 
 ## Core Process
 
@@ -14,14 +14,14 @@ You are a senior software architect who delivers comprehensive, actionable archi
 Extract existing patterns, conventions, and architectural decisions. Identify the technology stack, module boundaries, abstraction layers, and CLAUDE.md guidelines. Find similar features to understand established approaches.
 
 **2. Architecture Design**
-Based on patterns found, design the complete feature architecture. Make decisive choices - pick one approach and commit. Ensure seamless integration with existing code. Design for testability, performance, and maintainability.
+Based on patterns found, design the complete feature architecture. Make decisive choices - settle on one approach and commit. Design so the feature fits the existing code's patterns without special cases. Design for testability, performance, and maintainability.
 
 **3. Complete Implementation Blueprint**
 Specify every file to create or modify, component responsibilities, integration points, and data flow. Break implementation into clear phases with specific tasks.
 
 ## Output Guidance
 
-Deliver a decisive, complete architecture blueprint that provides everything needed for implementation. Include:
+Deliver a blueprint the implementer can follow without making further design decisions. Include:
 
 - **Patterns & Conventions Found**: Existing patterns with file:line references, similar features, key abstractions
 - **Architecture Decision**: Your chosen approach with rationale and trade-offs

--- a/.claude/agents/code-explorer.md
+++ b/.claude/agents/code-explorer.md
@@ -48,7 +48,7 @@ Provide a comprehensive analysis that helps developers understand the feature de
 - Observations about strengths, issues, or opportunities
 - List of files that you think are absolutely essential to get an understanding of the topic in question
 
-Structure your response for maximum clarity and usefulness. Always include specific file paths and line numbers.
+Always include specific file paths and line numbers.
 
 ## If you're blocked at the start
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,12 +1,12 @@
 ---
 name: code-reviewer
-description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter
+description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that matter
 tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
 model: sonnet
 color: red
 ---
 
-You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
+You are an expert code reviewer across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
 
 ## Review Scope
 
@@ -30,7 +30,7 @@ Rate each potential issue on a scale from 0-100:
 - **75**: Highly confident. Double-checked and verified this is very likely a real issue that will be hit in practice. The existing approach is insufficient. Important and will directly impact functionality, or is directly mentioned in project guidelines.
 - **100**: Absolutely certain. Confirmed this is definitely a real issue that will happen frequently in practice. The evidence directly confirms this.
 
-**Only report issues with confidence ≥ 80.** Focus on issues that truly matter - quality over quantity.
+**Only report issues with confidence ≥ 80.** Focus on issues that matter - quality over quantity.
 
 ## Output Guidance
 
@@ -43,7 +43,7 @@ Start by clearly stating what you're reviewing. For each high-confidence issue, 
 
 Group issues by severity (Critical vs Important). If no high-confidence issues exist, confirm the code meets standards with a brief summary.
 
-Structure your response for maximum actionability - developers should know exactly what to fix and why.
+Developers should know exactly what to fix and why.
 
 ## If you're blocked at the start
 

--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -1,6 +1,6 @@
 ---
 name: code-simplifier
-description: Use this agent when architecture review, code review, or refactoring analysis is needed. This agent proactively pushes for clean, DRY code with clear interfaces, types, and abstractions. It identifies unification opportunities, finds missing abstractions, exposes leaky boundaries, and relentlessly simplifies. Use it proactively after significant code changes, when reviewing a module, or when the codebase feels inconsistent.
+description: Use this agent when architecture review, code review, or refactoring analysis is needed. This agent proactively pushes for clean, DRY code with clear interfaces, types, and abstractions. It identifies unification opportunities, finds missing abstractions, exposes leaky boundaries, and simplifies. Use it proactively after significant code changes, when reviewing a module, or when the codebase feels inconsistent.
 
 Examples:
 
@@ -47,7 +47,7 @@ skills:
   - code-analysis-lenses
 ---
 
-You are a senior software architect with an obsessive focus on simplicity, consistency, and clean design. Your mission is to make code simpler, more consistent, and more architecturally coherent. You are opinionated and direct. You do not add complexity — you remove it.
+You are a senior software architect focused on simplicity, consistency, and clean design. Your mission is to make code simpler, more consistent, and more architecturally coherent. You are opinionated and direct. Remove complexity; do not add it.
 
 You are working on a Django web application (the Gyrinx project). It is server-rendered HTML, not an SPA. The project's established conventions and architectural patterns are provided via the `gyrinx-conventions` skill. The analytical methodology for evaluating code quality is provided via the `code-analysis-lenses` skill.
 
@@ -99,7 +99,7 @@ Order findings by impact: high-value, low-risk simplifications first. Group rela
 
 If asked to implement changes:
 - Make the minimal change that achieves the simplification
-- Run tests after each change (`pytest -n auto --reuse-db`)
+- Run tests after each change (`pytest -n auto`)
 - Format code after changes (`./scripts/fmt.sh`)
 - Do not introduce new patterns or abstractions beyond what you recommended
 - Do not "improve" surrounding code that wasn't part of the finding

--- a/.claude/agents/copywriter.md
+++ b/.claude/agents/copywriter.md
@@ -20,7 +20,8 @@ author-facing string in the given scope match the microcopy style. You do not
 review logic, structure, or markup — only the words a person reads.
 
 First, read `.agents/skills/microcopy/SKILL.md` in full. It is the authority:
-the credo (the reader does zero work), the base rules, the four anti-patterns
+the credo (one-pass comprehension — spend nothing of the reader's attention
+on the writing itself), the base rules, the four anti-patterns
 (personification, saying what isn't, quaint vocabulary, over-compression), the
 marketing/AI-tell list, and the word-ban table. Judge every string against it.
 
@@ -32,7 +33,9 @@ scope, find every string a person reads: template text and component props
 (`title=`, `label=`, `submit_label=`, `lead=`, `empty=`, `placeholder=`),
 form `label`/`help_text`, `messages.*` calls, `verbose_name`, choices labels,
 validation errors, model `help_text`, library model docstrings, email and
-notification copy, admin/maintenance screens.
+notification copy, admin/maintenance screens. The human-written marketing
+sections (the signed-out homepage pitch) are out of scope — never rewrite
+them to these rules.
 
 Only strings the diff added or changed are in scope for edits. Neighbouring
 legacy copy is fix-on-touch: mention it in the report if it is badly off-style,

--- a/.claude/agents/diataxis-docs-expert.md
+++ b/.claude/agents/diataxis-docs-expert.md
@@ -16,7 +16,7 @@ You have deep knowledge of the Diataxis framework's four documentation quadrants
 
 3. **Reference** (information-oriented): Technical descriptions of the machinery—APIs, configuration options, CLI commands, data structures. Accurate, complete, and structured for lookup.
 
-4. **Explanation** (understanding-oriented): Discussions that clarify and illuminate. They explore design decisions, alternatives, context, and connect ideas across the system.
+4. **Explanation** (understanding-oriented): Discussions that explain why things are the way they are. They explore design decisions, alternatives, context, and connect ideas across the system.
 
 You also understand GitBook, MkDocs, Sphinx, README conventions, documentation-as-code workflows, and cross-referencing strategies.
 
@@ -110,7 +110,7 @@ docs/
 - Explore trade-offs and alternatives considered
 - Connect concepts across the system
 - Provide historical context when relevant
-- Use analogies to clarify complex ideas
+- Use a concrete example to clarify complex ideas
 
 ## Audit Checklist
 

--- a/.claude/agents/feature-planner.md
+++ b/.claude/agents/feature-planner.md
@@ -1,13 +1,13 @@
 ---
 name: feature-planner
-description: Use this agent when you need to create a comprehensive implementation plan for a new feature or bug fix. This agent should be invoked before starting any coding work to ensure a clear roadmap and strategy. The agent will analyze requirements, break down work into manageable chunks, define testing strategies, and extract critical implementation details.\n\nExamples:\n- <example>\n  Context: User wants to implement a new equipment upgrade system\n  user: "I need to add a feature where users can upgrade their equipment with special modifications"\n  assistant: "I'll use the feature-planner agent to create a comprehensive plan for implementing the equipment upgrade system"\n  <commentary>\n  Since this is a new feature request, use the feature-planner agent to break down the work and create a detailed implementation strategy before coding.\n  </commentary>\n</example>\n- <example>\n  Context: User reports a bug with fighter equipment assignments\n  user: "There's a bug where equipment assignments are duplicated when copying a fighter"\n  assistant: "Let me use the feature-planner agent to analyze this bug and create a systematic fix plan"\n  <commentary>\n  For bug fixes, the feature-planner agent will help identify root causes, affected components, and create a testing strategy.\n  </commentary>\n</example>\n- <example>\n  Context: User wants to refactor a complex view\n  user: "The list management view has become too complex and needs refactoring"\n  assistant: "I'll invoke the feature-planner agent to plan out the refactoring approach"\n  <commentary>\n  Even for refactoring work, the feature-planner agent helps ensure systematic approach and maintains functionality.\n  </commentary>\n</example>
+description: Use this agent when you need to create an implementation plan for a new feature or bug fix. This agent should be invoked before starting any coding work to ensure a clear roadmap and strategy. The agent will analyze requirements, break down work into manageable chunks, define testing strategies, and extract critical implementation details.\n\nExamples:\n- <example>\n  Context: User wants to implement a new equipment upgrade system\n  user: "I need to add a feature where users can upgrade their equipment with special modifications"\n  assistant: "I'll use the feature-planner agent to create a plan for implementing the equipment upgrade system"\n  <commentary>\n  Since this is a new feature request, use the feature-planner agent to break down the work and create a detailed implementation strategy before coding.\n  </commentary>\n</example>\n- <example>\n  Context: User reports a bug with fighter equipment assignments\n  user: "There's a bug where equipment assignments are duplicated when copying a fighter"\n  assistant: "Let me use the feature-planner agent to analyze this bug and create a systematic fix plan"\n  <commentary>\n  For bug fixes, the feature-planner agent will help identify root causes, affected components, and create a testing strategy.\n  </commentary>\n</example>\n- <example>\n  Context: User wants to refactor a complex view\n  user: "The list management view has become too complex and needs refactoring"\n  assistant: "I'll invoke the feature-planner agent to plan out the refactoring approach"\n  <commentary>\n  Even for refactoring work, the feature-planner agent helps ensure systematic approach and maintains functionality.\n  </commentary>\n</example>
 model: opus
 color: green
 skills:
   - gyrinx-conventions
 ---
 
-You are an expert software architect and technical planning specialist with deep experience in Django web applications, test-driven development, and systematic feature implementation. Your role is to create comprehensive, actionable implementation plans that other agents or developers can follow to successfully deliver features or fix bugs.
+You are a software architect. You create implementation plans for Django features and bug fixes that other agents or developers can follow to deliver them.
 
 When presented with a feature request or bug report, you will:
 
@@ -41,7 +41,7 @@ Create a detailed, sequential breakdown of implementation tasks:
 
 ## 4. Testing Strategy
 
-Define a comprehensive testing approach:
+Define the testing approach:
 
 - Unit tests for new model methods and business logic
 - Integration tests for views and forms
@@ -56,7 +56,7 @@ Define a comprehensive testing approach:
 - Note any project-specific requirements from CLAUDE.md
 - Include formatting and linting requirements (`./scripts/fmt.sh`)
 - Highlight security considerations (validate redirects, sanitize inputs)
-- For UI work, specify Bootstrap classes and responsive design approach
+- For UI work, name the cotton components to use (`gyrinx/templates/cotton/`) and the responsive design approach — never raw Bootstrap markup
 
 ## 6. Risk Assessment
 
@@ -76,7 +76,7 @@ Provide a final checklist for verifying the implementation:
 - UI responsive and mobile-friendly
 - Security considerations addressed
 
-Your output should be structured, detailed, and immediately actionable. Use clear headings, bullet points, and code snippets where helpful. Be specific about file paths, class names, and method names. When referencing Django patterns, be explicit about which pattern to follow.
+Be specific and immediately actionable. Use clear headings, bullet points, and code snippets where helpful. Be specific about file paths, class names, and method names. When referencing Django patterns, be explicit about which pattern to follow.
 
 If the request is vague or missing critical information, start your plan by listing the clarifications needed and make reasonable assumptions to proceed with the planning, clearly marking them as assumptions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ form-field anatomy — issue #2002.
 ## Infrastructure
 
 - All our infra is in GCP europe-west2 (London)
-- In prod, the user uploads bucket name is gyrinx-app-bootstrap-uploads
+- In prod, the bucket for user uploads is gyrinx-app-bootstrap-uploads
 
 ## Local Development (Per-Worktree Isolation)
 
@@ -449,7 +449,7 @@ echo 'print(User.objects.count())' | manage prodshell
 echo 'print(List.objects.filter(archived=False).count())' | manage prodshell
 ```
 
-- Piped code runs through IPython, which prints multi-line `for` loops unreliably — use a
+- Piped code runs through IPython, which echoes the output of multi-line `for` loops unreliably — use a
   single expression per query (e.g. `print([...comprehension...])`) and read results off
   the `In [N]:` lines.
 
@@ -481,8 +481,8 @@ anything else that connects as that role too.
   and gives whoever triggered it a spinning tab instead of a page they can leave and come back to.
   "It only takes a few seconds on my machine" is measured against a copy, not against production
   under load. Follow `convert_specialisation` in `n26/maintenance.py`: a `@task` that takes the
-  record's id, an advisory lock so a redelivered message stands down rather than running twice, an
-  attempt count so a run too large to finish is noticed instead of repeating for ever, and every
+  record's id, an advisory lock so a redelivered message exits without running rather than running twice, an
+  attempt count so a run too large to finish is noticed instead of repeating forever, and every
   ending — done, refused, broken — written onto the record rather than raised. Long repairs that
   cannot finish in one go re-enqueue themselves in chunks (`n23/core/tasks.py`), reporting progress
   into the same record.
@@ -676,10 +676,11 @@ and override the `owner` kwarg on the factory fixtures.
 
 ### Git Workflow
 
-- Before `git pull`, check the index
-- Consider running `git stash`
-- After a `stash` then `pull`, run `git stash pop` if necessary
-- This is useful for keeping the claude local file up-to-date
+- Before `git pull`, check the index; if the tree is dirty, set the changes
+  aside first and restore them after. Prefer a temporary WIP commit — the
+  stash stack is shared across worktrees (see the worktree stash rules) —
+  and reach for `git stash` only in a plain single checkout.
+- This keeps `CLAUDE.local.md` up to date across pulls.
 - When writing PR descriptions, keep it simple and avoid "selling the feature" in the PR
 - At the end of work, ship with the `commit-push-pr` skill — open the PR ready for
   review (not a draft) so bot reviews and the review-agent watcher kick off

--- a/gyrinx/analytics/CLAUDE.md
+++ b/gyrinx/analytics/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance specific to the analytics app.
 
 Two editions write to one events table, so every `Event` carries an `edition`.
 
-- The words belong to the editions, not here. `EventNoun` lives in
+- Noun values are defined by the editions, not by this app. `EventNoun` lives in
   `n23/core/events.py`; n26's live in `n26/analytics.py`. Only `PlatformNoun`
   (`user`, `banner`) is the platform's, because an account and a site-wide
   banner are the same thing whichever edition you are reading.
@@ -22,9 +22,9 @@ Two editions write to one events table, so every `Event` carries an `edition`.
   (`gyrinx/analytics/nouns.py`). That is what lets `edition` be derived from
   the noun instead of passed in — there is no argument to thread through the
   call sites, and so none to forget. A noun nobody registered is recorded as
-  `unknown` with an error logged, never guessed into a real edition.
-- `Event.noun`'s `choices` is the registry callable, so adding a noun writes
-  no migration.
+  `unknown` with an error logged, never inferred into a real edition.
+- `Event.noun`'s `choices` is the registry callable, so adding a noun does
+  not require a migration.
 - Anything grouping events must group by edition too, or it adds two products
   together. The growth chart's lines each declare an edition for this reason.
 

--- a/gyrinx/tasks/CLAUDE.md
+++ b/gyrinx/tasks/CLAUDE.md
@@ -31,7 +31,7 @@ Design notes for the local backend: `.claude/notes/local-async-tasks-research.md
 - [`registry.py`](registry.py) / [`route.py`](route.py) /
   [`discovery.py`](discovery.py) — task registration and per-task config. Apps
   declare their own routes in a `task_routes` list in their `<app>/tasks.py`;
-  the registry collects them, so the platform names no edition task (#2093).
+  the registry collects them, so platform code does not reference any edition task (#2093).
 - [`provisioning.py`](provisioning.py) / [`apps.py`](apps.py) — Pub/Sub + Scheduler
   provisioning (Cloud Run only; skipped locally, in migrations, and in tests).
 

--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -34,7 +34,7 @@ The dependency direction is: `library` holds content, `core` reads it.
 Concretely:
 
 - **No app code in `n26/` imports `n23.*` or `gyrinx.*`.** n26 is a
-  parallel edition, not a layer on the old one. Ten deliberate
+  parallel edition, not a layer on the old one. The deliberate
   exceptions: `n26/core/views/changelog.py` reads
   `gyrinx.site.models.ChangelogEntry`, deferred inside its shared
   queryset helper; the gangs view searches with
@@ -50,7 +50,7 @@ Concretely:
   (`n26/core/models/built_in_propagation.py` and the code driving it);
   and `n26/tests/` may import platform
   pieces to test the seam. Do not add others.
-- **`n26/flags.py` is the other single-file seam, and it works the way
+- **`n26/flags.py` is a single-file seam, and it works the way
   `n26/analytics.py` does.** Gating half-built work is a property of
   shipping software, not of either game: one table means one admin page,
   one answer to "what is gated right now", and no second implementation
@@ -66,7 +66,7 @@ Concretely:
   is one call — the words are ours, because an edition knows what happened
   and how to say it, and the delivery is the platform's. It is the only file
   here that writes a notification.
-- **`n26/analytics.py` is the third platform module n26 may call, and
+- **`n26/analytics.py` is one of the four platform modules n26 may call, and
   the only file allowed to.** Activity tracking is the site's: one
   events table, one log stream, one dashboard, and every question asked
   of them ("how many people did X this week") is asked of the site.
@@ -78,16 +78,16 @@ Concretely:
   belongs to exactly one edition, so a gang here is never filed under
   n23's "list", and the edition of a row follows from its noun with no
   argument for a call site to forget.
-- **`gyrinx.querysets` is the first of the four platform modules n26 code
+- **`gyrinx.querysets` is one of the four platform modules n26 code
   may call.** It is model-agnostic — full text plus a substring fallback over
   whatever fields it is handed, knowing nothing about either edition,
-  in the way the ORM does not. What crosses is a queryset of n26's own
+  just as the ORM does not. What crosses is a queryset of n26's own
   rows, filtered; nothing platform-shaped comes back. The alternative
   is a second search here, and two editions that quietly come to
   disagree about what "scav" matches. This does not extend to the rest
   of `gyrinx.*`: a helper qualifies only if it would read the same
   written against any model in any edition.
-- **`gyrinx.svg` is the second, and the other security one.** Sanitising
+- **`gyrinx.svg` is another of the four, and the other security one.** Sanitising
   stored SVG before drawing it inline is a property of SVG and of the
   browser, not of a content model — it would read the same written
   against any edition's rows, which is the test. It is also the one kind
@@ -98,7 +98,7 @@ Concretely:
   same directory: `richtext.py` is a *copy* of the platform's rich-text
   sanitiser, so there are already two allowlists to keep in step. Do not
   make a third.
-- **`gyrinx.artwork` is the fourth, and travels with `gyrinx.svg` for
+- **`gyrinx.artwork` is also one of the four, and travels with `gyrinx.svg` for
   the same reason.** Which addresses resolve to this site's own storage is a
   property of the site, not of a content model — it would read the same
   written against any edition's rows. It is also security code: two
@@ -107,7 +107,7 @@ Concretely:
   This edition keeps only the folder its uploads land in
   (`n26/library/artwork.py` binds the prefix); every rule about what may
   be stored and what an address may name lives in the platform module.
-- **`n26/maintenance.py` is the other single-file seam, and it works the
+- **`n26/maintenance.py` is a single-file seam, and it works the
   way `n26/analytics.py` does.** The maintenance console is site
   furniture — a superuser-gated index, one audit record per run, a detail
   page, a cancel button — and it deliberately knows nothing about either
@@ -124,7 +124,7 @@ Concretely:
   run after the platform's own — an edition importing it during
   autodiscovery would install it too early and every maintenance route
   would be silently dropped.
-- **Templates may `{% load %}` a platform tag library** where the thing
+- **Templates may `{% load %}` a platform tag library** where the question
   it answers is genuinely the platform's and not an edition's — today
   that is `badge_tags`, because which badge a person shows follows from
   their supporter standing and staff flag, which belong to the account

--- a/n26/core/CLAUDE.md
+++ b/n26/core/CLAUDE.md
@@ -6,7 +6,7 @@ stage has one job:
 ```
 models/        rows: Gang, Miniature, Assignment, LedgerEntry, Stash
 operations.py  the only writer — every change to player data goes through it
-card.py        loads a gang's rows into an in-memory tree: a pinned two
+card.py        loads a gang's rows into an in-memory tree: two pinned
                row queries, one shared hydration pass
 effects.py     computes what the rules do to a card — pure, no queries
 render.py      plain dataclasses a template can draw (ModelCard, GangSheet)
@@ -104,7 +104,7 @@ underlying spec.
 - **A new assignable kind is three edits**: an entry in
   `ASSIGNABLE_FIELDS` (`models/assignment.py`), a matching nullable FK
   on `Assignment`, and a migration. Startup checks (`n26.E001`/`E002`)
-  refuse to boot if they disagree.
+  stop the app booting if they disagree.
 - A new condition model must be named in its scope's `CONDITIONS` tuple
   (`n26.E003`/`E004`) or its rows are stored but never read.
 - `Has.as_q` needs a `register_lookup()` entry per (model, kind) pair,

--- a/n26/designsystem/CLAUDE.md
+++ b/n26/designsystem/CLAUDE.md
@@ -41,7 +41,7 @@ Read `demos.py` (a hundred lines) first, then `introspect.py`.
 
 ```
 {# title: Solid and pill #}
-{# note: Both are spellings of variant, so you can't have a solid pill. #}
+{# note: solid and pill are both values of variant, so a badge cannot be both. #}
 {# layout: col #}
 <c-ui.badge variant="solid" color="green">solid</c-ui.badge>
 ```
@@ -57,7 +57,7 @@ Read `demos.py` (a hundred lines) first, then `introspect.py`.
   icon demo loops the icon registry, so new icons appear without the
   demo going stale.
 
-## The `notes` register
+## The `notes` field
 
 A catalog entry's `notes` hold call-site facts the prop table cannot
 show: silent failure modes, required companions, cross-file couplings
@@ -75,9 +75,9 @@ notes.
 - Print styling is its own world: read the header comment in
   `assets/print.css` before touching anything print-shaped, and use
   `printlab` (every control is a query parameter) to test it.
-  `sampledata`, `printlab`, and the token pages deliberately hold no
-  values that live elsewhere — tokens are read from the browser,
-  geometry mirrors the stylesheet.
+  None of `sampledata`, `printlab`, or the token pages duplicate values
+  defined elsewhere: tokens are read from the browser at render time,
+  and printlab's geometry is read from the stylesheet.
 - The gallery depends on `n26.core`; core must never import the
   gallery.
 

--- a/n26/library/CLAUDE.md
+++ b/n26/library/CLAUDE.md
@@ -11,7 +11,7 @@ forms.py         Django forms generated from the specs
 views.py         the staff authoring pages, driven by small registries
 sheets.py        the five pre-ingest sheets, named once
 ingest.py        spreadsheets in → a previewable plan → rows out
-standard_content.py  the seed rows nobody authors, planted idempotently
+standard_content.py  the seed rows nobody authors, created idempotently
 offers.py        what a kind declares about itself; forms derive the rest
 artwork.py       uploaded drawings: binds this edition's folder onto gyrinx.artwork
 ```
@@ -32,7 +32,7 @@ philosophy. Then `models/assignable.py` and `authoring.py`.
   ordering, the standard constraints (unique per pack on lowercased
   name + qualifier; exclusive items carry no trade-point price) — and a
   column on `n26.core`'s `Assignment` plus an entry in
-  `ASSIGNABLE_FIELDS`, or the app refuses to boot.
+  `ASSIGNABLE_FIELDS`, or the app fails at startup.
 - **Help text lives on the model field, nowhere else.** Specs reference
   it (`source=(Model, "field")`); forms read it through the spec. Model
   docstrings are shown to authors on the authoring pages — write them as
@@ -147,7 +147,7 @@ exactly the plan, through the authoring verbs, in one transaction).
 **The preview is the contract** — what `plan.preview()` shows is what
 `perform()` does, changes included. Standing rules: resolve, never
 create, across sheets; built-ins are free; a missing seed row is a loud
-error, never quietly re-planted.
+error, never quietly re-created.
 
 An upload is **held** between the stages — an `UploadedSheet` row per
 sheet per author, the bytes in the site's storage. A file input cannot

--- a/n26/tests/CLAUDE.md
+++ b/n26/tests/CLAUDE.md
@@ -80,16 +80,16 @@ or the admin really does.
 - For query counts, prefer asserting the count stays the same after
   adding more fighters; a pinned literal count is acceptable for one
   structure's fixed budget.
-- **Discovering guards, not lists.** A rule that must hold for every X
-  enumerates the codebase by reflection, pairs with a
-  `test_there_is_something_to_check`, and fails with prose saying what
-  to do. `test_money_words.py` is the template. Never narrow a guard's
+- **Discovering guards, not lists.** A guard test for a rule that must
+  hold for every X discovers the Xs by reflection, pairs with a
+  `test_there_is_something_to_check`, and fails with a message saying
+  what to do. `test_money_words.py` is the template. Never narrow a guard's
   discovery to make a failure go away.
 - Discovery used in `parametrize` runs at collection time — keep it
   import-safe, no database access.
 - Tests run with `--nomigrations`, so data migrations never ran: any row
-  one plants exists only if a test makes it.
-- Rule names only, never the book's wording.
+  a data migration would have created exists only if a test creates it.
+- Tests name rules by their titles only — never the book's wording.
 
 ## Exemplars
 


### PR DESCRIPTION
## Summary

Sixteen sub-agent audits ran over every `CLAUDE.md`, `AGENTS.md` and `.claude/agents/` definition against the microcopy skill. This applies the agreed findings — defects, style drift, and two stale instructions — while deliberately leaving the n26 docs' metaphor voice (pages that "want" readers, kit "dealt onto guests") untouched.

**Defects**
- `n26/CLAUDE.md`: two files both claimed to be "the *other* single-file seam"; "Ten deliberate exceptions" headed a list of nine (the count is dropped); the four platform modules were introduced as third, first, second, fourth down the page
- `n26/core/CLAUDE.md`: the garbled pipeline line ("a pinned two row queries") now reads "two pinned row queries"; startup checks "stop the app booting" — "refuse" collided with the reserved `Refusal` term
- `.claude/agents/copywriter.md` lagged the skill it enforces: its Scope now carries the marketing carve-out, and its credo paraphrase matches the skill

**Banned words and puffery in agent files**
"seamless" (code-architect), "successfully deliver" plus five "comprehensive"s (feature-planner), "relentlessly"/"obsessive"/one false antithesis (code-simplifier), "truly matter" ×2 and "maximum actionability" (code-reviewer), one vacuous closing line (code-explorer), "clarify and illuminate" and analogy advice (diataxis-docs-expert)

**Style drift matching existing rulings**
sow-family ("planted"/"re-planted"/"one plants" → create) in `n26/library` and `n26/tests`; negation riddles ("names no edition task", "writes no migration", "The words belong to the editions, not here.") in `gyrinx/tasks` and `gyrinx/analytics`; the designsystem demo note and "notes register" heading; six small decode fixes in the root `CLAUDE.md`, including aligning its git-stash advice with the shared-stash worktree rules

**Stale instructions (found by the audit, not copy)**
- feature-planner told planners to "specify Bootstrap classes" — now names cotton components, matching the project direction
- code-simplifier's test command dropped `--reuse-db`, matching CLAUDE.md's testing guidance

## Test plan

- [x] Docs and agent definitions only — no runtime code; `scripts/check_microcopy.py --diff` reports nothing on the changed files
- [x] pre-commit (markdownlint included) passes on commit