### PR TITLE
refactor: rename n26 learn identifiers — Operation.select, views.skills, n26-skills

### DIFF
--- a/.claude/notes/n26-skills-surface-design.md
+++ b/.claude/notes/n26-skills-surface-design.md
@@ -57,7 +57,7 @@ the access to an equipment list.
 Expressed against what exists:
 
 ```
-learnable_for(miniature, computed) =
+selectable_for(miniature, computed) =
     for each collection in Collection.objects.containing(Family.MODEL):
         if placements_for(computed, collection):  ->  it is theirs
 ```
@@ -164,7 +164,7 @@ refusal in the shape of `NotEnoughCredits`, a story for how a counter
 reconciles (credits are recomputed from the ledger; counter values are not),
 and the advancement content itself.
 
-Recommendation: ship **free and recorded** first — `op.learn(miniature,
+Recommendation: ship **free and recorded** first — `op.select(miniature,
 skill)`, a zero-paid `Reason.REWARD` assignment with a ledger entry, rating
 contribution equal to the skill's reference price (zero for every core skill,
 so the default is no rating change and content can decide otherwise). Treat
@@ -219,7 +219,7 @@ it, differing in how they are addressed and what pressing does.
 1. **Content first.** Give the standard "Skills & Powers" collection its
    contents: a selector sweeping every skill, and one sweeping every power.
    Nothing below is testable end to end until it lists something.
-2. **Access.** `learnable_for(miniature, computed)` in `n26/core/access.py`,
+2. **Access.** `selectable_for(miniature, computed)` in `n26/core/access.py`,
    built on `Collection.objects.containing(Family.MODEL)` and
    `placements_for`. Pure read, no new rows.
 3. **Browse.** The learn view: resection by placements, drop the unplaced
@@ -228,7 +228,7 @@ it, differing in how they are addressed and what pressing does.
 4. **The page.** The second address onto the picker shape, GET only at first.
    A reader can see their sets and what is in them before anything can be
    written.
-5. **The write.** `Operation.learn`, free, `Reason.REWARD`, ledger entry,
+5. **The write.** `Operation.select`, free, `Reason.REWARD`, ledger entry,
    rating from reference price.
 6. **The card.** The href, computed in the view, and the button in `actions`.
 
@@ -240,7 +240,7 @@ tests and never reached the UI" complaint.
 - **Access.** A fighter whose profile has a grid has the collection; one
   without has nothing. A Venator has nothing before their trees are picked and
   the placed sets after. A gear collection with placements into it is never
-  learnable.
+  selectable.
 - **Sectioning.** Two entries with different grids see the same sets under
   different tiers, from one collection and one rule — the assertion the Escher
   sandbox already makes about the founding offer, now made about the whole

--- a/n26/core/access.py
+++ b/n26/core/access.py
@@ -167,7 +167,7 @@ def placed_collections(computed):
     return {str(placement.section.collection_id) for placement in computed.placements}
 
 
-def learnable_for(computed, among=None):
+def selectable_for(computed, among=None):
     """The collections this fighter may select from: the ones their grid
     places a category into, kept to those holding what a model is.
 

--- a/n26/core/navigation.py
+++ b/n26/core/navigation.py
@@ -269,7 +269,7 @@ FIGHTER_SCREENS = {
     "n26-edit-fighter": "Edit another model",
     "n26-equip": "Equip another fighter",
     "n26-fighter-options": "Options for another fighter",
-    "n26-learn": "Select skills for another fighter",
+    "n26-select": "Select skills for another fighter",
 }
 
 #: Where a screen with no per-fighter address sends the switcher.

--- a/n26/core/navigation.py
+++ b/n26/core/navigation.py
@@ -269,7 +269,7 @@ FIGHTER_SCREENS = {
     "n26-edit-fighter": "Edit another model",
     "n26-equip": "Equip another fighter",
     "n26-fighter-options": "Options for another fighter",
-    "n26-select": "Select skills for another fighter",
+    "n26-skills": "Select skills for another fighter",
 }
 
 #: Where a screen with no per-fighter address sends the switcher.

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -1704,7 +1704,7 @@ class Operation:
             self.reconcile_defaults(bought)
         return bought
 
-    def learn(self, miniature, thing, note=""):
+    def select(self, miniature, thing, note=""):
         """Take on something a model *is* — a skill, a power.
 
         Free, and recorded as a reward. No credits move: what a fighter

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -573,7 +573,7 @@ class ModelCard:
     #: like a choice's own href — this module knows what a grid *is* and
     #: not where a browsing screen lives. Empty draws no control, which
     #: is what a print sheet and a hire preview want.
-    learn_href: str = ""
+    select_href: str = ""
     #: The collections this model's grid places a category into, by id.
     #: Standing access, computed rather than assigned: it is what a
     #: screen for selecting is built on, and asking which of these hold

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -573,7 +573,7 @@ class ModelCard:
     #: like a choice's own href — this module knows what a grid *is* and
     #: not where a browsing screen lives. Empty draws no control, which
     #: is what a print sheet and a hire preview want.
-    select_href: str = ""
+    skills_href: str = ""
     #: The collections this model's grid places a category into, by id.
     #: Standing access, computed rather than assigned: it is what a
     #: screen for selecting is built on, and asking which of these hold

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -79,7 +79,7 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
             nowhere.
             {% endcomment %}
             <c-n26.model-card.mode when="edit">
-                {% if card.skill_choices or card.select_href %}
+                {% if card.skill_choices or card.skills_href %}
                     <div class="mt-1 flex flex-wrap items-center gap-1">
                         {% for choice in card.skill_choices %}
                             {% if choice.href %}
@@ -90,13 +90,13 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
                                 <c-n26.link>Choose {{ choice.kind_label|lower }}</c-n26.link>
                             {% endif %}
                         {% endfor %}
-                        {% if card.select_href %}
+                        {% if card.skills_href %}
                             <c-ui.tooltip size="sm">
                                 <c-ui.button size="xs"
                                              variant="default"
                                              :outlined="True"
                                              class="py-0!"
-                                             href="{{ card.select_href }}"
+                                             href="{{ card.skills_href }}"
                                              aria-label="Select a skill">
                                     <span class="n26-icon-only">
                                         <c-n26.icon name="pencil" class="size-3" />

--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -79,7 +79,7 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
             nowhere.
             {% endcomment %}
             <c-n26.model-card.mode when="edit">
-                {% if card.skill_choices or card.learn_href %}
+                {% if card.skill_choices or card.select_href %}
                     <div class="mt-1 flex flex-wrap items-center gap-1">
                         {% for choice in card.skill_choices %}
                             {% if choice.href %}
@@ -90,13 +90,13 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
                                 <c-n26.link>Choose {{ choice.kind_label|lower }}</c-n26.link>
                             {% endif %}
                         {% endfor %}
-                        {% if card.learn_href %}
+                        {% if card.select_href %}
                             <c-ui.tooltip size="sm">
                                 <c-ui.button size="xs"
                                              variant="default"
                                              :outlined="True"
                                              class="py-0!"
-                                             href="{{ card.learn_href }}"
+                                             href="{{ card.select_href }}"
                                              aria-label="Select a skill">
                                     <span class="n26-icon-only">
                                         <c-n26.icon name="pencil" class="size-3" />

--- a/n26/core/templates/n26/select.html
+++ b/n26/core/templates/n26/select.html
@@ -18,7 +18,7 @@ Radios in a form, no script. A reader who leaves without clicking Save has
 changed nothing, and the footer offers the leaving to the same place a save
 lands on: the model's own page, which is where the control leading here sits.
 {% endcomment %}
-{% block head_title %}{% if nothing_to_learn %}Skills{% else %}{{ chosen }}{% endif %} — {{ miniature.name }}{% endblock head_title %}
+{% block head_title %}{% if nothing_to_select %}Skills{% else %}{{ chosen }}{% endif %} — {{ miniature.name }}{% endblock head_title %}
 {% block nav_switcher %}
     {% gang_switcher gang as gang_switcher_ %}
     <c-n26.quick-switcher.of :switcher="gang_switcher_" hotkey="f" />
@@ -72,7 +72,7 @@ lands on: the model's own page, which is where the control leading here sits.
                 </c-ui.breadcrumbs.item>
             </c-ui.breadcrumbs>
         </c-slot>
-        {% if nothing_to_learn %}
+        {% if nothing_to_select %}
             {% comment %}
             Nobody has graded this fighter in a category, so no list is theirs
             to select from. The screen still exists — the address names the

--- a/n26/core/templates/n26/skills.html
+++ b/n26/core/templates/n26/skills.html
@@ -14,7 +14,7 @@ listing they browse keeps every unplaced set visible, but another house's sets
 are not theirs to select. A fighter whose grid names none of them gets the same
 page with a line where the list would be, and no act at the foot of it.
 
-Radios in a form, no script. A reader who leaves without clicking Save has
+Radios in a form, no script. A reader who leaves without clicking Select has
 changed nothing, and the footer offers the leaving to the same place a save
 lands on: the model's own page, which is where the control leading here sits.
 {% endcomment %}

--- a/n26/core/test_navigation.py
+++ b/n26/core/test_navigation.py
@@ -243,10 +243,10 @@ class TestWhichFightersAreListed:
         gang = make_gang("The Ashen Choir")
         here = hire(gang, "Vex")
         other = hire(gang, "Karn")
-        switcher = fighter_switcher(gang, here, route="n26-learn")
+        switcher = fighter_switcher(gang, here, route="n26-select")
         assert {item.href for item in switcher.items} == {
-            reverse("n26-learn", args=[here.pk]),
-            reverse("n26-learn", args=[other.pk]),
+            reverse("n26-select", args=[here.pk]),
+            reverse("n26-select", args=[other.pk]),
         }
         assert switcher.menu_label == "Select skills for another fighter"
 

--- a/n26/core/test_navigation.py
+++ b/n26/core/test_navigation.py
@@ -243,10 +243,10 @@ class TestWhichFightersAreListed:
         gang = make_gang("The Ashen Choir")
         here = hire(gang, "Vex")
         other = hire(gang, "Karn")
-        switcher = fighter_switcher(gang, here, route="n26-select")
+        switcher = fighter_switcher(gang, here, route="n26-skills")
         assert {item.href for item in switcher.items} == {
-            reverse("n26-select", args=[here.pk]),
-            reverse("n26-select", args=[other.pk]),
+            reverse("n26-skills", args=[here.pk]),
+            reverse("n26-skills", args=[other.pk]),
         }
         assert switcher.menu_label == "Select skills for another fighter"
 

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1288,7 +1288,7 @@ def test_what_a_fighter_is_gets_no_controls(client, tester, gang, fighter, house
     from n26.library.authoring import create_skill
 
     with operation(gang, actor=tester) as op:
-        op.learn(fighter, create_skill("Marksman"))
+        op.select(fighter, create_skill("Marksman"))
 
     client.force_login(tester)
     body = client.get(equip_url(fighter, house_list)).content.decode()

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -455,13 +455,13 @@ class TestWhatMayBeClickedOn:
         from n26.library.authoring import create_skill
 
         with operation(gang, actor=tester) as op:
-            learned = op.learn(fighter, create_skill("Marksman"))
+            selected = op.select(fighter, create_skill("Marksman"))
 
         client.force_login(tester)
-        assert client.post(url(route, learned)).status_code == 404
+        assert client.post(url(route, selected)).status_code == 404
 
-        learned.refresh_from_db()
-        assert learned.archived is False
+        selected.refresh_from_db()
+        assert selected.archived is False
         assert_reconciled(gang)
 
     def test_the_equip_page_offers_none_of_them_either(
@@ -475,7 +475,7 @@ class TestWhatMayBeClickedOn:
         from n26.library.authoring import create_skill
 
         with operation(gang, actor=tester) as op:
-            op.learn(fighter, create_skill("Marksman"))
+            op.select(fighter, create_skill("Marksman"))
 
         held = owned_things(build_card(fighter), AT)
         assert thing_key(sword.assignable) in held

--- a/n26/core/views/__init__.py
+++ b/n26/core/views/__init__.py
@@ -47,7 +47,6 @@ from n26.core.views.gangs import (
 )
 from n26.core.views.hire import hire_card, hire_fighter
 from n26.core.views.history import gang_history
-from n26.core.views.learn import learn
 from n26.core.views.options import fighter_options
 from n26.core.views.owned import (
     accessorise_assignment,
@@ -59,6 +58,7 @@ from n26.core.views.owned import (
     tally_counter,
 )
 from n26.core.views.printing import print_gang, print_setup
+from n26.core.views.select import select
 
 __all__ = [
     "accessorise_assignment",
@@ -94,7 +94,7 @@ __all__ = [
     "gangs",
     "hire_card",
     "hire_fighter",
-    "learn",
+    "select",
     "preview_view",
     "print_gang",
     "print_setup",

--- a/n26/core/views/__init__.py
+++ b/n26/core/views/__init__.py
@@ -58,7 +58,7 @@ from n26.core.views.owned import (
     tally_counter,
 )
 from n26.core.views.printing import print_gang, print_setup
-from n26.core.views.select import select
+from n26.core.views.skills import skills
 
 __all__ = [
     "accessorise_assignment",
@@ -94,7 +94,7 @@ __all__ = [
     "gangs",
     "hire_card",
     "hire_fighter",
-    "select",
+    "skills",
     "preview_view",
     "print_gang",
     "print_setup",

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -56,7 +56,7 @@ def _edit_state(own, computed, field):
     """
     from n26.core.effects import stands_whatever_happens
     from n26.core.models import Assignment, Reason
-    from n26.core.views.learn import _key
+    from n26.core.views.select import _key
 
     kind_class = Assignment._meta.get_field(field).related_model
     # The live library, as every player-facing offer reads it — an
@@ -124,7 +124,7 @@ def _edits_offer(own, computed, field, heading):
     appears in the list above once it is ticked.
     """
     from n26.core.render import ChoiceOffer, Choosable, ChoosableGroup
-    from n26.core.views.learn import _key
+    from n26.core.views.select import _key
 
     state = _edit_state(own, computed, field)
     current, rest = [], []
@@ -228,7 +228,7 @@ def _apply_edits(op, miniature, own, computed, field, ticked):
     ticked absence is added in the owner's name.
     """
     from n26.core.models import Reason
-    from n26.core.views.learn import _key
+    from n26.core.views.select import _key
 
     state = _edit_state(own, computed, field)
     added, taken, restored = [], [], []
@@ -285,8 +285,8 @@ def render_card_update(request, miniature, at):
     from n26.core.render import build_model_card
     from n26.core.views.choose import link_slots
     from n26.core.views.htmx import with_toasts
-    from n26.core.views.learn import link_skills
     from n26.core.views.owned import link_counters, link_possession_actions
+    from n26.core.views.select import link_skills
 
     gang = miniature.membership.gang
     own = build_card(miniature, with_statlines=True, with_options=True)
@@ -367,13 +367,13 @@ def edit_fighter(request, pk):
     from n26.core.views.choose import link_slots
     from n26.core.views.gangs import _fighter_named
     from n26.core.views.htmx import is_htmx, stay_or_redirect
-    from n26.core.views.learn import apply_ticks, link_skills, skills_offer
     from n26.core.views.owned import (
         accessorise_dialogs,
         link_counters,
         link_possession_actions,
         owned_dialog,
     )
+    from n26.core.views.select import apply_ticks, link_skills, skills_offer
 
     miniature = _own_miniature_or_404(request, pk)
     gang = miniature.membership.gang
@@ -399,7 +399,7 @@ def edit_fighter(request, pk):
         index = build_modifier_index([node.assignable for node in own.all_nodes()])
         try:
             with operation(gang, actor=request.user) as op:
-                learned, cleared = apply_ticks(
+                selected, cleared = apply_ticks(
                     op,
                     miniature,
                     own,
@@ -414,7 +414,7 @@ def edit_fighter(request, pk):
             N26Noun.MODEL,
             EventVerb.UPDATE,
             miniature,
-            learned=len(learned),
+            selected=len(selected),
             cleared=len(cleared),
         )
         # What moved, by name: a box ticked by mistake is easiest to spot
@@ -422,7 +422,7 @@ def edit_fighter(request, pk):
         moved = [
             phrase
             for phrase in (
-                f"selected {', '.join(learned)}" if learned else "",
+                f"selected {', '.join(selected)}" if selected else "",
                 f"lost {', '.join(cleared)}" if cleared else "",
             )
             if phrase

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -56,7 +56,7 @@ def _edit_state(own, computed, field):
     """
     from n26.core.effects import stands_whatever_happens
     from n26.core.models import Assignment, Reason
-    from n26.core.views.select import _key
+    from n26.core.views.skills import _key
 
     kind_class = Assignment._meta.get_field(field).related_model
     # The live library, as every player-facing offer reads it — an
@@ -124,7 +124,7 @@ def _edits_offer(own, computed, field, heading):
     appears in the list above once it is ticked.
     """
     from n26.core.render import ChoiceOffer, Choosable, ChoosableGroup
-    from n26.core.views.select import _key
+    from n26.core.views.skills import _key
 
     state = _edit_state(own, computed, field)
     current, rest = [], []
@@ -228,7 +228,7 @@ def _apply_edits(op, miniature, own, computed, field, ticked):
     ticked absence is added in the owner's name.
     """
     from n26.core.models import Reason
-    from n26.core.views.select import _key
+    from n26.core.views.skills import _key
 
     state = _edit_state(own, computed, field)
     added, taken, restored = [], [], []
@@ -286,7 +286,7 @@ def render_card_update(request, miniature, at):
     from n26.core.views.choose import link_slots
     from n26.core.views.htmx import with_toasts
     from n26.core.views.owned import link_counters, link_possession_actions
-    from n26.core.views.select import link_skills
+    from n26.core.views.skills import link_skills
 
     gang = miniature.membership.gang
     own = build_card(miniature, with_statlines=True, with_options=True)
@@ -373,7 +373,7 @@ def edit_fighter(request, pk):
         link_possession_actions,
         owned_dialog,
     )
-    from n26.core.views.select import apply_ticks, link_skills, skills_offer
+    from n26.core.views.skills import apply_ticks, link_skills, skills_offer
 
     miniature = _own_miniature_or_404(request, pk)
     gang = miniature.membership.gang

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -246,8 +246,8 @@ def gang_sheet(request, pk):
     from n26.core.owned import DIALOGS, EquipHost
     from n26.core.render import render_gang
     from n26.core.views.choose import link_slots
-    from n26.core.views.learn import link_skills
     from n26.core.views.owned import link_stash_actions, owned_dialog
+    from n26.core.views.select import link_skills
 
     gang = _any_gang_or_404(pk)
     yours = gang.owner_id == getattr(request.user, "id", None)

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -247,7 +247,7 @@ def gang_sheet(request, pk):
     from n26.core.render import render_gang
     from n26.core.views.choose import link_slots
     from n26.core.views.owned import link_stash_actions, owned_dialog
-    from n26.core.views.select import link_skills
+    from n26.core.views.skills import link_skills
 
     gang = _any_gang_or_404(pk)
     yours = gang.owner_id == getattr(request.user, "id", None)

--- a/n26/core/views/select.py
+++ b/n26/core/views/select.py
@@ -23,7 +23,7 @@ than the gap: it is theirs whether or not anybody has graded them, so
 the switcher on the next fighter's screen can offer it without knowing
 which of them have a grid.
 
-What clicking writes is usually ``Operation.learn``: free, recorded, and
+What clicking writes is usually ``Operation.select``: free, recorded, and
 caused by nothing, so what a fighter earned survives the assignment that
 opened the set up to them.
 
@@ -78,13 +78,13 @@ def link_skills(*cards, among=None):
     """
     from n26.core.access import model_collections
 
-    learnable = {
+    selectable = {
         str(collection.pk)
         for collection in (model_collections() if among is None else among)
     }
     for card in cards:
-        if card.id and set(card.placed_in) & learnable:
-            card.learn_href = reverse("n26-learn", args=[card.id])
+        if card.id and set(card.placed_in) & selectable:
+            card.select_href = reverse("n26-select", args=[card.id])
 
 
 def _key(thing):
@@ -325,10 +325,10 @@ def _answer_with(op, miniature, thing, questions, lists):
     """
     slot = _question_for(thing, questions, lists)
     if slot is None:
-        return op.learn(miniature, thing)
+        return op.select(miniature, thing)
     anchor = getattr(slot.anchor, "assignment", None)
     if anchor is None:
-        return op.learn(miniature, thing)
+        return op.select(miniature, thing)
     questions.remove(slot)
     host = {}
     if getattr(slot.anchor, "broadcast", False):
@@ -379,7 +379,7 @@ def apply_ticks(op, miniature, card, computed, ticked):
     # Removals first: clearing the skill that answered a question opens
     # it again, so a replacement ticked in the same save can answer it
     # rather than land as a second starting skill beside a fresh Choose.
-    learned, cleared = [], []
+    selected, cleared = [], []
     for key, option in options.items():
         if key in granted or key in ticked or key not in rows:
             continue
@@ -395,8 +395,8 @@ def apply_ticks(op, miniature, card, computed, ticked):
             continue
         if key in ticked and key not in rows:
             _answer_with(op, miniature, option.thing, questions, lists)
-            learned.append(option.name)
-    return learned, cleared
+            selected.append(option.name)
+    return selected, cleared
 
 
 def _known_on(card):
@@ -431,7 +431,7 @@ def _marked(offer, known):
 
 
 @login_required
-def learn(request, pk):
+def select(request, pk):
     """What this fighter may select, and the click that selects it.
 
     GET asks and writes nothing. POST names one thing from the list the
@@ -448,7 +448,7 @@ def learn(request, pk):
     Marksman" is a bug however honestly it got there.
     """
     from n26.analytics import EventVerb, N26Noun, record
-    from n26.core.access import learnable_for
+    from n26.core.access import selectable_for
     from n26.core.browse import (
         EQUIPMENT_LIST,
         browse,
@@ -481,7 +481,7 @@ def learn(request, pk):
     # it. The gang is still the breadcrumb's parent, one step further up.
     their_page = reverse("n26-edit-fighter", args=[miniature.pk])
 
-    collections = learnable_for(computed)
+    collections = selectable_for(computed)
     if not collections:
         # Nobody has graded this fighter in a category, so there is
         # nothing they could select — a gap in the content, and a page
@@ -489,11 +489,11 @@ def learn(request, pk):
         # switcher every other fighter's skills screen draws.
         return render(
             request,
-            "n26/learn.html",
+            "n26/select.html",
             {
                 "gang": gang,
                 "miniature": miniature,
-                "nothing_to_learn": True,
+                "nothing_to_select": True,
                 "action": request.path,
                 "back": back,
                 "their_page": their_page,
@@ -559,7 +559,7 @@ def learn(request, pk):
             with operation(gang, actor=request.user) as op:
                 questions = _open_questions(computed)
                 lists = {id(slot): _offered_keys(slot, computed) for slot in questions}
-                learned = _answer_with(op, miniature, picked.thing, questions, lists)
+                selected = _answer_with(op, miniature, picked.thing, questions, lists)
         except Refusal as refusal:
             messages.error(request, str(refusal))
             return redirect(here)
@@ -567,7 +567,7 @@ def learn(request, pk):
             request,
             N26Noun.ASSIGNMENT,
             EventVerb.CREATE,
-            learned,
+            selected,
             gang_id=str(gang.pk),
             miniature_id=str(miniature.pk),
             thing=picked.name,
@@ -578,11 +578,11 @@ def learn(request, pk):
 
     return render(
         request,
-        "n26/learn.html",
+        "n26/select.html",
         {
             "gang": gang,
             "miniature": miniature,
-            "nothing_to_learn": False,
+            "nothing_to_select": False,
             "chosen": chosen,
             "offer": offer,
             "action": here,

--- a/n26/core/views/skills.py
+++ b/n26/core/views/skills.py
@@ -84,7 +84,7 @@ def link_skills(*cards, among=None):
     }
     for card in cards:
         if card.id and set(card.placed_in) & selectable:
-            card.select_href = reverse("n26-select", args=[card.id])
+            card.skills_href = reverse("n26-skills", args=[card.id])
 
 
 def _key(thing):
@@ -431,7 +431,7 @@ def _marked(offer, known):
 
 
 @login_required
-def select(request, pk):
+def skills(request, pk):
     """What this fighter may select, and the click that selects it.
 
     GET asks and writes nothing. POST names one thing from the list the
@@ -489,7 +489,7 @@ def select(request, pk):
         # switcher every other fighter's skills screen draws.
         return render(
             request,
-            "n26/select.html",
+            "n26/skills.html",
             {
                 "gang": gang,
                 "miniature": miniature,
@@ -578,7 +578,7 @@ def select(request, pk):
 
     return render(
         request,
-        "n26/select.html",
+        "n26/skills.html",
         {
             "gang": gang,
             "miniature": miniature,

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1487,7 +1487,7 @@ def model_card():
         # This fighter has a grid, so there is a screen of what she may select
         # and the Skills row carries the way to it. A card with no grid — and
         # every card on a print sheet — leaves this empty and draws nothing.
-        select_href="#",
+        skills_href="#",
         # A Wyrd's powers, which are not skills. Drawn apart on the card
         # because the rules treat them apart, even though they are chosen the
         # same way — see ModelCard.powers.

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1487,7 +1487,7 @@ def model_card():
         # This fighter has a grid, so there is a screen of what she may select
         # and the Skills row carries the way to it. A card with no grid — and
         # every card on a print sheet — leaves this empty and draws nothing.
-        learn_href="#",
+        select_href="#",
         # A Wyrd's powers, which are not skills. Drawn apart on the card
         # because the rules treat them apart, even though they are chosen the
         # same way — see ModelCard.powers.

--- a/n26/tests/sandbox/actions.py
+++ b/n26/tests/sandbox/actions.py
@@ -312,13 +312,13 @@ def leave_trading_post(gang, actor=None):
         return op.leave_trading_post()
 
 
-def learn(miniature, thing, actor=None, note=""):
+def select(miniature, thing, actor=None, note=""):
     """Take on a skill or a power — free, and nothing causes it."""
     from n26.core.operations import operation
 
     gang = miniature.gang
     with operation(gang, actor=actor or gang.owner) as op:
-        return op.learn(miniature, thing, note=note)
+        return op.select(miniature, thing, note=note)
 
 
 def tally(assignment, change, actor=None, note=""):

--- a/n26/tests/sandbox/test_builtin_backfill.py
+++ b/n26/tests/sandbox/test_builtin_backfill.py
@@ -40,8 +40,8 @@ from n26.tests.sandbox.actions import (
     found_gang,
     hire,
     hire_with_option,
-    learn,
     offer_option,
+    select,
     sell,
 )
 
@@ -389,7 +389,7 @@ class TestWhatTheOwnerAlreadySettled:
         fighter = hire(gang, ganger, "Ana", paid=50)
         strip_provenance(gang)
         nerves = create_skill("Nerves of Steel")
-        learn(fighter, nerves)
+        select(fighter, nerves)
         member = add_built_in(ganger, nerves)
         rating = settled(gang).rating
 

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -1102,15 +1102,15 @@ def _gang_url(gang):
 
 
 def _skills_url(miniature):
-    return reverse("n26-select", args=[miniature.pk])
+    return reverse("n26-skills", args=[miniature.pk])
 
 
-def _select_views():
-    """The select *module* — ``n26.core.views.select`` is the view function
+def _skills_views():
+    """The skills *module* — ``n26.core.views.skills`` is the view function
     on the package, which shadows the submodule for a normal import."""
     import importlib
 
-    return importlib.import_module("n26.core.views.select")
+    return importlib.import_module("n26.core.views.skills")
 
 
 class TestAnsweringDoesNotTouchTheReadPath:
@@ -1137,11 +1137,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_reading_the_edit_page_does_not_build_the_choose_list(
         self, client, player, leader_yolanda, monkeypatch
     ):
-        select_views = _select_views()
+        skills_views = _skills_views()
 
         calls = []
         monkeypatch.setattr(
-            select_views,
+            skills_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )
@@ -1152,11 +1152,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_reading_the_gang_sheet_does_not_build_the_choose_list(
         self, client, player, leader_yolanda, monkeypatch
     ):
-        select_views = _select_views()
+        skills_views = _skills_views()
 
         calls = []
         monkeypatch.setattr(
-            select_views,
+            skills_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )
@@ -1167,11 +1167,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_reading_the_skills_screen_does_not_build_the_choose_list(
         self, client, player, leader_yolanda, monkeypatch
     ):
-        select_views = _select_views()
+        skills_views = _skills_views()
 
         calls = []
         monkeypatch.setattr(
-            select_views,
+            skills_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )
@@ -1182,9 +1182,9 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_saving_a_tick_builds_the_choose_list_once(
         self, client, player, leader_yolanda, library, monkeypatch
     ):
-        select_views = _select_views()
+        skills_views = _skills_views()
 
-        real = select_views._offered_keys
+        real = skills_views._offered_keys
         calls = []
 
         def counted(*args, **kwargs):
@@ -1192,7 +1192,7 @@ class TestAnsweringDoesNotTouchTheReadPath:
             calls.append(result)
             return result
 
-        monkeypatch.setattr(select_views, "_offered_keys", counted)
+        monkeypatch.setattr(skills_views, "_offered_keys", counted)
         client.force_login(player)
         post_skills(client, leader_yolanda, library["skills"]["Catfall"])
         assert len(calls) == 1
@@ -1204,9 +1204,9 @@ class TestAnsweringDoesNotTouchTheReadPath:
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
-        select_views = _select_views()
+        skills_views = _skills_views()
 
-        real = select_views._offered_keys
+        real = skills_views._offered_keys
         counts = []
 
         def wrapped(*args, **kwargs):
@@ -1215,7 +1215,7 @@ class TestAnsweringDoesNotTouchTheReadPath:
             counts.append(len(captured.captured_queries))
             return result
 
-        monkeypatch.setattr(select_views, "_offered_keys", wrapped)
+        monkeypatch.setattr(skills_views, "_offered_keys", wrapped)
         extras = [
             create_skill(f"Trick {index}", category=sets["agility"], position=index)
             for index in range(10, 18)
@@ -1243,11 +1243,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
-        select_views = _select_views()
+        skills_views = _skills_views()
 
         calls = []
         monkeypatch.setattr(
-            select_views,
+            skills_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )

--- a/n26/tests/sandbox/test_editing_skills.py
+++ b/n26/tests/sandbox/test_editing_skills.py
@@ -54,11 +54,11 @@ from n26.tests.sandbox.actions import (
     create_subtype,
     found_gang,
     hire_with_option,
-    learn,
     modifier,
     offers_choice,
     places,
     section_of,
+    select,
     targets_model,
 )
 
@@ -284,7 +284,7 @@ class TestWhatTheSquareShows:
     def test_what_she_already_knows_arrives_ticked(
         self, client, player, yolanda, library
     ):
-        learn(yolanda, library["skills"]["Catfall"])
+        select(yolanda, library["skills"]["Catfall"])
         client.force_login(player)
         page = client.get(edit_url(yolanda)).content.decode()
 
@@ -357,8 +357,8 @@ class TestWhatTheSquareShows:
             carried_by=keen,
         )
         assign(keen, miniature=yolanda)
-        learn(yolanda, library["skills"]["Connected"])
-        learn(yolanda, library["skills"]["Dodge"])
+        select(yolanda, library["skills"]["Connected"])
+        select(yolanda, library["skills"]["Dodge"])
         client.force_login(player)
         page = client.get(edit_url(yolanda)).content.decode()
 
@@ -473,7 +473,7 @@ class TestTheRestOfTheLibrary:
     ):
         """And the other half of it, which the narrower listing could
         not do at all: what was selected can be taken away."""
-        learn(yolanda, library["skills"]["Bull Charge"])
+        select(yolanda, library["skills"]["Bull Charge"])
         client.force_login(player)
         post_skills(client, yolanda, tab=ALL_SETS)
 
@@ -486,7 +486,7 @@ class TestTheRestOfTheLibrary:
         """Held, so it is theirs whatever the placements say — and it is
         drawn where they will look for it rather than a tab away, since
         the reader wanting to clear it is looking at what she has."""
-        learn(yolanda, library["skills"]["Bull Charge"])
+        select(yolanda, library["skills"]["Bull Charge"])
         client.force_login(player)
         offer = offer_on(client, yolanda, OWN_SETS)
 
@@ -497,7 +497,7 @@ class TestTheRestOfTheLibrary:
         """Drawn among their own, it is off the panel: a box and a
         search row for the same skill would be two controls settling one
         thing."""
-        learn(yolanda, library["skills"]["Bull Charge"])
+        select(yolanda, library["skills"]["Bull Charge"])
         client.force_login(player)
         offered = {option.name for option in more_on(client, yolanda, OWN_SETS)}
 
@@ -595,7 +595,7 @@ class TestSavingTheSquare:
     ):
         """The row is archived rather than deleted — the ledger goes on
         saying she once had it — so what the card shows is what changed."""
-        learn(yolanda, library["skills"]["Catfall"])
+        select(yolanda, library["skills"]["Catfall"])
         client.force_login(player)
         post_skills(client, yolanda)
 
@@ -607,8 +607,8 @@ class TestSavingTheSquare:
     ):
         """Two she knows and one box cleared: settling the whole list must
         not take away the one nobody touched."""
-        learn(yolanda, library["skills"]["Catfall"])
-        learn(yolanda, library["skills"]["Connected"])
+        select(yolanda, library["skills"]["Catfall"])
+        select(yolanda, library["skills"]["Connected"])
         client.force_login(player)
         post_skills(client, yolanda, library["skills"]["Connected"])
 
@@ -621,7 +621,7 @@ class TestSavingTheSquare:
         """A duplicate skill means nothing in the game, and a card reading
         "Catfall, Catfall" is a bug however honestly each row was
         written."""
-        learn(yolanda, library["skills"]["Catfall"])
+        select(yolanda, library["skills"]["Catfall"])
         client.force_login(player)
         post_skills(client, yolanda, library["skills"]["Catfall"])
 
@@ -676,7 +676,7 @@ class TestSavingTheSquare:
 
         thalia = hire_with_option(gang, gang_sister, "Thalia")
         badge = assign(wyrd, miniature=thalia)
-        learn(thalia, library["powers"]["Terrify"])
+        select(thalia, library["powers"]["Terrify"])
         remove(badge)
 
         client.force_login(player)
@@ -854,7 +854,7 @@ class TestAnOpenStartingSkill:
         assert held_by(leader_yolanda) == []
         assert_reconciled(gang)
 
-    def test_keeping_the_starting_skill_and_ticking_another_learns_the_extra(
+    def test_keeping_the_starting_skill_and_ticking_another_selects_the_extra(
         self, client, player, gang, leader_yolanda, library
     ):
         catfall = library["skills"]["Catfall"]
@@ -1084,13 +1084,13 @@ class TestTheQueryBudget:
             return len(captured.captured_queries)
 
         for skill in stock[:2]:
-            learn(yolanda, skill)
+            select(yolanda, skill)
         # The first reading pays one-time caches that no later one does.
         measure()
         few = measure()
 
         for skill in stock[2:]:
-            learn(yolanda, skill)
+            select(yolanda, skill)
         many = measure()
 
         assert few == many, f"{few} queries knowing 2, {many} knowing 8"
@@ -1102,15 +1102,15 @@ def _gang_url(gang):
 
 
 def _skills_url(miniature):
-    return reverse("n26-learn", args=[miniature.pk])
+    return reverse("n26-select", args=[miniature.pk])
 
 
-def _learn_views():
-    """The learn *module* — ``n26.core.views.learn`` is the view function
+def _select_views():
+    """The select *module* — ``n26.core.views.select`` is the view function
     on the package, which shadows the submodule for a normal import."""
     import importlib
 
-    return importlib.import_module("n26.core.views.learn")
+    return importlib.import_module("n26.core.views.select")
 
 
 class TestAnsweringDoesNotTouchTheReadPath:
@@ -1137,11 +1137,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_reading_the_edit_page_does_not_build_the_choose_list(
         self, client, player, leader_yolanda, monkeypatch
     ):
-        learn_views = _learn_views()
+        select_views = _select_views()
 
         calls = []
         monkeypatch.setattr(
-            learn_views,
+            select_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )
@@ -1152,11 +1152,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_reading_the_gang_sheet_does_not_build_the_choose_list(
         self, client, player, leader_yolanda, monkeypatch
     ):
-        learn_views = _learn_views()
+        select_views = _select_views()
 
         calls = []
         monkeypatch.setattr(
-            learn_views,
+            select_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )
@@ -1167,11 +1167,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_reading_the_skills_screen_does_not_build_the_choose_list(
         self, client, player, leader_yolanda, monkeypatch
     ):
-        learn_views = _learn_views()
+        select_views = _select_views()
 
         calls = []
         monkeypatch.setattr(
-            learn_views,
+            select_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )
@@ -1182,9 +1182,9 @@ class TestAnsweringDoesNotTouchTheReadPath:
     def test_saving_a_tick_builds_the_choose_list_once(
         self, client, player, leader_yolanda, library, monkeypatch
     ):
-        learn_views = _learn_views()
+        select_views = _select_views()
 
-        real = learn_views._offered_keys
+        real = select_views._offered_keys
         calls = []
 
         def counted(*args, **kwargs):
@@ -1192,7 +1192,7 @@ class TestAnsweringDoesNotTouchTheReadPath:
             calls.append(result)
             return result
 
-        monkeypatch.setattr(learn_views, "_offered_keys", counted)
+        monkeypatch.setattr(select_views, "_offered_keys", counted)
         client.force_login(player)
         post_skills(client, leader_yolanda, library["skills"]["Catfall"])
         assert len(calls) == 1
@@ -1204,9 +1204,9 @@ class TestAnsweringDoesNotTouchTheReadPath:
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
-        learn_views = _learn_views()
+        select_views = _select_views()
 
-        real = learn_views._offered_keys
+        real = select_views._offered_keys
         counts = []
 
         def wrapped(*args, **kwargs):
@@ -1215,7 +1215,7 @@ class TestAnsweringDoesNotTouchTheReadPath:
             counts.append(len(captured.captured_queries))
             return result
 
-        monkeypatch.setattr(learn_views, "_offered_keys", wrapped)
+        monkeypatch.setattr(select_views, "_offered_keys", wrapped)
         extras = [
             create_skill(f"Trick {index}", category=sets["agility"], position=index)
             for index in range(10, 18)
@@ -1243,11 +1243,11 @@ class TestAnsweringDoesNotTouchTheReadPath:
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
-        learn_views = _learn_views()
+        select_views = _select_views()
 
         calls = []
         monkeypatch.setattr(
-            learn_views,
+            select_views,
             "_offered_keys",
             lambda *args, **kwargs: calls.append(1) or frozenset(),
         )

--- a/n26/tests/sandbox/test_selecting_skills.py
+++ b/n26/tests/sandbox/test_selecting_skills.py
@@ -144,7 +144,7 @@ def computed_for(miniature):
 
 
 def skills_url(miniature):
-    return reverse("n26-select", args=[miniature.pk])
+    return reverse("n26-skills", args=[miniature.pk])
 
 
 def edit_url(miniature):
@@ -285,8 +285,8 @@ class TestTheWordForIt:
         ]
 
         for body in pages:
-            # Only drawn text is swept: a class name or an id is code, not
-            # words anybody reads.
+            # Only text between tags is swept. Attribute values — a class,
+            # an id, an aria-label — are stripped with the tag around them.
             drawn = re.sub(r"<[^>]*>", " ", body)
             assert not re.search(r"\blearn(s|ed|ing)?\b", drawn, re.IGNORECASE)
 
@@ -737,7 +737,7 @@ class TestTheSkillsRow:
     ):
         from n26.core.render import render_gang
         from n26.core.views.choose import link_slots
-        from n26.core.views.select import link_skills
+        from n26.core.views.skills import link_skills
 
         gang = leader_yolanda.gang
         sheet = render_gang(gang)
@@ -745,19 +745,19 @@ class TestTheSkillsRow:
         link_skills(*sheet.models)
 
         (card,) = sheet.models
-        assert card.select_href == skills_url(leader_yolanda)
+        assert card.skills_href == skills_url(leader_yolanda)
         assert card.skill_choices[0].href.startswith(
             reverse("n26-gang", args=[gang.pk])
         )
 
     def test_a_gridless_fighter_gets_no_way_in(self, gang, gridless, catalogue):
         from n26.core.render import render_gang
-        from n26.core.views.select import link_skills
+        from n26.core.views.skills import link_skills
 
         hire_with_option(gang, gridless, "Nobody")
         sheet = render_gang(gang)
         link_skills(*sheet.models)
 
         (card,) = sheet.models
-        assert card.select_href == ""
+        assert card.skills_href == ""
         assert card.skill_choices == []

--- a/n26/tests/sandbox/test_selecting_skills.py
+++ b/n26/tests/sandbox/test_selecting_skills.py
@@ -21,7 +21,7 @@ import pytest
 from django.contrib.auth.models import User
 from django.urls import reverse
 
-from n26.core.access import learnable_for, model_collections
+from n26.core.access import model_collections, selectable_for
 from n26.core.card import build_card, build_modifier_index
 from n26.core.effects import compute
 from n26.core.models import Reason
@@ -40,12 +40,12 @@ from n26.tests.sandbox.actions import (
     create_wargear,
     found_gang,
     hire_with_option,
-    learn,
     modifier,
     offers_choice,
     places,
     remove,
     section_of,
+    select,
     targets_model,
 )
 
@@ -144,7 +144,7 @@ def computed_for(miniature):
 
 
 def skills_url(miniature):
-    return reverse("n26-learn", args=[miniature.pk])
+    return reverse("n26-select", args=[miniature.pk])
 
 
 def edit_url(miniature):
@@ -165,11 +165,11 @@ class TestTheGridIsTheAccess:
     collection where their placements name one of its sections."""
 
     def test_a_graded_fighter_reaches_the_collection(self, yolanda, catalogue):
-        assert learnable_for(computed_for(yolanda)) == [catalogue]
+        assert selectable_for(computed_for(yolanda)) == [catalogue]
 
     def test_a_fighter_with_no_grid_reaches_nothing(self, gang, gridless, catalogue):
         nobody = hire_with_option(gang, gridless, "Nobody")
-        assert learnable_for(computed_for(nobody)) == []
+        assert selectable_for(computed_for(nobody)) == []
 
     def test_a_wargear_that_places_a_set_opens_the_collection(
         self, gang, gridless, sets, tiers, catalogue
@@ -185,16 +185,16 @@ class TestTheGridIsTheAccess:
         )
         nobody = hire_with_option(gang, gridless, "Nobody")
         carried = assign(manual, miniature=nobody)
-        assert learnable_for(computed_for(nobody)) == [catalogue]
+        assert selectable_for(computed_for(nobody)) == [catalogue]
 
         remove(carried)
-        assert learnable_for(computed_for(nobody)) == []
+        assert selectable_for(computed_for(nobody)) == []
 
     def test_a_gear_collection_is_never_selectable(
         self, gang, gang_sister, sets, catalogue
     ):
         """A placement may aim at any collection's schema, including an
-        equipment list's. Learning is about what a model *is*, so a list
+        equipment list's. Selecting is about what a model *is*, so a list
         of gear never becomes a skills screen however it is placed."""
         gear_list = create_collection("House List", contains=[Wargear])
         gear_primary = section_of(gear_list, "Primary", 0)
@@ -209,7 +209,7 @@ class TestTheGridIsTheAccess:
         fighter = hire_with_option(gang, gang_sister, "Yolanda")
         assign(badge, miniature=fighter)
 
-        assert gear_list not in learnable_for(computed_for(fighter))
+        assert gear_list not in selectable_for(computed_for(fighter))
         assert gear_list not in model_collections()
 
     def test_asking_the_roster_costs_one_query(
@@ -228,7 +228,7 @@ class TestTheGridIsTheAccess:
         with CaptureQueriesContext(connection) as captured:
             among = model_collections()
             for one in computed:
-                assert learnable_for(one, among=among) == [catalogue]
+                assert selectable_for(one, among=among) == [catalogue]
         assert len(captured.captured_queries) == 1
 
 
@@ -274,7 +274,7 @@ class TestTheWordForIt:
 
         assert 'aria-label="Select a skill"' in body
 
-    def test_no_surface_still_says_learn(self, client, player, yolanda, library):
+    def test_no_surface_says_learn(self, client, player, yolanda, library):
         """A discovering check rather than a list: every rendered word of
         this feature is swept, so a surface added later cannot quietly
         reintroduce the old verb."""
@@ -285,8 +285,8 @@ class TestTheWordForIt:
         ]
 
         for body in pages:
-            # The href and the URL name keep "learn" — those are code, not
-            # words anybody reads. Only drawn text is swept.
+            # Only drawn text is swept: a class name or an id is code, not
+            # words anybody reads.
             drawn = re.sub(r"<[^>]*>", " ", body)
             assert not re.search(r"\blearn(s|ed|ing)?\b", drawn, re.IGNORECASE)
 
@@ -351,7 +351,7 @@ class TestWhatTheScreenShows:
     def test_what_she_already_knows_is_said_rather_than_withheld(
         self, client, player, yolanda, library
     ):
-        learn(yolanda, library["skills"]["Catfall"])
+        select(yolanda, library["skills"]["Catfall"])
         client.force_login(player)
         offer = client.get(skills_url(yolanda)).context["offer"]
 
@@ -550,7 +550,7 @@ class TestSelecting:
         "Marksman, Marksman" is a bug however honestly each row was
         written."""
         catfall = library["skills"]["Catfall"]
-        learn(yolanda, catfall)
+        select(yolanda, catfall)
         client.force_login(player)
         response = client.post(
             skills_url(yolanda),
@@ -579,10 +579,10 @@ class TestSelecting:
 
     def test_it_costs_nothing_and_is_recorded_as_a_reward(self, gang, yolanda, library):
         before = gang.credits
-        learned = learn(yolanda, library["skills"]["Catfall"])
+        selected = select(yolanda, library["skills"]["Catfall"])
 
-        assert learned.ledger_entry.paid == 0
-        assert learned.ledger_entry.reason == Reason.REWARD
+        assert selected.ledger_entry.paid == 0
+        assert selected.ledger_entry.reason == Reason.REWARD
         gang.refresh_from_db()
         assert gang.credits == before
         assert_reconciled(gang)
@@ -593,8 +593,8 @@ class TestSelecting:
         plain = create_skill("Spring Up", category=sets["agility"], position=9)
         dear = create_power("Ember Storm", "Double", category=sets["powers"], price=30)
 
-        assert learn(yolanda, plain).ledger_entry.rating_contribution == 0
-        assert learn(yolanda, dear).ledger_entry.rating_contribution == 30
+        assert select(yolanda, plain).ledger_entry.rating_contribution == 0
+        assert select(yolanda, dear).ledger_entry.rating_contribution == 30
         gang.refresh_from_db()
         assert gang.rating == 55 + 30
         assert_reconciled(gang)
@@ -613,17 +613,17 @@ class TestSelecting:
             carried_by=legacy,
         )
         carried = add_legacy_profile(yolanda, legacy)
-        learned = learn(yolanda, library["skills"]["Bull Charge"])
+        selected = select(yolanda, library["skills"]["Bull Charge"])
 
         remove(carried)
         yolanda.refresh_from_db()
-        learned.refresh_from_db()
-        assert learned.archived is False
+        selected.refresh_from_db()
+        assert selected.archived is False
         assert "Bull Charge" in [line.name for line in card_for(yolanda).skills]
         assert_reconciled(gang)
 
     def test_a_selected_power_draws_on_the_powers_row(self, yolanda, library):
-        learn(yolanda, library["powers"]["Terrify"])
+        select(yolanda, library["powers"]["Terrify"])
         card = card_for(yolanda)
         assert [line.name for line in card.powers] == ["Terrify (Double)"]
         assert card.skills == []
@@ -737,7 +737,7 @@ class TestTheSkillsRow:
     ):
         from n26.core.render import render_gang
         from n26.core.views.choose import link_slots
-        from n26.core.views.learn import link_skills
+        from n26.core.views.select import link_skills
 
         gang = leader_yolanda.gang
         sheet = render_gang(gang)
@@ -745,19 +745,19 @@ class TestTheSkillsRow:
         link_skills(*sheet.models)
 
         (card,) = sheet.models
-        assert card.learn_href == skills_url(leader_yolanda)
+        assert card.select_href == skills_url(leader_yolanda)
         assert card.skill_choices[0].href.startswith(
             reverse("n26-gang", args=[gang.pk])
         )
 
     def test_a_gridless_fighter_gets_no_way_in(self, gang, gridless, catalogue):
         from n26.core.render import render_gang
-        from n26.core.views.learn import link_skills
+        from n26.core.views.select import link_skills
 
         hire_with_option(gang, gridless, "Nobody")
         sheet = render_gang(gang)
         link_skills(*sheet.models)
 
         (card,) = sheet.models
-        assert card.learn_href == ""
+        assert card.select_href == ""
         assert card.skill_choices == []

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -1251,7 +1251,7 @@ class TestTheSiteBanner:
         fighter = hire_with_option(gang, profile, "Yolanda")
 
         live_banner()
-        skills_url = reverse("n26-learn", args=[fighter.pk])
+        skills_url = reverse("n26-select", args=[fighter.pk])
         body = client.get(skills_url).content.decode()
 
         # The page is the one that holds an `action`, and its form still

--- a/n26/tests/test_platform_integration.py
+++ b/n26/tests/test_platform_integration.py
@@ -1251,7 +1251,7 @@ class TestTheSiteBanner:
         fighter = hire_with_option(gang, profile, "Yolanda")
 
         live_banner()
-        skills_url = reverse("n26-select", args=[fighter.pk])
+        skills_url = reverse("n26-skills", args=[fighter.pk])
         body = client.get(skills_url).content.decode()
 
         # The page is the one that holds an `action`, and its form still

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -118,8 +118,8 @@ urlpatterns = [
     path("fighters/<str:pk>/refund/", views.refund_fighter, name="n26-refund-fighter"),
     path("fighters/<str:pk>/equip/", views.equip, name="n26-equip"),
     # Addressed by fighter, not by slot: what they may select is their
-    # grid rather than a question anybody asked — see n26.core.views.learn.
-    path("fighters/<str:pk>/skills/", views.learn, name="n26-learn"),
+    # grid rather than a question anybody asked — see n26.core.views.select.
+    path("fighters/<str:pk>/skills/", views.select, name="n26-select"),
     # What a gang already owns, addressed by the assignment rather than by
     # whoever is carrying it: the same acts serve a fighter's card, a
     # weapon's ammo and the stash, and every screen that grows them later

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -118,8 +118,8 @@ urlpatterns = [
     path("fighters/<str:pk>/refund/", views.refund_fighter, name="n26-refund-fighter"),
     path("fighters/<str:pk>/equip/", views.equip, name="n26-equip"),
     # Addressed by fighter, not by slot: what they may select is their
-    # grid rather than a question anybody asked — see n26.core.views.select.
-    path("fighters/<str:pk>/skills/", views.select, name="n26-select"),
+    # grid rather than a question anybody asked — see n26.core.views.skills.
+    path("fighters/<str:pk>/skills/", views.skills, name="n26-skills"),
     # What a gang already owns, addressed by the assignment rather than by
     # whoever is carrying it: the same acts serve a fighter's card, a
     # weapon's ammo and the stash, and every screen that grows them later


### PR DESCRIPTION
Closes #2379

The microcopy vocabulary bans "learn" for skills: a model selects a skill. The player copy and the URL path (`/fighters/<pk>/skills/`) already said so, but the code around them still said learn, so anyone editing it was invited to write the banned word back into a string.

This renames the identifiers only. Nothing a player sees changes.

The verb goes where a verb is wanted:

- `Operation.learn` → `Operation.select`
- `learnable_for` → `selectable_for`
- sandbox helper `actions.learn` → `actions.select`; `test_learning_skills.py` → `test_selecting_skills.py`
- the analytics property recorded on the edit page's skills update is now `selected` rather than `learned`

The screen is named by its noun, matching its path and every sibling fighter route, and keeping clear of the selector-grammar module `n26.core.select` that forty-one files import by that bare name:

- `n26/core/views/learn.py` → `skills.py`, and the view `learn` → `skills`
- route name `n26-learn` → `n26-skills` (the path is unchanged)
- template `n26/learn.html` → `n26/skills.html`
- `ModelCard.learn_href` → `skills_href`, `nothing_to_learn` → `nothing_to_select`

The gang history describes an old event through the assignment and its slot type's name, neither of which this touches, so already-written history reads the same.

Checked: n26 suite passes (4,592 tests). `test_selling_is_the_act_in_the_open_and_the_rest_share_a_chevron` in the listing tests fails identically on `main`, so it is unrelated. `scripts/check_microcopy.py` no longer flags "learn" in any touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8epw69qrh6pHegMxbUqz7
