### PR TITLE
feat: attach one modifier to several things from a kind's listing

### DIFF
--- a/n26/library/templates/authoring/_leaf_table.html
+++ b/n26/library/templates/authoring/_leaf_table.html
@@ -1,0 +1,30 @@
+{% comment %}
+The rows of one kind's listing. Takes `rows` and `bulk`; with `bulk` each
+row leads with a box to tick, and the table sits inside the form the
+boxes submit through.
+{% endcomment %}
+<c-ui.table>
+    <tbody>
+        {% for row in rows %}
+            {# :hidden rather than x-show: a table row's own display value is not `block`. #}
+            <tr x-data="{ haystack: '{{ row.search|escapejs }}' }"
+                x-init="register(haystack)"
+                :hidden="!matches(haystack)">
+                {% if bulk %}
+                    <td class="w-0 pr-0">
+                        <input type="checkbox"
+                               name="pk"
+                               value="{{ row.pk }}"
+                               aria-label="Select {{ row.label }}"
+                               class="size-4 accent-[var(--color-accent)] focus-ring">
+                    </td>
+                {% endif %}
+                {% include "authoring/_name_cell.html" with row=row %}
+                {# The author's own note reads as one more thing the row says about itself. #}
+                <td class="w-full text-muted">
+                    {{ row.notes|join:" · " }}{% if row.notes and row.help %} · {% endif %}{{ row.help }}
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</c-ui.table>

--- a/n26/library/templates/authoring/attach_modifier.html
+++ b/n26/library/templates/authoring/attach_modifier.html
@@ -1,0 +1,61 @@
+{% extends "authoring/base.html" %}
+{% comment %}
+One modifier onto several things of a kind, at an address of its own.
+The listing's ticked rows arrive in the query string and are listed
+back so the author can see what they picked; the post carries them as
+hidden fields. Nothing changes until the form posts.
+{% endcomment %}
+{% block head_title %}
+    Attach a modifier
+{% endblock head_title %}
+{% block content %}
+    <c-n26.form-page action="{% url 'authoring-attach-modifier' kind %}"
+                     title="Attach a modifier to {{ count }} {{ noun }}"
+                     lead="This attaches the modifier to each {{ verbose_name }} below. One that already carries it is left as it is."
+                     submit_label="Attach to {{ count }} {{ noun }}"
+                     cancel_url="{% url 'authoring-leaf' kind %}">
+        <c-slot name="breadcrumb">
+            <c-ui.breadcrumbs>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Content library</c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' kind %}">
+                    {{ verbose_name_plural|capfirst }}
+                </c-ui.breadcrumbs.item>
+                <c-ui.breadcrumbs.item :current="True">
+                    Attach a modifier
+                </c-ui.breadcrumbs.item>
+            </c-ui.breadcrumbs>
+        </c-slot>
+        {% csrf_token %}
+        {% for row in rows %}
+            <input type="hidden" name="pk" value="{{ row.pk }}">
+        {% endfor %}
+        <c-n26.form-section title="What to attach">
+            <c-ui.field data-field label="Modifier" for="attach-modifier">
+                <c-n26.filter-select placeholder="Type to filter modifiers">
+                    <c-ui.select.native name="modifier"
+                                        id="attach-modifier"
+                                        placeholder="Pick a modifier"
+                                        required>
+                        {% for mod in attachable_modifiers %}
+                            <c-ui.select.option value="{{ mod.pk }}">
+                                {{ mod.label }}
+                            </c-ui.select.option>
+                        {% endfor %}
+                    </c-ui.select.native>
+                </c-n26.filter-select>
+            </c-ui.field>
+        </c-n26.form-section>
+        <c-n26.form-section title="{{ verbose_name_plural|capfirst }} it goes on">
+            <c-ui.table>
+                <tbody>
+                    {% for row in rows %}
+                        <tr>
+                            {% include "authoring/_name_cell.html" with row=row %}
+                            <td class="w-full text-muted">{{ row.help }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </c-ui.table>
+        </c-n26.form-section>
+    </c-n26.form-page>
+{% endblock content %}

--- a/n26/library/templates/authoring/leaf.html
+++ b/n26/library/templates/authoring/leaf.html
@@ -54,7 +54,7 @@ twice in a row.
     visible rows out of the DOM instead would not be reactive: nothing
     in that read mentions the query, so the number would never change.
     {% endcomment %}
-    <div x-data="{ query: '', haystacks: [], register(haystack) { this.haystacks.push(haystack) }, matches(haystack) { const q = this.query.trim().toLowerCase(); return !q || haystack.includes(q); }, get shown() { return this.haystacks.filter(h => this.matches(h)).length }, }"
+    <div x-data="{ query: '', haystacks: [], register(haystack) { this.haystacks.push(haystack) }, matches(haystack) { const q = this.query.trim().toLowerCase(); return !q || haystack.includes(q); }, get shown() { return this.haystacks.filter(h => this.matches(h)).length }, ticked: 0, count() { this.ticked = this.$root.querySelectorAll('input[name=pk]:checked').length }, tickShown(on) { this.$root.querySelectorAll('tr:not([hidden]) input[name=pk]').forEach(box => { box.checked = on }); this.count() }, }"
          class="mt-8 flex flex-col gap-3">
         {% if rows %}
             <c-n26.search-bar :live="True"
@@ -65,22 +65,41 @@ twice in a row.
                       x-text="shown">{{ count }}</span>
                 of {{ count }} {{ verbose_name_plural }}
             </p>
-            <c-ui.table>
-                <tbody>
-                    {% for row in rows %}
-                        {# :hidden rather than x-show: a table row's own display value is not `block`. #}
-                        <tr x-data="{ haystack: '{{ row.search|escapejs }}' }"
-                            x-init="register(haystack)"
-                            :hidden="!matches(haystack)">
-                            {% include "authoring/_name_cell.html" with row=row %}
-                            {# The author's own note reads as one more thing the row says about itself. #}
-                            <td class="w-full text-muted">
-                                {{ row.notes|join:" · " }}{% if row.notes and row.help %} · {% endif %}{{ row.help }}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </c-ui.table>
+            {% comment %}
+            Ticking several rows and acting on them is a form the whole
+            table sits in. The act itself is a page of its own, reached
+            with the ticked rows in its address, so nothing here changes
+            anything and the selection survives a reload. The bar's
+            count and its select-all are script: without it the boxes
+            still tick one by one and the button still leads on.
+            {% endcomment %}
+            {% if bulk_attach %}
+                <form method="get"
+                      action="{% url 'authoring-attach-modifier' kind %}"
+                      @change="count()">
+                    <c-n26.action-bar :surface="True" class="mb-3">
+                        <label class="flex items-center gap-2 text-sm" x-cloak>
+                            <input type="checkbox"
+                                   class="size-4 accent-[var(--color-accent)] focus-ring"
+                                   @change="tickShown($event.target.checked)">
+                            Select all shown
+                        </label>
+                        <span class="text-sm text-muted">
+                            <span class="font-semibold text-ink-900 tabular-nums dark:text-ink-100"
+                                  x-text="ticked">0</span>
+                            selected
+                        </span>
+                        <c-slot name="trailing">
+                            <c-ui.button type="submit" variant="primary">
+                                Attach a modifier
+                            </c-ui.button>
+                        </c-slot>
+                    </c-n26.action-bar>
+                    {% include "authoring/_leaf_table.html" with rows=rows bulk=True %}
+                </form>
+            {% else %}
+                {% include "authoring/_leaf_table.html" with rows=rows bulk=False %}
+            {% endif %}
             <p x-show="shown === 0"
                x-cloak
                class="py-6 text-center text-sm text-muted">No {{ verbose_name_plural }} match that.</p>

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -1284,8 +1284,104 @@ def leaf(request, kind):
             "kind_help": kind_help(model),
             "rows": rows,
             "count": len(rows),
+            # Ticking rows to act on several at once is offered only
+            # where the act exists: hanging a modifier on a thing that
+            # can carry one.
+            "bulk_attach": _carries_modifiers(kind),
         },
     )
+
+
+@staff_member_required
+def attach_modifier(request, kind):
+    """Hang one modifier on several things of a kind at once.
+
+    The listing's tick boxes lead here with the ticked rows in the
+    address, so the page survives a reload and Back is a real answer.
+    Nothing changes until the form posts, and the post carries the
+    same rows as hidden fields. A thing that already carries the
+    modifier is left alone and counted, so the same selection can be
+    posted twice without harm.
+    """
+    from n26.library import authoring
+    from n26.library.models import Modifier
+
+    spec = _spec_for(kind)
+    model = _model_for(spec)
+    if not _carries_modifiers(kind):
+        raise Http404(f"A {kind} cannot carry modifiers")
+    singular = model._meta.verbose_name
+    plural = model._meta.verbose_name_plural
+
+    asked = request.POST if request.method == "POST" else request.GET
+    things = list(_selected(_rows(model, kind), asked.getlist("pk")))
+    if not things:
+        messages.error(request, f"Select at least one {singular} first.")
+        return redirect("authoring-leaf", kind=kind)
+    if not Modifier.objects.exists():
+        messages.error(request, "No modifiers to attach yet. Create one first.")
+        return redirect("authoring-leaf", kind=kind)
+
+    if request.method == "POST":
+        modifier = get_object_or_404(Modifier, pk=request.POST.get("modifier", ""))
+        had = set(
+            model.objects.filter(
+                pk__in=[thing.pk for thing in things], modifiers=modifier
+            ).values_list("pk", flat=True)
+        )
+        with transaction.atomic():
+            for thing in things:
+                if thing.pk not in had:
+                    authoring.attach_modifiers_to(thing, [modifier])
+        attached = len(things) - len(had)
+        if attached == 0:
+            said = f"Every selected {singular} already had {modifier.name}."
+        else:
+            noun = singular if attached == 1 else plural
+            said = f"Attached {modifier.name} to {attached} {noun}."
+            if had:
+                said += f" {len(had)} already had it."
+        messages.success(request, said)
+        return redirect("authoring-leaf", kind=kind)
+
+    rows = [
+        {
+            **_naming(thing),
+            "pk": thing.pk,
+            "url": reverse("authoring-detail", args=[kind, thing.pk]),
+        }
+        for thing in things
+    ]
+    attachable = [
+        {
+            "pk": modifier.pk,
+            "label": f"{modifier.name} — {modifier.scope}: {modifier.effect}",
+        }
+        for modifier in _reading_sentences(Modifier.objects.all())
+    ]
+    return render(
+        request,
+        "authoring/attach_modifier.html",
+        {
+            "kind": kind,
+            "verbose_name": singular,
+            "verbose_name_plural": plural,
+            "noun": singular if len(rows) == 1 else plural,
+            "rows": rows,
+            "count": len(rows),
+            "attachable_modifiers": attachable,
+        },
+    )
+
+
+def _selected(rows, pks):
+    """The rows a page was handed, by pk — none at all if a pk is not
+    even the shape of one, rather than an error page for a mistyped
+    address."""
+    try:
+        return rows.filter(pk__in=pks) if pks else rows.none()
+    except ValueError, ValidationError:
+        return rows.none()
 
 
 @staff_member_required

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -2142,8 +2142,13 @@ def row_printing(body, words):
 
 
 def cells_of(row):
-    """A row's cells, in the order they are read."""
-    return re.findall(r"<td\b.*?</td>", row, re.S)
+    """A row's cells, in the order they are read. A box to tick is a
+    control rather than something read, so it is left out."""
+    return [
+        cell
+        for cell in re.findall(r"<td\b.*?</td>", row, re.S)
+        if 'type="checkbox"' not in cell
+    ]
 
 
 def words_in(markup):
@@ -7048,3 +7053,142 @@ class TestTheAboutColumn:
         body = client.get(f"/n26/authoring/rule/{rule.pk}/").content.decode()
         assert "Assigned to" in body
         assert "No gang yet." in body
+
+
+class TestAttachingAModifierToSeveral:
+    """The listing of a kind that can carry modifiers lets an author tick
+    rows and hang one modifier on all of them from a page of its own.
+    The ticked rows travel in the address, so the page reloads and Back
+    works; a thing that already carries the modifier is left as it is."""
+
+    @pytest.fixture
+    def gang_types(self, default_pack):
+        from n26.library.authoring import create_gang_type
+
+        return [create_gang_type(name) for name in ("Escher", "Goliath", "Orlock")]
+
+    @pytest.fixture
+    def grant(self, default_pack):
+        from n26.library.authoring import (
+            create_subtype,
+            ef_adds,
+            modifier,
+            targets_every_model,
+        )
+
+        return modifier(
+            "Everyone is Agile",
+            targets_every_model(),
+            ef_adds(create_subtype("Agile")),
+        )
+
+    def test_the_listing_offers_a_box_per_row_where_modifiers_can_hang(
+        self, author, client, gang_types
+    ):
+        body = client.get("/n26/authoring/gang-type/").content.decode()
+        assert body.count('name="pk"') == 3
+        assert "Attach a modifier" in body
+        assert 'action="/n26/authoring/gang-type/attach-modifier/"' in body
+
+    def test_a_kind_that_cannot_carry_modifiers_offers_none(
+        self, author, client, fighter_stats
+    ):
+        body = client.get("/n26/authoring/stat/").content.decode()
+        assert 'name="pk"' not in body
+        assert "Attach a modifier" not in body
+        assert client.get("/n26/authoring/stat/attach-modifier/").status_code == 404
+
+    def test_the_page_names_what_was_ticked_and_offers_every_modifier(
+        self, author, client, gang_types, grant
+    ):
+        escher, goliath, _ = gang_types
+        response = client.get(
+            "/n26/authoring/gang-type/attach-modifier/",
+            {"pk": [str(escher.pk), str(goliath.pk)]},
+        )
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "Attach a modifier to 2 gang types" in body
+        assert "Escher" in body
+        assert "Goliath" in body
+        assert "Orlock" not in body
+        assert "Everyone is Agile" in body
+
+    def test_posting_hangs_it_on_each_and_counts_those_that_had_it(
+        self, author, client, gang_types, grant
+    ):
+        from n26.library.authoring import attach_modifiers_to
+
+        escher, goliath, orlock = gang_types
+        attach_modifiers_to(escher, [grant])
+
+        response = client.post(
+            "/n26/authoring/gang-type/attach-modifier/",
+            {"pk": [str(t.pk) for t in gang_types], "modifier": str(grant.pk)},
+            follow=True,
+        )
+
+        assert response.redirect_chain[-1][0] == "/n26/authoring/gang-type/"
+        assert [m.message for m in response.context["messages"]] == [
+            "Attached Everyone is Agile to 2 gang types. 1 already had it."
+        ]
+        for gang_type in gang_types:
+            assert list(gang_type.modifiers.all()) == [grant]
+
+    def test_posting_again_changes_nothing_and_says_so(
+        self, author, client, gang_types, grant
+    ):
+        data = {"pk": [str(t.pk) for t in gang_types], "modifier": str(grant.pk)}
+        client.post("/n26/authoring/gang-type/attach-modifier/", data, follow=True)
+        response = client.post(
+            "/n26/authoring/gang-type/attach-modifier/", data, follow=True
+        )
+        assert [m.message for m in response.context["messages"]] == [
+            "Every selected gang type already had Everyone is Agile."
+        ]
+        for gang_type in gang_types:
+            assert gang_type.modifiers.count() == 1
+
+    def test_nothing_ticked_sends_the_author_back_with_a_word(
+        self, author, client, gang_types, grant
+    ):
+        response = client.get("/n26/authoring/gang-type/attach-modifier/", follow=True)
+        assert response.redirect_chain[-1][0] == "/n26/authoring/gang-type/"
+        assert [m.message for m in response.context["messages"]] == [
+            "Select at least one gang type first."
+        ]
+
+    def test_a_mistyped_address_is_not_an_error_page(
+        self, author, client, gang_types, grant
+    ):
+        response = client.get(
+            "/n26/authoring/gang-type/attach-modifier/", {"pk": "not-a-pk"}
+        )
+        assert response.status_code == 302
+
+    def test_the_page_costs_the_same_however_many_modifiers_there_are(
+        self, author, client, gang_types, grant
+    ):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from n26.library.authoring import (
+            create_subtype,
+            ef_adds,
+            modifier,
+            targets_every_model,
+        )
+
+        address = "/n26/authoring/gang-type/attach-modifier/"
+        data = {"pk": [str(t.pk) for t in gang_types]}
+        with CaptureQueriesContext(connection) as few:
+            client.get(address, data)
+        for number in range(6):
+            modifier(
+                f"Everyone is Agile {number}",
+                targets_every_model(),
+                ef_adds(create_subtype(f"Agile {number}")),
+            )
+        with CaptureQueriesContext(connection) as more:
+            client.get(address, data)
+        assert len(more) <= len(few)

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -324,6 +324,12 @@ urlpatterns = [
         authoring_views.create,
         name="authoring-create",
     ),
+    # Before the pk route for the same reason as "new".
+    path(
+        "authoring/<slug:kind>/attach-modifier/",
+        authoring_views.attach_modifier,
+        name="authoring-attach-modifier",
+    ),
     path(
         "authoring/<slug:kind>/<str:pk>/delete/",
         authoring_views.thing_delete,


### PR DESCRIPTION
Second of three stacked PRs finishing #2293: attach one modifier to several things at once from a kind's listing.

## Why

Hanging a modifier on a carrier is done on the carrier's own page, one at a time. The standing grants for lasting effects want the same two modifiers on every gang type — seventeen visits each — and the same shape recurs whenever a default is declared above the profile. This is the general tool.

## What

On any kind listing whose rows can carry modifiers (derived from the model's `modifiers` field, never enumerated — foundation kinds like stats show nothing new):

- each row leads with a tick box, and an **action bar** above the table shows how many are ticked and a primary "Attach a modifier" button. The table sits in a GET form, so the selection travels in the address. "Select all shown" respects the in-page search and is script only; without it the boxes tick one by one and the button still leads on.
- the button opens `authoring/<kind>/attach-modifier/?pk=…`: a page of its own, reloadable and Back-safe, listing what was ticked and offering every modifier through the same filterable picker the detail page uses. One green "Attach to N gang types".
- POST attaches to each row that does not already carry it, in one transaction, and reports "Attached X to 15 gang types. 2 already had it." — posting the same selection twice is harmless. Nothing ticked, or pks that are not even the shape of a pk, sends the author back with a word rather than an error page.

Bulk *detach* is deliberately not built; the bar is shaped so a second action is a second button and a second page.

## Tests

`TestAttachingAModifierToSeveral` in the authoring-views suite: boxes and bar appear on gang types and not on stats (whose attach page 404s); the page names the ticked rows and offers modifiers; POST attaches and counts those that already had it; a second POST changes nothing and says so; nothing ticked redirects with a message; a mistyped pk is not an error page; the page's query count does not grow with the number of modifiers. The listing tests' cell helper now leaves the tick-box cell out, as a control rather than something read.

Screenshots (desktop and 390px, with 20 gang types and 578 modifiers behind the picker) checked in the browser; copy passed through the copywriter.

## Try it

`/n26/authoring/gang-type/` → tick a few → "Attach a modifier" → pick one → "Attach to N gang types".


## Notes from review

- `except ValueError, ValidationError:` in `_selected` is the unparenthesised form PEP 758 added in Python 3.14, which this project requires; ruff's formatter writes it that way. It parses and imports on 3.14.6.
- A row ticked and then hidden by the in-page search still submits. Deliberate: an explicit tick is not discarded by an unrelated filter. "Select all shown" ticks only what is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6APgvkju7S2c862oPYkNb
