### PR TITLE
fix: place the model card kit menus against the window so the weapon table stops cutting them off

### DIFF
--- a/n26/core/static/n26/menu-position.js
+++ b/n26/core/static/n26/menu-position.js
@@ -1,0 +1,84 @@
+/**
+ * Places a dropdown menu in viewport coordinates instead of beside its
+ * trigger in the page's flow.
+ *
+ * A menu positioned with `absolute` is clipped by any ancestor that
+ * scrolls, and `overflow-x: auto` clips top and bottom as well as left
+ * and right — the browser gives an element one scroll box, not one per
+ * axis. So a menu inside a sideways-scrolling table loses whatever hangs
+ * below the last row. `fixed` is measured against the viewport and no
+ * scroll box clips it.
+ *
+ * The kit's own placement is kept everywhere else: this runs only for
+ * <c-ui.dropdown strategy="fixed">, which replaces positionDropdown on
+ * the component so that reopening, scrolling and resizing all come back
+ * through here.
+ *
+ * Above and below are the only two placements: a menu that opens to the
+ * side is never one of these, and the strategy does not claim to serve
+ * one.
+ */
+(function () {
+    // Kept clear of the viewport edges, so a menu against the bottom of
+    // the window still reads as a box rather than as a cut-off list.
+    const MARGIN = 8;
+
+    window.n26PositionMenu = function (trigger, content, options) {
+        if (!trigger || !content) return;
+
+        // A collapsed menu is in the flow under its trigger and nothing
+        // places it. Whatever a wider window left behind is cleared, so
+        // a resize down does not strand it over the page.
+        if (options.collapsible && window.innerWidth < 768) {
+            content.style.position = "";
+            content.style.top = "";
+            content.style.left = "";
+            return;
+        }
+
+        const align = options.align || "start";
+        const offset = parseInt(options.offset, 10) || 0;
+        const flip = options.flip !== false;
+
+        const t = trigger.getBoundingClientRect();
+
+        // Cleared before measuring: the kit's own placement may have left
+        // an edge set, and two opposing edges on one box decide its size.
+        content.style.position = "fixed";
+        content.style.right = "";
+        content.style.bottom = "";
+        content.style.transform = "";
+
+        const width = content.offsetWidth;
+        const height = content.offsetHeight;
+
+        const below = t.bottom + offset;
+        const above = t.top - offset - height;
+        let top = options.position === "top" ? above : below;
+        if (flip) {
+            const overflowsBelow = top + height > window.innerHeight - MARGIN;
+            if (overflowsBelow && above > MARGIN) {
+                top = above;
+            } else if (top < MARGIN) {
+                top = below;
+            }
+        }
+
+        let left = t.left;
+        if (align === "end") {
+            left = t.right - width;
+        } else if (align === "center") {
+            left = t.left + t.width / 2 - width / 2;
+        }
+        // A narrow window can leave no room on the side the alignment
+        // asks for, and a menu half off the screen is unreadable either
+        // way — so the window wins over the alignment.
+        left = Math.min(
+            Math.max(MARGIN, left),
+            window.innerWidth - width - MARGIN,
+        );
+
+        content.style.top = Math.max(MARGIN, top) + "px";
+        content.style.left = left + "px";
+    };
+})();

--- a/n26/core/templates/cotton/n26/owned_actions.html
+++ b/n26/core/templates/cotton/n26/owned_actions.html
@@ -37,7 +37,13 @@ it lands in. A line with nothing to click draws nothing.
 {% if layout == "menu" %}
     {% if sell or more or add %}
         <span class="flex shrink-0 items-center {{ class }}">
-            <c-ui.dropdown align="end" min_width="10rem">
+            {% comment %}
+            strategy="fixed": this menu is drawn beside a name inside the
+            card's weapon table, which scrolls sideways on a narrow
+            screen. A menu placed in that box is cut off at its edges —
+            see <c-ui.dropdown>.
+            {% endcomment %}
+            <c-ui.dropdown align="end" min_width="10rem" strategy="fixed">
                 <c-slot name="trigger">
                     <c-ui.button size="xs"
                                  variant="ghost"

--- a/n26/core/templates/cotton/ui/dropdown/index.html
+++ b/n26/core/templates/cotton/ui/dropdown/index.html
@@ -1,0 +1,93 @@
+{% comment %}
+<c-ui.dropdown> — a trigger and the menu it opens.
+
+Overrides the kit's dropdown to add `strategy`. Everything else is the
+kit's own markup and behaviour, and the default keeps them exactly.
+
+The kit places the menu with `position: absolute`, which any scrolling
+ancestor clips — and `overflow-x: auto` clips top and bottom too, because
+an element gets one scroll box rather than one per axis. A menu beside a
+name inside a sideways-scrolling stat table therefore loses whatever
+hangs below the last row. `strategy="fixed"` measures the menu against
+the window instead, where no scroll box reaches it; the placement itself
+is n26/core/static/n26/menu-position.js, installed over the component's
+own positionDropdown so that opening, scrolling and resizing all come
+back through it.
+
+Only `bottom` and `top` are placed that way. A menu that opens to the
+side has no call to escape a scroll box, and the strategy does not claim
+to serve one.
+
+Every other prop is the kit's, unchanged.
+
+  strategy    absolute (default) or fixed. Use fixed where the menu sits
+              inside something that scrolls.
+{% endcomment %}
+<c-vars
+  position="bottom"
+  align="start"
+  offset="4"
+  trigger_text=""
+  min_width="12rem"
+  :auto_position="True"
+  :collapsible="False"
+  strategy="absolute"
+/>
+
+<div
+  x-data="dropdownMenu()"
+  x-init="position = '{{ position }}'; align = '{{ align }}'; offset = {{ offset }}; responsive = {{ auto_position|lower }}; collapsible = {{ collapsible|lower }} || !!$root.closest('[data-dropdown-collapse]');{% if strategy == 'fixed' %} positionDropdown = () => window.n26PositionMenu($refs.trigger, $refs.content, { position, align, offset, flip: responsive, collapsible });{% endif %} $watch('dropdownMenu', value => { if (value) positionDropdown() })"
+  x-bind="root"
+  @dropdown-close="close()"
+  {{ attrs }}
+  class="relative inline-block">
+
+  {% if trigger %}
+    <div x-ref="trigger" x-bind="trigger">
+      {{ trigger }}
+    </div>
+  {% elif trigger_text %}
+    <button
+      type="button"
+      x-ref="trigger"
+      x-bind="trigger"
+      class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium
+             rounded-control border transition-colors
+             border-ink-300 dark:border-ink-700
+             bg-ink-50 dark:bg-ink-800
+             text-ink-700 dark:text-ink-300
+             hover:bg-ink-100 dark:hover:bg-ink-700
+             focus-ring"
+      :class="{ 'ring-[length:var(--focus-ring-width)] ring-[var(--focus-ring-color)]': dropdownMenu }"
+      aria-haspopup="true"
+      :aria-expanded="dropdownMenu">
+      {{ trigger_text }}
+      <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-180': dropdownMenu }"
+           fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+      </svg>
+    </button>
+  {% else %}
+    <div class="text-red-500 text-sm">Error: Dropdown requires either 'trigger' slot or 'trigger_text' prop</div>
+  {% endif %}
+
+  <div
+    x-ref="content"
+    x-bind="content"
+    x-cloak
+    class="z-50 rounded-control border shadow-lg
+           border-[color:var(--color-box-border)]
+           bg-white dark:bg-ink-900
+           max-h-[calc(100vh-4rem)] sm:max-h-[80vh]
+           overflow-y-auto overflow-x-hidden
+           scrollbar-thin scrollbar-thumb-ink-400 scrollbar-track-ink-100
+           dark:scrollbar-thumb-ink-600 dark:scrollbar-track-ink-800"
+    :class="collapsible
+              ? 'static md:absolute w-full min-w-0 md:w-auto md:min-w-[var(--dd-min)] mt-1 md:mt-0'
+              : 'absolute min-w-[var(--dd-min)]'"
+    style="--dd-min: {{ min_width }}"
+    role="menu"
+    aria-orientation="vertical">
+    {{ slot }}
+  </div>
+</div>

--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -605,6 +605,12 @@ banner, is_impersonating / impersonator, gtm_container_id, messages, user.
         what it does to a control is drawn by [data-busy] in app.css.
         {% endcomment %}
         <script defer src="{% static 'n26/busy.js' %}"></script>
+        {% comment %}
+        Read by <c-ui.dropdown strategy="fixed">, which hands it the trigger
+        and the menu when it opens. Deferred like everything else here: the
+        component only calls it once Alpine has walked the page.
+        {% endcomment %}
+        <script defer src="{% static 'n26/menu-position.js' %}"></script>
         <script defer src="{% static 'designsystem/vendor/htmx.min.js' %}"></script>
         {% comment %}
         Order matters: the kit's factories must be defined before Alpine walks

--- a/n26/core/test_menu_position.py
+++ b/n26/core/test_menu_position.py
@@ -1,0 +1,75 @@
+"""Where a dropdown menu is placed when it sits inside something that scrolls.
+
+What does the placing is JavaScript, and nothing here runs it. What can be
+checked from Python is the wiring, and each of these breaks in silence: a
+shell that stops loading the file, a component that calls a function no
+longer defined under that name, or a card menu that quietly goes back to
+being placed the ordinary way and is cut off at the table's edges again.
+"""
+
+from pathlib import Path
+
+from django.contrib.staticfiles import finders
+from django.template.loader import get_template
+
+MENU_JS = "n26/menu-position.js"
+
+#: The name the component calls and the script defines. Written out rather
+#: than derived, so a rename has to be made in both places on purpose.
+PLACER = "n26PositionMenu"
+
+
+def source_of(template_name: str) -> str:
+    return Path(get_template(template_name).origin.name).read_text()
+
+
+def script() -> str:
+    found = finders.find(MENU_JS)
+    assert found, f"{MENU_JS} is not where the static files are looked for"
+    return Path(found).read_text()
+
+
+class TestEveryPageLoads:
+    """A menu asking for the fixed strategy calls the script the moment it
+    opens, so a shell that does not load it has menus that cannot place
+    themselves."""
+
+    def test_the_app_shell_loads_it(self):
+        assert MENU_JS in source_of("n26/layouts/base.html")
+
+    def test_the_gallery_shell_loads_it(self):
+        """Otherwise the dropdown page documents a strategy it cannot show."""
+        assert MENU_JS in source_of("designsystem/base.html")
+
+
+class TestTheComponentAndTheScriptAgree:
+    def test_both_halves_name_the_same_function(self):
+        assert PLACER in source_of("cotton/ui/dropdown/index.html")
+        assert PLACER in script()
+
+    def test_the_component_installs_it_over_the_kits_own_placement(self):
+        """The kit calls positionDropdown again on every scroll and resize.
+        Replacing that method is what keeps an open menu with its trigger;
+        placing the menu once at open time would leave it behind."""
+        assert "positionDropdown = " in source_of("cotton/ui/dropdown/index.html")
+
+    def test_the_default_leaves_the_kits_placement_alone(self):
+        """Only a menu that asks for it is placed against the window."""
+        source = source_of("cotton/ui/dropdown/index.html")
+
+        assert 'strategy="absolute"' in source
+        assert "{% if strategy == 'fixed' %}" in source
+
+
+class TestTheCardMenuAsksForIt:
+    def test_the_menu_beside_a_name_escapes_the_weapon_tables_scroll_box(self):
+        """The model card draws its weapons in a table that scrolls sideways
+        on a narrow screen. A menu placed inside that box loses whatever hangs
+        past its edges, which is most of the menu on the last weapon."""
+        assert 'strategy="fixed"' in source_of("cotton/n26/owned_actions.html")
+
+    def test_the_weapon_table_is_still_the_box_this_is_about(self):
+        """If the table stops scrolling, the strategy above stops earning its
+        place — and if it keeps scrolling under a different class, the reason
+        written beside the strategy stops being true."""
+        assert "overflow-x-auto" in source_of("cotton/n26/model_card/body.html")

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -126,7 +126,9 @@ GROUPS: list[Group] = [
                     "Needs either a trigger slot or trigger_text — with neither it "
                     "renders a visible red error rather than failing silently. Set "
                     ":collapsible to have it render inline below the md breakpoint "
-                    "instead of as a popover."
+                    'instead of as a popover. Set strategy="fixed" where the menu '
+                    "sits inside something that scrolls, which otherwise cuts it off "
+                    "at the box's edges."
                 ),
                 parts=(
                     Part(

--- a/n26/designsystem/templates/designsystem/base.html
+++ b/n26/designsystem/templates/designsystem/base.html
@@ -186,6 +186,7 @@ document.addEventListener('alpine:init', () => {
         page demonstrates the real behaviour rather than a picture of it.
         {% endcomment %}
         <script defer src="{% static 'n26/busy.js' %}"></script>
+        <script defer src="{% static 'n26/menu-position.js' %}"></script>
         <script defer src="{% static 'django_cotton_ui/cotton-ui.min.js' %}"></script>
         <script defer src="{% static 'designsystem/vendor/alpine-collapse.min.js' %}"></script>
         <script defer src="{% static 'designsystem/vendor/alpine-focus.min.js' %}"></script>

--- a/n26/designsystem/templates/designsystem/demos/dropdown/40-inside-a-scroll-box.html
+++ b/n26/designsystem/templates/designsystem/demos/dropdown/40-inside-a-scroll-box.html
@@ -1,0 +1,40 @@
+{# title: Inside something that scrolls #}
+{# note: Both boxes below scroll sideways. The left menu is placed the ordinary way and the box cuts it off — at the bottom as well as the sides, because an element gets one scroll box and not one per axis. The right menu is strategy="fixed", measured against the window instead, so the box does not reach it. Open both. #}
+<div class="flex flex-wrap gap-8">
+    <div class="w-64 overflow-x-auto border border-box-border p-3">
+        <div class="w-96">
+            <c-ui.dropdown trigger_text="Cut off" align="end">
+                <c-ui.dropdown.item>
+                    Add accessory
+                </c-ui.dropdown.item>
+                <c-ui.dropdown.item>
+                    Sell
+                </c-ui.dropdown.item>
+                <c-ui.dropdown.item>
+                    Reassign
+                </c-ui.dropdown.item>
+                <c-ui.dropdown.item>
+                    Delete
+                </c-ui.dropdown.item>
+            </c-ui.dropdown>
+        </div>
+    </div>
+    <div class="w-64 overflow-x-auto border border-box-border p-3">
+        <div class="w-96">
+            <c-ui.dropdown trigger_text="Whole" align="end" strategy="fixed">
+                <c-ui.dropdown.item>
+                    Add accessory
+                </c-ui.dropdown.item>
+                <c-ui.dropdown.item>
+                    Sell
+                </c-ui.dropdown.item>
+                <c-ui.dropdown.item>
+                    Reassign
+                </c-ui.dropdown.item>
+                <c-ui.dropdown.item>
+                    Delete
+                </c-ui.dropdown.item>
+            </c-ui.dropdown>
+        </div>
+    </div>
+</div>

--- a/n26/tests/sandbox/test_listing.py
+++ b/n26/tests/sandbox/test_listing.py
@@ -300,7 +300,13 @@ class TestWhatACopyOffers:
             "Refund",
             "Delete",
         ]
-        assert {action.tone for action in copy.more} == {SECONDARY}
+        # The tone is what sorts the menu into groups and colours the last
+        # of them, so it is the structure that decides Delete is the one
+        # that ends with nothing to show for it.
+        assert {action.tone for action in copy.more} == {SECONDARY, DANGER}
+        assert [action.label for action in copy.more if action.tone == DANGER] == [
+            "Delete"
+        ]
 
     def test_every_act_on_a_copy_is_a_link_to_a_confirmation(
         self, fighter, house_list, armed


### PR DESCRIPTION
The menus #2386 put beside each weapon, profile, accessory and gear line on the model-edit page were drawn half-missing — the left of the first item sliced off, and everything below it gone.

## What was wrong

The card draws its weapons in a table wrapped in a sideways scroller, so the stat columns can be scrolled on a narrow screen. The kit's dropdown places its menu with `position: absolute`, and that scroller clips it — on **every** side, not just the two the class names. A browser gives an element one scroll box rather than one per axis, so `overflow-x: auto` quietly makes `overflow-y` behave the same way, and the menu loses whatever hangs past the last row.

Measured in Chrome at 1280px: the menu ran from x=328 into a box starting at x=362, and down to y=654 in a box ending at y=490.

The scroller has to stay. At 390px the weapon table wants 347px in a 298px box, so removing it would push the card off the side of the phone.

## The fix

`<c-ui.dropdown>` gains a `strategy` prop. `strategy="fixed"` measures the menu against the window, where no scroll box reaches it, and the model card's menus ask for it. The default is unchanged, so every other dropdown on the site behaves exactly as it did.

The placement itself is a small script installed over the component's own `positionDropdown`, so opening, scrolling and resizing all come back through it — an open menu stays with its trigger rather than being left behind on the page.

The kit's dropdown template is copied into `cotton/ui/` to add the one branch, the way the `button` and `tabs` overrides already do.

## Also in here

`test_listing.py` had a stale assertion. #2386 gave Delete and Remove the danger tone in the structure on purpose, but the test still said every act behind the chevron was secondary — the suite has been red on `main` since it merged. The assertion now says what the menu actually does.

## How to try it

1. Open a model that holds a gun: `/n26/fighters/<pk>/edit/`
2. Open the chevron beside the **last** weapon in the table — the whole menu draws, over the card and the page below it
3. Scroll the page with it open; the menu stays put beside its trigger
4. Narrow the window to phone width and do it again
5. Side by side in the gallery: `/n26/design/c/dropdown/` → "Inside something that scrolls"

Verified in Chrome at 1280px, 768px and 390px, with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuFcioe1gv6G4nLtdejZN1
