### PR TITLE
fix: stop Enter in the n26 search-bar submitting the first Hire or Buy

### DIFF
--- a/n26/core/templates/cotton/n26/search_bar.html
+++ b/n26/core/templates/cotton/n26/search_bar.html
@@ -18,6 +18,12 @@ The submit is drawn only where clicking it does something — any bar that is no
 live, and a live one given an `action`. A live bar with no action has its
 submit prevented; there is nothing to ask for that is not already on screen.
 
+Enter in a live box that has no Search button of its own does nothing. The
+filter already runs as you type. Enter would otherwise submit the surrounding
+form, and the first Buy or Hire in that form is what the browser activates —
+even a row the filter has hidden. A nested bar that is the filter of a GET
+form is not live, so Enter still submits that search.
+
 The field is a plain <input> with its own border stripped, since the kit has no
 input group and c-ui.input would draw a second border inside this one. It
 carries the same token classes, so it themes identically.
@@ -66,6 +72,7 @@ carries the same token classes, so it themes identically.
             placeholder="{{ placeholder }}"
             autocomplete="off"
             {% if live %}x-model="{{ model }}"{% endif %}
+            {% if live %}{% if nested or not action %}@keydown.enter.prevent{% endif %}{% endif %}
             class="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-ink-900 outline-none
                    placeholder:text-ink-400 dark:text-ink-100 dark:placeholder:text-ink-500">
 

--- a/n26/core/templates/n26/add_gang_to_campaign.html
+++ b/n26/core/templates/n26/add_gang_to_campaign.html
@@ -96,17 +96,10 @@ a reader who cannot find one is told where it went.
                 as the equipment catalogue lays out the same pair. A row of
                 filters is a row of actions, which is what action-bar is.
                 {% endcomment %}
-                {% comment %}
-                Enter in the search box would otherwise add a gang. The list
-                sits inside the page's form, every control above it is a
-                plain button, and the footer draws no submit — so the form's
-                default button is the first row's Add, hidden or not.
-                {% endcomment %}
                 <c-n26.search-bar :live="True"
                                   :nested="True"
                                   model="query"
                                   placeholder="Search gangs"
-                                  @keydown.enter.prevent=""
                                   class="n26-gang-filters" />
                 <c-n26.action-bar class="n26-gang-filters">
                     {% if player_options %}

--- a/n26/core/test_tab_links.py
+++ b/n26/core/test_tab_links.py
@@ -166,3 +166,32 @@ class TestTheSearchBarsButton:
     def test_a_live_bar_with_nowhere_to_submit_has_no_button(self):
         html = render('<c-n26.search-bar :live="True" model="query" />')
         assert 'type="submit"' not in html
+
+
+class TestTheSearchBarsEnterKey:
+    """Enter in a live box that has no Search button of its own does
+    nothing. The filter already runs as you type; Enter would otherwise
+    submit the surrounding form and activate its first Buy or Hire —
+    even a row the filter has hidden. A nested bar that is the filter
+    of a GET form is not live, so Enter still submits that search."""
+
+    def test_a_nested_live_bar_swallows_enter(self):
+        html = render('<c-n26.search-bar :live="True" :nested="True" model="query" />')
+        assert "@keydown.enter.prevent" in html
+
+    def test_a_live_bar_with_nowhere_to_submit_swallows_enter(self):
+        html = render('<c-n26.search-bar :live="True" model="query" />')
+        assert "@keydown.enter.prevent" in html
+
+    def test_a_nested_bar_that_filters_a_get_form_still_submits_on_enter(self):
+        html = render(
+            '<c-n26.search-bar :nested="True" name="q" placeholder="Search the history" />'
+        )
+        assert "@keydown.enter.prevent" not in html
+
+    def test_a_live_bar_with_a_search_button_still_submits_on_enter(self):
+        html = render(
+            '<c-n26.search-bar :live="True" model="query" action="/n26/gangs/" />'
+        )
+        assert 'type="submit"' in html
+        assert "@keydown.enter.prevent" not in html

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -366,6 +366,8 @@ def test_the_filter_bar_offers_nothing_to_submit(client, tester, fighter, house_
     assert 'role="search"' in body
     # Every submit on this page buys something.
     assert body.count('type="submit"') == body.count('name="thing"')
+    # Enter in the box would otherwise buy the first listed item.
+    assert "@keydown.enter.prevent" in body
 
 
 def test_the_strip_names_each_section_once(client, tester, gang, fighter):

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -636,6 +636,17 @@ class TestStashManagement:
         assert ">Equip</h1>" in body
         assert "Buy Equipment" not in body
 
+    def test_the_search_box_does_not_buy_on_enter(
+        self, client, tester, gang, house_list
+    ):
+        """The bar narrows rows already on the page, as you type. Enter
+        would otherwise submit the Buy form and buy the first listed
+        item into the stash."""
+        client.force_login(tester)
+        body = client.get(equip_url(gang, house_list)).content.decode()
+        assert 'role="search"' in body
+        assert "@keydown.enter.prevent" in body
+
     def test_a_held_item_on_the_browsed_list_draws_in_stash(
         self, client, tester, gang, house_list
     ):

--- a/n26/core/test_views_hire.py
+++ b/n26/core/test_views_hire.py
@@ -90,6 +90,16 @@ def test_the_list_draws_with_prices(client, tester, gang, ganger):
     assert "55" in body
 
 
+def test_the_search_box_does_not_hire_on_enter(client, tester, gang, ganger):
+    """The bar narrows rows already on the page, as you type. Enter
+    would otherwise submit the hire form and start a hire of whichever
+    fighter is first in the unfiltered list."""
+    client.force_login(tester)
+    body = client.get(hire_url(gang)).content.decode()
+    assert 'role="search"' in body
+    assert "@keydown.enter.prevent" in body
+
+
 def card_url(gang, profile):
     return reverse("n26-hire-card", args=[gang.pk, profile.pk])
 

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -868,7 +868,10 @@ GROUPS: list[Group] = [
                     "<input> carrying the kit's own token classes — c-ui.input would "
                     "draw a second border inside this one. The submit button sits "
                     "outside that group. It is a real form, so it submits without "
-                    "JavaScript."
+                    "JavaScript. A live bar with no Search button swallows Enter so "
+                    "it cannot submit a surrounding form's first Buy or Hire. A "
+                    "nested bar that is the filter of a GET form is not live, so "
+                    "Enter still submits that search."
                 ),
             ),
             Component(

--- a/n26/tests/sandbox/test_gang_history.py
+++ b/n26/tests/sandbox/test_gang_history.py
@@ -426,3 +426,8 @@ class TestThePageIsTheOwners:
         searched = client.get(at, {"q": "renamed"}).content.decode()
         assert "renamed" in searched
         assert "hired" not in searched
+        # Enter in this box commits the GET search. A live filter would
+        # swallow it; this bar is the form's own field.
+        page = client.get(at).content.decode()
+        assert 'role="search"' in page
+        assert "@keydown.enter.prevent" not in page


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pressing Enter in a live n26 search box was buying or hiring whatever sat first in the unfiltered list. The box already filters as you type; Enter is never needed. Players press it anyway, and the browser treated that as clicking the first Buy or Hire.

That happens because hire and equip are one form, every Buy/Hire is a submit of that form, and the search box sits inside it as a nested `<c-n26.search-bar>`. Alpine only hides rows. The first submit button in the document is still the unfiltered top of the list.

## What changed

`<c-n26.search-bar>` now swallows Enter on a live bar that has no Search button of its own (`@keydown.enter.prevent` on the field). Hire, fighter equip, gang equip, and “add a gang to a campaign” all pick that up from the component. The campaign add-gang page no longer needs its own call-site guard.

A nested bar that *is* the filter of a GET form (gang history) is not live, so Enter still submits that search. A live bar that has a Search button (the gangs table, which can ask the server) still submits on Enter.

## How to try it

1. Open an n26 hire page, type in the search box, press Enter. Nothing should hire.
2. Open a fighter or gang equip page, same thing — Enter should not buy.
3. Open a gang’s history, type in the search box, press Enter. That search should still run.

[n26_search_enter_does_not_hire_or_buy.mp4](https://cursor.com/agents/bc-8374df92-8312-4ce3-8532-b05d13890549/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fn26_search_enter_does_not_hire_or_buy.mp4)

[Hire page after Enter on Leader — still listing, credits unchanged](https://cursor.com/agents/bc-8374df92-8312-4ce3-8532-b05d13890549/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhire_after_enter.webp)
[Equip page after Enter on Sword — still listing, credits unchanged](https://cursor.com/agents/bc-8374df92-8312-4ce3-8532-b05d13890549/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fequip_after_enter.webp)
[History page after Enter on hired — GET search still ran](https://cursor.com/agents/bc-8374df92-8312-4ce3-8532-b05d13890549/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_after_enter.webp)

Fixes #2299
Fixes #2399


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8374df92-8312-4ce3-8532-b05d13890549?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8374df92-8312-4ce3-8532-b05d13890549&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

