### PR TITLE
feat: let the n26 accessory kebab detach a WeaponAccessory

### DIFF
--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -195,9 +195,11 @@ class Listing:
 class OwnedPartRow:
     """Something hanging off a copy the fighter holds: ammo, an accessory.
 
-    No move among its actions. A part belongs to the thing it hangs off
-    and ``Operation.move`` refuses an assignment with a parent, so
-    offering one would be offering a click that cannot work.
+    A bought accessory can come off and stay held, or move onto another
+    gun this fighter already carries — those acts land in ``more`` when
+    the copy carries an address for them. A firing line cannot leave its
+    gun, and a sight the gun came with cannot either: both stay Sell,
+    Refund and Remove.
     """
 
     id: str
@@ -418,6 +420,22 @@ def copy_row(copy, refunds=True):
                 # the wrong gun. Removed rather than deleted, because what
                 # is left afterwards is still the fighter's gun.
                 more=(
+                    # First the acts that leave the fighter holding it,
+                    # then the ways of parting with it — the same order
+                    # a loose copy uses. Each is drawn only where the
+                    # copy has an address: detach where a bought
+                    # accessory can stay held, fitting where another gun
+                    # on this card can take it.
+                    *(
+                        (Action("Detach", LINK, part.detach_href, SECONDARY),)
+                        if part.detach_href
+                        else ()
+                    ),
+                    *(
+                        (Action("Fit to a weapon", LINK, part.fit_href, SECONDARY),)
+                        if part.fit_href
+                        else ()
+                    ),
                     *(
                         (Action("Refund", LINK, part.refund_href, SECONDARY),)
                         if refunds

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -255,8 +255,9 @@ def _parts_of(node, host):
     A bought accessory can leave the gun and stay on this fighter, or
     move onto another gun they already hold. Those addresses are only
     written where the act has somewhere to go: the stash is never asked
-    to unbolt onto a fighter, and a card with one gun has nowhere else
-    to fit the sight.
+    to unbolt onto a fighter, and a stash fit goes through Reassign so
+    it can name every gun on the roster. A card with one gun has
+    nowhere else to fit the sight.
     """
     at = host.at
     other_guns = tuple(
@@ -264,6 +265,10 @@ def _parts_of(node, host):
         for weapon in weapons_on(host)
         if weapon.assignment.pk != node.assignment.pk
     )
+    # Same gate a loose accessory uses: the stash never draws ?fit= or
+    # ?detach=. Fitting from the stash is Reassign, which lists the
+    # roster's guns; a fighter-scoped picker would only see stash guns.
+    on_fighter = not host.is_stash
     parts = []
     for child in node.children:
         if child.is_weapon_profile and not child.assignable.name:
@@ -280,9 +285,13 @@ def _parts_of(node, host):
                 refund_href=with_query(at, refund=pk),
                 remove_href=with_query(at, remove=pk),
                 detach_href=(
-                    with_query(at, detach=pk) if keepable and not host.is_stash else ""
+                    with_query(at, detach=pk) if keepable and on_fighter else ""
                 ),
-                fit_href=(with_query(at, fit=pk) if keepable and other_guns else ""),
+                fit_href=(
+                    with_query(at, fit=pk)
+                    if keepable and on_fighter and other_guns
+                    else ""
+                ),
             )
         )
     return tuple(parts)

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -120,6 +120,17 @@ def can_unbolt(assignment):
     )
 
 
+def cannot_unbolt_reason(name):
+    """Why a built-in or a firing line cannot leave the weapon.
+
+    Said to both a Detach and a Fit click — the rule is the same
+    whichever destination they named.
+    """
+    return (
+        f"You cannot take {name} off the weapon. Only a bought accessory can come off."
+    )
+
+
 def thing_key(thing):
     """One string naming a piece of content — what a form submits to name it.
 
@@ -243,7 +254,7 @@ def _part_name(node):
     return node.name
 
 
-def _parts_of(node, host):
+def _parts_of(node, host, guns):
     """The children drawn beneath a thing, each with an address of its own.
 
     A weapon's *unnamed* profile is the weapon — the book prints an
@@ -261,9 +272,7 @@ def _parts_of(node, host):
     """
     at = host.at
     other_guns = tuple(
-        weapon
-        for weapon in weapons_on(host)
-        if weapon.assignment.pk != node.assignment.pk
+        weapon for weapon in guns if weapon.assignment.pk != node.assignment.pk
     )
     # Same gate a loose accessory uses: the stash never draws ?fit= or
     # ?detach=. Fitting from the stash is Reassign, which lists the
@@ -332,12 +341,13 @@ def possessions(host: EquipHost):
     """
     from n26.library.models import Weapon, WeaponAccessory
 
-    # Whether this card has anywhere to fit an accessory, asked once for
-    # the whole of it. A fighter carrying no gun is offered no fitting:
-    # a screen must not ask a question its answer refuses. The stash is
-    # never asked — its accessories are fitted from the gang sheet,
-    # where the guns of the whole roster are in reach.
-    fittable = not host.is_stash and bool(weapons_on(host))
+    # The guns on this card, asked once and handed to each part list.
+    # A fighter carrying no gun is offered no fitting: a screen must
+    # not ask a question its answer refuses. The stash is never asked
+    # — its accessories are fitted from the gang sheet, where the guns
+    # of the whole roster are in reach.
+    guns = weapons_on(host)
+    fittable = not host.is_stash and bool(guns)
 
     index = {}
     for node in host.roots:
@@ -358,7 +368,7 @@ def possessions(host: EquipHost):
                 key=key,
                 name=node.name,
                 rating=node.rating,
-                parts=_parts_of(node, host),
+                parts=_parts_of(node, host, guns),
                 sell_href=with_query(at, sell=pk),
                 reassign_href=with_query(at, reassign=pk),
                 refund_href=with_query(at, refund=pk),

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -48,7 +48,16 @@ class EquipHost:
 
 #: URL parameters that can open one assignment dialog. Their order is the
 #: precedence when an address names more than one.
-DIALOGS = ("sell", "reassign", "fit", "refund", "remove", "accessorise", "rechoose")
+DIALOGS = (
+    "sell",
+    "reassign",
+    "fit",
+    "detach",
+    "refund",
+    "remove",
+    "accessorise",
+    "rechoose",
+)
 
 
 def with_query(url, **params):
@@ -95,6 +104,22 @@ def is_detachable(thing):
     return is_possession(thing) and not isinstance(thing, WeaponProfile)
 
 
+def can_unbolt(assignment):
+    """Can this be taken off what it hangs from and still held?
+
+    The same rule a sale uses when it asks which accessories to keep
+    (:func:`n26.core.operations.detachable_children`), asked of one
+    assignment rather than of a parent's children. A firing line cannot
+    — it *is* the weapon. A sight the gun came with cannot — it belongs
+    to the package, and selling that package takes it back.
+    """
+    return (
+        assignment.parent_id is not None
+        and assignment.caused_by_id is None
+        and is_detachable(assignment.assignable)
+    )
+
+
 def thing_key(thing):
     """One string naming a piece of content — what a form submits to name it.
 
@@ -108,7 +133,9 @@ def thing_key(thing):
 class OwnedPart:
     """Something hanging off a thing the model owns: ammo, an accessory.
 
-    No re-homing: a part belongs to its parent and moves only with it.
+    A bought accessory can come off and stay held; a firing line and a
+    sight the gun came with cannot, and those two carry no detach or fit
+    address.
     """
 
     id: str
@@ -121,6 +148,14 @@ class OwnedPart:
     sell_href: str
     refund_href: str
     remove_href: str
+    #: Where to go to take this off and keep it on this fighter. Only a
+    #: bought accessory has one — the same rule a sale uses when it asks
+    #: which extras to keep.
+    detach_href: str = ""
+    #: Where to go to bolt this onto a different gun this fighter is
+    #: carrying. Empty where there is no other gun, or where the part
+    #: cannot be unbolted.
+    fit_href: str = ""
 
 
 @dataclass(frozen=True)
@@ -208,7 +243,7 @@ def _part_name(node):
     return node.name
 
 
-def _parts_of(node, at):
+def _parts_of(node, host):
     """The children drawn beneath a thing, each with an address of its own.
 
     A weapon's *unnamed* profile is the weapon — the book prints an
@@ -216,12 +251,25 @@ def _parts_of(node, at):
     the same rule ``n26.render.WeaponLine.own_line`` keeps for the card.
     It also cannot be sold apart from its gun, which is the same fact
     said about money.
+
+    A bought accessory can leave the gun and stay on this fighter, or
+    move onto another gun they already hold. Those addresses are only
+    written where the act has somewhere to go: the stash is never asked
+    to unbolt onto a fighter, and a card with one gun has nowhere else
+    to fit the sight.
     """
+    at = host.at
+    other_guns = tuple(
+        weapon
+        for weapon in weapons_on(host)
+        if weapon.assignment.pk != node.assignment.pk
+    )
     parts = []
     for child in node.children:
         if child.is_weapon_profile and not child.assignable.name:
             continue
         pk = str(child.assignment.pk)
+        keepable = can_unbolt(child.assignment)
         parts.append(
             OwnedPart(
                 id=pk,
@@ -231,6 +279,10 @@ def _parts_of(node, at):
                 sell_href=with_query(at, sell=pk),
                 refund_href=with_query(at, refund=pk),
                 remove_href=with_query(at, remove=pk),
+                detach_href=(
+                    with_query(at, detach=pk) if keepable and not host.is_stash else ""
+                ),
+                fit_href=(with_query(at, fit=pk) if keepable and other_guns else ""),
             )
         )
     return tuple(parts)
@@ -297,7 +349,7 @@ def possessions(host: EquipHost):
                 key=key,
                 name=node.name,
                 rating=node.rating,
-                parts=_parts_of(node, at),
+                parts=_parts_of(node, host),
                 sell_href=with_query(at, sell=pk),
                 reassign_href=with_query(at, reassign=pk),
                 refund_href=with_query(at, refund=pk),

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -80,8 +80,7 @@ itself.
                 There is no weapon here to fit it to.
             {% endif %}
         {% elif dialog.kind == "detach" %}
-            {{ dialog.name }} is taken off the weapon. This fighter still holds
-            it.
+            {{ dialog.name }} is taken off the weapon. You still hold it.
         {% elif dialog.kind == "refund" %}
             {{ dialog.sum }} It and anything attached to it are removed from the
             gang, undoing the purchase.

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -3,20 +3,20 @@
 
     <c-n26.owned-dialog :dialog="dialog">{% csrf_token %}</c-n26.owned-dialog>
 
-Six questions in one panel — sell, move, fit, refund, remove, accessorise —
-since the difference between them is a sentence and, for four of them, one
-control. Which is being asked, along with the figures, the roster, the guns
-and the accessories that fit, arrives in `dialog` from n26.core.views.owned.
-The panel itself is <c-n26.dialog>, where the open-state rules are written
-down.
+Sell, move, fit, detach, refund, remove, accessorise and rechoose share
+one panel, since the difference between them is a sentence and, for most
+of them, one control. Which is being asked, along with the figures, the
+roster, the guns and the accessories that fit, arrives in `dialog` from
+n26.core.views.owned. The panel itself is <c-n26.dialog>, where the
+open-state rules are written down.
 
 Only the clicked submit is sent, so a move is told apart by `to=stash`
-arriving. Move and fit are one act with one address, asked as two questions:
-which model holds a thing is not the same question as which gun it is bolted
-to. Three of the six can end up with nothing to submit: a move with nobody
-else on the roster posts a hidden to=stash and draws no select, a fit draws
-no submit where the card carries no gun, and accessorise draws none when
-nothing in the library fits the weapon.
+arriving. Move, fit and detach are one act with one address, asked as
+three questions: which model holds a thing is not the same question as
+which gun it is bolted to, or whether it stays held unfitted. A move
+with nobody else on the roster posts a hidden to=stash and draws no
+select, a fit draws no submit where the card carries no gun, and
+accessorise draws none when nothing in the library fits the weapon.
 
 Accessorise is also the one an equip page draws for every weapon on it rather
 than only for the one the URL names, so those panels are passed open="" and an
@@ -79,6 +79,9 @@ itself.
             {% else %}
                 There is no weapon here to fit it to.
             {% endif %}
+        {% elif dialog.kind == "detach" %}
+            {{ dialog.name }} is taken off the weapon. This fighter still holds
+            it.
         {% elif dialog.kind == "refund" %}
             {{ dialog.sum }} It and anything attached to it are removed from the
             gang, undoing the purchase.
@@ -149,7 +152,9 @@ itself.
         </c-n26.radio-cards>
     {% endif %}
 
-    {% if dialog.kind == "reassign" or dialog.kind == "fit" %}
+    {% if dialog.kind == "detach" %}
+        <input type="hidden" name="to" value="detach">
+    {% elif dialog.kind == "reassign" or dialog.kind == "fit" %}
         {% if dialog.weapons %}
             <input type="hidden" name="to" value="weapon">
             <c-ui.field label="Weapon" for="reassign-weapon">

--- a/n26/core/templates/cotton/n26/owned_lines.html
+++ b/n26/core/templates/cotton/n26/owned_lines.html
@@ -9,9 +9,10 @@ to it. The weapon's own firing line is not among them; it *is* the weapon.
 
 Which acts a copy offers, and which of them is red, is the structure's word and
 not this template's (see n26/includes/row_action.html), so an act added there
-appears here with nothing edited. A part offers no move, because
-Operation.move refuses a firing line. The Sell and more-menu pair is
-<c-n26.owned-actions>, which the model's own card folds into one menu.
+appears here with nothing edited. A bought accessory can come off and stay
+held; a firing line cannot, and that difference is the structure's too. The
+Sell and more-menu pair is <c-n26.owned-actions>, which the model's own card
+folds into one menu.
 
 Every control is a link to a real address: the dialogs behind them are server
 states a reader can send and reload, and links keep this out of the

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -525,7 +525,7 @@ class TestKitActionsOnTheCard:
         body = client.get(f"{edit_url(vex)}?detach={bolted.pk}").content.decode()
 
         assert "Detach Telescopic sight?" in body
-        assert "This fighter still holds" in body
+        assert "You still hold it." in body
         assert reverse("n26-reassign", args=[bolted.pk]) in body
         assert 'name="to" value="detach"' in body
 

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -474,6 +474,61 @@ class TestKitActionsOnTheCard:
         assert "<dialog" in body
         assert reverse("n26-sell", args=[sword.pk]) in body
 
+    def test_a_bolted_accessory_offers_detach_and_not_remove_alone(
+        self, client, tester, gang, vex, gun
+    ):
+        from n26.library.authoring import create_weapon_accessory
+
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        with operation(gang, actor=tester) as op:
+            bolted = op.buy(gun, thing=sight)
+
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+        at = edit_url(vex)
+
+        assert "Detach" in body
+        assert f"{at}?detach={bolted.pk}" in body
+        assert f"{at}?remove={bolted.pk}" in body
+        assert f"{at}?fit={bolted.pk}" not in body
+        assert "More for Telescopic sight" in body
+
+    def test_a_second_gun_lets_the_accessory_be_fitted_to_it(
+        self, client, tester, gang, vex, gun
+    ):
+        from n26.library.authoring import create_weapon, create_weapon_accessory
+
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        stub = create_weapon("Stub gun", price=5, profiles=[("", 0)])
+        with operation(gang, actor=tester) as op:
+            bolted = op.buy(gun, thing=sight)
+            op.buy(vex, thing=stub, paid=5)
+
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+        at = edit_url(vex)
+
+        assert f"{at}?detach={bolted.pk}" in body
+        assert f"{at}?fit={bolted.pk}" in body
+        assert "Fit to a weapon" in body
+
+    def test_the_url_opens_the_detach_dialog_on_this_page(
+        self, client, tester, gang, vex, gun
+    ):
+        from n26.library.authoring import create_weapon_accessory
+
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        with operation(gang, actor=tester) as op:
+            bolted = op.buy(gun, thing=sight)
+
+        client.force_login(tester)
+        body = client.get(f"{edit_url(vex)}?detach={bolted.pk}").content.decode()
+
+        assert "Detach Telescopic sight?" in body
+        assert "This fighter still holds" in body
+        assert reverse("n26-reassign", args=[bolted.pk]) in body
+        assert 'name="to" value="detach"' in body
+
     def test_the_url_opens_the_accessory_dialog_on_this_page(
         self, client, tester, vex, gun
     ):

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1359,6 +1359,33 @@ class TestDetachingAnAccessory:
         assert "There is nowhere to move" in response.content.decode()
         assert_reconciled(gang)
 
+    def test_another_fighters_gun_is_nowhere_to_fit_it(
+        self, client, tester, gang, fighter, other, gun, bolted
+    ):
+        """The picker only names this fighter's guns, so a click that
+        names somebody else's is hand-made — and it fits nothing."""
+        from n26.library.authoring import create_weapon
+
+        with operation(gang, actor=tester) as op:
+            theirs = op.buy(
+                other,
+                thing=create_weapon("Autogun", price=20, profiles=[("", 0)]),
+                paid=20,
+            )
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "weapon", "weapon": str(theirs.pk)},
+            follow=True,
+        )
+
+        bolted.refresh_from_db()
+        assert bolted.parent_id == gun.pk
+        assert bolted.miniature_root_id == fighter.pk
+        assert "There is nowhere to move" in response.content.decode()
+        assert_reconciled(gang)
+
 
 @pytest.fixture
 def house_list(gang, tester):

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1253,8 +1253,68 @@ class TestDetachingAnAccessory:
 
         builtin.refresh_from_db()
         assert builtin.parent_id == gun.pk
-        assert "There is nowhere to move" in response.content.decode()
+        assert "You cannot take Telescopic sight off the weapon." in (
+            response.content.decode()
+        )
         assert_reconciled(gang)
+
+    def test_a_stash_gun_offers_the_part_no_fit_or_detach(
+        self, gang, tester, sight, stash
+    ):
+        """Stash accessories are fitted through Reassign, which lists
+        every gun on the roster. A ?fit= address would only see stash
+        guns, and Detach would ask to unbolt onto a fighter who is not
+        holding it."""
+        from n26.core.card import build_gang_card
+        from n26.core.owned import EquipHost, possessions
+        from n26.library.authoring import create_weapon
+
+        with operation(gang, actor=tester) as op:
+            stash_gun = op.buy(
+                stash,
+                thing=create_weapon("Stub gun", price=5, profiles=[("", 0)]),
+                paid=5,
+            )
+            bolted = op.buy(stash_gun, thing=sight)
+            op.buy(
+                stash,
+                thing=create_weapon("Autogun", price=20, profiles=[("", 0)]),
+                paid=20,
+            )
+
+        host = EquipHost.stash(gang, build_gang_card(gang), AT)
+        part = None
+        for copies in possessions(host).values():
+            for copy in copies:
+                for child in copy.parts:
+                    if child.id == str(bolted.pk):
+                        part = child
+        assert part is not None
+        assert part.detach_href == ""
+        assert part.fit_href == ""
+
+    def test_a_stash_address_does_not_open_the_fighter_fit_question(
+        self, gang, tester, sight, stash
+    ):
+        """Hand-made ?fit= on the stash must not draw the fighter picker."""
+        from django.test import RequestFactory
+
+        from n26.core.card import build_gang_card
+        from n26.core.owned import EquipHost
+        from n26.core.views.owned import owned_dialog
+        from n26.library.authoring import create_weapon
+
+        with operation(gang, actor=tester) as op:
+            stash_gun = op.buy(
+                stash,
+                thing=create_weapon("Stub gun", price=5, profiles=[("", 0)]),
+                paid=5,
+            )
+            bolted = op.buy(stash_gun, thing=sight)
+
+        request = RequestFactory().get(AT, {"fit": str(bolted.pk)})
+        host = EquipHost.stash(gang, build_gang_card(gang), AT)
+        assert owned_dialog(request, host) is None
 
     def test_the_gun_it_already_hangs_off_is_nowhere_to_fit_it(
         self, client, tester, gang, gun, bolted

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1059,6 +1059,219 @@ class TestFittingOneTheFighterIsCarrying:
         assert f'id="{gone}" hx-swap-oob="delete"' in body
 
 
+class TestDetachingAnAccessory:
+    """A bought sight can come off the gun and stay on the fighter. The
+    write is the same move that fitted it; the kebab asks it as its own
+    question so Reassign stays about which model holds a thing."""
+
+    @pytest.fixture
+    def bolted(self, gang, tester, gun, sight):
+        with operation(gang, actor=tester) as op:
+            return op.buy(gun, thing=sight)
+
+    @pytest.fixture
+    def other_gun(self, gang, tester, fighter):
+        from n26.library.authoring import create_weapon
+
+        weapon = create_weapon("Stub gun", price=5, profiles=[("", 0)])
+        with operation(gang, actor=tester) as op:
+            return op.buy(fighter, thing=weapon, paid=5)
+
+    @staticmethod
+    def dialog(fighter, **query):
+        from django.test import RequestFactory
+
+        from n26.core.card import build_card
+        from n26.core.owned import EquipHost
+        from n26.core.views.owned import owned_dialog
+
+        request = RequestFactory().get(AT, query)
+        host = EquipHost.fighter(fighter.gang, build_card(fighter), fighter, AT)
+        return owned_dialog(request, host)
+
+    @staticmethod
+    def part_of(fighter, assignment):
+        from n26.core.card import build_card
+        from n26.core.owned import owned_things
+
+        held = owned_things(build_card(fighter), AT)
+        for copies in held.values():
+            for copy in copies:
+                for part in copy.parts:
+                    if part.id == str(assignment.pk):
+                        return part
+        raise AssertionError(f"no part {assignment.pk}")
+
+    def test_a_bolted_accessory_offers_detach(self, fighter, gun, bolted):
+        part = self.part_of(fighter, bolted)
+        assert part.detach_href == f"{AT}&detach={bolted.pk}"
+
+    def test_a_card_with_another_gun_also_offers_to_fit_it(
+        self, fighter, gun, bolted, other_gun
+    ):
+        part = self.part_of(fighter, bolted)
+        assert part.fit_href == f"{AT}&fit={bolted.pk}"
+
+    def test_a_card_with_one_gun_is_offered_nowhere_else_to_fit_it(
+        self, fighter, gun, bolted
+    ):
+        """Fitting it to the gun it already hangs off is not a move."""
+        part = self.part_of(fighter, bolted)
+        assert part.fit_href == ""
+
+    def test_ammo_is_offered_neither(self, gang, tester, fighter, gun):
+        from n26.library.authoring import add_weapon_profile
+
+        warp = add_weapon_profile(gun.assignable, name="hot-shot", price=10)
+        with operation(gang, actor=tester) as op:
+            ammo = op.buy_weapon_profile(gun, warp)
+
+        part = self.part_of(fighter, ammo)
+        assert part.detach_href == ""
+        assert part.fit_href == ""
+
+    def test_a_sight_the_gun_came_with_is_offered_neither(
+        self, gang, tester, fighter, gun, sight
+    ):
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        part = self.part_of(fighter, builtin)
+        assert part.detach_href == ""
+        assert part.fit_href == ""
+
+    def test_the_question_is_answered_by_the_move_that_does_it(self, fighter, bolted):
+        dialog = self.dialog(fighter, detach=str(bolted.pk))
+
+        assert dialog["title"] == "Detach Telescopic sight?"
+        assert dialog["action"] == reverse("n26-reassign", args=[bolted.pk])
+        assert dialog["submit_label"] == "Detach"
+        assert dialog["submit_variant"] == "primary"
+
+    def test_the_fit_question_omits_the_gun_it_already_hangs_off(
+        self, fighter, gun, bolted, other_gun
+    ):
+        dialog = self.dialog(fighter, fit=str(bolted.pk))
+
+        assert dialog["title"] == "Fit Telescopic sight to a weapon"
+        assert dialog["weapons"] == [{"pk": str(other_gun.pk), "label": "Stub gun"}]
+
+    def test_a_built_in_sight_is_asked_neither_question(
+        self, gang, tester, fighter, gun, sight
+    ):
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        assert self.dialog(fighter, detach=str(builtin.pk)) is None
+        assert self.dialog(fighter, fit=str(builtin.pk)) is None
+
+    def test_a_click_leaves_it_held_on_the_fighter(
+        self, client, tester, gang, fighter, gun, bolted
+    ):
+        client.force_login(tester)
+        gang.refresh_from_db()
+        before = gang.credits
+
+        response = client.post(url("n26-reassign", bolted), {"to": "detach"})
+
+        assert response.status_code == 302
+        bolted.refresh_from_db()
+        assert bolted.parent_id is None
+        assert bolted.miniature_id == fighter.pk
+        assert bolted.archived is False
+        gang.refresh_from_db()
+        assert gang.credits == before
+        assert_reconciled(gang)
+
+    def test_the_click_says_so(self, client, tester, fighter, gun, bolted):
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", bolted), {"to": "detach"}, follow=True
+        )
+
+        assert "Detached Telescopic sight." in response.content.decode()
+
+    def test_a_click_fits_it_to_the_other_gun(
+        self, client, tester, gang, fighter, gun, bolted, other_gun
+    ):
+        client.force_login(tester)
+        gang.refresh_from_db()
+        before = gang.credits
+
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "weapon", "weapon": str(other_gun.pk)},
+        )
+
+        assert response.status_code == 302
+        bolted.refresh_from_db()
+        assert bolted.parent_id == other_gun.pk
+        assert bolted.miniature_root_id == fighter.pk
+        gang.refresh_from_db()
+        assert gang.credits == before
+        assert_reconciled(gang)
+
+    def test_the_screen_is_told_about_both_rows_it_changed(
+        self, client, tester, fighter, gun, bolted
+    ):
+        """The gun loses the part; the accessory becomes a row of its own."""
+        from n26.core.owned import thing_key
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "detach"},
+            headers={"HX-Request": "true"},
+        )
+
+        body = response.content.decode()
+        assert f'data-row="{thing_key(gun.assignable)}"' in body
+        assert f'data-row="{thing_key(bolted.assignable)}"' in body
+
+    def test_a_built_in_sight_cannot_be_taken_off(
+        self, client, tester, gang, fighter, gun, sight
+    ):
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", builtin), {"to": "detach"}, follow=True
+        )
+
+        builtin.refresh_from_db()
+        assert builtin.parent_id == gun.pk
+        assert "There is nowhere to move" in response.content.decode()
+        assert_reconciled(gang)
+
+    def test_the_gun_it_already_hangs_off_is_nowhere_to_fit_it(
+        self, client, tester, gang, gun, bolted
+    ):
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "weapon", "weapon": str(gun.pk)},
+            follow=True,
+        )
+
+        bolted.refresh_from_db()
+        assert bolted.parent_id == gun.pk
+        assert "There is nowhere to move" in response.content.decode()
+        assert_reconciled(gang)
+
+
 @pytest.fixture
 def house_list(gang, tester):
     thing = create_wargear("Knife", price=10)

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1263,6 +1263,32 @@ class TestDetachingAnAccessory:
         )
         assert_reconciled(gang)
 
+    def test_a_built_in_sight_cannot_be_fitted_to_another_gun(
+        self, client, tester, gang, fighter, gun, sight, other_gun
+    ):
+        """There may be another gun, but the sight belongs to the
+        package — that is a rule, not an empty destination list."""
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", builtin),
+            {"to": "weapon", "weapon": str(other_gun.pk)},
+            follow=True,
+        )
+
+        builtin.refresh_from_db()
+        assert builtin.parent_id == gun.pk
+        body = response.content.decode()
+        assert "You cannot take Telescopic sight off the weapon." in body
+        assert "There is nowhere to move" not in body
+        assert_reconciled(gang)
+
     def test_a_stash_gun_offers_the_part_no_fit_or_detach(
         self, gang, tester, sight, stash
     ):

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1258,9 +1258,9 @@ class TestDetachingAnAccessory:
 
         builtin.refresh_from_db()
         assert builtin.parent_id == gun.pk
-        assert "You cannot take Telescopic sight off the weapon." in (
-            response.content.decode()
-        )
+        body = response.content.decode()
+        assert "You cannot take Telescopic sight off the weapon." in body
+        assert "Only a bought accessory can come off." in body
         assert_reconciled(gang)
 
     def test_a_built_in_sight_cannot_be_fitted_to_another_gun(
@@ -1286,6 +1286,8 @@ class TestDetachingAnAccessory:
         assert builtin.parent_id == gun.pk
         body = response.content.decode()
         assert "You cannot take Telescopic sight off the weapon." in body
+        assert "Only a bought accessory can come off." in body
+        assert "stay held" not in body
         assert "There is nowhere to move" not in body
         assert_reconciled(gang)
 

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1160,6 +1160,11 @@ class TestDetachingAnAccessory:
         assert dialog["title"] == "Fit Telescopic sight to a weapon"
         assert dialog["weapons"] == [{"pk": str(other_gun.pk), "label": "Stub gun"}]
 
+    def test_one_gun_is_nowhere_to_fit_a_bolted_accessory(self, fighter, gun, bolted):
+        """The control is not drawn, so a hand-made address opens no
+        panel — not an empty picker that says there is no weapon."""
+        assert self.dialog(fighter, fit=str(bolted.pk)) is None
+
     def test_a_built_in_sight_is_asked_neither_question(
         self, gang, tester, fighter, gun, sight
     ):
@@ -1315,6 +1320,29 @@ class TestDetachingAnAccessory:
         request = RequestFactory().get(AT, {"fit": str(bolted.pk)})
         host = EquipHost.stash(gang, build_gang_card(gang), AT)
         assert owned_dialog(request, host) is None
+
+    def test_a_stash_click_is_told_detach_is_for_a_fighter(
+        self, client, tester, gang, sight, stash
+    ):
+        from n26.library.authoring import create_weapon
+
+        with operation(gang, actor=tester) as op:
+            stash_gun = op.buy(
+                stash,
+                thing=create_weapon("Stub gun", price=5, profiles=[("", 0)]),
+                paid=5,
+            )
+            bolted = op.buy(stash_gun, thing=sight)
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", bolted), {"to": "detach"}, follow=True
+        )
+
+        bolted.refresh_from_db()
+        assert bolted.parent_id == stash_gun.pk
+        assert "You cannot take Telescopic sight off here." in response.content.decode()
+        assert_reconciled(gang)
 
     def test_the_gun_it_already_hangs_off_is_nowhere_to_fit_it(
         self, client, tester, gang, gun, bolted

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -825,23 +825,25 @@ def reassign_assignment(request, pk):
             destination = None
         else:
             try:
-                destination = (
-                    Assignment.objects.filter(
-                        pk=request.POST.get("weapon", ""),
-                        gang_root=gang,
-                        archived=False,
-                    )
-                    .exclude(weapon=None)
-                    # Nothing hangs off itself, and nothing moves onto
-                    # the gun it already hangs off. The operation says
-                    # the first by raising rather than refusing, so a
-                    # hand-made click naming either is answered here
-                    # with the same sentence as any other impossible
-                    # destination.
-                    .exclude(pk=assignment.pk)
-                    .exclude(pk=assignment.parent_id)
-                    .first()
-                )
+                named = Assignment.objects.filter(
+                    pk=request.POST.get("weapon", ""),
+                    gang_root=gang,
+                    archived=False,
+                ).exclude(weapon=None)
+                # Nothing hangs off itself, and nothing moves onto
+                # the gun it already hangs off. The operation says
+                # the first by raising rather than refusing, so a
+                # hand-made click naming either is answered here
+                # with the same sentence as any other impossible
+                # destination.
+                named = named.exclude(pk=assignment.pk).exclude(pk=assignment.parent_id)
+                # A fighter's Fit picker only names that fighter's
+                # guns. The stash picker names the roster, so this
+                # filter stays off when the accessory is not on a
+                # model.
+                if assignment.miniature_root_id:
+                    named = named.filter(miniature_root=assignment.miniature_root)
+                destination = named.first()
             except ValidationError:
                 destination = None
     else:

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -822,30 +822,34 @@ def reassign_assignment(request, pk):
         # onto another gun would offer a keep the sale of that package
         # takes back.
         if assignment.parent_id is not None and not can_unbolt(assignment):
+            messages.error(
+                request,
+                f"You cannot take {name} off the weapon. "
+                "Only a bought accessory can come off and stay held.",
+            )
+            return _unchanged(request, back)
+        try:
+            named = Assignment.objects.filter(
+                pk=request.POST.get("weapon", ""),
+                gang_root=gang,
+                archived=False,
+            ).exclude(weapon=None)
+            # Nothing hangs off itself, and nothing moves onto
+            # the gun it already hangs off. The operation says
+            # the first by raising rather than refusing, so a
+            # hand-made click naming either is answered here
+            # with the same sentence as any other impossible
+            # destination.
+            named = named.exclude(pk=assignment.pk).exclude(pk=assignment.parent_id)
+            # A fighter's Fit picker only names that fighter's
+            # guns. The stash picker names the roster, so this
+            # filter stays off when the accessory is not on a
+            # model.
+            if assignment.miniature_root_id:
+                named = named.filter(miniature_root=assignment.miniature_root)
+            destination = named.first()
+        except ValidationError:
             destination = None
-        else:
-            try:
-                named = Assignment.objects.filter(
-                    pk=request.POST.get("weapon", ""),
-                    gang_root=gang,
-                    archived=False,
-                ).exclude(weapon=None)
-                # Nothing hangs off itself, and nothing moves onto
-                # the gun it already hangs off. The operation says
-                # the first by raising rather than refusing, so a
-                # hand-made click naming either is answered here
-                # with the same sentence as any other impossible
-                # destination.
-                named = named.exclude(pk=assignment.pk).exclude(pk=assignment.parent_id)
-                # A fighter's Fit picker only names that fighter's
-                # guns. The stash picker names the roster, so this
-                # filter stays off when the accessory is not on a
-                # model.
-                if assignment.miniature_root_id:
-                    named = named.filter(miniature_root=assignment.miniature_root)
-                destination = named.first()
-            except ValidationError:
-                destination = None
     else:
         try:
             destination = Miniature.objects.filter(

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -455,6 +455,12 @@ def owned_dialog(request, host: EquipHost):
             for node in weapons_on(host)
             if node.assignment.pk != assignment.parent_id
         )
+        # Already on a gun, and no other gun on this card: the control
+        # is not drawn, so a hand-made address is a page without a
+        # panel. A loose accessory with no gun still gets the empty
+        # panel — that is the question with nothing to name.
+        if assignment.parent_id is not None and not weapons:
+            return None
         return dialog | {
             "title": f"Fit {name} to a weapon",
             "weapons": [
@@ -804,6 +810,13 @@ def reassign_assignment(request, pk):
             )
             return _unchanged(request, back)
         destination = assignment.miniature_root
+        if destination is None:
+            messages.error(
+                request,
+                f"You cannot take {name} off here. "
+                "Detach leaves it on the fighter who holds it.",
+            )
+            return _unchanged(request, back)
     elif wanted == "weapon":
         # A sight the gun came with belongs to the package. Moving it
         # onto another gun would offer a keep the sale of that package

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -67,6 +67,7 @@ from n26.core.owned import (
     DIALOGS,
     EquipHost,
     can_unbolt,
+    cannot_unbolt_reason,
     is_possession,
     thing_key,
     weapons_on,
@@ -803,11 +804,7 @@ def reassign_assignment(request, pk):
         # model that already holds it — read off the assignment, not the
         # form, so a hand-made click cannot name somebody else.
         if not can_unbolt(assignment):
-            messages.error(
-                request,
-                f"You cannot take {name} off the weapon. "
-                "Only a bought accessory can come off and stay held.",
-            )
+            messages.error(request, cannot_unbolt_reason(name))
             return _unchanged(request, back)
         destination = assignment.miniature_root
         if destination is None:
@@ -822,11 +819,7 @@ def reassign_assignment(request, pk):
         # onto another gun would offer a keep the sale of that package
         # takes back.
         if assignment.parent_id is not None and not can_unbolt(assignment):
-            messages.error(
-                request,
-                f"You cannot take {name} off the weapon. "
-                "Only a bought accessory can come off and stay held.",
-            )
+            messages.error(request, cannot_unbolt_reason(name))
             return _unchanged(request, back)
         try:
             named = Assignment.objects.filter(

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -34,11 +34,12 @@ The acts are deliberately distinct, and the ledger says which happened:
     sales at two prices.
 ``reassign``
     A move to another model, to the stash, or onto a weapon. No money,
-    and no re-pricing. The last of the three is how an accessory is
-    fitted to a gun: the same act, one level down the chain. It is asked
-    as a question of its own — ``?fit=`` rather than ``?reassign=`` —
-    because which model holds a thing and which gun it is bolted to are
-    not one question, however much they are one act.
+    and no re-pricing. Fitting an accessory to a gun, and taking one off
+    so the fighter still holds it, are the same act one level down the
+    chain. Each is asked as a question of its own — ``?fit=`` and
+    ``?detach=`` rather than ``?reassign=`` — because which model holds
+    a thing, which gun it is bolted to, and whether it stays held
+    unfitted are not one question, however much they are one act.
 ``refund``
     Undoing the purchase: every credit that was paid comes back. The amount
     paid and the rating part company at the first discount, which is why
@@ -65,6 +66,7 @@ from django.views.decorators.http import require_POST
 from n26.core.owned import (
     DIALOGS,
     EquipHost,
+    can_unbolt,
     is_possession,
     thing_key,
     weapons_on,
@@ -236,10 +238,11 @@ def _asked(request):
 
 
 #: The act a question submits to, where that is not the question's own
-#: name. Fitting an accessory to a gun is asked on its own, because
-#: Reassign is about which model holds a thing and this is not, and it is
+#: name. Fitting an accessory to a gun, and taking one off so the
+#: fighter still holds it, are asked on their own, because Reassign is
+#: about which model holds a thing and these are not, and both are
 #: answered by the move that does it.
-ROUTES = {"fit": "reassign"}
+ROUTES = {"fit": "reassign", "detach": "reassign"}
 
 
 def _panel(request, assignment, kind, at):
@@ -431,19 +434,41 @@ def owned_dialog(request, host: EquipHost):
         # naming something else draws no dialog at all. Without this a
         # gun's own address opens a picker holding that same gun, whose
         # answer would be attaching it to itself — a screen must not ask
-        # a question its answer refuses.
+        # a question its answer refuses. A sight the gun came with is
+        # the same: it belongs to the package, and a picker would offer
+        # a click that cannot keep it.
         if assignment.weapon_accessory_id is None:
             return None
-        # Every gun on the card, and not only the ones the accessory was
-        # written for: what fits what is information rather than a gate,
-        # and an owner may bolt anything to anything.
-        weapons = weapons_on(host)
+        if assignment.parent_id is not None and not can_unbolt(assignment):
+            return None
+        # Every gun on the card except the one it already hangs off, and
+        # not only the ones the accessory was written for: what fits
+        # what is information rather than a gate, and an owner may bolt
+        # anything to anything.
+        weapons = tuple(
+            node
+            for node in weapons_on(host)
+            if node.assignment.pk != assignment.parent_id
+        )
         return dialog | {
             "title": f"Fit {name} to a weapon",
             "weapons": [
                 {"pk": str(node.assignment.pk), "label": node.name} for node in weapons
             ],
             "submit_label": "Fit" if weapons else "",
+            "submit_variant": "primary",
+        }
+
+    if kind == "detach":
+        # Taking it off so this fighter still holds it. A URL naming
+        # anything that cannot be unbolted draws no dialog: the control
+        # is not drawn for those, and a hand-made address is a page
+        # without a panel rather than a question whose answer refuses.
+        if host.is_stash or not can_unbolt(assignment):
+            return None
+        return dialog | {
+            "title": f"Detach {name}?",
+            "submit_label": "Detach",
             "submit_variant": "primary",
         }
 
@@ -735,10 +760,12 @@ def reassign_assignment(request, pk):
     Nothing is charged and nothing is re-priced: the thing keeps the
     rating it was pinned at, and only where it lives changes.
 
-    Three destinations, told apart by ``to``. ``stash`` and a named
+    Four destinations, told apart by ``to``. ``stash`` and a named
     ``miniature`` are the two a fighter's own listing row offers. ``weapon``
-    names another assignment, which is how a stashed accessory is
-    bolted back onto a gun — the same act, one level down the chain.
+    names another assignment, which is how an accessory is bolted onto
+    a gun — the same act, one level down the chain. ``detach`` is the
+    other way on that chain: the accessory comes off the gun and this
+    fighter still holds it, unfitted.
 
     What may not be moved at all is ``Operation.move``'s answer rather
     than this view's: a weapon's firing line is part of its weapon, and
@@ -760,25 +787,38 @@ def reassign_assignment(request, pk):
     wanted = request.POST.get("to")
     if wanted == "stash":
         destination = getattr(gang, "stash", None)
+    elif wanted == "detach":
+        # This fighter, as a root of their own. The destination is the
+        # model that already holds it — read off the assignment, not the
+        # form, so a hand-made click cannot name somebody else.
+        destination = assignment.miniature_root if can_unbolt(assignment) else None
     elif wanted == "weapon":
-        try:
-            destination = (
-                Assignment.objects.filter(
-                    pk=request.POST.get("weapon", ""),
-                    gang_root=gang,
-                    archived=False,
-                )
-                .exclude(weapon=None)
-                # Nothing hangs off itself. The operation says so too, but
-                # it says it by raising rather than refusing, so a
-                # hand-made click naming its own weapon is answered here
-                # with the same sentence as any other impossible
-                # destination.
-                .exclude(pk=assignment.pk)
-                .first()
-            )
-        except ValidationError:
+        # A sight the gun came with belongs to the package. Moving it
+        # onto another gun would offer a keep the sale of that package
+        # takes back.
+        if assignment.parent_id is not None and not can_unbolt(assignment):
             destination = None
+        else:
+            try:
+                destination = (
+                    Assignment.objects.filter(
+                        pk=request.POST.get("weapon", ""),
+                        gang_root=gang,
+                        archived=False,
+                    )
+                    .exclude(weapon=None)
+                    # Nothing hangs off itself, and nothing moves onto
+                    # the gun it already hangs off. The operation says
+                    # the first by raising rather than refusing, so a
+                    # hand-made click naming either is answered here
+                    # with the same sentence as any other impossible
+                    # destination.
+                    .exclude(pk=assignment.pk)
+                    .exclude(pk=assignment.parent_id)
+                    .first()
+                )
+            except ValidationError:
+                destination = None
     else:
         try:
             destination = Miniature.objects.filter(
@@ -793,11 +833,17 @@ def reassign_assignment(request, pk):
         return _unchanged(request, back)
 
     # Fitting takes the thing out of a row of its own and draws it under
-    # the gun instead, so two rows on the screen change. The gun's row
-    # counts only where the reader is looking at it: a stash fit reaches
-    # a gun on somebody's card, and that is not the screen this answers.
-    landed = _row_behind(destination) if isinstance(destination, Assignment) else None
-    also = landed.key if landed and landed.miniature == touched.miniature else ""
+    # the gun instead; detaching does the reverse. Either way two rows
+    # on the screen change. The other row counts only where the reader
+    # is looking at it: a stash fit reaches a gun on somebody's card,
+    # and that is not the screen this answers.
+    if wanted == "detach":
+        also = thing_key(assignment.assignable)
+    else:
+        landed = (
+            _row_behind(destination) if isinstance(destination, Assignment) else None
+        )
+        also = landed.key if landed and landed.miniature == touched.miniature else ""
 
     try:
         with operation(gang, actor=request.user) as op:
@@ -815,12 +861,14 @@ def reassign_assignment(request, pk):
         miniature_id=str(came_from.pk) if came_from else None,
         thing=name,
         action="reassign",
-        to=wanted if wanted in ("stash", "weapon") else "model",
+        to=wanted if wanted in ("stash", "weapon", "detach") else "model",
     )
     if wanted == "stash":
         messages.success(request, f"Moved {name} to the stash.")
     elif wanted == "weapon":
         messages.success(request, f"Fitted {name} to {destination.assignable}.")
+    elif wanted == "detach":
+        messages.success(request, f"Detached {name}.")
     else:
         messages.success(request, f"Moved {name} to {destination.name}.")
     return _acted(request, touched, gang, back, also=also)

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -441,6 +441,11 @@ def owned_dialog(request, host: EquipHost):
             return None
         if assignment.parent_id is not None and not can_unbolt(assignment):
             return None
+        # Stash fitting is Reassign: that picker lists every gun on the
+        # roster. This question only sees the host's own guns, so a
+        # stash address would offer the wrong set.
+        if host.is_stash:
+            return None
         # Every gun on the card except the one it already hangs off, and
         # not only the ones the accessory was written for: what fits
         # what is information rather than a gate, and an owner may bolt
@@ -791,7 +796,14 @@ def reassign_assignment(request, pk):
         # This fighter, as a root of their own. The destination is the
         # model that already holds it — read off the assignment, not the
         # form, so a hand-made click cannot name somebody else.
-        destination = assignment.miniature_root if can_unbolt(assignment) else None
+        if not can_unbolt(assignment):
+            messages.error(
+                request,
+                f"You cannot take {name} off the weapon. "
+                "Only a bought accessory can come off and stay held.",
+            )
+            return _unchanged(request, back)
+        destination = assignment.miniature_root
     elif wanted == "weapon":
         # A sight the gun came with belongs to the package. Moving it
         # onto another gun would offer a keep the sale of that package

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1101,24 +1101,26 @@ GROUPS: list[Group] = [
                 summary=(
                     "Confirm a sale, a move, a refund or a removal of "
                     "something the gang owns — or ask which accessory to "
-                    "fit to a weapon, or which alternatives it is taken "
-                    "with."
+                    "fit to a weapon, whether to take one off, or which "
+                    "alternatives it is taken with."
                 ),
                 needs=(ALPINE,),
                 notes=(
-                    "One panel for six questions: sell, move, refund, remove, "
-                    "fit an accessory, and change what a thing was bought with. "
-                    "Each states what a reader cannot work out from the page — "
-                    "a sale states its arithmetic, a move that it charges "
-                    "nothing, a removal that the money stays spent, a refund "
-                    "what was paid. The stash is a button and the roster a "
-                    "select, and only the clicked submit is sent, which is the "
-                    "whole of how the view tells those two apart. Selling "
-                    "something with a part bolted to it is two sales at two "
-                    "prices, so each option carries its own figure rather than "
-                    "the lead carrying one. Changing what a thing was bought "
-                    "with draws the buying row's own controls rather than a "
-                    "second set, with the loader deciding which starts picked."
+                    "One panel for the owned questions: sell, move, refund, "
+                    "remove, fit an accessory, take one off, and change what "
+                    "a thing was bought with. Each states what a reader "
+                    "cannot work out from the page — a sale states its "
+                    "arithmetic, a move that it charges nothing, a removal "
+                    "that the money stays spent, a refund what was paid, a "
+                    "detach that the fighter still holds it. The stash is a "
+                    "button and the roster a select, and only the clicked "
+                    "submit is sent, which is the whole of how the view tells "
+                    "those two apart. Selling something with a part bolted to "
+                    "it is two sales at two prices, so each option carries "
+                    "its own figure rather than the lead carrying one. "
+                    "Changing what a thing was bought with draws the buying "
+                    "row's own controls rather than a second set, with the "
+                    "loader deciding which starts picked."
                 ),
             ),
             Component(

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1112,7 +1112,7 @@ GROUPS: list[Group] = [
                     "cannot work out from the page — a sale states its "
                     "arithmetic, a move that it charges nothing, a removal "
                     "that the money stays spent, a refund what was paid, a "
-                    "detach that the fighter still holds it. The stash is a "
+                    "detach that they still hold it. The stash is a "
                     "button and the roster a select, and only the clicked "
                     "submit is sent, which is the whole of how the view tells "
                     "those two apart. Selling something with a part bolted to "

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -2306,6 +2306,14 @@ def owned_context():
             "submit_label": "Fit",
             "submit_variant": "primary",
         },
+        "owned_detach_dialog": {
+            **named,
+            "kind": "detach",
+            "name": "Infra-sight",
+            "title": "Detach Infra-sight?",
+            "submit_label": "Detach",
+            "submit_variant": "primary",
+        },
         "owned_fit_nothing_dialog": {
             **named,
             "kind": "fit",

--- a/n26/designsystem/templates/designsystem/demos/owned-dialog/36-detaching.html
+++ b/n26/designsystem/templates/designsystem/demos/owned-dialog/36-detaching.html
@@ -1,0 +1,4 @@
+{# title: Taking an accessory off a gun #}
+{# note: Asked apart from the move and from fitting, because keeping it held on this fighter is not the same question as handing it to someone else or bolting it to a different gun. The destination is this fighter, so the panel posts that and draws no select. #}
+{# layout: full #}
+<c-n26.owned-dialog :dialog="owned_detach_dialog" modal="" />

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -146,6 +146,12 @@ class TestTheOwnedDialogsPage:
     """The two questions the panel grew reach the gallery drawn, not as a
     polite fallback."""
 
+    def test_taking_an_accessory_off_draws_its_own_question(self, reader):
+        page = reader.get("/n26/design/c/owned-dialog/").content.decode()
+        assert "Taking an accessory off a gun" in page
+        assert "Detach Infra-sight?" in page
+        assert 'name="to" value="detach"' in page
+
     def test_the_accessory_picker_draws_its_list(self, reader):
         page = reader.get("/n26/design/c/owned-dialog/").content.decode()
         assert "Fitting an accessory" in page

--- a/n26/tests/sandbox/test_listing.py
+++ b/n26/tests/sandbox/test_listing.py
@@ -30,6 +30,7 @@ from n26.core.listing import (
     price_field,
 )
 from n26.core.owned import owned_things, thing_key
+from n26.core.reconcile import assert_reconciled
 from n26.library.authoring import add_weapon_profile
 from n26.tests.sandbox.actions import (
     assign,
@@ -343,7 +344,7 @@ class TestWhatACopyOffers:
         assert [action.label for action in part.more] == ["Refund", "Remove"]
         assert part.sell.target == f"{AT}&sell={ammo.pk}"
 
-    def test_a_bought_accessory_offers_detach(self, fighter, house_list, armed):
+    def test_a_bought_accessory_offers_detach(self, gang, fighter, house_list, armed):
         """A sight is gear in its own right. Taking it off leaves the
         fighter holding it, so the row asks that before the ways of
         parting with it."""
@@ -370,6 +371,7 @@ class TestWhatACopyOffers:
         ]
         assert part.more[0].target == f"{AT}&detach={bolted.pk}"
         assert part.more[1].target == f"{AT}&fit={bolted.pk}"
+        assert_reconciled(gang)
 
 
 class TestWhatARowPrints:

--- a/n26/tests/sandbox/test_listing.py
+++ b/n26/tests/sandbox/test_listing.py
@@ -327,11 +327,10 @@ class TestWhatACopyOffers:
         ]
 
     def test_a_part_is_offered_no_move(self, fighter, house_list, armed):
-        """A part belongs to the thing it hangs off, and ``Operation.move``
-        refuses an assignment with a parent — so offering one here would
-        be offering a click that cannot work. It keeps the rest: buying
-        the wrong ammunition is as easy a mistake as buying the wrong
-        gun."""
+        """Ammunition belongs to the gun it names, and ``Operation.move``
+        refuses a firing line — so offering detach here would be offering
+        a click that cannot work. It keeps the rest: buying the wrong
+        ammunition is as easy a mistake as buying the wrong gun."""
         _, ammo, _ = armed
         row = rows_by_name(catalogue_for(fighter, house_list))["Autogun"]
         (part,) = [
@@ -343,6 +342,34 @@ class TestWhatACopyOffers:
 
         assert [action.label for action in part.more] == ["Refund", "Remove"]
         assert part.sell.target == f"{AT}&sell={ammo.pk}"
+
+    def test_a_bought_accessory_offers_detach(self, fighter, house_list, armed):
+        """A sight is gear in its own right. Taking it off leaves the
+        fighter holding it, so the row asks that before the ways of
+        parting with it."""
+        from n26.core.operations import operation
+        from n26.library.authoring import create_weapon_accessory
+
+        first, _, _ = armed
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        with operation(fighter.gang, actor=fighter.gang.owner) as op:
+            bolted = op.buy(first, thing=sight)
+        row = rows_by_name(catalogue_for(fighter, house_list))["Autogun"]
+        (part,) = [
+            part
+            for copy in row.copies
+            for part in copy.parts
+            if part.id == str(bolted.pk)
+        ]
+
+        assert [action.label for action in part.more] == [
+            "Detach",
+            "Fit to a weapon",
+            "Refund",
+            "Remove",
+        ]
+        assert part.more[0].target == f"{AT}&detach={bolted.pk}"
+        assert part.more[1].target == f"{AT}&fit={bolted.pk}"
 
 
 class TestWhatARowPrints:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2397.

On an n26 fighter card, a weapon accessory bolted to a gun only offered Sell and Remove. Remove archived it; Sell sold it. There was no way to take it off and keep it on the fighter, or to move it onto a different gun they already hold.

## What changed

The kebab on a bought, attached accessory now offers:

1. **Detach** — takes it off the weapon. The fighter still holds it, unfitted, the same shape as one bought from their equip page.
2. **Fit to a weapon** — when they carry another gun, the existing fit dialog lists those other guns (not the one it already hangs off).

Both are the same `Operation.move` that already re-homes a detachable accessory. They are asked as their own questions (`?detach=` and `?fit=`) and answered by `n26-reassign`, so Reassign stays about which model holds a thing.

A sight the gun came with (`caused_by` set) and a weapon's firing line are offered neither — the same rule a sale uses when it asks which extras to keep.

Hand-made addresses stay quiet or get a sentence: stash parts do not draw `?fit=` or `?detach=`; a one-gun card does not open an empty Fit panel; a built-in sight or a stash Detach is refused in words.

## How to try it

1. On an n26 fighter, fit a bought accessory to a weapon they hold (or buy one onto the gun with Add accessory).
2. Open the accessory kebab on the model's edit page (`/n26/fighters/<id>/edit`).
3. **Detach** confirms and leaves the sight on the fighter as loose gear.
4. If they hold a second gun, **Fit to a weapon** lists that gun and moves the sight onto it.

[Accessory kebab with Detach and Fit to a weapon](https://cursor.com/agents/bc-28859450-0473-4775-82ec-fac822ea10de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccessory_kebab_detach_and_fit.png)
[Detach confirmation](https://cursor.com/agents/bc-28859450-0473-4775-82ec-fac822ea10de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdetach_dialog.png)
[Sight held unfitted after Detach](https://cursor.com/agents/bc-28859450-0473-4775-82ec-fac822ea10de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsight_held_unfitted.png)
[detach_and_fit_accessory_kebab.mp4](https://cursor.com/agents/bc-28859450-0473-4775-82ec-fac822ea10de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdetach_and_fit_accessory_kebab.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28859450-0473-4775-82ec-fac822ea10de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28859450-0473-4775-82ec-fac822ea10de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

