### PR TITLE
feat: n26 accessory kebab can detach a WeaponAccessory onto the fighter

### DIFF
--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -195,9 +195,10 @@ class Listing:
 class OwnedPartRow:
     """Something hanging off a copy the fighter holds: ammo, an accessory.
 
-    No move among its actions. A part belongs to the thing it hangs off
-    and ``Operation.move`` refuses an assignment with a parent, so
-    offering one would be offering a click that cannot work.
+    A firing line has no move among its actions: it *is* the weapon's
+    line, and ``Operation.move`` refuses it. An accessory the gang
+    bought can come off, so Detach and Fit sit with Refund and Remove
+    when there is somewhere for them to go.
     """
 
     id: str
@@ -418,6 +419,19 @@ def copy_row(copy, refunds=True):
                 # the wrong gun. Removed rather than deleted, because what
                 # is left afterwards is still the fighter's gun.
                 more=(
+                    # Acts that leave the fighter holding it, before the
+                    # ways of parting with it — Detach onto their own
+                    # kit, Fit onto another gun they already carry.
+                    *(
+                        (Action("Detach", LINK, part.detach_href, SECONDARY),)
+                        if part.detach_href
+                        else ()
+                    ),
+                    *(
+                        (Action("Fit to a weapon", LINK, part.fit_href, SECONDARY),)
+                        if part.fit_href
+                        else ()
+                    ),
                     *(
                         (Action("Refund", LINK, part.refund_href, SECONDARY),)
                         if refunds

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -92,14 +92,12 @@ def detachable_children(assignment):
     *brought* — a sight that came with it as standard — belongs to the
     package rather than to the gang: what caused it goes, so it goes.
     """
-    from n26.core.owned import is_detachable
+    from n26.core.owned import can_unbolt
 
     return [
         child
         for child in assignment.children.all()
-        if not child.archived
-        and child.caused_by_id is None
-        and is_detachable(child.assignable)
+        if not child.archived and can_unbolt(child)
     ]
 
 

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -254,7 +254,8 @@ def _parts_of(node, at, *, can_refit=False):
     ``can_refit`` is whether this host carries another gun this part
     could move onto. A screen must not ask a question its answer
     refuses, so an accessory on the only gun is offered Detach and not
-    Fit.
+    Fit. The stash is never asked — its accessories are fitted from
+    the gang sheet, where the guns of the whole roster are in reach.
     """
     parts = []
     for child in node.children:
@@ -343,8 +344,9 @@ def possessions(host: EquipHost):
                 parts=_parts_of(
                     node,
                     at,
-                    can_refit=any(
-                        gun.assignment.pk != node.assignment.pk for gun in guns
+                    can_refit=(
+                        not host.is_stash
+                        and any(gun.assignment.pk != node.assignment.pk for gun in guns)
                     ),
                 ),
                 sell_href=with_query(at, sell=pk),

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -48,7 +48,16 @@ class EquipHost:
 
 #: URL parameters that can open one assignment dialog. Their order is the
 #: precedence when an address names more than one.
-DIALOGS = ("sell", "reassign", "fit", "refund", "remove", "accessorise", "rechoose")
+DIALOGS = (
+    "sell",
+    "reassign",
+    "fit",
+    "detach",
+    "refund",
+    "remove",
+    "accessorise",
+    "rechoose",
+)
 
 
 def with_query(url, **params):
@@ -95,6 +104,22 @@ def is_detachable(thing):
     return is_possession(thing) and not isinstance(thing, WeaponProfile)
 
 
+def can_unbolt(assignment):
+    """Can this copy come off what it hangs from and stay with the gang?
+
+    :func:`is_detachable` is about the *kind* of thing: a sight can, a
+    firing line cannot. This is about *this copy*. A sight the gun came
+    with belongs to the package — what caused it goes, so it goes — and
+    offering to take one off would be offering something the sale of the
+    gun takes straight back.
+    """
+    return (
+        assignment.parent_id is not None
+        and assignment.caused_by_id is None
+        and is_detachable(assignment.assignable)
+    )
+
+
 def thing_key(thing):
     """One string naming a piece of content — what a form submits to name it.
 
@@ -108,7 +133,10 @@ def thing_key(thing):
 class OwnedPart:
     """Something hanging off a thing the model owns: ammo, an accessory.
 
-    No re-homing: a part belongs to its parent and moves only with it.
+    A firing line stays put: it *is* the weapon's line. An accessory the
+    gang bought can come off — kept held, or fitted to another gun —
+    which is why those two addresses are here and empty for everything
+    that cannot.
     """
 
     id: str
@@ -121,6 +149,12 @@ class OwnedPart:
     sell_href: str
     refund_href: str
     remove_href: str
+    #: Where to go to take this off and leave the fighter holding it.
+    #: Empty for a firing line, and for a sight the gun came with.
+    detach_href: str = ""
+    #: Where to go to bolt this onto a different gun this fighter is
+    #: carrying. Empty unless there is another gun to name.
+    fit_href: str = ""
 
 
 @dataclass(frozen=True)
@@ -208,7 +242,7 @@ def _part_name(node):
     return node.name
 
 
-def _parts_of(node, at):
+def _parts_of(node, at, *, can_refit=False):
     """The children drawn beneath a thing, each with an address of its own.
 
     A weapon's *unnamed* profile is the weapon — the book prints an
@@ -216,12 +250,18 @@ def _parts_of(node, at):
     the same rule ``n26.render.WeaponLine.own_line`` keeps for the card.
     It also cannot be sold apart from its gun, which is the same fact
     said about money.
+
+    ``can_refit`` is whether this host carries another gun this part
+    could move onto. A screen must not ask a question its answer
+    refuses, so an accessory on the only gun is offered Detach and not
+    Fit.
     """
     parts = []
     for child in node.children:
         if child.is_weapon_profile and not child.assignable.name:
             continue
         pk = str(child.assignment.pk)
+        unbolt = can_unbolt(child.assignment)
         parts.append(
             OwnedPart(
                 id=pk,
@@ -231,6 +271,8 @@ def _parts_of(node, at):
                 sell_href=with_query(at, sell=pk),
                 refund_href=with_query(at, refund=pk),
                 remove_href=with_query(at, remove=pk),
+                detach_href=with_query(at, detach=pk) if unbolt else "",
+                fit_href=(with_query(at, fit=pk) if unbolt and can_refit else ""),
             )
         )
     return tuple(parts)
@@ -276,7 +318,8 @@ def possessions(host: EquipHost):
     # a screen must not ask a question its answer refuses. The stash is
     # never asked — its accessories are fitted from the gang sheet,
     # where the guns of the whole roster are in reach.
-    fittable = not host.is_stash and bool(weapons_on(host))
+    guns = weapons_on(host)
+    fittable = not host.is_stash and bool(guns)
 
     index = {}
     for node in host.roots:
@@ -297,7 +340,13 @@ def possessions(host: EquipHost):
                 key=key,
                 name=node.name,
                 rating=node.rating,
-                parts=_parts_of(node, at),
+                parts=_parts_of(
+                    node,
+                    at,
+                    can_refit=any(
+                        gun.assignment.pk != node.assignment.pk for gun in guns
+                    ),
+                ),
                 sell_href=with_query(at, sell=pk),
                 reassign_href=with_query(at, reassign=pk),
                 refund_href=with_query(at, refund=pk),

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -111,7 +111,9 @@ def can_unbolt(assignment):
     firing line cannot. This is about *this copy*. A sight the gun came
     with belongs to the package — what caused it goes, so it goes — and
     offering to take one off would be offering something the sale of the
-    gun takes straight back.
+    gun takes straight back. ``Operation.move`` refuses only the kind;
+    the copy's rule is held by whoever asks it, so a view refuses a
+    built-in itself before reaching the operation.
     """
     return (
         assignment.parent_id is not None

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -3,22 +3,21 @@
 
     <c-n26.owned-dialog :dialog="dialog">{% csrf_token %}</c-n26.owned-dialog>
 
-Seven questions in one panel — sell, move, fit, detach, refund, remove,
-accessorise — since the difference between them is a sentence and, for
-most of them, one control. Which is being asked, along with the figures,
-the roster, the guns and the accessories that fit, arrives in `dialog`
-from n26.core.views.owned. The panel itself is <c-n26.dialog>, where the
+Sell, move, fit, detach, refund, remove, accessorise and rechoose share
+one panel, since the difference between them is a sentence and, for most
+of them, one control. Which is being asked, along with the figures, the
+roster, the guns and the accessories that fit, arrives in `dialog` from
+n26.core.views.owned. The panel itself is <c-n26.dialog>, where the
 open-state rules are written down.
 
 Only the clicked submit is sent, so a move is told apart by `to=stash`
 arriving. Move, fit and detach are one act with one address, asked as
 three questions: which model holds a thing is not the same question as
 which gun it is bolted to, and taking it off that gun is not the same
-question as putting it on another. Three of the seven can end up with
-nothing to submit: a move with nobody else on the roster posts a hidden
-to=stash and draws no select, a fit draws no submit where the card
-carries no gun, and accessorise draws none when nothing in the library
-fits the weapon.
+question as putting it on another. Some end up with nothing to submit:
+a move with nobody else on the roster posts a hidden to=stash and draws
+no select, a fit draws no submit where the card carries no gun, and
+accessorise draws none when nothing in the library fits the weapon.
 
 Accessorise is also the one an equip page draws for every weapon on it rather
 than only for the one the URL names, so those panels are passed open="" and an

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -3,20 +3,22 @@
 
     <c-n26.owned-dialog :dialog="dialog">{% csrf_token %}</c-n26.owned-dialog>
 
-Six questions in one panel — sell, move, fit, refund, remove, accessorise —
-since the difference between them is a sentence and, for four of them, one
-control. Which is being asked, along with the figures, the roster, the guns
-and the accessories that fit, arrives in `dialog` from n26.core.views.owned.
-The panel itself is <c-n26.dialog>, where the open-state rules are written
-down.
+Seven questions in one panel — sell, move, fit, detach, refund, remove,
+accessorise — since the difference between them is a sentence and, for
+most of them, one control. Which is being asked, along with the figures,
+the roster, the guns and the accessories that fit, arrives in `dialog`
+from n26.core.views.owned. The panel itself is <c-n26.dialog>, where the
+open-state rules are written down.
 
 Only the clicked submit is sent, so a move is told apart by `to=stash`
-arriving. Move and fit are one act with one address, asked as two questions:
-which model holds a thing is not the same question as which gun it is bolted
-to. Three of the six can end up with nothing to submit: a move with nobody
-else on the roster posts a hidden to=stash and draws no select, a fit draws
-no submit where the card carries no gun, and accessorise draws none when
-nothing in the library fits the weapon.
+arriving. Move, fit and detach are one act with one address, asked as
+three questions: which model holds a thing is not the same question as
+which gun it is bolted to, and taking it off that gun is not the same
+question as putting it on another. Three of the seven can end up with
+nothing to submit: a move with nobody else on the roster posts a hidden
+to=stash and draws no select, a fit draws no submit where the card
+carries no gun, and accessorise draws none when nothing in the library
+fits the weapon.
 
 Accessorise is also the one an equip page draws for every weapon on it rather
 than only for the one the URL names, so those panels are passed open="" and an
@@ -78,6 +80,14 @@ itself.
                 gun and no other the fighter is carrying.
             {% else %}
                 There is no weapon here to fit it to.
+            {% endif %}
+        {% elif dialog.kind == "detach" %}
+            {% if dialog.stash_host %}
+                It will stay in the stash. Detaching it does not change its
+                rating.
+            {% else %}
+                The fighter will still hold it. Detaching it does not change
+                its rating.
             {% endif %}
         {% elif dialog.kind == "refund" %}
             {{ dialog.sum }} It and anything attached to it are removed from the
@@ -149,7 +159,9 @@ itself.
         </c-n26.radio-cards>
     {% endif %}
 
-    {% if dialog.kind == "reassign" or dialog.kind == "fit" %}
+    {% if dialog.kind == "detach" %}
+        <input type="hidden" name="to" value="held">
+    {% elif dialog.kind == "reassign" or dialog.kind == "fit" %}
         {% if dialog.weapons %}
             <input type="hidden" name="to" value="weapon">
             <c-ui.field label="Weapon" for="reassign-weapon">

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -474,6 +474,61 @@ class TestKitActionsOnTheCard:
         assert "<dialog" in body
         assert reverse("n26-sell", args=[sword.pk]) in body
 
+    def test_a_bolted_accessory_offers_detach_and_not_fit_alone(
+        self, client, tester, gang, vex, gun
+    ):
+        from n26.library.authoring import create_weapon_accessory
+
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        with operation(gang, actor=tester) as op:
+            bolted = op.buy(gun, thing=sight)
+
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+        at = edit_url(vex)
+
+        assert "Detach" in body
+        assert f"{at}?detach={bolted.pk}" in body
+        assert f"{at}?remove={bolted.pk}" in body
+        assert f"{at}?fit={bolted.pk}" not in body
+        assert "More for Telescopic sight" in body
+
+    def test_a_second_gun_lets_the_accessory_be_fitted_to_it(
+        self, client, tester, gang, vex, gun
+    ):
+        from n26.library.authoring import create_weapon, create_weapon_accessory
+
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        stub = create_weapon("Stub gun", price=5, profiles=[("", 0)])
+        with operation(gang, actor=tester) as op:
+            bolted = op.buy(gun, thing=sight)
+            op.buy(vex, thing=stub, paid=5)
+
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+        at = edit_url(vex)
+
+        assert f"{at}?detach={bolted.pk}" in body
+        assert f"{at}?fit={bolted.pk}" in body
+        assert "Fit to a weapon" in body
+
+    def test_the_url_opens_the_detach_dialog_on_this_page(
+        self, client, tester, gang, vex, gun
+    ):
+        from n26.library.authoring import create_weapon_accessory
+
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        with operation(gang, actor=tester) as op:
+            bolted = op.buy(gun, thing=sight)
+
+        client.force_login(tester)
+        body = client.get(f"{edit_url(vex)}?detach={bolted.pk}").content.decode()
+
+        assert "Take Telescopic sight off Lasgun?" in body
+        assert "The fighter will still hold it." in body
+        assert reverse("n26-reassign", args=[bolted.pk]) in body
+        assert 'name="to" value="held"' in body
+
     def test_the_url_opens_the_accessory_dialog_on_this_page(
         self, client, tester, vex, gun
     ):

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1070,6 +1070,11 @@ class TestDetachingAnAccessory:
             return op.buy(gun, thing=sight)
 
     @pytest.fixture
+    def loose(self, gang, tester, fighter, sight):
+        with operation(gang, actor=tester) as op:
+            return op.buy(fighter, thing=sight)
+
+    @pytest.fixture
     def second_gun(self, gang, fighter, tester):
         from n26.library.authoring import create_weapon
 
@@ -1311,6 +1316,41 @@ class TestDetachingAnAccessory:
         assert "Only a bought accessory can come off." in response.content.decode()
         builtin.refresh_from_db()
         assert builtin.parent_id == gun.pk
+        assert_reconciled(gang)
+
+    def test_a_hand_made_move_of_a_built_in_to_the_stash_is_refused(
+        self, client, tester, gang, gun, sight
+    ):
+        """The rule is about the part, so it holds whichever destination
+        a hand-made click names."""
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", builtin), {"to": "stash"}, follow=True
+        )
+
+        assert "Only a bought accessory can come off." in response.content.decode()
+        builtin.refresh_from_db()
+        assert builtin.parent_id == gun.pk
+        assert builtin.stash_id is None
+        assert_reconciled(gang)
+
+    def test_a_loose_accessory_has_nothing_to_come_off(
+        self, client, tester, gang, fighter, loose
+    ):
+        client.force_login(tester)
+
+        response = client.post(url("n26-reassign", loose), {"to": "held"}, follow=True)
+
+        assert "There is nowhere to move" in response.content.decode()
+        loose.refresh_from_db()
+        assert loose.miniature_root_id == fighter.pk
         assert_reconciled(gang)
 
     def test_a_firing_line_is_refused_in_words(self, client, tester, gang, gun):

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1059,6 +1059,288 @@ class TestFittingOneTheFighterIsCarrying:
         assert f'id="{gone}" hx-swap-oob="delete"' in body
 
 
+class TestDetachingAnAccessory:
+    """A sight bolted to a gun can come off and stay with the fighter.
+    Remove archives it; this does not. Fit to another gun they already
+    carry is the same move, asked as its own question."""
+
+    @pytest.fixture
+    def bolted(self, gang, tester, gun, sight):
+        with operation(gang, actor=tester) as op:
+            return op.buy(gun, thing=sight)
+
+    @pytest.fixture
+    def second_gun(self, gang, fighter, tester):
+        from n26.library.authoring import create_weapon
+
+        weapon = create_weapon("Autogun", price=20, profiles=[("", 0)])
+        with operation(gang, actor=tester) as op:
+            return op.buy(fighter, thing=weapon, paid=20)
+
+    @staticmethod
+    def dialog(fighter, **query):
+        from django.test import RequestFactory
+
+        from n26.core.card import build_card
+        from n26.core.owned import EquipHost
+        from n26.core.views.owned import owned_dialog
+
+        request = RequestFactory().get(AT, query)
+        host = EquipHost.fighter(fighter.gang, build_card(fighter), fighter, AT)
+        return owned_dialog(request, host)
+
+    @staticmethod
+    def part_of(fighter, parent, assignment):
+        from n26.core.card import build_card
+        from n26.core.owned import owned_things, thing_key
+
+        held = owned_things(build_card(fighter), AT)
+        (copy,) = held[thing_key(parent.assignable)]
+        return next(part for part in copy.parts if part.id == str(assignment.pk))
+
+    def test_a_bought_accessory_offers_detach(self, fighter, gun, bolted):
+        part = self.part_of(fighter, gun, bolted)
+        assert part.detach_href == f"{AT}&detach={bolted.pk}"
+
+    def test_the_only_gun_is_nowhere_to_fit_it(self, fighter, gun, bolted):
+        """A screen must not ask a question its answer refuses."""
+        part = self.part_of(fighter, gun, bolted)
+        assert part.fit_href == ""
+
+    def test_another_gun_is_somewhere_to_fit_it(self, fighter, gun, bolted, second_gun):
+        part = self.part_of(fighter, gun, bolted)
+        assert part.fit_href == f"{AT}&fit={bolted.pk}"
+
+    def test_a_sight_the_gun_came_with_is_offered_neither(
+        self, gang, tester, fighter, gun, sight
+    ):
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        part = self.part_of(fighter, gun, builtin)
+        assert part.detach_href == ""
+        assert part.fit_href == ""
+
+    def test_the_fighter_card_kebab_offers_detach(self, gang, fighter, gun, bolted):
+        """The accessory line on the card is the same kebab the listing
+        draws: Sell in the open, Detach among the rest. One gun, so Fit
+        is not offered."""
+        from n26.core.card import build_card
+        from n26.core.owned import EquipHost
+        from n26.core.render import build_model_card
+        from n26.core.views.owned import link_possession_actions
+
+        own = build_card(fighter)
+        card = build_model_card(fighter, card=own)
+        host = EquipHost.fighter(gang, own, fighter, AT)
+        link_possession_actions(card, host)
+
+        (weapon,) = [item for item in card.weapons if item.id == str(gun.pk)]
+        (line,) = weapon.accessories
+        assert [act.label for act in line.more] == ["Detach", "Refund", "Remove"]
+        assert line.more[0].target == f"{AT}&detach={bolted.pk}"
+
+    def test_the_kebab_names_detach_and_fit(self, fighter, gun, bolted, second_gun):
+        from n26.core.card import build_card
+        from n26.core.listing import copy_row
+        from n26.core.owned import owned_things, thing_key
+
+        held = owned_things(build_card(fighter), AT)
+        (copy,) = held[thing_key(gun.assignable)]
+        (part,) = copy_row(copy).parts
+
+        assert [action.label for action in part.more] == [
+            "Detach",
+            "Fit to a weapon",
+            "Refund",
+            "Remove",
+        ]
+
+    def test_the_question_names_the_gun_it_comes_off(self, fighter, gun, bolted):
+        dialog = self.dialog(fighter, detach=str(bolted.pk))
+
+        assert dialog["title"] == "Take Telescopic sight off Lasgun?"
+        assert dialog["action"] == reverse("n26-reassign", args=[bolted.pk])
+        assert dialog["submit_label"] == "Detach"
+
+    def test_the_panel_posts_the_held_destination(
+        self, client, tester, fighter, bolted
+    ):
+        """Rendered rather than read off the dialog: a detach that fell
+        through to the move's destinations would offer the roster, or
+        post a hidden stash field."""
+        client.force_login(tester)
+
+        response = client.get(
+            reverse("n26-equip", args=[fighter.pk]), {"detach": str(bolted.pk)}
+        )
+
+        body = response.content.decode()
+        assert "Take Telescopic sight off Lasgun?" in body
+        assert "The fighter will still hold it." in body
+        assert 'name="to" value="held"' in body or (
+            'name="to"' in body and 'value="held"' in body
+        )
+        assert 'id="reassign-to"' not in body
+        assert 'id="reassign-weapon"' not in body
+
+    def test_a_click_leaves_it_held_and_unfitted(
+        self, client, tester, gang, fighter, gun, bolted
+    ):
+        client.force_login(tester)
+        gang.refresh_from_db()
+        before = gang.credits
+
+        response = client.post(url("n26-reassign", bolted), {"to": "held"})
+
+        assert response.status_code == 302
+        bolted.refresh_from_db()
+        assert bolted.parent_id is None
+        assert bolted.miniature_id == fighter.pk
+        assert bolted.archived is False
+        gang.refresh_from_db()
+        assert gang.credits == before
+        assert_reconciled(gang)
+
+    def test_the_click_lands_back_on_the_fighters_equip_page(
+        self, client, tester, fighter, bolted
+    ):
+        client.force_login(tester)
+        response = client.post(url("n26-reassign", bolted), {"to": "held"})
+        assert response.url.startswith(reverse("n26-equip", args=[fighter.pk]))
+
+    def test_the_screen_is_told_about_both_rows_it_changed(
+        self, client, tester, fighter, gun, bolted
+    ):
+        """The gun loses the sight and the sight becomes a row of its
+        own, so both keys are delivered."""
+        from n26.core.owned import thing_key
+        from n26.core.templatetags.listing import row_dom_id
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "held"},
+            headers={"HX-Request": "true"},
+        )
+
+        body = response.content.decode()
+        assert f'data-row="{thing_key(gun.assignable)}"' in body
+        # This listing does not sell the sight, so the new root has no
+        # row on the page and the update says to take one away that was
+        # never there. The gun's row is the one that changed on screen.
+        gone = row_dom_id(thing_key(bolted.assignable))
+        assert f'id="{gone}" hx-swap-oob="delete"' in body
+
+    def test_the_fit_question_omits_the_gun_it_already_hangs_off(
+        self, fighter, gun, bolted, second_gun
+    ):
+        dialog = self.dialog(fighter, fit=str(bolted.pk))
+
+        assert dialog["title"] == "Fit Telescopic sight to a weapon"
+        assert dialog["weapons"] == [{"pk": str(second_gun.pk), "label": "Autogun"}]
+
+    def test_a_click_bolts_it_onto_the_other_gun(
+        self, client, tester, gang, fighter, gun, bolted, second_gun
+    ):
+        client.force_login(tester)
+        gang.refresh_from_db()
+        before = gang.credits
+
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "weapon", "weapon": str(second_gun.pk)},
+        )
+
+        assert response.status_code == 302
+        bolted.refresh_from_db()
+        assert bolted.parent_id == second_gun.pk
+        assert bolted.miniature_root_id == fighter.pk
+        gang.refresh_from_db()
+        assert gang.credits == before
+        assert_reconciled(gang)
+
+    def test_a_hand_made_click_naming_the_gun_it_is_on_is_answered_in_words(
+        self, client, tester, gang, gun, bolted
+    ):
+        client.force_login(tester)
+
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "weapon", "weapon": str(gun.pk)},
+            follow=True,
+        )
+
+        assert "There is nowhere to move" in response.content.decode()
+        bolted.refresh_from_db()
+        assert bolted.parent_id == gun.pk
+        assert_reconciled(gang)
+
+    def test_a_built_in_sight_is_asked_neither_question(
+        self, gang, tester, fighter, gun, sight
+    ):
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        assert self.dialog(fighter, detach=str(builtin.pk)) is None
+        assert self.dialog(fighter, fit=str(builtin.pk)) is None
+
+    def test_a_hand_made_detach_of_a_built_in_is_answered_in_words(
+        self, client, tester, gang, gun, sight
+    ):
+        from n26.core.models import Reason
+
+        with operation(gang, actor=tester) as op:
+            builtin = op.assign(
+                sight, parent=gun, caused_by=gun, paid=0, reason=Reason.DEFAULT
+            )
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", builtin), {"to": "held"}, follow=True
+        )
+
+        assert "There is nowhere to move" in response.content.decode()
+        builtin.refresh_from_db()
+        assert builtin.parent_id == gun.pk
+        assert_reconciled(gang)
+
+    def test_a_firing_line_is_refused_in_words(self, client, tester, gang, gun):
+        client.force_login(tester)
+        line = gun.children.exclude(weapon_profile=None).get()
+
+        response = client.post(url("n26-reassign", line), {"to": "held"}, follow=True)
+
+        line.refresh_from_db()
+        assert line.parent_id == gun.pk
+        assert "There is nowhere to move" in response.content.decode()
+        assert_reconciled(gang)
+
+    def test_a_sight_on_a_stashed_gun_stays_in_the_stash(
+        self, client, tester, gang, gun, bolted, stash
+    ):
+        with operation(gang, actor=tester) as op:
+            op.move(gun, stash)
+
+        client.force_login(tester)
+        response = client.post(url("n26-reassign", bolted), {"to": "held"})
+
+        assert response.status_code == 302
+        bolted.refresh_from_db()
+        assert bolted.parent_id is None
+        assert bolted.stash_id == stash.pk
+        assert bolted.miniature_id is None
+        assert_reconciled(gang)
+
+
 @pytest.fixture
 def house_list(gang, tester):
     thing = create_wargear("Knife", price=10)
@@ -1093,8 +1375,8 @@ def test_the_things_a_fighter_holds_are_counted_off_the_card(
 
 
 def test_a_part_is_offered_no_move(gang, fighter, tester):
-    """A part hangs off its parent and cannot be re-homed alone, so the
-    structure a row draws from has no move for it to offer."""
+    """A firing line hangs off its parent and cannot be re-homed alone,
+    so the structure a row draws from has no move for it to offer."""
     from n26.core.card import build_card
     from n26.core.owned import owned_things, thing_key
     from n26.library.authoring import add_weapon_profile, create_weapon
@@ -1161,6 +1443,8 @@ def test_every_copy_arrives_with_its_controls_already_pointed_somewhere(
     assert held.remove_href == f"{AT}&remove={gun.pk}"
     assert part.sell_href == f"{AT}&sell={ammo.pk}"
     assert part.remove_href == f"{AT}&remove={ammo.pk}"
+    assert part.detach_href == ""
+    assert part.fit_href == ""
 
 
 def test_a_copy_cannot_be_edited_after_it_is_built(gang, fighter, tester, sword):

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1219,7 +1219,6 @@ class TestDetachingAnAccessory:
         """The gun loses the sight and the sight becomes a row of its
         own, so both keys are delivered."""
         from n26.core.owned import thing_key
-        from n26.core.templatetags.listing import row_dom_id
 
         client.force_login(tester)
         response = client.post(
@@ -1230,11 +1229,7 @@ class TestDetachingAnAccessory:
 
         body = response.content.decode()
         assert f'data-row="{thing_key(gun.assignable)}"' in body
-        # This listing does not sell the sight, so the new root has no
-        # row on the page and the update says to take one away that was
-        # never there. The gun's row is the one that changed on screen.
-        gone = row_dom_id(thing_key(bolted.assignable))
-        assert f'id="{gone}" hx-swap-oob="delete"' in body
+        assert f'data-row="{thing_key(bolted.assignable)}"' in body
 
     def test_the_fit_question_omits_the_gun_it_already_hangs_off(
         self, fighter, gun, bolted, second_gun

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1107,6 +1107,11 @@ class TestDetachingAnAccessory:
         part = self.part_of(fighter, gun, bolted)
         assert part.fit_href == ""
 
+    def test_the_only_gun_draws_no_fit_panel(self, fighter, gun, bolted):
+        """The row draws no Fit, so its address opens nothing rather
+        than a panel with no weapon in it."""
+        assert self.dialog(fighter, fit=str(bolted.pk)) is None
+
     def test_another_gun_is_somewhere_to_fit_it(self, fighter, gun, bolted, second_gun):
         part = self.part_of(fighter, gun, bolted)
         assert part.fit_href == f"{AT}&fit={bolted.pk}"
@@ -1303,7 +1308,7 @@ class TestDetachingAnAccessory:
             url("n26-reassign", builtin), {"to": "held"}, follow=True
         )
 
-        assert "There is nowhere to move" in response.content.decode()
+        assert "Only a bought accessory can come off." in response.content.decode()
         builtin.refresh_from_db()
         assert builtin.parent_id == gun.pk
         assert_reconciled(gang)
@@ -1316,7 +1321,7 @@ class TestDetachingAnAccessory:
 
         line.refresh_from_db()
         assert line.parent_id == gun.pk
-        assert "There is nowhere to move" in response.content.decode()
+        assert "Only a bought accessory can come off." in response.content.decode()
         assert_reconciled(gang)
 
     def test_a_stashed_gun_is_offered_detach_and_not_fit(

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1319,6 +1319,25 @@ class TestDetachingAnAccessory:
         assert "There is nowhere to move" in response.content.decode()
         assert_reconciled(gang)
 
+    def test_a_stashed_gun_is_offered_detach_and_not_fit(
+        self, gang, tester, gun, bolted, stash
+    ):
+        """The stash fits from the gang sheet, where every gun is in
+        reach. Fit on this card would only list stash guns."""
+        from n26.core.card import build_gang_card
+        from n26.core.owned import EquipHost, possessions, thing_key
+        from n26.library.authoring import create_weapon
+
+        with operation(gang, actor=tester) as op:
+            op.move(gun, stash)
+            op.buy(stash, thing=create_weapon("Stub gun", price=5, profiles=[("", 0)]))
+
+        host = EquipHost.stash(gang, build_gang_card(gang), AT)
+        (copy,) = possessions(host)[thing_key(gun.assignable)]
+        part = next(p for p in copy.parts if p.id == str(bolted.pk))
+        assert part.detach_href == f"{AT}&detach={bolted.pk}"
+        assert part.fit_href == ""
+
     def test_a_sight_on_a_stashed_gun_stays_in_the_stash(
         self, client, tester, gang, gun, bolted, stash
     ):
@@ -1326,9 +1345,11 @@ class TestDetachingAnAccessory:
             op.move(gun, stash)
 
         client.force_login(tester)
-        response = client.post(url("n26-reassign", bolted), {"to": "held"})
+        response = client.post(url("n26-reassign", bolted), {"to": "held"}, follow=True)
 
-        assert response.status_code == 302
+        assert "Took Telescopic sight off Lasgun. It is in the stash." in (
+            response.content.decode()
+        )
         bolted.refresh_from_db()
         assert bolted.parent_id is None
         assert bolted.stash_id == stash.pk

--- a/n26/core/test_views_owned.py
+++ b/n26/core/test_views_owned.py
@@ -1401,6 +1401,32 @@ class TestDetachingAnAccessory:
         assert bolted.miniature_id is None
         assert_reconciled(gang)
 
+    def test_a_stash_detach_over_htmx_reloads_the_screen(
+        self, client, tester, gang, gun, bolted, stash
+    ):
+        """The stash tab draws only what is held, so the sight's own row
+        is new to the page. A partial update would deliver it as a swap
+        for a row that is not there, and htmx would drop it — the sight
+        would be in the stash and nowhere on the screen."""
+        with operation(gang, actor=tester) as op:
+            op.move(gun, stash)
+
+        client.force_login(tester)
+        response = client.post(
+            url("n26-reassign", bolted),
+            {"to": "held", "list": "stash"},
+            headers={"HX-Request": "true"},
+        )
+
+        assert response.status_code == 200
+        assert response["HX-Redirect"].startswith(
+            reverse("n26-equip-gang", args=[gang.pk])
+        )
+        assert "list=stash" in response["HX-Redirect"]
+        bolted.refresh_from_db()
+        assert bolted.stash_id == stash.pk
+        assert_reconciled(gang)
+
 
 @pytest.fixture
 def house_list(gang, tester):

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -66,6 +66,7 @@ from n26.core.owned import (
     DIALOGS,
     EquipHost,
     can_unbolt,
+    is_detachable,
     is_possession,
     thing_key,
     weapons_on,
@@ -791,24 +792,38 @@ def reassign_assignment(request, pk):
     name = str(assignment.assignable)
 
     # Why a firing line or a sight the gun came with cannot leave the
-    # weapon. Said to a Detach and to a Fit click alike: the rule is the
-    # same whichever destination they named.
+    # weapon. Said whichever destination the click named: the rule is
+    # about the part, not about where it was going.
     stays_on = (
-        f"You cannot take {name} off the weapon. Only a bought accessory can come off."
+        f"You cannot take {name} off {off}. Only a bought accessory can come off."
     )
+    # A sight the gun came with belongs to the package. Moving it
+    # anywhere — the stash, another model, another gun — would leave the
+    # gang holding something the sale of this gun is meant to take with
+    # it. The operation does not refuse this itself, so it is refused
+    # here before any destination is read. A firing line is left to the
+    # operation, which refuses it in its own words.
+    if (
+        assignment.parent_id is not None
+        and assignment.caused_by_id is not None
+        and is_detachable(assignment.assignable)
+    ):
+        messages.error(request, stays_on)
+        return _unchanged(request, back)
 
     wanted = request.POST.get("to")
     if wanted == "stash":
         destination = getattr(gang, "stash", None)
     elif wanted == "held":
         # Same host, unfitted. A sight on a fighter's gun stays with
-        # that fighter; one on a stashed gun stays in the stash. A copy
-        # that cannot come off — a firing line, a sight the gun came
-        # with, something already loose — is refused in words.
-        if not can_unbolt(assignment):
+        # that fighter; one on a stashed gun stays in the stash. Something
+        # already loose has nothing to come off; a firing line cannot.
+        if assignment.parent_id is None:
+            destination = None
+        elif not can_unbolt(assignment):
             messages.error(request, stays_on)
             return _unchanged(request, back)
-        if assignment.miniature_root_id:
+        elif assignment.miniature_root_id:
             destination = assignment.miniature_root
         else:
             destination = getattr(gang, "stash", None)
@@ -833,12 +848,6 @@ def reassign_assignment(request, pk):
             )
         except ValidationError:
             destination = None
-        # A sight the gun came with belongs to the package. Moving it
-        # onto another gun would leave the gang holding something the
-        # sale of this gun is meant to take with it.
-        if destination is not None and assignment.caused_by_id is not None:
-            messages.error(request, stays_on)
-            return _unchanged(request, back)
     else:
         try:
             destination = Miniature.objects.filter(

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -58,7 +58,7 @@ from dataclasses import dataclass
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
@@ -904,6 +904,15 @@ def reassign_assignment(request, pk):
             messages.success(request, f"Took {name} off {off}.")
     else:
         messages.success(request, f"Moved {name} to {destination.name}.")
+    if wanted == "held" and came_from is None and is_htmx(request):
+        # The stash's own tab draws only what is held, so the row the
+        # sight now has is new to the page: delivered as an out-of-band
+        # swap it would name a row that is not there, and htmx drops
+        # such an element without a word. A reload draws the screen as
+        # it now stands, and the message with it.
+        response = HttpResponse(status=200)
+        response["HX-Redirect"] = back
+        return response
     return _acted(request, touched, gang, back, also=also)
 
 

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -450,6 +450,11 @@ def owned_dialog(request, host: EquipHost):
             for node in weapons_on(host)
             if node.assignment.pk != assignment.parent_id
         ]
+        # A bolted accessory with no other gun on the card has nowhere
+        # to go, and the row does not draw Fit for it. A loose one still
+        # gets the panel, which says there is no weapon here.
+        if not weapons and assignment.parent_id is not None:
+            return None
         return dialog | {
             "title": f"Fit {name} to a weapon",
             "weapons": [
@@ -785,6 +790,13 @@ def reassign_assignment(request, pk):
     touched = _row_behind(assignment)
     name = str(assignment.assignable)
 
+    # Why a firing line or a sight the gun came with cannot leave the
+    # weapon. Said to a Detach and to a Fit click alike: the rule is the
+    # same whichever destination they named.
+    stays_on = (
+        f"You cannot take {name} off the weapon. Only a bought accessory can come off."
+    )
+
     wanted = request.POST.get("to")
     if wanted == "stash":
         destination = getattr(gang, "stash", None)
@@ -792,10 +804,11 @@ def reassign_assignment(request, pk):
         # Same host, unfitted. A sight on a fighter's gun stays with
         # that fighter; one on a stashed gun stays in the stash. A copy
         # that cannot come off — a firing line, a sight the gun came
-        # with, something already loose — is nowhere to send.
+        # with, something already loose — is refused in words.
         if not can_unbolt(assignment):
-            destination = None
-        elif assignment.miniature_root_id:
+            messages.error(request, stays_on)
+            return _unchanged(request, back)
+        if assignment.miniature_root_id:
             destination = assignment.miniature_root
         else:
             destination = getattr(gang, "stash", None)
@@ -824,7 +837,8 @@ def reassign_assignment(request, pk):
         # onto another gun would leave the gang holding something the
         # sale of this gun is meant to take with it.
         if destination is not None and assignment.caused_by_id is not None:
-            destination = None
+            messages.error(request, stays_on)
+            return _unchanged(request, back)
     else:
         try:
             destination = Miniature.objects.filter(

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -875,7 +875,10 @@ def reassign_assignment(request, pk):
     elif wanted == "weapon":
         messages.success(request, f"Fitted {name} to {destination.assignable}.")
     elif wanted == "held":
-        messages.success(request, f"Took {name} off {off}.")
+        if came_from is None:
+            messages.success(request, f"Took {name} off {off}. It is in the stash.")
+        else:
+            messages.success(request, f"Took {name} off {off}.")
     else:
         messages.success(request, f"Moved {name} to {destination.name}.")
     return _acted(request, touched, gang, back, also=also)

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -800,8 +800,8 @@ def reassign_assignment(request, pk):
     # A sight the gun came with belongs to the package. Moving it
     # anywhere — the stash, another model, another gun — would leave the
     # gang holding something the sale of this gun is meant to take with
-    # it. The operation does not refuse this itself, so it is refused
-    # here before any destination is read. A firing line is left to the
+    # it. The operation does not refuse this itself, so the view does,
+    # whichever destination was named. A firing line is left to the
     # operation, which refuses it in its own words.
     if (
         assignment.parent_id is not None

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -33,10 +33,10 @@ The acts are deliberately distinct, and the ledger says which happened:
     accessories are being sold with it or kept — because those are two
     sales at two prices.
 ``reassign``
-    A move to another model, to the stash, or onto a weapon. No money,
-    and no re-pricing. The last of the three is how an accessory is
-    fitted to a gun: the same act, one level down the chain. It is asked
-    as a question of its own — ``?fit=`` rather than ``?reassign=`` —
+    A move to another model, to the stash, onto a weapon, or off a
+    weapon onto the fighter still holding it. No money, and no
+    re-pricing. Fitting and detaching are asked as questions of their
+    own — ``?fit=`` and ``?detach=`` rather than ``?reassign=`` —
     because which model holds a thing and which gun it is bolted to are
     not one question, however much they are one act.
 ``refund``
@@ -65,6 +65,7 @@ from django.views.decorators.http import require_POST
 from n26.core.owned import (
     DIALOGS,
     EquipHost,
+    can_unbolt,
     is_possession,
     thing_key,
     weapons_on,
@@ -236,10 +237,10 @@ def _asked(request):
 
 
 #: The act a question submits to, where that is not the question's own
-#: name. Fitting an accessory to a gun is asked on its own, because
-#: Reassign is about which model holds a thing and this is not, and it is
-#: answered by the move that does it.
-ROUTES = {"fit": "reassign"}
+#: name. Fitting an accessory to a gun, and taking one off, are asked
+#: on their own, because Reassign is about which model holds a thing and
+#: these are not, and both are answered by the move that does it.
+ROUTES = {"fit": "reassign", "detach": "reassign"}
 
 
 def _panel(request, assignment, kind, at):
@@ -434,16 +435,40 @@ def owned_dialog(request, host: EquipHost):
         # a question its answer refuses.
         if assignment.weapon_accessory_id is None:
             return None
-        # Every gun on the card, and not only the ones the accessory was
-        # written for: what fits what is information rather than a gate,
-        # and an owner may bolt anything to anything.
-        weapons = weapons_on(host)
+        # A sight the gun came with belongs to the package. Unbolting it
+        # onto another gun would leave the gang holding something the
+        # sale of this gun is meant to take with it.
+        if assignment.caused_by_id is not None:
+            return None
+        # Every gun on the card except the one this already hangs off,
+        # and not only the ones the accessory was written for: what fits
+        # what is information rather than a gate, and an owner may bolt
+        # anything to anything. The gun it is already on is not a
+        # destination — fitting it there would be leaving it where it is.
+        weapons = [
+            node
+            for node in weapons_on(host)
+            if node.assignment.pk != assignment.parent_id
+        ]
         return dialog | {
             "title": f"Fit {name} to a weapon",
             "weapons": [
                 {"pk": str(node.assignment.pk), "label": node.name} for node in weapons
             ],
             "submit_label": "Fit" if weapons else "",
+            "submit_variant": "primary",
+        }
+
+    if kind == "detach":
+        # Only a copy that can come off and stay with the gang. A firing
+        # line cannot; a sight the gun came with cannot; something
+        # already loose has nothing to come off.
+        if not can_unbolt(assignment):
+            return None
+        parent = assignment.parent.assignable
+        return dialog | {
+            "title": f"Take {name} off {parent}?",
+            "submit_label": "Detach",
             "submit_variant": "primary",
         }
 
@@ -735,10 +760,12 @@ def reassign_assignment(request, pk):
     Nothing is charged and nothing is re-priced: the thing keeps the
     rating it was pinned at, and only where it lives changes.
 
-    Three destinations, told apart by ``to``. ``stash`` and a named
-    ``miniature`` are the two a fighter's own listing row offers. ``weapon``
-    names another assignment, which is how a stashed accessory is
-    bolted back onto a gun — the same act, one level down the chain.
+    Four destinations, told apart by ``to``. ``stash`` and a named
+    ``miniature`` are the two a fighter's own listing row offers.
+    ``weapon`` names another assignment, which is how an accessory is
+    bolted onto a gun — the same act, one level down the chain. ``held``
+    takes a bolted accessory off its gun and leaves it with whoever
+    (or whatever stash) was holding that gun.
 
     What may not be moved at all is ``Operation.move``'s answer rather
     than this view's: a weapon's firing line is part of its weapon, and
@@ -753,6 +780,7 @@ def reassign_assignment(request, pk):
     # Read before the move, because afterwards it names the new home and
     # the reader wants the screen they clicked on.
     came_from = assignment.miniature_root
+    off = str(assignment.parent.assignable) if assignment.parent_id else ""
     back = _back_to(request, assignment, gang)
     touched = _row_behind(assignment)
     name = str(assignment.assignable)
@@ -760,6 +788,17 @@ def reassign_assignment(request, pk):
     wanted = request.POST.get("to")
     if wanted == "stash":
         destination = getattr(gang, "stash", None)
+    elif wanted == "held":
+        # Same host, unfitted. A sight on a fighter's gun stays with
+        # that fighter; one on a stashed gun stays in the stash. A copy
+        # that cannot come off — a firing line, a sight the gun came
+        # with, something already loose — is nowhere to send.
+        if not can_unbolt(assignment):
+            destination = None
+        elif assignment.miniature_root_id:
+            destination = assignment.miniature_root
+        else:
+            destination = getattr(gang, "stash", None)
     elif wanted == "weapon":
         try:
             destination = (
@@ -773,11 +812,18 @@ def reassign_assignment(request, pk):
                 # it says it by raising rather than refusing, so a
                 # hand-made click naming its own weapon is answered here
                 # with the same sentence as any other impossible
-                # destination.
+                # destination. The gun it already hangs off is the same
+                # kind of nowhere: fitting it there would leave it put.
                 .exclude(pk=assignment.pk)
+                .exclude(pk=assignment.parent_id)
                 .first()
             )
         except ValidationError:
+            destination = None
+        # A sight the gun came with belongs to the package. Moving it
+        # onto another gun would leave the gang holding something the
+        # sale of this gun is meant to take with it.
+        if destination is not None and assignment.caused_by_id is not None:
             destination = None
     else:
         try:
@@ -793,11 +839,18 @@ def reassign_assignment(request, pk):
         return _unchanged(request, back)
 
     # Fitting takes the thing out of a row of its own and draws it under
-    # the gun instead, so two rows on the screen change. The gun's row
-    # counts only where the reader is looking at it: a stash fit reaches
-    # a gun on somebody's card, and that is not the screen this answers.
-    landed = _row_behind(destination) if isinstance(destination, Assignment) else None
-    also = landed.key if landed and landed.miniature == touched.miniature else ""
+    # the gun instead, so two rows on the screen change. Detaching does
+    # the reverse: the gun loses it and it becomes a row of its own.
+    # The other row counts only where the reader is looking at it: a
+    # stash fit reaches a gun on somebody's card, and that is not the
+    # screen this answers.
+    if wanted == "held":
+        also = thing_key(assignment.assignable)
+    else:
+        landed = (
+            _row_behind(destination) if isinstance(destination, Assignment) else None
+        )
+        also = landed.key if landed and landed.miniature == touched.miniature else ""
 
     try:
         with operation(gang, actor=request.user) as op:
@@ -815,12 +868,14 @@ def reassign_assignment(request, pk):
         miniature_id=str(came_from.pk) if came_from else None,
         thing=name,
         action="reassign",
-        to=wanted if wanted in ("stash", "weapon") else "model",
+        to=wanted if wanted in ("stash", "weapon", "held") else "model",
     )
     if wanted == "stash":
         messages.success(request, f"Moved {name} to the stash.")
     elif wanted == "weapon":
         messages.success(request, f"Fitted {name} to {destination.assignable}.")
+    elif wanted == "held":
+        messages.success(request, f"Took {name} off {off}.")
     else:
         messages.success(request, f"Moved {name} to {destination.name}.")
     return _acted(request, touched, gang, back, also=also)

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1109,7 +1109,7 @@ GROUPS: list[Group] = [
                 ),
                 needs=(ALPINE,),
                 notes=(
-                    "One panel for seven questions: sell, move, refund, remove, "
+                    "One panel for every question: sell, move, refund, remove, "
                     "fit an accessory, take one off a gun, and change what a "
                     "thing was bought with. Each states what a reader cannot "
                     "work out from the page — a sale states its arithmetic, a "

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1102,8 +1102,8 @@ GROUPS: list[Group] = [
                 tag="c-n26.owned-dialog",
                 template="n26/owned_dialog.html",
                 summary=(
-                    "Confirm a sale, a move, a refund, a removal or a "
-                    "detach of something the gang owns — or ask which "
+                    "Confirm a sale, a move, a refund, a removal or "
+                    "detaching something the gang owns — or ask which "
                     "accessory to fit to a weapon, or which alternatives "
                     "it is taken with."
                 ),
@@ -1114,8 +1114,8 @@ GROUPS: list[Group] = [
                     "thing was bought with. Each states what a reader cannot "
                     "work out from the page — a sale states its arithmetic, a "
                     "move that it charges nothing, a removal that the money "
-                    "stays spent, a refund what was paid, a detach that the "
-                    "fighter still holds it. The stash is a button and the "
+                    "stays spent, a refund what was paid, a detach that "
+                    "leaves the fighter holding it. The stash is a button and the "
                     "roster a select, and only the clicked submit is sent, "
                     "which is the whole of how the view tells those two apart. "
                     "Selling something with a part bolted to it is two sales "

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1102,26 +1102,28 @@ GROUPS: list[Group] = [
                 tag="c-n26.owned-dialog",
                 template="n26/owned_dialog.html",
                 summary=(
-                    "Confirm a sale, a move, a refund or a removal of "
-                    "something the gang owns — or ask which accessory to "
-                    "fit to a weapon, or which alternatives it is taken "
-                    "with."
+                    "Confirm a sale, a move, a refund, a removal or a "
+                    "detach of something the gang owns — or ask which "
+                    "accessory to fit to a weapon, or which alternatives "
+                    "it is taken with."
                 ),
                 needs=(ALPINE,),
                 notes=(
-                    "One panel for six questions: sell, move, refund, remove, "
-                    "fit an accessory, and change what a thing was bought with. "
-                    "Each states what a reader cannot work out from the page — "
-                    "a sale states its arithmetic, a move that it charges "
-                    "nothing, a removal that the money stays spent, a refund "
-                    "what was paid. The stash is a button and the roster a "
-                    "select, and only the clicked submit is sent, which is the "
-                    "whole of how the view tells those two apart. Selling "
-                    "something with a part bolted to it is two sales at two "
-                    "prices, so each option carries its own figure rather than "
-                    "the lead carrying one. Changing what a thing was bought "
-                    "with draws the buying row's own controls rather than a "
-                    "second set, with the loader deciding which starts picked."
+                    "One panel for seven questions: sell, move, refund, remove, "
+                    "fit an accessory, take one off a gun, and change what a "
+                    "thing was bought with. Each states what a reader cannot "
+                    "work out from the page — a sale states its arithmetic, a "
+                    "move that it charges nothing, a removal that the money "
+                    "stays spent, a refund what was paid, a detach that the "
+                    "fighter still holds it. The stash is a button and the "
+                    "roster a select, and only the clicked submit is sent, "
+                    "which is the whole of how the view tells those two apart. "
+                    "Selling something with a part bolted to it is two sales "
+                    "at two prices, so each option carries its own figure "
+                    "rather than the lead carrying one. Changing what a thing "
+                    "was bought with draws the buying row's own controls "
+                    "rather than a second set, with the loader deciding which "
+                    "starts picked."
                 ),
             ),
             Component(

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -2306,6 +2306,14 @@ def owned_context():
             "submit_label": "Fit",
             "submit_variant": "primary",
         },
+        "owned_detach_dialog": {
+            **named,
+            "kind": "detach",
+            "name": "Telescopic sight",
+            "title": "Take Telescopic sight off Meltagun?",
+            "submit_label": "Detach",
+            "submit_variant": "primary",
+        },
         "owned_fit_nothing_dialog": {
             **named,
             "kind": "fit",

--- a/n26/designsystem/templates/designsystem/demos/owned-dialog/36-detaching.html
+++ b/n26/designsystem/templates/designsystem/demos/owned-dialog/36-detaching.html
@@ -1,0 +1,4 @@
+{# title: Taking an accessory off a gun #}
+{# note: The fighter still holds it. Asked apart from the move, because taking a sight off a gun is not the same question as handing the sight to somebody else. #}
+{# layout: full #}
+<c-n26.owned-dialog :dialog="owned_detach_dialog" modal="" />

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -154,6 +154,13 @@ class TestTheOwnedDialogsPage:
         assert "Telescopic sight — 25¢" in page
         assert "Gun stabiliser — 30¢" in page
 
+    def test_detaching_an_accessory_draws_the_held_destination(self, reader):
+        page = reader.get("/n26/design/c/owned-dialog/").content.decode()
+        assert "Taking an accessory off a gun" in page
+        assert "Take Telescopic sight off Meltagun?" in page
+        assert "The fighter will still hold it." in page
+        assert 'value="held"' in page
+
     def test_selling_a_kitted_gun_draws_a_figure_against_each_answer(self, reader):
         page = reader.get("/n26/design/c/owned-dialog/").content.decode()
         assert "Selling a gun with something bolted to it" in page

--- a/n26/tests/sandbox/test_listing.py
+++ b/n26/tests/sandbox/test_listing.py
@@ -30,6 +30,7 @@ from n26.core.listing import (
     price_field,
 )
 from n26.core.owned import owned_things, thing_key
+from n26.core.reconcile import assert_reconciled
 from n26.library.authoring import add_weapon_profile
 from n26.tests.sandbox.actions import (
     assign,
@@ -344,6 +345,35 @@ class TestWhatACopyOffers:
 
         assert [action.label for action in part.more] == ["Refund", "Remove"]
         assert part.sell.target == f"{AT}&sell={ammo.pk}"
+
+    def test_a_bought_accessory_offers_detach(self, gang, fighter, house_list, armed):
+        """A sight is gear in its own right. Taking it off leaves the
+        fighter holding it, so the row asks that before the ways of
+        parting with it."""
+        from n26.core.operations import operation
+        from n26.library.authoring import create_weapon_accessory
+
+        first, _, _ = armed
+        sight = create_weapon_accessory("Telescopic sight", price=25)
+        with operation(fighter.gang, actor=fighter.gang.owner) as op:
+            bolted = op.buy(first, thing=sight)
+        row = rows_by_name(catalogue_for(fighter, house_list))["Autogun"]
+        (part,) = [
+            part
+            for copy in row.copies
+            for part in copy.parts
+            if part.id == str(bolted.pk)
+        ]
+
+        assert [action.label for action in part.more] == [
+            "Detach",
+            "Fit to a weapon",
+            "Refund",
+            "Remove",
+        ]
+        assert part.more[0].target == f"{AT}&detach={bolted.pk}"
+        assert part.more[1].target == f"{AT}&fit={bolted.pk}"
+        assert_reconciled(gang)
 
 
 class TestWhatARowPrints:

--- a/n26/tests/sandbox/test_listing.py
+++ b/n26/tests/sandbox/test_listing.py
@@ -327,11 +327,12 @@ class TestWhatACopyOffers:
         ]
 
     def test_a_part_is_offered_no_move(self, fighter, house_list, armed):
-        """A part belongs to the thing it hangs off, and ``Operation.move``
-        refuses an assignment with a parent — so offering one here would
-        be offering a click that cannot work. It keeps the rest: buying
-        the wrong ammunition is as easy a mistake as buying the wrong
-        gun."""
+        """A firing line belongs to the gun it names, and
+        ``Operation.move`` refuses it — so offering a move here would be
+        offering a click that cannot work. It keeps the rest: buying the
+        wrong ammunition is as easy a mistake as buying the wrong gun.
+        An accessory the gang bought is the other case, and its kebab
+        offers Detach."""
         _, ammo, _ = armed
         row = rows_by_name(catalogue_for(fighter, house_list))["Autogun"]
         (part,) = [


### PR DESCRIPTION
Fixes #2397. Supersedes #2402, which built the same feature on a parallel branch; the parts of it worth keeping are folded in here (see the last commit).

On an n26 fighter card, a weapon accessory bolted to a gun (a sight under an Autogun) only offered Sell and Remove. Remove archived it; there was no way to take it off and keep it.

The kebab now offers:

- **Detach** — takes the accessory off the gun. The fighter still holds it, unfitted, the same shape as one bought from their equip page. If the gun is in the stash, the accessory stays in the stash.
- **Fit to a weapon** — when they already carry another gun, the same picker a loose accessory already had, minus the gun this one is on.

A sight the gun came with, and a weapon's own firing line, are not offered either act. A hand-made request for one is refused with a sentence saying only a bought accessory can come off. Both writes go through `Operation.move`, so nothing is re-priced.

## Folded in from #2402

- A specific refusal for a built-in accessory or a firing line, on both Detach and Fit, instead of the generic "There is nowhere to move" message.
- `?fit=` on a bolted accessory with no other gun on the card opens nothing, matching the row not drawing the link, instead of an empty panel.
- Fighter-edit page tests for the kebab links and the Detach panel, and a listing test for the kebab order.

## Found in review

- A hand-made request could move a built-in accessory to the stash or another model, because Operation.move only refuses firing lines. The view now refuses a built-in whatever destination is named.
- On the stash tab, a detach over htmx delivered the sight's new row as a swap for a row the page never had, so the sight vanished until reload. That case now reloads the tab.

Not taken from #2402: restricting a Fit to the current fighter's guns. A crafted request naming another fighter's gun in the same gang moves it there, which is what Reassign already allows, so it stays as on main.

## How to try it

1. On an n26 fighter, fit a bought accessory to a weapon they hold.
2. Open the accessory kebab on the fighter's edit page or on the equip listing.
3. Detach — confirm. The fighter still holds the accessory as loose gear. Rating does not change.
4. With two guns, Fit to a weapon moves it onto the other one without going via the stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HriMwFNzGxZVtG89UVocet
