### PR TITLE
feat: offer the Unrestricted library tab on the n26 fighter equip page

### DIFF
--- a/n26/core/browse.py
+++ b/n26/core/browse.py
@@ -357,7 +357,7 @@ def browse(collection, terms=None):
     return _sectioned(str(collection), lines.values())
 
 
-def all_gear(name, terms=EQUIPMENT_LIST):
+def all_gear(name, terms=EQUIPMENT_LIST, *, for_use_notes=False):
     """Everything in the library a list could sell, browsed as one surface.
 
     Not a collection: nobody authored it and no gang holds it. The kinds
@@ -371,9 +371,11 @@ def all_gear(name, terms=EQUIPMENT_LIST):
     no gun above it would be a purchase with nowhere to land.
 
     What a discovery surface offers: the standard pack's content,
-    unarchived, the same question a picker asks. Nothing is loaded for
-    use notes — there is no fighter here to test a restriction against,
-    and noting this view afterwards would cost a query per line.
+    unarchived, the same question a picker asks. ``for_use_notes`` loads
+    the use lists of every kind that carries them, so a fighter's screen
+    can note this view (``with_use_notes``) for no query per line — the
+    same prefetch a sweep makes. Off, the lists are not loaded: the stash
+    is not a fighter, and noting nothing is not worth a query a kind.
 
     A fixed number of queries, one per kind plus its prefetches, however
     much the library holds.
@@ -382,8 +384,10 @@ def all_gear(name, terms=EQUIPMENT_LIST):
 
     from n26.library.models.assignable import (
         OPTION_OFFER_PATHS,
+        USABLE_BY_LISTS,
         Family,
         Optioned,
+        UsableBy,
         WeaponProfile,
     )
     from n26.library.models.collection import (
@@ -401,6 +405,8 @@ def all_gear(name, terms=EQUIPMENT_LIST):
         found = model.objects.selectable().select_related(
             "category__section", "built_ins"
         )
+        if for_use_notes and issubclass(model, UsableBy):
+            found = found.prefetch_related(*USABLE_BY_LISTS)
         if issubclass(model, Optioned):
             found = found.prefetch_related(*OPTION_OFFER_PATHS)
         if hasattr(model, "profiles"):

--- a/n26/core/browse.py
+++ b/n26/core/browse.py
@@ -375,7 +375,7 @@ def all_gear(name, terms=EQUIPMENT_LIST, *, for_use_notes=False):
     the use lists of every kind that carries them, so a fighter's screen
     can note this view (``with_use_notes``) for no query per line — the
     same prefetch a sweep makes. Off, the lists are not loaded: the stash
-    is not a fighter, and noting nothing is not worth a query a kind.
+    is not a fighter, and noting nothing is not worth a query per kind.
 
     Every line is priced at reference. A buying screen prices it again
     from the lists its buyer holds (:func:`priced_from`), so the library

--- a/n26/core/browse.py
+++ b/n26/core/browse.py
@@ -377,6 +377,10 @@ def all_gear(name, terms=EQUIPMENT_LIST, *, for_use_notes=False):
     same prefetch a sweep makes. Off, the lists are not loaded: the stash
     is not a fighter, and noting nothing is not worth a query a kind.
 
+    Every line is priced at reference. A buying screen prices it again
+    from the lists its buyer holds (:func:`priced_from`), so the library
+    itself never asks who is looking.
+
     A fixed number of queries, one per kind plus its prefetches, however
     much the library holds.
     """
@@ -436,6 +440,45 @@ def all_gear(name, terms=EQUIPMENT_LIST, *, for_use_notes=False):
                 )
             )
     return _sectioned(name, lines)
+
+
+def priced_from(view, listings):
+    """The same view, each line priced as the first listing offering the
+    item prices it.
+
+    A library line is a reference price and nothing more. A buyer buys
+    from the lists they hold, and those are what the price should come
+    from: their own list's line where it offers the item, at that list's
+    price and on its terms; the Trading Post's line where only the post
+    does, so its Trade Point figure is shown and charged; and the
+    library's own line where nothing held offers it. ``listings`` are
+    browsed views in order of precedence, the buyer's own lists before
+    the post — the same order their tabs stand in.
+
+    The listing's line is taken whole — entry, terms, parts and all —
+    because that is the purchase the listing would make, and a line
+    bought here must be the line bought there. Sectioning stays the
+    library's: the same thing sits in the same category whichever list
+    priced it.
+    """
+    offered = {}
+    for listing in reversed(listings):
+        for line in listing.all_lines():
+            offered[_key(line.thing)] = line
+    priced = CollectionView(name=view.name)
+    for section in view.sections:
+        regrouped = SectionGroup(name=section.name)
+        for category in section.categories:
+            regrouped.categories.append(
+                CategoryGroup(
+                    name=category.name,
+                    lines=[
+                        offered.get(_key(line.thing), line) for line in category.lines
+                    ],
+                )
+            )
+        priced.sections.append(regrouped)
+    return priced
 
 
 def offered_choices(thing):

--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -16,7 +16,8 @@
  * design library's stylesheet (n26/designsystem/assets/app.css) — this file
  * holds no styling and reads none. A control that must never go busy carries
  * `data-busy="off"` from its call site; so does a form, which opts out
- * everything inside it.
+ * everything inside it. A plain link to a page the server has to build
+ * carries `data-busy="link"` to be treated as a button is.
  *
  * What is deliberately left alone: a button that only moves something on
  * screen — a tab, a filter, a disclosure — starts no work and never goes
@@ -66,12 +67,16 @@
         if (!el.matches("button, a")) return;
         if (el.getAttribute("data-busy") === "on") return;
 
-        el.setAttribute("data-busy", "on");
-        el.setAttribute("aria-busy", "true");
         /* What the script put on is what the script takes off: markup may
          * carry the state itself, and a sweep that could not tell the two
-         * apart would quietly undo it. */
-        el.setAttribute("data-busy-applied", "");
+         * apart would quietly undo it. A link's own opt-in is kept here so
+         * it is put back when the link is released. */
+        el.setAttribute(
+            "data-busy-applied",
+            el.getAttribute("data-busy") || "",
+        );
+        el.setAttribute("data-busy", "on");
+        el.setAttribute("aria-busy", "true");
     }
 
     function disable(element) {
@@ -94,8 +99,10 @@
 
     function release(element) {
         if (element.hasAttribute("data-busy-applied")) {
+            var before = element.getAttribute("data-busy-applied");
             element.removeAttribute("data-busy-applied");
-            element.removeAttribute("data-busy");
+            if (before) element.setAttribute("data-busy", before);
+            else element.removeAttribute("data-busy");
             element.removeAttribute("aria-busy");
         }
         if (element.dataset.busyDisabled) {
@@ -189,7 +196,9 @@
      *
      * Only link *buttons*: `rounded-button` is what the library puts on both
      * shapes of <c-ui.button>, and app.css already reads it as "this is a
-     * button". A plain link in a sentence stays a plain link.
+     * button". A plain link in a sentence stays a plain link — unless its
+     * call site says the page behind it takes building, with
+     * `data-busy="link"`; a rail of equipment lists is one.
      *
      * Everything that is not a plain navigation of this tab is passed over —
      * a modified click opens elsewhere, a fragment goes nowhere the server is
@@ -201,7 +210,9 @@
         if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
             return;
 
-        var link = event.target.closest("a[href].rounded-button");
+        var link = event.target.closest(
+            'a[href].rounded-button, a[href][data-busy="link"]',
+        );
         if (!link || link.hasAttribute("download")) return;
         if (link.target && link.target !== "_self") return;
 

--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -17,7 +17,7 @@
  * holds no styling and reads none. A control that must never go busy carries
  * `data-busy="off"` from its call site; so does a form, which opts out
  * everything inside it. A plain link to a page the server has to build
- * carries `data-busy="link"` to be treated as a button is.
+ * carries `data-busy="link"` to be treated the way a button is.
  *
  * What is deliberately left alone: a button that only moves something on
  * screen — a tab, a filter, a disclosure — starts no work and never goes

--- a/n26/core/templates/n26/equip.html
+++ b/n26/core/templates/n26/equip.html
@@ -113,43 +113,37 @@ breadcrumb above it has the gang as well, so nothing is lost.
 
     Links, not client state: a list is a place you can be, so it goes in the URL
     — linkable, back-button-friendly, and the server renders the one you are on.
-    One list draws no rail; there is nothing to choose, and the search box
-    names the list it searches. Whether one is drawn is the view's decision
-    (`rail`), because the Unrestricted tab is drawn even alone.
+    The rail is always drawn: the Unrestricted tab stands beside every list,
+    and stands alone for a fighter holding none. The search box names the
+    list it searches.
     {% endcomment %}
     {% if catalogue %}
-        <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-4 {% if rail or post_is_shut %}md:grid-cols-[11rem_minmax(0,1fr)]{% endif %}">
+        <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-[11rem_minmax(0,1fr)]">
             {% comment %}
-            The rail and what sits under it are one grid cell, so the block
-            below the lists needs no placement of its own. It draws even where
-            there is no rail: one list is nothing to choose between, but the
-            gang can still be told it is tracking nothing.
+            The rail and what sits under it are one grid cell, so the blocks
+            below the lists need no placement of their own.
             {% endcomment %}
-            {% if rail or post_is_shut %}
-                <div class="flex flex-col gap-4 self-start">
-                    {% if rail %}
-                        <c-ui.navlist variant="sidebar" aria-label="Which list" class="text-sm">
-                            {% for tab in collection_tabs %}
-                                {% comment %}
-                                The full name where the tab shortened it, empty
-                                where nothing was lost — decided in the view,
-                                because a template tag written inside a
-                                component's attributes is not read as one.
-                                {% endcomment %}
-                                <c-ui.navlist.item href="{{ tab.href }}" :current="tab.current" title="{{ tab.title }}">
-                                    {{ tab.label }}
-                                </c-ui.navlist.item>
-                            {% endfor %}
-                        </c-ui.navlist>
-                    {% endif %}
-                    {% if everything %}
-                        {% include "n26/includes/unrestricted_note.html" %}
-                    {% endif %}
-                    {% if post_is_shut %}
-                        {% include "n26/includes/not_tracking_tp.html" %}
-                    {% endif %}
-                </div>
-            {% endif %}
+            <div class="flex flex-col gap-4 self-start">
+                <c-ui.navlist variant="sidebar" aria-label="Which list" class="text-sm">
+                    {% for tab in collection_tabs %}
+                        {% comment %}
+                        The full name where the tab shortened it, empty where
+                        nothing was lost — decided in the view, because a
+                        template tag written inside a component's attributes
+                        is not read as one.
+                        {% endcomment %}
+                        <c-ui.navlist.item href="{{ tab.href }}" :current="tab.current" title="{{ tab.title }}">
+                            {{ tab.label }}
+                        </c-ui.navlist.item>
+                    {% endfor %}
+                </c-ui.navlist>
+                {% if everything %}
+                    {% include "n26/includes/unrestricted_note.html" %}
+                {% endif %}
+                {% if post_is_shut %}
+                    {% include "n26/includes/not_tracking_tp.html" %}
+                {% endif %}
+            </div>
             {% comment %}
             The whole catalogue posts here. A purchase submitted by htmx gets
             back only the elements it changed — so the filters, the section on

--- a/n26/core/templates/n26/equip.html
+++ b/n26/core/templates/n26/equip.html
@@ -132,7 +132,10 @@ breadcrumb above it has the gang as well, so nothing is lost.
                         template tag written inside a component's attributes
                         is not read as one.
                         {% endcomment %}
-                        <c-ui.navlist.item href="{{ tab.href }}" :current="tab.current" title="{{ tab.title }}">
+                        <c-ui.navlist.item href="{{ tab.href }}"
+                                           :current="tab.current"
+                                           title="{{ tab.title }}"
+                                           data-busy="link">
                             {{ tab.label }}
                         </c-ui.navlist.item>
                     {% endfor %}

--- a/n26/core/templates/n26/equip.html
+++ b/n26/core/templates/n26/equip.html
@@ -114,19 +114,20 @@ breadcrumb above it has the gang as well, so nothing is lost.
     Links, not client state: a list is a place you can be, so it goes in the URL
     — linkable, back-button-friendly, and the server renders the one you are on.
     One list draws no rail; there is nothing to choose, and the search box
-    names the list it searches.
+    names the list it searches. Whether one is drawn is the view's decision
+    (`rail`), because the Unrestricted tab is drawn even alone.
     {% endcomment %}
-    {% if chosen %}
-        <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-4 {% if collection_tabs|length > 1 or post_is_shut %}md:grid-cols-[11rem_minmax(0,1fr)]{% endif %}">
+    {% if catalogue %}
+        <div class="mt-6 grid grid-cols-1 gap-x-6 gap-y-4 {% if rail or post_is_shut %}md:grid-cols-[11rem_minmax(0,1fr)]{% endif %}">
             {% comment %}
             The rail and what sits under it are one grid cell, so the block
             below the lists needs no placement of its own. It draws even where
             there is no rail: one list is nothing to choose between, but the
             gang can still be told it is tracking nothing.
             {% endcomment %}
-            {% if collection_tabs|length > 1 or post_is_shut %}
+            {% if rail or post_is_shut %}
                 <div class="flex flex-col gap-4 self-start">
-                    {% if collection_tabs|length > 1 %}
+                    {% if rail %}
                         <c-ui.navlist variant="sidebar" aria-label="Which list" class="text-sm">
                             {% for tab in collection_tabs %}
                                 {% comment %}
@@ -140,6 +141,9 @@ breadcrumb above it has the gang as well, so nothing is lost.
                                 </c-ui.navlist.item>
                             {% endfor %}
                         </c-ui.navlist>
+                    {% endif %}
+                    {% if everything %}
+                        {% include "n26/includes/unrestricted_note.html" %}
                     {% endif %}
                     {% if post_is_shut %}
                         {% include "n26/includes/not_tracking_tp.html" %}
@@ -155,8 +159,8 @@ breadcrumb above it has the gang as well, so nothing is lost.
             this is an ordinary form and the whole page is served.
             {% endcomment %}
             <form method="post"
-                  action="{% url 'n26-equip' miniature.pk %}?list={{ chosen.pk }}"
-                  hx-post="{% url 'n26-equip' miniature.pk %}?list={{ chosen.pk }}"
+                  action="{{ action }}"
+                  hx-post="{{ action }}"
                   hx-swap="none">
                 {% csrf_token %}
                 {% comment %}
@@ -187,7 +191,7 @@ breadcrumb above it has the gang as well, so nothing is lost.
                         <c-n26.search-bar :live="True"
                                           :nested="True"
                                           model="query"
-                                          placeholder="Search {{ chosen }}" />
+                                          placeholder="Search {{ browsing }}" />
                         {% if category_options or price_ceiling > price_floor or has_trade_points %}
                             {% comment %}
                             A size under the search field above them. These
@@ -271,9 +275,13 @@ breadcrumb above it has the gang as well, so nothing is lost.
         </div>
     {% else %}
         <p class="mt-6 text-muted">
-            No equipment lists yet — this fighter has nothing to browse. Lists
-            arrive with the gang's own content, or from the library's Trading
-            Post once one is created.
+            No equipment lists yet. Lists arrive with the gang's own content, or
+            from the library's Trading Post once one is created. Every item in
+            the library is on the
+            <c-n26.link href="?list=all">
+                Unrestricted
+            </c-n26.link>
+            tab.
         </p>
     {% endif %}
 {% endblock content %}

--- a/n26/core/templates/n26/gang_equip.html
+++ b/n26/core/templates/n26/gang_equip.html
@@ -76,7 +76,10 @@ sell is managed from the In stash tab.
         <div class="flex flex-col gap-4 self-start">
             <c-ui.navlist variant="sidebar" aria-label="Which list" class="text-sm">
                 {% for tab in collection_tabs %}
-                    <c-ui.navlist.item href="{{ tab.href }}" :current="tab.current" title="{{ tab.title }}">
+                    <c-ui.navlist.item href="{{ tab.href }}"
+                                       :current="tab.current"
+                                       title="{{ tab.title }}"
+                                       data-busy="link">
                         {{ tab.label }}
                     </c-ui.navlist.item>
                 {% endfor %}

--- a/n26/core/templates/n26/gang_equip.html
+++ b/n26/core/templates/n26/gang_equip.html
@@ -81,6 +81,9 @@ sell is managed from the In stash tab.
                     </c-ui.navlist.item>
                 {% endfor %}
             </c-ui.navlist>
+            {% if everything %}
+                {% include "n26/includes/unrestricted_note.html" %}
+            {% endif %}
             {% if post_is_shut %}
                 {% include "n26/includes/not_tracking_tp.html" %}
             {% endif %}
@@ -103,10 +106,9 @@ sell is managed from the In stash tab.
             </form>
         {% else %}
             <p class="text-muted">
-                No equipment lists yet — this gang has none of its own to browse.
-                Lists arrive with the gang's own content; everything the library
-                holds is on the All equipment tab, and everything held is on
-                the In stash tab.
+                No equipment lists yet. Lists arrive with the gang's own content.
+                Every item in the library is on the Unrestricted tab, and
+                everything the gang holds is on the In stash tab.
             </p>
         {% endif %}
     </div>

--- a/n26/core/templates/n26/includes/unrestricted_note.html
+++ b/n26/core/templates/n26/includes/unrestricted_note.html
@@ -9,13 +9,15 @@ fighter's; the gang's screen has none.
     <p class="mt-0.5 text-xs text-muted">
         {% if miniature %}
             Includes items outside {{ miniature.name }}'s equipment lists.
-            Items on those lists are priced as the lists price them, and
-            other items as the Trading Post does. Items
+            Items on those lists are priced as the lists price them. Other
+            items are priced as the Trading Post prices them, or at their
+            standard price where the post does not include them. Items
             {{ miniature.name }} cannot use are marked.
         {% else %}
             Includes items outside the gang's equipment lists. Items on
-            those lists are priced as the lists price them, and other items
-            as the Trading Post does.
+            those lists are priced as the lists price them. Other items are
+            priced as the Trading Post prices them, or at their standard
+            price where the post does not include them.
         {% endif %}
     </p>
 </div>

--- a/n26/core/templates/n26/includes/unrestricted_note.html
+++ b/n26/core/templates/n26/includes/unrestricted_note.html
@@ -8,10 +8,10 @@ fighter's; the gang's screen has none.
     <p class="text-sm font-medium text-ink-900 dark:text-ink-100">Every item in the library</p>
     <p class="mt-0.5 text-xs text-muted">
         {% if miniature %}
-            This tab is not limited to {{ miniature.name }}'s equipment lists.
+            Includes items outside {{ miniature.name }}'s equipment lists.
             Items {{ miniature.name }} cannot use are marked.
         {% else %}
-            This tab is not limited to the gang's equipment lists.
+            Includes items outside the gang's equipment lists.
         {% endif %}
     </p>
 </div>

--- a/n26/core/templates/n26/includes/unrestricted_note.html
+++ b/n26/core/templates/n26/includes/unrestricted_note.html
@@ -9,9 +9,13 @@ fighter's; the gang's screen has none.
     <p class="mt-0.5 text-xs text-muted">
         {% if miniature %}
             Includes items outside {{ miniature.name }}'s equipment lists.
-            Items {{ miniature.name }} cannot use are marked.
+            Items on those lists are priced as the lists price them, and
+            other items as the Trading Post does. Items
+            {{ miniature.name }} cannot use are marked.
         {% else %}
-            Includes items outside the gang's equipment lists.
+            Includes items outside the gang's equipment lists. Items on
+            those lists are priced as the lists price them, and other items
+            as the Trading Post does.
         {% endif %}
     </p>
 </div>

--- a/n26/core/templates/n26/includes/unrestricted_note.html
+++ b/n26/core/templates/n26/includes/unrestricted_note.html
@@ -1,0 +1,17 @@
+{% comment %}
+What the Unrestricted tab is, for a reader who has just opened it. Under the
+rail, like the Trading Post note, because it is a fact about the list they are
+on and not about anything in it. Wants `miniature` where the screen is a
+fighter's; the gang's screen has none.
+{% endcomment %}
+<div class="self-start rounded-box border border-box-border p-3">
+    <p class="text-sm font-medium text-ink-900 dark:text-ink-100">Every item in the library</p>
+    <p class="mt-0.5 text-xs text-muted">
+        {% if miniature %}
+            This tab is not limited to {{ miniature.name }}'s equipment lists.
+            Items {{ miniature.name }} cannot use are marked.
+        {% else %}
+            This tab is not limited to the gang's equipment lists.
+        {% endif %}
+    </p>
+</div>

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -204,12 +204,17 @@ def test_each_list_is_a_tab_of_its_own(client, tester, fighter, house_list):
 
     client.force_login(tester)
     tabs = client.get(equip_url(fighter, house_list)).context["collection_tabs"]
-    assert [tab["label"] for tab in tabs] == ["House List", "Trading Post"]
+    assert [tab["label"] for tab in tabs] == [
+        "House List",
+        "Trading Post",
+        "Unrestricted",
+    ]
     assert [tab["href"] for tab in tabs] == [
         f"?list={house_list.pk}",
         f"?list={Collection.objects.get(name='Trading Post').pk}",
+        "?list=all",
     ]
-    assert [tab["current"] for tab in tabs] == [True, False]
+    assert [tab["current"] for tab in tabs] == [True, False, False]
 
 
 def test_the_strip_holds_this_fighters_list_and_no_other_houses(
@@ -252,7 +257,11 @@ def test_the_strip_holds_this_fighters_list_and_no_other_houses(
 
     client.force_login(tester)
     tabs = client.get(equip_url(fighter)).context["collection_tabs"]
-    assert [tab["label"] for tab in tabs] == ["Ironhead Squats", "Trading Post"]
+    assert [tab["label"] for tab in tabs] == [
+        "Ironhead Squats",
+        "Trading Post",
+        "Unrestricted",
+    ]
 
 
 def test_a_collection_of_skills_is_no_tab_however_the_fighter_holds_it(
@@ -290,23 +299,28 @@ def test_a_collection_of_skills_is_no_tab_however_the_fighter_holds_it(
     client.force_login(tester)
     response = client.get(equip_url(fighter))
     assert [tab["label"] for tab in response.context["collection_tabs"]] == [
-        "Ironhead Squats"
+        "Ironhead Squats",
+        "Unrestricted",
     ]
     assert "Catfall" not in response.content.decode()
 
 
-def test_a_lone_list_draws_no_strip_and_the_search_box_says_where_you_are(
+def test_a_lone_list_is_still_a_choice_beside_the_library(
     client, tester, fighter, house_list
 ):
-    """One list is not a choice. A strip of one tab would be a control that
-    does nothing, so the only thing naming the list is the box you search
-    it with — which means that name has to be there."""
+    """One list would be no choice on its own, and the strip would be a
+    control that does nothing. But the library tab stands beside every
+    list, so a fighter with one list has two places to be — and the
+    search box still names the one they are on."""
     client.force_login(tester)
     response = client.get(equip_url(fighter))
     html = response.content.decode()
-    assert len(response.context["collection_tabs"]) == 1
+    assert [tab["label"] for tab in response.context["collection_tabs"]] == [
+        "House List",
+        "Unrestricted",
+    ]
     assert "Search House List" in html
-    assert 'aria-label="Which list"' not in html
+    assert 'aria-label="Which list"' in html
 
 
 def test_a_tab_drops_the_words_every_tab_shares(client, tester, gang, fighter):
@@ -2323,3 +2337,159 @@ class TestOpeningTheCopiesOfAnOwnedRow:
 
         assert opened.status_code == 200
         assert 'aria-expanded="true"' in opened.content.decode()
+
+
+class TestTheLibraryTab:
+    """Every item in the library, for the thing no held list offers —
+    the same tab the gang's screen has, noted for this fighter."""
+
+    @pytest.fixture
+    def library(self, default_pack):
+        """Gear no list the fighter holds offers, one piece of it
+        restricted to a subtype the fighter is not."""
+        from n26.library.authoring import create_subtype, create_weapon
+
+        walker = create_subtype("Walker")
+        create_wargear("Mesh Armour", price=15)
+        create_weapon(
+            "Autogun", price=20, profiles=[("", 0)], usable_by_subtypes=[walker]
+        )
+        return walker
+
+    def test_it_is_not_built_until_the_address_asks_for_it(
+        self, client, tester, fighter, house_list, library
+    ):
+        client.force_login(tester)
+        body = client.get(equip_url(fighter)).content.decode()
+
+        assert "Knife" in body
+        assert "Mesh Armour" not in body
+
+    def test_it_draws_the_library_noted_for_this_fighter(
+        self, client, tester, fighter, house_list, library
+    ):
+        """A list restricts what it offers; the library restricts nothing,
+        so a use restriction is likeliest to bite here — and it is drawn
+        the way it is on any list: a note, never a missing row."""
+        client.force_login(tester)
+        response = client.get(f"{equip_url(fighter)}?list=all")
+        rows = {row.name: row for row in response.context["catalogue"].all_rows()}
+
+        assert "Knife" in rows
+        assert "Mesh Armour" in rows
+        assert rows["Mesh Armour"].notes == ()
+        assert [note.text for note in rows["Autogun"].notes] == [
+            "usable by Walker only"
+        ]
+
+    def test_the_page_says_where_it_is(
+        self, client, tester, fighter, house_list, library
+    ):
+        client.force_login(tester)
+        response = client.get(f"{equip_url(fighter)}?list=all")
+        html = response.content.decode()
+        tabs = response.context["collection_tabs"]
+
+        assert [tab["current"] for tab in tabs] == [False, True]
+        assert "Search all equipment" in html
+        assert "Every item in the library" in html
+        assert f"{equip_url(fighter)}?list=all" in html
+
+    def test_buying_from_it_lands_on_the_fighter(
+        self, client, tester, gang, fighter, house_list, library
+    ):
+        from n26.core.reconcile import assert_reconciled
+        from n26.library.models import Wargear
+
+        armour = Wargear.objects.get(name="Mesh Armour")
+        client.force_login(tester)
+        response = client.post(
+            f"{equip_url(fighter)}?list=all", {"thing": key_of(armour)}
+        )
+
+        assert response.status_code == 302
+        assert response.url == f"{equip_url(fighter)}?list=all"
+        assert Assignment.objects.get(wargear=armour).miniature == fighter
+        gang.refresh_from_db()
+        assert gang.credits == 85
+        assert_reconciled(gang)
+
+    def test_a_fighter_with_no_list_is_pointed_at_it(
+        self, client, tester, fighter, library
+    ):
+        """No list is nothing to browse, which is exactly who the library
+        is for: the empty page names the tab, and the tab draws alone —
+        a rail of one, so a reader on it can see where they are."""
+        client.force_login(tester)
+        empty = client.get(equip_url(fighter))
+        assert empty.context["catalogue"] is None
+        assert 'href="?list=all"' in empty.content.decode()
+
+        response = client.get(f"{equip_url(fighter)}?list=all")
+        assert [tab["label"] for tab in response.context["collection_tabs"]] == [
+            "Unrestricted"
+        ]
+        assert 'aria-label="Which list"' in response.content.decode()
+        assert "Mesh Armour" in response.content.decode()
+
+
+class TestTheLibraryTabsQueryBudget:
+    """The library is hundreds of rows, and a query per row is how a page
+    stops loading. Pinned so it changes deliberately, and measured after
+    one warm request — the first request of a session writes its own row.
+    """
+
+    def measure(self, client, url):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        assert client.get(url).status_code == 200
+        with CaptureQueriesContext(connection) as captured:
+            assert client.get(url).status_code == 200
+        return len(captured.captured_queries)
+
+    @pytest.fixture
+    def stocked(self, default_pack):
+        from n26.library.authoring import create_subtype, create_weapon
+
+        walker = create_subtype("Walker")
+        create_wargear("Mesh Armour", price=15)
+        create_weapon(
+            "Autogun", price=20, profiles=[("", 0)], usable_by_subtypes=[walker]
+        )
+        return walker
+
+    def test_it_costs_a_fixed_number(
+        self, client, tester, fighter, house_list, stocked
+    ):
+        client.force_login(tester)
+
+        # The reader and their session, the gang, the fighter's card with
+        # its options, the roster behind the header's count, which held
+        # lists hold gear, the drawer's one question about campaigns —
+        # and the library: one query per gear kind, plus the guns' paid
+        # rounds, each kind's offers and each restricted kind's use
+        # lists. Never one per item.
+        assert self.measure(client, f"{equip_url(fighter)}?list=all") == 41
+
+    def test_it_costs_the_same_however_much_it_holds(
+        self, client, tester, fighter, house_list, stocked
+    ):
+        """Restricted weapons in particular: each carries three use
+        lists, and noting the library without them loaded would be three
+        queries a gun."""
+        from n26.library.authoring import create_weapon
+
+        client.force_login(tester)
+        url = f"{equip_url(fighter)}?list=all"
+
+        few = self.measure(client, url)
+        for index in range(5):
+            create_wargear(f"Filler {index}", price=5)
+            create_weapon(
+                f"Filler gun {index}",
+                price=5,
+                profiles=[("", 0)],
+                usable_by_subtypes=[stocked],
+            )
+        assert self.measure(client, url) == few

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -2414,6 +2414,60 @@ class TestTheLibraryTab:
         assert gang.credits == 85
         assert_reconciled(gang)
 
+    def test_a_listed_item_is_priced_as_the_fighters_list_prices_it(
+        self, client, tester, fighter, house_list, library
+    ):
+        """The library's own figure is a reference price. A fighter buys
+        from the lists they hold, so an item one of them offers is priced
+        as that list prices it, on that list's terms."""
+        from n26.core.views.equip import _screen
+
+        screen = _screen(fighter.gang, miniature=fighter, list_param="all")
+        lines = {str(line.thing): line for line in screen.view.all_lines()}
+
+        # The list's override, not the wargear's 20.
+        assert lines["Sword"].credits == 35
+        assert lines["Sword"].entry is not None
+        assert lines["Sword"].charges_trade_points is False
+        # Nothing held offers it: reference.
+        assert lines["Mesh Armour"].credits == 15
+        assert lines["Mesh Armour"].entry is None
+
+    def test_an_unlisted_item_is_priced_as_the_trading_post_prices_it(
+        self, client, tester, fighter, house_list, library
+    ):
+        """Where no held list offers it and the post does, the post's line
+        stands — Trade Points shown and charged, as on the post's own
+        tab — and the fighter's own list still wins over the post."""
+        from n26.library.authoring import create_trading_post
+        from n26.library.models import Wargear
+
+        create_wargear("Lho Sticks", price=5, trade_point_price=1)
+        sword = Wargear.objects.get(name="Sword")
+        sword.trade_point_price = 4
+        sword.save(update_fields=["trade_point_price"])
+        create_trading_post()
+
+        from n26.core.views.equip import _screen
+
+        screen = _screen(fighter.gang, miniature=fighter, list_param="all")
+        lines = {str(line.thing): line for line in screen.view.all_lines()}
+        client.force_login(tester)
+        response = client.get(f"{equip_url(fighter)}?list=all")
+        rows = {row.name: row for row in response.context["catalogue"].all_rows()}
+
+        assert lines["Lho Sticks"].trade_points == 1
+        assert lines["Lho Sticks"].shows_trade_points is True
+        assert lines["Lho Sticks"].charges_trade_points is True
+        assert lines["Sword"].credits == 35
+        assert lines["Sword"].charges_trade_points is False
+        assert lines["Mesh Armour"].shows_trade_points is False
+        # And what the page draws says the same: a figure on the post's
+        # line, none on the list's, and the slider to steer by it.
+        assert rows["Lho Sticks"].trade_points == 1
+        assert rows["Sword"].trade_points is None
+        assert response.context["has_trade_points"] is True
+
     def test_a_fighter_with_no_list_is_pointed_at_it(
         self, client, tester, fighter, library
     ):
@@ -2467,10 +2521,12 @@ class TestTheLibraryTabsQueryBudget:
         # The reader and their session, the gang, the fighter's card with
         # its options, the roster behind the header's count, which held
         # lists hold gear, the drawer's one question about campaigns —
-        # and the library: one query per gear kind, plus the guns' paid
+        # the library: one query per gear kind, plus the guns' paid
         # rounds, each kind's offers and each restricted kind's use
-        # lists. Never one per item.
-        assert self.measure(client, f"{equip_url(fighter)}?list=all") == 41
+        # lists — and a browse of each list held, which is what prices
+        # the library's lines. A fixed number per list, never one per
+        # item.
+        assert self.measure(client, f"{equip_url(fighter)}?list=all") == 51
 
     def test_it_costs_the_same_however_much_it_holds(
         self, client, tester, fighter, house_list, stocked

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -123,7 +123,7 @@ class TestWhichListsAreOffered:
             "In stash",
             "House List",
             "Trading Post",
-            "All equipment",
+            "Unrestricted",
         ]
         assert tabs[1]["current"]
         assert tabs[-1]["href"] == "?list=all"
@@ -149,7 +149,7 @@ class TestWhichListsAreOffered:
         assert [tab["label"] for tab in tabs] == [
             "In stash",
             "House List",
-            "All equipment",
+            "Unrestricted",
         ]
 
     def test_a_shortened_tab_keeps_its_full_name_on_the_link(
@@ -185,7 +185,7 @@ class TestWhichListsAreOffered:
         assert response.context["catalogue"] is None
         assert [tab["label"] for tab in response.context["collection_tabs"]] == [
             "In stash",
-            "All equipment",
+            "Unrestricted",
         ]
         assert "No equipment lists yet" in response.content.decode()
 

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -604,12 +604,13 @@ class TestTheQueryBudget:
 
         client.force_login(tester)
 
-        # The same page with the library in place of that browse: one
-        # query per gear kind, plus the guns' paid rounds and the wargear's
+        # The same page with the library beside that browse: one query
+        # per gear kind, plus the guns' paid rounds and the wargear's
         # offers — never one per item, and no use lists, because a gang has
-        # nothing to test a restriction against. Plus the drawer's one
-        # question about whether campaigns are open.
-        assert self.measure(client, equip_url(gang, scope="all")) == 31
+        # nothing to test a restriction against — and the browse of each
+        # list held, which prices the library's lines. Plus the drawer's
+        # one question about whether campaigns are open.
+        assert self.measure(client, equip_url(gang, scope="all")) == 41
 
     def test_the_library_costs_the_same_however_much_it_holds(
         self, client, tester, gang, house_list

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -390,8 +390,9 @@ def _screen(gang, miniature=None, list_param=""):
     """What an equip screen shows: card, collections, chosen list, view.
 
     ``miniature`` names whose screen this is; without one it is the
-    gang's, where ``list_param`` may also be one of the two tabs that are
-    not collections (:data:`STASH_SCOPE`, :data:`ALL_SCOPE`).
+    gang's. On either, ``list_param`` may be :data:`ALL_SCOPE`, the
+    library tab that is not a collection; on the gang's it may also be
+    :data:`STASH_SCOPE`.
 
     One derivation for the pages and for every partial update — an update
     re-derives here because the act it follows changed the state it
@@ -418,12 +419,16 @@ def _screen(gang, miniature=None, list_param=""):
             access.collection
             for access in collections_for(miniature, card=card, computed=computed)
         )
-        chosen = chosen_from(collections)
-        view = (
-            with_use_notes(browse(chosen), usability_for(computed))
-            if chosen is not None
-            else None
-        )
+        if list_param == ALL_SCOPE:
+            # The library, noted for this fighter the way any list is:
+            # the tab is there for the thing no held list offers, which
+            # is where a use restriction is likeliest to bite.
+            chosen, view = None, all_gear(ALL_LABEL, for_use_notes=True)
+        else:
+            chosen = chosen_from(collections)
+            view = browse(chosen) if chosen is not None else None
+        if view is not None:
+            view = with_use_notes(view, usability_for(computed))
         return Screen(gang, miniature, card, computed, collections, chosen, view)
 
     card = build_gang_card(gang, with_statlines=False)
@@ -774,6 +779,7 @@ def equip(request, pk):
     gang = miniature.gang
 
     wanted = request.GET.get("list", "")
+    everything = wanted == ALL_SCOPE
     screen = _screen(gang, miniature=miniature, list_param=wanted)
     collections, chosen, view = screen.collections, screen.chosen, screen.view
 
@@ -787,7 +793,13 @@ def equip(request, pk):
 
     def here(collection):
         params = [
-            *([("list", collection.pk)] if collection is not None else []),
+            *(
+                [("list", ALL_SCOPE)]
+                if everything
+                else [("list", collection.pk)]
+                if collection is not None
+                else []
+            ),
             *([("section", section)] if section else []),
             *([("owned", expanded_key)] if expanded_key else []),
         ]
@@ -801,7 +813,7 @@ def equip(request, pk):
             miniature,
             view,
             into=miniature.name,
-            collection=chosen.name,
+            collection=ALL_LABEL if everything else chosen.name,
             at=here(chosen),
             event={"miniature_id": str(miniature.pk)},
         )
@@ -866,8 +878,17 @@ def equip(request, pk):
     # Which list is being browsed is a tab when there are several. With
     # one there is nothing to choose, so no strip is drawn — the search
     # box names the list it is searching, which is where a reader looks
-    # to find out what they are buying from.
-    tabs = collection_tabs(collections, chosen)
+    # to find out what they are buying from. The library tab is drawn
+    # alone, though: a fighter holding no list at all is exactly who it
+    # is for, and a reader on it should see where they are.
+    tabs = fighter_tabs(collections, chosen, everything)
+    rail = len(tabs) > 1 or everything
+    # The whole catalogue posts back to the list it was drawn from — only
+    # that: the picker's own state travels in the form, not in the address
+    # it posts to.
+    scope = ALL_SCOPE if everything else chosen.pk if chosen is not None else ""
+    action = f"{request.path}?list={scope}" if scope else request.path
+    browsing = ALL_BROWSING if everything else str(chosen or "")
     from n26.core.render import roster as gang_roster
     from n26.core.render import summarise_roster
 
@@ -895,6 +916,10 @@ def equip(request, pk):
             "trade_points_href": trade_points_href(gang, request.user),
             "collections": collections,
             "collection_tabs": tabs,
+            "rail": rail,
+            "everything": everything,
+            "action": action,
+            "browsing": browsing,
             "chosen": chosen,
             "catalogue": catalogue,
             # This page holds every element a partial update replaces, so
@@ -993,13 +1018,19 @@ def picker_context(catalogue, view, gang=None):
     }
 
 
-#: The gang screen's library tab: not a collection, so it names itself in
-#: the URL where a collection would name its id. A ULID is never this
-#: word, so the two cannot collide.
+#: The library tab, on a model's screen and the gang's: not a collection,
+#: so it names itself in the URL where a collection would name its id. A
+#: ULID is never this word, so the two cannot collide.
 ALL_SCOPE = "all"
 
-#: What that tab is called, on the tab and as the list being browsed.
-ALL_LABEL = "All equipment"
+#: What that tab is called. Not "All": beside a fighter's own lists that
+#: reads as "all of this fighter's", and the tab is the opposite — what
+#: no held list restricts it to.
+ALL_LABEL = "Unrestricted"
+
+#: What the tab is browsing, where a sentence names it — the search
+#: box's placeholder.
+ALL_BROWSING = "all equipment"
 
 #: The stash-holdings tab — not a collection. Gear the current list does
 #: not sell is reached from here, rather than drawn beside the catalogue.
@@ -1008,17 +1039,26 @@ STASH_SCOPE = "stash"
 STASH_LABEL = "In stash"
 
 
+def library_tab(everything):
+    """The library tab, last on either screen."""
+    return {
+        "label": ALL_LABEL,
+        "title": "",
+        "href": f"?list={ALL_SCOPE}",
+        "current": everything,
+    }
+
+
+def fighter_tabs(collections, chosen, everything):
+    """The buyable collections and the library tab."""
+    tabs = collection_tabs(collections, chosen)
+    tabs.append(library_tab(everything))
+    return tabs
+
+
 def gang_tabs(collections, chosen, everything, *, stash=False):
     """The stash, buyable collections, and library tabs."""
-    tabs = collection_tabs(collections, chosen)
-    tabs.append(
-        {
-            "label": ALL_LABEL,
-            "title": "",
-            "href": f"?list={ALL_SCOPE}",
-            "current": everything,
-        }
-    )
+    tabs = fighter_tabs(collections, chosen, everything)
     tabs.insert(
         0,
         {
@@ -1128,7 +1168,7 @@ def equip_gang(request, pk):
             refunds=refunds,
             expanded_key=expanded_key,
         )
-        browsing = ALL_LABEL if everything else str(chosen or "")
+        browsing = ALL_BROWSING if everything else str(chosen or "")
     else:
         catalogue = None
         browsing = ""
@@ -1148,6 +1188,7 @@ def equip_gang(request, pk):
             "browsing": browsing,
             "catalogue": catalogue,
             "stash_tab": stash_tab,
+            "everything": everything,
             # Opted in the same way as a model's own screen.
             "htmx": True,
             "held_label": host.held_label,

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -881,9 +881,15 @@ def equip(request, pk):
     # The whole catalogue posts back to the list it was drawn from — only
     # that: the picker's own state travels in the form, not in the address
     # it posts to.
-    scope = ALL_SCOPE if everything else chosen.pk if chosen is not None else ""
-    action = f"{request.path}?list={scope}" if scope else request.path
-    browsing = ALL_BROWSING if everything else str(chosen or "")
+    if everything:
+        action = f"{request.path}?list={ALL_SCOPE}"
+        browsing = ALL_BROWSING
+    elif chosen is not None:
+        action = f"{request.path}?list={chosen.pk}"
+        browsing = str(chosen)
+    else:
+        action = request.path
+        browsing = ""
     from n26.core.render import roster as gang_roster
     from n26.core.render import summarise_roster
 

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -792,17 +792,15 @@ def equip(request, pk):
     expanded_key = request.POST.get("owned", request.GET.get("owned", ""))[:200]
 
     def here(collection):
-        params = [
-            *(
-                [("list", ALL_SCOPE)]
-                if everything
-                else [("list", collection.pk)]
-                if collection is not None
-                else []
-            ),
-            *([("section", section)] if section else []),
-            *([("owned", expanded_key)] if expanded_key else []),
-        ]
+        params = []
+        if everything:
+            params.append(("list", ALL_SCOPE))
+        elif collection is not None:
+            params.append(("list", collection.pk))
+        if section:
+            params.append(("section", section))
+        if expanded_key:
+            params.append(("owned", expanded_key))
         return f"{request.path}?{urlencode(params)}" if params else request.path
 
     if request.method == "POST" and view is not None:
@@ -875,14 +873,11 @@ def equip(request, pk):
         if view is not None
         else None
     )
-    # Which list is being browsed is a tab when there are several. With
-    # one there is nothing to choose, so no strip is drawn — the search
-    # box names the list it is searching, which is where a reader looks
-    # to find out what they are buying from. The library tab is drawn
-    # alone, though: a fighter holding no list at all is exactly who it
-    # is for, and a reader on it should see where they are.
-    tabs = fighter_tabs(collections, chosen, everything)
-    rail = len(tabs) > 1 or everything
+    # Which list is being browsed is a rail of tabs: the lists held, and
+    # the library beside them. A fighter holding no list has the library
+    # alone, and the rail is drawn all the same, so a reader on it can see
+    # where they are. The search box names the list it is searching.
+    tabs = list_tabs(collections, chosen, everything)
     # The whole catalogue posts back to the list it was drawn from — only
     # that: the picker's own state travels in the form, not in the address
     # it posts to.
@@ -916,7 +911,6 @@ def equip(request, pk):
             "trade_points_href": trade_points_href(gang, request.user),
             "collections": collections,
             "collection_tabs": tabs,
-            "rail": rail,
             "everything": everything,
             "action": action,
             "browsing": browsing,
@@ -1049,8 +1043,8 @@ def library_tab(everything):
     }
 
 
-def fighter_tabs(collections, chosen, everything):
-    """The buyable collections and the library tab."""
+def list_tabs(collections, chosen, everything):
+    """The buyable collections and, after them, the library tab."""
     tabs = collection_tabs(collections, chosen)
     tabs.append(library_tab(everything))
     return tabs
@@ -1058,7 +1052,7 @@ def fighter_tabs(collections, chosen, everything):
 
 def gang_tabs(collections, chosen, everything, *, stash=False):
     """The stash, buyable collections, and library tabs."""
-    tabs = fighter_tabs(collections, chosen, everything)
+    tabs = list_tabs(collections, chosen, everything)
     tabs.insert(
         0,
         {

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -400,7 +400,13 @@ def _screen(gang, miniature=None, list_param=""):
     on" would let the two quietly disagree.
     """
     from n26.core.access import collections_for, gang_collections
-    from n26.core.browse import all_gear, browse, usability_for, with_use_notes
+    from n26.core.browse import (
+        all_gear,
+        browse,
+        priced_from,
+        usability_for,
+        with_use_notes,
+    )
     from n26.core.card import build_card, build_gang_card, build_modifier_index
     from n26.core.effects import compute, compute_gang
 
@@ -420,10 +426,15 @@ def _screen(gang, miniature=None, list_param=""):
             for access in collections_for(miniature, card=card, computed=computed)
         )
         if list_param == ALL_SCOPE:
-            # The library, noted for this fighter the way any list is:
-            # the tab is there for the thing no held list offers, which
-            # is where a use restriction is likeliest to bite.
-            chosen, view = None, all_gear(ALL_LABEL, for_use_notes=True)
+            # The library, priced from the lists this fighter holds and
+            # noted for them the way any list is: the tab is there for
+            # the thing no held list offers, which is where a use
+            # restriction is likeliest to bite.
+            chosen = None
+            view = priced_from(
+                all_gear(ALL_LABEL, for_use_notes=True),
+                [browse(collection) for collection in collections],
+            )
         else:
             chosen = chosen_from(collections)
             view = browse(chosen) if chosen is not None else None
@@ -441,7 +452,11 @@ def _screen(gang, miniature=None, list_param=""):
     if list_param == STASH_SCOPE:
         chosen, view = None, None
     elif list_param == ALL_SCOPE:
-        chosen, view = None, all_gear(ALL_LABEL)
+        chosen = None
+        view = priced_from(
+            all_gear(ALL_LABEL),
+            [browse(collection) for collection in collections],
+        )
     else:
         chosen = chosen_from(collections)
         # No usability notes: those are about a fighter, and the stash is


### PR DESCRIPTION
## Summary

- The gang equip page's "All equipment" tab is renamed **Unrestricted** and is now offered on every fighter's equip page too, as the last tab beside their own lists. Beside a fighter's lists, "All" read as "all of this fighter's" — the tab is the opposite: every item in the library, whatever the fighter's lists offer.
- **Prices come from the lists held.** The library prices everything at reference; `priced_from` in `n26/core/browse.py` swaps each line for the first held listing that offers the item — the fighter's own list first, the Trading Post next, reference where nothing held offers it. A post-priced line keeps its Trade Point figure and charges it, so TP values and the TP slider show on a fighter's Unrestricted tab exactly as on the post's own tab. The stash page prices the same way from the gang's lists.
- On a fighter's page the library is drawn with the same use notes as any list ("usable by Walker only"). `all_gear(for_use_notes=True)` prefetches the use lists per kind so noting ~500 rows costs no query per line; the gang page leaves the prefetch off since the stash gets no notes.
- **The rail's tab goes busy as soon as it is clicked.** The equip rail's links carry `data-busy="link"`, a new opt-in in `n26/core/static/n26/busy.js` that treats a plain link as a button: the clicked tab spins immediately, and a page restored from the back/forward cache gets its opt-in back.
- A short note under the tab rail says what the tab is and where its prices come from. A fighter with no lists at all is pointed at it from the empty state; the rail is always drawn so a reader can see where they are.

Refs #2183 (that issue asks for a different "All" — all sections at once — so this tab avoids the word).

## Performance

Measured prod-like (cached template loader, no debug toolbar) against the local content mirror (341 weapons, 97 wargear), fighter holding one list:

| Page | Wall | SQL | Queries | HTML |
|---|---|---|---|---|
| Fighter, own list | 163ms | 59ms | 71 | 758KB |
| Fighter, Unrestricted | 355ms | 77ms | 87 | 1.9MB |

Query counts are pinned in tests and stay flat as content grows; pricing adds one fixed-size browse per held list (fighter fixture 51, gang 41). In the browser, section-tab presses on the ~440-row page produced no long tasks.

## Test plan

- [x] `pytest n26` — full suite green
- [x] Fighter equip page: rail shows lists + Unrestricted, note under the rail, "Search all equipment", a restricted weapon carries its note, buying lands on the fighter and returns to `?list=all`
- [x] Pricing: an item on the fighter's list is priced as that list prices it with no TP; an item only the post offers shows and charges its TP; the fighter's list wins over the post; the TP slider appears
- [x] Rail tab click sets `data-busy="on"` on the link at once
- [x] Gang equip page: In stash / lists / Unrestricted, gang wording of the note, budget re-pinned
- [x] Fighter with no lists: empty state links to `?list=all`; that page draws a one-tab rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xhszfuLW7UvchR2gR6vsF
