### PR TITLE
fix: let the n26 quick-switcher list scroll on a phone

### DIFF
--- a/n26/core/templates/cotton/n26/quick_switcher/index.html
+++ b/n26/core/templates/cotton/n26/quick_switcher/index.html
@@ -19,9 +19,11 @@ either way: the filter narrows what is already on the page and fetches nothing.
 fit() places the panel itself, fixed and clamped inside the window, against the
 rectangle of the [data-quick-switcher] root — so anything wrapped around this
 component must leave that root reachable. The kit writes offsets of its own on
-open, scroll and resize and they are wrong for a fixed box; these listeners are
-registered after the kit's and both run on a frame, so the fit lands after each
-of its writes and before the frame is drawn.
+open, scroll and resize and they are wrong for a fixed box; those listeners are
+dropped and replaced, so a scroll that started inside the panel is not treated
+as the switcher leaving the window. Rewriting position:fixed mid-gesture
+cancels the list's own scroll on a phone. The panel itself is not a scroll
+box — overflow=hidden on the dropdown — so only the list of rows scrolls.
 
 Focus lands in the filter box and never leaves it: Down and Up move a
 highlight, Enter clicks the highlighted row, Escape clears the filter before it
@@ -82,6 +84,7 @@ aria-activedescendant so the tinted row and the spoken one agree.
             </c-ui.button>
         {% endif %}
         <c-ui.dropdown align="{{ align }}"
+                       overflow="hidden"
                        min_width="min({{ min_width }}, calc(100vw - 1rem))">
             <c-slot name="trigger">
                 {% comment %}
@@ -188,6 +191,13 @@ aria-activedescendant so the tinted row and the spoken one agree.
                              if (this.query) { this.query = ''; this.active = '' } else { this.close() }
                          }
                      },
+                     // The panel is the dropdown's content box, the parent of
+                     // this scope. A scroll whose target lives inside it is
+                     // the list moving, not the page.
+                     inside(node) {
+                         const panel = this.$el.parentElement;
+                         return !!(panel && node instanceof Node && panel.contains(node));
+                     },
                      fit() {
                          const panel = this.$el.parentElement;
                          // A panel still opening has no width to measure, and
@@ -255,10 +265,23 @@ aria-activedescendant so the tinted row and the spoken one agree.
                              if (!this.visible.some(row => row.id === this.active)) this.active = '';
                          });
                          // Scroll as well as resize: a fixed box stays put
-                         // while the switcher scrolls away from under it, and
-                         // both are events the kit writes its own offsets on —
-                         // each write needs a fit landing after it.
-                         this.refit = () => { if (this.dropdownMenu) requestAnimationFrame(() => this.fit()) };
+                         // while the switcher scrolls away from under it.
+                         // An inner scroll is the list moving — refitting
+                         // would rewrite position:fixed and cancel it.
+                         this.refit = (event) => {
+                             if (!this.dropdownMenu) return;
+                             if (event && event.type === 'scroll' && this.inside(event.target)) return;
+                             requestAnimationFrame(() => this.fit());
+                         };
+                         // The kit's own listeners write absolute offsets
+                         // that are wrong for a fixed box. They are removed
+                         // so an inner scroll that skips our write does not
+                         // leave theirs standing, which would jump the panel.
+                         const kit = this._reposition;
+                         if (typeof kit === 'function') {
+                             window.removeEventListener('scroll', kit, true);
+                             window.removeEventListener('resize', kit);
+                         }
                          window.addEventListener('resize', this.refit);
                          window.addEventListener('scroll', this.refit, true);
                          {% if hotkey %}
@@ -318,7 +341,11 @@ aria-activedescendant so the tinted row and the spoken one agree.
                 the overflow it leaves in the panel, so a list that fits gains
                 a scrollbar and one pixel of scroll.
                 {% endcomment %}
-                <div :id="$id('n26-switcher') + '-list'" class="max-h-72 overflow-y-auto">{{ slot }}</div>
+                {% comment %}
+                overscroll-contain: reaching either end of this list must
+                not hand the gesture to the page underneath.
+                {% endcomment %}
+                <div :id="$id('n26-switcher') + '-list'" class="max-h-72 overflow-y-auto overscroll-contain">{{ slot }}</div>
                 {% comment %}
                 x-cloak, so a reader with no script never sees a line about a
                 filter they do not have.

--- a/n26/core/templates/cotton/ui/dropdown/index.html
+++ b/n26/core/templates/cotton/ui/dropdown/index.html
@@ -22,6 +22,10 @@ Every other prop is the kit's, unchanged.
 
   strategy    absolute (default) or fixed. Use fixed where the menu sits
               inside something that scrolls.
+  overflow    auto (default) or hidden. Hidden stops this panel being a
+              scroll box, for a caller that scrolls something inside it.
+              Two nested overflow-y-auto boxes hand a touch gesture to
+              the page on a phone.
 {% endcomment %}
 <c-vars
   position="bottom"
@@ -32,6 +36,7 @@ Every other prop is the kit's, unchanged.
   :auto_position="True"
   :collapsible="False"
   strategy="absolute"
+  overflow="auto"
 />
 
 <div
@@ -79,7 +84,8 @@ Every other prop is the kit's, unchanged.
            border-[color:var(--color-box-border)]
            bg-white dark:bg-ink-900
            max-h-[calc(100vh-4rem)] sm:max-h-[80vh]
-           overflow-y-auto overflow-x-hidden
+           {% if overflow == 'hidden' %}overflow-hidden{% else %}overflow-y-auto overflow-x-hidden{% endif %}
+           overscroll-contain
            scrollbar-thin scrollbar-thumb-ink-400 scrollbar-track-ink-100
            dark:scrollbar-thumb-ink-600 dark:scrollbar-track-ink-800"
     :class="collapsible

--- a/n26/core/test_menu_position.py
+++ b/n26/core/test_menu_position.py
@@ -60,6 +60,16 @@ class TestTheComponentAndTheScriptAgree:
         assert 'strategy="absolute"' in source
         assert "{% if strategy == 'fixed' %}" in source
 
+    def test_a_long_menu_does_not_hand_its_scroll_to_the_page(self):
+        """overscroll-contain stops a gesture that reached the end of the
+        menu from moving the page underneath. overflow=hidden is opt-in
+        for a caller that already scrolls something inside the panel."""
+        source = source_of("cotton/ui/dropdown/index.html")
+        assert "overscroll-contain" in source
+        assert 'overflow="auto"' in source
+        assert "overflow == 'hidden'" in source
+        assert "overflow-y-auto overflow-x-hidden" in source
+
 
 class TestTheCardMenuAsksForIt:
     def test_the_menu_beside_a_name_escapes_the_weapon_tables_scroll_box(self):

--- a/n26/core/test_quick_switcher.py
+++ b/n26/core/test_quick_switcher.py
@@ -202,6 +202,36 @@ class TestStayingOnTheScreen:
         html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")
         assert "this.fit()" in html
         assert "window.addEventListener('resize', this.refit)" in html
+        assert "window.addEventListener('scroll', this.refit, true)" in html
+
+    def test_a_scroll_inside_the_panel_does_not_refit_it(self):
+        """fit() writes position:fixed. Doing that mid-gesture cancels the
+        list's own scroll on a phone, and the page underneath moves
+        instead. The same filter is why the kit's listeners are dropped
+        rather than raced: theirs write first and would stay if ours
+        skipped."""
+        html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")
+        assert "this.inside(event.target)" in html
+        assert "event.type === 'scroll'" in html
+        assert "window.removeEventListener('scroll', kit, true)" in html
+        assert "window.removeEventListener('resize', kit)" in html
+
+    def test_the_panel_is_not_a_second_scroll_box(self):
+        """The list of rows is the scroller. A second overflow-y-auto on
+        the dropdown around it hands a touch gesture to the page."""
+        # The noscript strip also hides overflow as a box; the kit panel
+        # is the half that must not be a second scroll container.
+        panel = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>").split(
+            "<noscript>"
+        )[0]
+        assert "max-h-[calc(100vh-4rem)]" in panel
+        assert "overflow-hidden" in panel
+        assert "overflow-y-auto overflow-x-hidden" not in panel
+        assert "overscroll-contain" in panel
+
+    def test_reaching_the_end_of_the_list_does_not_scroll_the_page(self):
+        html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")
+        assert "max-h-72 overflow-y-auto overscroll-contain" in html
 
     def test_the_scriptless_strip_gives_up_its_width_rather_than_overflow(self):
         html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -128,7 +128,9 @@ GROUPS: list[Group] = [
                     ":collapsible to have it render inline below the md breakpoint "
                     'instead of as a popover. Set strategy="fixed" where the menu '
                     "sits inside something that scrolls, which otherwise cuts it off "
-                    "at the box's edges."
+                    'at the box\'s edges. Set overflow="hidden" when the caller '
+                    "scrolls something inside the panel — two overflow-y-auto boxes "
+                    "hand a touch gesture to the page on a phone."
                 ),
                 parts=(
                     Part(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2398.

On a phone, opening “+N more” and dragging the tab names scrolled the page behind the menu instead of the names. The same switcher is used on every n26 tab strip below `sm` (gang sheet, fighter edit, in-page `c-ui.tabs`).

Three things sat on top of each other:

1. The kit dropdown was itself a scroll box (`overflow-y-auto`).
2. The list of names inside it was a second scroll box (`max-h-72 overflow-y-auto`). Nested overflow-y-auto on iOS commonly hands the gesture to the page.
3. A capture-phase `scroll` listener called `fit()`, which rewrote `position: fixed` / `top` / `left` on every scroll — including one that started inside the menu. That cancelled whatever scroll the list had started. The kit's own scroll listener would have done the same if ours skipped.

What changed:

- The dropdown takes `overflow="hidden"` from the switcher, so only the list of rows scrolls.
- That list (and every dropdown panel) uses `overscroll-contain`, so reaching either end does not move the page.
- `fit()` ignores a scroll whose target is inside the panel.
- The kit's scroll/resize listeners are removed for this panel, so they cannot jump a fixed box when ours skip.

## How to try it

Open any n26 gang with two or more tabs on a phone, tap “+N more”, and drag the names. The names should move and the page should stay still.

The design-system page at `/n26/design/c/quick-switcher/` has a long filtered list that overflows `max-h-72`. Desktop DevTools will not fully reproduce the iOS touch bit.

## Checks

- 121 tests in `n26/core/test_quick_switcher.py`, `test_menu_position.py`, `test_ui_tabs.py`, `test_tab_links.py`, and `n26/designsystem/tests.py` passed.
- Playwright on a 390×844 touch viewport: list `scrollTop` moved, `window.scrollY` and the panel's `top`/`left` did not. Computed styles: panel `overflow-y: hidden` + `overscroll-behavior: contain`; list `overflow-y: auto` + `overscroll-behavior: contain`.

[Switcher menu open at the top of the list](https://cursor.com/agents/bc-34237975-0893-4198-bd87-99c7f0415f55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquick_switcher_menu_open.png)
[Switcher list scrolled; page behind unchanged](https://cursor.com/agents/bc-34237975-0893-4198-bd87-99c7f0415f55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquick_switcher_menu_scrolled.png)
[Tabs strip +N more menu open on a phone-width viewport](https://cursor.com/agents/bc-34237975-0893-4198-bd87-99c7f0415f55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftabs_plus_n_more_open.png)
[quick_switcher_list_scrolls_on_phone.mp4](https://cursor.com/agents/bc-34237975-0893-4198-bd87-99c7f0415f55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquick_switcher_list_scrolls_on_phone.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34237975-0893-4198-bd87-99c7f0415f55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34237975-0893-4198-bd87-99c7f0415f55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

