### PR TITLE
feat: maintenance op n26_rehost_gang_picks moves gang-held slot picks off models onto the gang

### DIFF
--- a/n26/core/rehost_picks.py
+++ b/n26/core/rehost_picks.py
@@ -90,17 +90,39 @@ def _astray(archived=False):
     )
 
 
+def _asked_of_this_model(pick):
+    """Whether the choice this pick settles was the model's own to make.
+
+    A slot pointing at the gang can still put its pick on a model on
+    purpose: a choice the gang carries for each of its members rides
+    every card, and settling it names the fighter whose card was
+    clicked, so that fighter's pick is theirs alone. Such a pick is not
+    stray, and hoisting it onto the gang would make one fighter's choice
+    everyone's. The two are told apart by what asked: a stray pick was
+    asked by the model's own line (its membership, or something it
+    carries), a deliberate one by a line the gang carries that is about
+    nobody in particular.
+    """
+    asked = pick.chosen_for
+    if asked is None:
+        return False
+    if asked.miniature_root_id is not None:
+        return asked.miniature_root_id == pick.miniature_id
+    return False
+
+
 def find(gang_id=None):
-    """What stands to be moved, gang by gang — or for one gang alone,
-    which is how a move re-reads its plan under the lock without
-    scanning the estate again."""
+    """What stands to be moved, gang by gang. ``gang_id`` narrows the
+    plan to that one gang."""
     astray = _astray()
     archived_astray = _astray(archived=True)
     if gang_id is not None:
         astray = astray.filter(gang_root_id=gang_id)
         archived_astray = archived_astray.filter(gang_root_id=gang_id)
     picks = list(
-        astray.select_related("miniature__membership").order_by("created", "id")
+        astray.select_related("miniature__membership", "chosen_for").order_by(
+            "created", "id"
+        )
     )
     archived = archived_astray.count()
     if not picks:
@@ -115,6 +137,13 @@ def find(gang_id=None):
                 f"pick {pick.pk} sits on a model that is not a member of the "
                 f"gang it is rooted in ({pick.gang_root_id}) — not the stray "
                 "pick this moves"
+            )
+            continue
+        if not _asked_of_this_model(pick):
+            problems.append(
+                f"pick {pick.pk} settles a choice the gang carries for each "
+                "of its models, and was made for this one on purpose — not "
+                "the stray pick this moves"
             )
             continue
         by_gang.setdefault(pick.gang_root_id, []).append(pick.pk)

--- a/n26/core/rehost_picks.py
+++ b/n26/core/rehost_picks.py
@@ -1,17 +1,16 @@
 """Moving a gang's picks off the models they were written on.
 
-A slot says where its pick lands: on the bearer, or on the gang where
+A slot sets where its pick lands: on the bearer, or on the gang where
 the slot is the Leader-picks-for-the-gang arrow. The Outcast Archetype
 slot is that arrow — the Leader is asked, the gang holds the pick, and
-it reaches every member through the gang. For a while the slot said
-``bearer`` instead, so the picks made in that window were written onto
-the Leader. Setting the slot back steers only the picks made after; the
-ones already written stay where they were put, and a gang whose pick
-sits on its Leader reads differently from one whose pick sits on the
-gang.
+it reaches every member through the gang. A pick is hosted where the
+slot pointed at the moment it was made, and changing the slot moves
+nothing already written: a pick made while the slot pointed at the
+bearer sits on the Leader, and a gang whose pick sits on its Leader
+reads differently from one whose pick sits on the gang.
 
-The repair finds every live pick whose slot says the gang and which sits
-on a model, and moves it onto the model's gang. Nothing else about the
+The repair finds every live pick whose slot points at the gang and which
+sits on a model, and moves it onto the model's gang. Nothing else about the
 pick changes: it still names the assignment that asked and the slot it
 settles, so the Leader's card still reads it as chosen, and it is still
 caused by the Leader's hire, so it still goes when the Leader does.
@@ -20,8 +19,8 @@ hosted in its own right and stays where it is.
 
 An archived pick on a model is counted and left alone: it draws nothing,
 and moving history is not a repair. Nothing here moves money: every
-pick's entry pins zero, so the books fold as they did — proved per
-gang, as every repair here proves it.
+pick's entry pins zero, so the books fold as they did, and each gang is
+proved to reconcile before its move commits.
 """
 
 from dataclasses import dataclass
@@ -35,8 +34,8 @@ class Refused(Exception):
 
 @dataclass(frozen=True)
 class Astray:
-    """Every live pick sitting on a model that its slot says the gang
-    holds, grouped by gang."""
+    """Every live pick sitting on a model while its slot points at the
+    gang, grouped by gang."""
 
     #: ``(gang id, pick ids)``, one per gang.
     gangs: tuple = ()
@@ -57,8 +56,8 @@ class Astray:
         lines = []
         if self.nothing_here:
             lines.append(
-                "nothing to move — every live pick of a slot the gang holds "
-                "sits on the gang"
+                "nothing to move — every live pick of a slot that points at "
+                "the gang sits on the gang"
             )
         for gang_id, ids in self.gangs:
             lines.append(
@@ -80,7 +79,7 @@ class Astray:
 
 
 def _astray(archived=False):
-    """The picks on a model whose slot says the gang holds them."""
+    """The picks on a model whose slot points at the gang."""
     from n26.core.models import Assignment
     from n26.library.models import Slot
 
@@ -91,12 +90,19 @@ def _astray(archived=False):
     )
 
 
-def find():
-    """What stands to be moved, gang by gang."""
+def find(gang_id=None):
+    """What stands to be moved, gang by gang — or for one gang alone,
+    which is how a move re-reads its plan under the lock without
+    scanning the estate again."""
+    astray = _astray()
+    archived_astray = _astray(archived=True)
+    if gang_id is not None:
+        astray = astray.filter(gang_root_id=gang_id)
+        archived_astray = archived_astray.filter(gang_root_id=gang_id)
     picks = list(
-        _astray().select_related("miniature__membership").order_by("created", "id")
+        astray.select_related("miniature__membership").order_by("created", "id")
     )
-    archived = _astray(archived=True).count()
+    archived = archived_astray.count()
     if not picks:
         return Astray(nothing_here=True, archived=archived)
 
@@ -148,7 +154,7 @@ def _rehost_one(gang_id, ids):
         # are moving; then the plan again, because it was read before
         # this transaction opened.
         gang = Gang.objects.select_for_update().get(pk=gang_id)
-        standing = dict(find().gangs)
+        standing = dict(find(gang_id).gangs)
         if standing.get(gang_id) != ids:
             return (
                 f"gang {gang_id}: skipped — its picks changed since the plan "

--- a/n26/core/rehost_picks.py
+++ b/n26/core/rehost_picks.py
@@ -1,0 +1,178 @@
+"""Moving a gang's picks off the models they were written on.
+
+A slot says where its pick lands: on the bearer, or on the gang where
+the slot is the Leader-picks-for-the-gang arrow. The Outcast Archetype
+slot is that arrow — the Leader is asked, the gang holds the pick, and
+it reaches every member through the gang. For a while the slot said
+``bearer`` instead, so the picks made in that window were written onto
+the Leader. Setting the slot back steers only the picks made after; the
+ones already written stay where they were put, and a gang whose pick
+sits on its Leader reads differently from one whose pick sits on the
+gang.
+
+The repair finds every live pick whose slot says the gang and which sits
+on a model, and moves it onto the model's gang. Nothing else about the
+pick changes: it still names the assignment that asked and the slot it
+settles, so the Leader's card still reads it as chosen, and it is still
+caused by the Leader's hire, so it still goes when the Leader does.
+Anything the pick caused — a power taken through what it offered — is
+hosted in its own right and stays where it is.
+
+An archived pick on a model is counted and left alone: it draws nothing,
+and moving history is not a repair. Nothing here moves money: every
+pick's entry pins zero, so the books fold as they did — proved per
+gang, as every repair here proves it.
+"""
+
+from dataclasses import dataclass
+
+from django.db import transaction
+
+
+class Refused(Exception):
+    """The repair found something other than the fault it was written for."""
+
+
+@dataclass(frozen=True)
+class Astray:
+    """Every live pick sitting on a model that its slot says the gang
+    holds, grouped by gang."""
+
+    #: ``(gang id, pick ids)``, one per gang.
+    gangs: tuple = ()
+    problems: tuple = ()
+    nothing_here: bool = False
+    #: Archived picks in the same position, counted and left alone.
+    archived: int = 0
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    @property
+    def pick_ids(self):
+        return tuple(pk for _, ids in self.gangs for pk in ids)
+
+    def preview(self):
+        lines = []
+        if self.nothing_here:
+            lines.append(
+                "nothing to move — every live pick of a slot the gang holds "
+                "sits on the gang"
+            )
+        for gang_id, ids in self.gangs:
+            lines.append(
+                f"gang {gang_id}: move {len(ids)} pick{'' if len(ids) == 1 else 's'} "
+                "off its models onto the gang"
+            )
+        if self.gangs:
+            total = len(self.pick_ids)
+            lines.append(
+                f"{total} pick{'' if total == 1 else 's'} across "
+                f"{len(self.gangs)} gang{'' if len(self.gangs) == 1 else 's'}"
+            )
+        if self.archived:
+            lines.append(
+                f"{self.archived} archived pick{'' if self.archived == 1 else 's'} "
+                "on a model, left alone"
+            )
+        return lines
+
+
+def _astray(archived=False):
+    """The picks on a model whose slot says the gang holds them."""
+    from n26.core.models import Assignment
+    from n26.library.models import Slot
+
+    return Assignment.objects.filter(
+        chosen_for_slot__assigned_to=Slot.WillBeAssignedTo.GANG,
+        archived=archived,
+        miniature__isnull=False,
+    )
+
+
+def find():
+    """What stands to be moved, gang by gang."""
+    picks = list(
+        _astray().select_related("miniature__membership").order_by("created", "id")
+    )
+    archived = _astray(archived=True).count()
+    if not picks:
+        return Astray(nothing_here=True, archived=archived)
+
+    problems = []
+    by_gang = {}
+    for pick in picks:
+        membership = getattr(pick.miniature, "membership", None)
+        if membership is None or membership.gang_id != pick.gang_root_id:
+            problems.append(
+                f"pick {pick.pk} sits on a model that is not a member of the "
+                f"gang it is rooted in ({pick.gang_root_id}) — not the stray "
+                "pick this moves"
+            )
+            continue
+        by_gang.setdefault(pick.gang_root_id, []).append(pick.pk)
+    gangs = tuple(
+        (gang_id, tuple(ids))
+        for gang_id, ids in sorted(by_gang.items(), key=lambda kv: kv[0])
+    )
+    return Astray(gangs=gangs, problems=tuple(problems), archived=archived)
+
+
+def apply(astray):
+    """Move what the plan names, gang by gang, and prove each gang's
+    books whole.
+
+    Each gang is its own transaction: one that cannot be made whole is
+    left exactly as it stood and reported, and the rest are repaired.
+    """
+    if astray.problems:
+        raise Refused("not moved: " + "; ".join(astray.problems))
+    if astray.nothing_here:
+        return list(astray.preview())
+
+    report = list(astray.preview())
+    for gang_id, ids in astray.gangs:
+        report.append(_rehost_one(gang_id, ids))
+    return report
+
+
+def _rehost_one(gang_id, ids):
+    """One gang's move, committed or rolled back on its own. Returns the
+    line the report carries for it."""
+    from n26.core.models import Assignment, Gang
+    from n26.core.reconcile import check_gang, repin_everything
+
+    with transaction.atomic():
+        # The gang first, so nothing lands on its books while its picks
+        # are moving; then the plan again, because it was read before
+        # this transaction opened.
+        gang = Gang.objects.select_for_update().get(pk=gang_id)
+        standing = dict(find().gangs)
+        if standing.get(gang_id) != ids:
+            return (
+                f"gang {gang_id}: skipped — its picks changed since the plan "
+                "was read; read it again"
+            )
+        moved = 0
+        for pick in Assignment.objects.select_for_update().filter(pk__in=ids):
+            pick.miniature = None
+            pick.gang = gang
+            # save() derives the gang root from the host and leaves the
+            # model root alone, so the old one is cleared here: a pick
+            # the gang holds is about nobody in particular.
+            pick.miniature_root = None
+            pick.save()
+            moved += 1
+        repin_everything(gang)
+        gang.refresh_from_db()
+        problems = check_gang(gang)
+        if problems:
+            transaction.set_rollback(True)
+            return (
+                f"gang {gang_id}: skipped — does not reconcile with its picks "
+                "moved: " + "; ".join(problems)
+            )
+    return (
+        f"gang {gang_id}: moved {moved} pick{'' if moved == 1 else 's'} onto the gang"
+    )

--- a/n26/core/rehost_picks.py
+++ b/n26/core/rehost_picks.py
@@ -104,11 +104,7 @@ def _asked_of_this_model(pick):
     nobody in particular.
     """
     asked = pick.chosen_for
-    if asked is None:
-        return False
-    if asked.miniature_root_id is not None:
-        return asked.miniature_root_id == pick.miniature_id
-    return False
+    return asked is not None and asked.miniature_root_id == pick.miniature_id
 
 
 def find(gang_id=None):
@@ -137,6 +133,12 @@ def find(gang_id=None):
                 f"pick {pick.pk} sits on a model that is not a member of the "
                 f"gang it is rooted in ({pick.gang_root_id}) — not the stray "
                 "pick this moves"
+            )
+            continue
+        if pick.chosen_for_id is None:
+            problems.append(
+                f"pick {pick.pk} names no choice it settles, so whose choice "
+                "it was cannot be read — not the stray pick this moves"
             )
             continue
         if not _asked_of_this_model(pick):

--- a/n26/core/templates/admin/maintenance/n26/_rehost_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_rehost_detail.html
@@ -10,7 +10,7 @@
 {% elif backfill.summary.preview %}
     <h2>What it is doing</h2>
     <p>
-        These are the picks it planned to move. Each gang is one transaction,
+        The preview listed these picks to move. Each gang is one transaction,
         so a gang whose picks have not moved yet stands exactly as it did, and
         a gang that fails to reconcile is left as it stood and named below.
     </p>

--- a/n26/core/templates/admin/maintenance/n26/_rehost_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_rehost_detail.html
@@ -1,0 +1,23 @@
+{% comment %}
+    The summary of one move run, on the Backfill detail page: what it
+    was going to move, and — once it has finished — what it did.
+{% endcomment %}
+{% if backfill.summary.report %}
+    <h2>What it did</h2>
+    <ul>
+        {% for line in backfill.summary.report %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% elif backfill.summary.preview %}
+    <h2>What it is doing</h2>
+    <p>
+        These are the picks it planned to move. Each gang is one transaction,
+        so a gang whose picks have not moved yet stands exactly as it did, and
+        a gang that fails to reconcile is left as it stood and named below.
+    </p>
+    <ul>
+        {% for line in backfill.summary.preview %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+{% if backfill.summary.attempts %}
+    <p>Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }}.</p>
+{% endif %}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -60,6 +60,7 @@ __all__ = [
     "Operation",
     "backfill_built_ins",
     "delete_nameless_gang_type",
+    "rehost_gang_picks",
     "repair_doubled_refunds",
     "run_batched",
     "task_routes",
@@ -156,6 +157,10 @@ class Operation(models.TextChoices):
         "n26_drop_duplicate_grants",
         "n26: the second copy a catch-up granted is dropped",
     )
+    REHOST_GANG_PICKS = (
+        "n26_rehost_gang_picks",
+        "n26: the picks a gang holds move off its models onto the gang",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -168,6 +173,7 @@ LOCK_KEYS = {
     Operation.CONVERT_VARIANT: 826_020_611,
     Operation.BACKFILL_BUILT_INS: 826_020_612,
     Operation.DROP_DUPLICATE_GRANTS: 826_020_613,
+    Operation.REHOST_GANG_PICKS: 826_020_614,
 }
 
 
@@ -828,6 +834,71 @@ def repair_doubled_refunds_view(request):
 
 
 @task
+def rehost_gang_picks(backfill_id, **said_by_whoever_enqueued_it):
+    """Move every live pick a gang holds off the model it was written
+    on and onto the gang, and prove every affected gang's books whole,
+    once.
+
+    A gang's worth of picks in one transaction: small enough to hold,
+    and a gang that fails to reconcile unwinds its own move.
+    """
+    from n26.core.rehost_picks import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.REHOST_GANG_PICKS,
+        "Gang pick rehosting",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
+REHOST_WORDS = {
+    "noun": "move",
+    "intro": (
+        "This moves picks between hosts in players' gangs. A slot says "
+        "where its pick lands: on the model that carries it, or on the "
+        "gang, where the model is asked and the gang holds the pick. "
+        "While the Outcast Archetype slot said the model instead, the "
+        "picks made in that window were written onto the Leader, and "
+        "setting the slot back steers only the picks made after. Every "
+        "live pick whose slot says the gang and which sits on a model is "
+        "moved onto that model's gang. It still names the assignment "
+        "that asked and the slot it settles, so the card that asked still "
+        "reads it as chosen, and it still goes when that model does. "
+        "Anything it caused stays where it is. An archived pick is "
+        "counted and left alone. No money moves; every gang is proved to "
+        "reconcile."
+    ),
+    "nothing_heading": "Nothing to move",
+    "nothing_flash": (
+        "There was nothing to move — every live pick of a slot the gang "
+        "holds sits on the gang."
+    ),
+    "nothing_words": "Every live pick of a slot the gang holds sits on the gang.",
+    "refuses_heading": "The move cannot run",
+    "button": "Move the picks onto their gangs",
+    "confirm": (
+        "Move every live pick of a slot the gang holds off its model and "
+        "onto the gang? This cannot be undone."
+    ),
+}
+
+
+def rehost_gang_picks_view(request):
+    """Preview the move (GET), or record a run and enqueue it."""
+    from n26.core.rehost_picks import find
+
+    return _deletion_view(
+        request,
+        Operation.REHOST_GANG_PICKS,
+        find,
+        rehost_gang_picks,
+        REHOST_WORDS,
+    )
+
+
+@task
 def audit_reconcile(backfill_id, **said_by_whoever_enqueued_it):
     """Check every unarchived gang's books against its ledger.
 
@@ -1119,6 +1190,27 @@ def drop_duplicate_grants_view(request):
 
 register_operation(
     MaintenanceOperation(
+        operation=Operation.REHOST_GANG_PICKS.value,
+        name=Operation.REHOST_GANG_PICKS.label,
+        added=date(2026, 9, 3),
+        description=(
+            "A slot says where its pick lands: on the model that carries "
+            "it, or on the gang. While the Outcast Archetype slot said the "
+            "model, the Leader's picks were written onto the Leader; the "
+            "slot says the gang again, and this moves those picks onto "
+            "their gangs. Each still names what asked it and the slot it "
+            "settles, so the Leader's card still reads it as chosen, and "
+            "it still goes when the Leader does. No money moves; every "
+            "gang is proved to reconcile."
+        ),
+        view=rehost_gang_picks_view,
+        detail_template="admin/maintenance/n26/_rehost_detail.html",
+    )
+)
+
+
+register_operation(
+    MaintenanceOperation(
         operation=Operation.DROP_DUPLICATE_GRANTS.value,
         name=Operation.DROP_DUPLICATE_GRANTS.label,
         added=date(2026, 8, 31),
@@ -1280,6 +1372,7 @@ task_routes = [
     TaskRoute(repair_doubled_refunds, ack_deadline=600, min_retry_delay=60),
     TaskRoute(backfill_built_ins, ack_deadline=600),
     TaskRoute(drop_duplicate_grants, ack_deadline=600),
+    TaskRoute(rehost_gang_picks, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -856,14 +856,14 @@ def rehost_gang_picks(backfill_id, **said_by_whoever_enqueued_it):
 REHOST_WORDS = {
     "noun": "move",
     "intro": (
-        "This moves picks between hosts in players' gangs. A slot says "
+        "This moves picks between hosts in players' gangs. A slot sets "
         "where its pick lands: on the model that carries it, or on the "
-        "gang, where the model is asked and the gang holds the pick. "
-        "While the Outcast Archetype slot said the model instead, the "
-        "picks made in that window were written onto the Leader, and "
-        "setting the slot back steers only the picks made after. Every "
-        "live pick whose slot says the gang and which sits on a model is "
-        "moved onto that model's gang. It still names the assignment "
+        "gang, where the model is asked and the gang holds the pick. A "
+        "pick is hosted where the slot pointed when it was made, so a "
+        "Leader's Archetype pick made while the slot pointed at the model "
+        "sits on the Leader, and changing the slot moves nothing already "
+        "written. Every live pick whose slot points at the gang and which "
+        "sits on a model is moved onto that model's gang. It still names the assignment "
         "that asked and the slot it settles, so the card that asked still "
         "reads it as chosen, and it still goes when that model does. "
         "Anything it caused stays where it is. An archived pick is "
@@ -872,15 +872,15 @@ REHOST_WORDS = {
     ),
     "nothing_heading": "Nothing to move",
     "nothing_flash": (
-        "There was nothing to move — every live pick of a slot the gang "
-        "holds sits on the gang."
+        "There was nothing to move — every live pick of a slot that points "
+        "at the gang sits on the gang."
     ),
-    "nothing_words": "Every live pick of a slot the gang holds sits on the gang.",
+    "nothing_words": "Every live pick of a slot that points at the gang sits on the gang.",
     "refuses_heading": "The move cannot run",
     "button": "Move the picks onto their gangs",
     "confirm": (
-        "Move every live pick of a slot the gang holds off its model and "
-        "onto the gang? This cannot be undone."
+        "Move every live pick of a slot that points at the gang off its "
+        "model and onto the gang? This cannot be undone."
     ),
 }
 
@@ -1194,11 +1194,11 @@ register_operation(
         name=Operation.REHOST_GANG_PICKS.label,
         added=date(2026, 9, 3),
         description=(
-            "A slot says where its pick lands: on the model that carries "
-            "it, or on the gang. While the Outcast Archetype slot said the "
-            "model, the Leader's picks were written onto the Leader; the "
-            "slot says the gang again, and this moves those picks onto "
-            "their gangs. Each still names what asked it and the slot it "
+            "A slot sets where its pick lands: on the model that carries "
+            "it, or on the gang. A Leader's Archetype pick made while the "
+            "slot pointed at the model sits on the Leader, and changing "
+            "the slot moves nothing already written; this moves those "
+            "picks onto their gangs. Each still names what asked it and the slot it "
             "settles, so the Leader's card still reads it as chosen, and "
             "it still goes when the Leader does. No money moves; every "
             "gang is proved to reconcile."

--- a/n26/tests/sandbox/test_rehost_picks.py
+++ b/n26/tests/sandbox/test_rehost_picks.py
@@ -1,14 +1,15 @@
 """Moving a gang's picks off the model they were written on.
 
-A slot that says the gang holds its pick was, for a while, saying the
-bearer, so the picks made then sit on the Leader. Setting the slot back
-steers only new picks. The repair moves the ones already written onto
-the gang, keeping everything that says which question they answer and
-why they exist, and proves each gang's books whole before it commits.
+A pick is hosted where its slot pointed when it was made, and changing
+the slot moves nothing already written: a pick made while the slot
+pointed at the bearer sits on the Leader after the slot points at the
+gang. The repair moves such picks onto the gang, keeping everything
+that says which question they settle and why they exist, and proves
+each gang's books whole before it commits.
 
-The fault is planted the way it happened: the slot is granted to the
-Leader by a modifier on their profile, says the bearer when the pick is
-made through the page, and says the gang afterwards.
+The fault is planted in the shape it takes: the slot is granted to the
+Leader by a modifier on their profile, points at the bearer when the
+pick is made through the page, and at the gang afterwards.
 """
 
 import pytest
@@ -109,6 +110,18 @@ def reader(client, owner):
     return client
 
 
+@pytest.fixture
+def console(db):
+    """The maintenance console, as a superuser sees it. Its own client,
+    because the player's is signed in as the gang's owner."""
+    from django.test import Client
+
+    superuser = User.objects.create_superuser("root", "root@example.com", "x")
+    client = Client()
+    client.force_login(superuser)
+    return client
+
+
 def _says(slot, host):
     slot.assigned_to = host
     slot.save(update_fields=["assigned_to"])
@@ -130,13 +143,13 @@ def choose(reader, gang, name, pickable):
     (line,) = card_of(gang, name).questions
     response = reader.post(line.href, {"thing": f"library.pickable:{pickable.pk}"})
     assert response.status_code == 302, response.content.decode()
-    return Assignment.objects.get(pickable=pickable, archived=False)
+    return Assignment.objects.get(pickable=pickable, gang_root=gang, archived=False)
 
 
 @pytest.fixture
 def astray(reader, gang, leader, scum, gang_slot, archetypes):
-    """A pick written while the slot said the bearer, under a slot that
-    now says the gang."""
+    """A pick written while the slot pointed at the bearer, under a slot
+    that now points at the gang."""
     pick = choose(reader, gang, "Leader", archetypes["Brawler"])
     assert pick.miniature == leader
     assert pick.caused_by == leader.membership
@@ -261,10 +274,111 @@ class TestMovingThePick:
         report = apply(find())
 
         assert report == [
-            "nothing to move — every live pick of a slot the gang holds sits on the gang"
+            "nothing to move — every live pick of a slot that points at the gang "
+            "sits on the gang"
         ]
         gang.refresh_from_db()
         assert_reconciled(gang)
+
+
+class TestAGangThatCannotBeMadeWhole:
+    """A gang is moved in its own transaction and proved before it
+    commits. One that does not reconcile, or whose picks changed while
+    the plan stood, is left exactly as it was and named on the report."""
+
+    def test_a_gang_that_does_not_reconcile_is_rolled_back(
+        self, gang, leader, astray, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "n26.core.reconcile.check_gang", lambda g: ["the books disagree"]
+        )
+
+        report = apply(find())
+
+        astray.refresh_from_db()
+        assert astray.miniature == leader
+        assert astray.gang is None
+        assert any(
+            line.startswith(f"gang {gang.pk}: skipped — does not reconcile")
+            for line in report
+        )
+
+    def test_a_gang_whose_picks_changed_since_the_plan_is_skipped(
+        self, gang, leader, astray
+    ):
+        from n26.tests.sandbox.actions import remove
+
+        plan = find()
+        remove(leader.membership)
+
+        report = apply(plan)
+
+        assert (
+            f"gang {gang.pk}: skipped — its picks changed since the plan was read; read it again"
+            in report
+        )
+        astray.refresh_from_db()
+        assert astray.archived
+        assert astray.miniature == leader
+
+
+class TestSeveralGangsAndSeveralPicks:
+    """Each gang is its own line and its own transaction, and a gang
+    with two Leaders moves both picks."""
+
+    @pytest.fixture
+    def crowd(
+        self,
+        reader,
+        gang,
+        leader,
+        scum,
+        gang_slot,
+        archetypes,
+        owner,
+        gang_type,
+        leader_profile,
+    ):
+        first = choose(reader, gang, "Leader", archetypes["Brawler"])
+        hire(gang, leader_profile, "Second", paid=LEADER_PRICE)
+        second = choose(reader, gang, "Second", archetypes["Wyrd"])
+        other = found_gang("The Others", gang_type, owner=owner, budget=1000)
+        hire(other, leader_profile, "Leader", paid=LEADER_PRICE)
+        third = choose(reader, other, "Leader", archetypes["Brawler"])
+        _says(gang_slot, "gang")
+        return {"gang": gang, "other": other, "picks": (first, second, third)}
+
+    def test_the_plan_names_each_gang_and_counts_the_whole(self, crowd):
+        plan = find()
+
+        assert plan.gangs == tuple(
+            sorted(
+                [
+                    (crowd["gang"].pk, tuple(p.pk for p in crowd["picks"][:2])),
+                    (crowd["other"].pk, (crowd["picks"][2].pk,)),
+                ]
+            )
+        )
+        assert (
+            f"gang {crowd['gang'].pk}: move 2 picks off its models onto the gang"
+            in (plan.preview())
+        )
+        assert "3 picks across 2 gangs" in plan.preview()
+
+    def test_every_pick_lands_on_its_own_gang(self, crowd):
+        report = apply(find())
+
+        for pick, home in zip(
+            crowd["picks"], (crowd["gang"], crowd["gang"], crowd["other"]), strict=True
+        ):
+            pick.refresh_from_db()
+            assert (pick.gang, pick.miniature) == (home, None)
+        assert f"gang {crowd['gang'].pk}: moved 2 picks onto the gang" in report
+        assert f"gang {crowd['other'].pk}: moved 1 pick onto the gang" in report
+        for g in (crowd["gang"], crowd["other"]):
+            g.refresh_from_db()
+            assert_reconciled(g)
+        assert find().nothing_here
 
 
 class TestTheConsole:
@@ -279,13 +393,10 @@ class TestTheConsole:
             is rehost_gang_picks_view
         )
 
-    def test_its_page_shows_the_plan_and_writes_nothing(self, client, gang, astray):
+    def test_its_page_shows_the_plan_and_writes_nothing(self, console, gang, astray):
         from gyrinx.maintenance.models import Backfill
 
-        superuser = User.objects.create_superuser("root", "root@example.com", "x")
-        client.force_login(superuser)
-
-        page = client.get(
+        page = console.get(
             reverse("admin:maintenance_n26_rehost_gang_picks")
         ).content.decode()
 
@@ -296,14 +407,11 @@ class TestTheConsole:
         assert not check_gang(gang)
 
     def test_applying_from_the_page_records_a_run_and_moves_the_pick(
-        self, client, gang, astray
+        self, console, gang, astray
     ):
         from gyrinx.maintenance.models import Backfill
 
-        superuser = User.objects.create_superuser("root", "root@example.com", "x")
-        client.force_login(superuser)
-
-        response = client.post(reverse("admin:maintenance_n26_rehost_gang_picks"))
+        response = console.post(reverse("admin:maintenance_n26_rehost_gang_picks"))
 
         assert response.status_code == 302
         (run,) = Backfill.objects.all()

--- a/n26/tests/sandbox/test_rehost_picks.py
+++ b/n26/tests/sandbox/test_rehost_picks.py
@@ -16,6 +16,8 @@ import pytest
 from django.contrib.auth.models import User
 from django.urls import reverse
 
+from n26.core.card import build_card, build_modifier_index
+from n26.core.effects import compute
 from n26.core.models import Assignment
 from n26.core.reconcile import assert_reconciled, check_gang
 from n26.core.rehost_picks import Refused, apply, find
@@ -25,10 +27,12 @@ from n26.library.authoring import (
     create_pickable,
     create_picklist,
     create_profile,
+    create_rule,
     create_slot,
     create_slot_type,
     ef_adds,
     modifier,
+    targets_every_model,
     targets_model,
 )
 from n26.maintenance import Operation, rehost_gang_picks_view
@@ -50,15 +54,26 @@ def slot_type(default_pack):
     return create_slot_type("Archetype", allows_repeats=False)
 
 
+#: What the gang's archetype gives every member once the gang holds it.
+PAYLOAD = "Unstable"
+
+
 @pytest.fixture
 def archetypes(slot_type):
-    return {name: create_pickable(name, slot_type) for name in ("Brawler", "Wyrd")}
+    made = {name: create_pickable(name, slot_type) for name in ("Brawler", "Wyrd")}
+    modifier(
+        f"Brawler: {PAYLOAD}",
+        targets_every_model(),
+        ef_adds(create_rule(PAYLOAD)),
+        attach_to=made["Brawler"],
+    )
+    return made
 
 
 @pytest.fixture
 def gang_slot(slot_type, archetypes):
-    """The Leader is asked. Which host the pick lands on is set by the
-    test, because the fault is the slot changing its mind."""
+    """The Leader is asked. Where the pick lands is set by each test,
+    because the fault is a slot pointed at one host and then the other."""
     return create_slot(
         "Gang archetype",
         slot_type,
@@ -122,9 +137,23 @@ def console(db):
     return client
 
 
-def _says(slot, host):
+def _point_slot_at(slot, host):
     slot.assigned_to = host
     slot.save(update_fields=["assigned_to"])
+
+
+def rides_as_broadcast(miniature, pickable):
+    """Whether the gang's pick rides this model's card as a broadcast row."""
+    return any(
+        node.broadcast and node.assignable == pickable
+        for node in build_card(miniature).all_nodes()
+    )
+
+
+def rules_on(miniature):
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return [line.name for line in compute(card, index).rules]
 
 
 def card_of(gang, name):
@@ -153,7 +182,7 @@ def astray(reader, gang, leader, scum, gang_slot, archetypes):
     pick = choose(reader, gang, "Leader", archetypes["Brawler"])
     assert pick.miniature == leader
     assert pick.caused_by == leader.membership
-    _says(gang_slot, "gang")
+    _point_slot_at(gang_slot, "gang")
     gang.refresh_from_db()
     assert_reconciled(gang)
     return pick
@@ -163,7 +192,7 @@ class TestFindingWhatSitsOnAModel:
     def test_a_pick_the_gang_already_holds_is_not_named(
         self, reader, gang, leader, gang_slot, archetypes
     ):
-        _says(gang_slot, "gang")
+        _point_slot_at(gang_slot, "gang")
         pick = choose(reader, gang, "Leader", archetypes["Brawler"])
         assert pick.gang == gang
 
@@ -210,6 +239,32 @@ class TestFindingWhatSitsOnAModel:
         astray.refresh_from_db()
         assert astray.miniature is not None
 
+    def test_a_pick_made_for_one_model_of_a_gang_carried_choice_refuses(
+        self, reader, gang, leader, scum, gang_slot, archetypes, gang_type
+    ):
+        """A choice the gang carries for each member rides every card, and
+        settling it names the fighter clicked. That fighter's pick is not
+        stray, whichever way the slot points, and is never hoisted."""
+        modifier(
+            "Everyone is asked their Archetype",
+            targets_every_model(),
+            ef_adds(gang_slot),
+            attach_to=gang_type,
+        )
+        _point_slot_at(gang_slot, "gang")
+        theirs = choose(reader, gang, "Scum", archetypes["Wyrd"])
+        assert theirs.miniature == scum
+        assert theirs.chosen_for.gang_id == gang.pk
+
+        plan = find()
+
+        assert not plan.ok
+        assert any("made for this one on purpose" in p for p in plan.problems)
+        with pytest.raises(Refused):
+            apply(plan)
+        theirs.refresh_from_db()
+        assert theirs.miniature == scum
+
 
 class TestMovingThePick:
     def test_the_pick_lands_on_the_gang_and_keeps_its_links(
@@ -236,6 +291,18 @@ class TestMovingThePick:
         apply(find())
 
         assert chosen_on(gang, "Leader") == "Brawler"
+
+    def test_the_gangs_pick_now_rides_every_members_card(
+        self, gang, scum, astray, archetypes
+    ):
+        """What the repair is for: a pick the gang holds is a fact about
+        every member, and what it gives reaches them through the gang."""
+        assert not rides_as_broadcast(scum, archetypes["Brawler"])
+
+        apply(find())
+
+        assert rides_as_broadcast(scum, archetypes["Brawler"])
+        assert PAYLOAD in rules_on(scum)
 
     def test_what_the_pick_caused_stays_where_it_is(
         self, gang, leader, astray, default_pack
@@ -345,7 +412,7 @@ class TestSeveralGangsAndSeveralPicks:
         other = found_gang("The Others", gang_type, owner=owner, budget=1000)
         hire(other, leader_profile, "Leader", paid=LEADER_PRICE)
         third = choose(reader, other, "Leader", archetypes["Brawler"])
-        _says(gang_slot, "gang")
+        _point_slot_at(gang_slot, "gang")
         return {"gang": gang, "other": other, "picks": (first, second, third)}
 
     def test_the_plan_names_each_gang_and_counts_the_whole(self, crowd):
@@ -364,6 +431,11 @@ class TestSeveralGangsAndSeveralPicks:
             in (plan.preview())
         )
         assert "3 picks across 2 gangs" in plan.preview()
+
+    def test_the_plan_can_be_read_for_one_gang_alone(self, crowd):
+        narrowed = find(crowd["other"].pk)
+
+        assert narrowed.gangs == ((crowd["other"].pk, (crowd["picks"][2].pk,)),)
 
     def test_every_pick_lands_on_its_own_gang(self, crowd):
         report = apply(find())

--- a/n26/tests/sandbox/test_rehost_picks.py
+++ b/n26/tests/sandbox/test_rehost_picks.py
@@ -1,0 +1,313 @@
+"""Moving a gang's picks off the model they were written on.
+
+A slot that says the gang holds its pick was, for a while, saying the
+bearer, so the picks made then sit on the Leader. Setting the slot back
+steers only new picks. The repair moves the ones already written onto
+the gang, keeping everything that says which question they answer and
+why they exist, and proves each gang's books whole before it commits.
+
+The fault is planted the way it happened: the slot is granted to the
+Leader by a modifier on their profile, says the bearer when the pick is
+made through the page, and says the gang afterwards.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled, check_gang
+from n26.core.rehost_picks import Refused, apply, find
+from n26.core.render import render_gang
+from n26.core.views.choose import link_slots
+from n26.library.authoring import (
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_slot,
+    create_slot_type,
+    ef_adds,
+    modifier,
+    targets_model,
+)
+from n26.maintenance import Operation, rehost_gang_picks_view
+from n26.tests.sandbox.actions import found_gang, hire
+
+pytestmark = pytest.mark.django_db
+
+LEADER_PRICE = 120
+GANGER_PRICE = 50
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("rehost-player")
+
+
+@pytest.fixture
+def slot_type(default_pack):
+    return create_slot_type("Archetype", allows_repeats=False)
+
+
+@pytest.fixture
+def archetypes(slot_type):
+    return {name: create_pickable(name, slot_type) for name in ("Brawler", "Wyrd")}
+
+
+@pytest.fixture
+def gang_slot(slot_type, archetypes):
+    """The Leader is asked. Which host the pick lands on is set by the
+    test, because the fault is the slot changing its mind."""
+    return create_slot(
+        "Gang archetype",
+        slot_type,
+        create_picklist("Archetypes", slot_type, members=list(archetypes.values())),
+        label="Archetype",
+        assigned_to="bearer",
+    )
+
+
+@pytest.fixture
+def leader_profile(person_type, gang_type, gang_slot):
+    """The slot reaches the Leader through a modifier on their profile,
+    so the assignment that asks is their membership."""
+    profile = create_profile(
+        "Outcast Leader", person_type, gang_type, price=LEADER_PRICE
+    )
+    modifier(
+        "Leader: the gang is asked its Archetype",
+        targets_model(),
+        ef_adds(gang_slot),
+        attach_to=profile,
+    )
+    return profile
+
+
+@pytest.fixture
+def ganger_profile(person_type, gang_type):
+    return create_profile("Hive Scum", person_type, gang_type, price=GANGER_PRICE)
+
+
+@pytest.fixture
+def gang(owner, gang_type):
+    return found_gang("The Unhosted", gang_type, owner=owner, budget=1000)
+
+
+@pytest.fixture
+def leader(gang, leader_profile):
+    return hire(gang, leader_profile, "Leader", paid=LEADER_PRICE)
+
+
+@pytest.fixture
+def scum(gang, ganger_profile):
+    return hire(gang, ganger_profile, "Scum", paid=GANGER_PRICE)
+
+
+@pytest.fixture
+def reader(client, owner):
+    client.force_login(owner)
+    return client
+
+
+def _says(slot, host):
+    slot.assigned_to = host
+    slot.save(update_fields=["assigned_to"])
+
+
+def card_of(gang, name):
+    sheet = render_gang(gang)
+    link_slots(gang, sheet, *sheet.models)
+    return next(card for card in sheet.models if card.name == name)
+
+
+def chosen_on(gang, name):
+    (line,) = card_of(gang, name).questions
+    return line.chosen
+
+
+def choose(reader, gang, name, pickable):
+    """Settle the one choice on this model's card, through the page."""
+    (line,) = card_of(gang, name).questions
+    response = reader.post(line.href, {"thing": f"library.pickable:{pickable.pk}"})
+    assert response.status_code == 302, response.content.decode()
+    return Assignment.objects.get(pickable=pickable, archived=False)
+
+
+@pytest.fixture
+def astray(reader, gang, leader, scum, gang_slot, archetypes):
+    """A pick written while the slot said the bearer, under a slot that
+    now says the gang."""
+    pick = choose(reader, gang, "Leader", archetypes["Brawler"])
+    assert pick.miniature == leader
+    assert pick.caused_by == leader.membership
+    _says(gang_slot, "gang")
+    gang.refresh_from_db()
+    assert_reconciled(gang)
+    return pick
+
+
+class TestFindingWhatSitsOnAModel:
+    def test_a_pick_the_gang_already_holds_is_not_named(
+        self, reader, gang, leader, gang_slot, archetypes
+    ):
+        _says(gang_slot, "gang")
+        pick = choose(reader, gang, "Leader", archetypes["Brawler"])
+        assert pick.gang == gang
+
+        assert find().nothing_here
+
+    def test_a_pick_of_a_bearer_slot_is_not_named(
+        self, reader, gang, leader, gang_slot, archetypes
+    ):
+        pick = choose(reader, gang, "Leader", archetypes["Brawler"])
+        assert pick.miniature == leader
+
+        assert find().nothing_here
+
+    def test_the_plan_names_the_gang_and_its_pick(self, gang, astray):
+        plan = find()
+
+        assert plan.ok
+        assert plan.gangs == ((gang.pk, (astray.pk,)),)
+        assert f"gang {gang.pk}: move 1 pick off its models onto the gang" in (
+            plan.preview()
+        )
+
+    def test_an_archived_pick_is_counted_and_not_named(self, gang, astray):
+        astray.archived = True
+        astray.save(update_fields=["archived"])
+
+        plan = find()
+
+        assert plan.nothing_here
+        assert plan.archived == 1
+        assert "1 archived pick on a model, left alone" in plan.preview()
+
+    def test_a_pick_on_a_model_outside_its_gang_refuses(
+        self, gang, astray, owner, gang_type
+    ):
+        elsewhere = found_gang("Elsewhere", gang_type, owner=owner, budget=1000)
+        Assignment.objects.filter(pk=astray.pk).update(gang_root=elsewhere)
+
+        plan = find()
+
+        assert not plan.ok
+        with pytest.raises(Refused):
+            apply(plan)
+        astray.refresh_from_db()
+        assert astray.miniature is not None
+
+
+class TestMovingThePick:
+    def test_the_pick_lands_on_the_gang_and_keeps_its_links(
+        self, gang, leader, astray, gang_slot
+    ):
+        before = (astray.caused_by_id, astray.chosen_for_id, astray.chosen_for_slot_id)
+
+        report = apply(find())
+
+        astray.refresh_from_db()
+        assert (astray.gang, astray.miniature) == (gang, None)
+        assert (astray.gang_root_id, astray.miniature_root_id) == (gang.pk, None)
+        assert (
+            astray.caused_by_id,
+            astray.chosen_for_id,
+            astray.chosen_for_slot_id,
+        ) == before
+        assert astray.caused_by == leader.membership
+        assert f"gang {gang.pk}: moved 1 pick onto the gang" in report
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_the_leaders_card_still_reads_it_as_chosen(self, gang, astray):
+        apply(find())
+
+        assert chosen_on(gang, "Leader") == "Brawler"
+
+    def test_what_the_pick_caused_stays_where_it_is(
+        self, gang, leader, astray, default_pack
+    ):
+        """A power taken through what the pick offered is hosted on the
+        Leader in its own right: it goes with the pick, not onto the gang."""
+        from n26.library.authoring import create_rule
+
+        below = Assignment.objects.create(
+            rule=create_rule("Freeze Time"),
+            miniature=leader,
+            caused_by=astray,
+        )
+
+        apply(find())
+
+        below.refresh_from_db()
+        assert below.miniature == leader
+        assert below.caused_by_id == astray.pk
+
+    def test_the_pick_still_goes_with_the_leader(self, gang, leader, astray):
+        from n26.tests.sandbox.actions import remove
+
+        apply(find())
+
+        remove(leader.membership)
+        astray.refresh_from_db()
+        assert astray.archived
+
+    def test_a_second_run_finds_nothing(self, astray):
+        apply(find())
+
+        assert find().nothing_here
+
+    def test_a_clean_gang_applies_to_nothing(self, gang, leader, scum):
+        report = apply(find())
+
+        assert report == [
+            "nothing to move — every live pick of a slot the gang holds sits on the gang"
+        ]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestTheConsole:
+    def test_the_operation_is_registered_and_named(self):
+        from gyrinx.maintenance.registry import operations, resolve_operation
+
+        assert Operation.REHOST_GANG_PICKS.value in {
+            op.operation for op in operations()
+        }
+        assert (
+            resolve_operation(Operation.REHOST_GANG_PICKS.value).view
+            is rehost_gang_picks_view
+        )
+
+    def test_its_page_shows_the_plan_and_writes_nothing(self, client, gang, astray):
+        from gyrinx.maintenance.models import Backfill
+
+        superuser = User.objects.create_superuser("root", "root@example.com", "x")
+        client.force_login(superuser)
+
+        page = client.get(
+            reverse("admin:maintenance_n26_rehost_gang_picks")
+        ).content.decode()
+
+        assert f"gang {gang.pk}: move 1 pick off its models onto the gang" in page
+        assert not Backfill.objects.exists()
+        astray.refresh_from_db()
+        assert astray.miniature is not None
+        assert not check_gang(gang)
+
+    def test_applying_from_the_page_records_a_run_and_moves_the_pick(
+        self, client, gang, astray
+    ):
+        from gyrinx.maintenance.models import Backfill
+
+        superuser = User.objects.create_superuser("root", "root@example.com", "x")
+        client.force_login(superuser)
+
+        response = client.post(reverse("admin:maintenance_n26_rehost_gang_picks"))
+
+        assert response.status_code == 302
+        (run,) = Backfill.objects.all()
+        assert run.status == Backfill.Status.DONE, run.error
+        assert f"gang {gang.pk}: moved 1 pick onto the gang" in run.summary["report"]
+        astray.refresh_from_db()
+        assert astray.gang == gang

--- a/n26/tests/sandbox/test_rehost_picks.py
+++ b/n26/tests/sandbox/test_rehost_picks.py
@@ -265,6 +265,16 @@ class TestFindingWhatSitsOnAModel:
         theirs.refresh_from_db()
         assert theirs.miniature == scum
 
+    def test_a_pick_that_names_no_choice_refuses_and_says_so(self, gang, astray):
+        Assignment.objects.filter(pk=astray.pk).update(chosen_for=None)
+
+        plan = find()
+
+        assert not plan.ok
+        assert any("names no choice it settles" in p for p in plan.problems)
+        with pytest.raises(Refused):
+            apply(plan)
+
 
 class TestMovingThePick:
     def test_the_pick_lands_on_the_gang_and_keeps_its_links(


### PR DESCRIPTION
Part of #2405 (step 2, the backfill). The authoring change (slot `Archetype` back to `assigned_to=gang`) is already live in prod; this is the repair that moves the picks written while it said `bearer`.

## What changed

A new maintenance console operation, **n26: the picks a gang holds move off its models onto the gang** (`n26_rehost_gang_picks`).

- `n26/core/rehost_picks.py`: `find()` selects every live pick whose slot says the gang holds it but which sits on a model, grouped by gang. It refuses if a pick's model is not a member of the gang the pick is rooted in. `apply()` moves each gang's picks under the gang lock, clears the model root, repins, and proves the gang reconciles or rolls that gang back and names it on the record.
- The pick keeps `caused_by`, `chosen_for` and `chosen_for_slot`, so the Leader's card still reads it as chosen and it still goes when the Leader is removed. Anything the pick caused (a Wyrd power on the Leader) stays where it is.
- Archived picks in the same position are counted on the preview and left alone.
- Matches by rule (`Slot.assigned_to == gang`) rather than by the Archetype slot's id, so it also covers any other slot flipped the same way. On prod today that is only the Archetype slot.
- Registered on the tasks framework through `_run_recorded` and the shared `_deletion_view` page, with its own lock key and a move-worded detail template.

## Prod shape (read 2 Sep)

- 11 live Leader picks of slot `Archetype` hosted on a model across 8 gangs, all unarchived. One of them caused a power on the same Leader.
- 54 already on the gang. 1 archived pick on a model, which this leaves alone.
- All entries pin zero paid and zero rating, so no numbers change.

## Smoke test

Forked `gyrinx_main`, planted 5 picks across 3 Outcast gangs using the real Leader profiles and the real choose page with the slot flipped to `bearer`, flipped it back, ran the console GET then POST. Record finished `done`; verified from outside: 0 picks left on a model, every pick's links unchanged, ledger entries unchanged, each Leader's card still shows its archetype, every gang reconciles.

## How to try it

1. Open `/admin/maintenance/` and pick the operation. GET lists each gang and how many picks move, and the archived count.
2. Click **Move the picks onto their gangs**. The record page shows the report.
3. Afterwards, on an Outcast gang whose Leader picked in that window, the Leader's card still shows the archetype and Hive Scum get the gang-held effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNmKpGRV9vVQgEkNRUXWRc
