### PR TITLE
feat: show the equip catalogue's wait when a rail tab is clicked

### DIFF
--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -13,15 +13,16 @@
  * second activation of a control already busy.
  *
  * The state is one attribute, `data-busy="on"`, written here and drawn by the
- * design library's stylesheet (n26/designsystem/assets/app.css) — this file
- * holds no styling of its own, and the one inline style it writes is the
- * `display: none` that hides a replaced element's contents, put back when
- * the wait ends. A control that must never go busy carries
- * `data-busy="off"` from its call site; so does a form, which opts out
- * everything inside it. A plain link to a page the server has to build
- * carries `data-busy="link"` to be treated the way a button is — or, inside
- * a container carrying `data-busy-replaces`, to show its page's arrival where
- * the page will land instead of on the link.
+ * design library's stylesheet (n26/designsystem/assets/app.css). This file
+ * writes no other styling itself. The one exception is the inline
+ * `display: none` style: it hides a replaced element's contents while the
+ * page loads, and removes it again when the wait ends. A control that must
+ * never go busy carries `data-busy="off"` from its call site; so does a
+ * form, which opts out everything inside it. A plain link to a page the
+ * server has to build carries `data-busy="link"` to be treated the way a
+ * button is. Inside a container carrying `data-busy-replaces`, the same
+ * link shows the wait where the new page will land, instead of on the link
+ * itself.
  *
  * What is deliberately left alone: a button that only moves something on
  * screen — a tab, a filter, a disclosure — starts no work and never goes
@@ -144,23 +145,25 @@
      *
      * A rail of lists sits beside the catalogue it changes, and the reader
      * is watching the catalogue, not the rail. A container carrying
-     * `data-busy-replaces="<selector>"` says so: the clicked link takes the
-     * container's current look at once (`is-current`, the marker the kit's
-     * navlist styles), and that element's contents give way to the spinner
-     * in the container's own `<template data-busy-wait>` until the page
-     * arrives. The link still goes busy, so a second click is refused, and
-     * app.css leaves its label in place inside such a container.
+     * `data-busy-replaces="<selector>"` marks that spot. The clicked link
+     * takes on the container's current look at once — `is-current`, the
+     * marker the kit's navlist styles use. The target element's contents
+     * give way to the spinner in the container's own
+     * `<template data-busy-wait>` until the page arrives. The link still
+     * goes busy, so a second click is refused. Inside such a container,
+     * app.css leaves the link's label in place.
      *
-     * Contents are hidden rather than removed, and put back on a restore
-     * from the back/forward cache, which returns the page as it was left.
+     * Contents are hidden, not removed. They come back when the page is
+     * restored from the back/forward cache, which returns the page exactly
+     * as it was left.
      */
     function replaceBody(link) {
         if (optedOut(link)) return;
         var container = link.closest("[data-busy-replaces]");
         if (!container) return;
 
-        /* The look and the announcement move together: a screen reader is
-         * told the same tab is current as a sighted reader is shown. */
+        /* The look and the announcement move together: a screen reader
+         * hears which tab is current, matching what a sighted reader sees. */
         container.querySelectorAll("a.is-current").forEach(function (was) {
             was.classList.remove("is-current");
             was.removeAttribute("aria-current");

--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -14,7 +14,9 @@
  *
  * The state is one attribute, `data-busy="on"`, written here and drawn by the
  * design library's stylesheet (n26/designsystem/assets/app.css) — this file
- * holds no styling and reads none. A control that must never go busy carries
+ * holds no styling of its own, and the one inline style it writes is the
+ * `display: none` that hides a replaced element's contents, put back when
+ * the wait ends. A control that must never go busy carries
  * `data-busy="off"` from its call site; so does a form, which opts out
  * everything inside it. A plain link to a page the server has to build
  * carries `data-busy="link"` to be treated the way a button is — or, inside
@@ -153,21 +155,27 @@
      * from the back/forward cache, which returns the page as it was left.
      */
     function replaceBody(link) {
+        if (optedOut(link)) return;
         var container = link.closest("[data-busy-replaces]");
         if (!container) return;
 
+        /* The look and the announcement move together: a screen reader is
+         * told the same tab is current as a sighted reader is shown. */
         container.querySelectorAll("a.is-current").forEach(function (was) {
             was.classList.remove("is-current");
+            was.removeAttribute("aria-current");
             was.setAttribute("data-busy-was-current", "");
         });
         link.classList.add("is-current");
+        link.setAttribute("aria-current", "page");
         link.setAttribute("data-busy-took-current", "");
 
         var body = document.querySelector(
             container.getAttribute("data-busy-replaces"),
         );
         var wait = container.querySelector("template[data-busy-wait]");
-        if (!body || !wait || body.hasAttribute("data-busy-replaced")) return;
+        if (!body || !wait || !wait.content.firstElementChild) return;
+        if (body.hasAttribute("data-busy-replaced")) return;
         Array.prototype.forEach.call(body.children, function (child) {
             child.style.setProperty("display", "none");
         });
@@ -194,12 +202,14 @@
             .querySelectorAll("[data-busy-took-current]")
             .forEach(function (link) {
                 link.classList.remove("is-current");
+                link.removeAttribute("aria-current");
                 link.removeAttribute("data-busy-took-current");
             });
         document
             .querySelectorAll("[data-busy-was-current]")
             .forEach(function (link) {
                 link.classList.add("is-current");
+                link.setAttribute("aria-current", "page");
                 link.removeAttribute("data-busy-was-current");
             });
     }

--- a/n26/core/static/n26/busy.js
+++ b/n26/core/static/n26/busy.js
@@ -17,7 +17,9 @@
  * holds no styling and reads none. A control that must never go busy carries
  * `data-busy="off"` from its call site; so does a form, which opts out
  * everything inside it. A plain link to a page the server has to build
- * carries `data-busy="link"` to be treated the way a button is.
+ * carries `data-busy="link"` to be treated the way a button is — or, inside
+ * a container carrying `data-busy-replaces`, to show its page's arrival where
+ * the page will land instead of on the link.
  *
  * What is deliberately left alone: a button that only moves something on
  * screen — a tab, a filter, a disclosure — starts no work and never goes
@@ -132,6 +134,74 @@
         document
             .querySelectorAll("[data-busy-applied], [data-busy-disabled]")
             .forEach(release);
+        restoreReplaced();
+    }
+
+    /*
+     * A page whose arrival is shown where it will land.
+     *
+     * A rail of lists sits beside the catalogue it changes, and the reader
+     * is watching the catalogue, not the rail. A container carrying
+     * `data-busy-replaces="<selector>"` says so: the clicked link takes the
+     * container's current look at once (`is-current`, the marker the kit's
+     * navlist styles), and that element's contents give way to the spinner
+     * in the container's own `<template data-busy-wait>` until the page
+     * arrives. The link still goes busy, so a second click is refused, and
+     * app.css leaves its label in place inside such a container.
+     *
+     * Contents are hidden rather than removed, and put back on a restore
+     * from the back/forward cache, which returns the page as it was left.
+     */
+    function replaceBody(link) {
+        var container = link.closest("[data-busy-replaces]");
+        if (!container) return;
+
+        container.querySelectorAll("a.is-current").forEach(function (was) {
+            was.classList.remove("is-current");
+            was.setAttribute("data-busy-was-current", "");
+        });
+        link.classList.add("is-current");
+        link.setAttribute("data-busy-took-current", "");
+
+        var body = document.querySelector(
+            container.getAttribute("data-busy-replaces"),
+        );
+        var wait = container.querySelector("template[data-busy-wait]");
+        if (!body || !wait || body.hasAttribute("data-busy-replaced")) return;
+        Array.prototype.forEach.call(body.children, function (child) {
+            child.style.setProperty("display", "none");
+        });
+        var shown = wait.content.firstElementChild.cloneNode(true);
+        shown.setAttribute("data-busy-shown", "");
+        body.setAttribute("aria-busy", "true");
+        body.setAttribute("data-busy-replaced", "");
+        body.appendChild(shown);
+    }
+
+    function restoreReplaced() {
+        document
+            .querySelectorAll("[data-busy-replaced]")
+            .forEach(function (body) {
+                var shown = body.querySelector("[data-busy-shown]");
+                if (shown) shown.remove();
+                Array.prototype.forEach.call(body.children, function (child) {
+                    child.style.removeProperty("display");
+                });
+                body.removeAttribute("aria-busy");
+                body.removeAttribute("data-busy-replaced");
+            });
+        document
+            .querySelectorAll("[data-busy-took-current]")
+            .forEach(function (link) {
+                link.classList.remove("is-current");
+                link.removeAttribute("data-busy-took-current");
+            });
+        document
+            .querySelectorAll("[data-busy-was-current]")
+            .forEach(function (link) {
+                link.classList.add("is-current");
+                link.removeAttribute("data-busy-was-current");
+            });
     }
 
     /*
@@ -241,6 +311,7 @@
             return;
 
         markBusy(link);
+        replaceBody(link);
     });
 
     /*

--- a/n26/core/templates/n26/equip.html
+++ b/n26/core/templates/n26/equip.html
@@ -124,22 +124,7 @@ breadcrumb above it has the gang as well, so nothing is lost.
             below the lists need no placement of their own.
             {% endcomment %}
             <div class="flex flex-col gap-4 self-start">
-                <c-ui.navlist variant="sidebar" aria-label="Which list" class="text-sm">
-                    {% for tab in collection_tabs %}
-                        {% comment %}
-                        The full name where the tab shortened it, empty where
-                        nothing was lost — decided in the view, because a
-                        template tag written inside a component's attributes
-                        is not read as one.
-                        {% endcomment %}
-                        <c-ui.navlist.item href="{{ tab.href }}"
-                                           :current="tab.current"
-                                           title="{{ tab.title }}"
-                                           data-busy="link">
-                            {{ tab.label }}
-                        </c-ui.navlist.item>
-                    {% endfor %}
-                </c-ui.navlist>
+                {% include "n26/includes/equip_rail.html" %}
                 {% if everything %}
                     {% include "n26/includes/unrestricted_note.html" %}
                 {% endif %}
@@ -156,6 +141,7 @@ breadcrumb above it has the gang as well, so nothing is lost.
             this is an ordinary form and the whole page is served.
             {% endcomment %}
             <form method="post"
+                  id="equip-catalogue"
                   action="{{ action }}"
                   hx-post="{{ action }}"
                   hx-swap="none">

--- a/n26/core/templates/n26/gang_equip.html
+++ b/n26/core/templates/n26/gang_equip.html
@@ -74,16 +74,7 @@ sell is managed from the In stash tab.
         the lists needs no placement of its own.
         {% endcomment %}
         <div class="flex flex-col gap-4 self-start">
-            <c-ui.navlist variant="sidebar" aria-label="Which list" class="text-sm">
-                {% for tab in collection_tabs %}
-                    <c-ui.navlist.item href="{{ tab.href }}"
-                                       :current="tab.current"
-                                       title="{{ tab.title }}"
-                                       data-busy="link">
-                        {{ tab.label }}
-                    </c-ui.navlist.item>
-                {% endfor %}
-            </c-ui.navlist>
+            {% include "n26/includes/equip_rail.html" %}
             {% if everything %}
                 {% include "n26/includes/unrestricted_note.html" %}
             {% endif %}
@@ -101,6 +92,7 @@ sell is managed from the In stash tab.
             link rather than a submit.
             {% endcomment %}
             <form method="post"
+                  id="equip-catalogue"
                   action="{{ action }}"
                   hx-post="{{ action }}"
                   hx-swap="none">

--- a/n26/core/templates/n26/includes/equip_rail.html
+++ b/n26/core/templates/n26/includes/equip_rail.html
@@ -1,12 +1,12 @@
 {% comment %}
-The rail of lists beside an equip catalogue — expects `collection_tabs`.
+The rail of lists beside an equip catalogue. Expects `collection_tabs`.
 
 Each tab is a link to a whole render, so a click is shown where its page will
-land rather than on the tab: the tab takes the current look at once, and the
+land, not on the tab. The tab takes on the current look at once. The
 catalogue's contents give way to the spinner below until the page arrives
 (n26/core/static/n26/busy.js). The catalogue's form carries the id named
-here; a page drawing the rail with no catalogue gets the tab's look and
-nothing more.
+here. A page that draws the rail without a catalogue gets only the tab's
+look.
 {% endcomment %}
 <c-ui.navlist variant="sidebar"
               aria-label="Which list"
@@ -14,9 +14,10 @@ nothing more.
               data-busy-replaces="#equip-catalogue">
     {% for tab in collection_tabs %}
         {% comment %}
-        The full name where the tab shortened it, empty where nothing was
-        lost — decided in the view, because a template tag written inside a
-        component's attributes is not read as one.
+        `title` holds the tab's full name where the label was shortened, and
+        is empty where nothing was cut. This is decided in the view, because
+        a template tag written inside a component's attributes is not read
+        as one.
         {% endcomment %}
         <c-ui.navlist.item href="{{ tab.href }}"
                            :current="tab.current"

--- a/n26/core/templates/n26/includes/equip_rail.html
+++ b/n26/core/templates/n26/includes/equip_rail.html
@@ -1,0 +1,33 @@
+{% comment %}
+The rail of lists beside an equip catalogue — expects `collection_tabs`.
+
+Each tab is a link to a whole render, so a click is shown where its page will
+land rather than on the tab: the tab takes the current look at once, and the
+catalogue's contents give way to the spinner below until the page arrives
+(n26/core/static/n26/busy.js). The catalogue's form carries the id named
+here; a page drawing the rail with no catalogue gets the tab's look and
+nothing more.
+{% endcomment %}
+<c-ui.navlist variant="sidebar"
+              aria-label="Which list"
+              class="text-sm"
+              data-busy-replaces="#equip-catalogue">
+    {% for tab in collection_tabs %}
+        {% comment %}
+        The full name where the tab shortened it, empty where nothing was
+        lost — decided in the view, because a template tag written inside a
+        component's attributes is not read as one.
+        {% endcomment %}
+        <c-ui.navlist.item href="{{ tab.href }}"
+                           :current="tab.current"
+                           title="{{ tab.title }}"
+                           data-busy="link">
+            {{ tab.label }}
+        </c-ui.navlist.item>
+    {% endfor %}
+    <template data-busy-wait>
+        <div class="flex justify-center py-10">
+            <c-ui.spinner size="sm" color="ink" />
+        </div>
+    </template>
+</c-ui.navlist>

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -309,8 +309,8 @@ def test_the_rail_says_where_a_clicked_tabs_page_will_land(
     client, tester, fighter, house_list
 ):
     """A tab is a whole render, so the wait is shown on the catalogue it
-    replaces rather than on the tab: the rail names the catalogue, the
-    catalogue carries that name, and the rail holds the spinner to draw."""
+    replaces, not on the tab. The rail names the catalogue, the catalogue
+    carries that name, and the rail holds the spinner to draw."""
     client.force_login(tester)
     html = client.get(equip_url(fighter)).content.decode()
 

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -305,6 +305,20 @@ def test_a_collection_of_skills_is_no_tab_however_the_fighter_holds_it(
     assert "Catfall" not in response.content.decode()
 
 
+def test_the_rail_says_where_a_clicked_tabs_page_will_land(
+    client, tester, fighter, house_list
+):
+    """A tab is a whole render, so the wait is shown on the catalogue it
+    replaces rather than on the tab: the rail names the catalogue, the
+    catalogue carries that name, and the rail holds the spinner to draw."""
+    client.force_login(tester)
+    html = client.get(equip_url(fighter)).content.decode()
+
+    assert 'data-busy-replaces="#equip-catalogue"' in html
+    assert 'id="equip-catalogue"' in html
+    assert "<template data-busy-wait>" in html
+
+
 def test_a_lone_list_is_still_a_choice_beside_the_library(
     client, tester, fighter, house_list
 ):

--- a/n26/core/test_views_gang_equip.py
+++ b/n26/core/test_views_gang_equip.py
@@ -452,6 +452,20 @@ class TestNothingSaysWhoMayUseIt:
         assert "Walker only" not in response.content.decode()
 
 
+class TestTheRail:
+    def test_it_says_where_a_clicked_tabs_page_will_land(
+        self, client, tester, gang, house_list
+    ):
+        """The same wait as a fighter's screen: on the catalogue, not the
+        tab."""
+        client.force_login(tester)
+        html = client.get(equip_url(gang)).content.decode()
+
+        assert 'data-busy-replaces="#equip-catalogue"' in html
+        assert 'id="equip-catalogue"' in html
+        assert "<template data-busy-wait>" in html
+
+
 class TestTheLibraryTab:
     """Everything a list could sell, for the thing no list carries."""
 

--- a/n26/designsystem/assets/app.css
+++ b/n26/designsystem/assets/app.css
@@ -1363,10 +1363,10 @@ a[data-busy="on"] {
     }
 }
 
-/* A link whose page's arrival is shown where the page will land — a rail
- * beside the catalogue it changes, marked data-busy-replaces — keeps its
- * label and draws no ring: the reader is watching the catalogue, and the link
- * has already taken the rail's current look. Still refused a second click. */
+/* A link inside a rail beside the catalogue it changes, marked
+ * data-busy-replaces, keeps its label and draws no ring when it goes busy.
+ * The reader is watching the catalogue, not the link, which has already
+ * taken the rail's current look. The second click is still refused. */
 [data-busy-replaces] a[data-busy="on"] {
     -webkit-text-fill-color: currentColor;
 }

--- a/n26/designsystem/assets/app.css
+++ b/n26/designsystem/assets/app.css
@@ -1362,3 +1362,19 @@ a[data-busy="on"] {
         transform: rotate(360deg);
     }
 }
+
+/* A link whose page's arrival is shown where the page will land — a rail
+ * beside the catalogue it changes, marked data-busy-replaces — keeps its
+ * label and draws no ring: the reader is watching the catalogue, and the link
+ * has already taken the rail's current look. Still refused a second click. */
+[data-busy-replaces] a[data-busy="on"] {
+    -webkit-text-fill-color: currentColor;
+}
+
+[data-busy-replaces] a[data-busy="on"] > * {
+    opacity: 1;
+}
+
+[data-busy-replaces] a[data-busy="on"]::after {
+    content: none;
+}

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -110,7 +110,11 @@ GROUPS: list[Group] = [
                     "hidden label, no second click — until the work ends; that comes "
                     "from n26/core/static/n26/busy.js and the [data-busy] rules in "
                     'app.css, and data-busy="off" on the button or its form opts a '
-                    "control out."
+                    'control out. A plain link opts in with data-busy="link"; inside '
+                    'a container carrying data-busy-replaces="<selector>" it takes '
+                    "the current look instead and that element's contents give way "
+                    "to the container's <template data-busy-wait> spinner, which is "
+                    "how the equip rail shows a list loading."
                 ),
             ),
             Component(

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -110,11 +110,12 @@ GROUPS: list[Group] = [
                     "hidden label, no second click — until the work ends; that comes "
                     "from n26/core/static/n26/busy.js and the [data-busy] rules in "
                     'app.css, and data-busy="off" on the button or its form opts a '
-                    'control out. A plain link opts in with data-busy="link"; inside '
-                    'a container carrying data-busy-replaces="<selector>" it takes '
-                    "the current look instead and that element's contents give way "
-                    "to the container's <template data-busy-wait> spinner, which is "
-                    "how the equip rail shows a list loading."
+                    'control out. A plain link opts in with data-busy="link". Inside '
+                    'a container carrying data-busy-replaces="<selector>", the link '
+                    "takes the container's current look instead, and the target "
+                    "element's contents give way to the spinner in the container's "
+                    "own <template data-busy-wait>. This is how the equip rail shows "
+                    "a list loading."
                 ),
             ),
             Component(


### PR DESCRIPTION
## Summary

- Clicking a tab on the equip rail used to turn the tab itself into a spinner, hiding the label the reader clicked. Now the wait shows on the catalogue instead. The tab takes the rail's current look at once, and the catalogue's contents give way to a centred spinner until the new page arrives. This is the same wait the section strip already uses.
- The mechanism lives in `n26/core/static/n26/busy.js`: a container carrying `data-busy-replaces="<selector>"` marks the place a link's page will land. The clicked link takes `is-current`, the marker the kit's navlist styles use. The previous current link gives it up, and the named element's contents are hidden behind the container's own `<template data-busy-wait>`. A back/forward-cache restore puts everything back. `app.css` keeps such a link's label visible instead of drawing the usual busy ring, and a second click is still refused.
- Both equip pages now draw the rail from a shared include, `n26/core/templates/n26/includes/equip_rail.html`. Both catalogue forms carry `id="equip-catalogue"` so the container named in `data-busy-replaces` can find its target.

Refs #2404

## Follow-up

`c-n26.tab-links` carries its own `busy=` prop (Alpine, used by the hire strip) that does the same hide-and-spinner by hand. Pointing it at `data-busy-replaces` would retire that duplicate. But its htmx mode fetches fragments without navigating, so the restore needs wiring to htmx's settle events first. Left for a separate change.

## Test plan

- [x] `pytest n26/core/test_views_equip.py n26/core/test_views_gang_equip.py` — 173 passed, including two new tests that check the rail names the catalogue, the catalogue carries the id, and the rail holds the spinner template
- [x] In the browser, clicked Unrestricted on a fighter's rail: the clicked tab took `is-current`, the previous one gave it up, the catalogue form got `aria-busy` with its children hidden and the spinner appended, and the landed page rendered cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xhszfuLW7UvchR2gR6vsF
