### PR TITLE
perf: answer a kit-menu click on the n26 fighter edit page with the confirmation panel alone

### DIFF
--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -7,10 +7,12 @@ draw the same thing.
 
   card — the n26.render.ModelCard.
   mode — as <c-n26.model-card> takes it; the mode-only regions read it.
-  htmx — passed to the counter controls, and set only by a screen holding the
-    card's host. Threaded rather than read from context: a control that
-    posts over htmx on a page with nowhere to put the answer would run the
-    act and change nothing on screen.
+  htmx — passed to the counter controls and to each piece of kit's menu,
+    and set only by a screen holding the card's host and the dialog host.
+    Threaded rather than read from context: a control that posts over htmx
+    on a page with nowhere to put the answer would run the act and change
+    nothing on screen, and a menu item that fetched its panel would land
+    it nowhere.
 
 A piece of kit with acts on it — the model's own page fills them in —
 carries one menu right beside its name, drawn by <c-n26.owned-actions>.
@@ -171,6 +173,7 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
                             <span class="min-w-0">{% include "n26/includes/assignable_name.html" %}</span>
                             <c-n26.owned-actions :sell="line.sell"
                                                  :more="line.more"
+                                                 :htmx="htmx"
                                                  layout="menu"
                                                  label="{{ line.name }}" />
                         </li>
@@ -286,6 +289,7 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
                                                 </span>
                                                 <c-n26.owned-actions :sell="profile.sell"
                                                                      :more="profile.more"
+                                                                     :htmx="htmx"
                                                                      layout="menu"
                                                                      label="{{ profile.name }}" />
                                             </span>
@@ -337,6 +341,7 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
                                                     </span>
                                                     <c-n26.owned-actions :sell="line.sell"
                                                                          :more="line.more"
+                                                                         :htmx="htmx"
                                                                          layout="menu"
                                                                          label="{{ line.name }}" />
                                                 </li>

--- a/n26/core/templates/cotton/n26/owned_actions.html
+++ b/n26/core/templates/cotton/n26/owned_actions.html
@@ -60,21 +60,21 @@ it lands in. A line with nothing to click draws nothing.
                     </c-ui.button>
                 </c-slot>
                 {% if add %}
-                    <c-ui.dropdown.item href="{{ add.target }}">{{ add.label }}</c-ui.dropdown.item>
+                    {% include "n26/includes/menu_item.html" with action=add %}
                     {% if sell or more %}<c-ui.dropdown.separator />{% endif %}
                 {% endif %}
                 {% if sell %}
-                    <c-ui.dropdown.item href="{{ sell.target }}">{{ sell.label }}</c-ui.dropdown.item>
+                    {% include "n26/includes/menu_item.html" with action=sell %}
                 {% endif %}
                 {% for action in more %}
                     {% if action.tone|tone_variant != "danger" %}
-                        <c-ui.dropdown.item href="{{ action.target }}">{{ action.label }}</c-ui.dropdown.item>
+                        {% include "n26/includes/menu_item.html" with action=action %}
                     {% endif %}
                 {% endfor %}
                 {% for action in more %}
                     {% if action.tone|tone_variant == "danger" %}
                         {% if add or sell or more|length > 1 %}<c-ui.dropdown.separator />{% endif %}
-                        <c-ui.dropdown.item href="{{ action.target }}" variant="danger">{{ action.label }}</c-ui.dropdown.item>
+                        {% include "n26/includes/menu_item.html" with action=action variant="danger" %}
                     {% endif %}
                 {% endfor %}
             </c-ui.dropdown>
@@ -111,26 +111,13 @@ it lands in. A line with nothing to click draws nothing.
                 {% endcomment %}
                 {% for action in more %}
                     {% if action.tone|tone_variant != "danger" %}
-                        {% if htmx %}
-                            <c-ui.dropdown.item href="{{ action.target }}"
-                                                hx-get="{{ action.target }}"
-                                                hx-swap="none">{{ action.label }}</c-ui.dropdown.item>
-                        {% else %}
-                            <c-ui.dropdown.item href="{{ action.target }}">{{ action.label }}</c-ui.dropdown.item>
-                        {% endif %}
+                        {% include "n26/includes/menu_item.html" with action=action %}
                     {% endif %}
                 {% endfor %}
                 {% for action in more %}
                     {% if action.tone|tone_variant == "danger" %}
                         {% if more|length > 1 %}<c-ui.dropdown.separator />{% endif %}
-                        {% if htmx %}
-                            <c-ui.dropdown.item href="{{ action.target }}"
-                                                variant="danger"
-                                                hx-get="{{ action.target }}"
-                                                hx-swap="none">{{ action.label }}</c-ui.dropdown.item>
-                        {% else %}
-                            <c-ui.dropdown.item href="{{ action.target }}" variant="danger">{{ action.label }}</c-ui.dropdown.item>
-                        {% endif %}
+                        {% include "n26/includes/menu_item.html" with action=action variant="danger" %}
                     {% endif %}
                 {% endfor %}
             </c-ui.dropdown>

--- a/n26/core/templates/cotton/n26/owned_actions.html
+++ b/n26/core/templates/cotton/n26/owned_actions.html
@@ -29,7 +29,7 @@ it lands in. A line with nothing to click draws nothing.
   label — the thing's name, for the chevron's accessible name.
   :htmx — as n26/includes/row_action.html: the click fetches the panel
     alone. Off by default; only a screen holding the update's hosts may
-    set it. Only buttons reads it.
+    set it. Both layouts read it.
 {% endcomment %}
 {% load listing %}
 <c-vars :sell="None" :more="None" :add="None" layout="buttons" label="" :htmx="False" class="" />
@@ -60,15 +60,15 @@ it lands in. A line with nothing to click draws nothing.
                     </c-ui.button>
                 </c-slot>
                 {% if add %}
-                    {% include "n26/includes/menu_item.html" with action=add %}
+                    {% include "n26/includes/menu_item.html" with action=add variant="" %}
                     {% if sell or more %}<c-ui.dropdown.separator />{% endif %}
                 {% endif %}
                 {% if sell %}
-                    {% include "n26/includes/menu_item.html" with action=sell %}
+                    {% include "n26/includes/menu_item.html" with action=sell variant="" %}
                 {% endif %}
                 {% for action in more %}
                     {% if action.tone|tone_variant != "danger" %}
-                        {% include "n26/includes/menu_item.html" with action=action %}
+                        {% include "n26/includes/menu_item.html" with action=action variant="" %}
                     {% endif %}
                 {% endfor %}
                 {% for action in more %}
@@ -106,12 +106,11 @@ it lands in. A line with nothing to click draws nothing.
                 Each of these opens a confirmation the server renders; on
                 a screen opted into partial updates (:htmx) the click
                 fetches the panel alone. Still a link underneath — see
-                n26/includes/row_action.html, including for why the
-                element is drawn twice rather than switching attributes.
+                n26/includes/menu_item.html.
                 {% endcomment %}
                 {% for action in more %}
                     {% if action.tone|tone_variant != "danger" %}
-                        {% include "n26/includes/menu_item.html" with action=action %}
+                        {% include "n26/includes/menu_item.html" with action=action variant="" %}
                     {% endif %}
                 {% endfor %}
                 {% for action in more %}

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -263,11 +263,20 @@ is named by the page's own heading directly below.
             {% endif %}
         </c-slot>
     </c-n26.view.model-edit>
-    {% if dialog %}
-        <c-n26.owned-dialog :dialog="dialog">
-            {% csrf_token %}
-        </c-n26.owned-dialog>
-    {% endif %}
+    {% comment %}
+    The host a kit menu's click swaps its confirmation into
+    (n26/includes/equip_panel.html), drawn with the panel the address
+    names so a plain visit and a reload show the same thing. The panel's
+    submit is an ordinary post: this page holds no row an update could
+    name, so the act draws the page again.
+    {% endcomment %}
+    <div id="n26-dialog-host">
+        {% if dialog %}
+            <c-n26.owned-dialog :dialog="dialog">
+                {% csrf_token %}
+            </c-n26.owned-dialog>
+        {% endif %}
+    </div>
     {% if renaming %}
         <c-n26.dialog title="Rename {{ renaming.name }}"
                       action="{% url 'n26-rename-fighter' renaming.pk %}?back=edit"

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -266,9 +266,7 @@ is named by the page's own heading directly below.
     {% comment %}
     The host a kit menu's click swaps its confirmation into
     (n26/includes/equip_panel.html), drawn with the panel the address
-    names so a plain visit and a reload show the same thing. The panel's
-    submit is an ordinary post: this page holds no row an update could
-    name, so the act draws the page again.
+    names so a plain visit and a reload show the same thing.
     {% endcomment %}
     <div id="n26-dialog-host">
         {% if dialog %}

--- a/n26/core/templates/n26/includes/equip_panel.html
+++ b/n26/core/templates/n26/includes/equip_panel.html
@@ -9,10 +9,14 @@ said with different content, and leaves the catalogue underneath untouched.
 Drawn as a panel this page opened rather than one the server put in front of
 the reader, because that is what it is: the address is corrected as it arrives,
 and leaving puts the address back instead of asking for the whole screen.
+
+`htmx` says whether the panel's own submit posts partially too. The equip
+screens hold every element such an update names; the model's own page does
+not, so there the act is an ordinary post and the page is drawn again.
 {% endcomment %}
 <div id="n26-dialog-host" hx-swap-oob="true">
     {% if dialog %}
-        <c-n26.owned-dialog :dialog="dialog" :redrawn="True" :htmx="True">
+        <c-n26.owned-dialog :dialog="dialog" :redrawn="True" :htmx="htmx">
             {% csrf_token %}
         </c-n26.owned-dialog>
     {% endif %}

--- a/n26/core/templates/n26/includes/equip_panel.html
+++ b/n26/core/templates/n26/includes/equip_panel.html
@@ -10,9 +10,8 @@ Drawn as a panel this page opened rather than one the server put in front of
 the reader, because that is what it is: the address is corrected as it arrives,
 and leaving puts the address back instead of asking for the whole screen.
 
-`htmx` says whether the panel's own submit posts partially too. The equip
-screens hold every element such an update names; the model's own page does
-not, so there the act is an ordinary post and the page is drawn again.
+`htmx` says whether the panel's own submit posts partially too — see
+n26.core.views.owned.panel_response for which screens may say so.
 {% endcomment %}
 <div id="n26-dialog-host" hx-swap-oob="true">
     {% if dialog %}

--- a/n26/core/templates/n26/includes/menu_item.html
+++ b/n26/core/templates/n26/includes/menu_item.html
@@ -1,0 +1,22 @@
+{% comment %}
+One item of an owned thing's more-menu. Expects `action` — an
+n26.core.listing.Action — and optionally `variant`.
+
+Every one of these opens a confirmation the server renders. On a screen that
+has opted into partial updates (`htmx` in context — see
+n26/includes/equip_hosts.html) the click fetches that panel alone and the
+response replaces the dialog host by id. Elsewhere, and without JavaScript, it
+is a plain link and the server serves the page with the panel open.
+
+Drawn twice rather than once with the attribute switched: a template tag
+inside a component's attribute list is not parsed and lands in the page as
+text. The label stays inside the tag on one line: a line break there is
+whitespace inside the item's own span.
+{% endcomment %}
+{# djlint:off #}
+{% if htmx %}
+    <c-ui.dropdown.item href="{{ action.target }}" variant="{{ variant|default:'' }}" hx-get="{{ action.target }}" hx-swap="none">{{ action.label }}</c-ui.dropdown.item>
+{% else %}
+    <c-ui.dropdown.item href="{{ action.target }}" variant="{{ variant|default:'' }}">{{ action.label }}</c-ui.dropdown.item>
+{% endif %}
+{# djlint:on #}

--- a/n26/core/templates/n26/includes/menu_item.html
+++ b/n26/core/templates/n26/includes/menu_item.html
@@ -1,6 +1,7 @@
 {% comment %}
 One item of an owned thing's more-menu. Expects `action` — an
-n26.core.listing.Action — and optionally `variant`.
+n26.core.listing.Action — and `variant`, the kit item's own (empty for the
+default).
 
 Every one of these opens a confirmation the server renders. On a screen that
 has opted into partial updates (`htmx` in context — see
@@ -10,13 +11,17 @@ is a plain link and the server serves the page with the panel open.
 
 Drawn twice rather than once with the attribute switched: a template tag
 inside a component's attribute list is not parsed and lands in the page as
-text. The label stays inside the tag on one line: a line break there is
-whitespace inside the item's own span.
+text. The formatter is off for the two tags because the label must stay on
+the closing line: a line break there is whitespace inside the item's span.
 {% endcomment %}
 {# djlint:off #}
 {% if htmx %}
-    <c-ui.dropdown.item href="{{ action.target }}" variant="{{ variant|default:'' }}" hx-get="{{ action.target }}" hx-swap="none">{{ action.label }}</c-ui.dropdown.item>
+    <c-ui.dropdown.item href="{{ action.target }}"
+                        variant="{{ variant }}"
+                        hx-get="{{ action.target }}"
+                        hx-swap="none">{{ action.label }}</c-ui.dropdown.item>
 {% else %}
-    <c-ui.dropdown.item href="{{ action.target }}" variant="{{ variant|default:'' }}">{{ action.label }}</c-ui.dropdown.item>
+    <c-ui.dropdown.item href="{{ action.target }}"
+                        variant="{{ variant }}">{{ action.label }}</c-ui.dropdown.item>
 {% endif %}
 {# djlint:on #}

--- a/n26/core/templates/n26/includes/weapon_name.html
+++ b/n26/core/templates/n26/includes/weapon_name.html
@@ -1,7 +1,8 @@
 {% comment %}
 A weapon's name on the card, with the menu of what can happen to it —
 Add accessory, Sell and the rest. Expects `weapon` — an
-n26.render.WeaponLine.
+n26.render.WeaponLine — and reads `htmx` from the card's context, as the
+other kit menus on the card do.
 
 A name with nothing to click is the bare name, so a gang sheet and a
 print card keep the cell's own text baseline.
@@ -12,6 +13,7 @@ print card keep the cell's own text baseline.
         <c-n26.owned-actions :sell="weapon.sell"
                              :more="weapon.more"
                              :add="weapon.accessorise"
+                             :htmx="htmx"
                              layout="menu"
                              label="{{ weapon.name }}" />
     </span>

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -540,6 +540,82 @@ class TestKitActionsOnTheCard:
         assert "Add an accessory to Lasgun" in body
         assert "Telescopic sight" in body
 
+    def test_a_kit_menu_item_fetches_its_panel(self, client, tester, vex, sword):
+        """The card's menu items ask for the confirmation alone, and the
+        page holds the host the answer lands in. Without script they are
+        still links, and the server draws the page with the panel open."""
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+
+        assert f'hx-get="{edit_url(vex)}?sell={sword.pk}"' in body
+        assert 'id="n26-dialog-host"' in body
+
+    def test_a_click_with_script_is_answered_with_the_panel_alone(
+        self, client, tester, vex, sword
+    ):
+        """The question is about one thing the model holds, so the card,
+        the edit boxes and the roster are not drawn to ask it. The panel
+        replaces the host by id and corrects the address to the one that
+        draws it on a plain visit."""
+        client.force_login(tester)
+        response = client.get(
+            f"{edit_url(vex)}?sell={sword.pk}", headers={"HX-Request": "true"}
+        )
+        body = response.content.decode()
+
+        assert response["HX-Replace-Url"] == f"{edit_url(vex)}?sell={sword.pk}"
+        assert 'id="n26-dialog-host" hx-swap-oob="true"' in body
+        assert "<dialog" in body
+        assert reverse("n26-sell", args=[sword.pk]) in body
+        assert "Characteristics" not in body
+        # This page holds no row an update could name, so the act itself
+        # is an ordinary post and the page is drawn again.
+        assert "hx-post" not in body
+
+    def test_the_accessory_question_is_answered_the_same_way(
+        self, client, tester, vex, gun
+    ):
+        from n26.library.authoring import create_weapon_accessory
+
+        create_weapon_accessory("Telescopic sight", price=25)
+        client.force_login(tester)
+        response = client.get(
+            f"{edit_url(vex)}?accessorise={gun.pk}", headers={"HX-Request": "true"}
+        )
+        body = response.content.decode()
+
+        assert 'id="n26-dialog-host" hx-swap-oob="true"' in body
+        assert "Add an accessory to Lasgun" in body
+        assert "Telescopic sight" in body
+
+    def test_the_panel_alone_costs_fewer_queries_than_the_page(
+        self, client, tester, vex, sword
+    ):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        client.force_login(tester)
+        with CaptureQueriesContext(connection) as whole:
+            client.get(f"{edit_url(vex)}?sell={sword.pk}")
+        with CaptureQueriesContext(connection) as panel:
+            client.get(
+                f"{edit_url(vex)}?sell={sword.pk}", headers={"HX-Request": "true"}
+            )
+
+        assert len(panel) < len(whole)
+
+    def test_a_click_naming_nothing_closes_the_panel(self, client, tester, vex):
+        """An address naming a dialog for something that is not there
+        answers with an empty host, which closes whatever was open."""
+        client.force_login(tester)
+        response = client.get(
+            f"{edit_url(vex)}?sell=nothing", headers={"HX-Request": "true"}
+        )
+        body = response.content.decode()
+
+        assert 'id="n26-dialog-host" hx-swap-oob="true"' in body
+        assert "<dialog" not in body
+
     def test_selling_lands_back_on_the_edit_page(
         self, client, tester, gang, vex, sword
     ):

--- a/n26/core/test_views_edit.py
+++ b/n26/core/test_views_edit.py
@@ -550,6 +550,25 @@ class TestKitActionsOnTheCard:
         assert f'hx-get="{edit_url(vex)}?sell={sword.pk}"' in body
         assert 'id="n26-dialog-host"' in body
 
+    def test_the_weapon_menu_fetches_its_panel_too(self, client, tester, vex, gun):
+        """A gun's name draws its own menu, through a different route
+        from the rest of the kit; it carries the same acts the same way."""
+        client.force_login(tester)
+        body = client.get(edit_url(vex)).content.decode()
+
+        assert f'hx-get="{edit_url(vex)}?accessorise={gun.pk}"' in body
+        assert f'hx-get="{edit_url(vex)}?sell={gun.pk}"' in body
+
+    def test_the_page_asked_for_whole_is_drawn_whole(self, client, tester, vex, sword):
+        """Only a click that named a panel gets the panel."""
+        client.force_login(tester)
+        body = client.get(
+            edit_url(vex), headers={"HX-Request": "true"}
+        ).content.decode()
+
+        assert "<html" in body
+        assert "Characteristics" in body
+
     def test_a_click_with_script_is_answered_with_the_panel_alone(
         self, client, tester, vex, sword
     ):
@@ -568,8 +587,7 @@ class TestKitActionsOnTheCard:
         assert "<dialog" in body
         assert reverse("n26-sell", args=[sword.pk]) in body
         assert "Characteristics" not in body
-        # This page holds no row an update could name, so the act itself
-        # is an ordinary post and the page is drawn again.
+        # The panel's own submit is not partial here (see panel_response).
         assert "hx-post" not in body
 
     def test_the_accessory_question_is_answered_the_same_way(

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -2125,6 +2125,16 @@ class TestOpeningAConfirmationWithoutRebuildingThePage:
 
         assert "clicked = true" in body
 
+    def test_the_panel_posts_partially_on_this_screen(
+        self, client, tester, fighter, gun_list, owned_gun
+    ):
+        """The equip screen holds every element an update names, so the
+        panel's own submit goes the same way the click that opened it did."""
+        client.force_login(tester)
+        body = self.asked(client, fighter, gun_list, owned_gun).content.decode()
+
+        assert "hx-post" in body
+
     def test_asking_with_nothing_named_closes_whatever_was_open(
         self, client, tester, fighter, gun_list, owned_gun
     ):

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -372,6 +372,7 @@ def edit_fighter(request, pk):
         link_counters,
         link_possession_actions,
         owned_dialog,
+        panel_response,
     )
     from n26.core.views.skills import apply_ticks, link_skills, skills_offer
 
@@ -613,24 +614,11 @@ def edit_fighter(request, pk):
         answer["HX-Replace-Url"] = request.get_full_path()
         return answer
 
-    # Drawn from the reading already in hand. A card is a fact about one
-    # model — what it holds, what modifiers make of that — so the gang is
-    # asked for only what the gang alone can answer, which on this page is
-    # the roster tally below. The card's own build carries the gang's
-    # assignments already, so what the gang grants still reaches it.
-    card = build_model_card(miniature, card=own, computed=computed)
-    link_slots(gang, card)
-    link_skills(card, among=sets)
-    # Only here. A counter is drawn wherever a card is; the model's own
-    # page is the one place it is moved, so this is the one place the
-    # lines are given addresses.
-    link_counters(card, back=request.get_full_path())
     # The same acts the equip listing offers, pointed at this page so
     # the confirmations open over it. A gang sheet and a print sheet
     # never call this, and their cards stay names with nothing to click.
     at = reverse("n26-edit-fighter", args=[miniature.pk])
     host = EquipHost.fighter(gang, own, miniature, at)
-    link_possession_actions(card, host, refunds=not gang.credits_unlimited)
 
     renaming = _fighter_named(request, gang, "rename")
     # One question at a time: a URL naming a rename and a sale draws
@@ -649,6 +637,30 @@ def edit_fighter(request, pk):
                 ),
                 None,
             )
+        # A click on a kit menu with script running is answered with
+        # the panel alone, before the card and the rest of the page are
+        # drawn: the question is about one thing the model holds, and
+        # the reading in hand already says everything the panel needs.
+        # Only a click that named a panel — a page asked for as a whole
+        # is drawn whole however it was asked for. The panel's own
+        # submit stays an ordinary post, since this page holds no row
+        # an update could name, so the act draws the page again.
+        if (panel := panel_response(request, dialog, htmx=False)) is not None:
+            return panel
+
+    # Drawn from the reading already in hand. A card is a fact about one
+    # model — what it holds, what modifiers make of that — so the gang is
+    # asked for only what the gang alone can answer, which on this page is
+    # the roster tally below. The card's own build carries the gang's
+    # assignments already, so what the gang grants still reaches it.
+    card = build_model_card(miniature, card=own, computed=computed)
+    link_slots(gang, card)
+    link_skills(card, among=sets)
+    # Only here. A counter is drawn wherever a card is; the model's own
+    # page is the one place it is moved, so this is the one place the
+    # lines are given addresses.
+    link_counters(card, back=request.get_full_path())
+    link_possession_actions(card, host, refunds=not gang.credits_unlimited)
 
     subtype_edits, subtype_more, subtype_edits_dirty = _edits_offer(
         own, computed, "subtype", "Subtypes"

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -573,6 +573,40 @@ def edit_fighter(request, pk):
     own = build_card(miniature, with_statlines=True, with_options=True)
     index = build_modifier_index([node.assignable for node in own.all_nodes()])
     computed = compute(own, index)
+
+    # The same acts the equip listing offers, pointed at this page so
+    # the confirmations open over it. A gang sheet and a print sheet
+    # never call this, and their cards stay names with nothing to click.
+    at = reverse("n26-edit-fighter", args=[miniature.pk])
+    host = EquipHost.fighter(gang, own, miniature, at)
+
+    renaming = _fighter_named(request, gang, "rename")
+    # One question at a time: a URL naming a rename and a sale draws
+    # the rename, because two open modals is not a state the page can
+    # mean. Accessorise is drawn per-weapon on the equip page; here
+    # there is one panel, the one the address names.
+    dialog = None
+    if not renaming and any(request.GET.get(kind) for kind in DIALOGS):
+        dialog = owned_dialog(request, host)
+        if dialog is None:
+            dialog = next(
+                (
+                    panel
+                    for panel in accessorise_dialogs(request, host)
+                    if panel["open"]
+                ),
+                None,
+            )
+        # A click on a kit menu with script running is answered with
+        # the panel alone: the question is about one thing the model
+        # holds, and the reading in hand already says everything the
+        # panel needs. Only a click that named a panel — a page asked
+        # for as a whole is drawn whole however it was asked for. This
+        # page holds no row an update could name, so the panel's own
+        # submit is not partial (see panel_response).
+        if (panel := panel_response(request, dialog, htmx=False)) is not None:
+            return panel
+
     # Asked once and used twice: the listing reads these collections, and
     # so does the card's Skills control.
     sets = model_collections()
@@ -613,40 +647,6 @@ def edit_fighter(request, pk):
         )
         answer["HX-Replace-Url"] = request.get_full_path()
         return answer
-
-    # The same acts the equip listing offers, pointed at this page so
-    # the confirmations open over it. A gang sheet and a print sheet
-    # never call this, and their cards stay names with nothing to click.
-    at = reverse("n26-edit-fighter", args=[miniature.pk])
-    host = EquipHost.fighter(gang, own, miniature, at)
-
-    renaming = _fighter_named(request, gang, "rename")
-    # One question at a time: a URL naming a rename and a sale draws
-    # the rename, because two open modals is not a state the page can
-    # mean. Accessorise is drawn per-weapon on the equip page; here
-    # there is one panel, the one the address names.
-    dialog = None
-    if not renaming and any(request.GET.get(kind) for kind in DIALOGS):
-        dialog = owned_dialog(request, host)
-        if dialog is None:
-            dialog = next(
-                (
-                    panel
-                    for panel in accessorise_dialogs(request, host)
-                    if panel["open"]
-                ),
-                None,
-            )
-        # A click on a kit menu with script running is answered with
-        # the panel alone, before the card and the rest of the page are
-        # drawn: the question is about one thing the model holds, and
-        # the reading in hand already says everything the panel needs.
-        # Only a click that named a panel — a page asked for as a whole
-        # is drawn whole however it was asked for. The panel's own
-        # submit stays an ordinary post, since this page holds no row
-        # an update could name, so the act draws the page again.
-        if (panel := panel_response(request, dialog, htmx=False)) is not None:
-            return panel
 
     # Drawn from the reading already in hand. A card is a fact about one
     # model — what it holds, what modifiers make of that — so the gang is

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -335,25 +335,6 @@ def collection_tabs(collections, chosen):
     ]
 
 
-def _panel_response(request, dialog):
-    """The confirmation panel alone, for an htmx GET that named one.
-
-    ``None`` for every other request, so a caller reads it as "not that
-    kind of click" and carries on rendering the screen.
-
-    ``HX-Replace-Url`` sets the address to the one that renders this
-    panel on a plain visit — so a reload draws it again and a link to it
-    works. Replaced rather than pushed: an open confirmation is not
-    somewhere to go back to, and the panel's own way out already stands
-    where the back button would.
-    """
-    if request.method != "GET" or not is_htmx(request):
-        return None
-    response = render(request, "n26/includes/equip_panel.html", {"dialog": dialog})
-    response["HX-Replace-Url"] = request.get_full_path()
-    return response
-
-
 @dataclass(frozen=True)
 class Screen:
     """What an equip screen is showing, derived in one place.
@@ -788,7 +769,11 @@ def equip(request, pk):
     """
     from n26.core.listing import build_catalogue
     from n26.core.owned import possessions
-    from n26.core.views.owned import accessorise_dialogs, owned_dialog
+    from n26.core.views.owned import (
+        accessorise_dialogs,
+        owned_dialog,
+        panel_response,
+    )
 
     miniature = _own_miniature_or_404(request, pk)
     gang = miniature.gang
@@ -871,7 +856,7 @@ def equip(request, pk):
     owned = possessions(host)
 
     dialog = owned_dialog(request, host)
-    if (panel := _panel_response(request, dialog)) is not None:
+    if (panel := panel_response(request, dialog)) is not None:
         return panel
 
     # The whole screen, as one structure: the browsed list joined to what
@@ -1099,7 +1084,11 @@ def equip_gang(request, pk):
     from n26.core.owned import possessions
     from n26.core.render import roster as gang_roster
     from n26.core.render import summarise_roster
-    from n26.core.views.owned import accessorise_dialogs, owned_dialog
+    from n26.core.views.owned import (
+        accessorise_dialogs,
+        owned_dialog,
+        panel_response,
+    )
 
     gang = _own_gang_or_404(request, pk)
 
@@ -1165,7 +1154,7 @@ def equip_gang(request, pk):
     refunds = not gang.credits_unlimited
 
     dialog = owned_dialog(request, host)
-    if (panel := _panel_response(request, dialog)) is not None:
+    if (panel := panel_response(request, dialog)) is not None:
         return panel
 
     if stash_tab:

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -59,6 +59,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponse
+from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
@@ -258,6 +259,30 @@ def _panel(request, assignment, kind, at):
         # writes; a dialog is a form of its own and has to say it here.
         "section": request.GET.get("section", ""),
     }
+
+
+def panel_response(request, dialog, *, htmx=True):
+    """The confirmation panel alone, for an htmx GET that named one.
+
+    ``None`` for every other request, so a caller reads it as "not that
+    kind of click" and carries on rendering the screen.
+
+    ``HX-Replace-Url`` sets the address to the one that renders this
+    panel on a plain visit — so a reload draws it again and a link to it
+    works. Replaced rather than pushed: an open confirmation is not
+    somewhere to go back to, and the panel's own way out already stands
+    where the back button would.
+
+    ``htmx`` is whether the panel's own submit may post partially: only
+    a screen holding every element such an update names may say so.
+    """
+    if request.method != "GET" or not is_htmx(request):
+        return None
+    response = render(
+        request, "n26/includes/equip_panel.html", {"dialog": dialog, "htmx": htmx}
+    )
+    response["HX-Replace-Url"] = request.get_full_path()
+    return response
 
 
 def accessorise_dialogs(request, host: EquipHost):

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -274,7 +274,10 @@ def panel_response(request, dialog, *, htmx=True):
     where the back button would.
 
     ``htmx`` is whether the panel's own submit may post partially: only
-    a screen holding every element such an update names may say so.
+    a screen holding every element such an update names may say so. The
+    equip screens do; the model's own page holds no row an update could
+    name, so there the act is an ordinary post and the page is drawn
+    again.
     """
     if request.method != "GET" or not is_htmx(request):
         return None


### PR DESCRIPTION
On an n26 fighter's edit page, opening Sell, Detach, Refund, Remove, Reassign or Add accessory from a piece of kit's menu took a couple of seconds with nothing on screen to say so. The menu items were plain links, so the server rebuilt the whole edit page — the card, both edit offers, the skills box and the roster — to show one confirmation panel. The equip screens already answer the same click over htmx with the panel by itself.

## What changed

- The edit page now answers a kit-menu click with the confirmation panel alone, swapped into a dialog host the page carries, with the address corrected to the one that draws the panel on a plain visit. Cancel puts the address back without a page load. Without JavaScript nothing changes: the link navigates and the server draws the page with the panel open.
- The panel's own submit on this page stays an ordinary post that draws the page again. The page holds no row a partial update could name, so a partial answer there would run the act and change nothing on screen.
- An htmx GET of the page with no panel named is still drawn whole; only a click that named a panel gets the panel.
- The equip screens' panel helper (`panel_response`) moves into the owned views and is shared. The menu layout of `owned-actions` draws its items through one `menu_item.html` include, which carries `hx-get` where the screen allows.

Measured on a dev database with the debug toolbar on, one fighter with two guns and a sight:

| Path | Before | After |
|---|---|---|
| Edit page, `?sell=`, htmx | ~2.2s, 108 queries, 1.4 MB (full page, nothing swapped) | ~180ms, 93 queries, 4 KB |
| Edit page, `?sell=`, plain navigation | ~2.0s, 108 queries | unchanged |

This is the first of two PRs from `.claude/notes/dialog-loading-state-plan.md`. The second adds a loading state to the shared dialog component so the panel opens the instant the click lands.

## How to try it

1. Open an n26 fighter's edit page (`/n26/fighters/<id>/edit/`) for a model holding some kit.
2. Open the menu beside a piece of kit and click Sell, Detach or Add accessory. The panel opens over the page without a reload; the address gains `?sell=<id>`.
3. Cancel: the panel closes and the address goes back, still without a reload.
4. Confirm: the act runs and the page is drawn again with the message.
5. Reload with `?sell=<id>` in the address: the page draws with the panel open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HriMwFNzGxZVtG89UVocet
