### PR TITLE
fix: wrap n26 radio-card titles and mark chosen multiple-select rows

### DIFF
--- a/n26/core/templates/cotton/n26/flair_link.html
+++ b/n26/core/templates/cotton/n26/flair_link.html
@@ -27,9 +27,10 @@ surrounding sentence.
 
   text — the label. Underlined when this is a link.
   href, underline, tone — passed straight to <c-n26.link>.
-  wrap — let a sentence-long label break; the badge follows the last word.
-    Off by default: a 1em mark after a short name must not take the next line
-    by itself.
+  wrap — let a sentence-long label break; the badge follows the last word
+    and is not sized as a 1em mark (a taller pill would ride up into the
+    line above). Off by default: a 1em mark after a short name must not
+    take the next line by itself.
   label — an accessible name for the badge, also its title tooltip. Left empty the
     badge is aria-hidden, which is right when the text already says the same thing.
 {% endcomment %}<c-vars
@@ -46,6 +47,7 @@ and friends — never left the extractor: nested brackets in one class are
 silently dropped, and an unsized svg is 300x150, which wraps under a short
 word. whitespace-nowrap holds the text and the badge as one unit so a 1em
 mark cannot take the next line by itself. wrap drops that hold so a sentence
-can break and the badge stays after the last word. slot.strip because an
-artwork file's own leading and trailing newlines would otherwise pad the badge.
-{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="{% if wrap %}inline{% else %}inline-flex items-center whitespace-nowrap{% endif %} {{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="ml-[0.25em] n26-icon-inline shrink-0 [--n26-icon-size:1em]" {% if label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>
+can break, and skips .n26-icon-inline: that class's vertical-align is for a
+1em mark, and a taller pill rides up into the line above. slot.strip because
+an artwork file's own leading and trailing newlines would otherwise pad the badge.
+{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="{% if wrap %}inline{% else %}inline-flex items-center whitespace-nowrap{% endif %} {{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="{% if wrap %}ml-1.5 inline-block align-middle{% else %}ml-[0.25em] n26-icon-inline shrink-0 [--n26-icon-size:1em]{% endif %}" {% if wrap %}{% elif label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>

--- a/n26/core/templates/cotton/n26/flair_link.html
+++ b/n26/core/templates/cotton/n26/flair_link.html
@@ -27,6 +27,9 @@ surrounding sentence.
 
   text — the label. Underlined when this is a link.
   href, underline, tone — passed straight to <c-n26.link>.
+  wrap — let a sentence-long label break; the badge follows the last word.
+    Off by default: a 1em mark after a short name must not take the next line
+    by itself.
   label — an accessible name for the badge, also its title tooltip. Left empty the
     badge is aria-hidden, which is right when the text already says the same thing.
 {% endcomment %}<c-vars
@@ -34,13 +37,15 @@ surrounding sentence.
     href=""
     underline="hover"
     tone="accent"
+    :wrap="False"
     label=""
     class=""
 />{% comment %}The badge is .n26-icon-inline, which sizes a child svg in em
 in app.css. The utilities that would have done the same — [&_svg]:size-[1em]
 and friends — never left the extractor: nested brackets in one class are
-silently dropped, and an unsized svg is 300×150, which wraps under a short
+silently dropped, and an unsized svg is 300x150, which wraps under a short
 word. whitespace-nowrap holds the text and the badge as one unit so a 1em
-mark cannot take the next line by itself. slot.strip because an artwork
-file's own leading and trailing newlines would otherwise pad the badge.
-{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="inline-flex items-center whitespace-nowrap {{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="ml-[0.25em] n26-icon-inline shrink-0 [--n26-icon-size:1em]" {% if label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>
+mark cannot take the next line by itself. wrap drops that hold so a sentence
+can break and the badge stays after the last word. slot.strip because an
+artwork file's own leading and trailing newlines would otherwise pad the badge.
+{% endcomment %}<c-n26.link href="{{ href }}" underline="{{ underline }}" tone="{{ tone }}" class="{% if wrap %}inline{% else %}inline-flex items-center whitespace-nowrap{% endif %} {{ class }}">{{ text }}<c-slot name="trailing">{% if slot.strip %}<span class="ml-[0.25em] n26-icon-inline shrink-0 [--n26-icon-size:1em]" {% if label %}role="img" aria-label="{{ label }}" title="{{ label }}"{% else %}aria-hidden="true"{% endif %}>{{ slot.strip|safe }}</span>{% endif %}</c-slot></c-n26.link>

--- a/n26/core/templates/cotton/n26/radio_cards/card.html
+++ b/n26/core/templates/cotton/n26/radio_cards/card.html
@@ -23,6 +23,8 @@ not read as a question.
   description — the muted line under it. Optional.
   wrap — let the label and description run to several lines instead of
     truncating, for options whose detail is a sentence rather than a phrase.
+    The badge after the name wraps with the last word; it does not hold
+    the line open.
   example — a concrete case, revealed on hover or keyboard focus of the small
     icon after the description, and set as its title for touch. Optional.
   disabled — the option cannot be picked here: the radio is disabled and the
@@ -53,7 +55,7 @@ input inside it, so it is right before any script runs and without one. The
 accent border and tint match the kit's checkbox cards.
 {% endcomment %}
 <label {{ attrs }}
-       class="flex items-start gap-3 rounded-box border-2 border-ink-200 p-4
+       class="flex min-w-0 items-start gap-3 rounded-box border-2 border-ink-200 p-4
               transition-[background-color,border-color]
               {% if disabled %}cursor-not-allowed opacity-50{% else %}cursor-pointer hover:bg-ink-500/5{% endif %}
               has-[:checked]:border-accent has-[:checked]:bg-accent/5
@@ -70,7 +72,7 @@ accent border and tint match the kit's checkbox cards.
         same placement it has in a heading or a table cell. tone="current"
         because the card's title has already set its colour.
         {% endcomment %}
-        <span class="block {% if not wrap %}truncate{% endif %} text-base font-semibold text-ink-900 dark:text-ink-100"><c-n26.flair-link text="{{ label }}" tone="current">{{ flair }}</c-n26.flair-link></span>
+        <span class="block {% if not wrap %}truncate{% endif %} text-base font-semibold text-ink-900 dark:text-ink-100"><c-n26.flair-link text="{{ label }}" tone="current" :wrap="wrap">{{ flair }}</c-n26.flair-link></span>
         {% if disabled and reason %}
             <span class="block text-muted">{{ reason }}</span>
         {% elif description %}

--- a/n26/core/templates/cotton/n26/radio_cards/index.html
+++ b/n26/core/templates/cotton/n26/radio_cards/index.html
@@ -49,8 +49,10 @@ whichever card the server says.
     {% comment %}
     auto-fill rather than a column count per breakpoint: how many cards fit a
     row follows from the one number saying how narrow a card may get.
+    min-w-0 on each child so a nowrap name cannot push the track wider than
+    the card; wrap is what lets a sentence stay inside that width.
     {% endcomment %}
-    <div class="grid gap-3" style="grid-template-columns: repeat(auto-fill, minmax({{ min }}, 1fr));">
+    <div class="grid gap-3 [&>*]:min-w-0" style="grid-template-columns: repeat(auto-fill, minmax({{ min }}, 1fr));">
         {{ slot }}
     </div>
 

--- a/n26/core/templates/cotton/ui/select/native.html
+++ b/n26/core/templates/cotton/ui/select/native.html
@@ -1,0 +1,68 @@
+{% comment %}
+<c-ui.select.native> — the real <select>, usable on its own.
+
+Overrides the kit: a multiple select is a list, not a dropdown. The kit
+paints every option the input's own fill, which hides the browser's
+selected highlight — Fighter and Vehicle then read as the same, and the
+chevron drawn for a one-of-many select sits on a list it does not open.
+Multiple drops that chrome and marks option:checked instead
+(.n26-select-multiple in app.css).
+
+  name — posted with the form.
+  placeholder — an empty disabled option, for a one-of-many select only.
+  multiple — more than one option may be chosen; the control is a list.
+  size — padding and type, not the HTML size attribute.
+{% endcomment %}
+<c-vars
+    name=""
+    placeholder="Select an option"
+    value=""
+    :required="False"
+    :disabled="False"
+    :multiple="False"
+    size="md"
+    :size_classes="{
+        'xs': 'text-xs px-2 py-1 pr-8',
+        'sm': 'text-sm px-3 py-1.5 pr-10',
+        'md': 'text-sm px-3 py-2 pr-10',
+        'lg': 'text-base px-4 py-2.5 pr-12',
+        'xl': 'text-lg px-5 py-3 pr-12',
+        '2xl': 'text-xl px-6 py-3.5 pr-14'
+    }"
+    :multiple_size_classes="{
+        'xs': 'text-xs px-2 py-1',
+        'sm': 'text-sm px-3 py-1.5',
+        'md': 'text-sm px-3 py-2',
+        'lg': 'text-base px-4 py-2.5',
+        'xl': 'text-lg px-5 py-3',
+        '2xl': 'text-xl px-6 py-3.5'
+    }"
+/>
+
+<select
+    name="{{ name }}"
+    {% if required %}required{% endif %}
+    {% if disabled %}disabled{% endif %}
+    {% if multiple %}multiple{% endif %}
+    {{ attrs }}
+    class="w-full rounded-control border transition-colors
+           {% if multiple %}
+             n26-select-multiple
+             {{ multiple_size_classes|get_item:size }}
+           {% else %}
+             appearance-none bg-[right_0.5rem_center] bg-no-repeat
+             {{ size_classes|get_item:size }}
+             [&>option]:text-ink-900 [&>option]:dark:text-ink-100 [&>option]:bg-white [&>option]:dark:bg-ink-900
+           {% endif %}
+           bg-[var(--color-input-bg)] shadow-[var(--shadow-input)]
+           border-ink-300 dark:border-ink-700
+           focus-ring
+           disabled:opacity-50 disabled:cursor-not-allowed"
+    {% if not multiple %}style="background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27%23999%27 stroke-width=%272%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3e%3cpolyline points=%276 9 12 15 18 9%27%3e%3c/polyline%3e%3c/svg%3e'); background-size: 1rem;"{% endif %}
+>
+    {% if placeholder and not multiple %}
+    <option value="" disabled {% if not value %}selected{% endif %}>{{ placeholder }}</option>
+    {% endif %}
+
+    {{ slot }}
+</select>

--- a/n26/core/test_page_header.py
+++ b/n26/core/test_page_header.py
@@ -112,3 +112,15 @@ class TestTheTypeKeepsItsMark:
         assert "n26-icon-inline" in html
         assert "[--n26-icon-size:1em]" in html
         assert html.index("Outcast") < html.index("<svg")
+
+    def test_a_sentence_is_allowed_to_break(self):
+        """nowrap after a short name is right; a sentence must be able to
+        break or the badge sits outside the box that holds it."""
+        html = render(
+            '<c-n26.flair-link text="The gang carrying it and all models"'
+            ' :wrap="True"><span>Deprecated</span></c-n26.flair-link>'
+        )
+
+        assert "whitespace-nowrap" not in html
+        assert "inline-flex" not in html
+        assert html.index("The gang") < html.index("Deprecated")

--- a/n26/core/test_page_header.py
+++ b/n26/core/test_page_header.py
@@ -122,5 +122,6 @@ class TestTheTypeKeepsItsMark:
         )
 
         assert "whitespace-nowrap" not in html
-        assert "inline-flex" not in html
+        assert "n26-icon-inline" not in html
+        assert "inline-block align-middle" in html
         assert html.index("The gang") < html.index("Deprecated")

--- a/n26/core/test_radio_cards.py
+++ b/n26/core/test_radio_cards.py
@@ -1,0 +1,67 @@
+"""How a radio card holds a long name and a badge.
+
+No database: a card is a template and a set of props. wrap means a
+sentence-long name and the pill after it stay inside the card: the
+badge follows the last word, and does not hold the line open.
+"""
+
+from django.template import Context, Template
+from django_cotton.compiler_regex import CottonCompiler
+
+
+def render(source: str, **context) -> str:
+    """Compile a call site the way the template loader would, then render it.
+
+    Cotton's `<c-…>` tags are rewritten by a loader, so a template built from a
+    string never sees them. Running the compiler by hand is what lets a test
+    write the call site it is testing.
+    """
+    return Template(CottonCompiler().process(source)).render(Context(context))
+
+
+class TestAWrappedCardLetsTheNameBreak:
+    """A kind card's name is a sentence. The badge follows the last word
+    rather than holding the whole line open."""
+
+    def test_a_sentence_and_a_pill_are_not_held_on_one_line(self):
+        html = render(
+            '<c-n26.radio-cards.card name="scope" value="gang" '
+            'label="The gang carrying it and all models" '
+            'description="Affects the gang." :wrap="True">'
+            '<c-slot name="flair"><span>Deprecated</span></c-slot>'
+            "</c-n26.radio-cards.card>"
+        )
+
+        title = html[html.index("The gang") : html.index("Affects the gang")]
+        assert "whitespace-nowrap" not in title
+        assert "truncate" not in title
+        assert "Deprecated" in title
+
+    def test_a_short_name_still_holds_its_badge_on_one_line(self):
+        html = render(
+            '<c-n26.radio-cards.card name="type" value="1" '
+            'label="Escher (HoB)">'
+            '<c-slot name="flair"><svg viewBox="0 0 24 24"></svg></c-slot>'
+            "</c-n26.radio-cards.card>"
+        )
+
+        assert "whitespace-nowrap" in html
+        assert "truncate" in html
+        assert html.index("Escher") < html.index("<svg")
+
+
+class TestTheGridGivesEachCardRoomToShrink:
+    """A nowrap name must not widen the track past the card. min-w-0 on
+    every child is what lets the card keep its border around its content.
+    """
+
+    def test_each_child_can_shrink_below_its_content(self):
+        html = render(
+            '<c-n26.radio-cards label="Who it reaches">'
+            '<c-n26.radio-cards.card name="scope" value="gang" '
+            'label="The gang carrying it and all models" />'
+            "</c-n26.radio-cards>"
+        )
+
+        assert "[&>*]:min-w-0" in html
+        assert "min-w-0" in html

--- a/n26/core/test_radio_cards.py
+++ b/n26/core/test_radio_cards.py
@@ -35,6 +35,7 @@ class TestAWrappedCardLetsTheNameBreak:
         title = html[html.index("The gang") : html.index("Affects the gang")]
         assert "whitespace-nowrap" not in title
         assert "truncate" not in title
+        assert "n26-icon-inline" not in title
         assert "Deprecated" in title
 
     def test_a_short_name_still_holds_its_badge_on_one_line(self):

--- a/n26/core/test_select_native.py
+++ b/n26/core/test_select_native.py
@@ -1,0 +1,53 @@
+"""How a native multiple select shows what is chosen.
+
+No database: the kit paints every option the input's own fill, so a
+chosen row and an unchosen one read as the same. The override drops
+that fill on a list and marks option:checked instead.
+"""
+
+from django.template import Context, Template
+from django_cotton.compiler_regex import CottonCompiler
+
+
+def render(source: str, **context) -> str:
+    """Compile a call site the way the template loader would, then render it.
+
+    Cotton's `<c-…>` tags are rewritten by a loader, so a template built from a
+    string never sees them. Running the compiler by hand is what lets a test
+    write the call site it is testing.
+    """
+    return Template(CottonCompiler().process(source)).render(Context(context))
+
+
+class TestAMultipleSelectShowsWhatIsChosen:
+    """A short list stays a native <select multiple>. The chosen row
+    has to carry a mark the unchosen rows do not."""
+
+    def test_a_list_is_not_drawn_as_a_dropdown(self):
+        html = render(
+            '<c-ui.select.native name="types" placeholder="" multiple>'
+            '<c-ui.select.option value="fighter" :selected="True">'
+            "Fighter</c-ui.select.option>"
+            '<c-ui.select.option value="vehicle">Vehicle</c-ui.select.option>'
+            "</c-ui.select.native>"
+        )
+
+        assert "n26-select-multiple" in html
+        assert "appearance-none" not in html
+        assert "background-image" not in html
+        assert "multiple" in html[html.index("<select") : html.index("</select>")]
+        assert "selected" in html
+        assert "Fighter" in html
+        assert "Vehicle" in html
+
+    def test_a_one_of_many_select_keeps_its_chevron(self):
+        html = render(
+            '<c-ui.select.native name="gang" placeholder="">'
+            '<c-ui.select.option value="escher">Escher</c-ui.select.option>'
+            "</c-ui.select.native>"
+        )
+
+        assert "n26-select-multiple" not in html
+        assert "appearance-none" in html
+        assert "background-image" in html
+        assert "multiple" not in html[html.index("<select") : html.index(">")]

--- a/n26/designsystem/assets/app.css
+++ b/n26/designsystem/assets/app.css
@@ -1378,3 +1378,26 @@ a[data-busy="on"] {
 [data-busy-replaces] a[data-busy="on"]::after {
     content: none;
 }
+
+/* A native <select multiple> is a list, not a dropdown. The kit paints
+ * every option the input's fill, which hides the browser's selected
+ * highlight in both modes — and its chevron is for a one-of-many
+ * select. Unlayered so the mark beats leftover option-fill utilities.
+ * The linear-gradient form is what Chrome will honour on option:checked;
+ * a plain background-color is ignored in favour of the system highlight,
+ * which on a dark page is the same ink as an unchosen row. */
+select.n26-select-multiple {
+    appearance: auto;
+    background-image: none;
+    min-height: 4.5rem;
+}
+
+select.n26-select-multiple option:checked {
+    background-color: var(--color-accent);
+    background-image: linear-gradient(
+        0deg,
+        var(--color-accent) 0%,
+        var(--color-accent) 100%
+    );
+    color: var(--color-accent-foreground);
+}

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -223,7 +223,9 @@ GROUPS: list[Group] = [
                 notes=(
                     'variant="native" (the default) needs no JS and gets the platform '
                     'picker. variant="listbox" routes to c-ui.menu, and its slot must '
-                    "then contain c-ui.menu.item — not c-ui.select.option."
+                    "then contain c-ui.menu.item — not c-ui.select.option. A multiple "
+                    "native select is a list: the kit's option fill would hide which "
+                    "rows are chosen, so the override marks option:checked instead."
                 ),
                 parts=(
                     Part(

--- a/n26/designsystem/templates/designsystem/demos/radio-cards/30-wrapping.html
+++ b/n26/designsystem/templates/designsystem/demos/radio-cards/30-wrapping.html
@@ -1,0 +1,22 @@
+{# title: A sentence-long name wraps #}
+{# note: wrap lets a name that is a sentence run to several lines. The badge follows the last word rather than holding the line open. #}
+{# layout: col #}
+<c-n26.radio-cards label="Who it reaches" min="15rem">
+    <c-n26.radio-cards.card name="demo-scope"
+                            value="gang-and-models"
+                            label="The gang carrying it and all models"
+                            description="Affects the gang and all models, in a different way per effect. Use with care."
+                            :wrap="True"
+                            :checked="True">
+        <c-slot name="flair">
+            <c-ui.badge color="amber" size="sm">
+                Deprecated
+            </c-ui.badge>
+        </c-slot>
+    </c-n26.radio-cards.card>
+    <c-n26.radio-cards.card name="demo-scope"
+                            value="gang"
+                            label="The gang carrying it"
+                            description="Applied only to the gang; does not reach the models."
+                            :wrap="True" />
+</c-n26.radio-cards>

--- a/n26/designsystem/templates/designsystem/demos/select/40-multiple.html
+++ b/n26/designsystem/templates/designsystem/demos/select/40-multiple.html
@@ -1,0 +1,14 @@
+{# title: The chosen row is marked #}
+{# note: A multiple select is a list. Chosen rows take the accent fill; without that mark, Fighter and Vehicle read as the same. #}
+{# layout: col #}
+<c-ui.select.native name="demo-profile-types"
+                    id="demo-profile-types"
+                    placeholder=""
+                    multiple>
+    <c-ui.select.option value="fighter" :selected="True">
+        Fighter
+    </c-ui.select.option>
+    <c-ui.select.option value="vehicle">
+        Vehicle
+    </c-ui.select.option>
+</c-ui.select.native>

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -85,10 +85,12 @@ class TestTheRadioCardsPage:
         page = reader.get("/n26/design/c/radio-cards/").content.decode()
         assert "One of these" in page
         assert "No badges, no detail, and a wider card" in page
+        assert "A sentence-long name wraps" in page
         # From the markup the demos rendered, not from their titles: a demo
         # directory the catalog cannot find yields "No examples yet" instead.
         assert 'name="demo-gang-type"' in page
         assert 'name="demo-purpose"' in page
+        assert 'name="demo-scope"' in page
 
 
 class TestTheTickListPage:

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -173,6 +173,18 @@ class TestTheOwnedDialogsPage:
         assert "Everything goes together. 91¢." in page
 
 
+class TestTheSelectPage:
+    """Its demos reach the gallery drawn, not as a polite fallback."""
+
+    def test_the_multiple_demo_draws_a_list_not_a_dropdown(self, reader):
+        page = reader.get("/n26/design/c/select/").content.decode()
+        assert "The chosen row is marked" in page
+        assert 'name="demo-profile-types"' in page
+        assert "n26-select-multiple" in page
+        assert "Fighter" in page
+        assert "Vehicle" in page
+
+
 class TestTheFilterSelectsPage:
     """Its props and its demos reach the gallery, and the select survives."""
 

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -4783,6 +4783,9 @@ class TestTheKindCards:
             fieldset = chunk.split("</fieldset>")[0]
             if 'name="scope_kind"' in fieldset or 'name="effect_kind"' in fieldset:
                 assert "truncate" not in fieldset
+                # wrap drops nowrap on the name plus its pill, so a long
+                # kind name and Deprecated stay inside the card.
+                assert "whitespace-nowrap" not in fieldset
 
     def test_the_cards_still_answer_to_the_selects_field_names(
         self, author, client, default_pack

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -6929,7 +6929,35 @@ class TestThePickersStillPostWhatTheySay:
         picker = re.search(r'<select[^>]*name="traits".*?</select>', body, re.S)
         assert picker, "the traits picker is not a <select>"
         assert "multiple" in picker.group(0)
+        assert "n26-select-multiple" in picker.group(0)
         assert f'value="{rending.pk}"' in picker.group(0)
+
+
+class TestAShortManyPickerShowsWhatIsChosen:
+    """Profile types is two options. Below min_options the filter box
+    leaves the native select in view, so the chosen row has to look
+    chosen."""
+
+    def test_the_profile_types_list_marks_the_chosen_row(
+        self, author, client, default_pack, fighter_type, vehicle_type
+    ):
+        body = client.get(
+            "/n26/authoring/modifiers/new/"
+            "?scope_kind=targets_model&effect_kind=ef_adds&chips=1"
+            "&conditions-0-kind=is_profile_type"
+            f"&conditions-0-profile_types={fighter_type.pk}"
+        ).content.decode()
+        picker = re.search(
+            r'<select[^>]*name="conditions-0-profile_types".*?</select>',
+            body,
+            re.S,
+        )
+        assert picker, "the profile types picker is not a <select>"
+        tag = picker.group(0)
+        assert "multiple" in tag
+        assert "n26-select-multiple" in tag
+        assert "Fighter" in tag
+        assert "Vehicle" in tag
 
 
 class TestTheDocumentation:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two authoring visual bugs on the modifier composer.

**Radio-card titles overflowed.** A long kind title plus a Deprecated pill (for example “The gang carrying it and all models”) sat on `c-n26.flair-link`, which is `inline-flex` and `whitespace-nowrap`. The title could not wrap, so the pill rode out through the card border. Wrapping cards now pass `wrap` through to the flair-link: the title can break, the pill stays on the line, and the card grid is `min-w-0` so the flex item can shrink.

**A short multiple select hid what was chosen.** Profile types is two options, so the filter box leaves the native `<select multiple>` in view. The kit paints every option the input’s own fill, which hides the browser’s selected highlight — Fighter and Vehicle then read as the same — and draws a dropdown chevron on a list that does not open. The native override drops that chrome on `multiple` and marks `option:checked` with the accent fill (Chrome only honours the linear-gradient form).

## How to try it

- `/n26/authoring/modifiers/new/` — the Deprecated kind card should keep its pill inside the border
- `/n26/authoring/modifiers/new/?scope_kind=targets_model&effect_kind=ef_adds&chips=1&conditions-0-kind=is_profile_type` — select Fighter; the chosen row should take the accent
- `/n26/design/c/radio-cards/` — “A sentence-long name wraps”
- `/n26/design/c/select/` — “The chosen row is marked”

[Profile types list with Fighter selected and accent-filled](https://cursor.com/agents/bc-b0fdc043-6560-4563-a1fb-c4039b2e86ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprofile_types_fighter_selected.webp)
[Gallery demo of a multiple select with Fighter marked](https://cursor.com/agents/bc-b0fdc043-6560-4563-a1fb-c4039b2e86ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fselect_gallery_chosen_row.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0fdc043-6560-4563-a1fb-c4039b2e86ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0fdc043-6560-4563-a1fb-c4039b2e86ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

