### PR TITLE
fix: omit the Add prompt from n26 printed slot rows

### DIFF
--- a/n26/core/printing.py
+++ b/n26/core/printing.py
@@ -87,12 +87,9 @@ def detail_groups(card) -> list[DetailGroup]:
     if card.equipment:
         groups.append(DetailGroup("Gear", ", ".join(e.name for e in card.equipment)))
     for choice in card.questions:
-        chosen = choice.chosen or "—"
-        if choice.is_resolved and not choice.is_full:
-            # On paper as on screen: a choice with room left says so,
-            # because the sheet is read away from the picker.
-            chosen = f"{chosen} (add)"
-        groups.append(DetailGroup(choice.kind_label, chosen))
+        # What it holds, or a blank. The Add on the screen card is a way
+        # into the picker, and nothing on paper can be added.
+        groups.append(DetailGroup(choice.kind_label, choice.chosen or "—"))
     for effect in card.effects:
         # "(when taken)" on paper as on screen. A printed card is read away
         # from the application, so an effect that has not happened yet has to

--- a/n26/core/test_printing.py
+++ b/n26/core/test_printing.py
@@ -9,7 +9,8 @@ in it.
 
 from dataclasses import dataclass
 
-from n26.core.printing import balance_columns, estimate_lines
+from n26.core.printing import balance_columns, detail_groups, estimate_lines
+from n26.core.render import ChoiceLine, ModelCard, Statline
 
 
 @dataclass(frozen=True)
@@ -96,3 +97,41 @@ class TestBalanceColumns:
         worse, and a greedy fill gets this wrong."""
         groups = [Group("a", 20), Group("b", 3), Group("c", 3), Group("d", 3)]
         assert labels(balance_columns(groups)) == [["a"], ["b", "c", "d"]]
+
+
+def card_with(*choices):
+    return ModelCard(
+        name="Ozostium",
+        rating=430,
+        statline=Statline(),
+        choices=list(choices),
+    )
+
+
+class TestDetailGroups:
+    """What a printed card writes for its loose assignables.
+
+    The column split is tested above; this is the words that go into it.
+    """
+
+    def test_a_partial_several_pick_prints_what_it_holds(self):
+        """Paper cannot add another pick. The Add on the screen card is a
+        way into the picker, and a printed card is read away from one."""
+        card = card_with(
+            ChoiceLine(
+                kind_label="Lasting Injuries",
+                chosen="Head Injury",
+                takes_several=True,
+                is_full=False,
+            )
+        )
+        groups = detail_groups(card)
+        assert [(group.label, group.text) for group in groups] == [
+            ("Lasting Injuries", "Head Injury")
+        ]
+
+    def test_an_unresolved_choice_prints_as_a_blank(self):
+        """An empty slot is a write-in on paper, not a prompt."""
+        card = card_with(ChoiceLine(kind_label="Archetype", chosen=None))
+        groups = detail_groups(card)
+        assert [(group.label, group.text) for group in groups] == [("Archetype", "—")]

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -441,3 +441,18 @@ class TestTheModelCardsTooltips:
         assert ">Choose</" in legacy[: legacy.index("</dd>")]
         injuries = page[page.index("Lasting Injuries</dt>") :]
         assert ">Add</" in injuries[: injuries.index("</dd>")]
+
+
+class TestThePrintSheet:
+    """Paper shows what a slot holds, not the control that fills it.
+
+    The sample card carries lasting injuries with room left, so the
+    screen card draws Add beside them. A printed card is read away from
+    the picker, and the Add has nowhere to go.
+    """
+
+    def test_a_partial_several_pick_does_not_print_add(self, reader):
+        page = reader.get("/n26/design/print/sheet/?specimen=cards").content.decode()
+        assert "Lasting Injuries" in page
+        assert "Eye Injury, Out Cold" in page
+        assert "(add)" not in page


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A several-pick slot that still has room — Lasting Injuries with one result, for example — drew **Add** on the screen card so the owner could pick again. Print copied that onto paper as `(add)` after the held names, so a card read "Head Injury (add)".

Nothing on paper can be added. `detail_groups` now writes only what the slot holds, or a dash if it is empty. The screen card is unchanged: Add still sits beside an open several-pick.

**How to try it**

- Print lab: `/n26/design/print/sheet/?specimen=cards` — Vesna Krail's Lasting Injuries should read "Eye Injury, Out Cold" with no `(add)`.
- Or print any gang whose fighter has a lasting injury and room for another.

**After**

[Printed fighter card: Lasting Injuries shows Eye Injury, Out Cold with no (add)](https://cursor.com/agents/bc-694fd56c-d140-4308-a69d-97df3b758198/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprint_card_after.png)

[Lasting Injuries print row without (add)](https://cursor.com/agents/bc-694fd56c-d140-4308-a69d-97df3b758198/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprint_lasting_injuries_after.png)

[Screen card still draws Add beside Lasting Injuries](https://cursor.com/agents/bc-694fd56c-d140-4308-a69d-97df3b758198/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreen_lasting_injuries_still_has_add.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-694fd56c-d140-4308-a69d-97df3b758198?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-694fd56c-d140-4308-a69d-97df3b758198&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

