### PR TITLE
fix: draw the model card Choose link at the same xs size as Add

### DIFF
--- a/n26/core/templates/cotton/n26/model_card/body.html
+++ b/n26/core/templates/cotton/n26/model_card/body.html
@@ -202,13 +202,13 @@ carries one menu right beside its name, drawn by <c-n26.owned-actions>.
                 {% comment %}
                 A choice of one is chosen; a choice of several has picks
                 added to it, and keeps its Add beside what it holds while
-                there is room. The Add is one size whether or not anything
-                is held yet, so the control does not shrink the moment a
-                pick lands.
+                there is room. Choose and Add are the same size, and Add
+                stays that size whether or not anything is held yet, so
+                the control does not shrink the moment a pick lands.
                 {% endcomment %}
                 {% if choice.takes_several and choice.is_resolved and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="ms-2 text-xs">Add</c-n26.link>
                 {% elif choice.takes_several and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="text-xs">Add</c-n26.link>
-                {% elif not choice.is_resolved and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always">Choose</c-n26.link>{% endif %}
+                {% elif not choice.is_resolved and not choice.is_full %}<c-n26.link href="{{ choice.href }}" underline="always" class="text-xs">Choose</c-n26.link>{% endif %}
             </dd>
         {% endfor %}
 

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -452,9 +452,13 @@ class TestTheModelCardsTooltips:
         thing."""
         page = reader.get("/n26/design/c/model-card/").content.decode()
         legacy = page[page.index("Gang Legacy</dt>") :]
-        assert ">Choose</" in legacy[: legacy.index("</dd>")]
+        legacy_dd = legacy[: legacy.index("</dd>")]
+        assert ">Choose</" in legacy_dd
+        assert "text-xs" in legacy_dd
         injuries = page[page.index("Lasting Injuries</dt>") :]
-        assert ">Add</" in injuries[: injuries.index("</dd>")]
+        injuries_dd = injuries[: injuries.index("</dd>")]
+        assert ">Add</" in injuries_dd
+        assert "text-xs" in injuries_dd
 
 
 class TestThePrintSheet:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A one-pick slot’s **Choose** sat at the card’s body size. A several-pick slot’s **Add** is `text-xs`. On a fighter card that meant Archetype or Gang Legacy’s way in looked like a different kind of control from Lasting Injuries’.

Choose now uses the same `text-xs` class as Add. Both compute at 12px.

## How to try it

- Any gang sheet whose model still has an open one-pick slot (Archetype, Gang Legacy, Affiliation, and the like) next to a Lasting Injuries **Add**
- `/n26/design/c/model-card/` — Gang Legacy **Choose** and Lasting Injuries **Add**

[Choose and Add on the fighter card, both text-xs](https://cursor.com/agents/bc-b0fdc043-6560-4563-a1fb-c4039b2e86ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffighter_card_choose_xs_after.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0fdc043-6560-4563-a1fb-c4039b2e86ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0fdc043-6560-4563-a1fb-c4039b2e86ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

