### PR TITLE
fix: prose says every model-scope narrowing, and a guard holds it to CONDITIONS

### DIFF
--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -683,7 +683,9 @@ def _narrowed(who, scope):
     subject, possessive, plural = who.subject, who.possessive, who.plural
     if said.named:
         subject = _and_then(said.named)
-        plural = True
+        # Names are said as authored and never inflected, so one name is
+        # one subject: "Champion gains", "Champion and Leader gain".
+        plural = len(said.named) != 1
     elif said.typed:
         # A Type is a possession every model has exactly one of, so the
         # narrowing reads as the model's own word — "every vehicle" —

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -519,6 +519,14 @@ def _and_then(names):
     return f"{', '.join(names[:-1])} and {names[-1]}"
 
 
+def _one_of(names):
+    """Several things any one of which will do, said as a list."""
+    names = list(names)
+    if len(names) == 1:
+        return names[0]
+    return f"{', '.join(names[:-1])} or {names[-1]}"
+
+
 def sentence_for(modifier, carriage=UNATTACHED, thing=None, chain=None):
     """One modifier, as a sentence about whoever carries it.
 
@@ -615,7 +623,7 @@ def _names_entries(row, said):
 def _names_type(row, said):
     types = [str(one).lower() for one in row.profile_types.all()]
     if types:
-        # An empty row narrows nothing, as its condition matches nothing.
+        # An empty row says nothing, as its condition narrows nothing.
         said.typed.append((row.negate, types))
 
 
@@ -680,8 +688,10 @@ def _narrowed(who, scope):
         else:
             subject = f"every {_and_then(types)}"
         plural = False
+    # A row naming several picks is satisfied by any one of them, so the
+    # sentence says "or": "with" holding any, "without" holding none.
     for negate, picks in said.holdings:
-        subject = f"{subject} {'without' if negate else 'with'} {_and_then(picks)}"
+        subject = f"{subject} {'without' if negate else 'with'} {_one_of(picks)}"
     if said.named or said.typed or said.holdings:
         possessive = f"{subject}'" if subject.endswith("s") else f"{subject}'s"
         weapons = " ".join([f"{possessive} weapons", *of_weapons])

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -41,7 +41,7 @@ warn about. It never explains how the app is built and never argues the
 design.
 """
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 
 from django.utils.text import capfirst
 
@@ -584,6 +584,47 @@ def _effect_field(modifier):
     return None
 
 
+@dataclass
+class _Narrowings:
+    """What a model scope's conditions have said, sorted by the shape
+    each takes in the sentence."""
+
+    #: Ranks or entries named outright: they replace the subject.
+    named: list = field(default_factory=list)
+    #: A Type narrowing, as ``(negated, lowercased type names)``.
+    typed: list = field(default_factory=list)
+    #: Picks the model must hold, as ``(negated, names)``.
+    holdings: list = field(default_factory=list)
+    #: Clauses about the moment rather than the model.
+    clauses: list = field(default_factory=list)
+
+
+#: How each condition a model scope can carry reaches the sentence, by
+#: the condition's related name on the scope. A kind missing here would
+#: be dropped without a word, so a test holds this to the scope's own
+#: ``CONDITIONS``; a weapon scope's conditions join the noun phrase in
+#: their own words instead.
+MODEL_NARROWINGS = {
+    "has_subtypes": lambda row, said: said.named.extend(
+        str(one) for one in row.subtypes.all()
+    ),
+    "is_profile": lambda row, said: said.named.extend(
+        str(one) for one in row.profiles.all()
+    ),
+    "is_profile_type": lambda row, said: (
+        (types := [str(one).lower() for one in row.profile_types.all()])
+        and said.typed.append((row.negate, types))
+    ),
+    "has_pickable": lambda row, said: (
+        (picks := [str(one) for one in row.pickables.all()])
+        and said.holdings.append((row.negate, picks))
+    ),
+    "counter_at_least": lambda row, said: said.clauses.append(
+        f"while their {row.counter} is {row.at_least} or more"
+    ),
+}
+
+
 def _narrowed(who, scope):
     """The subject once the scope's conditions have had their say.
 
@@ -600,42 +641,37 @@ def _narrowed(who, scope):
     """
     if not getattr(scope, "CONDITIONS", ()) or scope.pk is None:
         return who, ""
-    named, typed, clauses, of_weapons = [], [], [], []
+    said = _Narrowings()
+    of_weapons = []
     for related in scope.CONDITIONS:
+        say = MODEL_NARROWINGS.get(related)
         for row in getattr(scope, related).all():
-            if related == "has_subtypes":
-                named.extend(str(one) for one in row.subtypes.all())
-            elif related == "is_profile":
-                named.extend(str(one) for one in row.profiles.all())
-            elif related == "is_profile_type":
-                types = [str(one).lower() for one in row.profile_types.all()]
-                if types:
-                    typed.append((row.negate, types))
-            elif related == "counter_at_least":
-                clauses.append(f"while their {row.counter} is {row.at_least} or more")
+            if say is not None:
+                say(row, said)
             else:
                 of_weapons.append(str(row))
-    lead = " and ".join(clauses)
+    lead = " and ".join(said.clauses)
     weapons = " ".join([who.weapons, *of_weapons])
     subject, possessive, plural = who.subject, who.possessive, who.plural
-    if named:
-        subject = _and_then(named)
-        possessive = f"{subject}'" if subject.endswith("s") else f"{subject}'s"
-        weapons = " ".join([f"{possessive} weapons", *of_weapons])
+    if said.named:
+        subject = _and_then(said.named)
         plural = True
-    elif typed:
+    elif said.typed:
         # A Type is a possession every model has exactly one of, so the
         # narrowing reads as the model's own word — "every vehicle" —
         # in place of the gang-wide "every fighter". Ranks named
         # alongside are the more specific narrowing and win above.
-        negate, types = typed[0]
+        negate, types = said.typed[0]
         if negate:
             subject = "every model except " + _and_then(f"{kind}s" for kind in types)
         else:
             subject = f"every {_and_then(types)}"
-        possessive = f"{subject}'s"
-        weapons = " ".join([f"{possessive} weapons", *of_weapons])
         plural = False
+    for negate, picks in said.holdings:
+        subject = f"{subject} {'without' if negate else 'with'} {_and_then(picks)}"
+    if said.named or said.typed or said.holdings:
+        possessive = f"{subject}'" if subject.endswith("s") else f"{subject}'s"
+        weapons = " ".join([f"{possessive} weapons", *of_weapons])
     return (
         _Who(
             subject=subject,

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -604,24 +604,37 @@ class _Narrowings:
 #: be dropped without a word, so a test holds this to the scope's own
 #: ``CONDITIONS``; a weapon scope's conditions join the noun phrase in
 #: their own words instead.
+def _names_ranks(row, said):
+    said.named.extend(str(one) for one in row.subtypes.all())
+
+
+def _names_entries(row, said):
+    said.named.extend(str(one) for one in row.profiles.all())
+
+
+def _names_type(row, said):
+    types = [str(one).lower() for one in row.profile_types.all()]
+    if types:
+        # An empty row narrows nothing, as its condition matches nothing.
+        said.typed.append((row.negate, types))
+
+
+def _names_pick(row, said):
+    picks = [str(one) for one in row.pickables.all()]
+    if picks:
+        said.holdings.append((row.negate, picks))
+
+
+def _names_threshold(row, said):
+    said.clauses.append(f"while their {row.counter} is {row.at_least} or more")
+
+
 MODEL_NARROWINGS = {
-    "has_subtypes": lambda row, said: said.named.extend(
-        str(one) for one in row.subtypes.all()
-    ),
-    "is_profile": lambda row, said: said.named.extend(
-        str(one) for one in row.profiles.all()
-    ),
-    "is_profile_type": lambda row, said: (
-        (types := [str(one).lower() for one in row.profile_types.all()])
-        and said.typed.append((row.negate, types))
-    ),
-    "has_pickable": lambda row, said: (
-        (picks := [str(one) for one in row.pickables.all()])
-        and said.holdings.append((row.negate, picks))
-    ),
-    "counter_at_least": lambda row, said: said.clauses.append(
-        f"while their {row.counter} is {row.at_least} or more"
-    ),
+    "has_subtypes": _names_ranks,
+    "is_profile": _names_entries,
+    "is_profile_type": _names_type,
+    "has_pickable": _names_pick,
+    "counter_at_least": _names_threshold,
 }
 
 

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -138,6 +138,25 @@ class _Who:
     persistence: str
     #: Who an offer is put to.
     asked: str = "them"
+    #: Whether a narrowing may follow the subject as a phrase — "every
+    #: fighter with Cawdor". A pronoun or a clause cannot take one, and
+    #: its narrowings lead the sentence instead: "While holding Cawdor,
+    #: they gain …".
+    qualifiable: bool = True
+    #: Whether a narrowing has been appended to ``subject``, so that a
+    #: possessive can no longer be made by adding 's — "every fighter
+    #: with Cawdor's weapons" hands the weapons to Cawdor — and what is
+    #: owned is said the long way round instead (``_owned``).
+    qualified: bool = False
+
+
+def _owned(who, thing):
+    """What the subject has, as a noun phrase: "their Ballistic Skill",
+    or "the Ballistic Skill of every fighter with Cawdor" once the
+    subject carries a narrowing of its own."""
+    if who.qualified:
+        return f"the {thing} of {who.subject}"
+    return f"{who.possessive} {thing}"
 
 
 def _a(name):
@@ -182,6 +201,7 @@ def _who(carriage, thing=None):
             weapons="the weapons of whoever ends up carrying this",
             plural=False,
             persistence="while they carry it",
+            qualifiable=False,
         )
     return _Who(
         subject="they",
@@ -189,6 +209,7 @@ def _who(carriage, thing=None):
         weapons="their weapons",
         plural=True,
         persistence="while they have it",
+        qualifiable=False,
     )
 
 
@@ -364,7 +385,7 @@ def _says_changes_stat(effect, parts):
             hint,
         )
     return (
-        f"{who.possessive} {effect.stat.full_name} is {change}{_while(who)}.",
+        f"{_owned(who, effect.stat.full_name)} is {change}{_while(who)}.",
         hint,
     )
 
@@ -428,7 +449,7 @@ def _says_places_category(effect, parts):
                 "not happen, and the plan says why."
             ),
         )
-    return f"{who.possessive} {effect.category.name} set appears as {section}.", hint
+    return f"{_owned(who, f'{effect.category.name} set')} appears as {section}.", hint
 
 
 @_renders("requires_companions")
@@ -494,7 +515,7 @@ def _says_op_adds_miniature(effect, parts):
 @_renders("op_changes_counter")
 def _says_op_changes_counter(effect, parts):
     who = parts.who
-    counter = f"{who.possessive} {effect.counter}"
+    counter = _owned(who, str(effect.counter))
     if effect.mode == effect.Mode.ADD:
         moved = f"{effect.amount} is added to {counter}"
     elif effect.mode == effect.Mode.SUBTRACT:
@@ -511,20 +532,13 @@ def _says_op_changes_counter(effect, parts):
     )
 
 
-def _and_then(names):
-    """Several things a chain hands on, said as a list."""
+def _and_then(names, joiner="and"):
+    """Several names said as a list — "A, B and C", or with ``joiner``
+    "or" where any one of them will do."""
     names = list(names)
     if len(names) == 1:
         return names[0]
-    return f"{', '.join(names[:-1])} and {names[-1]}"
-
-
-def _one_of(names):
-    """Several things any one of which will do, said as a list."""
-    names = list(names)
-    if len(names) == 1:
-        return names[0]
-    return f"{', '.join(names[:-1])} or {names[-1]}"
+    return f"{', '.join(names[:-1])} {joiner} {names[-1]}"
 
 
 def sentence_for(modifier, carriage=UNATTACHED, thing=None, chain=None):
@@ -594,46 +608,59 @@ def _effect_field(modifier):
 
 @dataclass
 class _Narrowings:
-    """What a model scope's conditions have said, sorted by the shape
+    """What a model scope's conditions narrow it to, sorted by the shape
     each takes in the sentence."""
 
-    #: Ranks or entries named outright: they replace the subject.
+    #: Ranks or entries named outright: they become the subject.
     named: list = field(default_factory=list)
-    #: Ranks or entries the row leaves out: they follow the subject.
-    excepted: list = field(default_factory=list)
-    #: A Type narrowing, as ``(negated, lowercased type names)``.
-    typed: list = field(default_factory=list)
-    #: Picks the model must hold, as ``(negated, names)``.
-    holdings: list = field(default_factory=list)
+    #: Types the model must be, lowercased: "vehicle".
+    types: list = field(default_factory=list)
+    #: Ranks, entries or types the row leaves out, worded: "Champion",
+    #: "vehicles".
+    left_out: list = field(default_factory=list)
+    #: Whether one of ``left_out`` is a Type, which widens a gang-wide
+    #: subject to "every model" — a vehicle left out of "every fighter"
+    #: would read as though vehicles were fighters.
+    a_type_left_out: bool = False
+    #: Picks the model must hold or not hold, worded: "with Cawdor",
+    #: "without Cawdor or Delaque".
+    picks: list = field(default_factory=list)
     #: Clauses about the moment rather than the model.
     clauses: list = field(default_factory=list)
 
 
-def _names_ranks(row, said):
+def _names_ranks(row, found):
     names = [str(one) for one in row.subtypes.all()]
-    (said.excepted if row.negate else said.named).extend(names)
+    (found.left_out if row.negate else found.named).extend(names)
 
 
-def _names_entries(row, said):
+def _names_entries(row, found):
     names = [str(one) for one in row.profiles.all()]
-    (said.excepted if row.negate else said.named).extend(names)
+    (found.left_out if row.negate else found.named).extend(names)
 
 
-def _names_type(row, said):
+def _names_type(row, found):
     types = [str(one).lower() for one in row.profile_types.all()]
-    if types:
+    if not types:
         # An empty row says nothing, as its condition narrows nothing.
-        said.typed.append((row.negate, types))
+        return
+    if row.negate:
+        found.left_out.extend(f"{kind}s" for kind in types)
+        found.a_type_left_out = True
+    else:
+        found.types.extend(types)
 
 
-def _names_pick(row, said):
+def _names_pick(row, found):
     picks = [str(one) for one in row.pickables.all()]
     if picks:
-        said.holdings.append((row.negate, picks))
+        # A row naming several picks is satisfied by any one of them.
+        held = _and_then(picks, "or")
+        found.picks.append(f"without {held}" if row.negate else f"with {held}")
 
 
-def _names_threshold(row, said):
-    said.clauses.append(f"while their {row.counter} is {row.at_least} or more")
+def _names_threshold(row, found):
+    found.clauses.append(f"while their {row.counter} is {row.at_least} or more")
 
 
 #: How each condition a model scope can carry reaches the sentence, by
@@ -655,61 +682,76 @@ def _narrowed(who, scope):
     """The subject once the scope's conditions have had their say.
 
     Each narrowing has its own shape, because each means something
-    different. Ranks or entries named replace the subject outright —
-    "Champion and Leader" says who is reached better than any pronoun
-    could, in the names as authored, because a content name is never
-    inflected — and follow it after "except" when the row leaves them
-    out. A Type is the model's own word: "every vehicle". A pick held
-    joins as "with" or "without". A threshold becomes a clause in front,
-    being a condition on the moment rather than on the person, and the
-    sentence then drops its own "while" so as not to say the same thing
-    twice. A narrowing of the weapons joins the noun phrase, in the
-    words the condition row says of itself, so the modifier's own name
-    and this sentence cannot come to describe the selection differently.
+    different. Ranks or entries named become the subject — "Champion and
+    Leader" says who is reached better than any pronoun could, in the
+    names as authored, because a content name is never inflected — and
+    a Type beside them is their kind: "Champion vehicles". A Type alone
+    is the model's own word, "every vehicle". Whatever a row leaves out
+    follows after one "except"; a pick held joins as "with" or
+    "without", before the exception so it qualifies the subject and not
+    what was left out. A threshold becomes a clause in front, being a
+    condition on the moment rather than on the person, and the sentence
+    then drops its own "while" so as not to say the same thing twice.
+
+    A subject that is a pronoun or a clause takes no phrase after it, so
+    its narrowings lead the sentence as clauses too: "While holding
+    Cawdor, they gain …". A narrowing of the weapons joins the noun
+    phrase, in the words the condition row says of itself, so the
+    modifier's own name and this sentence cannot come to describe the
+    selection differently.
     """
     if not getattr(scope, "CONDITIONS", ()) or scope.pk is None:
         return who, ""
-    said = _Narrowings()
+    found = _Narrowings()
     of_weapons = []
     for related in scope.CONDITIONS:
-        say = MODEL_NARROWINGS.get(related)
+        record = MODEL_NARROWINGS.get(related)
         for row in getattr(scope, related).all():
-            if say is not None:
-                say(row, said)
+            if record is not None:
+                record(row, found)
             else:
                 of_weapons.append(str(row))
-    lead = " and ".join(said.clauses)
-    weapons = " ".join([who.weapons, *of_weapons])
-    subject, possessive, plural = who.subject, who.possessive, who.plural
-    if said.named:
-        subject = _and_then(said.named)
-        # Names are said as authored and never inflected, so one name is
-        # one subject: "Champion gains", "Champion and Leader gain".
-        plural = len(said.named) != 1
-    elif said.typed:
-        # A Type is a possession every model has exactly one of, so the
-        # narrowing reads as the model's own word — "every vehicle" —
-        # in place of the gang-wide "every fighter". Ranks named
-        # alongside are the more specific narrowing and win above.
-        negate, types = said.typed[0]
-        if negate:
-            # A Type left out joins whatever else is left out, so one
-            # "except" carries them all: "every model except vehicles
-            # and Champion".
-            subject = "every model"
-            said.excepted[:0] = [f"{kind}s" for kind in types]
-        else:
-            subject = f"every {_and_then(types)}"
+
+    subject, plural = who.subject, who.plural
+    if found.named:
+        subject = _and_then(found.named)
+        plural = len(found.named) != 1
+        if found.types:
+            subject = f"{subject} {_and_then(f'{kind}s' for kind in found.types)}"
+            plural = True
+    elif found.types:
+        subject = f"every {_and_then(found.types, 'or')}"
         plural = False
-    if said.excepted:
-        subject = f"{subject} except {_and_then(said.excepted)}"
-    # A row naming several picks is satisfied by any one of them, so the
-    # sentence says "or": "with" holding any, "without" holding none.
-    for negate, picks in said.holdings:
-        subject = f"{subject} {'without' if negate else 'with'} {_one_of(picks)}"
-    if said.named or said.excepted or said.typed or said.holdings:
-        possessive = f"{subject}'" if subject.endswith("s") else f"{subject}'s"
-        weapons = " ".join([f"{possessive} weapons", *of_weapons])
+    elif found.a_type_left_out and who.qualifiable:
+        subject = "every model"
+
+    clauses = list(found.clauses)
+    qualified = False
+    if who.qualifiable or subject != who.subject:
+        if found.picks:
+            subject = f"{subject} {' and '.join(found.picks)}"
+        if found.left_out:
+            subject = f"{subject} except {_and_then(found.left_out)}"
+        qualified = bool(found.picks or found.left_out)
+    else:
+        # "They with Cawdor" is no sentence: a pronoun's narrowings are
+        # said up front instead, and the closing "while" gives way to them.
+        clauses.extend(
+            "while "
+            + phrase.replace("with", "holding", 1).replace("withouting", "not holding")
+            for phrase in found.picks
+        )
+        if found.left_out:
+            clauses.append(f"unless they are {_and_then(found.left_out, 'or')}")
+    lead = " and ".join(clauses)
+
+    possessive, weapons = who.possessive, " ".join([who.weapons, *of_weapons])
+    if subject != who.subject:
+        if qualified:
+            weapons = " ".join([f"the weapons of {subject}", *of_weapons])
+        else:
+            possessive = f"{subject}'" if subject.endswith("s") else f"{subject}'s"
+            weapons = " ".join([f"{possessive} weapons", *of_weapons])
     return (
         _Who(
             subject=subject,
@@ -718,6 +760,8 @@ def _narrowed(who, scope):
             plural=plural,
             persistence="" if lead else who.persistence,
             asked=who.asked,
+            qualifiable=who.qualifiable,
+            qualified=qualified,
         ),
         lead,
     )

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -693,7 +693,11 @@ def _narrowed(who, scope):
         # alongside are the more specific narrowing and win above.
         negate, types = said.typed[0]
         if negate:
-            subject = "every model except " + _and_then(f"{kind}s" for kind in types)
+            # A Type left out joins whatever else is left out, so one
+            # "except" carries them all: "every model except vehicles
+            # and Champion".
+            subject = "every model"
+            said.excepted[:0] = [f"{kind}s" for kind in types]
         else:
             subject = f"every {_and_then(types)}"
         plural = False

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -599,6 +599,8 @@ class _Narrowings:
 
     #: Ranks or entries named outright: they replace the subject.
     named: list = field(default_factory=list)
+    #: Ranks or entries the row leaves out: they follow the subject.
+    excepted: list = field(default_factory=list)
     #: A Type narrowing, as ``(negated, lowercased type names)``.
     typed: list = field(default_factory=list)
     #: Picks the model must hold, as ``(negated, names)``.
@@ -607,17 +609,14 @@ class _Narrowings:
     clauses: list = field(default_factory=list)
 
 
-#: How each condition a model scope can carry reaches the sentence, by
-#: the condition's related name on the scope. A kind missing here would
-#: be dropped without a word, so a test holds this to the scope's own
-#: ``CONDITIONS``; a weapon scope's conditions join the noun phrase in
-#: their own words instead.
 def _names_ranks(row, said):
-    said.named.extend(str(one) for one in row.subtypes.all())
+    names = [str(one) for one in row.subtypes.all()]
+    (said.excepted if row.negate else said.named).extend(names)
 
 
 def _names_entries(row, said):
-    said.named.extend(str(one) for one in row.profiles.all())
+    names = [str(one) for one in row.profiles.all()]
+    (said.excepted if row.negate else said.named).extend(names)
 
 
 def _names_type(row, said):
@@ -637,6 +636,11 @@ def _names_threshold(row, said):
     said.clauses.append(f"while their {row.counter} is {row.at_least} or more")
 
 
+#: How each condition a model scope can carry reaches the sentence, by
+#: the condition's related name on the scope. A kind missing here would
+#: be dropped without a word, so a test holds this to the scope's own
+#: ``CONDITIONS``; a weapon scope's conditions join the noun phrase in
+#: their own words instead.
 MODEL_NARROWINGS = {
     "has_subtypes": _names_ranks,
     "is_profile": _names_entries,
@@ -649,16 +653,18 @@ MODEL_NARROWINGS = {
 def _narrowed(who, scope):
     """The subject once the scope's conditions have had their say.
 
-    Three shapes, because the three narrowings mean different things. A
-    condition on the ranks replaces the subject outright — "Champion and
-    Leader" says who is reached better than any pronoun could, in the
-    names as authored, because a content name is never inflected. A
-    threshold becomes a clause in front, being a condition on the moment
-    rather than on the person, and the sentence then drops its own
-    "while" so as not to say the same thing twice. A narrowing of the
-    weapons joins the noun phrase, in the words the condition row says
-    of itself, so the modifier's own name and this sentence cannot come
-    to describe the selection differently.
+    Each narrowing has its own shape, because each means something
+    different. Ranks or entries named replace the subject outright —
+    "Champion and Leader" says who is reached better than any pronoun
+    could, in the names as authored, because a content name is never
+    inflected — and follow it after "except" when the row leaves them
+    out. A Type is the model's own word: "every vehicle". A pick held
+    joins as "with" or "without". A threshold becomes a clause in front,
+    being a condition on the moment rather than on the person, and the
+    sentence then drops its own "while" so as not to say the same thing
+    twice. A narrowing of the weapons joins the noun phrase, in the
+    words the condition row says of itself, so the modifier's own name
+    and this sentence cannot come to describe the selection differently.
     """
     if not getattr(scope, "CONDITIONS", ()) or scope.pk is None:
         return who, ""
@@ -688,11 +694,13 @@ def _narrowed(who, scope):
         else:
             subject = f"every {_and_then(types)}"
         plural = False
+    if said.excepted:
+        subject = f"{subject} except {_and_then(said.excepted)}"
     # A row naming several picks is satisfied by any one of them, so the
     # sentence says "or": "with" holding any, "without" holding none.
     for negate, picks in said.holdings:
         subject = f"{subject} {'without' if negate else 'with'} {_one_of(picks)}"
-    if said.named or said.typed or said.holdings:
+    if said.named or said.excepted or said.typed or said.holdings:
         possessive = f"{subject}'" if subject.endswith("s") else f"{subject}'s"
         weapons = " ".join([f"{possessive} weapons", *of_weapons])
     return (

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -622,8 +622,10 @@ class _Narrowings:
     #: subject to "every model" — a vehicle left out of "every fighter"
     #: would read as though vehicles were fighters.
     a_type_left_out: bool = False
-    #: Picks the model must hold or not hold, worded: "with Cawdor",
-    #: "without Cawdor or Delaque".
+    #: Picks the model must hold or not hold, as ``(left out, names said
+    #: as any of them)``: ``(False, "Cawdor")``, ``(True, "Cawdor or
+    #: Delaque")``. Worded where the subject is known, because a phrase
+    #: and a clause say them differently.
     picks: list = field(default_factory=list)
     #: Clauses about the moment rather than the model.
     clauses: list = field(default_factory=list)
@@ -655,8 +657,7 @@ def _names_pick(row, found):
     picks = [str(one) for one in row.pickables.all()]
     if picks:
         # A row naming several picks is satisfied by any one of them.
-        held = _and_then(picks, "or")
-        found.picks.append(f"without {held}" if row.negate else f"with {held}")
+        found.picks.append((row.negate, _and_then(picks, "or")))
 
 
 def _names_threshold(row, found):
@@ -717,7 +718,8 @@ def _narrowed(who, scope):
         subject = _and_then(found.named)
         plural = len(found.named) != 1
         if found.types:
-            subject = f"{subject} {_and_then(f'{kind}s' for kind in found.types)}"
+            kinds = _and_then((f"{kind}s" for kind in found.types), "or")
+            subject = f"{subject} {kinds}"
             plural = True
     elif found.types:
         subject = f"every {_and_then(found.types, 'or')}"
@@ -729,7 +731,11 @@ def _narrowed(who, scope):
     qualified = False
     if who.qualifiable or subject != who.subject:
         if found.picks:
-            subject = f"{subject} {' and '.join(found.picks)}"
+            phrases = [
+                f"{'without' if left_out else 'with'} {held}"
+                for left_out, held in found.picks
+            ]
+            subject = f"{subject} {' and '.join(phrases)}"
         if found.left_out:
             subject = f"{subject} except {_and_then(found.left_out)}"
         qualified = bool(found.picks or found.left_out)
@@ -737,9 +743,8 @@ def _narrowed(who, scope):
         # "They with Cawdor" is no sentence: a pronoun's narrowings are
         # said up front instead, and the closing "while" gives way to them.
         clauses.extend(
-            "while "
-            + phrase.replace("with", "holding", 1).replace("withouting", "not holding")
-            for phrase in found.picks
+            f"while {'not holding' if left_out else 'holding'} {held}"
+            for left_out, held in found.picks
         )
         if found.left_out:
             clauses.append(f"unless they are {_and_then(found.left_out, 'or')}")

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -637,9 +637,10 @@ def _names_threshold(row, said):
 
 
 #: How each condition a model scope can carry reaches the sentence, by
-#: the condition's related name on the scope. A kind missing here would
-#: be dropped without a word, so a test holds this to the scope's own
-#: ``CONDITIONS``; a weapon scope's conditions join the noun phrase in
+#: the condition's related name on the scope. It must name every entry
+#: in the scope's ``CONDITIONS``: a kind missing here would be dropped
+#: without a word, and the sentence would claim a wider reach than the
+#: modifier has. A weapon scope's conditions join the noun phrase in
 #: their own words instead.
 MODEL_NARROWINGS = {
     "has_subtypes": _names_ranks,

--- a/n26/library/references.py
+++ b/n26/library/references.py
@@ -201,10 +201,13 @@ def reading_sentences(modifiers):
         for condition in getattr(related, "CONDITIONS", ()):
             model = related._meta.get_field(condition).related_model
             paths.append(f"{half}__{condition}")
+            # A many-to-many is not a concrete column, and a condition
+            # row's names live there: left out, each row's words are a
+            # query of their own on every sentence.
             paths.extend(
                 f"{half}__{condition}__{field.name}"
                 for field in model._meta.get_fields()
-                if field.concrete and (field.many_to_one or field.many_to_many)
+                if field.many_to_many or (field.concrete and field.many_to_one)
             )
 
     return modifiers.prefetch_related(*paths)

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -1196,6 +1196,13 @@ class TestEveryEffectCanBeSaid:
             "nothing can say is one the reach column drops in silence."
         )
 
+    def test_there_are_model_conditions_to_check(self):
+        from n26.library.models.modifier import TargetsMiniature
+
+        assert {"has_subtypes", "is_profile", "has_pickable"} <= set(
+            TargetsMiniature.CONDITIONS
+        )
+
     def test_every_model_condition_kind_has_words_for_who_it_narrows(self):
         from n26.library.models.modifier import TargetsMiniature
 

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -254,6 +254,27 @@ class TestAPickNarrowsTheSubject:
             "Every fighter with Cawdor gains Backstab, while the gang holds this."
         ]
 
+    def test_several_picks_read_as_any_of_them(self, escher, legacies, backstab):
+        """A row naming two picks reaches a model holding either, and the
+        sentence must not read as though it needs both."""
+        from n26.library.authoring import create_pickable, has_pickable
+
+        delaque = create_pickable("Delaque", legacies.slot_type)
+        attach_modifiers_to(
+            escher,
+            [
+                modifier(
+                    "Either legacy: Backstab",
+                    targets_every_model(has_pickable(legacies, delaque)),
+                    ef_adds(backstab),
+                )
+            ],
+        )
+
+        assert texts(prose_for(escher).does) == [
+            "Every fighter with Cawdor or Delaque gains Backstab, while the gang holds this."
+        ]
+
     def test_negated_it_says_without(self, escher, legacies, backstab):
         from n26.library.authoring import has_pickable
 

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -343,6 +343,34 @@ class TestNarrowingsCompose:
             "While holding Cawdor, they gain Backstab."
         ]
 
+    def test_a_pronouns_pick_left_out_leads_too(self, backstab, cawdor, default_pack):
+        rule = create_rule("Outsiders")
+        attach_modifiers_to(
+            rule,
+            [
+                modifier(
+                    "Outsiders",
+                    targets_model(has_pickable(cawdor, negate=True)),
+                    ef_adds(backstab),
+                )
+            ],
+        )
+        assert texts(prose_for(rule).does) == [
+            "While not holding Cawdor, they gain Backstab."
+        ]
+
+    def test_ranks_of_either_kind_read_or(
+        self, escher, backstab, fighter_type, vehicle_type, default_pack
+    ):
+        champion = create_subtype("Champion")
+        assert self.carried(
+            escher,
+            targets_every_model(
+                has_subtypes(champion), is_profile_type(fighter_type, vehicle_type)
+            ),
+            ef_adds(backstab),
+        ) == ["Champion fighters or vehicles gain Backstab, while the gang holds this."]
+
 
 class TestATypeNarrowsTheSubject:
     """A model's Type is the one narrowing a gang-wide reach can say in

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -197,6 +197,32 @@ class TestOneRankNamed:
         ]
 
 
+class TestATypeAndARankLeftOut:
+    """Two things left out share one "except"."""
+
+    def test_neither_vehicles_nor_champions(
+        self, escher, backstab, vehicle_type, default_pack
+    ):
+        champion = create_subtype("Champion")
+        attach_modifiers_to(
+            escher,
+            [
+                modifier(
+                    "Neither",
+                    targets_every_model(
+                        is_profile_type(vehicle_type, negate=True),
+                        has_subtypes(champion, negate=True),
+                    ),
+                    ef_adds(backstab),
+                )
+            ],
+        )
+
+        assert texts(prose_for(escher).does) == [
+            "Every model except vehicles and Champion gains Backstab, while the gang holds this."
+        ]
+
+
 class TestARankLeftOut:
     """A row that names the ranks it does not reach reads "except", never
     as if it reached those ranks alone."""

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -217,6 +217,62 @@ class TestATypeNarrowsTheSubject:
         ]
 
 
+class TestAPickNarrowsTheSubject:
+    """A model that must hold a pick is said with the pick beside it —
+    the scope's own words, so the sentence and the name agree."""
+
+    @pytest.fixture
+    def legacies(self, default_pack):
+        from n26.library.authoring import (
+            add_picklist_member,
+            create_pickable,
+            create_picklist,
+            create_slot_type,
+        )
+
+        slot_type = create_slot_type("Gang Legacy", plural_name="Gang Legacies")
+        table = create_picklist("Gang Legacies", slot_type)
+        cawdor = create_pickable("Cawdor", slot_type)
+        add_picklist_member(table, cawdor)
+        return cawdor
+
+    def test_a_grant_to_those_holding_a_pick_names_it(self, escher, legacies, backstab):
+        from n26.library.authoring import has_pickable
+
+        attach_modifiers_to(
+            escher,
+            [
+                modifier(
+                    "Cawdor legacy: Backstab",
+                    targets_every_model(has_pickable(legacies)),
+                    ef_adds(backstab),
+                )
+            ],
+        )
+
+        assert texts(prose_for(escher).does) == [
+            "Every fighter with Cawdor gains Backstab, while the gang holds this."
+        ]
+
+    def test_negated_it_says_without(self, escher, legacies, backstab):
+        from n26.library.authoring import has_pickable
+
+        attach_modifiers_to(
+            escher,
+            [
+                modifier(
+                    "No legacy: Backstab",
+                    targets_every_model(has_pickable(legacies, negate=True)),
+                    ef_adds(backstab),
+                )
+            ],
+        )
+
+        assert texts(prose_for(escher).does) == [
+            "Every fighter without Cawdor gains Backstab, while the gang holds this."
+        ]
+
+
 class TestTheMasterOfWhispers:
     """One power from a family, as a Primary pick — a rule doing three
     things, said as a paragraph.
@@ -1138,6 +1194,19 @@ class TestEveryEffectCanBeSaid:
             "n26/library/prose.py decorated @_renders(<the effect's column on "
             "Modifier>), returning the sentence and its hint — an effect "
             "nothing can say is one the reach column drops in silence."
+        )
+
+    def test_every_model_condition_kind_has_words_for_who_it_narrows(self):
+        from n26.library.models.modifier import TargetsMiniature
+
+        missing = sorted(set(TargetsMiniature.CONDITIONS) - set(prose.MODEL_NARROWINGS))
+
+        assert not missing, (
+            f"No words for the {', '.join(missing)} narrowing. Add it to "
+            "MODEL_NARROWINGS in n26/library/prose.py and pin the sentence "
+            "here — a condition the prose cannot say is one it drops in "
+            "silence, and the sentence then reaches more models than the "
+            "modifier does."
         )
 
     def test_every_scope_kind_has_words_for_who_it_reaches(self):

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -173,6 +173,28 @@ class TestTheArticleFollowsTheName:
         ]
 
 
+class TestARankLeftOut:
+    """A row that names the ranks it does not reach reads "except", never
+    as if it reached those ranks alone."""
+
+    def test_everyone_but_champions(self, escher, backstab, default_pack):
+        champion = create_subtype("Champion")
+        attach_modifiers_to(
+            escher,
+            [
+                modifier(
+                    "Not the champions",
+                    targets_every_model(has_subtypes(champion, negate=True)),
+                    ef_adds(backstab),
+                )
+            ],
+        )
+
+        assert texts(prose_for(escher).does) == [
+            "Every fighter except Champion gains Backstab, while the gang holds this."
+        ]
+
+
 class TestATypeNarrowsTheSubject:
     """A model's Type is the one narrowing a gang-wide reach can say in
     the model's own word: a grant to every vehicle in the gang says

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -14,6 +14,7 @@ from n26.library.authoring import (
     add_built_in,
     add_default_member,
     add_entry,
+    add_picklist_member,
     attach_modifiers_to,
     counter_at_least,
     create_affiliation,
@@ -23,6 +24,7 @@ from n26.library.authoring import (
     create_default_set,
     create_gang_type,
     create_hidden,
+    create_pickable,
     create_picklist,
     create_power,
     create_profile,
@@ -43,6 +45,7 @@ from n26.library.authoring import (
     ef_places,
     ef_removes,
     ef_requires_companions,
+    has_pickable,
     has_subtypes,
     has_traits,
     is_profile_type,
@@ -240,33 +243,24 @@ class TestATypeNarrowsTheSubject:
 
 
 class TestAPickNarrowsTheSubject:
-    """A model that must hold a pick is said with the pick beside it —
-    the scope's own words, so the sentence and the name agree."""
+    """A model that must hold a pick is said with the pick beside it:
+    "with" the pick, or "without" it when the row leaves holders out."""
 
     @pytest.fixture
-    def legacies(self, default_pack):
-        from n26.library.authoring import (
-            add_picklist_member,
-            create_pickable,
-            create_picklist,
-            create_slot_type,
-        )
-
+    def cawdor(self, default_pack):
         slot_type = create_slot_type("Gang Legacy", plural_name="Gang Legacies")
         table = create_picklist("Gang Legacies", slot_type)
         cawdor = create_pickable("Cawdor", slot_type)
         add_picklist_member(table, cawdor)
         return cawdor
 
-    def test_a_grant_to_those_holding_a_pick_names_it(self, escher, legacies, backstab):
-        from n26.library.authoring import has_pickable
-
+    def test_a_grant_to_those_holding_a_pick_names_it(self, escher, cawdor, backstab):
         attach_modifiers_to(
             escher,
             [
                 modifier(
                     "Cawdor legacy: Backstab",
-                    targets_every_model(has_pickable(legacies)),
+                    targets_every_model(has_pickable(cawdor)),
                     ef_adds(backstab),
                 )
             ],
@@ -276,18 +270,16 @@ class TestAPickNarrowsTheSubject:
             "Every fighter with Cawdor gains Backstab, while the gang holds this."
         ]
 
-    def test_several_picks_read_as_any_of_them(self, escher, legacies, backstab):
+    def test_several_picks_read_as_any_of_them(self, escher, cawdor, backstab):
         """A row naming two picks reaches a model holding either, and the
         sentence must not read as though it needs both."""
-        from n26.library.authoring import create_pickable, has_pickable
-
-        delaque = create_pickable("Delaque", legacies.slot_type)
+        delaque = create_pickable("Delaque", cawdor.slot_type)
         attach_modifiers_to(
             escher,
             [
                 modifier(
                     "Either legacy: Backstab",
-                    targets_every_model(has_pickable(legacies, delaque)),
+                    targets_every_model(has_pickable(cawdor, delaque)),
                     ef_adds(backstab),
                 )
             ],
@@ -297,15 +289,13 @@ class TestAPickNarrowsTheSubject:
             "Every fighter with Cawdor or Delaque gains Backstab, while the gang holds this."
         ]
 
-    def test_negated_it_says_without(self, escher, legacies, backstab):
-        from n26.library.authoring import has_pickable
-
+    def test_negated_it_says_without(self, escher, cawdor, backstab):
         attach_modifiers_to(
             escher,
             [
                 modifier(
                     "No legacy: Backstab",
-                    targets_every_model(has_pickable(legacies, negate=True)),
+                    targets_every_model(has_pickable(cawdor, negate=True)),
                     ef_adds(backstab),
                 )
             ],
@@ -1218,9 +1208,10 @@ class TestTheQueryCountStaysFlat:
             prose_for(much_used)
 
 
-class TestEveryEffectCanBeSaid:
-    """A discovering guard: an effect with no renderer is one the reach
-    column would drop without a word."""
+class TestEveryEffectScopeAndNarrowingCanBeSaid:
+    """Discovering guards: an effect with no renderer, a scope with no
+    subject, or a narrowing with no words is one the reach column would
+    drop without a word."""
 
     def test_there_is_something_to_check(self):
         from n26.library.models.modifier import EFFECT_FIELDS

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -176,6 +176,27 @@ class TestTheArticleFollowsTheName:
         ]
 
 
+class TestOneRankNamed:
+    """One rank named is one subject, and its verb agrees."""
+
+    def test_a_single_rank_reads_singular(self, escher, backstab, default_pack):
+        champion = create_subtype("Champion")
+        attach_modifiers_to(
+            escher,
+            [
+                modifier(
+                    "Champions only",
+                    targets_every_model(has_subtypes(champion)),
+                    ef_adds(backstab),
+                )
+            ],
+        )
+
+        assert texts(prose_for(escher).does) == [
+            "Champion gains Backstab, while the gang holds this."
+        ]
+
+
 class TestARankLeftOut:
     """A row that names the ranks it does not reach reads "except", never
     as if it reached those ranks alone."""

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -219,7 +219,7 @@ class TestATypeAndARankLeftOut:
         )
 
         assert texts(prose_for(escher).does) == [
-            "Every model except vehicles and Champion gains Backstab, while the gang holds this."
+            "Every model except Champion and vehicles gains Backstab, while the gang holds this."
         ]
 
 
@@ -242,6 +242,105 @@ class TestARankLeftOut:
 
         assert texts(prose_for(escher).does) == [
             "Every fighter except Champion gains Backstab, while the gang holds this."
+        ]
+
+
+class TestNarrowingsCompose:
+    """Two narrowings on one scope are both said, in an order that keeps
+    each attached to the right thing."""
+
+    @pytest.fixture
+    def cawdor(self, default_pack):
+        slot_type = create_slot_type("Gang Legacy", plural_name="Gang Legacies")
+        table = create_picklist("Gang Legacies", slot_type)
+        cawdor = create_pickable("Cawdor", slot_type)
+        add_picklist_member(table, cawdor)
+        return cawdor
+
+    def carried(self, escher, scope, effect, name="Composed"):
+        attach_modifiers_to(escher, [modifier(name, scope, effect)])
+        return texts(prose_for(escher).does)
+
+    def test_a_rank_and_a_type_are_the_ranks_of_that_kind(
+        self, escher, backstab, vehicle_type, default_pack
+    ):
+        champion = create_subtype("Champion")
+        assert self.carried(
+            escher,
+            targets_every_model(has_subtypes(champion), is_profile_type(vehicle_type)),
+            ef_adds(backstab),
+        ) == ["Champion vehicles gain Backstab, while the gang holds this."]
+
+    def test_either_type_reads_or(self, escher, backstab, fighter_type, vehicle_type):
+        assert self.carried(
+            escher,
+            targets_every_model(is_profile_type(fighter_type, vehicle_type)),
+            ef_adds(backstab),
+        ) == ["Every fighter or vehicle gains Backstab, while the gang holds this."]
+
+    def test_a_pick_qualifies_the_subject_not_what_is_left_out(
+        self, escher, backstab, vehicle_type, cawdor
+    ):
+        assert self.carried(
+            escher,
+            targets_every_model(
+                is_profile_type(vehicle_type, negate=True), has_pickable(cawdor)
+            ),
+            ef_adds(backstab),
+        ) == [
+            "Every model with Cawdor except vehicles gains Backstab, while the gang holds this."
+        ]
+
+    def test_two_pick_rows_are_joined(self, escher, backstab, cawdor):
+        delaque = create_pickable("Delaque", cawdor.slot_type)
+        assert self.carried(
+            escher,
+            targets_every_model(
+                has_pickable(cawdor), has_pickable(delaque, negate=True)
+            ),
+            ef_adds(backstab),
+        ) == [
+            "Every fighter with Cawdor and without Delaque gains Backstab, while the gang holds this."
+        ]
+
+    def test_what_a_qualified_subject_has_is_said_the_long_way_round(
+        self, escher, cawdor, fighter_stats
+    ):
+        assert self.carried(
+            escher,
+            targets_every_model(has_pickable(cawdor)),
+            ef_changes_stat(fighter_stats["BS"], mode="worsen", amount=1),
+        ) == [
+            "The Ballistic Skill of every fighter with Cawdor is 1 worse, while the gang holds this."
+        ]
+
+    def test_a_type_left_out_owns_the_long_way_round_too(
+        self, escher, vehicle_type, fighter_stats
+    ):
+        assert self.carried(
+            escher,
+            targets_every_model(is_profile_type(vehicle_type, negate=True)),
+            ef_changes_stat(fighter_stats["BS"], mode="worsen", amount=1),
+        ) == [
+            "The Ballistic Skill of every model except vehicles is 1 worse, while the gang holds this."
+        ]
+
+    def test_a_pronouns_narrowings_lead_the_sentence(
+        self, backstab, cawdor, default_pack
+    ):
+        """ "They with Cawdor" is no sentence; a bearer-reach modifier on
+        a rule says its narrowing first and drops the closing "while"."""
+        rule = create_rule("Veterans")
+        attach_modifiers_to(
+            rule,
+            [
+                modifier(
+                    "Veterans", targets_model(has_pickable(cawdor)), ef_adds(backstab)
+                )
+            ],
+        )
+        assert texts(prose_for(rule).does) == [
+            "While holding Cawdor, they gain Backstab."
         ]
 
 
@@ -1239,6 +1338,31 @@ class TestTheQueryCountStaysFlat:
 
         with django_assert_num_queries(budget):
             prose_for(much_used)
+
+    def test_narrowed_scopes_cost_no_query_per_row(
+        self, escher, backstab, default_pack
+    ):
+        """A condition row's names are many-to-many, and each was a query
+        of its own on every sentence until the prefetch reached them."""
+        champion = create_subtype("Champion")
+        slot_type = create_slot_type("Gang Legacy", plural_name="Gang Legacies")
+        cawdor = create_pickable("Cawdor", slot_type)
+        rule = create_rule("Narrowed")
+
+        def narrowed(number):
+            return modifier(
+                f"Narrowed {number}",
+                targets_every_model(has_subtypes(champion), has_pickable(cawdor)),
+                ef_adds(backstab),
+            )
+
+        attach_modifiers_to(rule, [narrowed(0)])
+        prose_for(rule)
+        budget = self._budget(rule)
+
+        attach_modifiers_to(rule, [narrowed(n) for n in range(1, 6)])
+
+        assert self._budget(rule) == budget
 
     def test_the_budget_is_what_it_is(self, much_used, django_assert_num_queries):
         """Pinned so that a new sweep is a decision somebody made.


### PR DESCRIPTION
Follow-up to the standing-grants stack (#2392–#2395). During the browser walkthrough the modifier page said "Every fighter gains Lasting Damage" for the *vehicle* grant, and the fix for that (#2392) treated one symptom. This closes the class.

## The bug class

`prose.py`'s `_narrowed` handled a model scope's conditions by name and let any kind it did not name fall through to the weapons clause — which a model sentence never reads. So a narrowing the renderer did not know was dropped in silence, and the sentence claimed a wider reach than the modifier has. Type narrowing was one case; **a pick held (`has_pickable`) was another, already live**: a Gang Legacy grant narrowed to "models holding Cawdor" read as "Every fighter gains …".

## What changes

- `MODEL_NARROWINGS`, a table from each condition kind on `TargetsMiniature` to what it says in the sentence: ranks and entries replace the subject, a Type says "every vehicle", a pick held joins as "with Cawdor" / "without Cawdor", a counter threshold leads as a clause. Weapon-scope conditions still join the noun phrase in their own words.
- A discovering guard in the prose suite: every kind in `TargetsMiniature.CONDITIONS` must be in that table, failing with prose saying what to add. A future condition cannot ship silent.
- Two pinned sentences for the pick narrowing, plain and negated.

`pytest n26/tests/sandbox/test_prose.py n26/library test_standing_grants.py test_lasting_effects.py test_authoring_views.py` — 862 passed.

## From review

The deep review found the composition cases the first cut missed, and they are the substance of this PR now:

- **Two narrowings on one scope compose.** A Type beside a rank reads "Champion vehicles"; a pick precedes what is left out ("every model with Cawdor except vehicles"), so it qualifies the subject and not the exception; two pick rows join ("with Cawdor and without Delaque"); a Type left out shares one "except" with ranks left out; either of two Types reads "or".
- **Pronoun subjects take clauses, not phrases.** A bearer-reach modifier on a rule read "They with Cawdor gain …"; its narrowings now lead the sentence: "While holding Cawdor, they gain Backstab."
- **What a qualified subject has is said the long way round.** "Every fighter with Cawdor's Ballistic Skill" handed the stat to Cawdor; the stat, category and counter sentences now read "the Ballistic Skill of every fighter with Cawdor", through one helper.
- One name is one subject: "Champion gains", "Champion and Leader gain". A row naming several picks is any-of: "with Cawdor or Delaque".
- **A condition row's names were a query each on every sentence.** `reading_sentences` prefetched a row's foreign keys but not its many-to-many names (the guard tested `concrete`, which a many-to-many never is), so the modifiers index paid one query per rank, entry, Type or pick row. The prefetch now reaches them; a budget test holds a narrowed scope flat and fails without the fix.
- Identifiers named for what they find rather than for speech; one list joiner with an "and"/"or" choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6APgvkju7S2c862oPYkNb
