### PR TITLE
feat: the Spyrer glitch and delegation injury tables join the lasting-effect seed

### DIFF
--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -239,24 +239,30 @@ founding one.
 
 > Draft, for review.
 
-A model taken out of action rolls on one of the book's two D66 tables
-and keeps the result for good. Each table is a slot type of its own —
-two, not one, so a fighter can never be handed vehicle damage — and
-the app never rolls: the dice are the table's, and a player adds the
-result they rolled.
+A model taken out of action rolls on a table and keeps the result for
+good. There are four tables: the book's Lasting Injury and Lasting
+Damage tables (D66), the Spyrer Hunting Rig Glitches a Spyrer's suit
+takes instead of injuries (D66), and the delegation injuries an
+alliance's models roll (D6). Each is a slot type of its own, so a
+fighter can never be handed vehicle damage — and the app never rolls:
+the dice are the table's, and a player adds the result they rolled.
 
 1. On **Foundations**, create the **lasting effect tables**. One press
-   makes both tables whole: a slot type each with *allows repeats* set —
-   a second Eye Injury is a second Eye Injury — every result at its
-   band, and a standing choice each. Each table's own page shows every
-   roll covered. (Five results sit on both tables at the same rolls; a
-   pack holds one pickable per name, so the damage twins arrive with a
-   qualifier, which players never see.)
-2. Standard content carries names and numbers only, so finish the ten
-   results that worsen a characteristic by hand: on each, attach a
-   **modifier** — targets the model, worsens that characteristic by
-   one. A result that changes no number needs nothing — the card says
-   the model has it, and the rest is played at the table.
+   makes all four tables whole: a slot type each with *allows repeats*
+   set — a second Eye Injury is a second Eye Injury — every result at
+   its band, and a standing choice each. Each table's own page shows
+   every roll covered. (Several results sit on more than one table at
+   the same rolls; a pack holds one pickable per name, so the later
+   twins arrive with a qualifier, which players never see.)
+2. Standard content carries names and numbers only, so finish the
+   results that change a number by hand. On each of the ten injury and
+   damage results that worsen a characteristic, attach a **modifier** —
+   targets the model, worsens that characteristic by one. On each of the
+   ten Spyrer glitch results (rolls 51 to 64), attach two: one that
+   worsens the characteristic, and one that *moves a counter* — the
+   Glitch Count, up by one. A result that changes no number needs
+   nothing — the card says the model has it, and the rest is played at
+   the table.
 3. Put each table's choice on the gang types rather than on the
    entries. Create a **modifier**: reaches *all models in the gang*,
    narrowed to those that *are a Fighter*, and *gives* the Lasting
@@ -266,6 +272,18 @@ result they rolled.
    that moment — gangs founded long ago included, because nothing is
    written on any model. A gang type created later needs the same two
    attachments.
+4. Spyre Hunters are the exception. On that gang type, take the
+   fighters' Lasting Injury modifier off and attach two in its place,
+   both reaching *all models in the gang* that *are a Fighter*: one
+   narrowed to models that have the **Spyrer** subtype, giving the
+   Spyrer Hunting Rig Glitches choice; the other narrowed to models
+   that do *not* have it, giving Lasting Injury as before. A Spyrer's
+   card then asks under Hunting Rig Glitches and never under Lasting
+   Injuries.
+5. A delegation's models roll on the D6 table. Giving them the
+   Delegation Lasting Injuries choice needs a way to reach exactly
+   those models; naming their entries one by one on the modifier is the
+   only way today, and which entries count is not yet settled.
 
 Taking one of those modifiers off a gang type takes the row off every
 card at once, and leaves what players had already picked where it is,

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -517,10 +517,12 @@ def _check_subtypes():
     return _count(Subtype, name__in=names), len(names)
 
 
-#: The two lasting-effect tables (core rules: the Lasting Injury and
-#: Lasting Damage tables), as ``(band low, band high, result)``. Names
-#: and bands only — what a result *does* is a modifier, which seeds
-#: never write, so the ten characteristic results are finished by hand.
+#: The lasting-effect tables (core rules: the Lasting Injury and Lasting
+#: Damage tables; the Spyre Hunters list's Hunting Rig Glitches; the
+#: alliance rules' delegation injuries), as ``(band low, band high,
+#: result)``. Names and bands only — what a result *does* is a modifier,
+#: which seeds never write, so the results that change a characteristic
+#: or move a counter are finished by hand.
 LASTING_INJURY_TABLE = [
     (11, 11, "Lesson Learnt"),
     (12, 12, "Eternal Enmity"),
@@ -558,48 +560,112 @@ LASTING_DAMAGE_TABLE = [
     (66, 66, "Catastrophic Explosion!"),
 ]
 
-#: On both tables at the same rolls. A pack holds one pickable per name,
-#: so the damage twin of each carries a qualifier — author-facing only,
-#: never a player's word.
-SHARED_LASTING_RESULTS = {
-    "Lesson Learnt",
-    "Eternal Enmity",
-    "Bitter Enmity",
-    "Personal Enmity",
-    "Captured",
-}
+#: A Spyrer's suit takes the hit: their own D66 in place of the Lasting
+#: Injury table. Ten results each move the Glitch Count as well.
+SPYRER_GLITCH_TABLE = [
+    (11, 11, "Lesson Learnt"),
+    (12, 12, "Eternal Enmity"),
+    (13, 13, "Bitter Enmity"),
+    (14, 14, "Personal Enmity"),
+    (15, 15, "Horrid Scars"),
+    (16, 16, "Impressive Scars"),
+    (21, 26, "Superficial Damage"),
+    (31, 46, "Grievous Wound"),
+    (51, 51, "Anxiety Suppression Damaged"),
+    (52, 52, "Neural Feedback"),
+    (53, 53, "Humbled"),
+    (54, 54, "Vox Ghosts"),
+    (55, 55, "Gyroscopic Destabilisation"),
+    (56, 56, "Seized Locomotors"),
+    (61, 61, "Targeting Uplink Disruption"),
+    (62, 62, "Stuttering Servos"),
+    (63, 63, "Damaged Musculature"),
+    (64, 64, "Reduced Plate Density"),
+    (65, 65, "Multiple Glitches"),
+    (66, 66, "Critical Overload"),
+]
 
-#: (slot type, plural, rows, the damage twins' qualifier)
+#: An alliance's delegation rolls a D6, not a D66.
+DELEGATION_INJURY_TABLE = [
+    (1, 2, "Out Cold"),
+    (3, 5, "Grievous Wound"),
+    (6, 6, "Critical Injury"),
+]
+
+#: ``(slot type, plural — the card's heading, rows, die, qualifier)``.
+#: A pack holds one pickable per name and qualifier, and several results
+#: sit on more than one table at the same rolls. A table's qualifier
+#: goes on each of its results that an earlier table already names, so
+#: the first table's rows stay plain and every later twin is told apart
+#: — author-facing only, never a player's word.
 LASTING_EFFECT_TABLES = [
-    ("Lasting Injury", "Lasting Injuries", LASTING_INJURY_TABLE, ""),
-    ("Lasting Damage", "Lasting Damage", LASTING_DAMAGE_TABLE, "vehicle"),
+    ("Lasting Injury", "Lasting Injuries", LASTING_INJURY_TABLE, "d66", ""),
+    ("Lasting Damage", "Lasting Damage", LASTING_DAMAGE_TABLE, "d66", "vehicle"),
+    (
+        "Spyrer Hunting Rig Glitch",
+        "Spyrer Hunting Rig Glitches",
+        SPYRER_GLITCH_TABLE,
+        "d66",
+        "spyrer",
+    ),
+    (
+        "Delegation Lasting Injury",
+        "Delegation Lasting Injuries",
+        DELEGATION_INJURY_TABLE,
+        "d6",
+        "delegation",
+    ),
 ]
 
 
+def _twin_qualifier(table_index, result):
+    """The qualifier a result carries on this table: the table's own if
+    an earlier table already names the result, else none."""
+    earlier = LASTING_EFFECT_TABLES[:table_index]
+    if any(result in {row[2] for row in rows} for _, _, rows, _, _ in earlier):
+        return LASTING_EFFECT_TABLES[table_index][4]
+    return ""
+
+
+#: Every result named on more than one table.
+SHARED_LASTING_RESULTS = {
+    result
+    for index, (_, _, rows, _, _) in enumerate(LASTING_EFFECT_TABLES)
+    for _, _, result in rows
+    if _twin_qualifier(index, result)
+}
+
+
 def _lasting_row(model, name, qualifier, slot_type, defaults):
-    """One pickable or slot, matched the way its uniqueness is defined:
-    per pack on lowercased name and qualifier, not per slot type. An
-    exact-key lookup scoped to the slot type would miss a row that
-    differs only in case or belongs to another type, then trip the
-    unique constraint trying to insert its double."""
-    row = model.objects.filter(name__iexact=name, qualifier__iexact=qualifier).first()
-    if row is None:
-        return model.objects.create(
-            name=name, qualifier=qualifier, slot_type=slot_type, **defaults
-        )
-    if row.slot_type_id != slot_type.pk:
+    """One pickable or slot for a table, matched three ways in turn.
+
+    Its own slot type's row of that name is the one, whatever qualifier
+    it was created with — a table seeded before a later table shared the
+    name must not gain a second copy. Failing that, a row of that name
+    and qualifier under another slot type is a name already claimed,
+    refused in words rather than tripping the per-pack unique constraint
+    (lowercased name and qualifier, not slot type) as a bare error.
+    Otherwise the row is created.
+    """
+    own = model.objects.filter(name__iexact=name, slot_type=slot_type).first()
+    if own is not None:
+        return own
+    taken = model.objects.filter(name__iexact=name, qualifier__iexact=qualifier).first()
+    if taken is not None:
         raise RuntimeError(
             f'A {model._meta.verbose_name} named "{name}" already belongs '
-            f'to the "{row.slot_type}" slot type, so the "{slot_type}" '
+            f'to the "{taken.slot_type}" slot type, so the "{slot_type}" '
             f"table cannot claim the name."
         )
-    return row
+    return model.objects.create(
+        name=name, qualifier=qualifier, slot_type=slot_type, **defaults
+    )
 
 
 def _create_lasting_effect_tables():
     from n26.library.models import Pickable, Picklist, PicklistMember, Slot, SlotType
 
-    for name, plural, rows, twin_qualifier in LASTING_EFFECT_TABLES:
+    for index, (name, plural, rows, dice, _) in enumerate(LASTING_EFFECT_TABLES):
         slot_type = SlotType.objects.filter(name__iexact=name).first()
         if slot_type is None:
             slot_type = SlotType.objects.create(
@@ -612,12 +678,13 @@ def _create_lasting_effect_tables():
             table = Picklist.objects.create(
                 name=f"{name} Table",
                 slot_type=slot_type,
-                dice="d66",
+                dice=dice,
                 roll_selects="band",
             )
         for position, (low, high, result) in enumerate(rows):
-            qualifier = twin_qualifier if result in SHARED_LASTING_RESULTS else ""
-            pickable = _lasting_row(Pickable, result, qualifier, slot_type, {})
+            pickable = _lasting_row(
+                Pickable, result, _twin_qualifier(index, result), slot_type, {}
+            )
             PicklistMember.objects.get_or_create(
                 picklist=table,
                 pickable=pickable,
@@ -639,8 +706,8 @@ def _create_lasting_effect_tables():
 def _check_lasting_effect_tables():
     from n26.library.models import PicklistMember, Slot, SlotType
 
-    names = [name for name, _, _, _ in LASTING_EFFECT_TABLES]
-    members = sum(len(rows) for _, _, rows, _ in LASTING_EFFECT_TABLES)
+    names = [name for name, _, _, _, _ in LASTING_EFFECT_TABLES]
+    members = sum(len(rows) for _, _, rows, _, _ in LASTING_EFFECT_TABLES)
     present = _count(SlotType, name__in=names)
     present += _count(
         PicklistMember,
@@ -680,12 +747,13 @@ STANDARD_CONTENT = {
             key="lasting-effect-tables",
             name="Lasting effect tables",
             help=(
-                "The Lasting Injury and Lasting Damage tables as D66 roll "
+                "The Lasting Injury and Lasting Damage tables, the Spyrer "
+                "Hunting Rig Glitches and the delegation injuries as roll "
                 "tables — a slot type, results at their bands, and a "
-                "standing choice each. Names and bands only: the ten "
-                "results that worsen a characteristic still need their "
+                "standing choice each. Names and bands only: results that "
+                "change a characteristic or move a counter still need their "
                 "modifiers attached, and each gang type a modifier that "
-                "gives every fighter or vehicle its choice."
+                "gives its models the right choice."
             ),
             check=_check_lasting_effect_tables,
             create=_create_lasting_effect_tables,

--- a/n26/tests/sandbox/test_lasting_effects.py
+++ b/n26/tests/sandbox/test_lasting_effects.py
@@ -86,7 +86,7 @@ def tables(default_pack, fighter_stats):
             "table": Picklist.objects.get(name=f"{name} Table"),
             "slot": Slot.objects.get(name=name),
         }
-        for name, _, _, _ in LASTING_EFFECT_TABLES
+        for name, _, _, _, _ in LASTING_EFFECT_TABLES
     }
 
 
@@ -157,10 +157,13 @@ class TestTheTablesAsSeeded:
     """Both tables cover their die exactly, with nothing doubled and
     nothing unrollable — pinned so a band changes deliberately."""
 
-    @pytest.mark.parametrize("name", [n for n, _, _, _ in LASTING_EFFECT_TABLES])
-    def test_the_table_is_whole(self, tables, name):
+    @pytest.mark.parametrize(
+        ("name", "rolls"),
+        [(n, {"d66": 36, "d6": 6}[dice]) for n, _, _, dice, _ in LASTING_EFFECT_TABLES],
+    )
+    def test_the_table_is_whole(self, tables, name, rolls):
         said = coverage(tables[name]["table"])
-        assert said.covered == said.total == 36
+        assert said.covered == said.total == rolls
         assert said.unclaimed == []
         assert said.doubled == []
         assert said.bandless == []
@@ -189,15 +192,42 @@ class TestTheTablesAsSeeded:
             STANDARD_CONTENT["lasting-effect-tables"].create()
 
     def test_the_shared_names_are_separate_results_per_table(self, tables):
-        """Lesson Learnt, the three Enmities and Captured sit on both
-        tables at the same rolls — as two pickables each, because a
-        pickable belongs to one slot type."""
+        """Lesson Learnt sits on three tables, Grievous Wound on three,
+        Out Cold on two — as one pickable per table, because a pickable
+        belongs to one slot type; the twins are told apart by qualifier."""
         from n26.library.models import Pickable
         from n26.library.standard_content import SHARED_LASTING_RESULTS
 
+        assert SHARED_LASTING_RESULTS >= {"Lesson Learnt", "Grievous Wound", "Out Cold"}
         for name in SHARED_LASTING_RESULTS:
+            on_tables = {
+                table
+                for table, _, rows, _, _ in LASTING_EFFECT_TABLES
+                if any(result == name for _, _, result in rows)
+            }
             types = {p.slot_type.name for p in Pickable.objects.filter(name=name)}
-            assert types == {"Lasting Injury", "Lasting Damage"}, name
+            assert types == on_tables, name
+
+    def test_a_table_seeded_before_a_later_twin_gains_no_second_copy(
+        self, default_pack
+    ):
+        """Production seeded the first two tables before the others
+        existed, so the Lasting Damage table's Superficial Damage carries
+        no qualifier. Seeding again must find that row, not make a twin
+        beside it and double the band."""
+        from n26.library.models import Pickable, PicklistMember
+
+        STANDARD_CONTENT["lasting-effect-tables"].create()
+        early = Pickable.objects.get(
+            name="Superficial Damage", slot_type__name="Lasting Damage"
+        )
+        assert early.qualifier == ""
+        STANDARD_CONTENT["lasting-effect-tables"].create()
+        assert Pickable.objects.filter(name="Superficial Damage").count() == 2
+        assert (
+            PicklistMember.objects.filter(pickable__name="Superficial Damage").count()
+            == 2
+        )
 
 
 class TestAFighterIsHurt:


### PR DESCRIPTION
The lasting-effects Foundations seed grows from two tables to the four the pre-ingest sheet holds: the **Spyrer Hunting Rig Glitches** (D66 — a Spyrer's suit takes the hit instead of the Lasting Injury table; ten results also move the Glitch Count) and the **delegation injuries** an alliance's models roll (a D6 table, the first D6 roll table in the library). Names and bands only, as before.

## Seeding against what production already has

Production has the first two tables seeded, and the later tables share result names with them (Lesson Learnt sits on three, Grievous Wound on three, Superficial Damage on two). A pack holds one pickable per name and qualifier, so a table's qualifier goes on each of its results that an *earlier* table already names — the first table's rows stay plain, and production's existing unqualified rows are exactly what a fresh seed would make. The row lookup now tries the table's own slot type first, so a result seeded before a later table shared its name is found rather than twinned (which would have doubled a band). Pinned by a test that seeds production's shape and seeds again; also re-run against a worktree database holding production's state: 35 of 62 → 62 of 62, all four tables whole, no second copy.

## The recipe

Two new steps. **Spyre Hunters**: on that gang type, the fighters' injury grant becomes two — Spyrers (the subtype) get the glitches choice, everyone else Lasting Injury — both conditions the composer already offers. **Delegations**: the D6 table exists, but reaching exactly a delegation's models needs their entries named one by one on the modifier, and which entries count is not yet settled; the recipe says so plainly.

## Prod steps after merge

1. Foundations → *Lasting effect tables* again (adds the two new tables; the first two are left as they are).
2. On the ten glitch results (rolls 51–64): a worsen-by-one modifier each, plus *moves a counter* — Glitch Count, +1.
3. On the Spyre Hunters gang type: detach the fighters' Lasting Injury grant; attach the two replacements.

Two things from the sheet to confirm, not changed here: it writes "Ld −1" for Impressive Scars and "Ld +1" for Head Injury and the Spyrer psychology glitches — the reverse of a penalty under the rules' "higher is better" psychology stats, so the sheet appears to use the classic target-number sign. The in-app modifiers say *worsen*/*improve* rather than a sign, so what matters is the direction: Head Injury is attached as *worsen Ld* (right); Impressive Scars has no modifier attached yet and needs one either way. And the sheet spells "Gyroscopic Destablisation"; the seed uses "Destabilisation".

`pytest n26/tests/sandbox/test_lasting_effects.py test_standing_grants.py n26/library test_authoring_views.py test_prose.py` — 862 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
