### PR TITLE
chore: make .codex bootstrap worktree-safe

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,21 +1,2 @@
 [shell_environment_policy]
 inherit = "core"
-
-[shell_environment_policy.set]
-CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"
-
-[mcp_servers.figma-desktop]
-url = "http://127.0.0.1:3845/mcp"
-
-[mcp_servers.figma-remote]
-url = "https://mcp.figma.com/mcp"
-
-[mcp_servers.github]
-url = "https://api.githubcopilot.com/mcp"
-
-# Set GITHUB_PAT in your environment (or a local override) for GitHub MCP auth.
-[mcp_servers.github.http_headers]
-Authorization = "Bearer ${GITHUB_PAT}"
-
-[mcp_servers.pushpush]
-url = "https://a.pushpu.sh/mcp"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,23 +1,3 @@
 {
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup_web.sh"
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/activate_venv_hook.sh"
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/.codex/run.sh
+++ b/.codex/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: .codex/run.sh <command> [args ...]" >&2
+  exit 2
+fi
+
+PROJECT_DIR=$(git rev-parse --show-toplevel)
+VENV_ACTIVATE="${PROJECT_DIR}/.venv/bin/activate"
+WORKTREE_LIB="${PROJECT_DIR}/scripts/lib/worktree.sh"
+
+if [ ! -f "$VENV_ACTIVATE" ]; then
+  echo "No worktree virtualenv found at ${PROJECT_DIR}/.venv." >&2
+  echo "Run .codex/setup.sh before running project commands." >&2
+  exit 1
+fi
+
+# The activation script includes the repository's per-worktree DB hook, which
+# sets DB_NAME, DJANGO_PORT and DB_CONFIG for this checkout.
+# shellcheck disable=SC1090
+source "$VENV_ACTIVATE"
+
+# Do not depend on the optional activation block installed by
+# setup-local-postgres.sh. Older main-worktree venvs may not contain it.
+# shellcheck disable=SC1090
+source "$WORKTREE_LIB"
+export DB_NAME
+DB_NAME=$(worktree_db_name "$PROJECT_DIR")
+export DJANGO_PORT
+DJANGO_PORT=$(worktree_port "$PROJECT_DIR")
+export DB_HOST=localhost
+export DB_PORT=5432
+export DB_CONFIG
+DB_CONFIG=$(db_config_for_local)
+export DJANGO_SETTINGS_MODULE=gyrinx.settings_dev
+
+PG_BIN_DIR=$(homebrew_postgres_bin)
+if [ -n "$PG_BIN_DIR" ]; then
+  export PATH="${PG_BIN_DIR}:${PATH}"
+fi
+
+exec "$@"

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_DIR=$(git rev-parse --show-toplevel)
+cd "$PROJECT_DIR"
+
+# Reuse the normal development bootstrap. In setup-only mode it provisions the
+# worktree venv and frontend dependencies, forks the per-worktree database,
+# migrates it, and builds CSS without leaving a server running.
+exec ./scripts/dev.sh --no-watch --setup-only

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Codex-managed worktrees need the local Django configuration. Codex copies
+# this ignored file without adding it to Git.
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   There is no need to prefix commands with `. .venv/bin/activate &&`.
 - The session hook also sets `DB_NAME` and `DJANGO_PORT` per-worktree — `manage` and `pytest`
   automatically target the correct database.
+- **Codex local worktrees:** configure `.codex/setup.sh` as the local-environment setup script.
+  Codex shell commands do not inherit Claude's `CLAUDE_ENV_FILE`, so run direct Python/Django
+  commands through `.codex/run.sh` (for example, `.codex/run.sh pytest` or
+  `.codex/run.sh manage check`). The existing `scripts/dev.sh` and `scripts/fmt.sh` activate the
+  worktree environment themselves.
 
 **Key Principles:**
 

--- a/docs/useful-scripts.md
+++ b/docs/useful-scripts.md
@@ -11,6 +11,7 @@ Starts the full development environment with a single command. Handles per-workt
 ```bash
 ./scripts/dev.sh              # Normal startup
 ./scripts/dev.sh --no-watch   # Skip CSS watcher
+./scripts/dev.sh --setup-only # Prepare the worktree without starting Django or npm run watch
 ./scripts/dev.sh --reset-db   # Drop and re-fork the worktree database
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -61,7 +61,8 @@ python scripts/screenshot.py --check
 
 - `dev.sh`: Starts the full development environment — forks the per-worktree database, runs
   migrations, and launches Django plus `npm run watch`. The single command you use day-to-day.
-  See [docs/useful-scripts.md](../docs/useful-scripts.md) for flags.
+  Pass `--setup-only` to prepare a worktree without starting Django or `npm run watch`.
+  See [docs/useful-scripts.md](../docs/useful-scripts.md) for the other flags.
 - `setup-local-postgres.sh`: One-time machine setup. Installs PostgreSQL 16 via Homebrew (macOS),
   initialises the cluster with ICU collation, and migrates data from any pre-existing Docker
   Postgres container.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -12,6 +12,9 @@
 #                                   # per-worktree .venv and node_modules in
 #                                   # child worktrees if missing.
 #   ./scripts/dev.sh --no-watch     # Skip npm watch (CSS already built)
+#   ./scripts/dev.sh --setup-only   # Prepare dependencies, database and CSS,
+#                                   # then exit without starting Django or
+#                                   # npm run watch
 #   ./scripts/dev.sh --reset-db     # Drop and re-fork the worktree database
 #   ./scripts/dev.sh --reset-venv   # Rebuild the worktree's .venv from scratch
 #                                   # (no-op in the main worktree)
@@ -27,9 +30,11 @@ source "$SCRIPT_DIR/lib/worktree.sh"
 NO_WATCH=false
 RESET_DB=false
 RESET_VENV=false
+SETUP_ONLY=false
 for arg in "$@"; do
   case "$arg" in
     --no-watch) NO_WATCH=true ;;
+    --setup-only) SETUP_ONLY=true ;;
     --reset-db) RESET_DB=true ;;
     --reset-venv) RESET_VENV=true ;;
     *) echo "Unknown argument: $arg"; exit 1 ;;
@@ -312,6 +317,16 @@ for css in "$CSS_FILE" "$N26_CSS_FILE"; do
 done
 CSS_SIZE=$(wc -c < "$CSS_FILE" | tr -d ' ')
 N26_CSS_SIZE=$(wc -c < "$N26_CSS_FILE" | tr -d ' ')
+
+if [ "$SETUP_ONLY" = true ]; then
+  echo
+  echo "Gyrinx worktree setup complete."
+  echo "  Worktree: $WT_LABEL"
+  echo "  Database: $DB_NAME"
+  echo "  Start:    ./scripts/dev.sh"
+  echo "  Dev URL:  http://localhost:${DJANGO_PORT}"
+  exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # Background process management


### PR DESCRIPTION
## Summary

- add Codex setup and command wrappers for isolated worktrees
- add a setup-only mode to `scripts/dev.sh`
- keep local `.env` available to Codex-managed worktrees
- remove stale Claude hooks and repository-level MCP configuration from `.codex`

## Testing

- ran `.codex/setup.sh` through virtualenv, dependency, database, migration, and CSS provisioning
- ran `./scripts/fmt.sh`
- ran `.codex/run.sh manage check`
- passed all pre-commit hooks