### PR TITLE
ci: run pytest-xdist with -n logical so the test job uses all 4 runner vCPUs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,9 +76,11 @@ jobs:
 
       - name: Run tests in parallel
         timeout-minutes: 60
+        # pyproject's `-n auto` counts physical cores, which on the 4-vCPU
+        # runner is 2. `-n logical` uses all 4; the later flag wins.
         run: |
           source .venv/bin/activate
-          pytest --durations=20 -v
+          pytest --durations=20 -v -n logical
 
       - name: Run Bandit security scan
         run: |


### PR DESCRIPTION
## Summary

- The CI test job runs pytest with \`-n auto\` from \`pyproject.toml\`. pytest-xdist resolves \`auto\` to the number of *physical* cores when psutil is installed, which on \`ubuntu-latest\` is 2 of the 4 vCPUs. The last green run's log shows \`created: 2/2 workers\` and took 20m12s in pytest alone.
- \`.github/workflows/test.yaml\` now passes \`-n logical\` after the addopts flag, so the job starts 4 workers. Local runs are unchanged.

This is the first step of splitting CI into a required core suite and a non-blocking full suite. This PR's own run is the measurement of how much the extra workers buy on a database-bound suite.

## Test plan

- [ ] The \`test\` job log shows \`created: 4/4 workers\`
- [ ] Compare the job's wall time against the ~21 minutes of recent runs on main

No open issue tracks CI test time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GsdfBg1yW7PoKwVJetAup