### PR TITLE
feat: give the Champion Archetype slot its own Pickables, and a repair that repoints existing picks

### DIFF
--- a/n26/core/repoint_champion_picks.py
+++ b/n26/core/repoint_champion_picks.py
@@ -1,0 +1,234 @@
+"""Moving a pick onto the pickable its slot's picklist now offers.
+
+A pick names the pickable that was picked and the slot that asked. The
+slot draws from a picklist, and pointing the slot at a different list
+moves nothing already picked: the pick goes on naming the pickable it
+named, which the list the slot now reads may not hold at all.
+
+That is what the Outcast archetypes leave behind. A Champion's Archetype
+and the gang's were picked from one list, so one pickable carried both
+readings; splitting them gives the Champion's slot a list of its own
+holding a pickable of the same name for each archetype, and every
+Champion's pick still names the gang's. Such a pick reads as chosen and
+draws its name, and everything under it — the skill sets it places, the
+powers it offers — is the gang's reading rather than the Champion's.
+
+The repair finds every live pick whose slot puts the pick on the model
+that made it, where the slot's picklist does not hold what was picked
+and does hold exactly one pickable of the same slot type under the same
+name — and points the pick at that one. Nothing else changes: the pick
+still names the assignment that asked and the slot it settles, and it is
+still caused by what caused it, so it still goes when that goes.
+
+An archived pick is counted and left alone: it draws nothing, and
+rewriting history is not a repair. No money moves — a pickable is priced
+at nothing and every pick's entry pins zero — and each gang is proved to
+reconcile before its own move commits.
+"""
+
+from dataclasses import dataclass
+
+from django.db import transaction
+from django.db.models import Exists, OuterRef
+
+
+class Refused(Exception):
+    """The repair found something other than the fault it was written for."""
+
+
+@dataclass(frozen=True)
+class Adrift:
+    """Every live pick naming something its slot's picklist no longer
+    offers, grouped by gang."""
+
+    #: ``(gang id, ((pick id, pickable id), ...))``, one per gang.
+    gangs: tuple = ()
+    problems: tuple = ()
+    nothing_here: bool = False
+    #: Archived picks in the same position, counted and left alone.
+    archived: int = 0
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    @property
+    def pick_ids(self):
+        return tuple(pk for _, moves in self.gangs for pk, _ in moves)
+
+    def preview(self):
+        lines = []
+        if self.nothing_here:
+            lines.append(
+                "nothing to move — every live pick names something its "
+                "slot's picklist offers"
+            )
+        for gang_id, moves in self.gangs:
+            lines.append(
+                f"gang {gang_id}: move {len(moves)} "
+                f"pick{'' if len(moves) == 1 else 's'} onto the pickable of "
+                "the same name on its slot's picklist"
+            )
+        if self.gangs:
+            total = len(self.pick_ids)
+            lines.append(
+                f"{total} pick{'' if total == 1 else 's'} across "
+                f"{len(self.gangs)} gang{'' if len(self.gangs) == 1 else 's'}"
+            )
+        if self.archived:
+            lines.append(
+                f"{self.archived} archived pick{'' if self.archived == 1 else 's'} "
+                "naming something off the list, left alone"
+            )
+        return lines
+
+
+def _adrift(archived=False):
+    """Live picks of a slot that puts the pick on the model, naming a
+    pickable that slot's picklist does not hold."""
+    from n26.core.models import Assignment
+    from n26.library.models import PicklistMember, Slot
+
+    offered = PicklistMember.objects.filter(
+        picklist_id=OuterRef("chosen_for_slot__picklist_id"),
+        pickable_id=OuterRef("pickable_id"),
+    )
+    return (
+        Assignment.objects.filter(
+            chosen_for_slot__assigned_to=Slot.WillBeAssignedTo.BEARER,
+            pickable__isnull=False,
+            archived=archived,
+        )
+        .annotate(on_the_list=Exists(offered))
+        .filter(on_the_list=False)
+    )
+
+
+def _same_name_on_the_list(pick):
+    """The one pickable on the slot's picklist that goes by the same
+    name and belongs to the same slot type — or what is wrong instead.
+
+    Matching is by the name a card prints, because that is the whole of
+    what a player picked: two pickables of one name are told apart for
+    authors by their qualifier, which never reaches anyone playing.
+    """
+    from n26.library.models import Pickable
+
+    matches = list(
+        Pickable.objects.filter(
+            listed_on__picklist_id=pick.chosen_for_slot.picklist_id,
+            slot_type_id=pick.pickable.slot_type_id,
+            name__iexact=pick.pickable.name,
+        )
+    )
+    if not matches:
+        return None, (
+            f"pick {pick.pk} names {pick.pickable.name}, and nothing of that "
+            "name is on its slot's picklist — not the pick this moves"
+        )
+    if len(matches) > 1:
+        return None, (
+            f"pick {pick.pk} names {pick.pickable.name}, and its slot's "
+            f"picklist offers {len(matches)} of that name, so which was "
+            "meant cannot be read — not the pick this moves"
+        )
+    return matches[0], None
+
+
+def find(gang_id=None):
+    """What stands to be moved, gang by gang. ``gang_id`` narrows the
+    plan to that one gang."""
+    adrift = _adrift()
+    archived_adrift = _adrift(archived=True)
+    if gang_id is not None:
+        adrift = adrift.filter(gang_root_id=gang_id)
+        archived_adrift = archived_adrift.filter(gang_root_id=gang_id)
+    picks = list(
+        adrift.select_related("pickable", "chosen_for_slot").order_by("created", "id")
+    )
+    archived = archived_adrift.count()
+    if not picks:
+        return Adrift(nothing_here=True, archived=archived)
+
+    problems = []
+    by_gang = {}
+    for pick in picks:
+        if pick.gang_root_id is None:
+            problems.append(
+                f"pick {pick.pk} is rooted in no gang, so whose books it "
+                "belongs to cannot be read — not the pick this moves"
+            )
+            continue
+        if pick.pickable.slot_type_id != pick.chosen_for_slot.slot_type_id:
+            problems.append(
+                f"pick {pick.pk} names a {pick.pickable.slot_type_id} pickable "
+                f"while its slot asks for {pick.chosen_for_slot.slot_type_id} "
+                "— not the pick this moves"
+            )
+            continue
+        replacement, problem = _same_name_on_the_list(pick)
+        if problem is not None:
+            problems.append(problem)
+            continue
+        by_gang.setdefault(pick.gang_root_id, []).append((pick.pk, replacement.pk))
+    gangs = tuple(
+        (gang_id, tuple(moves))
+        for gang_id, moves in sorted(by_gang.items(), key=lambda kv: kv[0])
+    )
+    return Adrift(gangs=gangs, problems=tuple(problems), archived=archived)
+
+
+def apply(adrift):
+    """Move what the plan names, gang by gang, and prove each gang's
+    books whole.
+
+    Each gang is its own transaction: one that cannot be made whole is
+    left exactly as it stood and reported, and the rest are repaired.
+    """
+    if adrift.problems:
+        raise Refused("not moved: " + "; ".join(adrift.problems))
+    if adrift.nothing_here:
+        return list(adrift.preview())
+
+    report = list(adrift.preview())
+    for gang_id, moves in adrift.gangs:
+        report.append(_repoint_one(gang_id, moves))
+    return report
+
+
+def _repoint_one(gang_id, moves):
+    """One gang's move, committed or rolled back on its own. Returns the
+    line the report carries for it."""
+    from n26.core.models import Assignment, Gang
+    from n26.core.reconcile import check_gang, repin_everything
+
+    with transaction.atomic():
+        # The gang first, so nothing lands on its books while its picks
+        # are moving; then the plan again, because it was read before
+        # this transaction opened.
+        gang = Gang.objects.select_for_update().get(pk=gang_id)
+        standing = dict(find(gang_id).gangs)
+        if standing.get(gang_id) != moves:
+            return (
+                f"gang {gang_id}: skipped — its picks changed since the plan "
+                "was read; read it again"
+            )
+        wanted = dict(moves)
+        repointed = 0
+        for pick in Assignment.objects.select_for_update().filter(pk__in=wanted):
+            pick.pickable_id = wanted[pick.pk]
+            pick.save()
+            repointed += 1
+        repin_everything(gang)
+        gang.refresh_from_db()
+        problems = check_gang(gang)
+        if problems:
+            transaction.set_rollback(True)
+            return (
+                f"gang {gang_id}: skipped — does not reconcile with its picks "
+                "moved: " + "; ".join(problems)
+            )
+    return (
+        f"gang {gang_id}: moved {repointed} "
+        f"pick{'' if repointed == 1 else 's'} onto its slot's own pickables"
+    )

--- a/n26/library/champion_archetypes.py
+++ b/n26/library/champion_archetypes.py
@@ -1,0 +1,286 @@
+"""Splitting the Outcast archetypes in two, one set for each choice.
+
+An Outcast gang's Archetype is picked by the Leader and held by the
+gang, so it reaches every member. A Champion picks an Archetype too, and
+that one belongs to the Champion alone. Both choices drew from a single
+picklist, so each of the five archetypes carried the two readings at
+once: the gang's, which places skill sets for every model, and the
+Champion's, which places them for the one model carrying the pick. No
+modifier can be scoped for both. Scoped to the model carrying it, it
+does nothing at all on a pick the gang holds; scoped to every model, it
+reaches the whole gang from a pick a Champion made.
+
+So the two are split. The Champion's slot gets a picklist of its own,
+holding five pickables of its own — the same names a card prints, told
+apart for authors by their qualifier — and each takes the modifiers that
+were only ever the Champion's. Which ones those are follows from the
+same argument: a modifier reaching the model carrying it can do nothing
+from a pick the gang holds, so it was written for the Champion's pick.
+
+Three of Wyrd's modifiers are not sorted by that rule, and each is named
+here: one that adds the Wyrd subtype to every Champion in the gang, one
+that offers a power to Champions and Leaders alike, and one that puts
+Wyrd Powers under Primary for everybody. The first belongs to the
+Champion's pick and becomes a modifier about the one model; the other
+two say something for each of the two picks, so each ends up with a
+modifier of its own.
+
+Everything here is found by id, and finding nothing is a normal outcome:
+a database with no Outcast content is left exactly as it stands.
+"""
+
+#: The Champion's own Archetype choice — the slot a Champion entry is
+#: granted, whose pick lands on the Champion.
+CHAMPION_SLOT = "01M0G9384562YPMERG9WG66GAJ"
+
+#: The five archetypes as the gang's Leader picks them, in the order the
+#: Leader's picklist prints them.
+ARCHETYPES = (
+    ("Brawler", "01M0G937MFA7PQQ09MF5BVF50C"),
+    ("Gunslinger", "01M0G937Q8PS2XCMAWC9HJE4ZK"),
+    ("Mastermind", "01M0G937SXCCQ20DQ8FGHKERSE"),
+    ("Survivor", "01M0G937WKKC28RHJM25T3GQ5S"),
+    ("Wyrd", "01M0G937Z5EJSVP5JPY3EZJ2T8"),
+)
+
+#: The Champion's copies keep the name a card prints and carry the
+#: qualifier that tells an author which of the two is which.
+QUALIFIER = "Champion Archetype"
+
+#: The list the Champion's slot draws from once the two are split.
+PICKLIST = "Champion Archetypes"
+
+#: The two ranks the Wyrd modifiers name.
+CHAMPION_SUBTYPE = "01KZGCRX75B135MSF88R921GW2"
+LEADER_SUBTYPE = "01KZGCRX9H75M4J0P90J69SH5S"
+
+#: Wyrd's three modifiers that the bearer rule does not sort.
+#: Adds the Wyrd subtype to every Champion in the gang — the Champion's
+#: own business, so it becomes a modifier about the model carrying it.
+WYRD_ADDS_TO_CHAMPIONS = "01KZYEVBEDD8ZRH12Z9ZBPQY39"
+#: Offers a power to Champions and Leaders alike, reaching only the
+#: model carrying it — from a gang-held pick that is nobody, so the
+#: Leader's copy has to reach every model and narrow to Leaders.
+WYRD_OFFERS_A_POWER = "01M146XA0E11JD9ZX570DKKFYB"
+#: Puts Wyrd Powers under Primary for every model in the gang, Champions
+#: included; the gang's pick governs everyone except Champions.
+WYRD_POWERS_ARE_PRIMARY = "01KZV4BPS7V1QB9CCB974TV9T8"
+
+#: What the two modifiers written for the Leader's and the Champion's
+#: Wyrd are called. Both follow the wording already on their neighbours.
+LEADER_OFFER = (
+    "Wyrd: Leader models — offers a choice of power from Primary (Skills & Powers)"
+)
+CHAMPION_WYRD_POWERS = (
+    "Wyrd: Champion (own pick) — puts Wyrd Powers under Primary (Skills & Powers)"
+)
+
+#: The reach values, spelled here rather than imported: this runs against
+#: whatever model classes it is handed, historical ones included.
+BEARER = "bearer"
+EVERY_MODEL = "every_model"
+
+
+def make_champion_archetypes(apps):
+    """Give the Champion's Archetype choice pickables of its own.
+
+    ``apps`` is any model registry — the real one, or a migration's
+    historical one. Returns the lines describing what changed; running
+    it again finds the split already made and returns one line saying so.
+    """
+    Pickable = apps.get_model("library", "Pickable")
+    Picklist = apps.get_model("library", "Picklist")
+    PicklistMember = apps.get_model("library", "PicklistMember")
+    Slot = apps.get_model("library", "Slot")
+    Subtype = apps.get_model("library", "Subtype")
+    Modifier = apps.get_model("library", "Modifier")
+
+    slot = Slot.objects.filter(pk=CHAMPION_SLOT).first()
+    if slot is None:
+        return ["nothing to split — this library holds no Champion Archetype slot"]
+    leaders = {}
+    for name, pk in ARCHETYPES:
+        leader = Pickable.objects.filter(pk=pk, slot_type_id=slot.slot_type_id).first()
+        if leader is None:
+            return [f"nothing to split — this library holds no {name} archetype"]
+        leaders[name] = leader
+
+    report = []
+    picklist = Picklist.objects.filter(
+        slot_type_id=slot.slot_type_id, name__iexact=PICKLIST
+    ).first()
+    if picklist is None:
+        picklist = Picklist.objects.create(
+            name=PICKLIST, slot_type_id=slot.slot_type_id, pack_id=slot.pack_id
+        )
+        report.append(f"created the {PICKLIST} picklist")
+
+    champions = {}
+    for position, (name, _) in enumerate(ARCHETYPES):
+        leader = leaders[name]
+        champion = Pickable.objects.filter(
+            slot_type_id=slot.slot_type_id,
+            name__iexact=name,
+            qualifier__iexact=QUALIFIER,
+        ).first()
+        if champion is None:
+            champion = Pickable.objects.create(
+                name=leader.name,
+                qualifier=QUALIFIER,
+                slot_type_id=leader.slot_type_id,
+                pack_id=leader.pack_id,
+                category_id=leader.category_id,
+                position=leader.position,
+            )
+            report.append(f"created {name} for the Champion's own pick")
+        champions[name] = champion
+        if not PicklistMember.objects.filter(
+            picklist=picklist, pickable=champion
+        ).exists():
+            PicklistMember.objects.create(
+                picklist=picklist, pickable=champion, position=position
+            )
+
+    report.extend(_wyrd_before_the_move(leaders["Wyrd"], Modifier))
+    for name, _ in ARCHETYPES:
+        moved = _move_what_only_the_champion_reads(leaders[name], champions[name])
+        if moved:
+            report.append(
+                f"{name}: moved {moved} modifier{'' if moved == 1 else 's'} "
+                "onto the Champion's pickable"
+            )
+    report.extend(
+        _wyrd_after_the_move(
+            apps, leaders["Wyrd"], champions["Wyrd"], Modifier, Subtype
+        )
+    )
+
+    if slot.picklist_id != picklist.pk:
+        slot.picklist_id = picklist.pk
+        slot.save(update_fields=["picklist"])
+        report.append(f"{slot.name} now draws from {PICKLIST}")
+
+    if not report:
+        return ["nothing to split — the Champion archetypes are already there"]
+    return report
+
+
+def _move_what_only_the_champion_reads(leader, champion):
+    """Hand over every modifier reaching only the model carrying it.
+
+    From a pick the gang holds such a modifier reaches nobody, so it can
+    only have been written for the pick a Champion makes. The rows
+    themselves are reused: what changes is which pickable carries them.
+    """
+    theirs = list(leader.modifiers.filter(targets_miniature__reach=BEARER))
+    for row in theirs:
+        leader.modifiers.remove(row)
+        champion.modifiers.add(row)
+    return len(theirs)
+
+
+def _wyrd_before_the_move(wyrd, Modifier):
+    """Narrow the Wyrd subtype grant to the model carrying it.
+
+    It reaches every Champion in the gang, which from the gang's own
+    pick makes every Champion a Wyrd. Once it reaches only the model
+    carrying it, the ordinary hand-over takes it to the Champion's
+    pickable with the rest.
+    """
+    adds = Modifier.objects.filter(
+        pk=WYRD_ADDS_TO_CHAMPIONS, targets_miniature__isnull=False
+    ).first()
+    if adds is None or not wyrd.modifiers.filter(pk=adds.pk).exists():
+        return []
+    scope = adds.targets_miniature
+    if scope.reach == BEARER:
+        return []
+    scope.reach = BEARER
+    scope.save(update_fields=["reach"])
+    return [f"{adds.name} now reaches the model carrying it"]
+
+
+def _wyrd_after_the_move(apps, wyrd, champion_wyrd, Modifier, Subtype):
+    """Give each of the two Wyrd picks its own reading of the two
+    modifiers that speak for both."""
+    HasSubtypes = apps.get_model("library", "HasSubtypes")
+    TargetsMiniature = apps.get_model("library", "TargetsMiniature")
+    OffersChoice = apps.get_model("library", "OffersChoice")
+    PlacesCategory = apps.get_model("library", "PlacesCategory")
+
+    champion_rank = Subtype.objects.filter(pk=CHAMPION_SUBTYPE).first()
+    leader_rank = Subtype.objects.filter(pk=LEADER_SUBTYPE).first()
+    report = []
+
+    offer = Modifier.objects.filter(
+        pk=WYRD_OFFERS_A_POWER,
+        offers_choice__isnull=False,
+        targets_miniature__isnull=False,
+    ).first()
+    if (
+        offer is not None
+        and champion_rank is not None
+        and leader_rank is not None
+        and champion_wyrd.modifiers.filter(pk=offer.pk).exists()
+    ):
+        for row in offer.targets_miniature.has_subtypes.all():
+            row.subtypes.set([champion_rank])
+        if not Modifier.objects.filter(
+            pack_id=offer.pack_id, name__iexact=LEADER_OFFER
+        ).exists():
+            scope = TargetsMiniature.objects.create(reach=EVERY_MODEL)
+            narrowing = HasSubtypes.objects.create(scope=scope)
+            narrowing.subtypes.set([leader_rank])
+            source = offer.offers_choice
+            wyrd.modifiers.add(
+                Modifier.objects.create(
+                    name=LEADER_OFFER,
+                    pack_id=offer.pack_id,
+                    targets_miniature=scope,
+                    offers_choice=OffersChoice.objects.create(
+                        of_kind_id=source.of_kind_id,
+                        from_section_id=source.from_section_id,
+                        label=source.label,
+                        will_be_assigned_to=source.will_be_assigned_to,
+                    ),
+                )
+            )
+            report.append(f"created {LEADER_OFFER}")
+
+    powers = Modifier.objects.filter(
+        pk=WYRD_POWERS_ARE_PRIMARY,
+        places_category__isnull=False,
+        targets_miniature__isnull=False,
+    ).first()
+    if (
+        powers is not None
+        and champion_rank is not None
+        and wyrd.modifiers.filter(pk=powers.pk).exists()
+    ):
+        scope = powers.targets_miniature
+        if not scope.has_subtypes.exists():
+            # The gang's pick governs every Outcast model except the
+            # Champions, who read their own pick instead.
+            narrowing = HasSubtypes.objects.create(scope=scope, negate=True)
+            narrowing.subtypes.set([champion_rank])
+            report.append(f"{powers.name} now reaches every model except Champions")
+        if not Modifier.objects.filter(
+            pack_id=powers.pack_id, name__iexact=CHAMPION_WYRD_POWERS
+        ).exists():
+            source = powers.places_category
+            wyrd_only = TargetsMiniature.objects.create(reach=BEARER)
+            champion_wyrd.modifiers.add(
+                Modifier.objects.create(
+                    name=CHAMPION_WYRD_POWERS,
+                    pack_id=powers.pack_id,
+                    targets_miniature=wyrd_only,
+                    places_category=PlacesCategory.objects.create(
+                        category_id=source.category_id,
+                        the_chosen=source.the_chosen,
+                        section_id=source.section_id,
+                    ),
+                )
+            )
+            report.append(f"created {CHAMPION_WYRD_POWERS}")
+
+    return report

--- a/n26/library/migrations/0077_champions_pick_their_own_archetype.py
+++ b/n26/library/migrations/0077_champions_pick_their_own_archetype.py
@@ -1,0 +1,34 @@
+"""The Champion's Archetype choice gets pickables of its own.
+
+One picklist served both the gang's Archetype and the Champion's, so one
+pickable carried both readings of the same archetype and its modifiers
+could be scoped correctly for only one of them. This builds the Champion
+a picklist of five pickables of its own, hands each the modifiers that
+were only ever the Champion's, and points the Champion's slot at the new
+list. ``n26/library/champion_archetypes.py`` states the rules and holds
+the ids.
+
+A library without the Outcast content — a fresh database, anyone's
+checkout before the content is loaded — is left exactly as it stands.
+Nothing is unpicked in reverse: the pickables the Champion's picks now
+name would be deleted out from under them.
+"""
+
+from django.db import migrations
+
+from n26.library.champion_archetypes import make_champion_archetypes
+
+
+def split_the_archetypes(apps, schema_editor):
+    for line in make_champion_archetypes(apps):
+        print(f"[archetypes] {line}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0076_contributes_to_counter_and_counter_drawn"),
+    ]
+
+    operations = [
+        migrations.RunPython(split_the_archetypes, migrations.RunPython.noop),
+    ]

--- a/n26/library/test_champion_archetypes.py
+++ b/n26/library/test_champion_archetypes.py
@@ -1,0 +1,326 @@
+"""Splitting the Outcast archetypes into a Leader set and a Champion set.
+
+The content is built here with the ids the shipped library carries, so
+what the test reshapes is the shape the migration will find. Everything
+asserted would still be true with no gang and no fighter: this is about
+what the library holds, not what a card reads.
+"""
+
+import pytest
+from django.apps import apps
+
+from n26.library.authoring import (
+    create_category,
+    create_collection,
+    create_pickable,
+    create_picklist,
+    create_section,
+    create_slot,
+    create_slot_type,
+    create_subtype,
+    ef_adds,
+    ef_offers_choice,
+    ef_places,
+    has_subtypes,
+    modifier,
+    section_of,
+    targets_every_model,
+    targets_model,
+)
+from n26.library.champion_archetypes import (
+    ARCHETYPES,
+    CHAMPION_SLOT,
+    CHAMPION_SUBTYPE,
+    CHAMPION_WYRD_POWERS,
+    LEADER_OFFER,
+    LEADER_SUBTYPE,
+    PICKLIST,
+    QUALIFIER,
+    WYRD_ADDS_TO_CHAMPIONS,
+    WYRD_OFFERS_A_POWER,
+    WYRD_POWERS_ARE_PRIMARY,
+    make_champion_archetypes,
+)
+from n26.library.models import Modifier, Pickable, Picklist, Slot
+
+pytestmark = pytest.mark.django_db
+
+#: The gang's own Archetype choice, whose pick the Leader makes and the
+#: gang holds. Only the Champion's slot is named by id in the module, so
+#: this one's is the test's own.
+GANG_SLOT = "01M0G9383Y8QY32V4MANZ3VHE3"
+
+
+@pytest.fixture
+def skills(default_pack):
+    """The two sections a placement can aim at."""
+    collection = create_collection("Skills & Powers")
+    return {
+        "primary": section_of(collection, "Primary", 0),
+        "secondary": section_of(collection, "Secondary", 1),
+    }
+
+
+@pytest.fixture
+def sets(default_pack):
+    heading = create_section("Skills")
+    return {
+        name: create_category(heading, name) for name in ("Combat", "Savant", "Cunning")
+    } | {"Wyrd Powers": create_category(create_section("Powers"), "Wyrd Powers")}
+
+
+@pytest.fixture
+def ranks(default_pack):
+    return {
+        "Champion": create_subtype("Champion", id=CHAMPION_SUBTYPE),
+        "Leader": create_subtype("Leader", id=LEADER_SUBTYPE),
+        "Wyrd": create_subtype("Wyrd"),
+    }
+
+
+@pytest.fixture
+def slot_type(default_pack):
+    return create_slot_type("Archetype", allows_repeats=False)
+
+
+@pytest.fixture
+def leaders(slot_type, sets, skills, ranks):
+    """The five archetypes as they stand today: one pickable each,
+    carrying the gang's reading and the Champion's at once."""
+    made = {}
+    for name, pk in ARCHETYPES:
+        pickable = create_pickable(name, slot_type, qualifier="Archetype", id=pk)
+        modifier(
+            f"{name}: Leader models — Savant is Primary",
+            targets_every_model(has_subtypes(ranks["Leader"])),
+            ef_places(sets["Savant"], skills["primary"]),
+            attach_to=pickable,
+        )
+        modifier(
+            f"{name}: Hive Scum — Cunning is Secondary",
+            targets_every_model(),
+            ef_places(sets["Cunning"], skills["secondary"]),
+            attach_to=pickable,
+        )
+        modifier(
+            f"{name}: Champion (own pick) — Combat is Primary",
+            targets_model(has_subtypes(ranks["Champion"])),
+            ef_places(sets["Combat"], skills["primary"]),
+            attach_to=pickable,
+        )
+        made[name] = pickable
+    return made
+
+
+@pytest.fixture
+def wyrd(leaders, ranks, sets, skills):
+    """Wyrd's three extra modifiers — the ones the bearer rule does not
+    sort on its own."""
+    from n26.library.models import Power
+
+    pickable = leaders["Wyrd"]
+    modifier(
+        "Wyrd, Champion models: adds Wyrd",
+        targets_every_model(has_subtypes(ranks["Champion"])),
+        ef_adds(ranks["Wyrd"]),
+        attach_to=pickable,
+        id=WYRD_ADDS_TO_CHAMPIONS,
+    )
+    modifier(
+        "Wyrd, Champion or Leader models: offers a choice of power from Primary",
+        targets_model(has_subtypes(ranks["Champion"], ranks["Leader"])),
+        ef_offers_choice(Power, from_section=skills["primary"]),
+        attach_to=pickable,
+        id=WYRD_OFFERS_A_POWER,
+    )
+    modifier(
+        "Wyrd: puts Wyrd Powers under Primary",
+        targets_every_model(),
+        ef_places(sets["Wyrd Powers"], skills["primary"]),
+        attach_to=pickable,
+        id=WYRD_POWERS_ARE_PRIMARY,
+    )
+    return pickable
+
+
+@pytest.fixture
+def outcast(slot_type, leaders, wyrd):
+    """Both slots, drawing from the one picklist."""
+    picklist = create_picklist(
+        "Archetypes", slot_type, members=[leaders[name] for name, _ in ARCHETYPES]
+    )
+    create_slot(
+        "Archetype",
+        slot_type,
+        picklist,
+        label="Archetype",
+        assigned_to="gang",
+        id=GANG_SLOT,
+    )
+    return create_slot(
+        "Archetype (Champion)",
+        slot_type,
+        picklist,
+        label="Archetype",
+        min_picks=0,
+        assigned_to="bearer",
+        id=CHAMPION_SLOT,
+    )
+
+
+def champion(name):
+    return Pickable.objects.get(name=name, qualifier=QUALIFIER)
+
+
+def scope_of(pk):
+    return Modifier.objects.get(pk=pk).targets_miniature
+
+
+def named_by(pk):
+    """The subtypes the one condition on this modifier's scope names,
+    and whether it is read the other way round."""
+    (row,) = scope_of(pk).has_subtypes.all()
+    return sorted(s.name for s in row.subtypes.all()), row.negate
+
+
+class TestABlankLibrary:
+    """Nothing to find is a normal outcome, not a failure: a fresh
+    database migrates before any content is loaded into it."""
+
+    def test_it_changes_nothing_and_says_so(self, db):
+        report = make_champion_archetypes(apps)
+
+        assert report == [
+            "nothing to split — this library holds no Champion Archetype slot"
+        ]
+        assert not Pickable.objects.exists()
+
+    def test_a_slot_without_its_archetypes_changes_nothing(
+        self, slot_type, default_pack
+    ):
+        create_slot(
+            "Archetype (Champion)",
+            slot_type,
+            create_picklist("Archetypes", slot_type),
+            assigned_to="bearer",
+            id=CHAMPION_SLOT,
+        )
+
+        report = make_champion_archetypes(apps)
+
+        assert report == ["nothing to split — this library holds no Brawler archetype"]
+        assert not Picklist.objects.filter(name=PICKLIST).exists()
+
+
+class TestTheChampionsOwnArchetypes:
+    def test_each_archetype_gains_a_copy_under_the_same_name(self, outcast):
+        make_champion_archetypes(apps)
+
+        for name, _ in ARCHETYPES:
+            copy = champion(name)
+            assert str(copy) == name
+            assert copy.authoring_label == f"{name} — {QUALIFIER}"
+            assert copy.slot_type_id == outcast.slot_type_id
+
+    def test_they_sit_on_a_list_of_their_own_in_the_printed_order(self, outcast):
+        make_champion_archetypes(apps)
+
+        picklist = Picklist.objects.get(name=PICKLIST)
+        assert [member.pickable.name for member in picklist.members.all()] == [
+            name for name, _ in ARCHETYPES
+        ]
+
+    def test_the_champions_slot_draws_from_that_list(self, outcast):
+        make_champion_archetypes(apps)
+
+        outcast.refresh_from_db()
+        assert outcast.picklist.name == PICKLIST
+
+    def test_the_gangs_slot_still_draws_from_the_old_one(self, outcast):
+        make_champion_archetypes(apps)
+
+        assert Slot.objects.get(pk=GANG_SLOT).picklist.name == "Archetypes"
+
+
+class TestWhichModifiersMoved:
+    """A modifier reaching only the model carrying it does nothing at all
+    on a pick the gang holds, so it was the Champion's all along."""
+
+    def test_the_champions_own_reading_moves_across(self, outcast, leaders):
+        make_champion_archetypes(apps)
+
+        for name, _ in ARCHETYPES:
+            moved = [m.name for m in champion(name).modifiers.all()]
+            assert f"{name}: Champion (own pick) — Combat is Primary" in moved
+
+    def test_the_gangs_reading_stays_where_it_was(self, outcast, leaders):
+        make_champion_archetypes(apps)
+
+        for name, _ in ARCHETYPES:
+            kept = [m.name for m in leaders[name].modifiers.all()]
+            assert f"{name}: Leader models — Savant is Primary" in kept
+            assert f"{name}: Hive Scum — Cunning is Secondary" in kept
+            assert f"{name}: Champion (own pick) — Combat is Primary" not in kept
+
+    def test_the_rows_themselves_are_reused(self, outcast, leaders):
+        before = Modifier.objects.count()
+
+        make_champion_archetypes(apps)
+
+        # Two new modifiers, both Wyrd's: the Leader's own offer and the
+        # Champion's own Wyrd Powers placement.
+        assert Modifier.objects.count() == before + 2
+
+
+class TestWyrd:
+    def test_the_subtype_grant_becomes_the_champions_own(self, outcast, wyrd):
+        make_champion_archetypes(apps)
+
+        assert scope_of(WYRD_ADDS_TO_CHAMPIONS).reach == "bearer"
+        assert champion("Wyrd").modifiers.filter(pk=WYRD_ADDS_TO_CHAMPIONS).exists()
+        assert not wyrd.modifiers.filter(pk=WYRD_ADDS_TO_CHAMPIONS).exists()
+
+    def test_the_power_offer_ends_up_on_both_pickables(self, outcast, wyrd):
+        make_champion_archetypes(apps)
+
+        assert champion("Wyrd").modifiers.filter(pk=WYRD_OFFERS_A_POWER).exists()
+        assert named_by(WYRD_OFFERS_A_POWER) == (["Champion"], False)
+
+        theirs = wyrd.modifiers.get(name=LEADER_OFFER)
+        assert theirs.targets_miniature.reach == "every_model"
+        assert named_by(theirs.pk) == (["Leader"], False)
+        assert (
+            theirs.offers_choice.from_section_id
+            == Modifier.objects.get(
+                pk=WYRD_OFFERS_A_POWER
+            ).offers_choice.from_section_id
+        )
+
+    def test_the_gangs_wyrd_powers_placement_skips_champions(self, outcast, wyrd):
+        make_champion_archetypes(apps)
+
+        assert wyrd.modifiers.filter(pk=WYRD_POWERS_ARE_PRIMARY).exists()
+        assert named_by(WYRD_POWERS_ARE_PRIMARY) == (["Champion"], True)
+
+    def test_the_champions_wyrd_places_the_powers_for_itself(self, outcast, wyrd):
+        make_champion_archetypes(apps)
+
+        own = champion("Wyrd").modifiers.get(name=CHAMPION_WYRD_POWERS)
+        assert own.targets_miniature.reach == "bearer"
+        assert not own.targets_miniature.has_subtypes.exists()
+        source = Modifier.objects.get(pk=WYRD_POWERS_ARE_PRIMARY).places_category
+        assert own.places_category.category_id == source.category_id
+        assert own.places_category.section_id == source.section_id
+
+
+class TestRunningItAgain:
+    def test_a_second_pass_finds_the_split_already_made(self, outcast):
+        make_champion_archetypes(apps)
+        counts = (Pickable.objects.count(), Modifier.objects.count())
+
+        report = make_champion_archetypes(apps)
+
+        assert report == [
+            "nothing to split — the Champion archetypes are already there"
+        ]
+        assert (Pickable.objects.count(), Modifier.objects.count()) == counts

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -62,6 +62,7 @@ __all__ = [
     "delete_nameless_gang_type",
     "rehost_gang_picks",
     "repair_doubled_refunds",
+    "repoint_champion_picks",
     "run_batched",
     "task_routes",
 ]
@@ -161,6 +162,10 @@ class Operation(models.TextChoices):
         "n26_rehost_gang_picks",
         "n26: the picks a gang holds move off its models onto the gang",
     )
+    REPOINT_CHAMPION_PICKS = (
+        "n26_repoint_champion_picks",
+        "n26: the Champion picks move onto the Champion archetypes",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -174,6 +179,7 @@ LOCK_KEYS = {
     Operation.BACKFILL_BUILT_INS: 826_020_612,
     Operation.DROP_DUPLICATE_GRANTS: 826_020_613,
     Operation.REHOST_GANG_PICKS: 826_020_614,
+    Operation.REPOINT_CHAMPION_PICKS: 826_020_615,
 }
 
 
@@ -899,6 +905,72 @@ def rehost_gang_picks_view(request):
 
 
 @task
+def repoint_champion_picks(backfill_id, **said_by_whoever_enqueued_it):
+    """Point every live pick at the pickable of its own name on its
+    slot's picklist, and prove every affected gang's books whole, once.
+
+    A gang's worth of picks in one transaction: small enough to hold,
+    and a gang that fails to reconcile unwinds its own move.
+    """
+    from n26.core.repoint_champion_picks import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.REPOINT_CHAMPION_PICKS,
+        "Champion pick repointing",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
+REPOINT_WORDS = {
+    "noun": "move",
+    "intro": (
+        "This moves picks between pickables in players' gangs. A slot "
+        "draws from a picklist, and pointing the slot at a different list "
+        "moves nothing already picked: the pick goes on naming what was "
+        "picked, which the list the slot now reads may not hold at all. "
+        "A Champion's Archetype and the gang's were picked from one list, "
+        "so every Champion's pick names the gang's archetype and reads "
+        "the gang's skill sets rather than the Champion's. Every live "
+        "pick of a slot that puts the pick on the model that made it, "
+        "where the slot's picklist does not hold what was picked, is "
+        "moved onto the pickable of the same name on that list. Nothing "
+        "else changes: the pick still names the assignment that asked and "
+        "the slot it settles, so the card still reads it as chosen, and "
+        "it still goes when that model does. An archived pick is counted "
+        "and left alone. No money moves; every gang is proved to "
+        "reconcile."
+    ),
+    "nothing_heading": "Nothing to move",
+    "nothing_flash": (
+        "There was nothing to move — every live pick names something its "
+        "slot's picklist offers."
+    ),
+    "nothing_words": "Every live pick names something its slot's picklist offers.",
+    "refuses_heading": "The move cannot run",
+    "button": "Move the picks onto their slot's own pickables",
+    "confirm": (
+        "Move every live pick onto the pickable of the same name on its "
+        "slot's picklist? This cannot be undone."
+    ),
+}
+
+
+def repoint_champion_picks_view(request):
+    """Preview the move (GET), or record a run and enqueue it."""
+    from n26.core.repoint_champion_picks import find
+
+    return _deletion_view(
+        request,
+        Operation.REPOINT_CHAMPION_PICKS,
+        find,
+        repoint_champion_picks,
+        REPOINT_WORDS,
+    )
+
+
+@task
 def audit_reconcile(backfill_id, **said_by_whoever_enqueued_it):
     """Check every unarchived gang's books against its ledger.
 
@@ -1211,6 +1283,28 @@ register_operation(
 
 register_operation(
     MaintenanceOperation(
+        operation=Operation.REPOINT_CHAMPION_PICKS.value,
+        name=Operation.REPOINT_CHAMPION_PICKS.label,
+        added=date(2026, 9, 4),
+        description=(
+            "A slot draws from a picklist, and pointing the slot at a "
+            "different list moves nothing already picked. A Champion's "
+            "Archetype and the gang's were picked from one list, so a "
+            "Champion's pick names the gang's archetype and reads the "
+            "gang's skill sets rather than the Champion's. This points "
+            "each such pick at the pickable of the same name on its "
+            "slot's own picklist. Each still names what asked it and the "
+            "slot it settles, so the card still reads it as chosen. No "
+            "money moves; every gang is proved to reconcile."
+        ),
+        view=repoint_champion_picks_view,
+        detail_template="admin/maintenance/n26/_rehost_detail.html",
+    )
+)
+
+
+register_operation(
+    MaintenanceOperation(
         operation=Operation.DROP_DUPLICATE_GRANTS.value,
         name=Operation.DROP_DUPLICATE_GRANTS.label,
         added=date(2026, 8, 31),
@@ -1373,6 +1467,7 @@ task_routes = [
     TaskRoute(backfill_built_ins, ack_deadline=600),
     TaskRoute(drop_duplicate_grants, ack_deadline=600),
     TaskRoute(rehost_gang_picks, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(repoint_champion_picks, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/tests/sandbox/test_repoint_champion_picks.py
+++ b/n26/tests/sandbox/test_repoint_champion_picks.py
@@ -1,0 +1,548 @@
+"""Moving a pick onto the pickable its slot's picklist now offers.
+
+A slot draws from a picklist, and pointing the slot at a different list
+moves nothing already picked: the pick goes on naming what was picked,
+which the list the slot now reads need not hold at all. The repair
+points such a pick at the pickable of the same name on the slot's own
+list, keeping everything that says which choice it settles and why it
+exists, and proves each gang's books whole before it commits.
+
+The fault is planted in the shape it takes: one picklist serves a
+Champion's own Archetype choice, the pick is made through the page, and
+the slot is then pointed at a list of Champion archetypes carrying the
+same names.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.card import build_card, build_modifier_index
+from n26.core.effects import compute
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled, check_gang
+from n26.core.render import render_gang
+from n26.core.repoint_champion_picks import Refused, apply, find
+from n26.core.views.choose import link_slots
+from n26.library.authoring import (
+    add_picklist_member,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_rule,
+    create_slot,
+    create_slot_type,
+    ef_adds,
+    modifier,
+    targets_model,
+)
+from n26.maintenance import Operation, repoint_champion_picks_view
+from n26.tests.sandbox.actions import found_gang, hire
+
+pytestmark = pytest.mark.django_db
+
+CHAMPION_PRICE = 90
+GANGER_PRICE = 50
+
+#: The names the two lists share — a pick made from one has to land on
+#: the same name on the other.
+NAMES = ("Brawler", "Wyrd")
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("repoint-player")
+
+
+@pytest.fixture
+def slot_type(default_pack):
+    return create_slot_type("Archetype", allows_repeats=False)
+
+
+#: What the Champion's own archetype gives the model that picked it.
+PAYLOAD = "Duellist"
+
+
+@pytest.fixture
+def shared(slot_type):
+    """The archetypes as one list held them, serving both choices."""
+    return {
+        name: create_pickable(name, slot_type, qualifier="Archetype") for name in NAMES
+    }
+
+
+@pytest.fixture
+def shared_list(slot_type, shared):
+    return create_picklist(
+        "Archetypes", slot_type, members=[shared[name] for name in NAMES]
+    )
+
+
+@pytest.fixture
+def champion_archetypes(slot_type):
+    """The Champion's own five, under the same names."""
+    made = {
+        name: create_pickable(name, slot_type, qualifier="Champion Archetype")
+        for name in NAMES
+    }
+    modifier(
+        f"Brawler: {PAYLOAD}",
+        targets_model(),
+        ef_adds(create_rule(PAYLOAD)),
+        attach_to=made["Brawler"],
+    )
+    return made
+
+
+@pytest.fixture
+def champion_list(slot_type, champion_archetypes):
+    return create_picklist(
+        "Champion Archetypes",
+        slot_type,
+        members=[champion_archetypes[name] for name in NAMES],
+    )
+
+
+@pytest.fixture
+def champion_slot(slot_type, shared_list):
+    """The Champion is asked and the Champion holds the pick. Which list
+    it draws from is set by each test, because the fault is a slot
+    pointed at one list and then the other."""
+    return create_slot(
+        "Archetype (Champion)",
+        slot_type,
+        shared_list,
+        label="Archetype",
+        min_picks=0,
+        assigned_to="bearer",
+    )
+
+
+@pytest.fixture
+def champion_profile(person_type, gang_type, champion_slot):
+    """The slot reaches the Champion through a modifier on their profile,
+    so the assignment that asks is their membership."""
+    profile = create_profile("Champion", person_type, gang_type, price=CHAMPION_PRICE)
+    modifier(
+        "Champion: the model is asked its Archetype",
+        targets_model(),
+        ef_adds(champion_slot),
+        attach_to=profile,
+    )
+    return profile
+
+
+@pytest.fixture
+def ganger_profile(person_type, gang_type):
+    return create_profile("Hive Scum", person_type, gang_type, price=GANGER_PRICE)
+
+
+@pytest.fixture
+def gang(owner, gang_type):
+    return found_gang("The Unlisted", gang_type, owner=owner, budget=1000)
+
+
+@pytest.fixture
+def champion(gang, champion_profile):
+    return hire(gang, champion_profile, "Champion", paid=CHAMPION_PRICE)
+
+
+@pytest.fixture
+def scum(gang, ganger_profile):
+    return hire(gang, ganger_profile, "Scum", paid=GANGER_PRICE)
+
+
+@pytest.fixture
+def reader(client, owner):
+    client.force_login(owner)
+    return client
+
+
+@pytest.fixture
+def console(db):
+    """The maintenance console, as a superuser sees it. Its own client,
+    because the player's is signed in as the gang's owner."""
+    from django.test import Client
+
+    superuser = User.objects.create_superuser("root", "root@example.com", "x")
+    client = Client()
+    client.force_login(superuser)
+    return client
+
+
+def _point_slot_at(slot, picklist):
+    slot.picklist = picklist
+    slot.save(update_fields=["picklist"])
+
+
+def rules_on(miniature):
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return [line.name for line in compute(card, index).rules]
+
+
+def card_of(gang, name):
+    sheet = render_gang(gang)
+    link_slots(gang, sheet, *sheet.models)
+    return next(card for card in sheet.models if card.name == name)
+
+
+def chosen_on(gang, name):
+    (line,) = card_of(gang, name).questions
+    return line.chosen
+
+
+def choose(reader, gang, name, pickable):
+    """Settle the one choice on this model's card, through the page."""
+    (line,) = card_of(gang, name).questions
+    response = reader.post(line.href, {"thing": f"library.pickable:{pickable.pk}"})
+    assert response.status_code == 302, response.content.decode()
+    return Assignment.objects.get(pickable=pickable, gang_root=gang, archived=False)
+
+
+@pytest.fixture
+def adrift(reader, gang, champion, champion_slot, shared, champion_list):
+    """A pick made from the shared list, under a slot that now draws
+    from the Champion's own."""
+    pick = choose(reader, gang, "Champion", shared["Brawler"])
+    assert pick.miniature == champion
+    assert pick.caused_by == champion.membership
+    _point_slot_at(champion_slot, champion_list)
+    gang.refresh_from_db()
+    assert_reconciled(gang)
+    return pick
+
+
+class TestFindingWhatIsOffTheList:
+    def test_a_pick_the_list_still_offers_is_not_named(
+        self, reader, gang, champion, shared
+    ):
+        pick = choose(reader, gang, "Champion", shared["Brawler"])
+        assert pick.pickable == shared["Brawler"]
+
+        assert find().nothing_here
+
+    def test_a_pick_of_a_slot_that_hands_the_gang_the_pick_is_not_named(
+        self, reader, gang, champion, champion_slot, shared, champion_list
+    ):
+        """Where the gang holds the pick, moving it is the gang's own
+        repair and not this one."""
+        choose(reader, gang, "Champion", shared["Brawler"])
+        champion_slot.assigned_to = "gang"
+        champion_slot.save(update_fields=["assigned_to"])
+        _point_slot_at(champion_slot, champion_list)
+
+        assert find().nothing_here
+
+    def test_the_plan_names_the_gang_and_its_pick(
+        self, gang, adrift, champion_archetypes
+    ):
+        plan = find()
+
+        assert plan.ok
+        assert plan.gangs == (
+            (gang.pk, ((adrift.pk, champion_archetypes["Brawler"].pk),)),
+        )
+        assert (
+            f"gang {gang.pk}: move 1 pick onto the pickable of the same name "
+            "on its slot's picklist" in plan.preview()
+        )
+
+    def test_an_archived_pick_is_counted_and_not_named(self, gang, adrift):
+        adrift.archived = True
+        adrift.save(update_fields=["archived"])
+
+        plan = find()
+
+        assert plan.nothing_here
+        assert plan.archived == 1
+        assert (
+            "1 archived pick naming something off the list, left alone"
+            in plan.preview()
+        )
+
+    def test_a_pick_with_no_match_on_the_list_refuses(
+        self, reader, gang, champion, champion_slot, shared, slot_type
+    ):
+        """Nothing of that name to move to is not this fault, and the
+        move cannot run at all while one stands."""
+        pick = choose(reader, gang, "Champion", shared["Wyrd"])
+        _point_slot_at(
+            champion_slot,
+            create_picklist(
+                "Champion Archetypes",
+                slot_type,
+                members=[create_pickable("Brawler", slot_type, qualifier="Champion")],
+            ),
+        )
+
+        plan = find()
+
+        assert not plan.ok
+        assert any("nothing of that name is on its slot" in p for p in plan.problems)
+        with pytest.raises(Refused):
+            apply(plan)
+        pick.refresh_from_db()
+        assert pick.pickable == shared["Wyrd"]
+
+    def test_a_pick_with_two_of_its_name_on_the_list_refuses(
+        self, gang, adrift, champion_list, slot_type
+    ):
+        add_picklist_member(
+            champion_list,
+            create_pickable("Brawler", slot_type, qualifier="Second Champion"),
+        )
+
+        plan = find()
+
+        assert not plan.ok
+        assert any("cannot be read" in p for p in plan.problems)
+        with pytest.raises(Refused):
+            apply(plan)
+
+
+class TestMovingThePick:
+    def test_the_pick_names_the_champions_own_and_keeps_its_links(
+        self, gang, champion, adrift, champion_archetypes
+    ):
+        before = (adrift.caused_by_id, adrift.chosen_for_id, adrift.chosen_for_slot_id)
+
+        report = apply(find())
+
+        adrift.refresh_from_db()
+        assert adrift.pickable == champion_archetypes["Brawler"]
+        assert (adrift.miniature, adrift.gang) == (champion, None)
+        assert (
+            adrift.caused_by_id,
+            adrift.chosen_for_id,
+            adrift.chosen_for_slot_id,
+        ) == before
+        assert adrift.caused_by == champion.membership
+        assert f"gang {gang.pk}: moved 1 pick onto its slot's own pickables" in report
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_the_champions_card_still_reads_it_as_chosen(self, gang, adrift):
+        apply(find())
+
+        assert chosen_on(gang, "Champion") == "Brawler"
+
+    def test_the_champion_now_reads_its_own_archetype(self, gang, champion, adrift):
+        """What the repair is for: until the pick names the Champion's
+        own pickable, what that pickable says reaches nobody."""
+        assert PAYLOAD not in rules_on(champion)
+
+        apply(find())
+
+        assert PAYLOAD in rules_on(champion)
+
+    def test_what_the_pick_caused_stays_where_it_is(self, gang, champion, adrift):
+        below = Assignment.objects.create(
+            rule=create_rule("Freeze Time"),
+            miniature=champion,
+            caused_by=adrift,
+        )
+
+        apply(find())
+
+        below.refresh_from_db()
+        assert below.miniature == champion
+        assert below.caused_by_id == adrift.pk
+
+    def test_the_pick_still_goes_with_the_champion(self, gang, champion, adrift):
+        from n26.tests.sandbox.actions import remove
+
+        apply(find())
+
+        remove(champion.membership)
+        adrift.refresh_from_db()
+        assert adrift.archived
+
+    def test_a_second_run_finds_nothing(self, adrift):
+        apply(find())
+
+        assert find().nothing_here
+
+    def test_a_clean_gang_applies_to_nothing(self, gang, champion, scum):
+        report = apply(find())
+
+        assert report == [
+            "nothing to move — every live pick names something its slot's "
+            "picklist offers"
+        ]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestAGangThatCannotBeMadeWhole:
+    """A gang is moved in its own transaction and proved before it
+    commits. One that does not reconcile, or whose picks changed while
+    the plan stood, is left exactly as it was and named on the report."""
+
+    def test_a_gang_that_does_not_reconcile_is_rolled_back(
+        self, gang, champion, adrift, shared, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "n26.core.reconcile.check_gang", lambda g: ["the books disagree"]
+        )
+
+        report = apply(find())
+
+        adrift.refresh_from_db()
+        assert adrift.pickable == shared["Brawler"]
+        assert any(
+            line.startswith(f"gang {gang.pk}: skipped — does not reconcile")
+            for line in report
+        )
+
+    def test_a_gang_whose_picks_changed_since_the_plan_is_skipped(
+        self, gang, champion, adrift, shared
+    ):
+        from n26.tests.sandbox.actions import remove
+
+        plan = find()
+        remove(champion.membership)
+
+        report = apply(plan)
+
+        assert (
+            f"gang {gang.pk}: skipped — its picks changed since the plan was "
+            "read; read it again" in report
+        )
+        adrift.refresh_from_db()
+        assert adrift.archived
+        assert adrift.pickable == shared["Brawler"]
+
+
+class TestSeveralGangsAndSeveralPicks:
+    """Each gang is its own line and its own transaction, and a gang
+    with two Champions moves both picks."""
+
+    @pytest.fixture
+    def crowd(
+        self,
+        reader,
+        gang,
+        champion,
+        champion_slot,
+        shared,
+        champion_list,
+        owner,
+        gang_type,
+        champion_profile,
+    ):
+        first = choose(reader, gang, "Champion", shared["Brawler"])
+        hire(gang, champion_profile, "Second", paid=CHAMPION_PRICE)
+        second = choose(reader, gang, "Second", shared["Wyrd"])
+        other = found_gang("The Others", gang_type, owner=owner, budget=1000)
+        hire(other, champion_profile, "Champion", paid=CHAMPION_PRICE)
+        third = choose(reader, other, "Champion", shared["Brawler"])
+        _point_slot_at(champion_slot, champion_list)
+        return {"gang": gang, "other": other, "picks": (first, second, third)}
+
+    def test_the_plan_names_each_gang_and_counts_the_whole(
+        self, crowd, champion_archetypes
+    ):
+        plan = find()
+
+        assert plan.gangs == tuple(
+            sorted(
+                [
+                    (
+                        crowd["gang"].pk,
+                        (
+                            (
+                                crowd["picks"][0].pk,
+                                champion_archetypes["Brawler"].pk,
+                            ),
+                            (crowd["picks"][1].pk, champion_archetypes["Wyrd"].pk),
+                        ),
+                    ),
+                    (
+                        crowd["other"].pk,
+                        ((crowd["picks"][2].pk, champion_archetypes["Brawler"].pk),),
+                    ),
+                ]
+            )
+        )
+        assert (
+            f"gang {crowd['gang'].pk}: move 2 picks onto the pickable of the "
+            "same name on its slot's picklist" in plan.preview()
+        )
+        assert "3 picks across 2 gangs" in plan.preview()
+
+    def test_the_plan_can_be_read_for_one_gang_alone(self, crowd, champion_archetypes):
+        narrowed = find(crowd["other"].pk)
+
+        assert narrowed.gangs == (
+            (
+                crowd["other"].pk,
+                ((crowd["picks"][2].pk, champion_archetypes["Brawler"].pk),),
+            ),
+        )
+
+    def test_every_pick_lands_on_the_name_it_had(self, crowd, champion_archetypes):
+        report = apply(find())
+
+        for pick, name in zip(
+            crowd["picks"], ("Brawler", "Wyrd", "Brawler"), strict=True
+        ):
+            pick.refresh_from_db()
+            assert pick.pickable == champion_archetypes[name]
+        assert (
+            f"gang {crowd['gang'].pk}: moved 2 picks onto its slot's own pickables"
+            in report
+        )
+        assert (
+            f"gang {crowd['other'].pk}: moved 1 pick onto its slot's own pickables"
+            in report
+        )
+        for g in (crowd["gang"], crowd["other"]):
+            g.refresh_from_db()
+            assert_reconciled(g)
+        assert find().nothing_here
+
+
+class TestTheConsole:
+    def test_the_operation_is_registered_and_named(self):
+        from gyrinx.maintenance.registry import operations, resolve_operation
+
+        assert Operation.REPOINT_CHAMPION_PICKS.value in {
+            op.operation for op in operations()
+        }
+        assert (
+            resolve_operation(Operation.REPOINT_CHAMPION_PICKS.value).view
+            is repoint_champion_picks_view
+        )
+
+    def test_its_page_shows_the_plan_and_writes_nothing(
+        self, console, gang, adrift, shared
+    ):
+        from gyrinx.maintenance.models import Backfill
+
+        page = console.get(
+            reverse("admin:maintenance_n26_repoint_champion_picks")
+        ).content.decode()
+
+        assert f"gang {gang.pk}: move 1 pick onto the pickable" in page
+        assert not Backfill.objects.exists()
+        adrift.refresh_from_db()
+        assert adrift.pickable == shared["Brawler"]
+        assert not check_gang(gang)
+
+    def test_applying_from_the_page_records_a_run_and_moves_the_pick(
+        self, console, gang, adrift, champion_archetypes
+    ):
+        from gyrinx.maintenance.models import Backfill
+
+        response = console.post(reverse("admin:maintenance_n26_repoint_champion_picks"))
+
+        assert response.status_code == 302
+        (run,) = Backfill.objects.all()
+        assert run.status == Backfill.Status.DONE, run.error
+        assert (
+            f"gang {gang.pk}: moved 1 pick onto its slot's own pickables"
+            in run.summary["report"]
+        )
+        adrift.refresh_from_db()
+        assert adrift.pickable == champion_archetypes["Brawler"]


### PR DESCRIPTION
Pieces 1 and 2 of #2405.

## What was wrong

In an Outcast gang the Leader picks the gang's Archetype and the gang holds
it, so it reaches every member. A Champion picks an Archetype of their own,
and that one is theirs alone. Both choices drew from the same picklist, so
one row per archetype had to carry both readings at once — the gang's,
which places skill sets for every model in the gang, and the Champion's,
which places them for the one model.

Nothing can be scoped to satisfy both. A modifier reaching "the model
carrying it" fires for nobody when the gang holds the pick; one reaching
"all models in the gang" fires for everybody when a Champion holds it. In
practice that meant a Champion's own Archetype was placing nothing — the
three placements written for it never ran — and the Wyrd archetype was
handing every Champion in the gang the Wyrd subtype off the *gang's* pick,
which the rules say the gang's Archetype does not govern.

## What changed

**Content (`library` migration 0077).** The Champion's slot gets a picklist
of its own, "Champion Archetypes", holding five pickables under the same
five names. Each takes the modifiers that were only ever the Champion's,
found by the rule that explains them: a modifier reaching only the model
carrying it can do nothing from a pick the gang holds. The Leader's
pickables keep the gang's reading.

Wyrd carries three modifiers that rule does not sort, so each is named
explicitly: the Champion subtype grant becomes a modifier about the one
model and moves across; the power offer moves to the Champion's pickable
narrowed to Champions, and the Leader's gains a copy narrowed to Leaders
that reaches every model (so the gang-held pick reaches its Leader); and
"puts Wyrd Powers under Primary" is narrowed on the Leader's side to every
model except Champions, with the Champion's pickable given its own copy.

The shaping logic lives in `n26/library/champion_archetypes.py` as a plain
function taking a model registry, so the migration runs it with historical
models and the unit test runs it with real ones. Finding no Outcast content
is a normal outcome — a fresh database migrates before content is loaded —
and a second run reports the split already made. The reverse is a no-op.

**Repair (`n26_repoint_champion_picks`).** Pointing a slot at a different
list moves nothing already picked, so every Champion's existing pick still
names the gang's archetype. The new maintenance operation finds every live
pick whose slot puts the pick on the model, whose slot's picklist does not
hold what was picked, and where that list offers exactly one pickable of
the same name — and points the pick at it. Nothing else changes: the pick
still names what asked it and the slot it settles, so the card still reads
it as chosen and it still goes when the model does. Archived picks are
counted and left alone, no money moves, and each gang is proved to
reconcile inside its own transaction or rolled back and named on the
record.

### Naming

The Champion's pickables keep the visible name — "Brawler", "Gunslinger",
"Mastermind", "Survivor", "Wyrd" — and carry the qualifier
"Champion Archetype", which is author-facing only. So a card and the gang
history read "Brawler" exactly as before, while the authoring pages show
"Brawler — Archetype" and "Brawler — Champion Archetype" side by side. The
uniqueness constraint on `Pickable` is (pack, lowercased name, lowercased
qualifier), so no rename was needed.

## Production counts

Read off `manage prodshell` before writing any of this:

- 101 live Champion Archetype picks across 63 gangs, plus 31 archived.
  All 101 sit on a model, as the slot says they should.
- Every one of them names one of the five shared pickables.
- The gang's own Archetype slot has 72 live picks; it is untouched here.
- Modifiers moving: three per archetype for Brawler, Gunslinger,
  Mastermind and Survivor, four for Wyrd — 16 rows, all reused rather than
  copied. Two new modifiers are written, both Wyrd's.

## Smoke evidence

Forked the content mirror (`createdb -T gyrinx_main gyrinx_smoke_champ`),
added the one modifier prod has that the mirror does not, and planted a
population at production's shape: 63 gangs, 105 live Champion picks, 8
archived.

Migration, on the fork:

```
Applying library.0077_champions_pick_their_own_archetype...
[archetypes] created the Champion Archetypes picklist
[archetypes] created Brawler for the Champion's own pick
... (five)
[archetypes] Wyrd, Champion models: adds Wyrd now reaches the model carrying it
[archetypes] Brawler: moved 3 modifiers onto the Champion's pickable
[archetypes] Gunslinger: moved 3 modifiers onto the Champion's pickable
[archetypes] Mastermind: moved 3 modifiers onto the Champion's pickable
[archetypes] Survivor: moved 3 modifiers onto the Champion's pickable
[archetypes] Wyrd: moved 4 modifiers onto the Champion's pickable
[archetypes] created Wyrd: Leader models — offers a choice of power from Primary (Skills & Powers)
[archetypes] Wyrd: puts Wyrd Powers under Primary (Skills & Powers) now reaches every model except Champions
[archetypes] created Wyrd: Champion (own pick) — puts Wyrd Powers under Primary (Skills & Powers)
[archetypes] Archetype (Champion) now draws from Champion Archetypes
```

Checked from outside the change, reading the rows back:

- 29 pickables became 34; 579 modifiers became 581. Nothing else moved.
- Each Leader pickable keeps its Leader-models and Hive-Scum readings and
  carries no bearer-scoped modifier; each Champion pickable carries only
  the Champion's.
- Wyrd, Leader side: `every model except Champion (all models)` on the Wyrd
  Powers placement, plus the new Leader-narrowed power offer at
  `Leader models (all models)`. Wyrd, Champion side: the subtype grant and
  the power offer both at `Champion models` reach `bearer`, plus the new
  bearer-scoped Wyrd Powers placement at `the model`.
- The Champion slot draws from "Champion Archetypes"; the gang's slot still
  draws from "Archetypes".
- Re-running the migration reports "nothing to split — the Champion
  archetypes are already there" and writes nothing.

Repair, driven through the real console with `django.test.Client` as a
superuser:

- GET showed "105 picks across 63 gangs" and "8 archived picks naming
  something off the list, left alone", and wrote no `Backfill` row.
- POST recorded one run, `done` in 9.2 seconds, 128 report lines, no gang
  skipped.
- Afterwards: 0 live picks still name a Leader pickable, 105 name a
  Champion one, the 8 archived picks are untouched, 0 of 63 gangs fail
  `check_gang`, and a second `find()` returns nothing.
- Compared all 113 picks row by row against a snapshot taken before the
  migration: 105 repointed, 8 left alone, and **not one** changed its
  printed name, its host, its cause, or the choice it settles. So the gang
  history, which names a pick by what its assignment points at now, still
  reads exactly as it did.
- Spot-checked a repointed Champion's card: it reads "Archetype: Wyrd" as
  before, now places Cunning under Primary and Savant under Secondary from
  its own pick, and carries the "Primary power" choice that only the
  Champion's Wyrd offers.

`pytest -q -n 4`: 9201 passed, 12 skipped, 1 xfailed.

## How to try it

1. `./scripts/dev.sh`, then `manage migrate` — the migration prints what it
   did, or says there is nothing to split.
2. As a superuser, open
   `/admin/maintenance/n26_repoint_champion_picks/` to preview the move,
   and post from that page to run it.
3. On a gang with a Champion who has picked an Archetype, the card should
   read the same name and now show that archetype's own skill placements.

## Note for whoever merges second

This branch's migration is `0077_champions_pick_their_own_archetype`,
renumbered after #2419 took 0076. The sibling branch `siskin-2405-draws-pick`
also adds an `n26/library` migration; whichever lands second has to renumber
again and repoint its dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
