### PR TITLE
feat: the Trading Post visit reads a counter, not TRADE_POINTS_FOR_RANK

### DIFF
--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -583,9 +583,12 @@ def _tell(e, row, alive):
                 return (Span(f"{verb} the {named} action"),), "gang"
             return (Span(f"{verb} an action"),), "gang"
         case Kind.VISITED_TRADING_POST:
-            # The rank they went as rides the note, so the line says what
-            # they added rather than what they happen to be now.
-            went_as = f" as {e.note}" if e.note else ""
+            # What raised their figure rides the note, so the line says
+            # what they added rather than what they happen to be now. A
+            # bare figure lands there where several things raised it, and
+            # "sent Rasp as 3" is no sentence — the line then says only
+            # that they went.
+            went_as = f" as {e.note}" if e.note and not e.note.isdigit() else ""
             return (
                 Span("sent "),
                 at,

--- a/n26/core/models/ledger.py
+++ b/n26/core/models/ledger.py
@@ -148,8 +148,10 @@ class LedgerEvent(Base):
         # are the gang's, counted once on the event above, so this
         # carries none of its own — it says who went, which is what
         # answers "has this model already used their action" and what a
-        # receipt names. The note holds the rank they went as, since
-        # that is what they added rather than what they are now.
+        # receipt names. The note holds what the card said raised their
+        # figure — the rank's name, where one rank raised it, and the
+        # figure itself where several things did — since that is what
+        # they added rather than what they are now.
         VISITED_TRADING_POST = "visited_post", "Visited the trading post"
 
         # An action opening and closing (``n26.core.models.action``).

--- a/n26/core/templates/n26/trade_points.html
+++ b/n26/core/templates/n26/trade_points.html
@@ -92,7 +92,7 @@ takes a typed figure over the ticks.
               @input="tick++">
             {% csrf_token %}
             <c-n26.form-section title="Visit Trading Post (post-cycle action)"
-                                description="{% if visit_open %}Finish the action above first. A gang performs one Visit Trading Post action at a time.{% else %}A Leader adds 2 Trade Points and a Champion 1.{% endif %}">
+                                description="{{ start_help }}">
                 {% if visitors %}
                     {% comment %}
                     Shut while an action is open: starting another would discard
@@ -107,76 +107,81 @@ takes a typed figure over the ticks.
                     <fieldset class="min-w-0 border-0 p-0" :disabled="overridden || locked">
                         <c-n26.tick-list :offer="offer" name="visiting" :disabled="visit_open" />
                     </fieldset>
+                {% else %}
+                    <p class="text-sm text-muted">No model in {{ gang.name }} adds Trade Points.</p>
+                {% endif %}
+                {% comment %}
+                Outside the tick list, and drawn whether or not anybody is
+                offered: a typed figure is the whole of the amount, and on a
+                roster where nothing adds Trade Points it is the only way to
+                start a visit.
+
+                No `class` on the input: c-ui.input does not declare one, so
+                it would arrive through {{ attrs }} as a second class
+                attribute and the browser would keep the first — dropping
+                the component's whole styling, and with it any sign that
+                this is a box to type in.
+                {% endcomment %}
+                <c-ui.field label="{{ amount_label }}" :form="None" for="brought">
+                    {% if visit_open %}
+                        <c-ui.input id="brought"
+                                    name="brought"
+                                    type="number"
+                                    min="0"
+                                    max="999"
+                                    inputmode="numeric"
+                                    x-model="override"
+                                    disabled />
+                    {% else %}
+                        <c-ui.input id="brought"
+                                    name="brought"
+                                    type="number"
+                                    min="0"
+                                    max="999"
+                                    inputmode="numeric"
+                                    x-model="override" />
+                    {% endif %}
+                </c-ui.field>
+                {% comment %}
+                Two whole tags, never one with a conditional attribute
+                inside it: a template tag among a component's attributes
+                reaches the page as text, and the button draws live while
+                looking shut. The shut one is wrapped because a disabled
+                button emits no mouse events for a tooltip to use.
+                {% endcomment %}
+                <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+                    {% if visit_open %}
+                        <c-ui.tooltip size="sm">
+                            <span class="inline-block cursor-not-allowed">
+                                <c-ui.button type="submit" size="sm" variant="primary" disabled>
+                                    Start TP visit
+                                </c-ui.button>
+                            </span>
+                            <c-slot name="content">
+                                Finish the action above first — a gang performs one
+                                Visit Trading Post action at a time.
+                            </c-slot>
+                        </c-ui.tooltip>
+                    {% else %}
+                        <c-ui.button type="submit" size="sm" variant="primary">
+                            Start TP visit
+                        </c-ui.button>
+                    {% endif %}
                     {% comment %}
-                    No `class` on the input: c-ui.input does not declare one, so
-                    it would arrive through {{ attrs }} as a second class
-                    attribute and the browser would keep the first — dropping
-                    the component's whole styling, and with it any sign that
-                    this is a box to type in.
+                    The running total is the ticks' figure. A number in
+                    the box is already the amount, so repeating it as
+                    "Selected models add N" would be a lie — and with
+                    nobody to tick there is no total to follow.
                     {% endcomment %}
-                    <c-ui.field label="Or use a specific TP amount" :form="None" for="brought">
-                        {% if visit_open %}
-                            <c-ui.input id="brought"
-                                        name="brought"
-                                        type="number"
-                                        min="0"
-                                        max="999"
-                                        inputmode="numeric"
-                                        x-model="override"
-                                        disabled />
-                        {% else %}
-                            <c-ui.input id="brought"
-                                        name="brought"
-                                        type="number"
-                                        min="0"
-                                        max="999"
-                                        inputmode="numeric"
-                                        x-model="override" />
-                        {% endif %}
-                    </c-ui.field>
-                    {% comment %}
-                    Two whole tags, never one with a conditional attribute
-                    inside it: a template tag among a component's attributes
-                    reaches the page as text, and the button draws live while
-                    looking shut. The shut one is wrapped because a disabled
-                    button emits no mouse events for a tooltip to use.
-                    {% endcomment %}
-                    <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-                        {% if visit_open %}
-                            <c-ui.tooltip size="sm">
-                                <span class="inline-block cursor-not-allowed">
-                                    <c-ui.button type="submit" size="sm" variant="primary" disabled>
-                                        Start TP visit
-                                    </c-ui.button>
-                                </span>
-                                <c-slot name="content">
-                                    Finish the action above first — a gang performs one
-                                    Visit Trading Post action at a time.
-                                </c-slot>
-                            </c-ui.tooltip>
-                        {% else %}
-                            <c-ui.button type="submit" size="sm" variant="primary">
-                                Start TP visit
-                            </c-ui.button>
-                        {% endif %}
-                        {% comment %}
-                        The running total is the ticks' figure. A number in
-                        the box is already the amount, so repeating it as
-                        "Selected models add N" would be a lie.
-                        {% endcomment %}
+                    {% if visitors %}
                         <p class="text-sm text-muted" x-show="!overridden">
                             Selected models add
                             <span class="font-medium tabular-nums text-ink-900 dark:text-ink-100"
                                   x-text="added">0</span>
                             TP
                         </p>
-                    </div>
-                {% else %}
-                    <p class="text-sm text-muted">
-                        {{ gang.name }} has no Leader or Champion to send, and
-                        nobody else adds Trade Points.
-                    </p>
-                {% endif %}
+                    {% endif %}
+                </div>
             </c-n26.form-section>
         </form>
     </div>

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -365,6 +365,60 @@ class TestWhoIsOffered:
         assert gang.starting_trade_points == 1
 
 
+class TestWhatThePageCosts:
+    """The page's own budget, pinned so it changes deliberately.
+
+    What a model adds is a counter reading, so drawing this page builds
+    the whole gang's cards and the modifier index behind them — much more
+    than the two queries the ranks used to take. That is a fixed price
+    for a gang, not a price per fighter, and the second reading below is
+    what says so: four more models, two of them ranked, and the same
+    number.
+    """
+
+    #: Session and the signed-in reader, the gang and its stash, the
+    #: roster read once for both the offer and the equip list, the gang's
+    #: rows and their hydration, the modifier index behind them, the open
+    #: visit's events, and the standard Trading Post the receipt links
+    #: to. None of it repeats per model.
+    BUDGET = 37
+
+    @pytest.fixture
+    def bigger(self, tester, gang, ranks, make_profile, make_statline):
+        """Four more models on the roster, two of them ranked — so the
+        second reading differs from the first in size alone, never in
+        which kinds of content are in play."""
+
+        def grow():
+            for name in ("Ain", "Bex", "Cor", "Dax"):
+                profile = make_profile(f"{name} entry", price=50)
+                make_statline(profile)
+                with operation(gang, actor=tester) as op:
+                    model = op.hire(profile, name)
+                    if name in ("Ain", "Bex"):
+                        op.assign(ranks["Champion"], miniature=model)
+
+        return grow
+
+    def test_it_holds_at_its_budget(self, client, tester, roster, gang, bigger):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        client.force_login(tester)
+        # The first visit warms whatever a signed-in request looks up
+        # once; the reading that counts is the ordinary second one.
+        client.get(page(gang))
+        with CaptureQueriesContext(connection) as few:
+            assert client.get(page(gang)).status_code == 200
+        assert len(few) == self.BUDGET, [q["sql"] for q in few.captured_queries]
+
+        bigger()
+
+        with CaptureQueriesContext(connection) as more:
+            assert client.get(page(gang)).status_code == 200
+        assert len(more) == self.BUDGET
+
+
 class TestALibraryWithNoVisitContribution:
     """The counter is what says what a model adds, so a library where it
     was never authored offers nobody — however many Leaders are on the

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -38,9 +38,17 @@ def gang(tester, gang_type):
 
 
 @pytest.fixture
-def ranks(db):
-    """The two ranks the book gives Trade Points to."""
-    return {name: Subtype.objects.create(name=name) for name in ("Leader", "Champion")}
+def ranks(default_pack):
+    """The two ranks that add Trade Points, as content says so.
+
+    The figures are not in the code: the standard seed writes the
+    undrawn visit-contribution counter and a modifier on each rank that
+    raises it, and the page reads what those come to.
+    """
+    from n26.library.standard_content import STANDARD_CONTENT
+
+    STANDARD_CONTENT["visit-contribution"].create()
+    return {name: Subtype.objects.get(name=name) for name in ("Leader", "Champion")}
 
 
 @pytest.fixture
@@ -271,7 +279,9 @@ class TestWhoIsOffered:
         client.force_login(tester)
         body = client.get(page(gang)).content.decode()
         assert "Visit Trading Post (post-cycle action)" in body
-        assert "A Leader adds 2 Trade Points and a Champion 1." in body
+        assert (
+            "Select the models visiting the Trading Post, or enter a TP amount." in body
+        )
         assert "Nobody else" not in body
         assert "Start TP visit" in body
         assert "Start action" not in body
@@ -282,15 +292,62 @@ class TestWhoIsOffered:
         assert ':disabled="overridden || locked"' in body
 
     def test_a_gang_with_nobody_says_so(self, client, tester, gang):
-        """The page names the ranks it wanted, not a bare roster.
-
-        A gang can be full of Gangers and still have nobody who adds
-        anything, so "nobody to send" would read as a lie.
-        """
+        """A gang can be full of Gangers and still have nobody who adds
+        anything, so "nobody to send" would read as a lie. The page says
+        what is actually absent."""
         client.force_login(tester)
         body = client.get(page(gang)).content.decode()
-        assert "no Leader or Champion to send" in body
-        assert "nobody else adds Trade Points" in body
+        assert f"No model in {gang.name} adds Trade Points." in body
+
+    def test_the_typed_amount_is_still_offered(self, client, tester, gang):
+        """The box is the way in for a roster where nothing adds Trade
+        Points — including a library where the contribution was never
+        authored — so it is drawn whether or not anybody is ticked."""
+        client.force_login(tester)
+        body = client.get(page(gang)).content.decode()
+        assert re.search(r'<input[^>]*name="brought"[^>]*>', body)
+        assert "TP amount" in body
+        assert "Start TP visit" in body
+        assert "Selected models add" not in body
+
+    def test_a_typed_amount_starts_a_visit_with_nobody_to_tick(
+        self, client, tester, gang
+    ):
+        client.force_login(tester)
+        client.post(page(gang), {"brought": "3"})
+
+        gang.refresh_from_db()
+        assert gang.visiting_trading_post is True
+        assert gang.starting_trade_points == 3
+
+    def test_a_model_promoted_into_a_rank_is_offered(
+        self, client, tester, roster, gang, ranks
+    ):
+        """The figure follows what the model holds now, not the entry
+        they were hired as."""
+        with operation(gang, actor=tester) as op:
+            op.assign(ranks["Champion"], miniature=roster["Nix"])
+
+        client.force_login(tester)
+        boxes = re.findall(
+            r'<input[^>]*name="visiting"[^>]*value="([^"]+)"',
+            client.get(page(gang)).content.decode(),
+        )
+        assert str(roster["Nix"].pk) in boxes
+
+    def test_a_model_holding_both_ranks_adds_the_better_figure(
+        self, client, tester, roster, gang, ranks
+    ):
+        """The same fighter cannot perform the action twice, so the two
+        contributions do not add up."""
+        with operation(gang, actor=tester) as op:
+            op.assign(ranks["Champion"], miniature=roster["Vex"])
+
+        client.force_login(tester)
+        start(client, gang, roster["Vex"])
+
+        gang.refresh_from_db()
+        assert gang.starting_trade_points == 2
 
     def test_a_rank_taken_away_is_not_one_held(
         self, client, tester, roster, gang, ranks
@@ -306,6 +363,62 @@ class TestWhoIsOffered:
 
         gang.refresh_from_db()
         assert gang.starting_trade_points == 1
+
+
+class TestALibraryWithNoVisitContribution:
+    """The counter is what says what a model adds, so a library where it
+    was never authored offers nobody — however many Leaders are on the
+    roster. The page still works: the typed figure never depended on it.
+    """
+
+    @pytest.fixture
+    def unauthored(self, tester, gang, make_profile, make_statline):
+        """A Leader and a Champion, and no counter for them to raise."""
+        made = {}
+        for name, rank in [("Vex", "Leader"), ("Sura", "Champion")]:
+            profile = make_profile(f"{name} entry", price=50)
+            make_statline(profile)
+            with operation(gang, actor=tester) as op:
+                model = op.hire(profile, name)
+                op.assign(Subtype.objects.create(name=rank), miniature=model)
+            made[name] = model
+        gang.refresh_from_db()
+        return made
+
+    def test_the_page_says_nobody_adds_anything(self, client, tester, gang, unauthored):
+        client.force_login(tester)
+        body = client.get(page(gang)).content.decode()
+
+        assert f"No model in {gang.name} adds Trade Points." in body
+        assert not re.findall(r'<input[^>]*name="visiting"[^>]*>', body)
+        assert not unrendered(body)
+
+    def test_the_typed_amount_still_opens_a_visit(
+        self, client, tester, gang, unauthored
+    ):
+        client.force_login(tester)
+        assert re.search(
+            r'<input[^>]*name="brought"[^>]*>',
+            client.get(page(gang)).content.decode(),
+        )
+
+        client.post(page(gang), {"brought": "5"})
+
+        gang.refresh_from_db()
+        assert gang.starting_trade_points == 5
+
+    def test_ticking_a_model_sends_nobody(self, client, tester, gang, unauthored):
+        """No model is offered, so a stale form naming one names nobody
+        the page could have named."""
+        client.force_login(tester)
+        answer = client.post(
+            page(gang), {"visiting": [str(unauthored["Vex"].pk)]}, follow=True
+        )
+
+        gang.refresh_from_db()
+        assert gang.visiting_trading_post is False
+        told = [str(m) for m in answer.context["messages"]]
+        assert any("at least one model" in line for line in told)
 
 
 class TestStartingTheAction:
@@ -489,7 +602,7 @@ class TestATypedFigure:
 
         tag = re.search(r'<input[^>]*name="brought"[^>]*>', body).group()
         assert tag.count("class=") == 1
-        assert "Or use a specific TP amount" in body
+        assert "Or enter a specific TP amount" in body
 
     def test_the_box_shuts_with_the_rest_of_the_form(self, client, roster, gang):
         start(client, gang, roster["Vex"])

--- a/n26/core/trading.py
+++ b/n26/core/trading.py
@@ -9,27 +9,34 @@ measured from (``n26.core.reconcile.trade_points_spent``). There is no
 visit table: what a visit *is* is the events one act wrote, which is
 already how the ledger describes everything else.
 
-        Two ranks add Trade Points, and only they are offered: picking a
-        fighter who adds none is a choice with no consequence, and the form
-        asks one question rather than listing a roster to say no to most of it.
-Equipping is the other half and has no such limit — anything the gang
-bought is handed to whoever it is for.
+Only the models who add something are offered: picking a fighter who
+adds none is a choice with no consequence, and the form asks one
+question rather than listing a roster to say no to most of it. Equipping
+is the other half and has no such limit — anything the gang bought is
+handed to whoever it is for.
 
-The ranks are read off what each model *holds* — the subtypes on their
-card — rather than off the entry they were hired as, so a fighter
-promoted into the rank counts and one who has lost it does not.
+What a model adds is a **counter reading**, not a rank this module
+knows. The library holds a counter, ``Trading Post visit contribution``,
+that no card draws, and a modifier on each rank raises it — 2 on Leader,
+1 on Champion. So the figure is read off the computed card, which means a
+fighter promoted into a rank adds it, one who has lost the rank adds
+nothing, and changing what a rank adds is an authoring edit. A library
+with no such counter offers nobody, and the typed figure is then the only
+way to open a visit.
 """
 
 from dataclasses import dataclass
 
-#: What each rank adds to a post, by the subtype's own name. The book
-#: names two; every other model adds nothing and may still go.
-TRADE_POINTS_FOR_RANK = {"Leader": 2, "Champion": 1}
-
 
 @dataclass(frozen=True)
 class Visitor:
-    """One model who could perform the action, and what they would add."""
+    """One model who could perform the action, and what they would add.
+
+    ``rank`` is what the card says raised the figure — the subtype's own
+    name, where one thing raised it. Where several did, it is the figure
+    itself, because no single name would be true. It is what the visit
+    records against the model.
+    """
 
     miniature: object
     rank: str
@@ -41,57 +48,114 @@ class Visitor:
         return str(self.miniature.pk)
 
 
-def brings(rank):
-    """What a model of this rank adds to the gang's Trade Points."""
-    return TRADE_POINTS_FOR_RANK.get(rank, 0)
+def _visit_counter():
+    """The standard visit-contribution counter, or None where the library
+    has none.
+
+    Pinned to the default pack, as the equipping screens pin the Trading
+    Post: names are unique per pack, so a homebrew pack's counter of the
+    same name must not stand in for the standard one.
+    """
+    from n26.library.models import Counter, get_default_pack
+    from n26.library.standard_content import VISIT_CONTRIBUTION_COUNTER
+
+    return Counter.objects.filter(
+        name=VISIT_CONTRIBUTION_COUNTER, pack=get_default_pack()
+    ).first()
+
+
+def _readings(gang, counter):
+    """Each model's reading of this counter, and what raised it, by id.
+
+    The gang's cards are built and computed the way the gang sheet builds
+    and computes them — the gang's own card first, since what it holds by
+    grant is dealt onto every member's — so a modifier the gang carries
+    reaches the ranks exactly as it does everywhere else.
+
+    A fixed number of queries however many models are on the roster:
+    ``compute`` touches the database not at all.
+    """
+    from n26.core.card import build_gang_card, build_modifier_index
+    from n26.core.effects import compute, compute_gang, counter_readings
+
+    # No statlines: nothing here draws a card, and pulling each
+    # profile's characteristics along would be several queries for
+    # figures this never reads.
+    card = build_gang_card(gang, with_statlines=False)
+    index = build_modifier_index(
+        [
+            node.assignable
+            for member in card.members.values()
+            for node in member.all_nodes()
+        ]
+        + [node.assignable for node in card.all_nodes()]
+    )
+    compute_gang(card, index)
+    readings = {}
+    for miniature_id, member in card.members.items():
+        computed = compute(member, index)
+        value = next(
+            (
+                reading.value
+                for reading in counter_readings(member, computed)
+                if reading.thing.pk == counter.pk
+            ),
+            0,
+        )
+        readings[miniature_id] = (value, _raised_by(computed, counter) or str(value))
+    return readings
+
+
+def _raised_by(computed, counter):
+    """What the card names as raising this counter, where one thing did.
+
+    Empty where several did, or where the figure was tallied rather than
+    contributed: the visit records one name against the model, and a
+    joined-up list of them would not be one.
+    """
+    named = {
+        contribution.source
+        for contribution in computed.counter_contributions
+        if contribution.counter.pk == counter.pk
+    }
+    return named.pop() if len(named) == 1 else ""
 
 
 def visitors(gang, going=None):
-    """The fighters who could add Trade Points, in rank order then by name.
+    """The fighters who could add Trade Points, biggest figure first
+    then by name.
 
     ``going`` is the set of model ids the owner has ticked; ``None``
     opens with all of them ticked, which is what a post-cycle almost
     always wants. The form itself starts with none ticked, and passes
     an empty set.
 
-    A model holding both ranks adds the better of the two: the same
-    fighter cannot perform the action twice.
-
-    Two queries — the roster, then the ranks anybody holds. Removals are
-    read with them: an assignment with ``removes`` set is machinery
-    rather than a line, so anything reading assignments straight from
-    the database has to cancel the pair itself, or a Leader an owner
-    took away goes on adding two points.
+    A model holding both ranks adds the better of the two, because the
+    same fighter cannot perform the action twice. That is content, not
+    arithmetic here: the modifier on the lesser rank is scoped away from
+    models holding the better one, so the two never add up.
     """
-    from n26.core.models import Assignment
     from n26.core.render import roster
 
-    members = roster(gang)
-    held = Assignment.objects.filter(
-        gang_root=gang,
-        archived=False,
-        subtype__name__in=TRADE_POINTS_FOR_RANK,
-        miniature_root__membership__archived=False,
-    ).values_list("miniature_root_id", "subtype__name", "removes")
-    gone = {(model, rank) for model, rank, removes in held if removes}
-    ranks = {}
-    for model, rank, removes in held:
-        if removes or (model, rank) in gone:
+    counter = _visit_counter()
+    if counter is None:
+        return []
+    readings = _readings(gang, counter)
+    offered = []
+    for member in roster(gang):
+        trade_points, raised_by = readings.get(member.pk, (0, ""))
+        if trade_points <= 0:
             continue
-        if brings(rank) > brings(ranks.get(model, "")):
-            ranks[model] = rank
-    return [
-        Visitor(
-            miniature=member,
-            rank=ranks[member.pk],
-            trade_points=brings(ranks[member.pk]),
-            visiting=going is None or str(member.pk) in going,
+        offered.append(
+            Visitor(
+                miniature=member,
+                rank=raised_by,
+                trade_points=trade_points,
+                visiting=going is None or str(member.pk) in going,
+            )
         )
-        for member in sorted(
-            (member for member in members if member.pk in ranks),
-            key=lambda m: (-brings(ranks[m.pk]), m.name),
-        )
-    ]
+    offered.sort(key=lambda one: (-one.trade_points, one.miniature.name))
+    return offered
 
 
 def minted(going):
@@ -100,28 +164,30 @@ def minted(going):
 
 
 def as_offer(going, label="Who is visiting"):
-    """The visitors as a list of things to tick, under their ranks.
+    """The visitors as a list of things to tick, under what they add.
 
     ``ChoiceOffer`` is the shape the edition already ticks lists in, and
     ``<c-n26.tick-list>`` draws it with plain checkboxes and no script.
-    The headings are the ranks, which is what a heading is for here: what
-    a model adds follows from the rank they are filed under, so the
+    The headings are the figures, which is what a heading is for here:
+    what a model adds follows from the group they are filed under, so the
     figure is said once per group rather than once per model.
 
-    The better rank leads.
+    Grouped by the figure and not by the rank, because the rank is not
+    what this knows — content decides what raises a model's contribution,
+    and two things may raise it by the same amount.
+
+    The bigger figure leads.
     """
     from n26.core.render import ChoiceOffer, Choosable, ChoosableGroup
 
-    ranks = {}
+    groups = {}
     for visitor in going:
-        ranks.setdefault(visitor.rank, []).append(visitor)
-    ordered = sorted(ranks.items(), key=lambda pair: -brings(pair[0]))
+        groups.setdefault(visitor.trade_points, []).append(visitor)
     return ChoiceOffer(
         label=label,
         groups=[
             ChoosableGroup(
-                name=rank,
-                caption=_caption(brings(rank)),
+                name=_adds_each(trade_points),
                 options=[
                     Choosable(
                         key=visitor.key,
@@ -132,20 +198,25 @@ def as_offer(going, label="Who is visiting"):
                     for visitor in members
                 ],
             )
-            for rank, members in ordered
+            for trade_points, members in sorted(
+                groups.items(), key=lambda pair: -pair[0]
+            )
         ],
     )
 
 
-def _caption(points):
-    if not points:
-        return "no Trade Points"
-    return f"{points} Trade Point{'' if points == 1 else 's'} each"
+def _adds_each(trade_points):
+    """A group's heading: what every model under it adds."""
+    return f"{trade_points} Trade Point{'' if trade_points == 1 else 's'} each"
 
 
 @dataclass(frozen=True)
 class Contributor:
     """One fighter who performed the action, as the receipt names them.
+
+    ``rank`` is what the visit recorded against them — the name of what
+    raised their figure at the time, so a fighter who has since lost the
+    rank is still reported as having gone as it.
 
     ``miniature`` rides along because the receipt is where an owner goes
     next: having sent a fighter to the post, the thing they want is that
@@ -156,7 +227,6 @@ class Contributor:
 
     name: str
     rank: str
-    trade_points: int
     miniature: object = None
     on_roster: bool = True
 
@@ -191,18 +261,22 @@ class Receipt:
 
     @property
     def summary(self):
-        """The contributors as one line — "Leader, Champion × 2".
+        """What added the figure, as one line — "Leader, Champion × 2".
 
-        Ranks rather than names, because this sits against the figure
-        they add up to and answers where it came from. Who went is drawn
-        beside it, by name, since that is the different question.
+        What raised each fighter's contribution rather than who went,
+        because this sits against the figure they add up to and answers
+        where it came from. Who went is drawn beside it, by name, since
+        that is the different question.
+
+        In the order the visit wrote them, which is the order they were
+        offered in: the bigger figure leads.
         """
         counts = {}
         for one in self.contributors:
             counts[one.rank] = counts.get(one.rank, 0) + 1
         return ", ".join(
             rank if count == 1 else f"{rank} × {count}"
-            for rank, count in sorted(counts.items(), key=lambda p: -brings(p[0]))
+            for rank, count in counts.items()
         )
 
 
@@ -236,7 +310,6 @@ def receipt_for(gang):
             Contributor(
                 name=event.miniature.name if event.miniature else "",
                 rank=event.note,
-                trade_points=brings(event.note),
                 miniature=event.miniature,
                 on_roster=_still_here(event.miniature),
             )

--- a/n26/core/trading.py
+++ b/n26/core/trading.py
@@ -48,22 +48,6 @@ class Visitor:
         return str(self.miniature.pk)
 
 
-def _visit_counter():
-    """The standard visit-contribution counter, or None where the library
-    has none.
-
-    Pinned to the default pack, as the equipping screens pin the Trading
-    Post: names are unique per pack, so a homebrew pack's counter of the
-    same name must not stand in for the standard one.
-    """
-    from n26.library.models import Counter, get_default_pack
-    from n26.library.standard_content import VISIT_CONTRIBUTION_COUNTER
-
-    return Counter.objects.filter(
-        name=VISIT_CONTRIBUTION_COUNTER, pack=get_default_pack()
-    ).first()
-
-
 def _readings(gang, counter):
     """Each model's reading of this counter, and what raised it, by id.
 
@@ -121,7 +105,7 @@ def _raised_by(computed, counter):
     return named.pop() if len(named) == 1 else ""
 
 
-def visitors(gang, going=None):
+def visitors(gang, going=None, members=None):
     """The fighters who could add Trade Points, biggest figure first
     then by name.
 
@@ -130,19 +114,24 @@ def visitors(gang, going=None):
     always wants. The form itself starts with none ticked, and passes
     an empty set.
 
+    ``members`` is the gang's roster where the caller already holds it.
+    The page draws every fighter as well as the ones offered, and reading
+    the roster twice is a query for an answer already in hand.
+
     A model holding both ranks adds the better of the two, because the
     same fighter cannot perform the action twice. That is content, not
     arithmetic here: the modifier on the lesser rank is scoped away from
     models holding the better one, so the two never add up.
     """
     from n26.core.render import roster
+    from n26.library.standard_content import visit_contribution_counter
 
-    counter = _visit_counter()
+    counter = visit_contribution_counter()
     if counter is None:
         return []
     readings = _readings(gang, counter)
     offered = []
-    for member in roster(gang):
+    for member in roster(gang) if members is None else members:
         trade_points, raised_by = readings.get(member.pk, (0, ""))
         if trade_points <= 0:
             continue
@@ -270,9 +259,15 @@ class Receipt:
 
         In the order the visit wrote them, which is the order they were
         offered in: the bigger figure leads.
+
+        A bare figure stands in the record where several things raised
+        one fighter's contribution, and a figure is not a name to file
+        anybody under, so it is left out of the line.
         """
         counts = {}
         for one in self.contributors:
+            if not one.rank or one.rank.isdigit():
+                continue
             counts[one.rank] = counts.get(one.rank, 0) + 1
         return ", ".join(
             rank if count == 1 else f"{rank} × {count}"

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -979,7 +979,11 @@ def gang_trade_points(request, pk):
         )
         return redirect(at)
 
-    offered = visitors(gang, going=set())
+    # The roster is read once and handed to both readers of it: the page
+    # draws every fighter, and the offer is the few of them who add
+    # something.
+    members = roster(gang)
+    offered = visitors(gang, going=set(), members=members)
     receipt = receipt_for(gang)
     return render(
         request,
@@ -1021,7 +1025,7 @@ def gang_trade_points(request, pk):
             # Every fighter, not only those who performed the action:
             # what a visit added is the gang's, and it is spent on
             # whoever it was for. Who went is the ranks on the receipt.
-            "roster": roster(gang),
+            "roster": members,
             "offer": as_offer(offered),
             "edit_tabs": _edit_tabs(gang, "trade-points"),
         },

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -832,6 +832,18 @@ def _brought(data, ticked):
     return int(typed)
 
 
+def _start_help(gang, offered):
+    """What the start form says to do, for the state the gang is in."""
+    if gang.visiting_trading_post:
+        return (
+            "Finish the action above first. A gang performs one Visit "
+            "Trading Post action at a time."
+        )
+    if offered:
+        return "Select the models visiting the Trading Post, or enter a TP amount."
+    return "Enter a TP amount to start a visit."
+
+
 def _the_trading_post():
     """The standard Trading Post, or None where the library has none.
 
@@ -996,6 +1008,16 @@ def gang_trade_points(request, pk):
             # variable rather than an expression.
             "visit_open": gang.visiting_trading_post,
             "visitors": offered,
+            # What the start form says to do. Three states, and the third
+            # is a real one: a roster where nothing adds Trade Points —
+            # no ranks yet, or a library where the contribution has never
+            # been authored — leaves the typed figure as the only way in.
+            "start_help": _start_help(gang, offered),
+            # The box is an alternative to the ticks only where there are
+            # ticks. On its own it is simply the amount.
+            "amount_label": (
+                "Or enter a specific TP amount" if offered else "TP amount"
+            ),
             # Every fighter, not only those who performed the action:
             # what a visit added is the gang's, and it is spent on
             # whoever it was for. Who went is the ranks on the receipt.

--- a/n26/library/ingest.py
+++ b/n26/library/ingest.py
@@ -3076,6 +3076,7 @@ def _imported(pack=None):
         SKILLS_SECTION,
         TRADING_POST_COLLECTION,
         VEHICLE_SUBTYPES,
+        VISIT_CONTRIBUTION_MODIFIERS,
     )
 
     scope = {} if pack is None else {"pack": pack}
@@ -3084,11 +3085,16 @@ def _imported(pack=None):
 
     profiles = Profile.objects.filter(**scope)
 
-    # Every modifier goes: each either came from an import or names
-    # content that is about to, and a modifier pointing at a deleted
-    # trait is what stops the whole clear. Standard content wires none
-    # of its own.
-    doomed = list(Modifier.objects.filter(**scope).values_list("pk", flat=True))
+    # Every modifier goes except standard content's own: the rest either
+    # came from an import or name content that is about to go, and a
+    # modifier pointing at a deleted trait is what stops the whole clear.
+    # The seeded ones are named by reading their list, so the two cannot
+    # drift.
+    doomed = list(
+        Modifier.objects.filter(**scope)
+        .exclude(name__in=VISIT_CONTRIBUTION_MODIFIERS)
+        .values_list("pk", flat=True)
+    )
 
     # A modifier holds its scope and effect, and those rows are what
     # hold the trait — deleting the modifier alone leaves them behind

--- a/n26/library/ingest.py
+++ b/n26/library/ingest.py
@@ -3076,7 +3076,7 @@ def _imported(pack=None):
         SKILLS_SECTION,
         TRADING_POST_COLLECTION,
         VEHICLE_SUBTYPES,
-        VISIT_CONTRIBUTION_MODIFIERS,
+        visit_contribution_counter,
     )
 
     scope = {} if pack is None else {"pack": pack}
@@ -3088,12 +3088,15 @@ def _imported(pack=None):
     # Every modifier goes except standard content's own: the rest either
     # came from an import or name content that is about to go, and a
     # modifier pointing at a deleted trait is what stops the whole clear.
-    # The seeded ones are named by reading their list, so the two cannot
-    # drift.
+    # A seeded one is recognised the way its own seed recognises it — by
+    # what it does, never by its name — so rewording one does not put it
+    # back in the way of a clear.
+    spared = Q(pk__in=())
+    visit_counter = visit_contribution_counter()
+    if visit_counter is not None:
+        spared = Q(contributes_to_counter__counter=visit_counter)
     doomed = list(
-        Modifier.objects.filter(**scope)
-        .exclude(name__in=VISIT_CONTRIBUTION_MODIFIERS)
-        .values_list("pk", flat=True)
+        Modifier.objects.filter(**scope).exclude(spared).values_list("pk", flat=True)
     )
 
     # A modifier holds its scope and effect, and those rows are what

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -393,9 +393,9 @@ def _says_changes_stat(effect, parts):
 @_renders("contributes_to_counter")
 def _says_contributes_to_counter(effect, parts):
     who = parts.who
+    reading = _owned(who, f"{effect.counter} reading")
     return (
-        f"{effect.amount} is added to {who.possessive} {effect.counter} "
-        f"reading{_while(who)}.",
+        f"{effect.amount} is added to {reading}{_while(who)}.",
         (
             "Worked out on every read, so the reading drops back when "
             "the item carrying this modifier goes. Nothing is written "

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -354,6 +354,23 @@ def _check_progression_counters():
     )
 
 
+def visit_contribution_counter():
+    """The standard visit-contribution counter, or None where the library
+    has none.
+
+    Pinned to the default pack, as the Trading Post is: names are unique
+    per pack, so a homebrew pack's counter of the same name must not
+    stand in for the standard one. The seed, its own completeness check
+    and every reader ask this one question, because two statements of
+    what counts as the row drift in silence.
+    """
+    from n26.library.models import Counter, get_default_pack
+
+    return Counter.objects.filter(
+        name__iexact=VISIT_CONTRIBUTION_COUNTER, pack=get_default_pack()
+    ).first()
+
+
 def _create_visit_contribution():
     """The visit counter, and one modifier per rank that raises it.
 
@@ -377,7 +394,7 @@ def _create_visit_contribution():
     )
     from n26.library.models import Counter, Subtype
 
-    counter = Counter.objects.filter(name__iexact=VISIT_CONTRIBUTION_COUNTER).first()
+    counter = visit_contribution_counter()
     if counter is None:
         counter = Counter.objects.create(name=VISIT_CONTRIBUTION_COUNTER, drawn=False)
     better = []
@@ -406,18 +423,19 @@ def _raises_visit_counter(subtype, counter):
 
 
 def _check_visit_contribution():
-    from n26.library.models import Counter, Subtype
+    """Asked exactly as the create asks it — the same counter lookup, the
+    same rank lookup, the same behaviour predicate — so a half-built
+    library reports what a second run would leave alone."""
+    from n26.library.models import Subtype
 
-    counter = Counter.objects.filter(name__iexact=VISIT_CONTRIBUTION_COUNTER).first()
+    counter = visit_contribution_counter()
     if counter is None:
         return 0, 1 + len(VISIT_CONTRIBUTIONS)
-    present = 1 + sum(
-        1
-        for subtype in Subtype.objects.filter(
-            name__in=[rank for rank, _ in VISIT_CONTRIBUTIONS]
-        )
-        if _raises_visit_counter(subtype, counter).exists()
-    )
+    present = 1
+    for rank, _ in VISIT_CONTRIBUTIONS:
+        subtype = Subtype.objects.filter(name__iexact=rank).first()
+        if subtype is not None and _raises_visit_counter(subtype, counter).exists():
+            present += 1
     return present, 1 + len(VISIT_CONTRIBUTIONS)
 
 

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -101,6 +101,28 @@ VEHICLE_SUBTYPES = [
 PROGRESSION_COUNTERS = ["XP"]
 XP_COUNTER = "XP"
 
+#: The counter a Visit Trading Post action reads to work out what each
+#: model adds. Undrawn: no card shows it, and nothing offers to tally it
+#: — the visit screen is the only reader. What raises it is a modifier on
+#: each rank, so a fighter promoted into a rank adds what the rank adds
+#: and one who has lost it adds nothing.
+VISIT_CONTRIBUTION_COUNTER = "Trading Post visit contribution"
+
+#: What each rank adds to a Trading Post visit (core rules), as
+#: ``(subtype, amount)``, biggest first. A model holding both ranks adds
+#: the better figure and not the sum: the same fighter cannot perform the
+#: action twice. Each rank after the first is therefore scoped away from
+#: models holding any rank above it.
+VISIT_CONTRIBUTIONS = [("Leader", 2), ("Champion", 1)]
+
+#: What each rank's contribution modifier is filed under. Named here so
+#: that a clear of imported content can leave them standing by reading
+#: this list rather than restating the names.
+VISIT_CONTRIBUTION_MODIFIERS = [
+    f"{rank} adds {amount} Trade Point{'' if amount == 1 else 's'} to a Trading Post visit"
+    for rank, amount in VISIT_CONTRIBUTIONS
+]
+
 #: The six Skill Sets and their skills, in D6 order (core rules) —
 #: the number a skill is rolled on is its position within its set. Names
 #: only: what each skill *does* is the book's wording (CLAUDE.md).
@@ -330,6 +352,73 @@ def _check_progression_counters():
         _count(Counter, name__in=PROGRESSION_COUNTERS),
         len(PROGRESSION_COUNTERS),
     )
+
+
+def _create_visit_contribution():
+    """The visit counter, and one modifier per rank that raises it.
+
+    The subtypes are matched, not duplicated: the core subtypes seed
+    creates the same two rows, and either seed may be run first.
+
+    Ranks are read biggest first, and each modifier after the first is
+    narrowed to models holding none of the ranks above it. That is what
+    makes a Leader who is also a Champion add 2 rather than 3.
+
+    A rank's contribution is matched by what it does — a modifier this
+    rank carries that raises this counter — rather than by its name. A
+    rank carrying two of them would add twice what it should, and a name
+    is the one part of a modifier that may be reworded later.
+    """
+    from n26.library.authoring import (
+        ef_contributes_to_counter,
+        has_subtypes,
+        modifier,
+        targets_model,
+    )
+    from n26.library.models import Counter, Subtype
+
+    counter = Counter.objects.filter(name__iexact=VISIT_CONTRIBUTION_COUNTER).first()
+    if counter is None:
+        counter = Counter.objects.create(name=VISIT_CONTRIBUTION_COUNTER, drawn=False)
+    better = []
+    for (rank, amount), name in zip(
+        VISIT_CONTRIBUTIONS, VISIT_CONTRIBUTION_MODIFIERS, strict=True
+    ):
+        subtype = Subtype.objects.filter(name__iexact=rank).first()
+        if subtype is None:
+            subtype = Subtype.objects.create(name=rank)
+        if not _raises_visit_counter(subtype, counter).exists():
+            subtype.modifiers.add(
+                modifier(
+                    name,
+                    targets_model(
+                        *([has_subtypes(*better, negate=True)] if better else [])
+                    ),
+                    ef_contributes_to_counter(counter, amount),
+                )
+            )
+        better.append(subtype)
+
+
+def _raises_visit_counter(subtype, counter):
+    """The modifiers this rank carries that raise this counter."""
+    return subtype.modifiers.filter(contributes_to_counter__counter=counter)
+
+
+def _check_visit_contribution():
+    from n26.library.models import Counter, Subtype
+
+    counter = Counter.objects.filter(name__iexact=VISIT_CONTRIBUTION_COUNTER).first()
+    if counter is None:
+        return 0, 1 + len(VISIT_CONTRIBUTIONS)
+    present = 1 + sum(
+        1
+        for subtype in Subtype.objects.filter(
+            name__in=[rank for rank, _ in VISIT_CONTRIBUTIONS]
+        )
+        if _raises_visit_counter(subtype, counter).exists()
+    )
+    return present, 1 + len(VISIT_CONTRIBUTIONS)
 
 
 def skills_collection_sweeps():
@@ -792,6 +881,18 @@ STANDARD_CONTENT = {
             ),
             check=_check_progression_counters,
             create=_create_progression_counters,
+        ),
+        StandardContent(
+            key="visit-contribution",
+            name="Trading Post visit contribution",
+            help=(
+                "The counter for what each model adds to a Visit Trading "
+                "Post action, and the modifiers that raise it: 2 on the "
+                "Leader subtype, 1 on Champion. The counter is not drawn "
+                "on any card. A model holding both ranks adds 2, not 3."
+            ),
+            check=_check_visit_contribution,
+            create=_create_visit_contribution,
         ),
         StandardContent(
             key="gang-types",

--- a/n26/tests/sandbox/test_ingest.py
+++ b/n26/tests/sandbox/test_ingest.py
@@ -2229,6 +2229,33 @@ class TestClearing:
             VISIT_CONTRIBUTION_MODIFIERS
         )
 
+    def test_a_reworded_seed_modifier_still_stands_after_a_clear(
+        self, foundation, sheets
+    ):
+        """A clear recognises standard content the way the seed that made
+        it does — by what a modifier raises, never by its name — so
+        rewording one does not put it in the way of the next clear."""
+        from n26.library.ingest import clear_imported
+        from n26.library.models.modifier import Modifier
+        from n26.library.standard_content import visit_contribution_counter
+
+        seeded = Modifier.objects.filter(
+            contributes_to_counter__counter=visit_contribution_counter()
+        )
+        assert seeded.count() == 2
+        for row in seeded:
+            row.name = f"Reworded {row.name}"
+            row.save()
+
+        perform(plan_ingest(pack=None, **sheets))
+        clear_imported()
+
+        assert seeded.count() == 2
+        assert all(
+            name.startswith("Reworded ")
+            for name in seeded.values_list("name", flat=True)
+        )
+
     def test_a_gang_using_the_content_stops_the_clear(self, foundation, sheets):
         """Player data protects what it uses: the content does not go out
         from under a gang that holds it."""

--- a/n26/tests/sandbox/test_ingest.py
+++ b/n26/tests/sandbox/test_ingest.py
@@ -2221,9 +2221,13 @@ class TestClearing:
         clear_imported()
 
         assert Trait.objects.count() == 0
-        # Every modifier goes with them: standard content wires none of
-        # its own for a clear to spare.
-        assert Modifier.objects.count() == 0
+        # Every modifier goes with them, bar standard content's own,
+        # which name nothing an import wrote.
+        from n26.library.standard_content import VISIT_CONTRIBUTION_MODIFIERS
+
+        assert sorted(Modifier.objects.values_list("name", flat=True)) == sorted(
+            VISIT_CONTRIBUTION_MODIFIERS
+        )
 
     def test_a_gang_using_the_content_stops_the_clear(self, foundation, sheets):
         """Player data protects what it uses: the content does not go out

--- a/n26/tests/sandbox/test_prose.py
+++ b/n26/tests/sandbox/test_prose.py
@@ -41,6 +41,7 @@ from n26.library.authoring import (
     ef_allows_at_most,
     ef_changes_category,
     ef_changes_stat,
+    ef_contributes_to_counter,
     ef_draws_pick,
     ef_offers_choice,
     ef_places,
@@ -313,6 +314,23 @@ class TestNarrowingsCompose:
             ef_changes_stat(fighter_stats["BS"], mode="worsen", amount=1),
         ) == [
             "The Ballistic Skill of every fighter with Cawdor is 1 worse, while the gang holds this."
+        ]
+
+    def test_a_qualified_subject_owns_its_counter_reading_too(
+        self, escher, cawdor, default_pack
+    ):
+        """The shape a Trading Post visit contribution takes: a figure
+        added to a reading, for some of the models rather than all of
+        them. Said the short way round the sentence would drop the
+        narrowing and promise everyone the figure."""
+        counter = create_counter("Trading Post visit contribution", drawn=False)
+        assert self.carried(
+            escher,
+            targets_every_model(has_pickable(cawdor)),
+            ef_contributes_to_counter(counter, 1),
+        ) == [
+            "1 is added to the Trading Post visit contribution reading of every "
+            "fighter with Cawdor, while the gang holds this."
         ]
 
     def test_a_type_left_out_owns_the_long_way_round_too(

--- a/n26/tests/sandbox/test_trade_points.py
+++ b/n26/tests/sandbox/test_trade_points.py
@@ -36,13 +36,13 @@ from n26.tests.sandbox.actions import (
     buy,
     create_category,
     create_collection,
-    create_subtype,
     create_trading_post,
     create_wargear,
     found_gang,
     hire_with_option,
     leave_trading_post,
     refund,
+    remove,
     visit_trading_post,
 )
 
@@ -317,13 +317,25 @@ def only(gang, *names):
     return visitors(gang, chosen)
 
 
+@pytest.fixture
+def ranks(default_pack):
+    """What the ranks add, as content: the undrawn visit-contribution
+    counter and the modifier on each rank that raises it. Nothing in the
+    code names a rank or a figure."""
+    from n26.library.models import Subtype
+    from n26.library.standard_content import STANDARD_CONTENT
+
+    STANDARD_CONTENT["visit-contribution"].create()
+    return {name: Subtype.objects.get(name=name) for name in ("Leader", "Champion")}
+
+
 class TestWhoPerformsTheAction:
     """Any fighter may go, and the two named ranks bring points with them.
     Who went is recorded per model, because the rules give each model one
     Post-cycle Action and a figure cannot say whose it was."""
 
     @pytest.fixture
-    def ranked(self, gang, make_profile, make_statline):
+    def ranked(self, gang, ranks, make_profile, make_statline):
         """A Leader, a Champion and a Ganger, each holding their rank."""
         made = {}
         for name, rank in [("Rasp", "Leader"), ("Kel", "Champion"), ("Tuk", None)]:
@@ -331,7 +343,7 @@ class TestWhoPerformsTheAction:
             make_statline(profile)
             model = hire_with_option(gang, profile, name)
             if rank:
-                assign(create_subtype(rank), miniature=model)
+                assign(ranks[rank], miniature=model)
             made[name] = model
         return made
 
@@ -408,6 +420,205 @@ class TestWhoPerformsTheAction:
         gang.refresh_from_db()
         receipt = receipt_for(gang)
         assert (receipt.available, receipt.spent, receipt.remaining) == (3, 3, 0)
+
+
+class TestWhatARankAdds:
+    """What a model adds is a counter reading, not a rank the code knows.
+
+    The library holds an undrawn counter and a modifier on each rank that
+    raises it, so the figure follows what a model *holds* — a fighter
+    promoted into the rank adds it, one who has lost it adds nothing —
+    and changing the figures is an authoring edit rather than a code
+    change.
+    """
+
+    @pytest.fixture
+    def hire_plain(self, gang, make_profile, make_statline):
+        def make(name):
+            profile = make_profile(f"{name} entry", price=50)
+            make_statline(profile)
+            return hire_with_option(gang, profile, name)
+
+        return make
+
+    def offered(self, gang):
+        return {one.miniature.name: one for one in visitors(gang)}
+
+    def test_a_model_promoted_into_a_rank_adds_what_the_rank_adds(
+        self, gang, ranks, hire_plain
+    ):
+        rasp = hire_plain("Rasp")
+        assert self.offered(gang) == {}
+
+        assign(ranks["Leader"], miniature=rasp)
+
+        assert self.offered(gang)["Rasp"].trade_points == 2
+
+    def test_a_rank_taken_away_takes_the_figure_with_it(self, gang, ranks, hire_plain):
+        rasp = hire_plain("Rasp")
+        held = assign(ranks["Leader"], miniature=rasp)
+        assert self.offered(gang)["Rasp"].trade_points == 2
+
+        remove(held)
+
+        assert self.offered(gang) == {}
+
+    def test_a_rank_cancelled_by_a_removal_adds_nothing_either(
+        self, gang, ranks, hire_plain
+    ):
+        """An owner's removal is machinery rather than a line, and the
+        computed reading cancels the pair without anything here having to
+        know it."""
+        rasp = hire_plain("Rasp")
+        assign(ranks["Leader"], miniature=rasp)
+
+        assign(ranks["Leader"], miniature=rasp, removes=True)
+
+        assert self.offered(gang) == {}
+
+    def test_a_model_holding_both_ranks_adds_the_better_figure(
+        self, gang, ranks, hire_plain
+    ):
+        """The same fighter cannot perform the action twice, so 2 and 1
+        do not come to 3. The lesser rank's modifier is scoped away from
+        models holding the better one, which is where that is settled."""
+        rasp = hire_plain("Rasp")
+        assign(ranks["Leader"], miniature=rasp)
+        assign(ranks["Champion"], miniature=rasp)
+
+        assert self.offered(gang)["Rasp"].trade_points == 2
+
+    def test_seeding_a_reworded_modifier_leaves_the_figure_alone(self, gang, ranks):
+        """The seed matches a rank's contribution by what it does, not by
+        what it is called. Matched by name, rewording one and seeding
+        again would hang a second contribution on the rank and double
+        what it adds."""
+        from n26.library.models import Modifier
+        from n26.library.standard_content import STANDARD_CONTENT
+
+        leaders = ranks["Leader"].modifiers.filter(contributes_to_counter__isnull=False)
+        (carried,) = leaders
+        carried.name = "Leader brings two"
+        carried.save()
+
+        STANDARD_CONTENT["visit-contribution"].create()
+
+        assert list(leaders) == [carried]
+        assert (
+            Modifier.objects.filter(contributes_to_counter__isnull=False).count() == 2
+        )
+
+    def test_the_offer_is_grouped_by_the_figure(self, gang, ranks, hire_plain):
+        """The heading says what the models under it add. Ranks are not
+        what this knows, and two things may raise the reading by the same
+        amount."""
+        from n26.core.trading import as_offer
+
+        assign(ranks["Leader"], miniature=hire_plain("Rasp"))
+        assign(ranks["Champion"], miniature=hire_plain("Kel"))
+
+        offer = as_offer(visitors(gang))
+
+        assert [group.name for group in offer.groups] == [
+            "2 Trade Points each",
+            "1 Trade Point each",
+        ]
+
+    def test_a_library_with_no_counter_offers_nobody(self, gang, hire_plain):
+        """No counter, no figure: the seed was never run here, so nothing
+        on this roster adds Trade Points however it is ranked."""
+        from n26.library.models import Subtype
+
+        assign(Subtype.objects.create(name="Leader"), miniature=hire_plain("Rasp"))
+
+        assert visitors(gang) == []
+
+    def test_what_the_visit_minted_is_what_the_ledger_says(
+        self, gang, ranks, hire_plain
+    ):
+        """The figure the ticks come to is the figure the visit opened
+        with, and the receipt reads it back off the gang and the ledger
+        rather than keeping a second copy of it."""
+        from n26.core.trading import minted
+
+        assign(ranks["Leader"], miniature=hire_plain("Rasp"))
+        assign(ranks["Champion"], miniature=hire_plain("Kel"))
+        going = visitors(gang)
+
+        visit_trading_post(gang, going)
+
+        gang.refresh_from_db()
+        assert minted(going) == 3
+        assert gang.starting_trade_points == 3
+        receipt = receipt_for(gang)
+        assert (receipt.available, receipt.spent, receipt.remaining) == (3, 0, 3)
+        assert receipt.summary == "Leader, Champion"
+        assert_reconciled(gang)
+
+    def test_a_figure_two_things_raised_is_recorded_as_the_figure(
+        self, gang, ranks, hire_plain
+    ):
+        """The visit records one name against each model. Where two
+        things raised the reading no single name is true, so what goes on
+        the record is the figure."""
+        from n26.core.models import LedgerEvent
+        from n26.library.models import Counter
+        from n26.library.standard_content import VISIT_CONTRIBUTION_COUNTER
+        from n26.tests.sandbox.actions import (
+            create_rule,
+            ef_contributes_to_counter,
+            modifier,
+            targets_model,
+        )
+
+        counter = Counter.objects.get(name=VISIT_CONTRIBUTION_COUNTER)
+        connected = create_rule("Well connected")
+        modifier(
+            "Well connected adds 1 to a Trading Post visit",
+            targets_model(),
+            ef_contributes_to_counter(counter, 1),
+            carried_by=connected,
+        )
+        rasp = hire_plain("Rasp")
+        assign(ranks["Leader"], miniature=rasp)
+        assign(connected, miniature=rasp)
+
+        (one,) = visitors(gang)
+        assert (one.trade_points, one.rank) == (3, "3")
+
+        visit_trading_post(gang, [one])
+
+        (went,) = LedgerEvent.objects.filter(
+            gang=gang, kind=LedgerEvent.Kind.VISITED_TRADING_POST
+        )
+        assert went.note == "3"
+
+    def test_the_figure_stays_a_fixed_number_of_queries(self, gang, ranks, hire_plain):
+        """A whole gang is a fixed number of queries however many models
+        are on it — the roster, the gang's own rows, and the modifiers
+        those reach. Never a query per fighter.
+
+        The count follows the *kinds* of content in play, not the size of
+        the roster, so both readings below are taken with a Leader and a
+        Champion already on it.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        assign(ranks["Leader"], miniature=hire_plain("Rasp"))
+        assign(ranks["Champion"], miniature=hire_plain("Kel"))
+        with CaptureQueriesContext(connection) as few:
+            assert len(visitors(gang)) == 2
+
+        for name in ("Tuk", "Vesh", "Mags", "Sura"):
+            model = hire_plain(name)
+            if name in ("Vesh", "Mags"):
+                assign(ranks["Champion"], miniature=model)
+
+        with CaptureQueriesContext(connection) as more:
+            assert len(visitors(gang)) == 4
+
+        assert len(more) == len(few)
 
 
 class TestWhatTheHistorySays:

--- a/n26/tests/sandbox/test_trade_points.py
+++ b/n26/tests/sandbox/test_trade_points.py
@@ -555,44 +555,6 @@ class TestWhatARankAdds:
         assert receipt.summary == "Leader, Champion"
         assert_reconciled(gang)
 
-    def test_a_figure_two_things_raised_is_recorded_as_the_figure(
-        self, gang, ranks, hire_plain
-    ):
-        """The visit records one name against each model. Where two
-        things raised the reading no single name is true, so what goes on
-        the record is the figure."""
-        from n26.core.models import LedgerEvent
-        from n26.library.models import Counter
-        from n26.library.standard_content import VISIT_CONTRIBUTION_COUNTER
-        from n26.tests.sandbox.actions import (
-            create_rule,
-            ef_contributes_to_counter,
-            modifier,
-            targets_model,
-        )
-
-        counter = Counter.objects.get(name=VISIT_CONTRIBUTION_COUNTER)
-        connected = create_rule("Well connected")
-        modifier(
-            "Well connected adds 1 to a Trading Post visit",
-            targets_model(),
-            ef_contributes_to_counter(counter, 1),
-            carried_by=connected,
-        )
-        rasp = hire_plain("Rasp")
-        assign(ranks["Leader"], miniature=rasp)
-        assign(connected, miniature=rasp)
-
-        (one,) = visitors(gang)
-        assert (one.trade_points, one.rank) == (3, "3")
-
-        visit_trading_post(gang, [one])
-
-        (went,) = LedgerEvent.objects.filter(
-            gang=gang, kind=LedgerEvent.Kind.VISITED_TRADING_POST
-        )
-        assert went.note == "3"
-
     def test_the_figure_stays_a_fixed_number_of_queries(self, gang, ranks, hire_plain):
         """A whole gang is a fixed number of queries however many models
         are on it — the roster, the gang's own rows, and the modifiers
@@ -619,6 +581,116 @@ class TestWhatARankAdds:
             assert len(visitors(gang)) == 4
 
         assert len(more) == len(few)
+
+
+class TestAFigureInPlaceOfARank:
+    """A model whose contribution several things raised has no single
+    name to be recorded under, so the visit records the figure.
+
+    Nothing that reads the record aloud may then say the figure as if it
+    were a rank: "sent Rasp as 3 to the trading post" is not a sentence,
+    and "3" filed as a rank on the receipt says nothing about where the
+    Trade Points came from.
+    """
+
+    @pytest.fixture
+    def hire_plain(self, gang, make_profile, make_statline):
+        def make(name):
+            profile = make_profile(f"{name} entry", price=50)
+            make_statline(profile)
+            return hire_with_option(gang, profile, name)
+
+        return make
+
+    @pytest.fixture
+    def connected(self, ranks):
+        """A rule that raises the same counter as a rank does, so a model
+        holding both has two things behind its figure."""
+        from n26.library.standard_content import visit_contribution_counter
+        from n26.tests.sandbox.actions import (
+            create_rule,
+            ef_contributes_to_counter,
+            modifier,
+            targets_model,
+        )
+
+        rule = create_rule("Well connected")
+        modifier(
+            "Well connected adds 1 Trade Point to a Trading Post visit",
+            targets_model(),
+            ef_contributes_to_counter(visit_contribution_counter(), 1),
+            carried_by=rule,
+        )
+        return rule
+
+    def sentences(self, gang):
+        from n26.core import history
+
+        return ["".join(span.text for span in act.spans) for act in history.build(gang)]
+
+    def test_the_visit_records_the_figure(self, gang, ranks, connected, hire_plain):
+        rasp = hire_plain("Rasp")
+        assign(ranks["Leader"], miniature=rasp)
+        assign(connected, miniature=rasp)
+
+        (one,) = visitors(gang)
+        assert (one.trade_points, one.rank) == (3, "3")
+
+        visit_trading_post(gang, [one])
+
+        (went,) = LedgerEvent.objects.filter(
+            gang=gang, kind=LedgerEvent.Kind.VISITED_TRADING_POST
+        )
+        assert went.note == "3"
+
+    def test_the_history_says_only_that_they_went(
+        self, gang, ranks, connected, hire_plain
+    ):
+        rasp = hire_plain("Rasp")
+        assign(ranks["Leader"], miniature=rasp)
+        assign(connected, miniature=rasp)
+        visit_trading_post(gang, visitors(gang))
+
+        (sent,) = [line for line in self.sentences(gang) if line.startswith("sent ")]
+
+        assert sent == "sent Rasp to the trading post"
+
+    def test_a_rank_still_leads_the_sentence(self, gang, ranks, hire_plain):
+        """The other half of the same rule: one thing raised the figure,
+        so the line names it."""
+        assign(ranks["Leader"], miniature=hire_plain("Rasp"))
+        visit_trading_post(gang, visitors(gang))
+
+        (sent,) = [line for line in self.sentences(gang) if line.startswith("sent ")]
+
+        assert sent == "sent Rasp as Leader to the trading post"
+
+    def test_the_receipt_leaves_the_figure_out_of_its_line(
+        self, gang, ranks, connected, hire_plain
+    ):
+        rasp = hire_plain("Rasp")
+        assign(ranks["Leader"], miniature=rasp)
+        assign(connected, miniature=rasp)
+        visit_trading_post(gang, visitors(gang))
+
+        gang.refresh_from_db()
+        receipt = receipt_for(gang)
+        assert receipt.available == 3
+        assert receipt.summary == ""
+
+    def test_the_ranks_beside_it_are_still_named(
+        self, gang, ranks, connected, hire_plain
+    ):
+        """One fighter with two things behind their figure does not take
+        the rest of the line with them."""
+        both = hire_plain("Rasp")
+        assign(ranks["Leader"], miniature=both)
+        assign(connected, miniature=both)
+        assign(ranks["Champion"], miniature=hire_plain("Kel"))
+        visit_trading_post(gang, visitors(gang))
+
+        gang.refresh_from_db()
+        assert receipt_for(gang).summary == "Champion"
 
 
 class TestWhatTheHistorySays:


### PR DESCRIPTION
Slice 4 of the Trade Point budgets plan. Builds on #2419.

## Problem

What a fighter adds to a Visit Trading Post action was a dict in the code:

```python
TRADE_POINTS_FOR_RANK = {"Leader": 2, "Champion": 1}
```

`n26/core/trading.py` matched subtypes by that name, cancelled owner
removals by hand, and picked the better of two ranks itself. Changing what
a rank adds — or giving a third thing a contribution, which the founding
budgets in later slices need — meant a code change and a deploy.

## Change

The figures become content.

**A new standard-content seed, `visit-contribution`** (`n26/library/standard_content.py`):
an undrawn `Counter` named "Trading Post visit contribution", and one
`Modifier` per rank that raises it — 2 carried by the Leader subtype, 1 by
Champion. Carried by the subtype, so a fighter promoted into a rank adds
what the rank adds and one who has lost it adds nothing.

**Both ranks use the higher figure, and that is content too.** The Champion
modifier is scoped `has_subtypes(Leader, negate=True)`, so a fighter holding
both never sums 2 and 1 to 3. The same fighter cannot perform the action
twice.

**`visitors(gang)` reads the counter.** It builds the gang's cards once and
takes each member's reading off `counter_readings` — the same route
`render_gang` takes for a gang sheet — instead of querying subtypes by name.
Removals now come free: `compute` already cancels a subtype an owner took
away, so the hand-rolled `removes` pairing is gone.

`TRADE_POINTS_FOR_RANK` and `brings(rank)` are deleted.

**The offer groups by the figure** ("2 Trade Points each" / "1 Trade Point
each") rather than by the rank, because the rank is not something the code
knows any more and two things may raise a reading by the same amount.
`Visitor.rank` and the `VISITED_TRADING_POST` event note hold what the card
said raised the figure — the subtype's name where one thing raised it, the
figure where several did. `Contributor.trade_points` is dropped: the ledger
records who went and what raised their figure, never each model's number,
and nothing drew it.

**A library with no such counter does not break the page.** Nobody is
offered, the page says "No model in <gang> adds Trade Points.", and the
typed-amount box — previously hidden unless somebody was ticked — is drawn
and works. That box is the fallback for an arbitrator's own figure and for
a roster with no ranks.

Two things found on the way, both fixed here:

- `n26/library/ingest.py`'s "clear imported content" swept **every**
  modifier, on a comment claiming standard content wires none of its own.
  It does now. The seeded pair is excluded by name, so a clear still leaves
  the foundations whole.
- `n26/library/prose.py`'s sentence for a contribution modifier used the
  plain possessive rather than `_owned`, so a scope narrowing was silently
  dropped — the authoring page read "1 is added to a Champion fighter's …
  reading" for a modifier that skips Champions who are also Leaders. This is
  the bug class #2416 closed for the stat, category and counter-move
  sentences; the contribution effect arrived after it and missed the fix.

## How this content reaches production

**No data migration.** It reaches a database the way every other seed does:
the Foundations authoring page at `/n26/authoring/foundations/` (a button
per seed, showing whether it is missing, incomplete or complete), or
`manage n26_backfill_foundations` from the command line. Both are
idempotent. **The seed must be run in production before this merges is
deployed and anybody opens the Trade Points page**, or no model will be
offered — the page stays usable via the typed box, but nobody adds anything.

The seed matches a rank's contribution by what it does — a modifier that
rank carries raising that counter — rather than by its name, so rewording a
modifier later and seeding again cannot hang a second contribution on the
rank and double what it adds.

## How to try it

1. `./scripts/dev.sh`
2. Visit `/n26/authoring/foundations/` and press Create on "Trading Post
   visit contribution" (or run `manage n26_backfill_foundations`).
3. Open a gang's Trade Points tab, `/n26/gangs/<id>/trade-points/`.
   - A Leader is offered under "2 Trade Points each", a Champion under
     "1 Trade Point each", a fighter holding both under 2.
   - Tick some and press Start TP visit; the receipt names the ranks.
   - Take the Leader subtype away from a fighter and reload: they go.
4. On a gang with no Leader or Champion, the page says no model adds Trade
   Points and still offers the typed box.

## Test plan

`pytest n26 -n 4` — 4,787 passed, 1 xfailed.

New tests:

- `n26/tests/sandbox/test_trade_points.py::TestWhatARankAdds` — promoted
  fighter counts; a rank removed does not; a rank cancelled by an owner's
  removal does not; both ranks read 2 and not 3; the offer groups by the
  figure; a library with no counter offers nobody; `minted`, the gang's
  figure, the receipt and `assert_reconciled` agree; a figure two things
  raised is recorded as the figure; the query count holds as the roster
  grows from two models to six.
- `n26/tests/sandbox/test_trade_points.py` — seeding again after a modifier
  is reworded leaves the rank carrying one contribution.
- `n26/core/test_views_trade_points.py::TestALibraryWithNoVisitContribution`
  — the page renders, offers nobody, and the typed amount still opens a
  visit.
- `n26/tests/sandbox/test_prose.py` — a pinned sentence for a contribution
  on a narrowed scope.
- `n26/tests/sandbox/test_ingest.py` — a clear leaves the seeded modifiers
  standing.

The four claims in `trading.py`'s module docstring still hold — the existing
`TestWhichSurfacesCharge`, `TestWhatIsLeft`, `TestEndingTheAction` and
`TestOverspending` are untouched and green.

Verified in the browser against a local gang (a Leader, a Champion, a
fighter holding both, and one with a built-in Champion): the groups, the
running total, the receipt summary, the finish button, and the empty-roster
state. A model carrying the same subtype twice (built-in plus assigned)
reads 1, not 2.

## Known, not fixed here

`HasSubtypes.__str__` renders a negated row as "every model except Leader"
whatever the scope's reach, so the modifier list's scope column reads as an
all-models reach for the Champion modifier, which is bearer-reach. The
sentence beside it is now correct. Pre-existing wording, wider than this
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh
