### PR TITLE
test: a delegation's injury table rides a hidden item that swaps the granted slot

### DIFF
--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -280,10 +280,18 @@ the dice are the table's, and a player adds the result they rolled.
    that do *not* have it, giving Lasting Injury as before. A Spyrer's
    card then asks under Hunting Rig Glitches and never under Lasting
    Injuries.
-5. A delegation's models roll on the D6 table. Giving them the
-   Delegation Lasting Injuries choice needs a way to reach exactly
-   those models; naming their entries one by one on the modifier is the
-   only way today, and which entries count is not yet settled.
+5. A delegation's models roll on the D6 table instead, and the swap
+   rides the models themselves rather than the gang types. Create a
+   **hidden** item named "Delegation" carrying two modifiers, both
+   reaching *the model carrying it*: one *takes away* the Lasting
+   Injury choice, the other *gives* the Delegation Lasting Injuries
+   choice. Then build it into each delegation entry — the fighters
+   under the Allies gang type. A delegation model's card asks under
+   Delegation Lasting Injuries and never under Lasting Injuries, in any
+   gang, while every gang type's own grants stay as they are. Anything
+   else the alliance rules say of a delegation belongs on the same
+   hidden item; an entry added to the Allies list later needs it built
+   in too.
 
 Taking one of those modifiers off a gang type takes the row off every
 card at once, and leaves what players had already picked where it is,

--- a/n26/tests/sandbox/test_lasting_effects.py
+++ b/n26/tests/sandbox/test_lasting_effects.py
@@ -36,11 +36,14 @@ from n26.library.standard_content import (
 )
 from n26.library.views import coverage
 from n26.tests.sandbox.actions import (
+    add_built_in,
     attach_modifiers_to,
     changes_stat,
     choose,
+    create_hidden,
     create_profile,
     ef_adds,
+    ef_removes,
     found_gang,
     hire,
     is_profile_type,
@@ -325,6 +328,52 @@ class TestAFighterIsHurt:
         assert not any(
             c.source == "Eye Injury" for c in computed_for(other).stat_changes
         )
+        assert_reconciled(gang)
+
+
+class TestADelegationIsHurt:
+    """An ally's delegation rolls a D6 of its own. The swap rides the
+    delegation entry as a hidden item that takes the gang type's injury
+    choice away and gives the delegation one, so no gang type's grant
+    has to know a delegation exists."""
+
+    @pytest.fixture
+    def bailiff(self, gang, gang_type, fighter_type, tables, standing):
+        marker = create_hidden("Delegation")
+        modifier(
+            "Delegation: no Lasting Injuries",
+            targets_model(),
+            ef_removes(tables["Lasting Injury"]["slot"]),
+            carried_by=marker,
+        )
+        modifier(
+            "Delegation: its own table",
+            targets_model(),
+            ef_adds(tables["Delegation Lasting Injury"]["slot"]),
+            carried_by=marker,
+        )
+        profile = create_profile("Bailiff", fighter_type, gang_type, price=60)
+        add_built_in(profile, marker)
+        return hire(gang, profile, "The Bailiff", paid=60)
+
+    def test_the_card_asks_under_the_delegations_table_alone(self, bailiff, yolanda):
+        assert choice_of(bailiff, "Delegation Lasting Injuries") is not None
+        assert choice_of(bailiff, "Lasting Injuries") is None
+        assert choice_of(yolanda, "Lasting Injuries") is not None
+        assert choice_of(yolanda, "Delegation Lasting Injuries") is None
+
+    def test_a_grievous_wound_lands_and_the_gang_reconciles(
+        self, gang, bailiff, tables
+    ):
+        table = tables["Delegation Lasting Injury"]["table"]
+        pick(
+            bailiff,
+            "Delegation Lasting Injuries",
+            result_named(table, "Grievous Wound"),
+        )
+
+        slot = choice_of(bailiff, "Delegation Lasting Injuries")
+        assert [p.assignable.name for p in slot.picks] == ["Grievous Wound"]
         assert_reconciled(gang)
 
 


### PR DESCRIPTION
Settles the last open point in the lasting-effects recipe: how an ally's delegation gets its D6 injury table instead of the gang's D66 one. No code changes — a recipe step and an executable-spec pin.

## The shape

The swap rides the delegation models, not the gang types. A **hidden item** "Delegation" carries two modifiers reaching the model carrying it: *takes away* the Lasting Injury choice, *gives* the Delegation Lasting Injuries choice. Built into each delegation entry (the fighters under the Allies gang type), it makes a delegation model's card ask under Delegation Lasting Injuries and never under Lasting Injuries — in any gang — while every gang type's own grants stay exactly as they are.

This is the pattern the compute code already names (a profile removing the general slot its type grants and granting a narrower one), so nothing new is needed: a removal of a *granted* slot is honoured before the slot's question is drawn. Chosen over a "Delegation" subtype because it touches none of the 21 gang types, keeps the marker and the behaviour in one object that any future delegation rule can hang on, and stays off the card's Type line.

## Pinned

`TestADelegationIsHurt` in the lasting-effects spec: a Bailiff hired from a profile carrying the hidden item asks under Delegation Lasting Injuries alone while the ganger beside it keeps Lasting Injuries; a Grievous Wound lands and the gang reconciles.

## Prod, by hand

1. Create hidden item "Delegation"; on it, the two modifiers above.
2. Build it into the 20 profiles under the Allies gang type. Built-in propagation reaches existing hires — sized at 12 live delegation models across 7 gangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
