### PR TITLE
feat: n26 maintenance op opens the FOUNDING Action on existing gangs

### DIFF
--- a/n26/core/templates/admin/maintenance/n26/_open_founding_actions_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_open_founding_actions_detail.html
@@ -1,0 +1,41 @@
+{% comment %}
+    The summary of one founding-action backfill run, on the Backfill
+    detail page: what it set out to do, how far the walk has got, and
+    what it came to. Every unarchived gang is walked and only some get
+    anything, so the walk and the totals are shown apart — a run that
+    says 1,979 walked and 1,929 opened has skipped 50, not lost them.
+{% endcomment %}
+{% if backfill.summary.preview %}
+    <h2>What this run set out to do</h2>
+    <ul>
+        {% for line in backfill.summary.preview %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+<h2>Progress</h2>
+<p>
+    {{ backfill.summary.done|default:0 }} of {{ backfill.summary.total|default:"?" }} gang{{ backfill.summary.total|pluralize }} walked.
+    {% if backfill.summary.attempts %}
+        Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }} since the last batch landed.
+    {% endif %}
+</p>
+<h2>Totals</h2>
+<table class="table">
+    <tr>
+        <th>Gangs given a Found and equip gang action</th>
+        <td>{{ backfill.summary.totals.opened|default:0 }}</td>
+    </tr>
+    <tr>
+        <th>Gangs skipped: they already had one, open or completed</th>
+        <td>{{ backfill.summary.totals.already_had_one|default:0 }}</td>
+    </tr>
+</table>
+{% if backfill.summary.failures %}
+    <h2>Gangs that could not be settled</h2>
+    <ul>
+        {% for gang_id, why in backfill.summary.failures.items %}
+            <li>
+                <code>{{ gang_id }}</code>: {{ why }}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/open_founding_actions.html
+++ b/n26/core/templates/admin/maintenance/n26/open_founding_actions.html
@@ -1,0 +1,69 @@
+{% extends "admin/base_site.html" %}
+{% comment %}
+The founding-action backfill's console page: how many gangs would get
+one, a run button, and the recent runs. There is nothing to preview
+beyond the count — every eligible gang is treated the same way — so the
+page is a figure and a button.
+Context from open_founding_actions_view (n26/maintenance.py): title,
+gangs, eligible, apply_url, recent.
+{% endcomment %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        Opens the Found and equip gang action on every unarchived gang that has
+        never had one. A gang founded before the action existed has none, so its
+        page has nothing for the owner to complete. Each of those gangs gets the
+        action a gang founded today has, and the same entry in its history.
+    </p>
+    <p>
+        A gang that already has one, open or completed, is skipped, so running
+        this again changes nothing. Archived gangs are left alone. No money
+        moves.
+    </p>
+    <p>{{ eligible }} of {{ gangs }} unarchived gang{{ gangs|pluralize }} would get the action.</p>
+    {% if eligible %}
+        <form method="post" class="mt-form">
+            {% csrf_token %}
+            <button type="submit" class="button default">Open the missing actions</button>
+        </form>
+    {% else %}
+        <h2>Nothing to open</h2>
+        <p>Every unarchived gang already has the Found and equip gang action.</p>
+    {% endif %}
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -1354,6 +1354,11 @@ def open_founding_actions(backfill_id, **said_by_whoever_enqueued_it):
     founding uses, so the same event is written and the gang's history
     reads as it would have.
 
+    Nobody is named as having done it, as the built-ins backfill does
+    the same way: the act is the estate catching up, not a person, and
+    filing it against whoever clicked in the admin would put a staff
+    username in a stranger's gang history.
+
     The walk is every unarchived gang rather than only the ones that
     qualify: ``run_batched`` needs a set that does not shrink as it is
     worked through, and a gang that already has one is stepped past
@@ -1364,11 +1369,10 @@ def open_founding_actions(backfill_id, **said_by_whoever_enqueued_it):
     gang lands, so a record read part-way says how far it has got.
     """
     from n26.core.models import Action, Gang
-    from n26.core.operations import operation
+    from n26.core.operations import Refusal, operation
 
     record = Backfill.objects.get(pk=backfill_id)
     totals = dict(record.summary.get("totals", {}))
-    actor = _who_asked(backfill_id)
 
     def add_to_totals(key):
         totals[key] = int(totals.get(key, 0)) + 1
@@ -1383,8 +1387,16 @@ def open_founding_actions(backfill_id, **said_by_whoever_enqueued_it):
         if Action.objects.filter(gang=gang, kind=Action.Kind.FOUNDING).exists():
             add_to_totals("already_had_one")
             return
-        with operation(gang, actor=actor) as op:
-            op.open_action(Action.Kind.FOUNDING)
+        try:
+            with operation(gang, actor=None) as op:
+                op.open_action(Action.Kind.FOUNDING)
+        except Refusal:
+            # The check above runs before the gang's line is held, so an
+            # owner can start the act in between and hold it by the time
+            # this gets the line. Refusing is that guard working: the
+            # gang has what this run came to give it.
+            add_to_totals("already_had_one")
+            return
         add_to_totals("opened")
 
     run_batched(
@@ -1395,6 +1407,24 @@ def open_founding_actions(backfill_id, **said_by_whoever_enqueued_it):
         do_one=do_one,
         again=lambda: open_founding_actions.enqueue(backfill_id=backfill_id),
     )
+
+
+def _preview_words(eligible, walked):
+    """What the run set out to do, in sentences the record keeps.
+
+    The second says what the run's own total counts, because the two
+    figures differ: every unarchived gang is walked and only some of
+    them get anything, so a run reporting more done than there were
+    gangs to change would otherwise read as a mistake.
+    """
+    return [
+        f"{eligible} of {walked} unarchived gang"
+        f"{'' if walked == 1 else 's'} "
+        f"{'has' if eligible == 1 else 'have'} never had a Found and "
+        "equip gang action.",
+        "Every unarchived gang is walked, so this run's total counts "
+        "gangs walked, not gangs changed.",
+    ]
 
 
 def open_founding_actions_view(request):
@@ -1419,11 +1449,12 @@ def open_founding_actions_view(request):
                 "has the Found and equip gang action.",
             )
             return HttpResponseRedirect(address)
+        walked = Gang.objects.filter(archived=False).count()
         backfill = Backfill.objects.create(
             operation=operation,
             triggered_by=request.user,
             status=Backfill.Status.RUNNING,
-            summary={"preview": {"eligible": eligible}, "attempts": 0},
+            summary={"preview": _preview_words(eligible, walked), "attempts": 0},
         )
         open_founding_actions.enqueue(backfill_id=str(backfill.id))
         messages.success(
@@ -1459,6 +1490,7 @@ register_operation(
             "left alone. No money moves."
         ),
         view=open_founding_actions_view,
+        detail_template="admin/maintenance/n26/_open_founding_actions_detail.html",
     )
 )
 

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -61,6 +61,7 @@ __all__ = [
     "backfill_built_ins",
     "delete_empty_affiliations",
     "delete_nameless_gang_type",
+    "open_founding_actions",
     "rehost_gang_picks",
     "repair_doubled_refunds",
     "repoint_champion_picks",
@@ -171,6 +172,10 @@ class Operation(models.TextChoices):
         "n26_delete_empty_affiliations",
         "n26: the emptied affiliation rows are deleted",
     )
+    OPEN_FOUNDING_ACTIONS = (
+        "n26_open_founding_actions",
+        "n26: the Found and equip gang action is opened on gangs that never had one",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -186,6 +191,7 @@ LOCK_KEYS = {
     Operation.REHOST_GANG_PICKS: 826_020_614,
     Operation.REPOINT_CHAMPION_PICKS: 826_020_615,
     Operation.DELETE_EMPTY_AFFILIATIONS: 826_020_616,
+    Operation.OPEN_FOUNDING_ACTIONS: 826_020_617,
 }
 
 
@@ -1322,6 +1328,141 @@ def drop_duplicate_grants_view(request):
     return render(request, "admin/maintenance/n26/drop_duplicate_grants.html", context)
 
 
+def gangs_without_a_founding_action():
+    """The unarchived gangs that have never had a founding action.
+
+    Never, rather than not at this moment: an owner who has completed
+    the act is done with it, and opening a second would put them back
+    where they started. So a completed one counts as much as an open
+    one.
+    """
+    from n26.core.models import Action, Gang
+
+    return Gang.objects.filter(archived=False).exclude(
+        actions__kind=Action.Kind.FOUNDING
+    )
+
+
+@task
+def open_founding_actions(backfill_id, **said_by_whoever_enqueued_it):
+    """Open a Found and equip gang action on every unarchived gang that
+    has never had one, a gang at a time.
+
+    A gang founded before the action existed has none, so nothing on
+    its page says the act is still to be completed and its owner would
+    have to start one by hand. Each is opened through the operation a
+    founding uses, so the same event is written and the gang's history
+    reads as it would have.
+
+    The walk is every unarchived gang rather than only the ones that
+    qualify: ``run_batched`` needs a set that does not shrink as it is
+    worked through, and a gang that already has one is stepped past
+    where it stands. It is also why a rerun does nothing but walk.
+
+    Batched, because the whole estate is walked and each gang commits on
+    its own. What the run has come to is added to the record as each
+    gang lands, so a record read part-way says how far it has got.
+    """
+    from n26.core.models import Action, Gang
+    from n26.core.operations import operation
+
+    record = Backfill.objects.get(pk=backfill_id)
+    totals = dict(record.summary.get("totals", {}))
+    actor = _who_asked(backfill_id)
+
+    def add_to_totals(key):
+        totals[key] = int(totals.get(key, 0)) + 1
+        _write(backfill_id, summary_patch={"totals": totals})
+
+    def do_one(pk):
+        gang = Gang.objects.filter(pk=pk, archived=False).first()
+        if gang is None:
+            # Archived, or gone, since the walk was counted. Either way
+            # it is not one of the gangs this run is for.
+            return
+        if Action.objects.filter(gang=gang, kind=Action.Kind.FOUNDING).exists():
+            add_to_totals("already_had_one")
+            return
+        with operation(gang, actor=actor) as op:
+            op.open_action(Action.Kind.FOUNDING)
+        add_to_totals("opened")
+
+    run_batched(
+        backfill_id,
+        operation=Operation.OPEN_FOUNDING_ACTIONS,
+        what="Founding actions",
+        items=Gang.objects.filter(archived=False),
+        do_one=do_one,
+        again=lambda: open_founding_actions.enqueue(backfill_id=backfill_id),
+    )
+
+
+def open_founding_actions_view(request):
+    """Say how many gangs would get one (GET), or record a run and
+    enqueue it."""
+    from n26.core.models import Gang
+
+    operation = Operation.OPEN_FOUNDING_ACTIONS
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That backfill is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        eligible = gangs_without_a_founding_action().count()
+        if not eligible:
+            messages.info(
+                request,
+                "There is nothing to open — every unarchived gang already "
+                "has the Found and equip gang action.",
+            )
+            return HttpResponseRedirect(address)
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"preview": {"eligible": eligible}, "attempts": 0},
+        )
+        open_founding_actions.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The backfill is running. This page shows what it does."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+    context = page_context(
+        request,
+        operation.label,
+        gangs=Gang.objects.filter(archived=False).count(),
+        eligible=gangs_without_a_founding_action().count(),
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+    )
+    return render(request, "admin/maintenance/n26/open_founding_actions.html", context)
+
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.OPEN_FOUNDING_ACTIONS.value,
+        name=Operation.OPEN_FOUNDING_ACTIONS.label,
+        added=date(2026, 9, 4),
+        description=(
+            "Open the Found and equip gang action on every unarchived "
+            "gang that has never had one. A gang founded before the "
+            "action existed has none, so its page has nothing for the "
+            "owner to complete. Each of those gangs gets the action a "
+            "gang founded today has, and the same entry in its history. "
+            "A gang that already has one, open or completed, is skipped, "
+            "so running this again changes nothing. Archived gangs are "
+            "left alone. No money moves."
+        ),
+        view=open_founding_actions_view,
+    )
+)
+
+
 register_operation(
     MaintenanceOperation(
         operation=Operation.REHOST_GANG_PICKS.value,
@@ -1551,6 +1692,7 @@ task_routes = [
     TaskRoute(rehost_gang_picks, ack_deadline=600, min_retry_delay=60),
     TaskRoute(repoint_champion_picks, ack_deadline=600, min_retry_delay=60),
     TaskRoute(delete_empty_affiliations, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(open_founding_actions, ack_deadline=600),
 ]
 
 

--- a/n26/tests/sandbox/test_founding_action_backfill.py
+++ b/n26/tests/sandbox/test_founding_action_backfill.py
@@ -1,0 +1,283 @@
+"""The founding-action backfill: every existing gang gets the act it
+was founded without.
+
+Founding a gang opens a Found and equip gang action, but gangs founded
+before that existed have none — nothing on their page says the act is
+still to be completed. The backfill walks the estate on the batched
+runner and opens one for each, through the same operation a founding
+uses, so the gang's history reads as it would have.
+
+Proven here: which gangs qualify, that each gets exactly one action and
+one event, that a gang already holding one — open or completed — is
+stepped past, that archived gangs are untouched, that the outcome lands
+on the record, and that a rerun and a redelivered message both change
+nothing.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+
+from gyrinx.maintenance.models import Backfill
+from n26.core.models import Action, Gang, LedgerEvent
+from n26.core.operations import operation
+from n26.core.reconcile import assert_reconciled
+from n26.maintenance import (
+    Operation,
+    gangs_without_a_founding_action,
+    open_founding_actions,
+)
+from n26.tests.sandbox.actions import found_gang
+
+pytestmark = pytest.mark.django_db
+
+FOUNDING = Action.Kind.FOUNDING
+
+
+@pytest.fixture
+def player():
+    return User.objects.create_user("founder")
+
+
+@pytest.fixture
+def record(db):
+    return Backfill.objects.create(
+        operation=Operation.OPEN_FOUNDING_ACTIONS,
+        status=Backfill.Status.RUNNING,
+        summary={"attempts": 0},
+    )
+
+
+@pytest.fixture
+def old_gang(gang_type, player, person_type, default_pack):
+    """A gang as one founded before the action existed: no action row,
+    and no event saying one was ever started."""
+
+    def _found(name="Before The Action", **kwargs):
+        gang = found_gang(name, gang_type, owner=player, budget=1000, **kwargs)
+        LedgerEvent.objects.filter(
+            gang=gang,
+            kind__in=[LedgerEvent.Kind.ACTION_OPENED, LedgerEvent.Kind.ACTION_CLOSED],
+        ).delete()
+        assert not Action.objects.filter(gang=gang).exists()
+        return gang
+
+    return _found
+
+
+def run(record):
+    open_founding_actions.func(backfill_id=str(record.pk))
+    record.refresh_from_db()
+    return record
+
+
+def opened_events(gang):
+    return LedgerEvent.objects.filter(
+        gang=gang, kind=LedgerEvent.Kind.ACTION_OPENED
+    ).count()
+
+
+class TestWhichGangsQualify:
+    """Never had one, rather than has not got one now: an owner who has
+    completed the act is done with it."""
+
+    def test_a_gang_founded_before_the_action_qualifies(self, old_gang):
+        gang = old_gang()
+
+        assert list(gangs_without_a_founding_action()) == [gang]
+
+    def test_a_gang_founded_since_does_not(self, gang_type, player, default_pack):
+        found_gang("Founded Today", gang_type, owner=player, budget=1000)
+
+        assert not gangs_without_a_founding_action().exists()
+
+    def test_a_gang_that_completed_its_founding_does_not(self, old_gang, player):
+        gang = old_gang()
+        with operation(gang, actor=player) as op:
+            op.open_action(FOUNDING)
+        with operation(gang, actor=player) as op:
+            op.close_action(gang.open_action(FOUNDING))
+
+        assert gang.open_action(FOUNDING) is None
+        assert not gangs_without_a_founding_action().exists()
+
+    def test_an_archived_gang_does_not(self, old_gang):
+        gang = old_gang()
+        gang.archive()
+
+        assert not gangs_without_a_founding_action().exists()
+
+
+class TestOpeningTheAction:
+    """One action per qualifying gang, opened the way a founding opens
+    it — so the event is there and the history reads the same."""
+
+    def test_each_qualifying_gang_gets_one_action_and_one_event(self, old_gang, record):
+        first = old_gang("First")
+        second = old_gang("Second")
+
+        run(record)
+
+        for gang in (first, second):
+            action = gang.open_action(FOUNDING)
+            assert action is not None
+            assert action.trade_points is None
+            assert action.opened.kind == LedgerEvent.Kind.ACTION_OPENED
+            assert opened_events(gang) == 1
+            gang.refresh_from_db()
+            assert_reconciled(gang)
+
+    def test_the_event_is_filed_against_whoever_asked_for_the_run(
+        self, old_gang, record
+    ):
+        """A repair that hands a gang something says who asked for it;
+        an act filed against nobody reads as the gang's own."""
+        boss = User.objects.create_superuser("chief", "chief@example.com", "password")
+        record.triggered_by = boss
+        record.save()
+        gang = old_gang()
+
+        run(record)
+
+        assert gang.open_action(FOUNDING).opened.actor_id == boss.pk
+
+    def test_the_gang_history_says_the_action_was_started(self, old_gang, record):
+        from n26.core.history import build
+
+        gang = old_gang()
+
+        run(record)
+
+        told = " ".join(line.search for line in build(gang))
+        assert "started the found and equip gang action" in told
+
+    def test_a_gang_that_already_has_one_keeps_the_one_it_has(
+        self, old_gang, player, record
+    ):
+        gang = old_gang()
+        with operation(gang, actor=player) as op:
+            already = op.open_action(FOUNDING)
+
+        run(record)
+
+        assert gang.open_action(FOUNDING).pk == already.pk
+        assert Action.objects.filter(gang=gang, kind=FOUNDING).count() == 1
+        assert opened_events(gang) == 1
+
+    def test_a_completed_founding_is_not_opened_again(self, old_gang, player, record):
+        """Completing the act is the owner saying they are done. A
+        backfill that reopened it would put them back at the start."""
+        gang = old_gang()
+        with operation(gang, actor=player) as op:
+            op.open_action(FOUNDING)
+        with operation(gang, actor=player) as op:
+            op.close_action(gang.open_action(FOUNDING))
+
+        run(record)
+
+        assert gang.open_action(FOUNDING) is None
+        assert Action.objects.filter(gang=gang, kind=FOUNDING).count() == 1
+
+    def test_an_archived_gang_is_left_alone(self, old_gang, record):
+        gang = old_gang()
+        gang.archive()
+
+        run(record)
+
+        assert not Action.objects.filter(gang=gang).exists()
+        assert opened_events(gang) == 0
+
+
+class TestTheRecord:
+    """Every ending is written onto the record rather than raised."""
+
+    def test_a_finished_run_says_what_it_opened(self, old_gang, record):
+        old_gang("First")
+        old_gang("Second")
+
+        run(record)
+
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["totals"]["opened"] == 2
+        assert record.summary["done"] == 2
+        assert record.summary["failures"] == {}
+
+    def test_a_gang_stepped_past_is_counted_too(
+        self, old_gang, gang_type, player, default_pack, record
+    ):
+        old_gang("Qualifies")
+        found_gang("Founded Today", gang_type, owner=player, budget=1000)
+
+        run(record)
+
+        assert record.summary["totals"]["opened"] == 1
+        assert record.summary["totals"]["already_had_one"] == 1
+
+    def test_a_run_over_nothing_still_ends_done(
+        self, gang_type, player, default_pack, record
+    ):
+        found_gang("Founded Today", gang_type, owner=player, budget=1000)
+
+        run(record)
+
+        assert record.status == Backfill.Status.DONE
+        assert "opened" not in record.summary["totals"]
+
+
+class TestRunningItTwice:
+    """Delivery is at-least-once and an operator may run a repair again;
+    neither may open a second action."""
+
+    def test_a_rerun_changes_nothing(self, old_gang, record):
+        gang = old_gang()
+        run(record)
+        again = Backfill.objects.create(
+            operation=Operation.OPEN_FOUNDING_ACTIONS,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": 0},
+        )
+
+        run(again)
+
+        assert Action.objects.filter(gang=gang, kind=FOUNDING).count() == 1
+        assert opened_events(gang) == 1
+        assert again.status == Backfill.Status.DONE
+        assert again.summary["totals"]["already_had_one"] == 1
+        assert "opened" not in again.summary["totals"]
+
+    def test_a_redelivered_message_opens_nothing_more(
+        self, old_gang, record, task_queue
+    ):
+        """The run holds its own lock, so a copy arriving while it works
+        stands down. A copy arriving after it has finished gets no
+        further: the record has reached an ending, endings are final,
+        and the claim refuses to start a second walk over it."""
+        gang = old_gang()
+
+        with task_queue.capture():
+            open_founding_actions.enqueue(backfill_id=str(record.pk))
+        task_queue.deliver_all()
+        task_queue.redeliver_last()
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.DONE
+        assert Action.objects.filter(gang=gang, kind=FOUNDING).count() == 1
+        assert opened_events(gang) == 1
+
+
+class TestTheEstate:
+    """The walk is every unarchived gang, so the set it steps through
+    does not shrink as it works — the cursor a batched run keeps is only
+    sound over a set that stays put."""
+
+    def test_the_walk_counts_every_unarchived_gang(
+        self, old_gang, gang_type, player, default_pack, record
+    ):
+        old_gang("Qualifies")
+        found_gang("Founded Today", gang_type, owner=player, budget=1000)
+        archived = old_gang("Gone")
+        archived.archive()
+
+        run(record)
+
+        assert record.summary["total"] == Gang.objects.filter(archived=False).count()
+        assert record.summary["total"] == 2

--- a/n26/tests/sandbox/test_founding_action_backfill.py
+++ b/n26/tests/sandbox/test_founding_action_backfill.py
@@ -126,11 +126,10 @@ class TestOpeningTheAction:
             gang.refresh_from_db()
             assert_reconciled(gang)
 
-    def test_the_event_is_filed_against_whoever_asked_for_the_run(
-        self, old_gang, record
-    ):
-        """A repair that hands a gang something says who asked for it;
-        an act filed against nobody reads as the gang's own."""
+    def test_nobody_is_named_as_having_started_it(self, old_gang, record):
+        """The estate catching up is not a person, and the owner of a
+        gang has never met whoever clicked in the admin — so their name
+        does not go in a stranger's history."""
         boss = User.objects.create_superuser("chief", "chief@example.com", "password")
         record.triggered_by = boss
         record.save()
@@ -138,7 +137,7 @@ class TestOpeningTheAction:
 
         run(record)
 
-        assert gang.open_action(FOUNDING).opened.actor_id == boss.pk
+        assert gang.open_action(FOUNDING).opened.actor_id is None
 
     def test_the_gang_history_says_the_action_was_started(self, old_gang, record):
         from n26.core.history import build
@@ -149,6 +148,24 @@ class TestOpeningTheAction:
 
         told = " ".join(line.search for line in build(gang))
         assert "started the found and equip gang action" in told
+
+    def test_the_history_line_carries_no_subject(self, old_gang, record):
+        """With no actor the page draws the sentence alone, as it does
+        for everything else the estate did to itself."""
+        from n26.core.history import build
+
+        gang = old_gang()
+
+        run(record)
+
+        started = [
+            line
+            for line in build(gang)
+            if "started the Found and equip gang action"
+            in "".join(span.text for span in line.spans)
+        ]
+        assert len(started) == 1
+        assert started[0].actor == ""
 
     def test_a_gang_that_already_has_one_keeps_the_one_it_has(
         self, old_gang, player, record
@@ -176,6 +193,39 @@ class TestOpeningTheAction:
 
         assert gang.open_action(FOUNDING) is None
         assert Action.objects.filter(gang=gang, kind=FOUNDING).count() == 1
+
+    def test_a_gang_that_gained_one_at_the_last_moment_is_counted(
+        self, old_gang, record, monkeypatch
+    ):
+        """The check for one already there runs before the gang's line
+        is held, so an owner can start the act in between and hold it by
+        the time the run gets the line. The refusal that follows is the
+        guard working: the gang has what the run came to give it, so it
+        is counted rather than filed as a failure."""
+        from n26.core.operations import Operation as GangOperation
+        from n26.core.operations import Refusal
+
+        slipped_in = old_gang("Slipped In")
+        plain = old_gang("Straightforward")
+        really_open = GangOperation.open_action
+
+        def open_action(self, kind, trade_points=None):
+            if self.gang.pk == slipped_in.pk:
+                raise Refusal(
+                    "Complete the open Found and equip gang action before "
+                    "starting another."
+                )
+            return really_open(self, kind, trade_points)
+
+        monkeypatch.setattr(GangOperation, "open_action", open_action)
+
+        run(record)
+
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["failures"] == {}
+        assert record.summary["totals"]["already_had_one"] == 1
+        assert record.summary["totals"]["opened"] == 1
+        assert plain.open_action(FOUNDING) is not None
 
     def test_an_archived_gang_is_left_alone(self, old_gang, record):
         gang = old_gang()

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -29,8 +29,8 @@ from n26.maintenance import (
     convert_outcast_affiliation_view,
     convert_variant_view,
     delete_empty_affiliations_view,
-    open_founding_actions_view,
     delete_nameless_gang_type_view,
+    open_founding_actions_view,
 )
 
 pytestmark = pytest.mark.django_db
@@ -684,10 +684,34 @@ class TestTheFoundingActionBackfill:
         assert response.status_code == 302
         run = Backfill.objects.get(operation=Operation.OPEN_FOUNDING_ACTIONS)
         assert run.status == Backfill.Status.DONE
-        assert run.summary["preview"] == {"eligible": 1}
+        assert run.summary["preview"] == [
+            "1 of 1 unarchived gang has never had a Found and equip gang action.",
+            "Every unarchived gang is walked, so this run's total counts "
+            "gangs walked, not gangs changed.",
+        ]
         assert run.summary["totals"]["opened"] == 1
         assert old_gang.open_action(Action.Kind.FOUNDING) is not None
+        old_gang.refresh_from_db()
         assert_reconciled(old_gang)
+
+    def test_the_record_page_labels_what_the_run_walked_and_opened(
+        self, client, superuser, old_gang
+    ):
+        """The walk and the totals differ, so the page says which is
+        which rather than dumping the summary as it was stored."""
+        client.force_login(superuser)
+        client.post(reverse("admin:maintenance_n26_open_founding_actions"))
+        run = Backfill.objects.get(operation=Operation.OPEN_FOUNDING_ACTIONS)
+
+        page = client.get(
+            reverse("admin:maintenance_backfill_detail", args=[run.id])
+        ).content.decode()
+
+        assert "gang walked" in page or "gangs walked" in page
+        assert "Gangs given a Found and equip gang action" in page
+        assert "Gangs skipped: they already had one, open or completed" in page
+        assert "never had a Found and equip gang action." in page
+        assert "{'opened'" not in page
 
     def test_applying_with_nothing_to_open_records_no_run(
         self, client, superuser, owner, default_pack, gang_type

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -29,6 +29,7 @@ from n26.maintenance import (
     convert_outcast_affiliation_view,
     convert_variant_view,
     delete_empty_affiliations_view,
+    open_founding_actions_view,
     delete_nameless_gang_type_view,
 )
 
@@ -603,3 +604,100 @@ def leftover_world(default_pack, person_type, owner):
     from n26.tests.sandbox.test_empty_affiliations import build_leftover_world
 
     return build_leftover_world(person_type, owner)
+
+
+class TestTheFoundingActionBackfill:
+    """The repair still on offer: gangs founded before the Found and
+    equip gang action existed are given one."""
+
+    @pytest.fixture
+    def old_gang(self, owner, default_pack, gang_type):
+        """A gang as one founded before the action existed."""
+        from n26.core.models import LedgerEvent
+        from n26.tests.sandbox.actions import found_gang
+
+        gang = found_gang("Before The Action", gang_type, owner=owner, budget=1000)
+        LedgerEvent.objects.filter(
+            gang=gang, kind=LedgerEvent.Kind.ACTION_OPENED
+        ).delete()
+        return gang
+
+    def test_its_lock_is_not_shared(self):
+        keys = list(LOCK_KEYS.values())
+        assert len(keys) == len(set(keys))
+        assert (
+            LOCK_KEYS[Operation.OPEN_FOUNDING_ACTIONS]
+            != LOCK_KEYS[Operation.REPOINT_CHAMPION_PICKS]
+        )
+
+    def test_the_operation_is_registered_and_named(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.OPEN_FOUNDING_ACTIONS.value in registered
+        found = resolve_operation(Operation.OPEN_FOUNDING_ACTIONS.value)
+        assert found.name == Operation.OPEN_FOUNDING_ACTIONS.label
+        assert found.view is open_founding_actions_view
+
+    def test_only_a_superuser_may_reach_it(self, client, staffer):
+        client.force_login(staffer)
+
+        response = client.get(reverse("admin:maintenance_n26_open_founding_actions"))
+
+        assert response.status_code in (302, 403)
+
+    def test_its_page_counts_the_gangs_and_writes_nothing(
+        self, client, superuser, old_gang
+    ):
+        from n26.core.models import Action
+
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_open_founding_actions"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "1 of 1 unarchived gang would get the action" in page
+        assert not Backfill.objects.exists()
+        assert not Action.objects.filter(gang=old_gang).exists()
+
+    def test_its_page_says_when_there_is_nothing_to_open(
+        self, client, superuser, owner, default_pack, gang_type
+    ):
+        from n26.tests.sandbox.actions import found_gang
+
+        found_gang("Founded Today", gang_type, owner=owner, budget=1000)
+        client.force_login(superuser)
+
+        response = client.get(reverse("admin:maintenance_n26_open_founding_actions"))
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "Nothing to open" in page
+
+    def test_applying_records_what_it_opened(self, client, superuser, old_gang):
+        from n26.core.models import Action
+
+        client.force_login(superuser)
+
+        response = client.post(reverse("admin:maintenance_n26_open_founding_actions"))
+
+        assert response.status_code == 302
+        run = Backfill.objects.get(operation=Operation.OPEN_FOUNDING_ACTIONS)
+        assert run.status == Backfill.Status.DONE
+        assert run.summary["preview"] == {"eligible": 1}
+        assert run.summary["totals"]["opened"] == 1
+        assert old_gang.open_action(Action.Kind.FOUNDING) is not None
+        assert_reconciled(old_gang)
+
+    def test_applying_with_nothing_to_open_records_no_run(
+        self, client, superuser, owner, default_pack, gang_type
+    ):
+        from n26.tests.sandbox.actions import found_gang
+
+        found_gang("Founded Today", gang_type, owner=owner, budget=1000)
+        client.force_login(superuser)
+
+        response = client.post(reverse("admin:maintenance_n26_open_founding_actions"))
+
+        assert response.status_code == 302
+        assert not Backfill.objects.exists()


### PR DESCRIPTION
## Problem

Founding a gang now opens a **Found and equip gang** action (#2423), but every gang founded before that shipped has none. Their gang pages have nothing for the owner to complete, and once the founding Trade Point budgets land there is no open action for those purchases to count against. The plan settles this as a backfill run from the maintenance console when the feature is broadly built, not a migration.

## Change

A new maintenance-console operation, `n26_open_founding_actions` — **"n26: the Found and equip gang action is opened on gangs that never had one"**. GET previews how many gangs would get one; POST records a `Backfill` row and enqueues the task.

The work runs on the tasks framework via `run_batched`: chunked commits, its own advisory lock, an attempt cap, and every ending (done, refused, broken) written onto the record rather than raised. Each gang is opened through `operation(gang, actor=None)` and `Operation.open_action(Action.Kind.FOUNDING)`, so the `ACTION_OPENED` event is written exactly as a founding writes it and the gang's history reads "started the Found and equip gang action".

The walk is every unarchived gang rather than only the ones that qualify: `run_batched`'s cursor is only sound over a set that does not shrink as it is worked through. A gang that already has a founding action, open or completed, is skipped where it stands — so a rerun changes nothing. The check for an existing action runs before the gang's line is held, so an owner can start the act in between; the `Refusal` that follows is caught and counted as "already had one", because a race must not turn the run's ending FAILED. Archived gangs are never touched. No money moves.

**No migration.** `Backfill.operation` is a bare slug with no choices and the registry supplies the label and the route, so `register_operation` is the whole of the wiring.

### Decision to confirm: nobody is named as having opened the action

The task passes `actor=None`, following `backfill_built_ins` (`n26/core/backfill_built_ins.py:112`) — the other estate-wide walk. The history line then draws with no subject: "started the Found and equip gang action", the same way every other act the estate did to itself draws. The alternative is `_who_asked(backfill_id)`, which files all 1,929 events against whoever clicked in the admin and puts a staff username in strangers' gang histories. It is a one-line change if that attribution is wanted instead; `test_nobody_is_named_as_having_started_it` pins the current choice.

## How to try it

Dev server, signed in as a superuser: **`/admin/maintenance/n26-open-founding-actions/`** (also listed on `/admin/maintenance/`). The page says "N of M unarchived gangs would get the action" and offers one button; running it redirects to the run's record. With nothing to open, the page says so and the button is not drawn.

The record page draws the run's own numbers rather than dumping the summary: what the run set out to do, "N of M gangs walked", and the two totals apart from it — so a run reading 1,979 walked against 1,929 opened is not mistaken for a miscount.

## Smoke test at production volume

Fork of the content mirror, populated to production's shape (production had 1,979 unarchived gangs on 2026-09-04): **2,099 gangs** (1,979 unarchived, 120 archived), 10,633 models, 75,702 assignments, 75,752 ledger events. 50 of the unarchived gangs kept a founding action, standing in for gangs founded after #2423 deploys; 1,929 were eligible.

Run through the real admin POST, timed end to end, then checked from outside the task with plain SQL:

| | before | after | delta |
|---|---|---|---|
| founding actions | 50 | 1,979 | +1,929 |
| open founding actions | 50 | 1,979 | +1,929 |
| `action_opened` events | 50 | 1,979 | +1,929 |
| unarchived gangs with no founding action | 1,929 | 0 | −1,929 |
| unarchived gangs with more than one | 0 | 0 | 0 |
| actions on archived gangs | 0 | 0 | 0 |

- **38.1 seconds** for the whole run, ending `Done` with `opened: 1929, already_had_one: 50`, no failures.
- Rerun through the console: preview reads "0 of 1,979", the page says "Nothing to open", no record is created, **every count unchanged**.
- The task forced to walk everything again on a fresh record: 5.0s, `Done`, `already_had_one: 1979`, **every count unchanged**.
- Every action's opening event is `action_opened`, kind `founding`, no trade points, carrying no credits/rating/Trade Points, pinned to its own gang.
- 60 gangs sampled at random all reconcile after the run.

The smoke database was dropped afterwards. Nothing was run against production.

### For whoever verifies the production run

Every gang goes through `Operation.settle`, which repins rating and credits by recomputing them. Two consequences worth checking beyond the action counts:

- A gang whose pins had already drifted gets them **corrected silently** by this run. That is a fix, not a bug, but it means the run can move rating and credits figures even though it moves no money of its own.
- `settle` raises `NotEnoughCredits` when recomputed remaining credits are negative, so a gang in that state is **filed as a failure on the record** and its action is not opened. The books audit (`n26_audit_reconcile`) is the way to find those first.

So compare rating and credits pins before and after, not only the action and event counts. Running `n26_audit_reconcile` immediately before this is the cheapest way to know which gangs are already drifted.

## Test plan

- `n26/tests/sandbox/test_founding_action_backfill.py` — which gangs qualify (never had one, so a completed founding does not); one action and one `ACTION_OPENED` event per eligible gang; nobody named as the actor and the history line carrying no subject; the history sentence; a gang that already has one keeps it; a completed founding is not reopened; a gang that gains one between the check and the lock is counted rather than failed; archived gangs untouched; the outcome and both totals written onto the record; a rerun is a no-op; and a redelivered message (via the `task_queue` fixture in manual mode) opens nothing more.
- `n26/tests/test_maintenance_console.py` — the operation is registered, named and superuser-gated, its lock is not shared, the page counts without writing, the nothing-to-open state, applying records what it opened, the record page labels what was walked and what was opened, and a POST with nothing to open records no run.
- `pytest n26/tests/sandbox/test_founding_action_backfill.py n26/tests/test_maintenance_console.py -n 4` — **81 passed**. `pytest n26 -n 4` — **4,924 passed** (before the review fixes).
- Manually exercised end to end on the dev server: preview page, POST, the run's record, and the nothing-to-open state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh
