### PR TITLE
fix: draw the n26 Actions square for staff owners only, and keep the stash card's Trading Post line

### DIFF
--- a/n26/core/templates/cotton/n26/stash/index.html
+++ b/n26/core/templates/cotton/n26/stash/index.html
@@ -21,8 +21,11 @@ contents shifts every fighter after it around the grid.
     wealth strip above is where that number lives.
   empty — what to say when there is nothing.
   actions — links after the title in a middot run (e.g. Equip), not buttons.
+  notice — a strip above the contents, ruled off from them. For a standing
+    fact about buying rather than about what is stored, which a reader
+    wants before reading a list rather than after it.
 {% endcomment %}
-<c-vars :lines="None" :total="0" empty="" actions="" class="" />
+<c-vars :lines="None" :total="0" empty="" actions="" notice="" class="" />
 
 <c-ui.card padding="none" class="{{ class }}">
     <c-slot name="header">
@@ -40,6 +43,9 @@ contents shifts every fighter after it around the grid.
             <span class="shrink-0 text-sm tabular-nums text-muted">{{ total }}¢</span>
         </div>
     </c-slot>
+    {% if notice.strip %}
+        <div class="border-b border-box-border px-4 py-3">{{ notice }}</div>
+    {% endif %}
     {% if lines %}
         <dl class="flex flex-col gap-1 px-4 py-3">
             {% regroup lines|dictsort:"kind" by kind as kinds %}

--- a/n26/core/templates/cotton/n26/view/gang_sheet.html
+++ b/n26/core/templates/cotton/n26/view/gang_sheet.html
@@ -21,6 +21,7 @@ opens with the Actions square, then the stash, then `members`.
     see <c-n26.actions-square>. Only the owner gets one.
   stash_empty — what to say when the stash is empty.
   stash_actions — a middot link after the Stash title (e.g. Equip).
+  stash_notice — a strip above the stash's contents; see <c-n26.stash>.
 {% endcomment %}
 {# The slots are declared: an undeclared slot name is not empty when nobody #}
 {# fills it — it resolves to the caller's own variable of that name. #}
@@ -42,6 +43,7 @@ opens with the Actions square, then the stash, then `members`.
     members=""
     stash_empty=""
     stash_actions=""
+    stash_notice=""
     class=""
 />
 
@@ -140,6 +142,7 @@ opens with the Actions square, then the stash, then `members`.
         <c-n26.stash :lines="sheet.stash" :total="sheet.stash_rating">
             {% if stash_actions %}<c-slot name="actions">{{ stash_actions }}</c-slot>{% endif %}
             {% if stash_empty %}<c-slot name="empty">{{ stash_empty }}</c-slot>{% endif %}
+            {% if stash_notice %}<c-slot name="notice">{{ stash_notice }}</c-slot>{% endif %}
         </c-n26.stash>
         {{ members }}
     </div>

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -215,6 +215,9 @@ that said it twice would be spending the width the name needs.
             <c-slot name="stash_actions">
                 <c-n26.action-link href="{% url 'n26-equip-gang' gang.pk %}">Equip</c-n26.action-link>
             </c-slot>
+            <c-slot name="stash_notice">
+                {% include "n26/includes/stash_trading_post.html" %}
+            </c-slot>
         {% endif %}
         <c-slot name="stash_empty">
             Nothing in the stash yet.

--- a/n26/core/templates/n26/includes/stash_trading_post.html
+++ b/n26/core/templates/n26/includes/stash_trading_post.html
@@ -1,0 +1,33 @@
+{% comment %}
+The Visit Trading Post action, said in one line under the stash.
+
+Here because the stash is where a gang's buying is read from and where its
+Trading Post purchases land. Both states, since "an action is open with three
+left" and "there is no action" are equally worth knowing before buying
+anything.
+
+Wants `trade_points_href`, so it draws nothing for a reader who could not act
+on it anyway.
+
+Reads the sheet rather than the gang: what a visit has left is a ledger query,
+and the sheet has already asked.
+{% endcomment %}
+{% if trade_points_href %}
+    <div class="flex flex-wrap items-center justify-between gap-2">
+        {% if sheet.visiting_trading_post %}
+            <span class="text-xs text-muted">
+                Trading Post visit open —
+                <span class="font-medium text-ink-900 dark:text-ink-100">{{ sheet.trade_points_left }} TP</span>
+                left
+            </span>
+            <c-ui.button size="xs" variant="default" href="{{ trade_points_href }}">
+                Manage visit
+            </c-ui.button>
+        {% else %}
+            <span class="text-xs text-muted">Not tracking TP</span>
+            <c-ui.button size="xs" variant="primary" href="{{ trade_points_href }}">
+                Set up TP visit →
+            </c-ui.button>
+        {% endif %}
+    </div>
+{% endif %}

--- a/n26/core/test_views_founding_action.py
+++ b/n26/core/test_views_founding_action.py
@@ -25,7 +25,9 @@ FOUNDING = Action.Kind.FOUNDING
 @pytest.fixture
 def tester(db):
     """The signed-in person these tests look at the app as."""
-    return User.objects.create_user("player")
+    # Staff, because the square and its address are staff-only while the
+    # action is built out; the non-staff owner has tests of their own.
+    return User.objects.create_user("player", is_staff=True)
 
 
 @pytest.fixture
@@ -346,6 +348,21 @@ class TestTheSquareOnTheGangPage:
         assert "Complete action" not in body
         assert "No action is open." not in body
 
+    def test_an_owner_who_is_not_staff_gets_no_square_yet(self, client, gang):
+        """Staff-only while the action is built out: the owner reads the
+        gang page as it was before the square, and the open action stays
+        open behind it."""
+        plain = User.objects.create_user("plain-player")
+        gang.owner = plain
+        gang.save(update_fields=["owner"])
+        client.force_login(plain)
+        body = client.get(sheet(gang)).content.decode()
+        assert "Found and equip gang" not in body
+        assert "No action is open." not in body
+        assert 'value="start"' not in body
+        assert "Nothing in the stash" in body
+        assert gang.open_action(FOUNDING) is not None
+
     def test_the_square_costs_the_page_nothing_per_fighter(
         self, client, gang, tester, make_profile, make_statline
     ):
@@ -453,6 +470,14 @@ class TestTheActsBehindIt:
     def test_somebody_elses_gang_is_not_theirs_to_act_on(self, client, gang):
         client.force_login(User.objects.create_user("stranger"))
         assert client.post(act_page(gang), {"act": "finish"}).status_code == 404
+
+    def test_an_owner_who_is_not_staff_cannot_reach_the_address(self, client, gang):
+        plain = User.objects.create_user("plain-player")
+        gang.owner = plain
+        gang.save(update_fields=["owner"])
+        client.force_login(plain)
+        assert client.post(act_page(gang), {"act": "finish"}).status_code == 404
+        assert gang.open_action(FOUNDING) is not None
 
     def test_signing_in_is_required(self, client, gang):
         client.logout()

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -23,7 +23,15 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def tester(db):
-    return User.objects.create_user("player")
+    # Staff, because the Actions square is staff-only while the actions
+    # are built out. The Trade Points page itself is every owner's.
+    return User.objects.create_user("player", is_staff=True)
+
+
+@pytest.fixture
+def player(db):
+    """An owner who is not staff: sees the stash line, never the square."""
+    return User.objects.create_user("plain-player")
 
 
 @pytest.fixture
@@ -208,18 +216,32 @@ class TestTheActionsSquare:
         assert "Trading Post visit open" in body
         assert "Manage visit" in body
 
-    def test_the_stash_card_no_longer_carries_it(self, client, tester, roster, gang):
-        """The line moved out of the stash: what a gang has open is not a
-        fact about what it is storing."""
+    def test_the_stash_card_still_carries_it(self, client, tester, roster, gang):
+        """The stash card keeps its Trading Post line for every owner while
+        the square is staff-only; a staff owner reads it in both places."""
         client.force_login(tester)
         start(client, gang, roster["Vex"])
 
         body = self.sheet(client, gang)
-        # The stash card's own heading, not the wealth strip's figure of
-        # the same name, which sits further up the page.
+        # The square's line comes first, then the stash card's own.
         assert body.index("Trading Post visit open") < body.index(">Stash</span>")
-        # Moved, not copied: one line on the page, not one per card.
+        assert body.count("Trading Post visit open") == 2
+
+    def test_an_owner_who_is_not_staff_gets_the_stash_line_and_no_square(
+        self, client, player, roster, gang
+    ):
+        gang.owner = player
+        gang.save(update_fields=["owner"])
+        client.force_login(player)
+        start(client, gang, roster["Vex"])
+
+        body = self.sheet(client, gang)
         assert body.count("Trading Post visit open") == 1
+        assert body.index(">Stash</span>") < body.index("Trading Post visit open")
+        assert "No action is open." not in body
+        assert "Found and equip gang" not in body
+        # The Trade Points page itself stays theirs.
+        assert f'href="{page(gang)}"' in body
 
     def test_it_leads_the_grid_ahead_of_the_stash(self, client, tester, gang):
         client.force_login(tester)

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -5,6 +5,7 @@ import json
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
+from django.http import Http404
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -13,6 +14,7 @@ from n26.core.views.changelog import changelog_entries
 from n26.core.views.permissions import (
     _any_gang_or_404,
     _own_gang_or_404,
+    may_see_actions_square,
     trade_points_href,
 )
 
@@ -280,10 +282,11 @@ def gang_sheet(request, pk):
             "sheet": sheet,
             "yours": yours,
             "trade_points_href": trade_points_href(gang, request.user),
-            # The gang's own actions, which are the owner's to perform: a
-            # reader who does not own it gets no square at all. One query
-            # for the whole page — the open founding action — since what a
-            # visit has left is already on the sheet.
+            # The gang's own actions, which are the owner's to perform.
+            # Drawn for staff owners only while the actions are built out;
+            # every other reader gets no square. One query for the whole
+            # page — the open founding action — since what a visit has
+            # left is already on the sheet.
             "actions_square": (
                 actions_square(
                     gang,
@@ -291,7 +294,7 @@ def gang_sheet(request, pk):
                     founding_at=reverse("n26-gang-founding-action", args=[gang.pk]),
                     visit_at=reverse("n26-gang-trade-points", args=[gang.pk]),
                 )
-                if yours
+                if may_see_actions_square(gang, request.user)
                 else None
             ),
             # Printing follows reading rather than owning, so a reader
@@ -1037,6 +1040,10 @@ def gang_founding_action(request, pk):
     from n26.core.operations import Refusal, operation
 
     gang = _own_gang_or_404(request, pk)
+    # The square that posts here is drawn for staff owners only while the
+    # action is built out, so the address is theirs alone too.
+    if not may_see_actions_square(gang, request.user):
+        raise Http404
     at = reverse("n26-gang", args=[gang.pk])
     if request.method != "POST":
         return redirect(at)

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -43,6 +43,22 @@ def trade_points_href(gang, user):
     return reverse("n26-gang-trade-points", args=[gang.pk])
 
 
+def may_see_actions_square(gang, user):
+    """Whether the gang page draws its Actions square for this reader.
+
+    The square is shown to staff who own the gang while the actions it
+    holds are still being built out. Everyone else reads the gang page
+    as it was before the square existed: the Trading Post visit line
+    stays on the stash card for every owner.
+    """
+    return bool(
+        user is not None
+        and user.is_authenticated
+        and user.is_staff
+        and gang.owner_id == user.pk
+    )
+
+
 def _own_gang_or_404(request, pk):
     """The gang, if it is the viewer's to act on.
 


### PR DESCRIPTION
## Problem

PR #2423 put an Actions square on every owner's gang page and moved the Trading Post visit line out of the stash card into it. Nothing hangs off the founding action yet (purchases and personal TP budgets come in later slices), so players saw a square with a button that changes nothing they can feel, and the visit line moved for them at the same time.

## Change

- The Actions square is drawn for **staff owners only** while the actions are built out. Its POST address is staff-only too (404 otherwise).
- The Trading Post visit line returns to the **stash card for every owner**, as it was before #2423 (`stash_trading_post.html` and the stash `notice` slot restored). A staff owner reads it in both places for now.
- Nothing else changes: the Trade Points page, the wealth strip figure and the equip-page links stay as they were.

## How to try it

Dev server for this branch: `http://localhost:9093`. As a non-staff owner the gang page shows the stash card with its Trading Post line and no square. As a staff owner the square leads the grid and the stash line is still there.

## Test plan

- [x] `pytest -n 4` on `test_views_founding_action.py`, `test_views_trade_points.py`, `test_views_equip.py`, `test_views_gang_equip.py`, `n26/designsystem`: 326 passed
- [x] New tests: non-staff owner gets no square and a 404 on the action address; non-staff owner sees the stash line once and no square; staff owner sees the line in both places

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh