### PR TITLE
docs: plain-English pass over the n26 library docs (recipes, concepts, CLAUDE.md)

### DIFF
--- a/n26/library/CLAUDE.md
+++ b/n26/library/CLAUDE.md
@@ -5,7 +5,7 @@ in the library flows through one chain, and nothing skips a layer:
 
 ```
 models/          the content rows (Weapon, Skill, Profile, Collection, …)
-authoring.py     the verbs: the one API that writes content
+authoring.py     the verbs — the one API that writes content
 specs.py         each verb described as data (its fields, their types)
 forms.py         Django forms generated from the specs
 views.py         the staff authoring pages, driven by small registries
@@ -16,7 +16,7 @@ offers.py        what a kind declares about itself; forms derive the rest
 artwork.py       uploaded drawings: binds this edition's folder onto gyrinx.artwork
 ```
 
-Read `models/base.py` (107 lines) first. It states the app's governing
+Read `models/base.py` (107 lines) first — it states the app's governing
 philosophy. Then read `models/assignable.py` and `authoring.py`.
 
 ## The model rules
@@ -30,23 +30,23 @@ philosophy. Then read `models/assignable.py` and `authoring.py`.
   A new kind is: `class X(Content, Assignable[, UsableBy][, Optioned])`,
   a class-level `family = Family.…`, a `Meta` with verbose names and
   ordering, the standard constraints (unique per pack on lowercased
-  name + qualifier; exclusive items carry no trade-point price), and a
+  name + qualifier; exclusive items carry no trade-point price) — and a
   column on `n26.core`'s `Assignment` plus an entry in
   `ASSIGNABLE_FIELDS`. Without all of these the app fails at startup.
 - **Help text lives on the model field, nowhere else.** Specs reference
   it (`source=(Model, "field")`); forms read it through the spec. Model
-  docstrings are shown to authors on the authoring pages, so write them
+  docstrings are shown to authors on the authoring pages — write them
   as product copy: a plain definition first, detail after.
 - **No rules text, ever.** Names, annotations, and numbers only; the
   book's wording is copyrighted.
-- A `qualifier` is author-facing only. It tells two same-named things
+- A `qualifier` is author-facing only — it tells two same-named things
   apart in authoring screens and must never reach a player. A test
   enforces this.
 - Validation is layered on purpose: database constraints for
   exactly-one invariants; `clean()` for cross-row sense checks; form
   errors in words for anything an author can trip. `save()` is for
   canonicalising values only (it runs for importers too, which never
-  call `full_clean`), never for validation.
+  call `full_clean`) — never for validation.
 - Migrations are hand-edited and descriptively named. Prefer renames
   over drop-and-add so authored data survives. `default_pack_id` is
   referenced by name in migrations and must stay importable from
@@ -76,7 +76,7 @@ Adding a verb means touching, in order:
 1. The verb in `authoring.py` (naming: `create_*` for new things,
    `add_*` for parts of a thing, `ef_*`/`op_*` for effects,
    `targets_*` for scopes, predicates read as predicates).
-2. A `Spec` in `specs.py`. Discovering tests fail on a scope, effect,
+2. A `Spec` in `specs.py` — discovering tests fail on a scope, effect,
    or condition verb (`targets_*`, `ef_*`, `op_*`) without one. Give
    `create_*` and `add_*` verbs one too, even though no guard forces it.
 3. The registries in `views.py`: `LEAF_KINDS` if it gets a page (and
@@ -87,20 +87,19 @@ Adding a verb means touching, in order:
    to the rows belonging to one carrier, and it can only do so where the
    carrier is handed to the form. The detail view does that for its part
    forms. A spec reused anywhere else gets a picker over the whole table
-   and rejects the stray row only afterwards. Nothing catches this: the
+   and rejects the stray row only afterwards. Nothing catches this — the
    picker looks wired and is simply wide.
 
 Several parallel lists are deliberate extension points, each guarded by
 a check or a generated constraint (`ASSIGNABLE_FIELDS`, `SCOPE_FIELDS`,
 `EFFECT_FIELDS`, `OFFERABLE_KINDS`, `GRANTABLE_FIELDS`, …). Widening one
-is one line plus a migration plus deliberate thought. Never do it
-quietly.
+is one line plus a migration plus deliberate thought — never quietly.
 
 Kinds declare, forms derive: `ATTACHMENT_ASKS` and
 `SUGGESTED_BUILT_INS` sit on the model class and `offers.py` computes
-what a form shows. No form hardcodes a kind there (the inline-create
+what a form shows — no form hardcodes a kind there (the inline-create
 shortcut for rules and subtypes in `forms.py` is the one deliberate
-exception). Note: `ATTACHMENT_ASKS` replaces rather than merges, so a
+exception). Note: `ATTACHMENT_ASKS` replaces rather than merges — a
 kind that declares its own must restate the inherited asks it still
 wants. `takes_built_ins` is the third of these declarations: a kind that
 only ever arrives by being *chosen* sets it False, its pages offer no
@@ -113,18 +112,18 @@ built-ins attachment, and `add_built_in` rejects one.
 for building whole rulebook setups (a corrupted gang, a hired mercenary
 crew) out of the library's pieces.
 
-**When a rulebook setup's authoring flow is settled, whether designed
-here, agreed with the maintainer, or proven in a sandbox test, write the
+**When a rulebook setup's authoring flow is settled — designed here,
+agreed with the maintainer, or proven in a sandbox test — write the
 steps into that file.** The rules for what goes in it:
 
 - Author-facing language only: the things to create and how to join
-  them. No technical internals, no code, no model or field names. The
+  them. No technical internals, no code, no model or field names — the
   words are the authoring pages' own (slot type, pickable, collection,
   modifier, *gives*, *offers a choice*).
 - Clear and simple. Match the register of the modifier option cards in
-  `specs.py`: short, concrete, one game example beats a paragraph.
+  `specs.py` — short, concrete, one game example beats a paragraph.
 - A step that is not yet possible says so, in one sentence.
-- The maintainer reviews and edits this file directly. Keep it prose
+- The maintainer reviews and edits this file directly — keep it prose
   they would happily rewrite, never generated output.
 
 ## Core Concepts — what each kind is
@@ -133,7 +132,7 @@ steps into that file.** The rules for what goes in it:
 section, rendered staff-only at `/n26/authoring/docs/concepts/`; both
 pages are listed at `/n26/authoring/docs/`. It holds **fact-based specs
 of the kinds**: a short summary, the fields a kind has of its own, and
-its behaviour: how far it reaches and how it comes to be there.
+its behaviour — how far it reaches and how it comes to be there.
 
 It is maintained exactly as the cookbook is. The maintainer reviews and
 edits it directly, so keep it prose they would happily rewrite. Say what
@@ -145,19 +144,19 @@ a field or a behaviour, write that in.
 Three stages: read (CSV → dicts), plan (→ an `IngestPlan` of frozen
 rows plus problems; reads the database, never writes), perform (executes
 exactly the plan, through the authoring verbs, in one transaction).
-**The preview is the contract**: what `plan.preview()` shows is what
+**The preview is the contract** — what `plan.preview()` shows is what
 `perform()` does, changes included. Standing rules: resolve, never
 create, across sheets; built-ins are free; a missing seed row is a loud
 error, never quietly re-created.
 
-An upload is **held** between the stages: an `UploadedSheet` row per
+An upload is **held** between the stages — an `UploadedSheet` row per
 sheet per author, with the bytes in the site's storage. A file input
 cannot be filled back in by the server, so holding the file is what lets
 a preview be read, reloaded, and then imported without choosing the file
 again. The three acts are three pages, each named in the address:
 `/authoring/ingest/` shows what is held, `…/ingest/sheet/<sheet>/`
 takes one file, `…/ingest/preview/` plans and imports. **The plan is
-never held.** It is made again on the visit that shows it and again on
+never held** — it is made again on the visit that shows it and again on
 the post that imports it, because the contract is about the library as
 it stands, and an import redirects back to a fresh reading rather than
 rendering its own result.
@@ -172,13 +171,13 @@ is silent.
 A new planned kind means four tables. `perform()` rejects a plan
 naming a kind missing from any of them rather than skipping it:
 
-- `PERFORM_ORDER`: where it falls in dependency order.
-- `SHEET_FIELDS`: what these sheets claim to know about it, split into
+- `PERFORM_ORDER` — where it falls in dependency order.
+- `SHEET_FIELDS` — what these sheets claim to know about it, split into
   identity / updatable / ignored. The partition must cover every field
   the planner puts in `fields`; a test proves it. A kind with nothing
   updatable states the reason in `NEVER_UPDATED`.
-- `CREATORS`: how it is made, or a reason in `NEVER_CREATED`.
-- `UPDATERS`: how it is changed, for any kind with updatable fields.
+- `CREATORS` — how it is made, or a reason in `NEVER_CREATED`.
+- `UPDATERS` — how it is changed, for any kind with updatable fields.
 
 Each set has its own rule for a member the sheet no longer names, and
 the deciding question is whether the set is somewhere hand-authored
@@ -186,13 +185,13 @@ content lives: traits, a list's lines and a fighter's skill grid are
 replaced; built-in kit and restrictions are only added to, with a note
 saying what was kept. The one exception inside a built-ins set is the
 fighter's equipment list, which is access rather than kit and comes one
-at a time: naming a list replaces whichever the set held
+at a time — naming a list replaces whichever the set held
 (`REPLACED_BUILT_INS`). A blank cell still replaces nothing.
 
 ## Comments
 
 A comment states a constraint, an invariant, or a consequence the code
-cannot show, briefly and in plain words. It must make sense to a reader
+cannot show — briefly, in plain words. It must make sense to a reader
 who has never seen any earlier version of this code: no people, no
 tickets or PRs, no "graduated from", no "used to be", no "for now".
 Longer reasoning belongs in the module docstring or a `n26/design/`

--- a/n26/library/CLAUDE.md
+++ b/n26/library/CLAUDE.md
@@ -5,7 +5,7 @@ in the library flows through one chain, and nothing skips a layer:
 
 ```
 models/          the content rows (Weapon, Skill, Profile, Collection, …)
-authoring.py     the verbs — the one API that writes content
+authoring.py     the verbs: the one API that writes content
 specs.py         each verb described as data (its fields, their types)
 forms.py         Django forms generated from the specs
 views.py         the staff authoring pages, driven by small registries
@@ -16,8 +16,8 @@ offers.py        what a kind declares about itself; forms derive the rest
 artwork.py       uploaded drawings: binds this edition's folder onto gyrinx.artwork
 ```
 
-Read `models/base.py` (107 lines) first — it states the app's governing
-philosophy. Then `models/assignable.py` and `authoring.py`.
+Read `models/base.py` (107 lines) first. It states the app's governing
+philosophy. Then read `models/assignable.py` and `authoring.py`.
 
 ## The model rules
 
@@ -30,41 +30,41 @@ philosophy. Then `models/assignable.py` and `authoring.py`.
   A new kind is: `class X(Content, Assignable[, UsableBy][, Optioned])`,
   a class-level `family = Family.…`, a `Meta` with verbose names and
   ordering, the standard constraints (unique per pack on lowercased
-  name + qualifier; exclusive items carry no trade-point price) — and a
+  name + qualifier; exclusive items carry no trade-point price), and a
   column on `n26.core`'s `Assignment` plus an entry in
-  `ASSIGNABLE_FIELDS`, or the app fails at startup.
+  `ASSIGNABLE_FIELDS`. Without all of these the app fails at startup.
 - **Help text lives on the model field, nowhere else.** Specs reference
   it (`source=(Model, "field")`); forms read it through the spec. Model
-  docstrings are shown to authors on the authoring pages — write them as
-  product copy: a plain definition first, detail after.
+  docstrings are shown to authors on the authoring pages, so write them
+  as product copy: a plain definition first, detail after.
 - **No rules text, ever.** Names, annotations, and numbers only; the
   book's wording is copyrighted.
-- A `qualifier` is author-facing only — it tells two same-named things
+- A `qualifier` is author-facing only. It tells two same-named things
   apart in authoring screens and must never reach a player. A test
   enforces this.
 - Validation is layered on purpose: database constraints for
   exactly-one invariants; `clean()` for cross-row sense checks; form
   errors in words for anything an author can trip. `save()` is for
   canonicalising values only (it runs for importers too, which never
-  call `full_clean`) — never for validation.
+  call `full_clean`), never for validation.
 - Migrations are hand-edited and descriptively named. Prefer renames
   over drop-and-add so authored data survives. `default_pack_id` is
   referenced by name in migrations and must stay importable from
-  `models/pack.py`; the app label is pinned to `library` — don't touch
+  `models/pack.py`. The app label is pinned to `library`. Do not change
   either.
 
 ## Modifiers
 
 A modifier is one **scope** (who it reaches) plus one **effect** (what it
 does), each a small typed row with an exactly-one constraint. Narrowing
-lives in **condition rows** hung off the scope. The grammar:
+lives in **condition rows** attached to the scope. The grammar:
 
 - Scopes compile to the shared selector algebra in `n26.core.select`
   via `as_selector()`.
 - Effects split by when they happen: computed at read time (`ef_*`
   verbs: adds, removes, changes a stat, offers a choice, places a
-  category) versus written at purchase time (`op_*` verbs, e.g. adds a
-  model).
+  category) versus written at purchase time (`op_*` verbs, for example
+  adds a model).
 - A new condition model must be named in its scope's `CONDITIONS`
   tuple, or its rows are stored but never read (a startup check
   catches this).
@@ -76,9 +76,9 @@ Adding a verb means touching, in order:
 1. The verb in `authoring.py` (naming: `create_*` for new things,
    `add_*` for parts of a thing, `ef_*`/`op_*` for effects,
    `targets_*` for scopes, predicates read as predicates).
-2. A `Spec` in `specs.py` — discovering tests refuse a scope, effect,
-   or condition verb (`targets_*`, `ef_*`, `op_*`) without one; give
-   `create_*` and `add_*` verbs one too even though no guard forces it.
+2. A `Spec` in `specs.py`. Discovering tests fail on a scope, effect,
+   or condition verb (`targets_*`, `ef_*`, `op_*`) without one. Give
+   `create_*` and `add_*` verbs one too, even though no guard forces it.
 3. The registries in `views.py`: `LEAF_KINDS` if it gets a page (and
    `LEAF_DESCRIBE` for the page's blurb); `DETAIL_KINDS` if the thing
    has parts added to it over time; `DETAIL_VIEWS` for a bespoke detail
@@ -86,53 +86,54 @@ Adding a verb means touching, in order:
 4. **The flow, if the spec uses `within=`.** That kind narrows a picker
    to the rows belonging to one carrier, and it can only do so where the
    carrier is handed to the form. The detail view does that for its part
-   forms; a spec reused anywhere else gets a picker over the whole table
-   and refuses the stray only afterwards. Nothing catches this — the
+   forms. A spec reused anywhere else gets a picker over the whole table
+   and rejects the stray row only afterwards. Nothing catches this: the
    picker looks wired and is simply wide.
 
 Several parallel lists are deliberate extension points, each guarded by
 a check or a generated constraint (`ASSIGNABLE_FIELDS`, `SCOPE_FIELDS`,
 `EFFECT_FIELDS`, `OFFERABLE_KINDS`, `GRANTABLE_FIELDS`, …). Widening one
-is one line plus a migration plus deliberate thought — never quietly.
+is one line plus a migration plus deliberate thought. Never do it
+quietly.
 
 Kinds declare, forms derive: `ATTACHMENT_ASKS` and
 `SUGGESTED_BUILT_INS` sit on the model class and `offers.py` computes
-what a form shows — no form hardcodes a kind there (the inline-create
+what a form shows. No form hardcodes a kind there (the inline-create
 shortcut for rules and subtypes in `forms.py` is the one deliberate
-exception). Note: `ATTACHMENT_ASKS` replaces rather than merges — a
+exception). Note: `ATTACHMENT_ASKS` replaces rather than merges, so a
 kind that declares its own must restate the inherited asks it still
 wants. `takes_built_ins` is the third of these declarations: a kind that
-only ever arrives by being *chosen* says False, its pages offer no
-built-ins attachment, and `add_built_in` refuses one.
+only ever arrives by being *chosen* sets it False, its pages offer no
+built-ins attachment, and `add_built_in` rejects one.
 
 ## Recipes — the living cookbook
 
 `recipes.md` (beside this file) is rendered, staff-only, at
-`/n26/authoring/recipes/`. It holds **author-facing walkthroughs** for
-building whole rulebook setups (a corrupted gang, a hired mercenary
+`/n26/authoring/docs/recipes/`. It holds **author-facing walkthroughs**
+for building whole rulebook setups (a corrupted gang, a hired mercenary
 crew) out of the library's pieces.
 
-**When a rulebook setup's authoring flow gets settled — designed here,
-argued out with the maintainer, or proven in a sandbox test — write the
+**When a rulebook setup's authoring flow is settled, whether designed
+here, agreed with the maintainer, or proven in a sandbox test, write the
 steps into that file.** The rules for what goes in it:
 
 - Author-facing language only: the things to create and how to join
-  them. No technical internals, no code, no model or field names —
-  the words are the authoring pages' own (slot type, pickable,
-  collection, modifier, *gives*, *offers a choice*).
+  them. No technical internals, no code, no model or field names. The
+  words are the authoring pages' own (slot type, pickable, collection,
+  modifier, *gives*, *offers a choice*).
 - Clear and simple. Match the register of the modifier option cards in
-  `specs.py` — short, concrete, one game example beats a paragraph.
-- A step that is not yet possible says so plainly, in one sentence.
-- The maintainer reviews and edits this file directly — keep it prose
+  `specs.py`: short, concrete, one game example beats a paragraph.
+- A step that is not yet possible says so, in one sentence.
+- The maintainer reviews and edits this file directly. Keep it prose
   they would happily rewrite, never generated output.
 
 ## Core Concepts — what each kind is
 
 `concepts.md` (beside this file) is the second page of the documentation
 section, rendered staff-only at `/n26/authoring/docs/concepts/`; both
-are listed at `/n26/authoring/docs/`. It holds **fact-based specs of the
-kinds**: a short summary, the fields a kind has of its own, and its
-behaviour — how far it reaches and how it comes to be there.
+pages are listed at `/n26/authoring/docs/`. It holds **fact-based specs
+of the kinds**: a short summary, the fields a kind has of its own, and
+its behaviour: how far it reaches and how it comes to be there.
 
 It is maintained exactly as the cookbook is. The maintainer reviews and
 edits it directly, so keep it prose they would happily rewrite. Say what
@@ -144,58 +145,58 @@ a field or a behaviour, write that in.
 Three stages: read (CSV → dicts), plan (→ an `IngestPlan` of frozen
 rows plus problems; reads the database, never writes), perform (executes
 exactly the plan, through the authoring verbs, in one transaction).
-**The preview is the contract** — what `plan.preview()` shows is what
+**The preview is the contract**: what `plan.preview()` shows is what
 `perform()` does, changes included. Standing rules: resolve, never
 create, across sheets; built-ins are free; a missing seed row is a loud
 error, never quietly re-created.
 
-An upload is **held** between the stages — an `UploadedSheet` row per
-sheet per author, the bytes in the site's storage. A file input cannot
-be filled back in by the server, so holding the file is what lets a
-preview be read, reloaded, and then imported without choosing the file
+An upload is **held** between the stages: an `UploadedSheet` row per
+sheet per author, with the bytes in the site's storage. A file input
+cannot be filled back in by the server, so holding the file is what lets
+a preview be read, reloaded, and then imported without choosing the file
 again. The three acts are three pages, each named in the address:
-`/authoring/ingest/` says what is held, `…/ingest/sheet/<sheet>/`
+`/authoring/ingest/` shows what is held, `…/ingest/sheet/<sheet>/`
 takes one file, `…/ingest/preview/` plans and imports. **The plan is
-never held** — it is made again on the visit that shows it and again on
+never held.** It is made again on the visit that shows it and again on
 the post that imports it, because the contract is about the library as
 it stands, and an import redirects back to a fresh reading rather than
 rendering its own result.
 
-Planning ends in one settling pass that decides every row's action —
-`create`, `update`, `unchanged`, or `resolved` for a row that is only a
-lookup — and, for an update, names each field that differs. Planning
-and performing ask one function what counts as the same row
-(`find_existing`), because two statements of that drift and the drift
+Planning ends in one settling pass that decides every row's action
+(`create`, `update`, `unchanged`, or `resolved` for a row that is only a
+lookup) and, for an update, names each field that differs. Planning
+and performing use one function to decide what counts as the same row
+(`find_existing`), because two statements of that drift, and the drift
 is silent.
 
-A new planned kind means four tables, and `perform()` refuses a plan
+A new planned kind means four tables. `perform()` rejects a plan
 naming a kind missing from any of them rather than skipping it:
 
-- `PERFORM_ORDER` — where it falls in dependency order.
-- `SHEET_FIELDS` — what these sheets claim to know about it, split into
+- `PERFORM_ORDER`: where it falls in dependency order.
+- `SHEET_FIELDS`: what these sheets claim to know about it, split into
   identity / updatable / ignored. The partition must cover every field
   the planner puts in `fields`; a test proves it. A kind with nothing
   updatable states the reason in `NEVER_UPDATED`.
-- `CREATORS` — how it is made, or a reason in `NEVER_CREATED`.
-- `UPDATERS` — how it is changed, for any kind with updatable fields.
+- `CREATORS`: how it is made, or a reason in `NEVER_CREATED`.
+- `UPDATERS`: how it is changed, for any kind with updatable fields.
 
-Sets each decide for themselves what happens to a member the sheet no
-longer names, and the deciding question is whether the set is somewhere
-hand-authored content lives: traits, a list's lines and a fighter's
-skill grid are replaced; built-in kit and restrictions are only added
-to, with a note saying what was kept. The one exception inside a
-built-ins set is the fighter's equipment list, which is access rather
-than kit and comes one at a time — naming a list replaces whichever the
-set held (`REPLACED_BUILT_INS`). A blank cell still replaces nothing.
+Each set has its own rule for a member the sheet no longer names, and
+the deciding question is whether the set is somewhere hand-authored
+content lives: traits, a list's lines and a fighter's skill grid are
+replaced; built-in kit and restrictions are only added to, with a note
+saying what was kept. The one exception inside a built-ins set is the
+fighter's equipment list, which is access rather than kit and comes one
+at a time: naming a list replaces whichever the set held
+(`REPLACED_BUILT_INS`). A blank cell still replaces nothing.
 
 ## Comments
 
 A comment states a constraint, an invariant, or a consequence the code
-cannot show — briefly, in plain words. It must make sense to a reader
+cannot show, briefly and in plain words. It must make sense to a reader
 who has never seen any earlier version of this code: no people, no
 tickets or PRs, no "graduated from", no "used to be", no "for now".
 Longer reasoning belongs in the module docstring or a `n26/design/`
-doc, cited by filename — and never cite a design doc's section numbers
-in user-visible messages. The examples to imitate:
+doc, cited by filename. Never cite a design doc's section numbers in
+user-visible messages. The examples to imitate:
 `models/statline.py` (why canonicalising happens in `save`),
 `models/pack.py` (why a function must stay importable).

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -1,73 +1,73 @@
 # N26 Core Types
 
-This should give you a solid grounding in how Gyrinx N26 fits together.
+How the parts of Gyrinx N26 fit together.
 
-If you take nothing else away:
+The four things to remember:
 
-1. **To control who gets a thing, control where it lands — do not look for a per-type switch.** Want it gang-wide? Build it into the gang type, or have a slot whose pick is assigned to the gang. Want it on one model? Build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on a pickable or a rule — reach is entirely a consequence of the **host**, so you aim content by choosing its arrival route.
+1. **To control who gets a thing, control where it lands. There is no per-type switch.** For something gang-wide, build it into the gang type, or use a slot whose pick is assigned to the gang. For something on one model, build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on a pickable or a rule. Reach follows entirely from the **host**, so you aim content by choosing how it arrives.
 
-2. **Behaviour comes from modifiers attached to carriers — and modifiers are shared, so edit with care.** A rule or a pickable starts as a name; its attached modifiers define its behaviour (scope + effect, conditions ANDed). Two practical consequences: attach a modifier to the content it should affect; and before editing an existing modifier, check its carriers, because the change applies everywhere it is attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once and removal will not reverse them.
+2. **Behaviour comes from modifiers attached to carriers, and modifiers are shared, so edit with care.** A rule or a pickable starts as a name. Its attached modifiers define its behaviour (scope plus effect, with conditions ANDed). Two practical consequences: attach a modifier to the content it should affect; and before editing an existing modifier, check its carriers, because the change applies everywhere it is attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once, and removing the carrier does not reverse them.
 
-3. **Being in a collection and being offered from a section of it are two separate authoring acts.** Entries and sweeps decide **membership** of the collection; **placement** decides whether a particular category appears. If you narrow a choice "from section: Primary" and the skill's category hasn't been placed into Primary for that fighter, it will not be offered — it's sitting in "Other". So a working "choose a Primary skill" needs both halves authored: the content in the collection, and a placement putting its category in that section for the right models.
+3. **Being in a collection and being offered from a section of it are two separate authoring acts.** Entries and selectors decide **membership** of the collection. **Placement** decides whether a particular category appears in a section. If you narrow a choice to "from section: Primary" and the skill's category has not been placed into Primary for that fighter, it is not offered: it is in "Other". So a working "choose a Primary skill" needs both halves authored: the content in the collection, and a placement putting its category in that section for the right models.
 
-4. **Use qualifiers and help text**. Assignables come with a qualifier is that is internal, for telling twins apart and disambiguation, and library text shows up next to objects in most places. Use it to make things clearer.
+4. **Use qualifiers and help text.** Every assignable has a qualifier, which is internal and tells two same-named things apart. Library help text is shown next to objects in most places. Use both to make things clearer.
 
 ## Assignment
 
-**An assignment has three components**: *what* is held (an **assignable** — a weapon, a skill, a pickable…), *who it is assigned to* (the **host**), and the source of the assignment (its **cause**). Removing the cause also removes the assignment. Every item on a card, from a hired fighter's profile to a granted rule, is an assignment.
+**An assignment has three components**: *what* is held (an **assignable**: a weapon, a skill, a pickable, and so on), *who it is assigned to* (the **host**), and the source of the assignment (its **cause**). Removing the cause also removes the assignment. Every item on a card, from a hired fighter's profile to a granted rule, is an assignment.
 
-An **assignable** is typically very simple: a piece of data that, once assigned, can carry modifiers. Sometimes they have extra configuration. Rules, skills and pickables are all assignables.
+An **assignable** is usually very simple: a piece of data that, once assigned, can carry modifiers. Some have extra configuration. Rules, skills and pickables are all assignables.
 
-The **host** is the specific object the assignment sits on: a model, the gang, a parent item (a scope fitted to a gun), or the stash *only*. Host decides *reach*: an assignment hosted on a model is that model's; an assignment hosted on the gang is **broadcast** to every member's card.
+The **host** is the specific object the assignment sits on: a model, the gang, a parent item (a scope fitted to a gun), or the stash. The host decides *reach*: an assignment hosted on a model is that model's; an assignment hosted on the gang is **broadcast** to every member's card.
 
-The **cause** is then the action that brought a particular assignment into existence, answering "why is this here?" Cause powers one important behaviour: **removal cascades down the cause chain**. Remove an assignment and everything caused by it (and caused by *those*, recursively) goes too. It's also where provenance comes from — the card can say "came with X" because the assignment knows its cause.
+The **cause** is the action that created a particular assignment. It answers "why is this here?" Cause drives one important behaviour: **removal cascades down the cause chain**. Remove an assignment and everything caused by it (and caused by *those*, recursively) is removed too. It is also where provenance comes from: the card can show "came with X" because the assignment records its cause.
 
-A **modifier** is attached to a specific instance of an assignable (e.g. the Aranthian pickable) which we call the **carrier**, asserting who it reaches (**scope**), and what it does (**effect**). Conditions limit the scope — AND-ed across conditions, any-of within a single condition — to allowlist modifier effects only in certain contexts.
+A **modifier** is attached to a specific assignable (for example the Aranthian pickable), which we call the **carrier**. It states who it reaches (**scope**) and what it does (**effect**). Conditions limit the scope. They are ANDed across conditions and any-of within a single condition, so an effect applies only in certain contexts.
 
-Modifiers are shared by design: they can attach on any number of specific assignables ("carriers"), and editing the modifier changes it everywhere it is carried.
+Modifiers are shared by design: one modifier can be attached to any number of carriers, and editing the modifier changes it everywhere it is carried.
 
 Effects are split by when they happen:
 
-- **computed** ones (gives, takes away, changes a stat, adds to a counter, offers a choice, places a category, draws the pick, notes a limit) are re-derived on every read and vanish with their carrier
-- **written** ones (brings a model, moves a counter) run once at arrival and are never undone by removal.
+- **computed** ones (gives, takes away, changes a stat, adds to a counter, offers a choice, places a category, draws the pick, notes a limit) are worked out again on every read and disappear with their carrier
+- **written** ones (brings a model, moves a counter) run once at arrival and are not undone by removal.
 
-We use **carrier** as a library-side word for one specific piece of *content*, typically because they "carry" a modifier. A power maul carries its "+1 Strength" modifier; the Clan House pickable carries a grant of the house slot. Carrier is about authoring — edit the carrier's modifier and it changes everywhere that carrier appears.
+We use **carrier** as a library-side word for one specific piece of *content*, because it "carries" a modifier. A power maul carries its "+1 Strength" modifier; the Clan House pickable carries a grant of the house slot. Carrier is an authoring word: edit the carrier's modifier and it changes everywhere that carrier appears.
 
-**Bearer** is used to describe the thing being affected by a modifier. The maul's modifier says "+1 Strength *to its bearer*" — whoever holds a *specific* maul, no name attached.
+**Bearer** is the thing a modifier affects. The maul's modifier reads "+1 Strength *to its bearer*": whoever holds a *specific* maul, with no name attached.
 
-So: you buy a power maul for Vex. The purchase writes one assignment — **assignable**: the maul, **host**: Vex, **cause**: the purchase. The maul's assignment points at its underlying **assignable**, which is a **carrier** of a **modifier** which now applies to its **bearer** — Vex. When the maul **assignment** is reassigned, the same assignment gets a new host and the modifier follows the maul, not Vex.
+So: you buy a power maul for Vex. The purchase writes one assignment. **Assignable**: the maul. **Host**: Vex. **Cause**: the purchase. The maul's assignment points at its underlying **assignable**, which is a **carrier** of a **modifier**, which now applies to its **bearer**, Vex. When the maul **assignment** is reassigned, the same assignment gets a new host, and the modifier follows the maul, not Vex.
 
-Often the host and the bearer coincide. But when the Outcast Leader answers the gang's Gang Legacy slot, the pickable they choose is assigned *to the gang*. When the gang is the host, every model sees it (and becomes the bearer), even though the Leader was the one asked:
+Often the host and the bearer are the same. But when the Outcast Leader settles the gang's Gang Legacy slot, the pickable they choose is assigned *to the gang*. When the gang is the host, every model sees it (and becomes the bearer), even though the Leader was the one who chose:
 
 1. The Leader's Profile (assignable) carries a modifier adding the Gang Legacy slot, which lands on the gang
-2. Choice made → one assignment row: assignable = the pickable, host = the gang, cause = the Leader
-3. Gang-hosted ⇒ broadcast to every model (but hidden, just used to apply modifiers)
-4. On each model, the pickable is the carrier of its modifiers, and they resolve against it as the bearer
+2. The choice is made. One assignment is written: assignable = the pickable, host = the gang, cause = the Leader
+3. Gang-hosted, so broadcast to every model (but hidden, used only to apply modifiers)
+4. On each model, the pickable is the carrier of its modifiers, and they resolve against that model as the bearer
 
 ## Hiring
 
 Hiring is a gang-hosted assignment which points at a specific profile, and which
-materialises its built-ins onto the new model ("miniature" below, internal terminology):
+materialises its built-ins onto the new model ("miniature" below is internal terminology):
 
-What the hire operation actually does, in order:
+What the hire operation does, in order:
 
 1. Writes a membership assignment: an assignment pointing at a profile, hosted on the gang, with the credits-paid information on it
 2. Creates the Miniature, pointing back at that assignment. The model shown in the gang is this pairing: a membership assignment plus a name.
-3. Sets "miniature root" on the membership assignment, pointing at the miniature. The assignment is hosted on the gang — the fighter is assigned to the gang — but the profile on the assignment sets their base rating.
-4. Materialises the built-ins: the stub gun and the house list become free assignments, hosted directly on Vex (not the gang!), caused by the membership. Delete Vex and the subtree cascade takes his kit with him.
+3. Sets "miniature root" on the membership assignment, pointing at the miniature. The assignment is hosted on the gang (the fighter is assigned to the gang), and the profile on the assignment sets their base rating.
+4. Materialises the built-ins: the stub gun and the house list become free assignments, hosted directly on Vex (not the gang), caused by the membership. Delete Vex and the cascade removes his kit with him.
 
 > Note from Tom: I'm not convinced that steps 1-3 above are the simplest way we could do this, but it is how it works now.
 
-So the relationships after one hire, spelled out:
+The relationships after one hire, spelled out:
 
 - `membership.gang = gang` ("host")
 - `membership.miniature_root = mini` ("whose membership is this?")
 - `mini.membership = membership` (the model)
 - `profile_role.role = primary`
 - equipment assignments: `miniature = mini` (host), `caused_by = membership` (lifecycle), `reason = default`, `paid = 0`
-- a ledger entry sits on the membership too, carrying the original price (or an override) to provide rating contribution
+- a ledger entry sits on the membership too, carrying the original price (or an override), which provides the rating contribution
 
-> Note: much of the code and docs call an assignment a "row" which is very confusing and should not be copied. If referring to an assignment, say assignment.
+> Note: much of the code and docs call an assignment a "row", which is confusing and should not be copied. If referring to an assignment, say assignment.
 
 ---
 
@@ -75,21 +75,21 @@ So the relationships after one hire, spelled out:
 
 ### A gang-level choice (slot type)
 
-*Who the gang sides with, which god it follows, or which corruption it has — chosen once, as a pick.*
+*Who the gang sides with, which god it follows, or which corruption it has: chosen once, as a pick.*
 
-Do not author a new kind for this. Create a **slot type** (Affiliation, Chaos God, Variant, or a new name), its **pickables**, a **picklist**, and a **slot** assigned to the gang. Grant that slot from a hidden built into the gang type, or from the gang type itself. Attach ordinary modifiers to each pickable to define its effects. For example, a pickable can open equipment lists to some ranks or grant another slot while the pick remains assigned.
+Do not author a new kind for this. Create a **slot type** (Affiliation, Chaos God, Variant, or a new name), its **pickables**, a **picklist**, and a **slot** assigned to the gang. Grant that slot from a hidden built into the gang type, or from the gang type itself. Attach ordinary modifiers to each pickable to define its effects. For example, a pickable can open equipment lists to some ranks, or grant another slot while the pick remains assigned.
 
-The slot type's name is the word the card and the history use. The slot's label is the question on one card. See **Slot type** below.
+The slot type's name is the word the card and the history use. The slot's label is the wording of the choice on one card. See **Slot type** below.
 
 ### Rule (special rule)
 
 *A named special rule on a card; its text stays in the book.*
 
-Fields of its own: none — but its annotation is part of its identity: a rule in variants share one printed name. We store the name, never the wording (copyright). A rule that also *does* something the app can work out carries ordinary modifiers.
+Fields of its own: none. Its annotation is part of its identity, so variants of a rule share one printed name. We store the name, never the wording (copyright). A rule that also *does* something the app can work out carries ordinary modifiers.
 
-Normally it arrives built into something (a profile's kit, a gang type) or given by a modifier. Reach: built into a profile, it hits the model's card; when given to the gang, every member's card. The card prints rules apart from skills, under their own heading.
+Normally it arrives built into something (a profile's kit, a gang type) or given by a modifier. Reach: built into a profile, it reaches the model's card; given to the gang, every member's card. The card prints rules apart from skills, under their own heading.
 
-Author note: we actually, mostly, don't want broadcast for gang rules. Instead we'd want to attach modifier which hits the models.
+Author note: we mostly do not want broadcast for gang rules. Instead, attach a modifier that reaches the models.
 
 ### Gang type
 
@@ -103,77 +103,77 @@ Assignable for the same reason a profile is: founding is a gang-hosted assignmen
 
 *A carrier for effects that draws no row of its own.*
 
-Fields of its own: none. Its name is authored to be read on the pages that explain things; its kind is never said.
+Fields of its own: none. Its name is authored to be read on the pages that explain things. Its kind is never shown.
 
-The bundle mechanism: some printed rules are a side effect with no item behind them (the Arachni-Rig's guns each knock a point off Attacks), so the option's set includes a hidden carrying the modifier. Being its own kind is the point — no sweep reaches it and the card draws nothing. Both givable and takeable-away, so one take-away can cancel a whole bundle.
+The bundle mechanism: some printed rules are a side effect with no item behind them (each of the Arachni-Rig's guns takes a point off Attacks), so the option's set includes a hidden item carrying the modifier. Being its own kind is the point: no selector reaches it and the card draws nothing. It can be both given and taken away, so one take-away can cancel a whole bundle.
 
 ### Profile
 
-*A fighter or vehicle entry — the thing a model is hired as.*
+*A fighter or vehicle entry: the thing a model is hired as.*
 
-Fields of its own: **profile type** (Fighter or Vehicle — a closed set; Leader, Champion and Ganger are subtypes, not types), **gang type** (every profile belongs to one), and **offered for hire** (unticked for a model nobody hires directly — mostly that means a pet; an adds-a-model effect can still bring it in). It also takes option sets. Its statline shape follows its profile type. Its price is the fighter alone, to which its built-in sets' prices add at hire time.
+Fields of its own: **profile type** (Fighter or Vehicle, a closed set; Leader, Champion and Ganger are subtypes, not types), **gang type** (every profile belongs to one), and **offered for hire** (unticked for a model nobody hires directly, which mostly means a pet; a brings-a-model effect can still bring it in). It also takes option sets. Its statline shape follows its profile type. Its price is the fighter alone. Its built-in sets' prices are added at hire time.
 
 ### Weapon
 
 *A weapon. Always has at least one firing line, the first of which is free.*
 
-Fields of its own: **slots** (weapon slots used on a card; asterisked weapons take 2) and a **statline shape** (SR, LR, Str, AP, L — set once on the weapon; every firing line reads it from there).
+Fields of its own: **slots** (weapon slots used on a card; asterisked weapons take 2) and a **statline shape** (SR, LR, Str, AP, L, set once on the weapon; every firing line reads it from there).
 
-A weapon's firing lines are assignables in their own right (WeaponProfile): the unnamed first line *is* the weapon, a named line is an ammo type, and buying one is an assignment hung off the weapon's assignment — so a stashed or reassigned weapon keeps its lines. Traits live on the lines, not the weapon; a weapon-level question ("has the Melee trait?") is derived from them.
+A weapon's firing lines are assignables in their own right (WeaponProfile): the unnamed first line *is* the weapon, a named line is an ammo type, and buying one is an assignment hung off the weapon's assignment, so a stashed or reassigned weapon keeps its lines. Traits live on the lines, not the weapon. A weapon-level question ("has the Melee trait?") is derived from them.
 
-**Weapon accessories** — sights, suspensors, focusing crystals — are their own type: assigned to a *weapon* rather than a model, hanging off that weapon's assignment, their effects landing on its firing lines. The book's bracket restrictions ("Las Weapons Only", "Weapons Marked With * Only") are stored as data on the accessory, informing at browse and attach, policing nothing.
+**Weapon accessories** (sights, suspensors, focusing crystals) are their own type. They are assigned to a *weapon* rather than a model, hang off that weapon's assignment, and their effects land on its firing lines. The book's bracket restrictions ("Las Weapons Only", "Weapons Marked With * Only") are stored as data on the accessory. They are shown at browse and attach time and block nothing.
 
 ### Wargear
 
-*Equipment that isn't a weapon — armour, grenades, pets, field gear.*
+*Equipment that is not a weapon: armour, grenades, pets, field gear.*
 
-Fields of its own: none — the shared set. It takes option sets (plain talons or razor-sharp). Carried by a model and priced like anything else. A thing that bolts onto a weapon is not wargear; that is a weapon accessory.
+Fields of its own: none beyond the shared set. It takes option sets (plain talons or razor-sharp). Carried by a model and priced like anything else. A thing that fits onto a weapon is not wargear; that is a weapon accessory.
 
 ### Skills and Powers
 
-*What a model has selected (skills) or manifests (powers), each homed in its set.*
+*What a model has selected (skills) or manifests (powers), each with a home category.*
 
-Fields of their own: none. A skill's set is its home category — the same catalogue every collection shares — and its D6 number in the book is its position within that category. A power is the same shape: its home is a category too, so it appears in the same fighter-sectioned views as the skill sets with no special casing (the book's own move: Wyrds treat the powers list as a Secondary Skill Set). A power's annotation carries what the book prints in brackets — "(Free), Continuous Effect" — never rules text.
+Fields of their own: none. A skill's set is its home category, in the same catalogue every collection shares, and its D6 number in the book is its position within that category. A power is the same shape: its home is a category too, so it appears in the same fighter-sectioned views as the skill sets with no special casing (the book does the same: Wyrds treat the powers list as a Secondary Skill Set). A power's annotation carries what the book prints in brackets ("(Free)", "Continuous Effect"), never rules text.
 
 Both print on the card under their own headings. They arrive built in, given by a modifier, or chosen through an offered choice, and reach whoever holds them.
 
 ### Other types
 
-- **Subtype** — *a model subtype: Leader, Ganger, Specialist, Mounted, Wyrd.* No fields of its own. Prints in the card's type line, and is what scopes match on ("Champion or Leader models").
-- **Trait** — *a weapon trait: Melee, Rapid Fire (1), Knockback (6+).* The parameter is the annotation, so Knockback (5+) and Knockback (6+) are two rows. Lives on firing lines, never on the weapon itself.
-- **Skill tree** — *"Agility" as a thing a gang can pick.* Most gangs never need one: a fixed skill set is just a category. Venators pick four and rank them, and a fact a gang owns has to be an assignment, which can only point at an assignable — this type fills that gap. Everything else about the set (its skills, where it sits for a fighter) belongs to the category. Chosen, so it takes no built-ins.
-- **Counter** — *a named tally a model keeps: XP, Kill Count.* The definition is content; who has one is ordinary assignment (XP rides fighter built-ins, with its opening value on the set's member — the 61 in "Starting XP 61"); the running value is player-side, changed only by tallying, which writes ledger events. A modifier can also add to a counter ("Adds to a counter"), which raises the reading for as long as its carrier is held and writes nothing down. A reading is then the tallied value plus whatever contributes to it, and a counter with contributions but no assignment still has a reading. **Drawn** off means the counter is only there for conditions to check: it appears on no card and no fighter page. The point of counters is that effects hang off values: "when XP is at least 5" reveals a promotion choice the moment the threshold is crossed, computed like everything else.
+- **Subtype**: *a model subtype: Leader, Ganger, Specialist, Mounted, Wyrd.* No fields of its own. Prints in the card's type line, and is what scopes match on ("Champion or Leader models").
+- **Trait**: *a weapon trait: Melee, Rapid Fire (1), Knockback (6+).* The parameter is the annotation, so Knockback (5+) and Knockback (6+) are two traits. Lives on firing lines, never on the weapon itself.
+- **Skill tree**: *"Agility" as a thing a gang can pick.* Most gangs never need one: a fixed skill set is just a category. Venators pick four and rank them. A fact a gang owns has to be an assignment, and an assignment can only point at an assignable, so this type fills that gap. Everything else about the set (its skills, where it sits for a fighter) belongs to the category. Chosen, so it takes no built-ins.
+- **Counter**: *a named tally a model keeps: XP, Kill Count.* The definition is content. Who has one is an ordinary assignment (XP arrives through fighter built-ins, with its opening value on the set's member: the 61 in "Starting XP 61"). The running value is player-side and is changed only by tallying, which writes ledger events. A modifier can also add to a counter ("Adds to a counter"), which raises the reading for as long as its carrier is held and writes nothing down. A reading is then the tallied value plus whatever contributes to it, and a counter with contributions but no assignment still has a reading. **Drawn** off means the counter exists only for conditions to check: it appears on no card and no fighter page. The point of counters is that effects depend on values: "when XP is at least 5" reveals a promotion choice the moment the threshold is crossed, computed like everything else.
 
 ### Collection
 
 *A named list of content: an equipment list, a trading post, a menu.*
 
-One field of its own: **prices its entries** — turned off for a menu, where nothing is for sale and the entries are simply choices.
+One field of its own: **prices its entries**. Turn it off for a menu, where nothing is for sale and the entries are simply choices.
 
-It holds things two ways: manual **entry** (hand-picked rows, optionally at this list's own price, and optionally narrowed to who *this list* offers the item to — the "(Forge-born only)" case) and **selectors** (sweeps like "every weapon", at their usual prices); an entry always beats a selector for the same item.
+It contains things in two ways: manual **entries** (hand-picked items, optionally at this list's own price, and optionally narrowed to who *this list* offers the item to, which is the "(Forge-born only)" case) and **selectors** (rules like "every weapon", at their usual prices). An entry always beats a selector for the same item.
 
-Collections arrive built into something (a profile's list, a gang type's) or given by a modifier. Reach: held by the gang, every fighter may browse it; held by or given to one model, theirs alone.
+Collections arrive built into something (a profile's list, a gang type's) or given by a modifier. Reach: held by the gang, every fighter may browse it; held by or given to one model, that model alone.
 
-Collections contain "sections" too — but these are not the same kind of Section as listed below, so let's call them "collection section" for a bit.
+Collections contain "sections" too, but these are not the same kind of Section as listed below, so this page calls them "collection sections".
 
 > Tom note: we are very likely to rename "collection sections" to Tiers, or possibly rename the "Section" object
 
-Within a collection, when displayed, items are grouped by collection section and Category:
+When a collection is displayed, its items are grouped by collection section and Category:
 
-- Membership is entries and sweeps — *placement* has nothing to do with whether a *thing is in the collection*.
-- Where it appears: when a fighter's view of a collection is built, everything unplaced falls into the collection's own default section (part of its schema, so its name and position are content too), or a code-level "Other", drawn last. So browsing Skills & Powers, an unplaced set ("category") is there, under Other.
-- But narrowing excludes it: a Primary-narrowed picker (e.g. used by the "offers a choice" modifier, by setting that the choice comes "from section") only shows categories *placed* within that section. An unplaced skill category lives in Other, not Primary, so it isn't offered. The fighter's own skills screen narrows this way too: it is the *fighter's* view, so a set nobody placed for them isn't on it.
-- The skills square on the edit page does not narrow. It draws every set the library holds, under two tabs: the sets a fighter's placements name (plus any they already hold something in) and, a click away, all of them. The placements sort that listing rather than shorten it — an owner settling what a model *is* may take a skill from any set, and a skill already held from an unplaced set could be removed nowhere else.
+- Membership is entries and selectors. *Placement* has nothing to do with whether a *thing is in the collection*.
+- Where it appears: when a fighter's view of a collection is built, everything unplaced falls into the collection's own default section (part of its schema, so its name and position are content too), or a code-level "Other", drawn last. So when browsing Skills & Powers, an unplaced set ("category") is there, under Other.
+- But narrowing excludes it: a Primary-narrowed picker (for example the "offers a choice" modifier with its choice set to come "from section") only shows categories *placed* within that section. An unplaced skill category is in Other, not Primary, so it is not offered. The fighter's own skills screen narrows this way too: it is the *fighter's* view, so a set nobody placed for them is not on it.
+- The skills box on the edit page does not narrow. It draws every set the library holds, under two tabs: the sets a fighter's placements name (plus any they already hold something in) and, a click away, all of them. The placements sort that listing rather than shorten it. An owner settling what a model *is* may take a skill from any set, and a skill already held from an unplaced set could be removed nowhere else.
 
 ### Slot type
 
 > Draft, for review.
 
-*What is chosen: Gang Legacy, Affiliation, Clan House, Chaos God, Variant — and new ones are authored.*
+*What is chosen: Gang Legacy, Affiliation, Clan House, Chaos God, Variant. New ones are authored.*
 
 Fields of its own: a **plural** (what several of them are called, so a page can say "Gang Legacies"), and **allows repeats** (whether one holder may pick the same pickable for two slots of this type).
 
-A slot type puts a name on one or more slots, and groups pickables. It is not an assignable: nothing holds a slot type. Its slots, picklists and pickables all name it, and authoring refuses a mismatch — a picklist of one slot type cannot sit behind another type's slot. Which slot type something belongs to is settled when it is made and never changed afterwards; something in the wrong slot type is a new one, made in the right one. Its page is where the whole slot type is built: its pickables, its picklists, and its slots.
+A slot type puts a name on one or more slots, and groups pickables. It is not an assignable: nothing holds a slot type. Its slots, picklists and pickables all name it, and the authoring pages do not accept a mismatch: a picklist of one slot type cannot sit behind another type's slot. Which slot type something belongs to is set when it is created and never changed afterwards. Something in the wrong slot type is created again in the right one. Its page is where the whole slot type is built: its pickables, its picklists, and its slots.
 
 ### Pickable
 
@@ -181,23 +181,23 @@ A slot type puts a name on one or more slots, and groups pickables. It is not an
 
 *A value that goes into a slot.*
 
-Fields of its own: the **slot type** it belongs to, and an optional **linked category** — plus the shared assignable set, so whatever the pickable means rides it as ordinary modifiers.
+Fields of its own: the **slot type** it belongs to, and an optional **linked category**, plus the shared assignable set, so whatever the pickable means is carried as ordinary modifiers.
 
-One thing offered in a slot: a specific value, of a particular slot type, that carries behaviour as ordinary modifiers. It never draws a row of its own: it appears under its slot's choice row when chosen. Without its slot it shows nothing and does nothing, so it arrives chosen, given, or as a slot's starting value — never as a bare built-in; the authoring form refuses one. Reach: whatever its own modifiers say, from wherever the pick landed.
+One thing offered in a slot: a specific value, of a particular slot type, that carries behaviour as ordinary modifiers. It never draws a line of its own: it appears under its slot's choice line when chosen. Without its slot it shows nothing and does nothing, so it arrives chosen, given, or as a slot's starting value, never as a bare built-in. The authoring form does not accept one. Reach: whatever its own modifiers say, from wherever the pick landed.
 
-The linked category is consulted for categorisation decisions: a rule that places "the chosen set" asks the pick which category it means, and the link is the answer. This is how a Skill Tree pick stands for the set it names — picking the Agility tree files the Agility category under whichever tier the asking rule says. Most pickables link nothing.
+The linked category is used for categorisation decisions: a rule that places "the chosen set" reads the pick's linked category to find which category it means. This is how a Skill Tree pick stands for the set it names: picking the Agility tree files the Agility category under whichever tier the placing rule names. Most pickables link nothing.
 
 ### Picklist
 
 > Draft, for review.
 
-*A flat, ordered list of pickables that the player chooses from.*
+*A flat, ordered list of pickables that the player picks from.*
 
-Fields of its own: a **slot type** and a **name**; and, where the list is a roll table, the **dice** it is rolled on and how a roll **selects** its row. Each pickable on it carries its place in the order and, where this list calls it something else, a wording of its own — and, on a roll table, the **band** of rolls that lands on it, "51" as readily as "21-26".
+Fields of its own: a **slot type** and a **name**; and, where the list is a roll table, the **dice** it is rolled on and how a roll **selects** its entry. Each pickable on it carries its place in the order and, where this list calls it something else, a wording of its own. On a roll table it also carries the **band** of rolls that lands on it, "51" or "21-26".
 
-A set of pickables available in a slot. One slot type throughout, no headings and no prices — where a collection is a catalogue, this is a menu. One slot type may have several different picklists, which is how a limited selection of the pickables is made available in certain situations: what a leader picks from and what a champion picks from could be two lists of one slot type. Not an assignable; a slot names it.
+A set of pickables available in a slot. One slot type throughout, no headings and no prices. Where a collection is a catalogue, this is a menu. One slot type may have several picklists, which is how a limited selection of the pickables is offered in certain situations: what a leader picks from and what a champion picks from could be two lists of one slot type. Not an assignable; a slot names it.
 
-A roll table is a picklist that names its dice and how a roll finds its row — the one row whose band holds it, or every row at or below it. The die is a closed set — D3, D6, D66 or 2D6 — so every roll it can produce is known. A band is plain numbers even on a D66, where "31-46" spans rolls that can never come up: a lookup only ever asks about a roll that did. Nothing rolls; the bands are authored and the picks are chosen.
+A roll table is a picklist that names its dice and how a roll finds its entry: the one entry whose band contains the roll, or every entry at or below it. The die is a closed set (D3, D6, D66 or 2D6), so every roll it can produce is known. A band is plain numbers even on a D66, where "31-46" spans rolls that can never come up. A lookup is only ever made for a roll that did. Nothing rolls: the bands are authored and the picks are chosen.
 
 ### Slot
 
@@ -207,7 +207,7 @@ A roll table is a picklist that names its dice and how a roll finds its row — 
 
 Fields of its own: its **slot type** and **picklist**; the **label** shown on the card; **min** and **max picks**; **assigned to** (whether the pick lands on the bearer or on the gang); **hidden**; and a position among the slots on one card.
 
-One specific, named use of a slot type. Assigning one to a model or gang — built into a profile, given by a modifier, or brought by an option when something is bought — causes the slot to show up. The card draws the label with what has been picked by the player, or what's set by default, or a control to pick, on the holder's own card and nowhere else: a slot the gang holds is asked once rather than on every fighter. Picking under the minimum adds a note on the card, never a refusal (no page prints these notes yet), and the picker stops offering at the maximum. A slot of one pick is settled by picking, and picking again replaces the pick; a slot of several is made a pick at a time, each option on the picker adding or taking back its own. A slot of nought picks asks nothing. **Hidden** makes the slot invisible while the pick still does everything it does — grouped hidden assignables, under one name.
+One specific, named use of a slot type. Assigning one to a model or gang (built into a profile, given by a modifier, or brought by an option when something is bought) makes the slot appear. The card draws the label with what the player has picked, or what is set by default, or a control to pick, on the holder's own card and nowhere else: a slot the gang holds appears once rather than on every fighter. Picking under the minimum adds a note on the card and blocks nothing (no page prints these notes yet), and the picker stops offering at the maximum. A slot of one pick is settled by picking, and picking again replaces the pick. A slot of several picks is filled a pick at a time, each option on the picker adding or removing its own. A slot of 0 picks shows no choice. **Hidden** makes the slot invisible while the pick still does everything it does: grouped hidden assignables, under one name.
 
 ### Picks
 
@@ -215,9 +215,9 @@ One specific, named use of a slot type. Assigning one to a model or gang — bui
 
 *Not a type: the assignment that settles a choice.*
 
-The pick is an ordinary assignment: the pickable, hosted where the slot says it lands, caused by the slot's own assignment and pointing back at it. So removing the slot removes the pick and everything the pickable gave; two slots of one slot type on one holder stay independent, even where one thing opened both; and nothing is worked out from what kind of thing was chosen. A pick is free and adds nothing to any rating.
+The pick is an ordinary assignment: the pickable, hosted where the slot says it lands, caused by the slot's own assignment and pointing back at it. So removing the slot removes the pick and everything the pickable gave. Two slots of one slot type on one holder stay independent, even where one thing opened both. Nothing is worked out from what kind of thing was chosen. A pick is free and adds nothing to any rating.
 
-A pick the gang holds is broadcast (but not displayed) to every member: a rule reaching "models with the Cawdor legacy" reaches them all, the fighter who was asked included. A pickable that carries the *draws the pick on the card* effect is displayed after all, on the cards its scope reaches — see below.
+A pick the gang holds is broadcast (but not displayed) to every member: a rule reaching "models with the Cawdor legacy" reaches them all, including the fighter who made the pick. A pickable that carries the *draws the pick on the card* effect is displayed after all, on the cards its scope reaches. See below.
 
 Where the slot type does not allow repeats, the picker marks the pickables already picked for another slot, and the card notes when one pickable is picked for two (no page prints these notes yet). Marks and notes, never locks: the narrowing informs, and an owner may still hand over a pickable no picklist offered.
 
@@ -225,20 +225,20 @@ Where the slot type does not allow repeats, the picker marks the pickables alrea
 
 ## Core types & concepts
 
-Hiding under a lot of the above is some shared underpinnings, which I've made reference to but might benefit from some more explanation.
+The types above share some underpinnings. This section explains them.
 
 ### Assignable
 
 *The shared shape of everything a gang, model or item can carry.*
 
-Not a thing itself — pretty much every type above is "an assignable". The
+Not a thing itself. Almost every type above is "an assignable". The
 shared fields: name; annotation (printed in brackets after the name);
-qualifier (tells two same-named things apart for authors — a player never
+qualifier (tells two same-named things apart for authors; a player never
 sees it); author help; price; Trade Point price; an exclusive flag
 (equipment-list only, never at the Trading Post); a home category (where
-it sorts in any list); a position (its order within that category — a
-skill's D6 number in its set); built-ins (what arrives free with it);
-its modifiers.
+it sorts in any list); a position (its order within that category, such
+as a skill's D6 number in its set); built-ins (what arrives free with
+it); its modifiers.
 
 ### Category
 
@@ -246,21 +246,21 @@ its modifiers.
 
 Fields: its Section, a name, a position.
 
-Used as a home for *item* in a collection, so every collection groups it the same way — an autogun is an Auto/Stub Weapon everywhere. The same name may recur under different sections (Primitive Weapons under both Ranged and Close Combat).
+Used as a home for an *item* in a collection, so every collection groups it the same way: an autogun is an Auto/Stub Weapon everywhere. The same name may recur under different sections (Primitive Weapons under both Ranged and Close Combat).
 
-A Category points at a Section, which is where the Category typically is organised. A Category's effective section can be changed ("placed") by a modifier.
+A Category points at a Section, which is where the Category is normally organised. A Category's effective section can be changed ("placed") by a modifier.
 
 ### Section
 
-*A heading of the catalogue, above categories — "Ranged Weapons".*
+*A heading of the catalogue, above categories: "Ranged Weapons".*
 
 Fields: a name and a position. Nothing else.
 
-A real object rather than free text so two spellings can't f(uc|or)k a collection. Never assigned, never reaches anything.
+A real object rather than free text, so two spellings cannot split a collection. Never assigned, never reaches anything.
 
-Who uses it: the gear surfaces — the equip pages group their catalogues by it (browse → _sectioned → group_by_home), and the ?section= in the equip page's URL names one of these.
+Who uses it: the gear surfaces. The equip pages group their catalogues by it, and the `?section=` in the equip page's URL names one of these.
 
-Not to be confused with a collection sections — e.g. Primary and Secondary in the Skills & Powers collection. See above.
+Not to be confused with collection sections, such as Primary and Secondary in the Skills & Powers collection. See above.
 
 > Tom note: we are very likely to rename "collection sections" to Tiers, or possibly rename the "Section" object
 
@@ -268,38 +268,38 @@ Not to be confused with a collection sections — e.g. Primary and Secondary in 
 
 *A named set of things an assignable comes with, free, at arrival.*
 
-Fields: a name and a price — priced absolutely, not as a difference:
+Fields: a name and a price. The price is absolute, not a difference:
 plain talons 0, razor-sharp 25. Its members each name exactly one thing
 from a deliberately narrow list: weapons, firing lines, wargear,
 subtypes, skills, rules, hiddens, collections, counters. Not profiles (a
-fighter cannot come with a fighter — that is what brings-a-model is for)
+fighter cannot come with a fighter; that is what brings-a-model is for)
 and not chosen kinds.
 
 Pointed at from two places: any assignable's own built-ins, and an
 option (razor-sharp talons are an option whose set holds the sharper
-claws). Materialised when the holder arrives — hired, founded, or bought
-— free, and "caused by" the holder, so removing the holder takes them
-along.
+claws). Materialised when the holder arrives (hired, founded, or bought),
+free, and "caused by" the holder, so removing the holder removes them
+too.
 
 A member that is a firing line names which of the set's weapons it
-rides, and is added from that gun's own row rather than from the
+belongs to, and is added from that gun's own line rather than from the
 general picker. A set that brings no such weapon can still hold the
-line — it then lands on whatever matching gun the acquirer already
+line. It then lands on whatever matching gun the acquirer already
 holds, which is how an option arms a weapon the built-ins bring.
 
 ### Offers a choice (an effect)
 
-*Puts an open question on the card; the player chooses one thing of a particular assignable type.*
+*Puts an open choice on the card; the player chooses one thing of a particular assignable type.*
 
 Fields:
 
-- the type it takes (exactly one — offering a choice of skill is not
+- the type it takes (exactly one: offering a choice of skill is not
 settled by choosing a power)
 - an optional collection section that narrows what a picker shows
-- a **label** ("skill tree 1") naming the choice row on the card and picking which row it files into
-- **will be assigned to** — whether the chosen thing lands on the bearer or on the gang.
+- a **label** ("skill tree 1") naming the choice line on the card and deciding which line it files into
+- **will be assigned to**: whether the chosen thing lands on the bearer or on the gang.
 
-(A minor third path exists: the code making the choice may name the host explicitly, which beats both — it is how a gang-carried offer that each fighter settles individually lands on the fighter who was clicked.)
+(A minor third path exists: the code making the choice may name the host explicitly, which beats both. This is how a gang-carried offer that each fighter settles individually lands on the fighter who was clicked.)
 
 > Tom note: we probably want to extend these to support multiple different types
 
@@ -307,9 +307,9 @@ settled by choosing a power)
 
 *Lists the pick carrying it on the cards this modifier reaches.*
 
-No fields: the scope is the whole of what it says. Carried by a pickable, so the line comes and goes with the pick, and it acts only on a pick **the gang** holds — a model's own pick is already the row of the choice that settled it.
+No fields: the scope is the whole of what it does. Carried by a pickable, so the line comes and goes with the pick, and it acts only on a pick **the gang** holds. A model's own pick is already shown in the choice line that settled it.
 
-The line is headed by the slot type's name ("Archetype") and holds what was picked. It leads nowhere: the choice is made and changed on the card that was asked for it, and that card draws its own choice row instead of this.
+The line is headed by the slot type's name ("Archetype") and holds what was picked. It leads nowhere: the choice is made and changed on the card that offered it, and that card draws its own choice line instead of this.
 
 For an Outcast gang's archetype, picked by the leader and played by every model except the Champions, who pick one of their own.
 
@@ -317,29 +317,29 @@ For an Outcast gang's archetype, picked by the leader and played by every model 
 
 *The append-only record of every purchase: what was asked, paid, and worth.*
 
-Fields on an entry: list price, discount, paid, Trade Points, **rating contribution** (pinned forever — the "rating" half of the price/rating split), reason (bought, free, granted, default…), and which collection entry priced it.
+Fields on an entry: list price, discount, paid, Trade Points, **rating contribution** (pinned forever: the "rating" half of the price/rating split), reason (bought, free, granted, default, and so on), and which collection entry priced it.
 
-Append-only; an entry's events must fold back to the entry, and reconcile checks exactly that. Ratings and credits are never nudged by differences — they are recomputed from this record and repinned. Rating sums the contributions of what models hold; the stash's rows count in wealth instead.
+Append-only. An entry's events must fold back to the entry, and reconcile checks exactly that. Ratings and credits are never adjusted by differences. They are recomputed from this record and repinned. Rating sums the contributions of what models hold; the stash's assignments count in wealth instead.
 
 ### Operation
 
-*The only writer of player data; everything else just reads.*
+*The only writer of player data; everything else only reads.*
 
-Some kind of actual change. Assign, buy, hire, choose, remove, move: each writes the assignment, the ledger entry, and the events together. Settling ends every operation by repinning the stash, the rating, and the credits from the ledger; spending past the founding budget raises there and unwinds the whole transaction — one of few hard refusals in the app.
+An actual change. Assign, buy, hire, choose, remove, move: each writes the assignment, the ledger entry, and the events together. Settling ends every operation by repinning the stash, the rating, and the credits from the ledger. Spending past the founding budget raises there and unwinds the whole transaction, one of the few hard blocks in the app.
 
 ### Gang
 
 *One player's gang: its type, its money, its colour.*
 
-Fields: name, gang type, founding date, starting credits (blank means unlimited, and the Refund control hides), credits, colour.
+Fields: name, gang type, founding date, starting credits (blank means unlimited, and the Refund control is hidden), credits, colour.
 
-Its rating is what its models are worth, recomputed from the ledger and pinned — never the stash. Its wealth is rating plus credits plus the stash's own pinned worth.
+Its rating is what its models are worth, recomputed from the ledger and pinned. The stash is never included. Its wealth is rating plus credits plus the stash's own pinned worth.
 
 ### Miniature
 
-*One model on the roster; the class dodges Django's "Model"*
+*One model on the roster; the class name avoids Django's "Model"*
 
-A model is a membership assignment naming a profile, plus everything riding it. Every user-facing word is "model" — the Python class name is the only place "miniature" appears.
+A model is a membership assignment naming a profile, plus everything attached to it. Every user-facing word is "model". The Python class name is the only place "miniature" appears.
 
 ### Stash
 
@@ -347,4 +347,4 @@ A model is a membership assignment naming a profile, plus everything riding it. 
 
 Fields: none of its own beyond its link to the gang and its pinned worth. Created at founding.
 
-A host like any other: can be assigned stuff. Its worth is repinned by every operation. Counts towards wealth.
+A host like any other: things can be assigned to it. Its worth is repinned by every operation. Counts towards wealth.

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -4,9 +4,9 @@ How the parts of Gyrinx N26 fit together.
 
 The four things to remember:
 
-1. **To control who gets a thing, control where it lands. There is no per-type switch.** For something gang-wide, build it into the gang type, or use a slot whose pick is assigned to the gang. For something on one model, build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on a pickable or a rule. Reach follows entirely from the **host**, so you aim content by choosing how it arrives.
+1. **To control who gets a thing, control where it lands — there is no per-type switch.** For something gang-wide, build it into the gang type, or use a slot whose pick is assigned to the gang. For something on one model, build it into the profile, or pick "the bearer". There is no "make this broadcast" setting on a pickable or a rule. Reach follows entirely from the **host**, so you aim content by choosing how it arrives.
 
-2. **Behaviour comes from modifiers attached to carriers, and modifiers are shared, so edit with care.** A rule or a pickable starts as a name. Its attached modifiers define its behaviour (scope plus effect, with conditions ANDed). Two practical consequences: attach a modifier to the content it should affect; and before editing an existing modifier, check its carriers, because the change applies everywhere it is attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once, and removing the carrier does not reverse them.
+2. **Behaviour comes from modifiers attached to carriers — and modifiers are shared, so edit with care.** A rule or a pickable starts as a name. Its attached modifiers define its behaviour (scope plus effect, with conditions ANDed). Two practical consequences: attach a modifier to the content it should affect; and before editing an existing modifier, check its carriers, because the change applies everywhere it is attached. Know the two effect families: computed effects (gives, takes away, stat changes, counter contributions, choices, placements, limits) come and go with their carrier and are safe to rework; written effects (brings a model, moves a counter) happen once, and removing the carrier does not reverse them.
 
 3. **Being in a collection and being offered from a section of it are two separate authoring acts.** Entries and selectors decide **membership** of the collection. **Placement** decides whether a particular category appears in a section. If you narrow a choice to "from section: Primary" and the skill's category has not been placed into Primary for that fighter, it is not offered: it is in "Other". So a working "choose a Primary skill" needs both halves authored: the content in the collection, and a placement putting its category in that section for the right models.
 
@@ -14,7 +14,7 @@ The four things to remember:
 
 ## Assignment
 
-**An assignment has three components**: *what* is held (an **assignable**: a weapon, a skill, a pickable, and so on), *who it is assigned to* (the **host**), and the source of the assignment (its **cause**). Removing the cause also removes the assignment. Every item on a card, from a hired fighter's profile to a granted rule, is an assignment.
+**An assignment has three components**: *what* is held (an **assignable** — a weapon, a skill, a pickable…), *who it is assigned to* (the **host**), and the source of the assignment (its **cause**). Removing the cause also removes the assignment. Every item on a card, from a hired fighter's profile to a granted rule, is an assignment.
 
 An **assignable** is usually very simple: a piece of data that, once assigned, can carry modifiers. Some have extra configuration. Rules, skills and pickables are all assignables.
 
@@ -33,9 +33,9 @@ Effects are split by when they happen:
 
 We use **carrier** as a library-side word for one specific piece of *content*, because it "carries" a modifier. A power maul carries its "+1 Strength" modifier; the Clan House pickable carries a grant of the house slot. Carrier is an authoring word: edit the carrier's modifier and it changes everywhere that carrier appears.
 
-**Bearer** is the thing a modifier affects. The maul's modifier reads "+1 Strength *to its bearer*": whoever holds a *specific* maul, with no name attached.
+**Bearer** is the thing a modifier affects. The maul's modifier reads "+1 Strength *to its bearer*" — whoever holds a *specific* maul, with no name attached.
 
-So: you buy a power maul for Vex. The purchase writes one assignment. **Assignable**: the maul. **Host**: Vex. **Cause**: the purchase. The maul's assignment points at its underlying **assignable**, which is a **carrier** of a **modifier**, which now applies to its **bearer**, Vex. When the maul **assignment** is reassigned, the same assignment gets a new host, and the modifier follows the maul, not Vex.
+So: you buy a power maul for Vex. The purchase writes one assignment — **assignable**: the maul, **host**: Vex, **cause**: the purchase. The maul's assignment points at its underlying **assignable**, which is a **carrier** of a **modifier**, which now applies to its **bearer**, Vex. When the maul **assignment** is reassigned, the same assignment gets a new host, and the modifier follows the maul, not Vex.
 
 Often the host and the bearer are the same. But when the Outcast Leader settles the gang's Gang Legacy slot, the pickable they choose is assigned *to the gang*. When the gang is the host, every model sees it (and becomes the bearer), even though the Leader was the one who chose:
 
@@ -53,7 +53,7 @@ What the hire operation does, in order:
 
 1. Writes a membership assignment: an assignment pointing at a profile, hosted on the gang, with the credits-paid information on it
 2. Creates the Miniature, pointing back at that assignment. The model shown in the gang is this pairing: a membership assignment plus a name.
-3. Sets "miniature root" on the membership assignment, pointing at the miniature. The assignment is hosted on the gang (the fighter is assigned to the gang), and the profile on the assignment sets their base rating.
+3. Sets "miniature root" on the membership assignment, pointing at the miniature. The assignment is hosted on the gang — the fighter is assigned to the gang — and the profile on the assignment sets their base rating.
 4. Materialises the built-ins: the stub gun and the house list become free assignments, hosted directly on Vex (not the gang), caused by the membership. Delete Vex and the cascade removes his kit with him.
 
 > Note from Tom: I'm not convinced that steps 1-3 above are the simplest way we could do this, but it is how it works now.
@@ -75,7 +75,7 @@ The relationships after one hire, spelled out:
 
 ### A gang-level choice (slot type)
 
-*Who the gang sides with, which god it follows, or which corruption it has: chosen once, as a pick.*
+*Who the gang sides with, which god it follows, or which corruption it has — chosen once, as a pick.*
 
 Do not author a new kind for this. Create a **slot type** (Affiliation, Chaos God, Variant, or a new name), its **pickables**, a **picklist**, and a **slot** assigned to the gang. Grant that slot from a hidden built into the gang type, or from the gang type itself. Attach ordinary modifiers to each pickable to define its effects. For example, a pickable can open equipment lists to some ranks, or grant another slot while the pick remains assigned.
 
@@ -85,7 +85,7 @@ The slot type's name is the word the card and the history use. The slot's label 
 
 *A named special rule on a card; its text stays in the book.*
 
-Fields of its own: none. Its annotation is part of its identity, so variants of a rule share one printed name. We store the name, never the wording (copyright). A rule that also *does* something the app can work out carries ordinary modifiers.
+Fields of its own: none — but its annotation is part of its identity, so variants of a rule share one printed name. We store the name, never the wording (copyright). A rule that also *does* something the app can work out carries ordinary modifiers.
 
 Normally it arrives built into something (a profile's kit, a gang type) or given by a modifier. Reach: built into a profile, it reaches the model's card; given to the gang, every member's card. The card prints rules apart from skills, under their own heading.
 
@@ -109,58 +109,58 @@ The bundle mechanism: some printed rules are a side effect with no item behind t
 
 ### Profile
 
-*A fighter or vehicle entry: the thing a model is hired as.*
+*A fighter or vehicle entry — the thing a model is hired as.*
 
-Fields of its own: **profile type** (Fighter or Vehicle, a closed set; Leader, Champion and Ganger are subtypes, not types), **gang type** (every profile belongs to one), and **offered for hire** (unticked for a model nobody hires directly, which mostly means a pet; a brings-a-model effect can still bring it in). It also takes option sets. Its statline shape follows its profile type. Its price is the fighter alone. Its built-in sets' prices are added at hire time.
+Fields of its own: **profile type** (Fighter or Vehicle — a closed set; Leader, Champion and Ganger are subtypes, not types), **gang type** (every profile belongs to one), and **offered for hire** (unticked for a model nobody hires directly, which mostly means a pet; a brings-a-model effect can still bring it in). It also takes option sets. Its statline shape follows its profile type. Its price is the fighter alone. Its built-in sets' prices are added at hire time.
 
 ### Weapon
 
 *A weapon. Always has at least one firing line, the first of which is free.*
 
-Fields of its own: **slots** (weapon slots used on a card; asterisked weapons take 2) and a **statline shape** (SR, LR, Str, AP, L, set once on the weapon; every firing line reads it from there).
+Fields of its own: **slots** (weapon slots used on a card; asterisked weapons take 2) and a **statline shape** (SR, LR, Str, AP, L — set once on the weapon; every firing line reads it from there).
 
 A weapon's firing lines are assignables in their own right (WeaponProfile): the unnamed first line *is* the weapon, a named line is an ammo type, and buying one is an assignment hung off the weapon's assignment, so a stashed or reassigned weapon keeps its lines. Traits live on the lines, not the weapon. A weapon-level question ("has the Melee trait?") is derived from them.
 
-**Weapon accessories** (sights, suspensors, focusing crystals) are their own type. They are assigned to a *weapon* rather than a model, hang off that weapon's assignment, and their effects land on its firing lines. The book's bracket restrictions ("Las Weapons Only", "Weapons Marked With * Only") are stored as data on the accessory. They are shown at browse and attach time and block nothing.
+**Weapon accessories** — sights, suspensors, focusing crystals — are their own type. They are assigned to a *weapon* rather than a model, hang off that weapon's assignment, and their effects land on its firing lines. The book's bracket restrictions ("Las Weapons Only", "Weapons Marked With * Only") are stored as data on the accessory. They are shown at browse and attach time and block nothing.
 
 ### Wargear
 
-*Equipment that is not a weapon: armour, grenades, pets, field gear.*
+*Equipment that is not a weapon — armour, grenades, pets, field gear.*
 
-Fields of its own: none beyond the shared set. It takes option sets (plain talons or razor-sharp). Carried by a model and priced like anything else. A thing that fits onto a weapon is not wargear; that is a weapon accessory.
+Fields of its own: none — the shared set. It takes option sets (plain talons or razor-sharp). Carried by a model and priced like anything else. A thing that fits onto a weapon is not wargear; that is a weapon accessory.
 
 ### Skills and Powers
 
 *What a model has selected (skills) or manifests (powers), each with a home category.*
 
-Fields of their own: none. A skill's set is its home category, in the same catalogue every collection shares, and its D6 number in the book is its position within that category. A power is the same shape: its home is a category too, so it appears in the same fighter-sectioned views as the skill sets with no special casing (the book does the same: Wyrds treat the powers list as a Secondary Skill Set). A power's annotation carries what the book prints in brackets ("(Free)", "Continuous Effect"), never rules text.
+Fields of their own: none. A skill's set is its home category — the same catalogue every collection shares — and its D6 number in the book is its position within that category. A power is the same shape: its home is a category too, so it appears in the same fighter-sectioned views as the skill sets with no special casing (the book does the same: Wyrds treat the powers list as a Secondary Skill Set). A power's annotation carries what the book prints in brackets ("(Free)", "Continuous Effect"), never rules text.
 
 Both print on the card under their own headings. They arrive built in, given by a modifier, or chosen through an offered choice, and reach whoever holds them.
 
 ### Other types
 
-- **Subtype**: *a model subtype: Leader, Ganger, Specialist, Mounted, Wyrd.* No fields of its own. Prints in the card's type line, and is what scopes match on ("Champion or Leader models").
-- **Trait**: *a weapon trait: Melee, Rapid Fire (1), Knockback (6+).* The parameter is the annotation, so Knockback (5+) and Knockback (6+) are two traits. Lives on firing lines, never on the weapon itself.
-- **Skill tree**: *"Agility" as a thing a gang can pick.* Most gangs never need one: a fixed skill set is just a category. Venators pick four and rank them. A fact a gang owns has to be an assignment, and an assignment can only point at an assignable, so this type fills that gap. Everything else about the set (its skills, where it sits for a fighter) belongs to the category. Chosen, so it takes no built-ins.
-- **Counter**: *a named tally a model keeps: XP, Kill Count.* The definition is content. Who has one is an ordinary assignment (XP arrives through fighter built-ins, with its opening value on the set's member: the 61 in "Starting XP 61"). The running value is player-side and is changed only by tallying, which writes ledger events. A modifier can also add to a counter ("Adds to a counter"), which raises the reading for as long as its carrier is held and writes nothing down. A reading is then the tallied value plus whatever contributes to it, and a counter with contributions but no assignment still has a reading. **Drawn** off means the counter exists only for conditions to check: it appears on no card and no fighter page. The point of counters is that effects depend on values: "when XP is at least 5" reveals a promotion choice the moment the threshold is crossed, computed like everything else.
+- **Subtype** — *a model subtype: Leader, Ganger, Specialist, Mounted, Wyrd.* No fields of its own. Prints in the card's type line, and is what scopes match on ("Champion or Leader models").
+- **Trait** — *a weapon trait: Melee, Rapid Fire (1), Knockback (6+).* The parameter is the annotation, so Knockback (5+) and Knockback (6+) are two traits. Lives on firing lines, never on the weapon itself.
+- **Skill tree** — *"Agility" as a thing a gang can pick.* Most gangs never need one: a fixed skill set is just a category. Venators pick four and rank them. A fact a gang owns has to be an assignment, and an assignment can only point at an assignable, so this type fills that gap. Everything else about the set (its skills, where it sits for a fighter) belongs to the category. Chosen, so it takes no built-ins.
+- **Counter** — *a named tally a model keeps: XP, Kill Count.* The definition is content. Who has one is an ordinary assignment (XP arrives through fighter built-ins, with its opening value on the set's member: the 61 in "Starting XP 61"). The running value is player-side and is changed only by tallying, which writes ledger events. A modifier can also add to a counter ("Adds to a counter"), which raises the reading for as long as its carrier is held and writes nothing down. A reading is then the tallied value plus whatever contributes to it, and a counter with contributions but no assignment still has a reading. **Drawn** off means the counter exists only for conditions to check: it appears on no card and no fighter page. The point of counters is that effects depend on values: "when XP is at least 5" reveals a promotion choice the moment the threshold is crossed, computed like everything else.
 
 ### Collection
 
 *A named list of content: an equipment list, a trading post, a menu.*
 
-One field of its own: **prices its entries**. Turn it off for a menu, where nothing is for sale and the entries are simply choices.
+One field of its own: **prices its entries** — turned off for a menu, where nothing is for sale and the entries are simply choices.
 
-It contains things in two ways: manual **entries** (hand-picked items, optionally at this list's own price, and optionally narrowed to who *this list* offers the item to, which is the "(Forge-born only)" case) and **selectors** (rules like "every weapon", at their usual prices). An entry always beats a selector for the same item.
+It contains things in two ways: manual **entries** (hand-picked items, optionally at this list's own price, and optionally narrowed to who *this list* offers the item to — the "(Forge-born only)" case) and **selectors** (rules like "every weapon", at their usual prices). An entry always beats a selector for the same item.
 
 Collections arrive built into something (a profile's list, a gang type's) or given by a modifier. Reach: held by the gang, every fighter may browse it; held by or given to one model, that model alone.
 
-Collections contain "sections" too, but these are not the same kind of Section as listed below, so this page calls them "collection sections".
+Collections contain "sections" too — but these are not the same kind of Section as listed below, so this page calls them "collection sections".
 
 > Tom note: we are very likely to rename "collection sections" to Tiers, or possibly rename the "Section" object
 
 When a collection is displayed, its items are grouped by collection section and Category:
 
-- Membership is entries and selectors. *Placement* has nothing to do with whether a *thing is in the collection*.
+- Membership is entries and selectors — *placement* has nothing to do with whether a *thing is in the collection*.
 - Where it appears: when a fighter's view of a collection is built, everything unplaced falls into the collection's own default section (part of its schema, so its name and position are content too), or a code-level "Other", drawn last. So when browsing Skills & Powers, an unplaced set ("category") is there, under Other.
 - But narrowing excludes it: a Primary-narrowed picker (for example the "offers a choice" modifier with its choice set to come "from section") only shows categories *placed* within that section. An unplaced skill category is in Other, not Primary, so it is not offered. The fighter's own skills screen narrows this way too: it is the *fighter's* view, so a set nobody placed for them is not on it.
 - The skills box on the edit page does not narrow. It draws every set the library holds, under two tabs: the sets a fighter's placements name (plus any they already hold something in) and, a click away, all of them. The placements sort that listing rather than shorten it. An owner settling what a model *is* may take a skill from any set, and a skill already held from an unplaced set could be removed nowhere else.
@@ -169,7 +169,7 @@ When a collection is displayed, its items are grouped by collection section and 
 
 > Draft, for review.
 
-*What is chosen: Gang Legacy, Affiliation, Clan House, Chaos God, Variant. New ones are authored.*
+*What is chosen: Gang Legacy, Affiliation, Clan House, Chaos God, Variant — and new ones are authored.*
 
 Fields of its own: a **plural** (what several of them are called, so a page can say "Gang Legacies"), and **allows repeats** (whether one holder may pick the same pickable for two slots of this type).
 
@@ -181,7 +181,7 @@ A slot type puts a name on one or more slots, and groups pickables. It is not an
 
 *A value that goes into a slot.*
 
-Fields of its own: the **slot type** it belongs to, and an optional **linked category**, plus the shared assignable set, so whatever the pickable means is carried as ordinary modifiers.
+Fields of its own: the **slot type** it belongs to, and an optional **linked category** — plus the shared assignable set, so whatever the pickable means is carried as ordinary modifiers.
 
 One thing offered in a slot: a specific value, of a particular slot type, that carries behaviour as ordinary modifiers. It never draws a line of its own: it appears under its slot's choice line when chosen. Without its slot it shows nothing and does nothing, so it arrives chosen, given, or as a slot's starting value, never as a bare built-in. The authoring form does not accept one. Reach: whatever its own modifiers say, from wherever the pick landed.
 
@@ -195,9 +195,9 @@ The linked category is used for categorisation decisions: a rule that places "th
 
 Fields of its own: a **slot type** and a **name**; and, where the list is a roll table, the **dice** it is rolled on and how a roll **selects** its entry. Each pickable on it carries its place in the order and, where this list calls it something else, a wording of its own. On a roll table it also carries the **band** of rolls that lands on it, "51" or "21-26".
 
-A set of pickables available in a slot. One slot type throughout, no headings and no prices. Where a collection is a catalogue, this is a menu. One slot type may have several picklists, which is how a limited selection of the pickables is offered in certain situations: what a leader picks from and what a champion picks from could be two lists of one slot type. Not an assignable; a slot names it.
+A set of pickables available in a slot. One slot type throughout, no headings and no prices — where a collection is a catalogue, this is a menu. One slot type may have several picklists, which is how a limited selection of the pickables is offered in certain situations: what a leader picks from and what a champion picks from could be two lists of one slot type. Not an assignable; a slot names it.
 
-A roll table is a picklist that names its dice and how a roll finds its entry: the one entry whose band contains the roll, or every entry at or below it. The die is a closed set (D3, D6, D66 or 2D6), so every roll it can produce is known. A band is plain numbers even on a D66, where "31-46" spans rolls that can never come up. A lookup is only ever made for a roll that did. Nothing rolls: the bands are authored and the picks are chosen.
+A roll table is a picklist that names its dice and how a roll finds its entry — the one entry whose band contains the roll, or every entry at or below it. The die is a closed set — D3, D6, D66 or 2D6 — so every roll it can produce is known. A band is plain numbers even on a D66, where "31-46" spans rolls that can never come up. A lookup is only ever made for a roll that did. Nothing rolls: the bands are authored and the picks are chosen.
 
 ### Slot
 
@@ -207,7 +207,7 @@ A roll table is a picklist that names its dice and how a roll finds its entry: t
 
 Fields of its own: its **slot type** and **picklist**; the **label** shown on the card; **min** and **max picks**; **assigned to** (whether the pick lands on the bearer or on the gang); **hidden**; and a position among the slots on one card.
 
-One specific, named use of a slot type. Assigning one to a model or gang (built into a profile, given by a modifier, or brought by an option when something is bought) makes the slot appear. The card draws the label with what the player has picked, or what is set by default, or a control to pick, on the holder's own card and nowhere else: a slot the gang holds appears once rather than on every fighter. Picking under the minimum adds a note on the card and blocks nothing (no page prints these notes yet), and the picker stops offering at the maximum. A slot of one pick is settled by picking, and picking again replaces the pick. A slot of several picks is filled a pick at a time, each option on the picker adding or removing its own. A slot of 0 picks shows no choice. **Hidden** makes the slot invisible while the pick still does everything it does: grouped hidden assignables, under one name.
+One specific, named use of a slot type. Assigning one to a model or gang — built into a profile, given by a modifier, or brought by an option when something is bought — makes the slot appear. The card draws the label with what the player has picked, or what is set by default, or a control to pick, on the holder's own card and nowhere else: a slot the gang holds appears once rather than on every fighter. Picking under the minimum adds a note on the card and blocks nothing (no page prints these notes yet), and the picker stops offering at the maximum. A slot of one pick is settled by picking, and picking again replaces the pick. A slot of several picks is filled a pick at a time, each option on the picker adding or removing its own. A slot of 0 picks shows no choice. **Hidden** makes the slot invisible while the pick still does everything it does: grouped hidden assignables, under one name.
 
 ### Picks
 
@@ -231,14 +231,14 @@ The types above share some underpinnings. This section explains them.
 
 *The shared shape of everything a gang, model or item can carry.*
 
-Not a thing itself. Almost every type above is "an assignable". The
+Not a thing itself — almost every type above is "an assignable". The
 shared fields: name; annotation (printed in brackets after the name);
-qualifier (tells two same-named things apart for authors; a player never
+qualifier (tells two same-named things apart for authors — a player never
 sees it); author help; price; Trade Point price; an exclusive flag
 (equipment-list only, never at the Trading Post); a home category (where
-it sorts in any list); a position (its order within that category, such
-as a skill's D6 number in its set); built-ins (what arrives free with
-it); its modifiers.
+it sorts in any list); a position (its order within that category — a
+skill's D6 number in its set); built-ins (what arrives free with it);
+its modifiers.
 
 ### Category
 
@@ -246,21 +246,21 @@ it); its modifiers.
 
 Fields: its Section, a name, a position.
 
-Used as a home for an *item* in a collection, so every collection groups it the same way: an autogun is an Auto/Stub Weapon everywhere. The same name may recur under different sections (Primitive Weapons under both Ranged and Close Combat).
+Used as a home for an *item* in a collection, so every collection groups it the same way — an autogun is an Auto/Stub Weapon everywhere. The same name may recur under different sections (Primitive Weapons under both Ranged and Close Combat).
 
 A Category points at a Section, which is where the Category is normally organised. A Category's effective section can be changed ("placed") by a modifier.
 
 ### Section
 
-*A heading of the catalogue, above categories: "Ranged Weapons".*
+*A heading of the catalogue, above categories — "Ranged Weapons".*
 
 Fields: a name and a position. Nothing else.
 
 A real object rather than free text, so two spellings cannot split a collection. Never assigned, never reaches anything.
 
-Who uses it: the gear surfaces. The equip pages group their catalogues by it, and the `?section=` in the equip page's URL names one of these.
+Who uses it: the gear surfaces — the equip pages group their catalogues by it, and the `?section=` in the equip page's URL names one of these.
 
-Not to be confused with collection sections, such as Primary and Secondary in the Skills & Powers collection. See above.
+Not to be confused with collection sections — e.g. Primary and Secondary in the Skills & Powers collection. See above.
 
 > Tom note: we are very likely to rename "collection sections" to Tiers, or possibly rename the "Section" object
 
@@ -268,23 +268,23 @@ Not to be confused with collection sections, such as Primary and Secondary in th
 
 *A named set of things an assignable comes with, free, at arrival.*
 
-Fields: a name and a price. The price is absolute, not a difference:
+Fields: a name and a price — priced absolutely, not as a difference:
 plain talons 0, razor-sharp 25. Its members each name exactly one thing
 from a deliberately narrow list: weapons, firing lines, wargear,
 subtypes, skills, rules, hiddens, collections, counters. Not profiles (a
-fighter cannot come with a fighter; that is what brings-a-model is for)
+fighter cannot come with a fighter — that is what brings-a-model is for)
 and not chosen kinds.
 
 Pointed at from two places: any assignable's own built-ins, and an
 option (razor-sharp talons are an option whose set holds the sharper
-claws). Materialised when the holder arrives (hired, founded, or bought),
-free, and "caused by" the holder, so removing the holder removes them
+claws). Materialised when the holder arrives — hired, founded, or bought
+— free, and "caused by" the holder, so removing the holder removes them
 too.
 
 A member that is a firing line names which of the set's weapons it
 belongs to, and is added from that gun's own line rather than from the
 general picker. A set that brings no such weapon can still hold the
-line. It then lands on whatever matching gun the acquirer already
+line — it then lands on whatever matching gun the acquirer already
 holds, which is how an option arms a weapon the built-ins bring.
 
 ### Offers a choice (an effect)
@@ -293,13 +293,13 @@ holds, which is how an option arms a weapon the built-ins bring.
 
 Fields:
 
-- the type it takes (exactly one: offering a choice of skill is not
+- the type it takes (exactly one — offering a choice of skill is not
 settled by choosing a power)
 - an optional collection section that narrows what a picker shows
 - a **label** ("skill tree 1") naming the choice line on the card and deciding which line it files into
-- **will be assigned to**: whether the chosen thing lands on the bearer or on the gang.
+- **will be assigned to** — whether the chosen thing lands on the bearer or on the gang.
 
-(A minor third path exists: the code making the choice may name the host explicitly, which beats both. This is how a gang-carried offer that each fighter settles individually lands on the fighter who was clicked.)
+(A minor third path exists: the code making the choice may name the host explicitly, which beats both — it is how a gang-carried offer that each fighter settles individually lands on the fighter who was clicked.)
 
 > Tom note: we probably want to extend these to support multiple different types
 
@@ -317,9 +317,9 @@ For an Outcast gang's archetype, picked by the leader and played by every model 
 
 *The append-only record of every purchase: what was asked, paid, and worth.*
 
-Fields on an entry: list price, discount, paid, Trade Points, **rating contribution** (pinned forever: the "rating" half of the price/rating split), reason (bought, free, granted, default, and so on), and which collection entry priced it.
+Fields on an entry: list price, discount, paid, Trade Points, **rating contribution** (pinned forever — the "rating" half of the price/rating split), reason (bought, free, granted, default, and so on), and which collection entry priced it.
 
-Append-only. An entry's events must fold back to the entry, and reconcile checks exactly that. Ratings and credits are never adjusted by differences. They are recomputed from this record and repinned. Rating sums the contributions of what models hold; the stash's assignments count in wealth instead.
+Append-only. An entry's events must fold back to the entry, and reconcile checks exactly that. Ratings and credits are never adjusted by differences — they are recomputed from this record and repinned. Rating sums the contributions of what models hold; the stash's assignments count in wealth instead.
 
 ### Operation
 
@@ -333,13 +333,13 @@ An actual change. Assign, buy, hire, choose, remove, move: each writes the assig
 
 Fields: name, gang type, founding date, starting credits (blank means unlimited, and the Refund control is hidden), credits, colour.
 
-Its rating is what its models are worth, recomputed from the ledger and pinned. The stash is never included. Its wealth is rating plus credits plus the stash's own pinned worth.
+Its rating is what its models are worth, recomputed from the ledger and pinned — never the stash. Its wealth is rating plus credits plus the stash's own pinned worth.
 
 ### Miniature
 
 *One model on the roster; the class name avoids Django's "Model"*
 
-A model is a membership assignment naming a profile, plus everything attached to it. Every user-facing word is "model". The Python class name is the only place "miniature" appears.
+A model is a membership assignment naming a profile, plus everything attached to it. Every user-facing word is "model" — the Python class name is the only place "miniature" appears.
 
 ### Stash
 

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -1,7 +1,7 @@
 # Recipes
 
 How to build specific rulebook setups out of the library's pieces. Each
-recipe is a set of steps to follow in the authoring pages: the things to
+recipe is a set of steps to follow in the authoring pages — the things to
 create, and how to join them. A recipe is added here once the way to
 author its setup is settled, so this page grows with the library.
 
@@ -19,11 +19,11 @@ chosen pickable.
 Use a **slot type** for this gang-level choice. Follow the same six steps
 as a Gang Legacy, and assign the slot to the gang.
 
-1. Create a **slot type** named "Variant": the slot type is the thing
-   being chosen. Give it a plural. Turn *allows repeats* off. Everything
-   below is built on its page.
-2. Add a **pickable** for each corruption: "Genestealer Cult Corrupted",
-   "Chaos Corrupted", "Malstrain Corrupted".
+1. Create a **slot type** named "Variant" — what is being chosen — and
+   give it a plural. Turn *allows repeats* off. Everything below is
+   built on its page.
+2. Add a **pickable** for each corruption — "Genestealer Cult
+   Corrupted", "Chaos Corrupted", "Malstrain Corrupted".
 3. Add a **picklist** named "Variants" containing those three.
 4. Add a **slot** labelled "Variant", taking 0–1 (most gangs leave it
    empty), assigned to the gang.
@@ -44,7 +44,7 @@ Each effect is a modifier carried by the corruption's pickable: *gives*,
 items. Pickables are chosen rather than bought or hired, so built-in
 items would never be assigned.
 
-**New fighters to hire.** Create the profiles: Aberrant, Abominant,
+**New fighters to hire.** Create the profiles — Aberrant, Abominant,
 Helot Cult Witch, Chaos Spawn, Brood Scum. Create a collection listing
 them at their prices. On the pickable: targets the gang, *gives* the
 collection.
@@ -95,8 +95,8 @@ the sheet shows where they have gone past the book.
 
 **Losing the gang's own special rules.** This needs a small change to
 each gang type, made once, and then one step per corruption. On each
-gang type, create a **hidden** item named for it, such as "Escher gang
-rules", and put it in the gang type's built-in items. Move the house's
+gang type, create a **hidden** item named for it — "Escher gang
+rules" — and put it in the gang type's built-in items. Move the house's
 special rules onto it: one *gives* modifier per rule, targeting the
 gang. What the gang holds reaches its fighters, so a rule that improves
 their weapons or changes a characteristic works from there. Only a rule
@@ -120,17 +120,16 @@ A gang legacy is a choice a fighter makes once. Each pickable opens an
 equipment list to the fighter who picks it. The same six steps build any
 slot type. This one is written out because it uses all of them.
 
-1. Create a **slot type** named "Gang Legacy": the slot type is the
-   thing being chosen. Give it a plural, so a page can name several of
-   them. Set *allows repeats* to [whether one gang may hold the same
+1. Create a **slot type** named "Gang Legacy" — what is being chosen —
+   and give it a plural, so a page can name several of them. Set *allows repeats* to [whether one gang may hold the same
    legacy twice]. Everything below is built on its page.
 2. Add a **pickable** for each legacy: [the legacies the rules give].
 3. On each pickable's page, attach a **modifier**: targets the model,
    *gives* that legacy's equipment list. The list is an ordinary
    collection at its own prices, so a fighter who picks a legacy buys
-   from that list at that list's prices. [Anything else a legacy grants,
-   such as something scoped to a rank or something reaching the gang,
-   is a further modifier on the same pickable.]
+   from that list at that list's prices. [Anything else a legacy grants
+   — something scoped to a rank, something reaching the gang — is a
+   further modifier on the same pickable.]
 4. Add a **picklist** containing the pickables a fighter may pick from.
    Add more than one where [different fighters are offered different
    legacies]. A slot type may have as many picklists as it needs, and a
@@ -156,7 +155,7 @@ in and name a **starting pick** beside it. The player can change it
 afterwards the way they would change any pick.
 
 Two things this build cannot do yet. A gang cannot be given something
-because one of its fighters holds a legacy: a condition checks what a
+because one of its fighters holds a legacy — a condition checks what a
 model has, never what any model in the gang has. And a picklist cannot
 be limited to a particular moment. It is open whenever the fighter's
 equip page is.
@@ -168,7 +167,7 @@ without one: the Goliath equipment list has "Heavy rock saw (Forge-born
 only)", while the Genestealer Cult and Corpse Grinder lists offer the
 same saw to anyone. The restriction belongs to that one list's entry.
 
-1. List the item on the collection as usual: one entry, at the price
+1. List the item on the collection as usual — one entry, at the price
    the list charges.
 2. On that entry, set what the book names in the bracket: *offered to
    fighter entries* for "(Forge-born only)", or *offered to subtypes*
@@ -183,7 +182,7 @@ A restriction can go in three places:
 
 - **On the entry**, as above, when one list restricts one of its items.
 - **On the item**, when the restriction is true wherever the item is
-  listed: a saddle that only a mounted model can use, however many
+  listed — a saddle that only a mounted model can use, however many
   lists offer it. Set *usable by* on the item's own page, and every
   list that offers the item applies it.
 - **A whole list of its own**, when the book gives a rank its own list
@@ -198,15 +197,15 @@ seven characteristics, and a result of 1, 2–5 or 6 decides the number.
 The player rolls at the table and records the result as hire options.
 
 1. Give the profile the middle band (2–5) as its printed statline,
-   leaving the columns the book does not roll blank. The card shows a
+   leaving the columns the book does not roll blank — the card shows a
    dash for those.
-2. For each rolled characteristic, add an **option group** named for it,
-   such as "Warped Monstrosity: Strength", with three options: *rolled
-   2–5*, which changes nothing (the printed number stands), *rolled 1*,
-   and *rolled 6*.
-3. For the 1 and 6 options, create a **hidden** item, such as "Strength
-   rolled 6", carrying a modifier that targets the model and *changes a
-   stat*, set to that band's number. Put it in that option's set.
+2. For each rolled characteristic, add an **option group** named for it —
+   "Warped Monstrosity: Strength" — with three options: *rolled 2–5*,
+   which changes nothing (the printed number stands), *rolled 1*, and
+   *rolled 6*.
+3. For the 1 and 6 options, create a **hidden** item — "Strength rolled
+   6" — carrying a modifier that targets the model and *changes a stat*,
+   set to that band's number. Put it in that option's set.
 
 At hire the player picks what they rolled, group by group. Each changed
 cell on the card names what changed it. Nothing is enforced: a group
@@ -219,11 +218,11 @@ Wyrd are one build: a model has one power of the player's choice from a
 named family, and may select more powers from that family as if they
 were Primary skills.
 
-1. Create a **category** for the family, such as "Psychoteric Whispers",
-   under the Wyrd Powers section, and file every power in the family
+1. Create a **category** for the family — "Psychoteric Whispers" — under
+   the Wyrd Powers section, and file every power in the family
    there. A power with no category falls into the collection's default
    section, which no Primary offer can reach.
-2. Have one **collection**, "Skills & Powers", whose selectors include
+2. Have one **collection** — "Skills & Powers" — whose selectors include
    *every skill* and *every power*. Give it the sections the grades are
    written in terms of: Primary, Secondary, and one marked default for
    everything not placed. Using selectors rather than entries means a
@@ -232,8 +231,8 @@ were Primary skills.
    *puts a category into a section*, placing the family in **Primary
    (Skills & Powers)**; and *offers a choice* of **power** from
    **Primary (Skills & Powers)**. The carrier is a **rule** for
-   something a fighter entry always has (put the rule in the entry's
-   built-in items), a **subtype** for something bought or granted, or
+   something a fighter entry always has — put the rule in the entry's
+   built-in items — a **subtype** for something bought or granted, or
    the **fighter entry** itself.
 4. Leave the offer's label blank. A blank label reads "Primary power"
    and puts the choice in the card's **Powers** line, beside the powers
@@ -243,7 +242,7 @@ were Primary skills.
 The two modifiers work together, and placement comes first: the offer is
 limited to whatever is Primary *for this model*, and the placement is
 what puts the family there. **An offer with no placement behind it is a
-choice with no options.** The player clicks Choose and lands on an empty
+choice with no options** — the player clicks Choose and lands on an empty
 page. The reverse is a valid setup rather than a mistake: place the
 family and offer nothing, and the model may select powers from it at any
 time but is not given a first one.
@@ -262,7 +261,7 @@ rolls. The player rolls at the table and adds the result they rolled.
 
 1. On **Foundations**, create the **lasting effect tables**. One click
    creates all four tables in full: a slot type each with *allows
-   repeats* on (a second Eye Injury is a second Eye Injury), every
+   repeats* on — a second Eye Injury is a second Eye Injury — every
    result at its band, and a standing choice each. Each table's own
    page shows every roll covered. (Several results appear on more than
    one table at the same rolls. A pack has one pickable per name, so
@@ -273,9 +272,9 @@ rolls. The player rolls at the table and adds the result they rolled.
    damage results that worsen a characteristic, attach a **modifier**:
    targets the model, worsens that characteristic by one. On each of
    the ten Spyrer glitch results (rolls 51 to 64), attach two: one that
-   worsens the characteristic, and one that *moves a counter*, the
+   worsens the characteristic, and one that *moves a counter* — the
    Glitch Count, up by one. A result that changes no number needs
-   nothing. The card shows that the model has it, and the rest is
+   nothing — the card shows that the model has it, and the rest is
    played at the table.
 3. Put each table's choice on the gang types rather than on the
    entries. Create a **modifier**: targets *all models in the gang*,
@@ -283,7 +282,7 @@ rolls. The player rolls at the table and adds the result they rolled.
    Injury choice. Create a matching one for vehicles and Lasting Damage.
    Then on the gang types page, tick every gang type and attach both.
    Every fighter in every gang of those types has its empty line from
-   that moment, including gangs founded long ago, because nothing is
+   that moment — gangs founded long ago included, because nothing is
    written on any model. A gang type created later needs the same two
    modifiers attached.
 4. Spyre Hunters are the exception. On that gang type, remove the
@@ -299,7 +298,7 @@ rolls. The player rolls at the table and adds the result they rolled.
    a **hidden** item named "Delegation" carrying two modifiers, both
    targeting *the model carrying it*: one *takes something away*, the
    Lasting Injury choice; the other *gives* the Delegation Lasting
-   Injuries choice. Then build it into each delegation entry: the
+   Injuries choice. Then build it into each delegation entry — the
    fighters under the Allies gang type. A delegation model's card then
    shows a Delegation Lasting Injuries line and never a Lasting Injuries
    line, in any gang, and every gang type's own modifiers stay as they

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -1,41 +1,41 @@
 # Recipes
 
 How to build specific rulebook setups out of the library's pieces. Each
-recipe is a set of steps to follow in the authoring pages — the things to
-create, and how to join them. A recipe is written here the day we settle
-how its setup is authored, so this page grows with the library.
+recipe is a set of steps to follow in the authoring pages: the things to
+create, and how to join them. A recipe is added here once the way to
+author its setup is settled, so this page grows with the library.
 
-Where a step is not yet possible, it says so plainly.
+Where a step is not yet possible, the recipe says so.
 
 ## Corrupted gangs
 
 Genestealer Cult, Chaos and Malstrain corruption are one build with
-different contents: a corruption is a choice the gang makes once, and
-all of its effects come from modifiers attached to the chosen pickable.
+different contents. A corruption is a choice the player makes once for
+the gang, and all of its effects come from modifiers attached to the
+chosen pickable.
 
 ### The choice
 
 Use a **slot type** for this gang-level choice. Follow the same six steps
-as a Gang Legacy, assigning the pick to the gang.
+as a Gang Legacy, and assign the slot to the gang.
 
-1. Create a **slot type** named "Variant" — what is being chosen — and
-   give it a plural. Turn *allows repeats* off. Everything below is
-   built on its page.
-2. Add a **pickable** for each corruption — "Genestealer Cult
-   Corrupted", "Chaos Corrupted", "Malstrain Corrupted".
-3. Add a **picklist** named "Variants" holding those three.
+1. Create a **slot type** named "Variant": the slot type is the thing
+   being chosen. Give it a plural. Turn *allows repeats* off. Everything
+   below is built on its page.
+2. Add a **pickable** for each corruption: "Genestealer Cult Corrupted",
+   "Chaos Corrupted", "Malstrain Corrupted".
+3. Add a **picklist** named "Variants" containing those three.
 4. Add a **slot** labelled "Variant", taking 0–1 (most gangs leave it
    empty), assigned to the gang.
-5. Create a **hidden** if the gang type should carry the question
-   without drawing a line of its own, or skip this and attach the grant
-   to the gang type directly.
-6. On that hidden or gang type: targets the gang, *gives* the Variant
-   slot.
+5. Create a **hidden** item if the gang type should carry the choice
+   without showing a line of its own on the card. Otherwise skip this
+   step and attach the modifier to the gang type directly.
+6. On that hidden item or gang type, create a **modifier**: targets the
+   gang, *gives* the Variant slot.
 
-Every gang of those types now shows an open "Variant" question on its
-sheet. Most players never make that choice. Players who use it make one
-pick. The chosen pickable's modifiers provide the effects described
-below.
+Every gang of those types now shows an open "Variant" choice on its
+sheet. Most players leave it empty. Players who use it make one pick,
+and the chosen pickable's modifiers provide the effects described below.
 
 ### What a corruption grants
 
@@ -44,22 +44,23 @@ Each effect is a modifier carried by the corruption's pickable: *gives*,
 items. Pickables are chosen rather than bought or hired, so built-in
 items would never be assigned.
 
-**New fighters to hire.** Create the profiles — Aberrant, Abominant,
+**New fighters to hire.** Create the profiles: Aberrant, Abominant,
 Helot Cult Witch, Chaos Spawn, Brood Scum. Create a collection listing
 them at their prices. On the pickable: targets the gang, *gives* the
 collection.
 
-Once a gang carries that collection, its hire page grows a section named
-after the collection, holding exactly those fighters at exactly the
-prices the collection states — a price written on an entry is what the
-row asks and what the gang is charged. A gang without the corruption
-sees no such section.
+Once a gang carries that collection, its hire page shows a section named
+after the collection. The section lists exactly those fighters at the
+prices the collection states: the price written on an entry is the price
+the gang is charged. A gang without the corruption does not see that
+section.
 
 **The Wyrd upgrade.** Create a "Wyrd" **subtype** carrying two modifiers:
-*offers a choice* of power from the right Wyrd Powers list, and *puts the
-Wyrd Powers category into* the Primary section. List the subtype in the
-corruption's collection at 35 credits. A player buys it for their Leader
-whenever suits — at hire or later; the book's timing is theirs to honour.
+*offers a choice* of power from the right Wyrd Powers list, and *puts a
+category into a section*, placing Wyrd Powers in the Primary section.
+List the subtype in the corruption's collection at 35 credits. A player
+can buy it for their Leader at hire or later. The app does not enforce
+when the book allows the purchase.
 
 **Familiars.** Create the familiar as **wargear**, usable by Leaders and
 Champions, and put it in a collection. On the pickable: targets models
@@ -76,237 +77,239 @@ the gang. On the Chaos Corrupted pickable: targets the gang, *gives*
 that slot. Attach each god's effects to that god's pickable.
 
 **Post-cycle actions (Chaos).** Create each action as a **rule**. On the
-pickable: targets the gang, *gives* the rule. They print on the gang's
+pickable: targets the gang, *gives* the rule. They appear on the gang's
 card.
 
 **Counts and bans.** Each is one modifier on the pickable. For "0–2
 Aberrants": targets the gang, *notes a limit*, set to 2, naming the
-Aberrant profile — the gang's sheet says nothing until a third one is
-hired, and then it says the roster is over. For "no Brutes, Hangers-on or
-Pets from your own list": the same again with the limit set to nought,
-naming the subtype, and the sheet reads "none allowed" — nought is how a
-ban is written. For "up to one Familiar each": target models that are
-Leaders or Champions, name the familiar and set the limit to 1; that one is
-counted per model and its note lands on the fighter's own card, which is
-what "each" means. None of the three refuses anything. A player hires and
-buys what they like, and the sheet says where they have gone past the book.
+Aberrant profile. The gang's sheet shows nothing until a third Aberrant
+is hired, and then shows that the roster is over the limit. For "no
+Brutes, Hangers-on or Pets from your own list": the same again, naming
+the subtype, with the limit set to 0. The sheet then reads "none
+allowed". A limit of 0 is how a ban is written. For "up to one Familiar
+each": targets models that are Leaders or Champions, naming the familiar,
+with the limit set to 1. That limit is counted per model, and its note
+appears on the fighter's own card, which is what "each" means. None of
+the three blocks anything. A player can hire and buy what they like, and
+the sheet shows where they have gone past the book.
 
-**Losing the gang's own special rules.** This wants a small change to the
-gang types themselves, once, and then it is one step per corruption. On
-each gang type, create a **hidden** item named for it — "Escher gang
-rules" — and put it in the gang type's built-in items. Move the house's
-special rules onto it: one *gives* modifier per rule, aimed at the gang.
-That is the whole of it — what the gang holds reaches its fighters, so a
-rule that improves their weapons or shifts a characteristic does so from
-there, and only a rule you want printed on each fighter's card as well
-needs a second *gives* aimed at the model. The rules are then granted
-rather than built in, so there is a single thing standing behind the lot.
-On each corruption's pickable, add *takes something away* naming that
-hidden item: aimed at the gang, which is where the item sits, and aimed at
-the model too if the fighters' own cards were given rules of their own.
-Everything the hidden item was handing out goes with it, and drop the
-corruption and it all comes back. Starting Skills and Skill Access live on
-the fighter entries, so they are untouched either way.
+**Losing the gang's own special rules.** This needs a small change to
+each gang type, made once, and then one step per corruption. On each
+gang type, create a **hidden** item named for it, such as "Escher gang
+rules", and put it in the gang type's built-in items. Move the house's
+special rules onto it: one *gives* modifier per rule, targeting the
+gang. What the gang holds reaches its fighters, so a rule that improves
+their weapons or changes a characteristic works from there. Only a rule
+you also want printed on each fighter's card needs a second *gives*
+targeting the model. The rules are then granted rather than built in, so
+one item stands behind all of them. On each corruption's pickable, add
+*takes something away* naming that hidden item: targeting the gang,
+which is where the item sits, and targeting the model too if the
+fighters' cards were given rules of their own. Everything the hidden
+item granted goes with it. Remove the corruption and it all comes back.
+Starting Skills and Skill Access live on the fighter entries, so they
+are not affected either way.
 
 ## A Gang Legacy
 
-> Draft, for review. The shape below is the authoring one; everything in
-> square brackets is a fact about the rules rather than about the app,
-> and is still to be filled in.
+> Draft, for review. The steps below are the authoring steps. Everything
+> in square brackets is a fact about the rules rather than about the
+> app, and is still to be filled in.
 
-A gang legacy is a choice a fighter makes once, each pickable opening an
-equipment list to whoever picks it. The same six steps build any slot
-type; this one is worth writing down because it uses all of them.
+A gang legacy is a choice a fighter makes once. Each pickable opens an
+equipment list to the fighter who picks it. The same six steps build any
+slot type. This one is written out because it uses all of them.
 
-1. Create a **slot type** named "Gang Legacy" — what is being chosen —
-   and give it a plural, so a page can say several of them. Set *allows
-   repeats* to [whether one gang may hold the same legacy twice].
-   Everything below is built on its page.
+1. Create a **slot type** named "Gang Legacy": the slot type is the
+   thing being chosen. Give it a plural, so a page can name several of
+   them. Set *allows repeats* to [whether one gang may hold the same
+   legacy twice]. Everything below is built on its page.
 2. Add a **pickable** for each legacy: [the legacies the rules give].
 3. On each pickable's page, attach a **modifier**: targets the model,
    *gives* that legacy's equipment list. The list is an ordinary
    collection at its own prices, so a fighter who picks a legacy buys
-   from that list at that list's prices. [Anything else a legacy grants
-   — something scoped to a rank, something reaching the gang — is a
-   further modifier on the same pickable.]
-4. Add a **picklist** holding what a fighter may choose from. Add more
-   than one where [different fighters are offered different legacies]:
-   a slot type may have as many picklists as it needs, and a fighter is
-   offered exactly the one their slot draws on.
+   from that list at that list's prices. [Anything else a legacy grants,
+   such as something scoped to a rank or something reaching the gang,
+   is a further modifier on the same pickable.]
+4. Add a **picklist** containing the pickables a fighter may pick from.
+   Add more than one where [different fighters are offered different
+   legacies]. A slot type may have as many picklists as it needs, and a
+   fighter is offered only the one their slot uses.
 5. Add a **slot** per picklist, labelled "Gang Legacy", taking [how many
-   picks], assigned to [the bearer — or the gang, where the pick is the
-   gang's and is broadcast to every member, whoever was asked].
+   picks], assigned to [the bearer, or the gang where the pick belongs
+   to the gang and applies to every member].
 6. Build the matching slot into each fighter entry that may take one.
-   An entry with no legacy carries no slot at all, and its card asks
-   nothing.
+   An entry with no legacy carries no slot, and its card shows no Gang
+   Legacy line.
 
 A fighter hired from an entry carrying the slot arrives with an open
-"Gang Legacy" row on their card. Clicking it offers that picklist;
-picking one opens the legacy's equipment list on their equip page and
-changes nothing else. The pick is free and adds nothing to the gang's
-rating.
+"Gang Legacy" line on their card. Clicking it shows that picklist.
+Picking a legacy opens the legacy's equipment list on the fighter's
+equip page and changes nothing else. The pick is free and adds nothing
+to the gang's rating.
 
-A picklist with one pickable on it is still a choice: the row stays open
-until the player picks, and nothing is written for them.
+A picklist with one pickable is still a choice: the line stays open
+until the player picks, and nothing is picked for them.
 
-To have an entry arrive with its legacy already settled, build the slot
-in and name a **starting pick** beside it. The player changes it
-afterwards the way they would change any choice.
+To have an entry arrive with its legacy already picked, build the slot
+in and name a **starting pick** beside it. The player can change it
+afterwards the way they would change any pick.
 
 Two things this build cannot do yet. A gang cannot be given something
-for one of its fighters holding a legacy — a condition reads what a
-model has, never what anyone in the gang has. And a picklist cannot say
-that it is only for a particular moment; it is open whenever the
-fighter's equip page is.
+because one of its fighters holds a legacy: a condition checks what a
+model has, never what any model in the gang has. And a picklist cannot
+be limited to a particular moment. It is open whenever the fighter's
+equip page is.
 
 ## An item one list restricts
 
-Some lists print a restriction beside a line that other lists print
-plainly: the Goliath equipment list's "Heavy rock saw (Forge-born only)",
-where the Genestealer Cult and Corpse Grinder lists offer the same saw to
-anyone. The restriction belongs to that one list's offer.
+Some lists print a restriction beside an item that other lists print
+without one: the Goliath equipment list has "Heavy rock saw (Forge-born
+only)", while the Genestealer Cult and Corpse Grinder lists offer the
+same saw to anyone. The restriction belongs to that one list's entry.
 
-1. List the item on the collection as usual — one entry, at whatever
-   price the list charges.
-2. On that entry, name what the book names in the bracket: *offered to
-   fighter entries* for "(Forge-born only)", *offered to subtypes* for a
-   line the list offers only to Leaders and Champions. Leave it blank on
-   every other list that offers the item.
+1. List the item on the collection as usual: one entry, at the price
+   the list charges.
+2. On that entry, set what the book names in the bracket: *offered to
+   fighter entries* for "(Forge-born only)", or *offered to subtypes*
+   for an item the list offers only to Leaders and Champions. Leave both
+   blank on every other list that offers the item.
 
-The saw still shows on the list for everyone, marked for the fighters the
-list does not offer it to, and an owner may buy it for them anyway.
-Nothing is refused — the list says.
+The saw still shows on the list for everyone. It is marked for the
+fighters the list does not offer it to, and an owner can still buy it
+for them. Nothing is blocked: the list shows the restriction.
 
-Three places a restriction can go, and which one to reach for:
+A restriction can go in three places:
 
-- **On the entry**, as above: one list narrows one of its lines.
-- **On the item**, for what is true of it wherever it is listed — a
-  saddle no model without a mount can use, however many lists offer it.
-  The item's own page asks the same question as *usable by*, and every
-  list that offers the item honours the answer.
-- **A whole list of its own**, for when the book gives a rank its own
-  list rather than restricting lines one at a time. Create the
-  collection, and give it to those models with a modifier; every line in
-  it is then theirs alone, with nothing to narrow.
+- **On the entry**, as above, when one list restricts one of its items.
+- **On the item**, when the restriction is true wherever the item is
+  listed: a saddle that only a mounted model can use, however many
+  lists offer it. Set *usable by* on the item's own page, and every
+  list that offers the item applies it.
+- **A whole list of its own**, when the book gives a rank its own list
+  rather than restricting items one at a time. Create the collection
+  and give it to those models with a modifier. Every item in it is then
+  offered only to them, with nothing to restrict.
 
 ## A model with a rolled statline
 
 The Chaos Spawn's Warped Monstrosity: the book rolls a D6 for each of
-seven characteristics, and 1, 2–5 or 6 decides the number. The dice
-happen at the table; the roster takes the result as hire options.
+seven characteristics, and a result of 1, 2–5 or 6 decides the number.
+The player rolls at the table and records the result as hire options.
 
-1. Give the profile the middle band (2–5) as its own printed statline,
-   leaving the unrolled columns blank — the card shows a dash.
-2. For each rolled characteristic, add an **option group** named for it —
-   "Warped Monstrosity: Strength" — with three options: *rolled 2–5*,
-   which adds nothing (the printed number stands), and *rolled 1* and
-   *rolled 6*.
-3. For the 1 and 6 options, create a **hidden** item — "Strength rolled
-   6" — carrying a modifier that targets the model and *changes a stat*,
-   set to the rolled band's number. Put it in that option's set.
+1. Give the profile the middle band (2–5) as its printed statline,
+   leaving the columns the book does not roll blank. The card shows a
+   dash for those.
+2. For each rolled characteristic, add an **option group** named for it,
+   such as "Warped Monstrosity: Strength", with three options: *rolled
+   2–5*, which changes nothing (the printed number stands), *rolled 1*,
+   and *rolled 6*.
+3. For the 1 and 6 options, create a **hidden** item, such as "Strength
+   rolled 6", carrying a modifier that targets the model and *changes a
+   stat*, set to that band's number. Put it in that option's set.
 
-At hire the player picks what they rolled, group by group, and each
-shifted cell on the card names what set it. Nothing is enforced: a group
-left on 2–5 keeps the printed number, and the card just says.
+At hire the player picks what they rolled, group by group. Each changed
+cell on the card names what changed it. Nothing is enforced: a group
+left on 2–5 keeps the printed number, and the card shows the result.
 
 ## One power from a family, as a Primary pick
 
-The Master of Shadow's Master of Whispers, the Psyrender, a bought Wyrd —
-one build: a model knows one power of the player's choice from a named
-family, and may select more of that family as if they were Primary skills.
+The Master of Shadow's Master of Whispers, the Psyrender and a bought
+Wyrd are one build: a model has one power of the player's choice from a
+named family, and may select more powers from that family as if they
+were Primary skills.
 
-1. Create a **category** for the family — "Psychoteric Whispers" — under
-   the Wyrd Powers section, and file every power in the family there. A
-   power left with no category falls into the collection's default
-   section, where no Primary offer can reach it.
-2. Have one **collection** — "Skills & Powers" — whose selectors sweep
-   *every skill* and *every power*, with the sections every grade is
+1. Create a **category** for the family, such as "Psychoteric Whispers",
+   under the Wyrd Powers section, and file every power in the family
+   there. A power with no category falls into the collection's default
+   section, which no Primary offer can reach.
+2. Have one **collection**, "Skills & Powers", whose selectors include
+   *every skill* and *every power*. Give it the sections the grades are
    written in terms of: Primary, Secondary, and one marked default for
-   everything unplaced. Sweeping rather than listing means a power
-   authored later joins the surface with no entry to write.
+   everything not placed. Using selectors rather than entries means a
+   power authored later joins the collection with no entry to write.
 3. On the carrier, create two **modifiers**, both targeting the model:
-   *puts the category into a section*, the family into **Primary (Skills
-   & Powers)**; and *offers a choice* of **power** from **Primary (Skills
-   & Powers)**. The carrier is a **rule** for something a fighter entry
-   always has — put the rule in the entry's built-in items — a
-   **subtype** for something bought or granted, or the **fighter entry**
-   itself.
-4. Leave the offer's label blank. Blank derives "Primary power" and files
-   the question in the card's **Powers** row, beside the powers the model
-   already knows. Any other wording gives the question a row of its own,
-   headed by exactly what was written.
+   *puts a category into a section*, placing the family in **Primary
+   (Skills & Powers)**; and *offers a choice* of **power** from
+   **Primary (Skills & Powers)**. The carrier is a **rule** for
+   something a fighter entry always has (put the rule in the entry's
+   built-in items), a **subtype** for something bought or granted, or
+   the **fighter entry** itself.
+4. Leave the offer's label blank. A blank label reads "Primary power"
+   and puts the choice in the card's **Powers** line, beside the powers
+   the model already has. Any other label gives the choice a line of its
+   own, headed by that label.
 
-The two modifiers are one thing, and the order to think of them in is
-placement first: the offer narrows to whatever is Primary *for this
-model*, and the placement is what puts the family there. **An offer with
-no placement behind it is a question with nothing on it** — the player
-clicks Choose and lands on an empty page. The reverse is a real setup
-rather than a mistake: place the family and offer nothing, and the model
-may select powers from it whenever they like, but was never handed the
-founding one.
+The two modifiers work together, and placement comes first: the offer is
+limited to whatever is Primary *for this model*, and the placement is
+what puts the family there. **An offer with no placement behind it is a
+choice with no options.** The player clicks Choose and lands on an empty
+page. The reverse is a valid setup rather than a mistake: place the
+family and offer nothing, and the model may select powers from it at any
+time but is not given a first one.
 
 ## The Lasting Injury and Lasting Damage tables
 
 > Draft, for review.
 
-A model taken out of action rolls on a table and keeps the result for
-good. There are four tables: the book's Lasting Injury and Lasting
-Damage tables (D66), the Spyrer Hunting Rig Glitches a Spyrer's suit
-takes instead of injuries (D66), and the delegation injuries an
-alliance's models roll (D6). Each is a slot type of its own, so a
-fighter can never be handed vehicle damage — and the app never rolls:
-the dice are the table's, and a player adds the result they rolled.
+A model taken out of action rolls on a table and keeps the result
+permanently. There are four tables: the book's Lasting Injury and
+Lasting Damage tables (D66), the Spyrer Hunting Rig Glitches table a
+Spyrer's suit rolls on instead of injuries (D66), and the delegation
+injuries table an alliance's models roll on (D6). Each is a slot type of
+its own, so a fighter can never be given vehicle damage. The app never
+rolls. The player rolls at the table and adds the result they rolled.
 
-1. On **Foundations**, create the **lasting effect tables**. One press
-   makes all four tables whole: a slot type each with *allows repeats*
-   set — a second Eye Injury is a second Eye Injury — every result at
-   its band, and a standing choice each. Each table's own page shows
-   every roll covered. (Several results sit on more than one table at
-   the same rolls; a pack holds one pickable per name, so the later
-   twins arrive with a qualifier, which players never see.)
+1. On **Foundations**, create the **lasting effect tables**. One click
+   creates all four tables in full: a slot type each with *allows
+   repeats* on (a second Eye Injury is a second Eye Injury), every
+   result at its band, and a standing choice each. Each table's own
+   page shows every roll covered. (Several results appear on more than
+   one table at the same rolls. A pack has one pickable per name, so
+   the later copies are created with a qualifier, which players never
+   see.)
 2. Standard content carries names and numbers only, so finish the
    results that change a number by hand. On each of the ten injury and
-   damage results that worsen a characteristic, attach a **modifier** —
-   targets the model, worsens that characteristic by one. On each of the
-   ten Spyrer glitch results (rolls 51 to 64), attach two: one that
-   worsens the characteristic, and one that *moves a counter* — the
+   damage results that worsen a characteristic, attach a **modifier**:
+   targets the model, worsens that characteristic by one. On each of
+   the ten Spyrer glitch results (rolls 51 to 64), attach two: one that
+   worsens the characteristic, and one that *moves a counter*, the
    Glitch Count, up by one. A result that changes no number needs
-   nothing — the card says the model has it, and the rest is played at
-   the table.
+   nothing. The card shows that the model has it, and the rest is
+   played at the table.
 3. Put each table's choice on the gang types rather than on the
-   entries. Create a **modifier**: reaches *all models in the gang*,
+   entries. Create a **modifier**: targets *all models in the gang*,
    narrowed to those that *are a Fighter*, and *gives* the Lasting
-   Injury choice. Create its twin for vehicles and Lasting Damage. Then
-   on the gang types page tick every gang type and attach each one.
-   Every fighter in every gang of those types has its empty row from
-   that moment — gangs founded long ago included, because nothing is
+   Injury choice. Create a matching one for vehicles and Lasting Damage.
+   Then on the gang types page, tick every gang type and attach both.
+   Every fighter in every gang of those types has its empty line from
+   that moment, including gangs founded long ago, because nothing is
    written on any model. A gang type created later needs the same two
-   attachments.
-4. Spyre Hunters are the exception. On that gang type, take the
-   fighters' Lasting Injury modifier off and attach two in its place,
-   both reaching *all models in the gang* that *are a Fighter*: one
+   modifiers attached.
+4. Spyre Hunters are the exception. On that gang type, remove the
+   fighters' Lasting Injury modifier and attach two in its place, both
+   targeting *all models in the gang* that *are a Fighter*: one
    narrowed to models that have the **Spyrer** subtype, giving the
    Spyrer Hunting Rig Glitches choice; the other narrowed to models
    that do *not* have it, giving Lasting Injury as before. A Spyrer's
-   card then asks under Hunting Rig Glitches and never under Lasting
-   Injuries.
-5. A delegation's models roll on the D6 table instead, and the swap
-   rides the models themselves rather than the gang types. Create a
-   **hidden** item named "Delegation" carrying two modifiers, both
-   reaching *the model carrying it*: one *takes away* the Lasting
-   Injury choice, the other *gives* the Delegation Lasting Injuries
-   choice. Then build it into each delegation entry — the fighters
-   under the Allies gang type. A delegation model's card asks under
-   Delegation Lasting Injuries and never under Lasting Injuries, in any
-   gang, while every gang type's own grants stay as they are. Anything
-   else the alliance rules say of a delegation belongs on the same
-   hidden item; an entry added to the Allies list later needs it built
-   in too.
+   card then shows a Hunting Rig Glitches line and never a Lasting
+   Injuries line.
+5. A delegation's models roll on the D6 table instead, and the swap is
+   made on the models themselves rather than on the gang types. Create
+   a **hidden** item named "Delegation" carrying two modifiers, both
+   targeting *the model carrying it*: one *takes something away*, the
+   Lasting Injury choice; the other *gives* the Delegation Lasting
+   Injuries choice. Then build it into each delegation entry: the
+   fighters under the Allies gang type. A delegation model's card then
+   shows a Delegation Lasting Injuries line and never a Lasting Injuries
+   line, in any gang, and every gang type's own modifiers stay as they
+   are. Anything else the alliance rules give a delegation belongs on
+   the same hidden item. An entry added to the Allies list later needs
+   it built in too.
 
-Taking one of those modifiers off a gang type takes the row off every
-card at once, and leaves what players had already picked where it is,
-as plain lines they can remove.
+Removing one of those modifiers from a gang type removes the line from
+every card at once. Results players had already picked stay where they
+are, as plain lines the player can remove.
 
-The player's picker then lists the results in roll order with their
-bands leading, so someone who rolled 24 scans to "21-26" and adds Out
-Cold.
+The player's picker lists the results in roll order with the band first,
+so a player who rolled 24 finds "21-26" and adds Out Cold.


### PR DESCRIPTION
## Summary

A words-only pass over the three prose files in `n26/library/`, applying the microcopy rules (`.agents/skills/microcopy/SKILL.md`). Headings, step counts, facts and the UI labels the text quotes are unchanged, so every anchor and test still holds.

- `recipes.md` (rendered at `/n26/authoring/docs/recipes/`): personification removed (cards no longer "ask", sheets no longer "say", lists no longer "refuse"); "nought" is 0, "One press" is "One click"; dash-joined asides are full sentences; the lasting-tables recipe now quotes the composer label "Takes something away" rather than "takes away"; "choice" and "line" are used consistently for the card element.
- `concepts.md` (rendered at `/n26/authoring/docs/concepts/`): the same pass; also fixes a typo in summary point 4, replaces the regex joke in the Section entry, and uses "selector" (the field's name) where the text said "sweep". The Gang type and Hidden sections are left verbatim so #2439's insertion between them merges cleanly.
- `CLAUDE.md`: the same pass; also points at the current recipes URL (the old `/n26/authoring/recipes/` is a redirect).

## Test plan

- [x] `python scripts/check_microcopy.py` over both rendered docs reports nothing
- [x] `n26/tests/sandbox/test_authoring_views.py::TestTheDocumentation` (12 passed)
- [ ] Open `/n26/authoring/docs/recipes/` and `/n26/authoring/docs/concepts/` as staff and read one section of each cold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRzBagWabXzS7LQGxtc7nh
