### PR TITLE
ci: run the fresh-database migrate on a PR only when the migration graph changed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -149,14 +149,16 @@ jobs:
   # migration that made the table it had adopted, and only a database that
   # already had the table hid it.
   #
-  # Its own job rather than a step in `test` so a four-minute migrate does not
-  # sit in front of the test result.
+  # Its own job rather than a step in `test` so the migrate does not sit in
+  # front of the test result.
   #
-  # On a pull request the migrate only runs when the change touches the
-  # migration graph or the settings that list the apps in it: nothing else can
-  # break a from-scratch apply, and the migrate costs six minutes of Django
-  # re-rendering model state between 400-odd migrations. Every other event runs
-  # it unconditionally.
+  # On a pull request the migrate only runs when the change touches what a
+  # from-scratch apply depends on, as scripts/fresh_database_needed.py decides:
+  # migration files, an app's apps.py, the settings, the dependency lock, and
+  # the project modules the migrations import. Most of the migrate's time is
+  # Django re-rendering model state between migrations, which a pull request
+  # that touches none of those cannot change. Every other event runs it
+  # unconditionally.
   fresh-database:
     runs-on: ubuntu-latest
     services:
@@ -186,6 +188,9 @@ jobs:
 
       - name: Decide whether the migration graph changed
         id: graph
+        # Runs on the runner's python before the project environment exists;
+        # the script is standard library only. A failure in the script fails
+        # the step, so the check never skips the migrate by accident.
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -196,15 +201,14 @@ jobs:
             echo "not a pull request: migrating"
             exit 0
           fi
-          changed=$(git diff --name-only --no-renames "origin/$BASE_REF...HEAD" \
-            | grep -E '(^|/)migrations/[^/]+\.py$|^gyrinx/settings[A-Za-z_]*\.py$' || true)
+          changed=$(python3 scripts/fresh_database_needed.py "origin/$BASE_REF")
           if [ -n "$changed" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "migration graph changed:"
+            echo "the migration graph or something it depends on changed:"
             echo "$changed"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "no migration or settings change: skipping the migrate"
+            echo "nothing the migration graph depends on changed: skipping the migrate"
           fi
 
       - uses: ./.github/actions/python-env

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -151,6 +151,12 @@ jobs:
   #
   # Its own job rather than a step in `test` so a four-minute migrate does not
   # sit in front of the test result.
+  #
+  # On a pull request the migrate only runs when the change touches the
+  # migration graph or the settings that list the apps in it: nothing else can
+  # break a from-scratch apply, and the migrate costs six minutes of Django
+  # re-rendering model state between 400-odd migrations. Every other event runs
+  # it unconditionally.
   fresh-database:
     runs-on: ubuntu-latest
     services:
@@ -174,18 +180,47 @@ jobs:
       DB_CONFIG: '{"user":"postgres","password":"postgres"}'
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The migration-graph check diffs against the base branch.
+          fetch-depth: 0
+
+      - name: Decide whether the migration graph changed
+        id: graph
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "not a pull request: migrating"
+            exit 0
+          fi
+          changed=$(git diff --name-only --no-renames "origin/$BASE_REF...HEAD" \
+            | grep -E '(^|/)migrations/[^/]+\.py$|^gyrinx/settings[A-Za-z_]*\.py$' || true)
+          if [ -n "$changed" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "migration graph changed:"
+            echo "$changed"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "no migration or settings change: skipping the migrate"
+          fi
 
       - uses: ./.github/actions/python-env
+        if: steps.graph.outputs.run == 'true'
 
       # A database of its own, so the run starts from genuinely nothing rather
       # than from whatever the service image left in `postgres`.
       - name: Create an empty database
+        if: steps.graph.outputs.run == 'true'
         env:
           PGPASSWORD: postgres
         run: |
           psql -h localhost -U postgres -c 'CREATE DATABASE gyrinx_fresh;'
 
       - name: Migrate the empty database
+        if: steps.graph.outputs.run == 'true'
         timeout-minutes: 30
         run: |
           source .venv/bin/activate

--- a/gyrinx/tests/test_fresh_database_needed.py
+++ b/gyrinx/tests/test_fresh_database_needed.py
@@ -1,0 +1,73 @@
+"""The rule that decides whether a pull request needs the fresh-database
+migrate. See scripts/fresh_database_needed.py."""
+
+import pytest
+
+from scripts.fresh_database_needed import (
+    migration_imports,
+    module_path,
+    paths_needing_fresh_migrate,
+)
+
+pytestmark = pytest.mark.core
+
+IMPORTS = {
+    "n26/core/fields",
+    "n23/content/house_icons",
+    "n23/core/models/list",
+    "n23/content/models",
+}
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("n23/core/migrations/0207_x.py", True),
+        ("n26/library/migrations/__init__.py", True),
+        ("gyrinx/settings.py", True),
+        ("gyrinx/settings_dev.py", True),
+        ("gyrinx/settings/n26.py", True),
+        ("n26/library/apps.py", True),
+        ("uv.lock", True),
+        ("n26/core/fields.py", True),
+        ("n23/content/house_icons.py", True),
+        ("n23/core/models/list/fighter.py", True),
+        ("n23/core/models/__init__.py", True),
+        ("n23/content/models/skill.py", True),
+        ("n26/core/views.py", False),
+        ("pyproject.toml", False),
+        ("n26/core/fields_extra.py", False),
+        ("gyrinx/templates/cotton/btn.html", False),
+        ("docs/migrations/notes.md", False),
+        (".github/workflows/test.yaml", False),
+    ],
+)
+def test_which_changes_need_a_fresh_migrate(path, expected):
+    assert (paths_needing_fresh_migrate([path], IMPORTS) == [path]) is expected
+
+
+def test_matches_are_reported_in_order_and_others_dropped():
+    changed = [
+        "n26/core/views.py",
+        "n23/core/migrations/0207_x.py",
+        "README.md",
+        "n26/core/fields.py",
+    ]
+    assert paths_needing_fresh_migrate(changed, IMPORTS) == [
+        "n23/core/migrations/0207_x.py",
+        "n26/core/fields.py",
+    ]
+
+
+def test_module_path_treats_a_package_init_as_the_package():
+    assert module_path("n23/core/models/__init__.py") == "n23/core/models"
+    assert module_path("n23/core/models/crew.py") == "n23/core/models/crew"
+
+
+def test_the_real_migrations_import_project_modules():
+    imports = migration_imports()
+    assert "n26/core/fields" in imports
+    assert "n23/content/house_icons" in imports
+    assert paths_needing_fresh_migrate(["n26/core/fields.py"], imports) == [
+        "n26/core/fields.py"
+    ]

--- a/scripts/fresh_database_needed.py
+++ b/scripts/fresh_database_needed.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Say whether a change can break applying the migration graph from scratch.
+
+The fresh-database CI job migrates an empty database. On a pull request it
+only needs to when the change touches something that apply depends on:
+
+- a migration file; an app's apps.py, whose label every dependency names;
+  the settings that list the apps in the graph; the dependency lock, since a
+  Django upgrade can retire an operation an old migration still uses;
+- a project module that a migration imports (an icon table, a field type,
+  a model package a data migration reads through), or a package above one.
+
+Prints the matching paths, one per line, and nothing when there are none.
+Imports one level deep are read straight out of the migration files, so the
+set follows the migrations as they are written; what those modules import in
+turn is not followed.
+
+    scripts/fresh_database_needed.py            # against origin/main
+    scripts/fresh_database_needed.py origin/dev # against another base
+
+Runs on the system interpreter before the project's environment exists, so it
+uses the standard library only.
+"""
+
+import pathlib
+import re
+import subprocess  # nosec B404 — runs one fixed git command to list changed files
+import sys
+from collections.abc import Iterable
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+ALWAYS = (
+    re.compile(r"(^|/)migrations/[^/]+\.py$"),
+    re.compile(r"(^|/)apps\.py$"),
+    re.compile(r"^gyrinx/settings"),
+    re.compile(r"^uv\.lock$"),
+)
+
+PROJECT_IMPORT = re.compile(
+    r"^\s*(?:from|import)\s+((?:n23|n26|gyrinx)(?:\.[A-Za-z0-9_]+)*)", re.MULTILINE
+)
+
+
+def migration_imports(root: pathlib.Path = ROOT) -> set[str]:
+    """Project modules the migrations import, as repo-relative paths sans .py."""
+    found: set[str] = set()
+    for migration in root.glob("*/*/migrations/*.py"):
+        for module in PROJECT_IMPORT.findall(migration.read_text(encoding="utf-8")):
+            found.add(module.replace(".", "/"))
+    return found
+
+
+def module_path(changed_file: str) -> str:
+    path = pathlib.PurePosixPath(changed_file)
+    if path.name == "__init__.py":
+        return path.parent.as_posix()
+    return path.with_suffix("").as_posix()
+
+
+def touches_import(changed_file: str, imports: Iterable[str]) -> bool:
+    changed = module_path(changed_file)
+    for module in imports:
+        if changed == module or changed.startswith(module + "/"):
+            return True
+        if module.startswith(changed + "/"):
+            # A package whose __init__ runs when the module beneath it loads.
+            return True
+    return False
+
+
+def paths_needing_fresh_migrate(
+    changed_files: Iterable[str], imports: Iterable[str]
+) -> list[str]:
+    imports = list(imports)
+    matched = []
+    for path in changed_files:
+        if any(pattern.search(path) for pattern in ALWAYS):
+            matched.append(path)
+        elif path.endswith(".py") and touches_import(path, imports):
+            matched.append(path)
+    return matched
+
+
+def changed_files_against(base: str) -> list[str]:
+    out = subprocess.run(  # nosec B607 — fixed argv; git resolved from PATH like every repo tool
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "--diff-filter=AMD",
+            f"{base}...HEAD",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    ).stdout
+    return [line for line in out.splitlines() if line]
+
+
+def main(argv: list[str]) -> int:
+    base = argv[1] if len(argv) > 1 else "origin/main"
+    changed = changed_files_against(base)
+    for path in paths_needing_fresh_migrate(changed, migration_imports()):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

After the core-suite split, `fresh-database` became the slowest required check on a pull request at about 6.5 minutes, against 2.5 to 5 minutes for the `test` job. Almost all of it is `manage migrate` applying 408 migrations to an empty database, and the time is Django re-rendering model state between migrations rather than SQL: the three slowest steps are a single AddField or AlterField on an empty table, at 18 to 22 seconds each.

- **On a pull request, the migrate runs only when the change touches something a from-scratch apply depends on.** `scripts/fresh_database_needed.py` diffs the PR against its base and matches: migration files, any app's `apps.py` (custom labels every dependency names), anything under `gyrinx/settings`, `uv.lock` (a Django bump can retire an operation an old migration uses), and the project modules the migrations import, which it reads out of the migration files themselves so the set follows the code. Imports one level deep only; what those modules import in turn is not followed.
- **When nothing matches**, the install, database and migrate steps are skipped and the job finishes in about 20 seconds. **Pushes to main always migrate.**
- **The job reports a real result either way.** The steps are skipped, not the job, so the required check shows success rather than skipped. The script's git call raises on failure, so a bad base ref fails the check instead of quietly skipping the migrate.
- The rule is a pure function with tests in `gyrinx/tests/test_fresh_database_needed.py`, and the script is standard library only because it runs on the runner's interpreter before the project environment is installed.

Two things this does not cover, unchanged from before: a model change with no migration is only caught by the local pre-commit hook (`scripts/check_migrations.sh`), not by CI; and the ruleset has no merge queue, so the push-to-main run is main's one layer of coverage.

On an ordinary PR the time to a mergeable state drops from about 6.5 minutes to the `test` job's 2.5 to 5 minutes.

## Test plan

- [ ] On this PR, the fresh-database job logs "nothing the migration graph depends on changed: skipping the migrate" and passes in well under a minute
- [ ] After merge, the push-to-main run logs "not a pull request: migrating" and applies the full graph as before
- [ ] The next PR that adds a migration logs the matching path and runs the migrate

## How to try it locally

```bash
scripts/fresh_database_needed.py origin/main   # paths on this branch that would trigger the migrate
pytest gyrinx/tests/test_fresh_database_needed.py gyrinx/tests/test_csrf.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GsdfBg1yW7PoKwVJetAup
