### PR TITLE
test: pin the n26 Trade Points page at 38 queries after #2428 and #2438 met on main

### DIFF
--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -401,9 +401,10 @@ class TestWhatThePageCosts:
     #: Session and the signed-in reader, the gang and its stash, the
     #: roster read once for both the offer and the equip list, the gang's
     #: rows and their hydration, the modifier index behind them, the open
-    #: visit's events, and the standard Trading Post the receipt links
-    #: to. None of it repeats per model.
-    BUDGET = 37
+    #: visit's events, the open visit's Action row the receipt now reads
+    #: beside them, and the standard Trading Post the receipt links to.
+    #: None of it repeats per model.
+    BUDGET = 38
 
     @pytest.fixture
     def bigger(self, tester, gang, ranks, make_profile, make_statline):


### PR DESCRIPTION
## Problem

Main is red on `n26/core/test_views_trade_points.py::TestWhatThePageCosts::test_it_holds_at_its_budget` (38 == 37). PR #2428 pinned the Trade Points page at 37 against a base without #2438; #2438 changed the page against a base without #2428. Together the receipt reads the open visit's Action row beside its events: one query more.

## Change

Re-pin the budget at 38 and say why on the constant. The flat-as-the-roster-grows assertion is untouched. Slice 8 of the TP budgets work will look for the avoidable query.

## Test plan

- [x] `pytest -n 4 n26/core/test_views_trade_points.py`: 70 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh