### PR TITLE
refactor: the Visit Trading Post action reads its Action row alone; Gang.starting_trade_points is no longer written

### DIFF
--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -31,6 +31,7 @@ from django.urls import reverse
 from n26.core.campaigns import NO_CEILING
 from n26.core.effects import kind_of
 from n26.core.models import Assignment, CampaignEvent, LedgerEvent, Reason
+from n26.core.models.action import read_note
 
 Kind = LedgerEvent.Kind
 
@@ -565,8 +566,13 @@ def _tell(e, row, alive):
             if now:
                 return (Span(f"set the budget to {now}"),), "money"
             return (Span("changed the budget"),), "money"
+        # A trip to the trading post wrote these before it was an action
+        # of its own. Nothing writes them now; the sentences stay so that
+        # a gang's older history still reads. Finishing says "completed",
+        # the word an action's own ending uses, so a gang that visited
+        # either side of the change reads as one story.
         case Kind.TRADE_POINTS_SET if e.note == "closed":
-            return (Span("finished the Visit Trading Post action"),), "money"
+            return (Span("completed the Visit Trading Post action"),), "money"
         case Kind.TRADE_POINTS_SET:
             brought = e.note
             if brought == "1":
@@ -576,12 +582,24 @@ def _tell(e, row, alive):
                     Span(f"visited the Trading Post with {brought} Trade Points"),
                 ), "money"
             return (Span("visited the Trading Post"),), "money"
-        case Kind.ACTION_OPENED | Kind.ACTION_CLOSED:
-            named = _action_named(e.note)
-            verb = "started" if e.kind == Kind.ACTION_OPENED else "completed"
-            if named:
-                return (Span(f"{verb} the {named} action"),), "gang"
-            return (Span(f"{verb} an action"),), "gang"
+        case Kind.ACTION_OPENED:
+            named, brought = read_note(e.note)
+            if not named:
+                return (Span("started an action"),), "gang"
+            if brought is None:
+                return (Span(f"started the {named} action"),), "gang"
+            return (
+                Span(f"started the {named} action with {_points(brought)}"),
+            ), "gang"
+        case Kind.ACTION_CLOSED:
+            named, left = read_note(e.note)
+            if not named:
+                return (Span("completed an action"),), "gang"
+            if left is None or left <= 0:
+                return (Span(f"completed the {named} action"),), "gang"
+            return (
+                Span(f"completed the {named} action, discarding {_points(left, True)}"),
+            ), "gang"
         case Kind.VISITED_TRADING_POST:
             # What raised their figure rides the note, so the line says
             # what they added rather than what they happen to be now. A
@@ -627,18 +645,14 @@ def _tell(e, row, alive):
     return (Span(e.get_kind_display().casefold()),), category
 
 
-def _action_named(note):
-    """The action's own name, read from the kind its note holds.
-
-    Empty for a note naming no kind this edition has, which leaves the
-    sentence saying an action was started without inventing which.
-    """
-    from n26.core.models import Action
-
-    try:
-        return Action.Kind(note).label
-    except ValueError:
-        return ""
+def _points(figure, unspent=False):
+    """A figure of Trade Points as a sentence can carry it."""
+    noun = "unspent Trade Point" if unspent else "Trade Point"
+    if figure == 0:
+        return f"no {noun}s"
+    if figure == 1:
+        return f"1 {noun}"
+    return f"{figure} {noun}s"
 
 
 def _for(model, at, word="for"):

--- a/n26/core/models/action.py
+++ b/n26/core/models/action.py
@@ -83,3 +83,34 @@ class Action(Base):
     @property
     def is_open(self):
         return self.closed_id is None
+
+
+def note_for(kind, figure=None):
+    """The note for the event opening or closing an action of this kind.
+
+    The kind comes first, so the history can say which action was
+    started without a join. A figure follows it where the act has one:
+    what a visit brought when it opened, and what it still had when it
+    closed. An act with no figure carries the kind alone.
+    """
+    if figure is None:
+        return str(kind)
+    return f"{kind} {figure}"
+
+
+def read_note(note):
+    """An action note's two parts: the kind's name, and its figure.
+
+    The name is empty for a note naming no kind this edition has, which
+    leaves a sentence saying an action was started without inventing
+    which one. The figure is None where the note carries none.
+    """
+    kind, _, figure = note.partition(" ")
+    try:
+        name = Action.Kind(kind).label
+    except ValueError:
+        return "", None
+    try:
+        return name, int(figure)
+    except ValueError:
+        return name, None

--- a/n26/core/models/gang.py
+++ b/n26/core/models/gang.py
@@ -67,6 +67,12 @@ class Gang(Base, Owned, Archived, Rated):
         default=0,
         help_text="Cash in hand. Pinned: starting budget less everything spent.",
     )
+    #: Nothing reads or writes this, and the column goes in the next
+    #: deploy. It is kept for one because dropping a column the outgoing
+    #: revision still reads gives every request that revision serves an
+    #: error for the seconds the two overlap. The help text below still
+    #: describes the figure as live; correcting it would take a
+    #: migration of its own, for a field with one deploy left.
     starting_trade_points = models.PositiveIntegerField(
         null=True,
         blank=True,

--- a/n26/core/models/ledger.py
+++ b/n26/core/models/ledger.py
@@ -158,11 +158,10 @@ class LedgerEvent(Base):
         # what every later purchase is measured against, so a reader owed
         # an explanation of "where did my credits go" is owed this too.
         BUDGET_SET = "budget_set", "Budget set"
-        # A Visit Trading Post action opening or closing. Like the budget
-        # it moves nothing of its own, and unlike it the event is the
-        # boundary the spending is measured from: what a visit has left
-        # is what it added less every Trade Point the log records after
-        # it, so writing one both opens a visit and closes the one before.
+        # A Visit Trading Post action opening or closing, from before it
+        # was an action row. Nothing writes one now — the pair below say
+        # it for every kind of action — and the kind stays so that a
+        # gang's older history still has a word for what it did.
         TRADE_POINTS_SET = "trade_points_set", "Trade Points set"
         # One fighter performing that action. The Trade Points they add
         # are the gang's, counted once on the event above, so this
@@ -177,7 +176,9 @@ class LedgerEvent(Base):
         # An action opening and closing (``n26.core.models.action``).
         # Neither moves anything of its own: what an action did is the
         # log between the two. The note holds the kind, so a reader of
-        # the history can be told which action without a join.
+        # the history can be told which action without a join, and the
+        # figure the act carried where it carried one — what a visit
+        # brought, and what it still had when it ended.
         ACTION_OPENED = "action_opened", "Action started"
         ACTION_CLOSED = "action_closed", "Action completed"
 

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -569,7 +569,7 @@ class Operation:
                 "before starting another."
             )
 
-    def open_action(self, kind, trade_points=None, opened=None):
+    def open_action(self, kind, trade_points=None):
         """Start one of this gang's actions, and say so in its history.
 
         An action is a thing performed over several clicks — founding and
@@ -579,32 +579,37 @@ class Operation:
         record leaves behind.
 
         ``trade_points`` is what performing this brought, where it brings
-        anything. Nothing is priced and no money moves.
-
-        ``opened`` is that event, where the act has already written one
-        of its own. A visit to the trading post writes the boundary its
-        spending is measured from, and pointing the row at that rather
-        than at a second event of this method's own keeps one act to one
-        line in the gang's history.
+        anything. Nothing is priced and no money moves. The figure rides
+        the event's note as well as the row, so the history can say what
+        the gang set out with without reading a second table.
         """
         from n26.core.models import Action
+        from n26.core.models.action import note_for
 
         gang = self.gang
         self._refuse_if_open(kind)
-        if opened is None:
-            opened = self.event(None, LedgerEvent.Kind.ACTION_OPENED, note=kind)
+        opened = self.event(
+            None,
+            LedgerEvent.Kind.ACTION_OPENED,
+            note=note_for(kind, trade_points),
+        )
         action = Action.objects.create(
             gang=gang, kind=kind, opened=opened, trade_points=trade_points
         )
         gang.forget_open_actions()
         return action
 
-    def close_action(self, action, closed=None):
+    def close_action(self, action):
         """Finish an action, and say so in its history.
 
         What it did stays where it was written — the log between the two
         events — so closing changes nothing but the state: from here the
         gang may start another of the same kind.
+
+        What the act still had rides the closing event's note, where it
+        had anything to have: the book takes a visit's unspent Trade
+        Points away when it ends, and a log that recorded only the
+        ending would leave a reader no way to see what they lost.
 
         The row is read again here, under the gang's own line, because
         the caller's copy was read before that line was taken: two
@@ -617,19 +622,24 @@ class Operation:
         Either miss — already closed, or not this gang's — does nothing
         and returns None, so the caller can say so rather than report an
         act that did not happen.
-
-        ``closed`` is the event that ended it, where the act wrote one of
-        its own — the counterpart of ``opened`` above.
         """
         from n26.core.models import Action
+        from n26.core.models.action import note_for
+        from n26.core.reconcile import trade_points_spent_for
 
         fresh = Action.objects.filter(
             pk=action.pk, gang=self.gang, closed__isnull=True
         ).first()
         if fresh is None:
             return None
-        if closed is None:
-            closed = self.event(None, LedgerEvent.Kind.ACTION_CLOSED, note=fresh.kind)
+        left = None
+        if fresh.trade_points is not None:
+            left = fresh.trade_points - trade_points_spent_for(fresh)
+        closed = self.event(
+            None,
+            LedgerEvent.Kind.ACTION_CLOSED,
+            note=note_for(fresh.kind, left),
+        )
         fresh.closed = closed
         fresh.save(update_fields=["closed", "modified"])
         self.gang.forget_open_actions()
@@ -643,16 +653,16 @@ class Operation:
         not the same as not going — one fighter going is what opens the
         post at all.
 
-        Nothing is priced and nothing moves. The event written here is
-        the boundary the spending is measured from, so opening a visit
-        also closes whatever was open before, and what that one had left
-        stops counting — which is the book's "unspent Trade Points are
-        lost", arrived at by not counting them rather than by taking
-        them away.
+        Nothing is priced and nothing moves. What the visit has spent is
+        the purchases pointing back at its row, so the book's "unspent
+        Trade Points are lost" needs nothing taken away: closing the row
+        stops anything else counting against it, and a later visit is a
+        different row with a figure of its own.
 
-        Each fighter's own event says they went, in the same batch, so a
-        receipt can name them and the gang's history can say what each
-        model did with their action.
+        Each fighter's own event says they went, in the same batch as
+        the one that opened the action, so a receipt can name them and
+        the gang's history can say what each model did with their
+        action.
 
         ``brought`` overrides what they add up to. The operation takes
         what it is given, the way a purchase does: a territory that adds
@@ -671,9 +681,7 @@ class Operation:
         self._refuse_if_open(kind)
         going = [visitor for visitor in visitors if visitor.visiting]
         amount = minted(going) if brought is None else brought
-        self.open_action(
-            kind, trade_points=amount, opened=self._set_trade_points(amount)
-        )
+        self.open_action(kind, trade_points=amount)
         for visitor in going:
             self.event(
                 visitor.miniature,
@@ -703,30 +711,8 @@ class Operation:
         open_now = self.gang.open_action(Action.Kind.TRADING_POST_VISIT)
         if open_now is None:
             return self.gang
-        self.close_action(open_now, closed=self._set_trade_points(None))
+        self.close_action(open_now)
         return self.gang
-
-    def _set_trade_points(self, amount):
-        """Write what the gang has to spend, and the boundary with it.
-
-        Returns the boundary event, which is what the visit's own row
-        points at: one act, one line in the history, and a receipt that
-        can name who performed it from the batch that line carries.
-
-        Written every time, even where the figure has not changed —
-        which is the one place this parts company with ``set_budget``. A
-        second visit adding the same amount is a second visit, and a
-        guard that skipped the write would leave the first one's
-        spending counting against it.
-        """
-        gang = self.gang
-        gang.starting_trade_points = amount
-        gang.save(update_fields=["starting_trade_points", "modified"])
-        return self.event(
-            None,
-            LedgerEvent.Kind.TRADE_POINTS_SET,
-            note="closed" if amount is None else str(amount),
-        )
 
     def edit_notes(self, miniature, notes):
         """Store the owner's notes as written, and say they changed.

--- a/n26/core/reconcile.py
+++ b/n26/core/reconcile.py
@@ -6,10 +6,7 @@ cache, and each can be recomputed. These functions do the recomputing, so a
 test (or a management command) can prove the caches are honest.
 """
 
-from datetime import UTC, datetime
-
-from django.db.models import DateTimeField, Q, Subquery, Sum, Value
-from django.db.models.functions import Coalesce
+from django.db.models import Sum
 
 from n26.core.models import Assignment, LedgerEntry
 from n26.core.models.assignment import ASSIGNABLE_FIELDS
@@ -91,13 +88,6 @@ def total_spent(gang):
     )
 
 
-#: What "since the allowance was set" means for a gang that has never
-#: set one: since always. A gang can spend at a post without an allowance
-#: — the purchase asks first and then goes through — so those points have
-#: to count against nothing rather than not count at all.
-_SINCE_ALWAYS = datetime(1, 1, 1, tzinfo=UTC)
-
-
 def trade_points_spent_for(action):
     """Every Trade Point that counted against one action.
 
@@ -127,53 +117,38 @@ def trade_points_spent_for(action):
 def trade_points_spent(gang):
     """What the gang's open Visit Trading Post action has spent.
 
-    Two sets of purchases, summed in one query. The first is what points
-    at the gang's open visit, which is the whole of it for a purchase
-    that recorded one — asked as a join rather than by naming the row, so
-    nothing has to know which visit is open before asking. The second is
-    a purchase under this visit that names no action at all — one
-    written before the visit had a row to point at — found instead by
-    when its assignment was created, measured from the boundary event
-    the visit wrote. The second half is here only while such purchases
-    exist.
+    ``trade_points_spent_for`` by another route: the visit is asked for
+    as a join rather than named, so a screen wanting the figure needs no
+    query of its own to find out which visit is open first.
 
-    Either way the visit an event belongs to is the visit its *purchase*
-    belongs to, and never the visit its own event happened in. A refund
-    is an event of its own, written whenever the owner gets round to it,
-    so counting by event time would let the undoing of an earlier
-    visit's purchase land inside this one — handing back kit bought last
-    time would mint Trade Points the visit never brought.
+    A purchase made with nothing open counts against nothing, which is
+    what the owner was told when they said they meant it. It is not
+    swept into the next visit: the gang would then open one already
+    short of what its fighters brought.
+
+    The visit an event belongs to is the visit its *purchase* belongs
+    to, and never the visit its own event happened in. A refund is an
+    event of its own, written whenever the owner gets round to it, and
+    it sits on the assignment the purchase made — so handing back kit
+    bought last time returns its points to that visit, and mints none
+    for this one.
 
     Events about no assignment are outside this by construction: the
-    boundary event itself is one, and none of them moves Trade Points.
+    two an action writes are among them, and none of them moves Trade
+    Points.
 
-    One query, boundary and all. Every screen showing what a gang has
-    left asks this, and a gang's page is a fixed number of queries by
-    invariant rather than by hope.
+    One query. Every screen showing what a gang has left asks this, and
+    a gang's page is a fixed number of queries by invariant rather than
+    by hope.
     """
     from n26.core.models import Action, LedgerEvent
 
-    since = (
-        LedgerEvent.objects.filter(gang=gang, kind=LedgerEvent.Kind.TRADE_POINTS_SET)
-        .order_by("-created")
-        .values("created")[:1]
-    )
-    unstamped = Q(
-        assignment__ledger_entry__action__isnull=True,
-        assignment__created__gte=Coalesce(
-            Subquery(since),
-            Value(_SINCE_ALWAYS, output_field=DateTimeField()),
-        ),
-    )
-    counted = unstamped | Q(
-        assignment__ledger_entry__action__gang=gang,
-        assignment__ledger_entry__action__kind=Action.Kind.TRADING_POST_VISIT,
-        assignment__ledger_entry__action__closed__isnull=True,
-    )
     return (
-        LedgerEvent.objects.filter(gang=gang)
-        .filter(counted)
-        .aggregate(total=Sum("trade_points_delta"))["total"]
+        LedgerEvent.objects.filter(
+            gang=gang,
+            assignment__ledger_entry__action__kind=Action.Kind.TRADING_POST_VISIT,
+            assignment__ledger_entry__action__closed__isnull=True,
+        ).aggregate(total=Sum("trade_points_delta"))["total"]
         or 0
     )
 

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -340,7 +340,7 @@ class TestWhoIsOffered:
 
         gang.refresh_from_db()
         assert gang.visiting_trading_post is True
-        assert gang.starting_trade_points == 3
+        assert gang.open_visit_brought == 3
 
     def test_a_model_promoted_into_a_rank_is_offered(
         self, client, tester, roster, gang, ranks
@@ -369,7 +369,7 @@ class TestWhoIsOffered:
         start(client, gang, roster["Vex"])
 
         gang.refresh_from_db()
-        assert gang.starting_trade_points == 2
+        assert gang.open_visit_brought == 2
 
     def test_a_rank_taken_away_is_not_one_held(
         self, client, tester, roster, gang, ranks
@@ -384,7 +384,7 @@ class TestWhoIsOffered:
         start(client, gang, roster["Vex"], roster["Sura"])
 
         gang.refresh_from_db()
-        assert gang.starting_trade_points == 1
+        assert gang.open_visit_brought == 1
 
 
 class TestWhatThePageCosts:
@@ -398,13 +398,19 @@ class TestWhatThePageCosts:
     number.
     """
 
-    #: Session and the signed-in reader, the gang and its stash, the
-    #: roster read once for both the offer and the equip list, the gang's
-    #: rows and their hydration, the modifier index behind them, the open
-    #: visit's events, the open visit's Action row the receipt now reads
-    #: beside them, and the standard Trading Post the receipt links to.
-    #: None of it repeats per model.
-    BUDGET = 38
+    #: The page with the post shut. Session and the signed-in reader, the
+    #: gang and its stash, the roster read once for both the offer and
+    #: the equip list, the gang's rows and their hydration, the modifier
+    #: index behind them, the actions the gang has open, and the standard
+    #: Trading Post the receipt links to. None of it repeats per model.
+    BUDGET = 37
+
+    #: The same page with a visit open, which is the state it is for.
+    #: There is a receipt to draw then, and it costs two readings of the
+    #: log: who performed the action, and what the visit has spent. Both
+    #: are one query however many fighters went and however much the gang
+    #: has bought, so this is a second fixed price and not a second rate.
+    WITH_A_VISIT = 39
 
     @pytest.fixture
     def bigger(self, tester, gang, ranks, make_profile, make_statline):
@@ -440,6 +446,29 @@ class TestWhatThePageCosts:
         with CaptureQueriesContext(connection) as more:
             assert client.get(page(gang)).status_code == 200
         assert len(more) == self.BUDGET
+
+    def test_an_open_visit_adds_the_receipts_two_readings(
+        self, client, tester, roster, gang, bigger
+    ):
+        """A visit open is the state the page exists for, so its cost is
+        pinned too: the two readings the receipt takes, and no more —
+        not one per fighter who went, and not one per purchase."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        client.force_login(tester)
+        start(client, gang, roster["Vex"], roster["Sura"])
+        client.get(page(gang))
+
+        with CaptureQueriesContext(connection) as few:
+            assert client.get(page(gang)).status_code == 200
+        assert len(few) == self.WITH_A_VISIT, [q["sql"] for q in few.captured_queries]
+
+        bigger()
+
+        with CaptureQueriesContext(connection) as more:
+            assert client.get(page(gang)).status_code == 200
+        assert len(more) == self.WITH_A_VISIT
 
 
 class TestALibraryWithNoVisitContribution:
@@ -482,7 +511,7 @@ class TestALibraryWithNoVisitContribution:
         client.post(page(gang), {"brought": "5"})
 
         gang.refresh_from_db()
-        assert gang.starting_trade_points == 5
+        assert gang.open_visit_brought == 5
 
     def test_ticking_a_model_sends_nobody(self, client, tester, gang, unauthored):
         """No model is offered, so a stale form naming one names nobody
@@ -508,7 +537,7 @@ class TestStartingTheAction:
 
         gang.refresh_from_db()
         assert gang.visiting_trading_post is True
-        assert gang.starting_trade_points == 3
+        assert gang.open_visit_brought == 3
         assert gang.trade_points_left == 3
 
     def test_a_fighter_who_adds_nothing_is_not_a_visitor(self, client, roster, gang):
@@ -552,7 +581,7 @@ class TestStartingTheAction:
         )
 
         gang.refresh_from_db()
-        assert gang.starting_trade_points == 3
+        assert gang.open_visit_brought == 3
         assert gang.trade_points_left == 3
         told = [str(m) for m in answer.context["messages"]]
         assert any("Complete the open" in line for line in told)
@@ -647,13 +676,13 @@ class TestATypedFigure:
         start(client, gang, roster["Vex"])
 
         gang.refresh_from_db()
-        assert gang.starting_trade_points == 2
+        assert gang.open_visit_brought == 2
 
     def test_a_typed_figure_wins(self, client, roster, gang):
         start(client, gang, roster["Vex"], brought=7)
 
         gang.refresh_from_db()
-        assert gang.starting_trade_points == 7
+        assert gang.open_visit_brought == 7
 
     def test_a_typed_nought_wins_too(self, client, roster, gang):
         """Nought is a figure somebody meant, not an empty box."""
@@ -661,13 +690,13 @@ class TestATypedFigure:
 
         gang.refresh_from_db()
         assert gang.visiting_trading_post is True
-        assert gang.starting_trade_points == 0
+        assert gang.open_visit_brought == 0
 
     def test_an_empty_box_falls_back_to_the_ticks(self, client, roster, gang):
         start(client, gang, roster["Vex"], brought="")
 
         gang.refresh_from_db()
-        assert gang.starting_trade_points == 2
+        assert gang.open_visit_brought == 2
 
     def test_a_typed_figure_needs_nobody_ticked(self, client, roster, gang):
         """The box replaces the ticks: a number there is the amount, and
@@ -676,7 +705,7 @@ class TestATypedFigure:
 
         gang.refresh_from_db()
         assert gang.visiting_trading_post is True
-        assert gang.starting_trade_points == 4
+        assert gang.open_visit_brought == 4
         told = [str(m) for m in answer.context["messages"]]
         assert any("adding 4 Trade Points" in line for line in told)
 
@@ -853,7 +882,7 @@ class TestFinishingTheAction:
 
         gang.refresh_from_db()
         assert gang.visiting_trading_post is False
-        assert gang.starting_trade_points is None
+        assert gang.open_visit_brought is None
         assert gang.trade_points_left is None
 
     def test_it_says_unspent_points_were_discarded(self, client, roster, gang):

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -363,11 +363,18 @@ def visit_contribution_counter():
     stand in for the standard one. The seed, its own completeness check
     and every reader ask this one question, because two statements of
     what counts as the row drift in silence.
+
+    The pack is named by its slug rather than fetched first, so a page
+    asking this pays one query and not two. A library with no default
+    pack has no counter in it either, which is the same None.
     """
-    from n26.library.models import Counter, get_default_pack
+    from django.conf import settings
+
+    from n26.library.models import Counter
 
     return Counter.objects.filter(
-        name__iexact=VISIT_CONTRIBUTION_COUNTER, pack=get_default_pack()
+        name__iexact=VISIT_CONTRIBUTION_COUNTER,
+        pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
     ).first()
 
 

--- a/n26/tests/sandbox/test_trade_points.py
+++ b/n26/tests/sandbox/test_trade_points.py
@@ -28,7 +28,7 @@ import pytest
 from django.contrib.auth.models import User
 
 from n26.core.browse import EQUIPMENT_LIST, TRADING_POST, browse, terms_for
-from n26.core.models import LedgerEvent
+from n26.core.models import Action, LedgerEvent
 from n26.core.reconcile import assert_reconciled
 from n26.core.trading import receipt_for, visitors
 from n26.tests.sandbox.actions import (
@@ -141,7 +141,7 @@ class TestWhatIsLeft:
     def test_a_gang_that_has_never_been_to_a_post_has_no_visit_open(self, gang):
         """Not an allowance of nothing: the rules shut the post to a gang
         where nobody performed the action, so there is no figure at all."""
-        assert gang.starting_trade_points is None
+        assert gang.open_visit is None
         assert gang.visiting_trading_post is False
         assert gang.trade_points_left is None
 
@@ -221,14 +221,16 @@ class TestEndingTheAction:
 
         assert (
             LedgerEvent.objects.filter(
-                gang=gang, kind=LedgerEvent.Kind.TRADE_POINTS_SET, note="closed"
+                gang=gang,
+                kind=LedgerEvent.Kind.ACTION_CLOSED,
+                note__startswith=Action.Kind.TRADING_POST_VISIT,
             ).count()
             == 1
         )
         told = [
             act
             for act in history.build(gang)
-            if "finished the Visit Trading Post action"
+            if "completed the Visit Trading Post action"
             in " ".join(span.text for span in act.spans)
         ]
         assert len(told) == 1
@@ -237,7 +239,9 @@ class TestEndingTheAction:
         leave_trading_post(gang)
 
         assert not LedgerEvent.objects.filter(
-            gang=gang, kind=LedgerEvent.Kind.TRADE_POINTS_SET
+            gang=gang,
+            kind=LedgerEvent.Kind.ACTION_CLOSED,
+            note__startswith=Action.Kind.TRADING_POST_VISIT,
         ).exists()
 
     def test_what_went_before_stops_counting(self, gang, fighter, post):
@@ -308,13 +312,13 @@ class TestEndingTheAction:
 
         gang.refresh_from_db()
         assert gang.trade_points_left == 4
-        # Opened, closed, opened again: the boundary is written every
-        # time, whatever the figure.
+        # Opened, closed, opened again: two rows, and neither one's
+        # spending reaches the other, whatever the figure.
         assert (
-            LedgerEvent.objects.filter(
-                gang=gang, kind=LedgerEvent.Kind.TRADE_POINTS_SET
+            Action.objects.filter(
+                gang=gang, kind=Action.Kind.TRADING_POST_VISIT
             ).count()
-            == 3
+            == 2
         )
 
     def test_the_visit_moves_no_money(self, gang):
@@ -600,7 +604,7 @@ class TestWhatARankAdds:
 
         gang.refresh_from_db()
         assert minted(going) == 3
-        assert gang.starting_trade_points == 3
+        assert gang.open_visit_brought == 3
         receipt = receipt_for(gang)
         assert (receipt.available, receipt.spent, receipt.remaining) == (3, 0, 3)
         assert receipt.summary == "Leader, Champion"
@@ -748,6 +752,11 @@ class TestWhatTheHistorySays:
     """The ledger records Trade Points on the purchase that spent them, so
     the gang's history can say what a trip cost as well as what it bought."""
 
+    def sentences(self, gang):
+        from n26.core import history
+
+        return ["".join(span.text for span in act.spans) for act in history.build(gang)]
+
     def test_a_purchase_reports_the_points_it_spent(self, gang, fighter, post):
         from n26.core import history
 
@@ -808,6 +817,74 @@ class TestWhatTheHistorySays:
         opened = history.build(gang)[-1]
         assert opened.trade_points == 0
         assert opened.credits == 0
+
+    def test_the_visit_says_what_it_set_out_with(self, gang):
+        """The figure is in the sentence, not in a table the reader would
+        have to go and look at."""
+        visit_trading_post(gang, brought=4)
+
+        assert self.sentences(gang)[-1] == (
+            "started the Visit Trading Post action with 4 Trade Points"
+        )
+
+    def test_one_point_is_one_point(self, gang):
+        visit_trading_post(gang, brought=1)
+
+        assert self.sentences(gang)[-1] == (
+            "started the Visit Trading Post action with 1 Trade Point"
+        )
+
+    def test_a_visit_that_brought_none_says_so(self, gang):
+        """A visit that brought nothing is still a visit, and its line
+        says what it was worth rather than leaving the figure out."""
+        visit_trading_post(gang, brought=0)
+
+        assert self.sentences(gang)[-1] == (
+            "started the Visit Trading Post action with no Trade Points"
+        )
+
+    def test_finishing_says_what_the_book_took_away(self, gang, fighter, post):
+        """Unspent Trade Points are lost when the action ends, and a log
+        that recorded only the ending would leave the reader no way to
+        see what they lost."""
+        visit_trading_post(gang, brought=4)
+        buy(fighter, line_for(browse(post, TRADING_POST), "Flak plate"))
+
+        leave_trading_post(gang)
+
+        assert self.sentences(gang)[-1] == (
+            "completed the Visit Trading Post action, discarding 1 unspent Trade Point"
+        )
+
+    def test_a_visit_that_spent_everything_loses_nothing(self, gang, fighter, post):
+        """Nothing was taken away, so the line says nothing about it —
+        rather than reporting a loss of zero."""
+        visit_trading_post(gang, brought=3)
+        buy(fighter, line_for(browse(post, TRADING_POST), "Flak plate"))
+
+        leave_trading_post(gang)
+
+        assert self.sentences(gang)[-1] == "completed the Visit Trading Post action"
+
+    def test_a_visit_that_overspent_loses_nothing_either(self, gang, fighter, post):
+        """An owner who said they meant to go past the figure is not then
+        told they threw points away."""
+        visit_trading_post(gang, brought=1)
+        buy(fighter, line_for(browse(post, TRADING_POST), "Flak plate"))
+
+        leave_trading_post(gang)
+
+        assert self.sentences(gang)[-1] == "completed the Visit Trading Post action"
+
+    def test_founding_carries_no_figure(self, gang, player):
+        """An action that brings no Trade Points says nothing about
+        them, opening or closing."""
+        from n26.core.operations import operation
+
+        with operation(gang, actor=player) as op:
+            op.close_action(gang.open_action(Action.Kind.FOUNDING))
+
+        assert self.sentences(gang)[-1] == "completed the Found and equip gang action"
 
 
 class TestWhatAPurchaseCountsAgainst:
@@ -873,26 +950,23 @@ class TestWhatAPurchaseCountsAgainst:
         assert gang.trade_points_left == 4
         assert_reconciled(gang)
 
-    def test_a_purchase_naming_no_action_is_counted_all_the_same(
-        self, gang, fighter, post
-    ):
-        """A purchase written before the visit had a row to point at names
-        no action, and the visit it belongs to is found instead by when
-        its assignment was created, measured from the boundary the visit
-        wrote. The figure comes out the same either way."""
+    def test_a_purchase_naming_no_action_counts_against_none(self, gang, fighter, post):
+        """The purchase stands and the money is spent; the points count
+        against nothing, which is what the owner was told when they said
+        they meant it. The visit is not made to pay for it — a gang
+        would then open one already short of what its fighters brought."""
         from n26.core.models import LedgerEntry
 
         visit_trading_post(gang, brought=4)
         bought = buy(fighter, line_for(browse(post, TRADING_POST), "Flak plate"))
         gang.refresh_from_db()
-        stamped = gang.trade_points_spent
+        assert gang.trade_points_spent == 3
 
         LedgerEntry.objects.filter(pk=bought.ledger_entry.pk).update(action=None)
 
         gang.refresh_from_db()
-        assert stamped == 3
-        assert gang.trade_points_spent == stamped
-        assert gang.trade_points_left == 1
+        assert gang.trade_points_spent == 0
+        assert gang.trade_points_left == 4
 
     def test_a_closed_action_still_says_what_it_spent(self, gang, fighter, post):
         """The figure survives the visit ending. What an action spent is
@@ -933,8 +1007,12 @@ class TestWhatAPurchaseCountsAgainst:
 
 
 class TestTheActionIsTheState:
-    """What a screen reads is the action row. The figure kept beside it on
-    the gang is a copy, and where the two disagree the row wins."""
+    """What a screen reads is the action row, and only the action row.
+
+    A figure once sat beside it on the gang. Nothing writes that any
+    more, and these say nothing reads it either: set to whatever you
+    like, it changes not one figure a screen shows.
+    """
 
     def test_the_receipt_reads_the_action(self, gang):
         from n26.core.models import Gang
@@ -1036,12 +1114,37 @@ class TestReadingTheFigureOffTheGangsOwnRow:
         assert fetched.visiting_trading_post is False
 
 
+def as_it_was(gang, brought, note=None):
+    """Put a gang at a post the way one stood before actions were rows:
+    a figure on the gang, and the boundary event its visit wrote.
+
+    Nothing writes that shape any more, so a test about what became of
+    it has to build it. The event goes through an operation, as every
+    event does; the figure is set straight on the row, because the
+    column it lands in is on its way out and no writer is left to ask.
+    """
+    from n26.core.models import Gang
+    from n26.core.operations import operation
+
+    with operation(gang, actor=gang.owner) as op:
+        op.event(
+            None,
+            LedgerEvent.Kind.TRADE_POINTS_SET,
+            note=str(brought) if note is None else note,
+        )
+    Gang.objects.filter(pk=gang.pk).update(starting_trade_points=brought)
+    gang.refresh_from_db()
+
+
 class TestOpeningTheVisitsThatWereAlreadyOpen:
-    """The data migration behind the change: a gang at a post before there
-    were action rows gets one, pointing at the boundary event its visit
-    already wrote, and the purchases the figure was read from are stamped
-    with it. Run here against the live models, which is what the migration
-    sees on the way past."""
+    """The data migration behind the change: a gang at a post before
+    there were action rows gets one, pointing at the boundary event its
+    visit already wrote, and the purchases the figure was read from are
+    stamped with it.
+
+    Run against the live models, which is what the migration sees on the
+    way past.
+    """
 
     def run_it(self):
         import importlib
@@ -1053,28 +1156,23 @@ class TestOpeningTheVisitsThatWereAlreadyOpen:
         )
         module.open_the_visits(apps, None)
 
-    def undo(self, gang):
-        """Put the gang back as it was before actions were rows: the
-        figure and the boundary event, and nothing else."""
-        from n26.core.models import Action
-
-        Action.objects.filter(gang=gang).delete()
-        gang.refresh_from_db()
-        assert gang.starting_trade_points is not None
-        assert gang.visiting_trading_post is False
-
     @pytest.fixture
     def mid_visit(self, gang, fighter, post, equipment_list):
-        """A gang partway through a visit, with one purchase that counted
-        Trade Points and one that did not."""
-        visit_trading_post(gang, brought=4)
+        """A gang partway through a visit of the old shape, with one
+        purchase that counted Trade Points and one that did not.
+
+        The boundary is written first: the migration finds the purchases
+        by when they were made, so anything older than it belongs to an
+        earlier visit and is meant to be passed over.
+        """
+        as_it_was(gang, brought=4)
         counted = buy(fighter, line_for(browse(post, TRADING_POST), "Flak plate"))
         free = buy(
             fighter, line_for(browse(equipment_list, EQUIPMENT_LIST), "Mesh armour")
         )
         gang.refresh_from_db()
-        assert gang.trade_points_left == 1
-        self.undo(gang)
+        assert gang.visiting_trading_post is False
+        assert counted.ledger_entry.action is None
         return {"counted": counted, "free": free}
 
     def test_it_opens_an_action_for_the_visit(self, gang, mid_visit):
@@ -1111,6 +1209,7 @@ class TestOpeningTheVisitsThatWereAlreadyOpen:
         assert free.action is None
 
     def test_what_is_left_reads_the_same_either_way(self, gang, mid_visit):
+        """4 brought and 3 spent, before the migration and after."""
         self.run_it()
 
         gang.refresh_from_db()
@@ -1128,8 +1227,6 @@ class TestOpeningTheVisitsThatWereAlreadyOpen:
         assert gang.trade_points_left == 1
 
     def test_a_gang_with_no_visit_open_is_left_alone(self, gang, fighter, post):
-        from n26.core.models import Action
-
         buy(fighter, line_for(browse(post, TRADING_POST), "Mesh armour"))
 
         self.run_it()
@@ -1137,3 +1234,82 @@ class TestOpeningTheVisitsThatWereAlreadyOpen:
         assert not Action.objects.filter(
             gang=gang, kind=Action.Kind.TRADING_POST_VISIT
         ).exists()
+
+    def test_a_figure_with_no_act_behind_it_is_not_made_a_visit(self, gang):
+        """A gang holding the figure and nothing else has no event for
+        the row to point at, so it is left as it is rather than given a
+        visit nobody performed."""
+        from n26.core.models import Gang
+
+        Gang.objects.filter(pk=gang.pk).update(starting_trade_points=4)
+
+        self.run_it()
+
+        gang.refresh_from_db()
+        assert gang.visiting_trading_post is False
+
+
+class TestWhatTheOlderHistorySays:
+    """A gang that visited a post before it was an action row still holds
+    those events, and its history still has to read. The sentences are
+    kept for them, and nothing writes another."""
+
+    def sentences(self, gang):
+        from n26.core import history
+
+        return ["".join(span.text for span in act.spans) for act in history.build(gang)]
+
+    def test_an_old_visit_says_what_it_brought(self, gang):
+        as_it_was(gang, brought=4)
+
+        assert (
+            self.sentences(gang)[-1] == "visited the Trading Post with 4 Trade Points"
+        )
+
+    def test_one_point_is_one_point(self, gang):
+        as_it_was(gang, brought=1)
+
+        assert self.sentences(gang)[-1] == "visited the Trading Post with 1 Trade Point"
+
+    def test_a_boundary_carrying_no_figure_says_only_that_they_went(self, gang):
+        as_it_was(gang, brought=0, note="")
+
+        assert self.sentences(gang)[-1] == "visited the Trading Post"
+
+    def test_an_old_visit_ends_with_the_word_a_new_one_ends_with(self, gang):
+        """One act, one verb: a gang that visited either side of the
+        change reads as one story."""
+        as_it_was(gang, brought=4)
+        as_it_was(gang, brought=0, note="closed")
+
+        assert self.sentences(gang)[-1] == "completed the Visit Trading Post action"
+
+    def test_a_fighter_going_is_told_by_the_rank_they_went_as(self, gang, fighter):
+        from n26.core.operations import operation
+
+        with operation(gang, actor=gang.owner) as op:
+            op.event(fighter, LedgerEvent.Kind.VISITED_TRADING_POST, note="Leader")
+
+        assert self.sentences(gang)[-1] == (
+            f"sent {fighter.name} as Leader to the trading post"
+        )
+
+    def test_a_bare_figure_leaves_the_rank_out(self, gang, fighter):
+        """Several things raised their figure, so no single name would be
+        true and the line says only that they went."""
+        from n26.core.operations import operation
+
+        with operation(gang, actor=gang.owner) as op:
+            op.event(fighter, LedgerEvent.Kind.VISITED_TRADING_POST, note="3")
+
+        assert self.sentences(gang)[-1] == f"sent {fighter.name} to the trading post"
+
+    def test_none_of_these_notes_reach_the_page(self, gang):
+        """The note on each is a record for the code — the sentence has
+        already said the figure and the word that closed the visit."""
+        from n26.core import history
+
+        as_it_was(gang, brought=4)
+        as_it_was(gang, brought=0, note="closed")
+
+        assert [act.note for act in history.build(gang)[-2:]] == ["", ""]


### PR DESCRIPTION
Slice 8 of the Trade Point budgets plan, part 1 of 2. This is the code change; the column drop is a second PR, opened once this has deployed.

## What changed

A trip to the trading post was recorded twice: as an `Action` row, and as a figure kept beside it on the gang (`Gang.starting_trade_points`). Since #2438 nothing has read that figure. Now nothing writes it either. The field stays declared so the outgoing revision keeps serving while this deploys; dropping the column is the next PR.

**There is no migration here.** The field's help text still describes the figure as live, and it is wrong for one deploy — correcting it would cost a migration number for a field with one deploy left, and the numbers ahead are spoken for. The `#:` comment above the field says what is true.

Three things follow from that:

**One shape for every action.** Opening and closing a visit now write `ACTION_OPENED` and `ACTION_CLOSED`, as founding does. `Operation._set_trade_points` goes, and with it the `opened=` / `closed=` parameters on `open_action` / `close_action` — nothing has an event of its own to hand over any more. `TRADE_POINTS_SET` stays as a `Kind`, and `history.py` keeps its sentences, so the events already written still read; finishing one of those now says "completed" rather than "finished", the word an action's own ending uses, so a gang that visited either side of the change reads as one story.

**The history says what a visit was worth, and what finishing it took away.** An action's note now carries its kind and, where the act has one, its figure. So the gang history reads:

- "started the Visit Trading Post action with 4 Trade Points"
- "completed the Visit Trading Post action, discarding 1 unspent Trade Point"

The book takes unspent points away when the action ends; a log that recorded only the ending never said what that was. `note_for` / `read_note` in `n26/core/models/action.py` hold the format so the writer and the reader cannot drift. An action carrying no Trade Points — founding — says nothing about them, as before.

**Spend is a join, not a time window.** `reconcile.trade_points_spent` sums by `LedgerEntry.action` alone. A purchase made with no action open counts against nothing, which is what the owner was told when they confirmed it; it is no longer swept into the next visit.

## Production readiness

The timestamp window was a fallback for purchases written before the visit had a row to point at. Migration `0044` (in #2438, on main) stamps every open visit's purchases with its action, so **the assumption this PR relies on is that 0044 has run in production before this deploys.** After that there is nothing left for the window to find, and dropping it changes no figure for any gang.

## Query counts

The Trade Points page with the post shut is back to the **37** it was pinned at before the `Action` row was added, so this reverts the hotfix pin from #2441. The action-row read is genuinely needed on this page — the receipt names who performed the visit from the opening event's batch — so it is paid for elsewhere: `visit_contribution_counter` now names the default pack by its slug instead of fetching the pack row first, which was a duplicate of the lookup the Trading Post link already makes on the same request.

The page **with a visit open** is now pinned too, at **39** — that state was never measured before. The two extra are the receipt's readings of the log: who performed the action, and what the visit has spent. Both are one query however many fighters went and however much the gang has bought, and the test proves that by growing the roster.

Query counts on the gang page and both equip pages are unchanged.

## Tests

The four claims in `n26/tests/sandbox/test_trade_points.py` still hold, along with the receipt, the actions square's visit line, the wealth strip figure, the overspend confirmation and refunds landing on the visit that paid for them.

New:

- every history sentence is pinned, including the three cases where the closing line says nothing about a loss (nothing left, everything spent, overspent);
- `TestWhatTheOlderHistorySays` covers the sentences kept for events already written — `TRADE_POINTS_SET` in all its forms and `VISITED_TRADING_POST`. Nothing writes those any more, so nothing else exercises them;
- `TestOpeningTheVisitsThatWereAlreadyOpen` still runs migration 0044 against the live models. Its subject — a gang holding the figure with no action row — can no longer be produced by the code, so `as_it_was()` builds it: the boundary event through an operation, the figure straight onto the row.

One test went: `test_a_purchase_naming_no_action_is_counted_all_the_same` was the timestamp window's own test. It is replaced by one saying such a purchase counts against nothing.

A fresh database migrates zero-to-head. `pytest -n 4` is green across the repo.

Copy on the history sentences reviewed by the copywriter agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh
