### PR TITLE
feat: impersonate a gang or campaign's owner from the n26 account menu

### DIFF
--- a/gyrinx/context_processors.py
+++ b/gyrinx/context_processors.py
@@ -52,10 +52,26 @@ def impersonation(request):
     Set by :class:`gyrinx.middleware.ImpersonationMiddleware`. When
     ``is_impersonating`` is true, ``request.user`` is the impersonated user and
     ``impersonator`` is the real admin.
+
+    ``impersonate_target`` is the owner of whatever the page is showing, when
+    that is somebody the viewer may impersonate — the account menu turns it
+    into a way straight into that account. It is empty while an overlay is
+    already active, because starting a second one is refused.
     """
+    from gyrinx.impersonation import can_impersonate_target, page_subject
+
+    is_impersonating = getattr(request, "is_impersonating", False)
+    subject = page_subject(request)
+    target = None
+    if not is_impersonating and can_impersonate_target(
+        getattr(request, "user", None), subject
+    ):
+        target = subject
+
     return {
-        "is_impersonating": getattr(request, "is_impersonating", False),
+        "is_impersonating": is_impersonating,
         "impersonator": getattr(request, "impersonator", None),
+        "impersonate_target": target,
     }
 
 

--- a/gyrinx/context_processors.py
+++ b/gyrinx/context_processors.py
@@ -57,14 +57,21 @@ def impersonation(request):
     that is somebody the viewer may impersonate — the account menu turns it
     into a way straight into that account. It is empty while an overlay is
     already active, because starting a second one is refused.
+
+    The subject is checked first so that every other page pays one ``getattr``:
+    only a page that named a subject goes on to resolve ``request.user``, which
+    on a request the middleware never reached — an error page, say — can raise
+    again on each access.
     """
     from gyrinx.impersonation import can_impersonate_target, page_subject
 
     is_impersonating = getattr(request, "is_impersonating", False)
     subject = page_subject(request)
     target = None
-    if not is_impersonating and can_impersonate_target(
-        getattr(request, "user", None), subject
+    if (
+        subject is not None
+        and not is_impersonating
+        and can_impersonate_target(getattr(request, "user", None), subject)
     ):
         target = subject
 

--- a/gyrinx/impersonation.py
+++ b/gyrinx/impersonation.py
@@ -1,4 +1,4 @@
-"""Admin impersonation: session keys and permission helpers.
+"""Admin impersonation: session keys, permission helpers, and the page subject.
 
 Impersonation is a per-request overlay. The admin stays authenticated — the
 session's ``_auth_user_id`` is unchanged — and the target user's id is stored in

--- a/gyrinx/impersonation.py
+++ b/gyrinx/impersonation.py
@@ -42,3 +42,23 @@ def can_impersonate_target(admin, target) -> bool:
         and target.is_active
         and target.pk != admin.pk
     )
+
+
+# Attribute the view sets to say whose content the page is showing. Read by
+# :func:`gyrinx.context_processors.impersonation` to offer the admin a way
+# straight into that account.
+PAGE_SUBJECT_ATTR = "impersonation_page_subject"
+
+
+def note_page_subject(request, user) -> None:
+    """Record that this page is showing ``user``'s content.
+
+    Only pages that open for someone other than their owner have a subject
+    worth naming — a page scoped to the viewer is already about them.
+    """
+    setattr(request, PAGE_SUBJECT_ATTR, user)
+
+
+def page_subject(request):
+    """Whose content the page is showing, or ``None`` if nothing said."""
+    return getattr(request, PAGE_SUBJECT_ATTR, None)

--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -66,6 +66,15 @@ Concretely:
   is one call — the words are ours, because an edition knows what happened
   and how to say it, and the delivery is the platform's. It is the only file
   here that writes a notification.
+- **`n26/impersonation.py` is a single-file seam of the same shape.** Signing
+  in as somebody else is the site's: one session key, one middleware that
+  swaps the user for a request, one log of who went into whose account and
+  when. A second implementation here would give the two editions separate
+  records of that, which is the one thing an audit of it must not have. What
+  crosses is one call — an edition knows which of its pages open for somebody
+  other than their owner, and says so; the platform decides whether the
+  reader may go in, and draws the way into the account menu. It is the only
+  file here that names the overlay.
 - **`n26/analytics.py` is one of the four platform modules n26 may call, and
   the only file allowed to.** Activity tracking is the site's: one
   events table, one log stream, one dashboard, and every question asked

--- a/n26/CLAUDE.md
+++ b/n26/CLAUDE.md
@@ -44,7 +44,9 @@ Concretely:
   events through `gyrinx.analytics`; `n26/maintenance.py` offers this
   edition's repairs through `gyrinx.maintenance` and runs them on
   `gyrinx.tasks`; `n26/flags.py` claims this edition's gated features
-  through `gyrinx.site.flags`; models that need a durable status column
+  through `gyrinx.site.flags`; `n26/impersonation.py` says whose content
+  a page is showing through `gyrinx.impersonation`; models that need a
+  durable status column
   with row-locked transitions use `gyrinx.state_machine`, the pattern
   the task framework's own records use
   (`n26/core/models/built_in_propagation.py` and the code driving it);
@@ -73,8 +75,8 @@ Concretely:
   records of that, which is the one thing an audit of it must not have. What
   crosses is one call — an edition knows which of its pages open for somebody
   other than their owner, and says so; the platform decides whether the
-  reader may go in, and draws the way into the account menu. It is the only
-  file here that names the overlay.
+  reader may go in, and the edition draws the way in its own account menu.
+  It is the only file here that names the overlay.
 - **`n26/analytics.py` is one of the four platform modules n26 may call, and
   the only file allowed to.** Activity tracking is the site's: one
   events table, one log stream, one dashboard, and every question asked
@@ -147,7 +149,9 @@ Concretely:
   `core:notifications`, the account page and the inbox both editions
   send a reader to, plus `core:dice`, a roller that knows nothing about
   either game, plus the banner's own dismiss and click-tracking
-  routes, which act on a platform-owned Banner. Writing the path out
+  routes, which act on a platform-owned Banner, plus
+  `core:impersonate-start` and `core:impersonate-stop`, which act on the
+  session rather than on anything either edition owns. Writing the path out
   instead is the worse option, not the safer one: a name that stops
   resolving raises on render, while a path that stops existing serves a
   404 in silence for as long as nobody clicks it. What crosses is a

--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -6,7 +6,8 @@
 The n26 page shell. Block names and order match the platform base template
 (head_title, stylesheet, body, content, extra_body, extra_script) so templates
 written against it extend this one unchanged. Context it reads, all optional:
-banner, is_impersonating / impersonator, gtm_container_id, messages, user.
+banner, is_impersonating / impersonator / impersonate_target,
+gtm_container_id, messages, user.
 {% endcomment %}<!DOCTYPE html>
 <html lang="en-gb">
     <head>
@@ -379,6 +380,35 @@ banner, is_impersonating / impersonator, gtm_container_id, messages, user.
                             <c-ui.dropdown.item href="{% url 'authoring-index' %}">
                                 Content Library
                             </c-ui.dropdown.item>
+                            {% comment %}
+                            The way into the account whose gang or campaign is
+                            on screen, set by the read guards in
+                            n26.core.views.permissions and narrowed to a target
+                            this reader may take by
+                            gyrinx.context_processors.impersonation. Absent on
+                            a page that is already the reader's own, and while
+                            an overlay is running — a second one is refused.
+
+                            Starting is a POST, and the kit's menu row is a
+                            type="button" that cannot submit one, so the click
+                            is caught on the form around it: the row's own
+                            handler closes the menu, the click bubbles, and the
+                            form submits. Nothing is lost without JavaScript
+                            because this menu's panel is Alpine's and is not
+                            there at all.
+                            {% endcomment %}
+                            {% if impersonate_target %}
+                                <form method="post"
+                                      action="{% url 'core:impersonate-start' impersonate_target.pk %}"
+                                      role="none"
+                                      x-on:click="$el.requestSubmit()">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                                    <c-ui.dropdown.item variant="danger">
+                                        Impersonate {{ impersonate_target.username }}
+                                    </c-ui.dropdown.item>
+                                </form>
+                            {% endif %}
                         </c-ui.dropdown.group>
                     {% endif %}
                     {% if logout_url_ %}

--- a/n26/core/templates/n26/layouts/base.html
+++ b/n26/core/templates/n26/layouts/base.html
@@ -396,12 +396,16 @@ gtm_container_id, messages, user.
                             form submits. Nothing is lost without JavaScript
                             because this menu's panel is Alpine's and is not
                             there at all.
+
+                            requestSubmit is preferred so the form's own submit
+                            event fires, and guarded because it throws where it
+                            is missing (Safari before 16).
                             {% endcomment %}
                             {% if impersonate_target %}
                                 <form method="post"
                                       action="{% url 'core:impersonate-start' impersonate_target.pk %}"
                                       role="none"
-                                      x-on:click="$el.requestSubmit()">
+                                      x-on:click="$el.requestSubmit ? $el.requestSubmit() : $el.submit()">
                                     {% csrf_token %}
                                     <input type="hidden" name="next" value="{{ request.get_full_path }}">
                                     <c-ui.dropdown.item variant="danger">

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -181,7 +181,7 @@ def campaign(request, pk):
 
     accepted = CampaignParticipant.State.ACCEPTED
 
-    found = _any_campaign_or_404(pk)
+    found = _any_campaign_or_404(request, pk)
     reading = getattr(request.user, "id", None)
     yours = found.owner_id == reading
     # Only the acts that will be drawn are built; how many more there are is
@@ -366,7 +366,7 @@ def add_gang(request, pk):
     from n26.core.forms import BringGangForm
     from n26.core.operations import Refusal, operation
 
-    found = _any_campaign_or_404(pk)
+    found = _any_campaign_or_404(request, pk)
     arbitrating = found.owner_id == getattr(request.user, "id", None)
     if not arbitrating and not _plays_in(found, request.user):
         raise Http404("No such campaign")
@@ -456,7 +456,7 @@ def remove_gang(request, pk, gang_pk):
     from n26.core.models import CampaignMembership
     from n26.core.operations import operation
 
-    found = _any_campaign_or_404(pk)
+    found = _any_campaign_or_404(request, pk)
     membership = get_object_or_404(
         CampaignMembership.objects.select_related("gang"),
         campaign=found,

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -252,7 +252,7 @@ def gang_sheet(request, pk):
     from n26.core.views.owned import link_stash_actions, owned_dialog
     from n26.core.views.skills import link_skills
 
-    gang = _any_gang_or_404(pk)
+    gang = _any_gang_or_404(request, pk)
     yours = gang.owner_id == getattr(request.user, "id", None)
     at = reverse("n26-gang", args=[gang.pk])
     card = build_gang_card(gang)
@@ -600,7 +600,7 @@ def _written_page(request, pk, *, field, template):
     """
     from n26.core.render import roster, summarise_roster
 
-    gang = _any_gang_or_404(pk)
+    gang = _any_gang_or_404(request, pk)
     yours = gang.owner_id == getattr(request.user, "id", None)
     members = roster(gang)
     entries = [

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -5,15 +5,20 @@ which gangs and fighters exist is not something to be probed for. The
 exceptions are the two read guards, ``_any_gang_or_404`` and
 ``_any_campaign_or_404``: a roster and a campaign are things players
 send each other, so owner-scoping is the rule for acting on one and not
-for reading it. All of them catch the ULIDField refusal, because a pk
-that is not a ULID is only ever a bad link and a 500 is the wrong answer
-to one.
+for reading it. Those two also record whose content the page is showing
+(``n26.impersonation.note_page_subject``), because they are exactly the
+pages that open for somebody other than the owner — an admin reading one
+is offered a way straight into that account. All of them catch the
+ULIDField refusal, because a pk that is not a ULID is only ever a bad link
+and a 500 is the wrong answer to one.
 """
 
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.http import url_has_allowed_host_and_scheme
+
+from n26.impersonation import note_page_subject
 
 
 def _safe_redirect(request, url, fallback_url="/"):
@@ -86,7 +91,7 @@ def _own_gang_or_404(request, pk):
         raise Http404("No such gang") from None
 
 
-def _any_gang_or_404(pk):
+def _any_gang_or_404(request, pk):
     """The gang, whoever owns it — a roster anybody may read.
 
     A gang sheet is shareable: the address one player sends another shows
@@ -105,7 +110,7 @@ def _any_gang_or_404(pk):
     from n26.core.models.gang import open_visit_points
 
     try:
-        return get_object_or_404(
+        gang = get_object_or_404(
             Gang.objects.select_related("gang_type", "owner", "stash").annotate(
                 open_visit_points=open_visit_points()
             ),
@@ -114,9 +119,11 @@ def _any_gang_or_404(pk):
         )
     except ValidationError:
         raise Http404("No such gang") from None
+    note_page_subject(request, gang.owner)
+    return gang
 
 
-def _any_campaign_or_404(pk):
+def _any_campaign_or_404(request, pk):
     """The campaign, whoever arbitrates it — a table its players may read.
 
     Not owner-scoped: the address an arbitrator sends round shows the same
@@ -137,13 +144,15 @@ def _any_campaign_or_404(pk):
     from n26.core.models import Campaign
 
     try:
-        return get_object_or_404(
+        campaign = get_object_or_404(
             Campaign.objects.select_related("owner"),
             pk=pk,
             archived=False,
         )
     except ValidationError:
         raise Http404("No such campaign") from None
+    note_page_subject(request, campaign.owner)
+    return campaign
 
 
 def _own_campaign_or_404(request, pk):

--- a/n26/core/views/printing.py
+++ b/n26/core/views/printing.py
@@ -231,7 +231,7 @@ def print_setup(request, pk):
 
     from n26.core.render import WEAPON_SLOTS_PER_CARD
 
-    gang = _any_gang_or_404(pk)
+    gang = _any_gang_or_404(request, pk)
     yours = gang.owner_id == request.user.id
     loaded = _config_for(request, gang)
     sheet = render_gang(gang)
@@ -325,7 +325,7 @@ def print_gang(request, pk):
     from n26.core.card import build_gang_card
     from n26.core.render import stash_lines
 
-    gang = _any_gang_or_404(pk)
+    gang = _any_gang_or_404(request, pk)
     config = _config_for(request, gang)
     wanted, weapon_ids, include_header, include_stash, include_notes = _what_to_print(
         request, gang, config

--- a/n26/impersonation.py
+++ b/n26/impersonation.py
@@ -1,0 +1,19 @@
+"""Saying whose content a page is showing, for the platform's overlay.
+
+A single-file seam of the same shape as ``n26/notifications.py``. Signing in
+as somebody else is the site's, not an edition's: one session key, one
+middleware that swaps the user for a request, one log of who went into whose
+account and when. A second implementation here would give the two editions
+separate records of that, which is the one thing an audit of it must not
+have.
+
+What crosses is one call. An edition knows which of its pages open for
+somebody other than their owner — a roster and a campaign, and nothing else
+— and says so; the platform decides whether the reader may go in, and the
+account menu draws the way. This is the only file here that names the
+overlay.
+"""
+
+from gyrinx.impersonation import note_page_subject
+
+__all__ = ["note_page_subject"]

--- a/n26/tests/test_impersonate_menu.py
+++ b/n26/tests/test_impersonate_menu.py
@@ -31,7 +31,9 @@ def overseer(client):
 
 @pytest.fixture
 def player():
-    return User.objects.create_user("player")
+    """Not named "player": the shared ``owner`` fixture takes that username,
+    and a test asking for both would trip the unique constraint."""
+    return User.objects.create_user("gang-owner")
 
 
 @pytest.fixture
@@ -70,7 +72,7 @@ class TestWhoIsOffered:
         body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
 
         assert start_url(player) in body
-        assert "Impersonate player" in body
+        assert "Impersonate gang-owner" in body
 
     def test_your_own_gang_offers_nothing(self, client, overseer, make_gang):
         """You are already signed in as yourself."""
@@ -88,7 +90,7 @@ class TestWhoIsOffered:
         body = client.get(reverse("n26-campaign", args=[campaign.pk])).content.decode()
 
         assert start_url(player) in body
-        assert "Impersonate player" in body
+        assert "Impersonate gang-owner" in body
 
     def test_a_page_about_nobody_offers_nothing(self, client, overseer):
         """The gangs index is a list, not somebody's page."""
@@ -119,8 +121,29 @@ class TestWhoIsOffered:
 
         assert "Impersonate" not in body
 
+    def test_a_reader_who_is_not_signed_in_is_offered_nothing(self, client, make_gang):
+        """A roster opens for whoever holds its address, so this path runs
+        with no user at all."""
+        gang = make_gang("The Ashen Choir")
+
+        response = client.get(reverse("n26-gang", args=[gang.pk]))
+
+        assert response.status_code == 200
+        assert "Impersonate" not in response.content.decode()
+
 
 class TestWhatItDoes:
+    def test_the_page_it_comes_back_to_is_the_one_you_were_on(
+        self, client, overseer, player, make_gang
+    ):
+        """The way back rides on the form, not on the address of the act."""
+        gang = make_gang("The Ashen Choir")
+        page = reverse("n26-gang", args=[gang.pk])
+
+        body = client.get(page).content.decode()
+
+        assert f'name="next" value="{page}"' in body
+
     def test_it_starts_the_overlay_and_comes_back_to_the_page(
         self, client, overseer, player, make_gang
     ):
@@ -131,18 +154,23 @@ class TestWhatItDoes:
 
         assert response.status_code == 200
         assert response.redirect_chain[-1][0] == page
-        body = response.content.decode()
-        assert "Impersonating" in body
-        assert "player" in body
+        assert "Impersonating" in response.content.decode()
 
     def test_nothing_is_offered_while_an_overlay_is_running(
         self, client, overseer, player, make_gang
     ):
-        """Starting a second one is refused, so offering it would be a lie."""
+        """Starting a second one is refused, so offering it would be a lie.
+
+        The account gone into is itself a superuser, so the staff group is
+        still drawn and the reader still passes every other check. What
+        withholds the row is the running overlay and nothing else.
+        """
+        deputy = User.objects.create_superuser("deputy", "deputy@example.com")
         gang = make_gang("The Ashen Choir")
         page = reverse("n26-gang", args=[gang.pk])
-        client.post(start_url(player), {"next": page})
+        client.post(start_url(deputy), {"next": page})
 
         body = client.get(page).content.decode()
 
-        assert "Impersonate player" not in body
+        assert "Staff only" in body
+        assert "Impersonate" not in body

--- a/n26/tests/test_impersonate_menu.py
+++ b/n26/tests/test_impersonate_menu.py
@@ -1,0 +1,148 @@
+"""The account menu's way into the account whose page is on screen.
+
+Here rather than beside the views because the overlay is the platform's, not
+the edition's, and only these tests may reach across to it.
+
+A roster and a campaign are the two things that open for somebody other than
+their owner, so they are the two pages that can name an account to go into.
+Everything else in n26 is owner-scoped and 404s a stranger, which leaves
+nobody to offer.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from gyrinx.site.models import Availability, FeatureFlag
+from n26.core.models import Campaign, Gang
+from n26.flags import CAMPAIGNS
+
+pytestmark = [pytest.mark.django_db, pytest.mark.core]
+
+
+@pytest.fixture
+def overseer(client):
+    """The superuser these tests read the app as. Staff too, because the
+    menu group the way in sits in is the staff one."""
+    person = User.objects.create_superuser("overseer", "overseer@example.com")
+    client.force_login(person)
+    return person
+
+
+@pytest.fixture
+def player():
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def make_gang(gang_type, player):
+    def make(name, owner=None):
+        return Gang.objects.create(
+            name=name,
+            owner=owner or player,
+            gang_type=gang_type,
+            starting_credits=1000,
+            credits=1000,
+        )
+
+    return make
+
+
+@pytest.fixture
+def campaigns_open():
+    """The flag rows are seeded by a data migration, which does not run
+    under --nomigrations."""
+    return FeatureFlag.objects.create(
+        slug=CAMPAIGNS, name="Campaigns", availability=Availability.EVERYONE
+    )
+
+
+def start_url(person):
+    return reverse("core:impersonate-start", args=[person.pk])
+
+
+class TestWhoIsOffered:
+    def test_a_gang_somebody_else_owns_names_its_owner(
+        self, client, overseer, player, make_gang
+    ):
+        gang = make_gang("The Ashen Choir")
+
+        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+
+        assert start_url(player) in body
+        assert "Impersonate player" in body
+
+    def test_your_own_gang_offers_nothing(self, client, overseer, make_gang):
+        """You are already signed in as yourself."""
+        gang = make_gang("The Ashen Choir", owner=overseer)
+
+        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+
+        assert "Impersonate" not in body
+
+    def test_a_campaign_names_its_arbitrator(
+        self, client, overseer, player, campaigns_open
+    ):
+        campaign = Campaign.objects.create(name="Dust Falls", owner=player, budget=1000)
+
+        body = client.get(reverse("n26-campaign", args=[campaign.pk])).content.decode()
+
+        assert start_url(player) in body
+        assert "Impersonate player" in body
+
+    def test_a_page_about_nobody_offers_nothing(self, client, overseer):
+        """The gangs index is a list, not somebody's page."""
+        body = client.get(reverse("n26-gangs")).content.decode()
+
+        assert "Impersonate" not in body
+
+    def test_staff_who_are_not_superusers_are_not_offered_it(
+        self, client, player, make_gang
+    ):
+        """The row sits in the staff group, but the act is a superuser's."""
+        author = User.objects.create_user("author", is_staff=True)
+        client.force_login(author)
+        gang = make_gang("The Ashen Choir")
+
+        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+
+        assert "Impersonate" not in body
+
+    def test_an_owner_who_has_been_deactivated_is_not_offered(
+        self, client, overseer, player, make_gang
+    ):
+        player.is_active = False
+        player.save()
+        gang = make_gang("The Ashen Choir")
+
+        body = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+
+        assert "Impersonate" not in body
+
+
+class TestWhatItDoes:
+    def test_it_starts_the_overlay_and_comes_back_to_the_page(
+        self, client, overseer, player, make_gang
+    ):
+        gang = make_gang("The Ashen Choir")
+        page = reverse("n26-gang", args=[gang.pk])
+
+        response = client.post(start_url(player), {"next": page}, follow=True)
+
+        assert response.status_code == 200
+        assert response.redirect_chain[-1][0] == page
+        body = response.content.decode()
+        assert "Impersonating" in body
+        assert "player" in body
+
+    def test_nothing_is_offered_while_an_overlay_is_running(
+        self, client, overseer, player, make_gang
+    ):
+        """Starting a second one is refused, so offering it would be a lie."""
+        gang = make_gang("The Ashen Choir")
+        page = reverse("n26-gang", args=[gang.pk])
+        client.post(start_url(player), {"next": page})
+
+        body = client.get(page).content.decode()
+
+        assert "Impersonate player" not in body


### PR DESCRIPTION
## Summary

- Superusers browsing a gang sheet or campaign page that belongs to somebody else now get an **Impersonate _name_** row in the n26 account menu, under **Staff only**. One click signs them in as that account and returns to the same page, where the existing red banner takes over.
- Until now the only way in was the n23 side of the app, which offers the same act on its own list and campaign pages. n26 had the banner and the **Stop impersonating** button but no way to start.
- The row is drawn only when it would actually work: never on a page you already own, never for staff who are not superusers, never for a deactivated account, and never while an overlay is already running (starting a second one is refused).

## How it works

Two pages in n26 open for somebody other than their owner — a gang sheet and a campaign, both shareable by design. Every other page is owner-scoped and answers a stranger with a 404, so there is nobody to offer.

Those two pages are reached through one guard each, so the guards are where the page says whose content it is showing: `_any_gang_or_404` and `_any_campaign_or_404` in `n26/core/views/permissions.py` now take `request` and record the owner on it. `gyrinx.context_processors.impersonation` narrows that to a target the reader may take, and the layout draws the row.

`n26/impersonation.py` is a new single-file seam, the shape n26 already uses for platform furniture like `n26/notifications.py`: signing in as somebody else is the site's mechanism — one session key, one middleware, one audit log — so n26 names it in one file rather than importing it around the edition. The boundary rule is documented in `n26/CLAUDE.md`.

Starting is a `POST`, and the component kit's menu row renders a `type="button"` that cannot submit one, so the click is caught on the form wrapped around it. Nothing is lost without JavaScript: this menu's panel is built by Alpine and is not present at all without it.

## Test plan

- [x] `pytest n26 n23/core/tests/test_impersonation.py gyrinx/tests` — 5410 passed
- [x] New suite `n26/tests/test_impersonate_menu.py`: who is offered the row (another owner's gang, another arbitrator's campaign, your own gang, a list page, staff-not-superuser, deactivated owner) and what it does (starts the overlay and returns to the page; nothing offered while one is running)
- [x] Browser pass at 1280px and 390px, light and dark: row draws in the Staff only group, its colour matches the Sign out row exactly in both schemes, no console errors
- [x] Mouse click and keyboard Enter both start the overlay and land back on the gang page with the banner up
- [x] Checked across the gang's other pages: drawn on the lore and print-setup pages, absent from the printout itself (no nav), absent from the history page (owner-only, so a stranger never sees it)
- [x] `./scripts/fmt.sh`, `scripts/check_raw_markup.py`, `scripts/check_microcopy.py` clean; copywriter pass on the new label

## How to try it

With the dev server running, sign in as a superuser and open a gang belonging to another account (`/n26/gangs/<id>/`). Open the account menu top right — the row is the last entry under **Staff only**.

## Notes

- No migration.
- Touches `n26/core/views/permissions.py` and `n26/core/views/campaigns.py`, which #2444 and #2431 also change. Neither renames the guards, so whoever lands second takes the signature change.
- The row sits inside the menu group gated on `is_staff`, while the act itself requires `is_superuser`. A superuser without the staff flag would not see the group at all — not a shape this project creates, but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDVAvMQrGwaLcHHuxpUoZ3