### PR TITLE
feat: the n26 Actions square shows recent gang history, and a model card shows its founding Trade Points

### DIFF
--- a/n26/core/actions.py
+++ b/n26/core/actions.py
@@ -9,10 +9,12 @@ a sentence of help, and one button that moves it on.
 
 ``ActionsSquare`` gathers them into the one place a gang's page reports
 them: a square in the same grid as the stash and the models, so what is
-open is read beside what it is being spent on.
+open is read beside what it is being spent on. It carries the gang's
+last few acts too — what has been done is the other half of what is
+open, and a reader deciding what to do next wants both in one place.
 
-Nothing here queries beyond asking the gang for its open action, and
-nothing here knows HTML.
+What the square costs is the gang's open actions and the last stretch
+of its story. Nothing here knows HTML.
 """
 
 from dataclasses import dataclass
@@ -30,6 +32,10 @@ VISIT_HELP = (
     "Click when you have finished at the Trading Post. Unspent Trade "
     "Points are lost when you complete the action."
 )
+
+#: How many acts the square prints. Enough to say what has been going on
+#: without becoming the history page, which is one click away.
+SNAPSHOT = 5
 
 
 @dataclass(frozen=True)
@@ -66,6 +72,21 @@ class VisitLine:
 
 
 @dataclass(frozen=True)
+class HistoryLine:
+    """One act from the gang's story, as the square prints it.
+
+    ``told`` is the sentence with the actor left off, so a screen can
+    draw who did it apart from what they did the way the history page
+    does. The sentence is the history's own — the square tells nothing a
+    second way.
+    """
+
+    when: object
+    actor: str
+    told: str
+
+
+@dataclass(frozen=True)
 class ActionsSquare:
     """What a gang has open, and the ways to start something.
 
@@ -76,11 +97,17 @@ class ActionsSquare:
 
     ``start_founding`` is where the start form posts, and is empty while
     a founding action is open.
+
+    ``history`` is the gang's last few acts, newest first, and is empty
+    for a gang nothing has been done to yet. The square says so rather
+    than drawing a heading over nothing.
     """
 
     founding: ActionCard | None = None
     visit: VisitLine | None = None
+    history: tuple = ()
     start_founding: str = ""
+    history_href: str = ""
 
     @property
     def anything_open(self):
@@ -121,13 +148,34 @@ def visit_card(receipt, at):
     )
 
 
-def actions_square(gang, sheet, *, founding_at, visit_at):
-    """The gang page's Actions square: what is open, and what may start.
+def history_lines(gang, viewer=None, limit=SNAPSHOT):
+    """The gang's last few acts as the square prints them, newest first.
+
+    The sentences are built by the history's own builder, so the square
+    and the history page cannot describe one act two ways.
+    """
+    from n26.core import history
+
+    return tuple(
+        HistoryLine(
+            when=act.when,
+            actor=act.actor,
+            told="".join(span.text for span in act.spans),
+        )
+        for act in history.latest(gang, limit=limit, viewer=viewer)
+    )
+
+
+def actions_square(gang, sheet, *, founding_at, visit_at, history_at, viewer=None):
+    """The gang page's Actions square: what is open, what has been done,
+    and what may start.
 
     The visit is read off the sheet rather than the gang, because what an
     open one has left is a ledger query and the sheet has already asked
     it. The founding action costs nothing beyond that: the gang read
-    every action it has open in one go, and the sheet already asked.
+    every action it has open in one go, and the sheet already asked. The
+    story is the one thing here that is nobody else's reading, and it is
+    bounded — the last stretch of events, whatever the gang's age.
     """
     founding = founding_card(gang, founding_at)
     visit = None
@@ -136,5 +184,7 @@ def actions_square(gang, sheet, *, founding_at, visit_at):
     return ActionsSquare(
         founding=founding,
         visit=visit,
+        history=history_lines(gang, viewer=viewer),
         start_founding="" if founding is not None else founding_at,
+        history_href=history_at,
     )

--- a/n26/core/founding.py
+++ b/n26/core/founding.py
@@ -39,25 +39,36 @@ def budget_granted(computed):
     contribution named the counter — a model with none pays nothing to
     find that out.
     """
-    from n26.library.standard_content import (
-        FOUNDING_BUDGET_COUNTER,
-        founding_budget_counter,
-    )
+    from n26.library.standard_content import founding_budget_counter
 
-    wanted = FOUNDING_BUDGET_COUNTER.casefold()
-    named = [
-        contribution
-        for contribution in computed.counter_contributions
-        if contribution.counter.name.casefold() == wanted
-    ]
-    if not named:
+    if not _names_the_counter(computed):
         return 0
     standard = founding_budget_counter()
     if standard is None:
         return 0
+    return _raised_by(computed, standard)
+
+
+def _names_the_counter(computed):
+    """Whether anything on this card raises the founding allowance, by
+    the counter's name alone. Settled without a query, which is what
+    keeps a model with no allowance costing what it always did."""
+    from n26.library.standard_content import FOUNDING_BUDGET_COUNTER
+
+    wanted = FOUNDING_BUDGET_COUNTER.casefold()
+    return any(
+        contribution.counter.name.casefold() == wanted
+        for contribution in computed.counter_contributions
+    )
+
+
+def _raised_by(computed, standard):
+    """What this card raises the standard counter by. Pinned to the row
+    rather than the name: a homebrew pack's counter called the same thing
+    is a different counter and grants nothing here."""
     return sum(
         contribution.amount
-        for contribution in named
+        for contribution in computed.counter_contributions
         if contribution.counter.pk == standard.pk
     )
 
@@ -129,3 +140,53 @@ def budget_for(gang, miniature, computed):
         granted=granted,
         spent=trade_points_spent_by(action, miniature),
     )
+
+
+def budgets_by_model(gang, computed):
+    """Every model's founding budget under the open action, and nothing
+    at all where no founding action is open or nobody on the roster has
+    an allowance.
+
+    ``computed`` is each member's fold, keyed by model id, off the card
+    the roster was dealt from. What a model may spend is already in
+    there; what it has spent is the ledger's. Keyed by the id written
+    out, which is how a drawn card carries its model's — the two sides of
+    this join arrive from different queries and only the written form is
+    the same on both.
+
+    A fixed cost for the whole roster rather than a query a fighter: the
+    standard counter is asked for once, and what has gone is one sum
+    grouped by whoever spent it. A gang whose books grant no such
+    allowance pays for neither — nothing on any of its cards names the
+    counter.
+    """
+    from n26.core.models import Action
+    from n26.core.reconcile import trade_points_spent_by_model
+    from n26.library.standard_content import founding_budget_counter
+
+    named = {
+        model_id: fold
+        for model_id, fold in computed.items()
+        if _names_the_counter(fold)
+    }
+    if not named:
+        return {}
+    action = gang.open_action(Action.Kind.FOUNDING)
+    if action is None:
+        return {}
+    standard = founding_budget_counter()
+    if standard is None:
+        return {}
+    spent = {
+        str(model_id): total
+        for model_id, total in trade_points_spent_by_model(action).items()
+    }
+    budgets = {}
+    for model_id, fold in named.items():
+        granted = _raised_by(fold, standard)
+        if granted <= 0:
+            continue
+        budgets[str(model_id)] = FoundingBudget(
+            action=action, granted=granted, spent=spent.get(str(model_id), 0)
+        )
+    return budgets

--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -115,6 +115,13 @@ class Act:
         return " ".join(words).casefold()
 
 
+#: How many events back a snapshot reads. Acts are made of events — one
+#: hire is a dozen of them — so a window counted in acts is not something
+#: a query can ask for, and this is many times the handful of acts any
+#: snapshot wants.
+SNAPSHOT_WINDOW = 200
+
+
 def build(gang, viewer=None):
     """Every act in this gang's history, oldest first.
 
@@ -123,21 +130,59 @@ def build(gang, viewer=None):
     length — the events, their records, the living — and nothing per
     row.
     """
+    return _acts_from(_events(gang), viewer, alive=_alive(gang))
+
+
+def latest(gang, limit=5, viewer=None):
+    """The gang's last few acts, newest first.
+
+    The whole history is not read to print five lines of it: the last
+    stretch of events is, and the acts those events make up. An act whose
+    events straddle the far end of that stretch would be told short,
+    which is why the window is many times the number of acts asked for
+    and why what comes back is taken from the near end.
+
+    Models are named here rather than linked. This is the way through to
+    the history page, which links them, and asking which of them are
+    still on the roster is a query a snapshot need not spend.
+
+    Two queries, and a third only where the stretch holds a propagated
+    grant: the events, the records they name, and what those grants are
+    now part of.
+    """
+    acts = _acts_from(_events(gang, window=SNAPSHOT_WINDOW), viewer, alive=frozenset())
+    return list(reversed(acts))[:limit]
+
+
+def _events(gang, window=None):
+    """The gang's events, oldest first — all of them, or the last
+    ``window`` of them read back to front and turned round."""
+    rows = gang.ledger_events.select_related(
+        "miniature", "actor", "campaign", "campaign_asset__asset__kind"
+    )
+    if window is None:
+        return list(rows.order_by("created", "id"))
+    newest = list(rows.order_by("-created", "-id")[:window])
+    newest.reverse()
+    return newest
+
+
+def _alive(gang):
+    """The models still on the roster. The history keeps the dead, but
+    only the living have a page to link to — a departed model's name
+    reads as words."""
     from n26.core.models import Miniature
 
-    events = list(
-        gang.ledger_events.select_related(
-            "miniature", "actor", "campaign", "campaign_asset__asset__kind"
-        ).order_by("created", "id")
-    )
-    rows = _rows_for(events)
-    # The history keeps the dead, but only the living have a page to
-    # link to — a departed model's name reads as words.
-    alive = set(
+    return set(
         Miniature.objects.filter(
             membership__gang=gang, membership__archived=False
         ).values_list("pk", flat=True)
     )
+
+
+def _acts_from(events, viewer, *, alive):
+    """The acts these events tell, oldest first."""
+    rows = _rows_for(events)
     sources = _comes_with_sources(events, rows)
     acts = []
     #: Where each thing's opening act landed, so an old record's grant

--- a/n26/core/reconcile.py
+++ b/n26/core/reconcile.py
@@ -142,6 +142,33 @@ def trade_points_spent_by(action, miniature):
     )
 
 
+def trade_points_spent_by_model(action):
+    """What every model has spent against one action, keyed by model id.
+
+    The same sum as :func:`trade_points_spent_by`, asked once for the
+    whole roster rather than once per model: a screen drawing a line for
+    each fighter with an allowance would otherwise pay a query a line,
+    and a gang's page is a fixed number of queries by invariant.
+
+    Purchases that recorded no buyer are left out rather than gathered
+    under a blank name — nobody's own allowance buys into the stash.
+
+    One query.
+    """
+    from n26.core.models import LedgerEvent
+
+    buyer = "assignment__ledger_entry__spent_by"
+    spends = (
+        LedgerEvent.objects.filter(
+            assignment__ledger_entry__action=action,
+            **{f"{buyer}__isnull": False},
+        )
+        .values(buyer)
+        .annotate(total=Sum("trade_points_delta"))
+    )
+    return {row[buyer]: row["total"] or 0 for row in spends}
+
+
 def trade_points_spent(gang):
     """What the gang's open Visit Trading Post action has spent.
 

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -614,6 +614,17 @@ class ModelCard:
     owned_by: str | None = None
     xp: int = 0
     xp_target: int | None = None
+    #: What this model has left of the Trade Points its books give it to
+    #: spend as it joins the gang, or None where it has none to spend.
+    #: Goes negative where the owner said they meant to overspend: Trade
+    #: Points inform, and only credits are refused.
+    trade_points_left: int | None = None
+    #: Whether the model has such an allowance at all. Stated rather than
+    #: inferred from the figure above, as ``GangSheet.trade_points_left``
+    #: is: a surface asking "is that a nought or an absence" of a number
+    #: is a surface that will one day get it wrong. It is the owner's
+    #: business, so only a card drawn for them shows it.
+    founding_budget: bool = False
     #: What the player wrote about this model — the only lines on a card
     #: written rather than earned. Editor HTML, sanitised where drawn: a
     #: card can be read by people who are not its owner.
@@ -1320,7 +1331,9 @@ def _choosable(
     )
 
 
-def build_model_card(miniature, card=None, computed=None, assignment_set=None):
+def build_model_card(
+    miniature, card=None, computed=None, assignment_set=None, budget=None
+):
     """Everything needed to draw one model's card.
 
     Pass ``computed`` (from ``n26.effects.compute``) to fold in what
@@ -1328,6 +1341,12 @@ def build_model_card(miniature, card=None, computed=None, assignment_set=None):
     shifted characteristics, forbidden combinations. Without it the card
     shows only what is literally assigned. Pass ``assignment_set`` to show
     one named selection instead of everything the model owns.
+
+    ``budget`` is this model's founding allowance
+    (``n26.core.founding.FoundingBudget``) where its books give it one and
+    the gang is still being founded. Handed in rather than read here: what
+    has been spent is one sum for the whole roster, and a card that asked
+    for its own would be a query a fighter.
     """
     if card is None:
         card = build_card(miniature, with_statlines=True, assignment_set=assignment_set)
@@ -1347,6 +1366,8 @@ def build_model_card(miniature, card=None, computed=None, assignment_set=None):
         # by the build (``n26.core.card.set_by_hand``), because drawing
         # a card may not query.
         stat_overrides=card.stat_overrides,
+        trade_points_left=budget.remaining if budget is not None else None,
+        founding_budget=budget is not None,
     )
 
 
@@ -1363,6 +1384,8 @@ def card_to_model_card(
     notes="",
     lore="",
     image_url="",
+    trade_points_left=None,
+    founding_budget=False,
 ):
     """Turn a card into the structure a renderer draws.
 
@@ -1713,6 +1736,8 @@ def card_to_model_card(
         counters=sorted(counters, key=lambda line: not line.is_xp),
         xp=xp if counted_xp is None else counted_xp,
         xp_target=xp_target,
+        trade_points_left=trade_points_left,
+        founding_budget=founding_budget,
     )
 
 
@@ -2124,6 +2149,7 @@ def render_gang(gang, with_effects=True, *, card=None):
     """A whole gang sheet. A fixed number of queries, whatever its size."""
     from n26.core.card import build_gang_card, build_modifier_index, carriers
     from n26.core.effects import compute, compute_gang, counter_readings
+    from n26.core.founding import budgets_by_model
     from n26.core.models import CampaignMembership
 
     models = roster(gang)
@@ -2167,6 +2193,11 @@ def render_gang(gang, with_effects=True, *, card=None):
         gang_computed.counters if gang_computed else counter_readings(gang_card)
     )
     campaign = _campaign_block(gang_card, membership, campaign_keys, readings)
+    # What each model still has of the Trade Points its books give it to
+    # spend as it joins. Off the fold that has just been worked out, plus
+    # one sum of what the whole roster has spent — never a query a
+    # fighter — and nothing at all for a gang whose books grant none.
+    budgets = budgets_by_model(gang, computed) if with_effects else {}
     gang_rows, gang_rules = _gang_rows(gang_card, gang_computed, campaign_keys)
     return GangSheet(
         name=gang.name,
@@ -2194,7 +2225,10 @@ def render_gang(gang, with_effects=True, *, card=None):
         image_url=(gang.image.url if gang.image else ""),
         models=[
             build_model_card(
-                model, card=cards.get(model.pk), computed=computed.get(model.pk)
+                model,
+                card=cards.get(model.pk),
+                computed=computed.get(model.pk),
+                budget=budgets.get(str(model.pk)),
             )
             for model in models
         ],

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -2145,8 +2145,15 @@ def stash_lines(gang_card):
     ]
 
 
-def render_gang(gang, with_effects=True, *, card=None):
-    """A whole gang sheet. A fixed number of queries, whatever its size."""
+def render_gang(gang, with_effects=True, *, card=None, for_owner=False):
+    """A whole gang sheet. A fixed number of queries, whatever its size.
+
+    ``for_owner`` says the sheet is being drawn for the person who owns
+    the gang, and is what puts the owner-only figures on it — what each
+    model has left of its founding Trade Points. Off by default, so a
+    reader who does not own the gang, a print run and a text card neither
+    show the figure nor pay the reads it takes to work out.
+    """
     from n26.core.card import build_gang_card, build_modifier_index, carriers
     from n26.core.effects import compute, compute_gang, counter_readings
     from n26.core.founding import budgets_by_model
@@ -2196,8 +2203,9 @@ def render_gang(gang, with_effects=True, *, card=None):
     # What each model still has of the Trade Points its books give it to
     # spend as it joins. Off the fold that has just been worked out, plus
     # one sum of what the whole roster has spent — never a query a
-    # fighter — and nothing at all for a gang whose books grant none.
-    budgets = budgets_by_model(gang, computed) if with_effects else {}
+    # fighter — and nothing at all for a gang whose books grant none, or
+    # for a reader the figure is not for.
+    budgets = budgets_by_model(gang, computed) if with_effects and for_owner else {}
     gang_rows, gang_rules = _gang_rows(gang_card, gang_computed, campaign_keys)
     return GangSheet(
         name=gang.name,

--- a/n26/core/templates/cotton/n26/actions_square/index.html
+++ b/n26/core/templates/cotton/n26/actions_square/index.html
@@ -9,6 +9,11 @@ drawn whether or not anything is open — a square that came and went would
 shift every card after it, and a reader deciding what to do next is owed
 "nothing is open" as plainly as they are owed what is.
 
+Under that, the gang's last few acts. What has been done is the other half
+of what is open, and a reader who wants more than the snapshot follows it
+through to the history page. The sentences are the history page's own, so
+neither describes an act the other way.
+
 Every way to start an action posts rather than links, so nothing that
 follows links can start one. The header holds the title alone, at the
 same height as the stash card's beside it; the controls live in the body.
@@ -18,6 +23,7 @@ Whoever draws this owns the gang. There is no reader-facing shape.
   :square — a n26.core.actions.ActionsSquare.
   class — extra classes on the card.
 {% endcomment %}
+{% load humanize %}
 <c-vars :square="None" class="" />
 
 <c-ui.card padding="none" class="{{ class }}">
@@ -66,5 +72,38 @@ Whoever draws this owns the gang. There is no reader-facing shape.
                 </c-ui.button>
             </form>
         {% endif %}
+    </div>
+    {% comment %}
+    The story, newest first, ruled off from what is open above it. Each
+    time is relative, with the full one on the element itself: a snapshot
+    says how long ago, and the page it links to spends a column on the
+    exact time.
+
+    Models are named rather than linked. The way through to a model is the
+    roster below, and the way through to the whole story is the link at the
+    foot of this.
+    {% endcomment %}
+    <div class="flex flex-col gap-2 border-t border-box-border px-4 py-3">
+        <h3 class="text-xs font-semibold uppercase tracking-wide text-muted">Recent history</h3>
+        {% if square.history %}
+            <ol class="flex flex-col gap-1.5">
+                {% for line in square.history %}
+                    <li class="flex items-baseline justify-between gap-3 text-xs">
+                        <span class="min-w-0 flex-1 text-ink-700 dark:text-ink-300">
+                            {% if line.actor %}<span class="font-medium text-ink-900 dark:text-ink-100">{{ line.actor }}</span>{% endif %}
+                            {{ line.told }}
+                        </span>
+                        <time datetime="{{ line.when|date:'c' }}"
+                              title="{{ line.when }}"
+                              class="shrink-0 text-muted">{{ line.when|naturaltime }}</time>
+                    </li>
+                {% endfor %}
+            </ol>
+        {% else %}
+            <p class="text-xs text-muted">No history for this gang yet.</p>
+        {% endif %}
+        <div>
+            <c-n26.link href="{{ square.history_href }}" class="text-xs">Full history</c-n26.link>
+        </div>
     </div>
 </c-ui.card>

--- a/n26/core/templates/cotton/n26/model_card/index.html
+++ b/n26/core/templates/cotton/n26/model_card/index.html
@@ -5,8 +5,10 @@ they carry.
     <c-n26.model-card :card="card" mode="edit" />
 
 Draws a n26.render.ModelCard (n26/core/render.py) and computes nothing; the
-figure beside the name is the model's pinned rating. card.collections and
-card.effects are on the structure and deliberately not drawn.
+figure beside the name is the model's pinned rating, with what it has left of
+its founding Trade Points ahead of it where its books grant any and the gang
+is still being founded. card.collections and card.effects are on the
+structure and deliberately not drawn.
 
 mode decides how much of the card is clickable: gang keeps the controls to the
 actions slot, edit brings out the choice buttons and a menu on each piece of
@@ -62,10 +64,27 @@ control by the actions opens it.
             </div>
 
             <div class="flex shrink-0 flex-col items-end gap-1.5">
-                <c-ui.tooltip size="sm">
-                    <span class="text-sm font-medium tabular-nums">{{ card.rating }}¢<span class="sr-only"> rating, including weapons and wargear</span></span>
-                    <c-slot name="content">Rating, including weapons and wargear</c-slot>
-                </c-ui.tooltip>
+                <div class="flex items-baseline gap-1 text-sm font-medium tabular-nums">
+                    {% comment %}
+                    What the model has left of the Trade Points its books
+                    give it to spend as it joins, ahead of the rating and
+                    quieter than it: the allowance runs out with the
+                    founding, and the rating is the figure a card is read
+                    by. Drawn only where the owner is reading — what one
+                    of their fighters may still spend is their business.
+                    {% endcomment %}
+                    {% if card.founding_budget %}
+                        <c-n26.model-card.mode when="gang edit">
+                            <span class="text-muted"
+                                  title="Trade Points {{ card.name }} can spend while the Found and equip gang action is open.">{{ card.trade_points_left }} TP<span class="sr-only"> Trade Points left to spend while the gang is being founded</span></span>
+                            <span aria-hidden="true" class="text-muted">·</span>
+                        </c-n26.model-card.mode>
+                    {% endif %}
+                    <c-ui.tooltip size="sm">
+                        <span>{{ card.rating }}¢<span class="sr-only"> rating, including weapons and wargear</span></span>
+                        <c-slot name="content">Rating, including weapons and wargear</c-slot>
+                    </c-ui.tooltip>
+                </div>
 
                 {% if actions or card.image_url %}
                     <div class="flex flex-nowrap items-center gap-2">

--- a/n26/core/templates/cotton/n26/model_card/index.html
+++ b/n26/core/templates/cotton/n26/model_card/index.html
@@ -75,8 +75,10 @@ control by the actions opens it.
                     {% endcomment %}
                     {% if card.founding_budget %}
                         <c-n26.model-card.mode when="gang edit">
-                            <span class="text-muted"
-                                  title="Trade Points {{ card.name }} can spend while the Found and equip gang action is open.">{{ card.trade_points_left }} TP<span class="sr-only"> Trade Points left to spend while the gang is being founded</span></span>
+                            <c-ui.tooltip size="sm">
+                                <span class="text-muted">{{ card.trade_points_left }} TP<span class="sr-only"> Trade Points left to spend while the gang is being founded</span></span>
+                                <c-slot name="content">Trade Points {{ card.name }} can spend while the Found and equip gang action is open</c-slot>
+                            </c-ui.tooltip>
                             <span aria-hidden="true" class="text-muted">·</span>
                         </c-n26.model-card.mode>
                     {% endif %}

--- a/n26/core/test_views_founding_action.py
+++ b/n26/core/test_views_founding_action.py
@@ -411,6 +411,137 @@ class TestTheSquareOnTheGangPage:
         assert measure() == few
 
 
+class TestTheStoryUnderIt:
+    """The square prints the gang's last few acts under what is open.
+
+    What has been done is the other half of what is open, and the
+    sentences are the history page's own — neither describes an act the
+    other way. Anything more than the snapshot is a click away.
+    """
+
+    @pytest.fixture(autouse=True)
+    def signed_in(self, client, tester):
+        client.force_login(tester)
+
+    def test_the_latest_acts_are_printed(self, client, gang):
+        body = client.get(sheet(gang)).content.decode()
+        assert "started the Found and equip gang action" in body
+        assert "created the gang" in body
+
+    def test_the_newest_act_is_at_the_top(self, client, gang, tester):
+        with operation(gang, actor=tester) as op:
+            op.close_action(gang.open_action(FOUNDING))
+
+        body = client.get(sheet(gang)).content.decode()
+        square = body[: body.index("Nothing in the stash")]
+        assert square.index("completed the Found and equip gang action") < square.index(
+            "created the gang"
+        )
+
+    def test_no_more_than_a_handful_are_printed(
+        self, client, gang, tester, make_profile, make_statline
+    ):
+        """A snapshot, not the history page: the square would push the
+        roster off the screen if it grew with the gang."""
+        from n26.core.actions import SNAPSHOT
+
+        profile = make_profile("Ganger", price=10)
+        make_statline(profile)
+        for name in ("Ain", "Bex", "Cor", "Dax", "Eth", "Fen"):
+            with operation(gang, actor=tester) as op:
+                op.hire(profile, name)
+
+        body = client.get(sheet(gang)).content.decode()
+        square = body[: body.index("Nothing in the stash")]
+        assert square.count("hired ") == SNAPSHOT
+
+    def test_the_way_through_to_the_whole_story_is_there(self, client, gang):
+        body = client.get(sheet(gang)).content.decode()
+        assert "Full history" in body
+        assert reverse("n26-gang-history", args=[gang.pk]) in body
+
+    def test_a_gang_nothing_has_been_done_to_says_so(self, client, tester, gang_type):
+        """A row written with no operation behind it: the square draws a
+        sentence rather than a heading over nothing."""
+        bare = Gang.objects.create(
+            name="The Rust Sermon",
+            owner=tester,
+            gang_type=gang_type,
+            starting_credits=1000,
+            credits=1000,
+        )
+
+        body = client.get(sheet(bare)).content.decode()
+        assert "No history for this gang yet." in body
+        assert "Full history" in body
+
+    def test_a_reader_who_does_not_own_it_gets_none_of_it(self, client, gang):
+        client.force_login(User.objects.create_user("stranger"))
+        body = client.get(sheet(gang)).content.decode()
+        assert "Full history" not in body
+        assert "started the Found and equip gang action" not in body
+
+
+class TestWhatTheSquareCosts:
+    """The square is a fixed number of reads, whatever the gang.
+
+    A page's query count is an invariant here: neither a roster that grew
+    nor a story that got longer may add one.
+    """
+
+    def test_it_is_pinned_at_three_reads(self, gang, tester, django_assert_num_queries):
+        """Which actions the gang has open, the last stretch of its
+        events, and the records those events name.
+
+        The sheet is built first, from a row of its own, so its reads are
+        not counted here — a gang holds what it read about its own open
+        actions, and one already asked would hide a read this makes.
+        """
+        from n26.core.actions import actions_square
+        from n26.core.render import render_gang
+
+        sheet_of = render_gang(Gang.objects.get(pk=gang.pk))
+        fresh = Gang.objects.get(pk=gang.pk)
+
+        with django_assert_num_queries(3):
+            actions_square(
+                fresh,
+                sheet_of,
+                founding_at=act_page(fresh),
+                visit_at="/visit",
+                history_at="/history",
+                viewer=tester,
+            )
+
+    def test_a_longer_story_costs_the_page_nothing_more(
+        self, client, gang, tester, make_profile, make_statline
+    ):
+        """The snapshot reads the last stretch of events rather than the
+        whole story, so a gang played for a season draws its square for
+        what a new one pays."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        client.force_login(tester)
+        profile = make_profile("Ganger", price=1)
+        make_statline(profile)
+        with operation(gang, actor=tester) as op:
+            model = op.hire(profile, "Vex")
+
+        def measure():
+            with CaptureQueriesContext(connection) as captured:
+                assert client.get(sheet(gang)).status_code == 200
+            return len(captured.captured_queries)
+
+        measure()
+        short = measure()
+        for number in range(60):
+            with operation(gang, actor=tester) as op:
+                op.rename(model, f"Vex {number}")
+
+        assert measure() == short
+
+
 class TestTheActsBehindIt:
     @pytest.fixture(autouse=True)
     def signed_in(self, client, tester):

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -257,7 +257,10 @@ def gang_sheet(request, pk):
     yours = gang.owner_id == getattr(request.user, "id", None)
     at = reverse("n26-gang", args=[gang.pk])
     card = build_gang_card(gang)
-    sheet = render_gang(gang, card=card)
+    # for_owner puts the owner-only figures on the cards — what a model
+    # has left of its founding Trade Points — and is what keeps a
+    # stranger's read from paying for figures they are not shown.
+    sheet = render_gang(gang, card=card, for_owner=yours)
     dialog = None
     link_campaign(sheet.campaign, request.user)
     if yours:

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -292,15 +292,19 @@ def gang_sheet(request, pk):
             "trade_points_href": trade_points_href(gang, request.user),
             # The gang's own actions, which are the owner's to perform.
             # Drawn for staff owners only while the actions are built out;
-            # every other reader gets no square. One query for the whole
-            # page — the open founding action — since what a visit has
-            # left is already on the sheet.
+            # every other reader gets no square. A fixed handful of
+            # queries for the whole page, whatever the roster: the open
+            # actions, and the last stretch of the gang's story with the
+            # records it names. What a visit has left is already on the
+            # sheet.
             "actions_square": (
                 actions_square(
                     gang,
                     sheet,
                     founding_at=reverse("n26-gang-founding-action", args=[gang.pk]),
                     visit_at=reverse("n26-gang-trade-points", args=[gang.pk]),
+                    history_at=reverse("n26-gang-history", args=[gang.pk]),
+                    viewer=request.user,
                 )
                 if may_see_actions_square(gang, request.user)
                 else None

--- a/n26/designsystem/catalog.py
+++ b/n26/designsystem/catalog.py
@@ -1769,7 +1769,11 @@ GROUPS: list[Group] = [
                     "would shift every card after it. The header holds the "
                     "title alone, so it stays the height of the stash card's; "
                     "the start control is a plain form in the body, drawn "
-                    "wherever the founding action is not open."
+                    "wherever the founding action is not open. The acts under "
+                    "it are built by n26.core.history, which is what stops the "
+                    "square and the history page describing one act two ways, "
+                    "and their times are relative, so the component loads "
+                    "humanize."
                 ),
             ),
             Component(
@@ -1967,7 +1971,10 @@ GROUPS: list[Group] = [
                     "asking — the counter lines included, which draw as settled "
                     "numbers wherever nobody may move them. XP is both a line "
                     "and a cell in the statline: the cell carries the target "
-                    "beside it, the line is where the number is changed. A stored model's card is three segmented tabs — Card, "
+                    "beside it, the line is where the number is changed. What a "
+                    "model has left of its founding Trade Points sits ahead of "
+                    "the rating in the gang and edit modes alone: the figure is "
+                    "the owner's business. A stored model's card is three segmented tabs — Card, "
                     "then Lore and Notes, the sections a player writes; a card with "
                     "no id (a preview, a picker option) draws the body plain. "
                     "Two modes: gang, the sheet's — dense, with the open "

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -6,13 +6,16 @@ prove the ORM does.
 """
 
 from dataclasses import dataclass, replace
+from datetime import timedelta
 
+from django.utils import timezone
 from django.utils.text import slugify
 
 from n26.core.actions import (
     FOUNDING_HELP,
     VISIT_HELP,
     ActionsSquare,
+    HistoryLine,
     VisitLine,
     open_card,
 )
@@ -2031,6 +2034,13 @@ CARD_IMAGE = (
 )
 
 
+def model_card_founding():
+    """The sample card while the gang is still being founded: what this
+    model has left of the Trade Points its books give it to spend as it
+    joins, ahead of its rating."""
+    return replace(model_card(), founding_budget=True, trade_points_left=3)
+
+
 def model_card_written():
     """The sample card with its picture and its Lore and Notes tabs filled."""
     return replace(model_card(), notes=CARD_NOTES, lore=CARD_LORE, image_url=CARD_IMAGE)
@@ -2112,6 +2122,20 @@ def gang_sheet_context():
     )
     founding_open = open_card(Action.Kind.FOUNDING, "#", help=FOUNDING_HELP)
     a_visit = VisitLine(trade_points_left=3, href="#")
+    # Fixed times, counted back from when the page is drawn, so the
+    # relative times the square prints read as a story rather than as
+    # five copies of one date frozen at the moment this file was written.
+    now = timezone.now()
+    lately = tuple(
+        HistoryLine(when=now - timedelta(minutes=minutes), actor=actor, told=told)
+        for minutes, actor, told in (
+            (4, "You", "bought the Lasgun for Yolanda"),
+            (11, "You", "hired Yolanda, a Ganger"),
+            (26, "You", "renamed Vespa to Vespa Kray"),
+            (140, "You", "started the Found and equip gang action"),
+            (141, "You", "created the gang, a House Escher gang"),
+        )
+    )
     return {
         "gang": sheet,
         # The two shapes an action card has: a visit, which has figures to
@@ -2121,13 +2145,24 @@ def gang_sheet_context():
             Action.Kind.TRADING_POST_VISIT, "#", help=VISIT_HELP, facts=visit_facts
         ),
         "sample_action_founding": founding_open,
-        # The Actions square's four states. The start row is offered only
+        # The Actions square's states. The start row is offered only
         # where no founding action is open, which is what the empty
         # start_founding says.
-        "sample_square_empty": ActionsSquare(start_founding="#"),
-        "sample_square_founding": ActionsSquare(founding=founding_open),
-        "sample_square_visit": ActionsSquare(visit=a_visit, start_founding="#"),
-        "sample_square_both": ActionsSquare(founding=founding_open, visit=a_visit),
+        "sample_square_empty": ActionsSquare(
+            history=lately, start_founding="#", history_href="#"
+        ),
+        "sample_square_founding": ActionsSquare(
+            founding=founding_open, history=lately, history_href="#"
+        ),
+        "sample_square_visit": ActionsSquare(
+            visit=a_visit, history=lately, start_founding="#", history_href="#"
+        ),
+        "sample_square_both": ActionsSquare(
+            founding=founding_open, visit=a_visit, history=lately, history_href="#"
+        ),
+        # A gang nothing has been done to yet. The square says so rather
+        # than drawing a heading over nothing.
+        "sample_square_no_history": ActionsSquare(start_founding="#", history_href="#"),
         # Two tallies: the Visit Trading Post card's, and the one the
         # overspend confirmation draws under it. The second carries two
         # totals, which is what the component's per-row emphasis is for.

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -2129,7 +2129,7 @@ def gang_sheet_context():
     lately = tuple(
         HistoryLine(when=now - timedelta(minutes=minutes), actor=actor, told=told)
         for minutes, actor, told in (
-            (4, "You", "bought the Lasgun for Yolanda"),
+            (4, "You", "bought Lasgun for Yolanda"),
             (11, "You", "hired Yolanda, a Ganger"),
             (26, "You", "renamed Vespa to Vespa Kray"),
             (140, "You", "started the Found and equip gang action"),

--- a/n26/designsystem/templates/designsystem/demos/actions-square/10-nothing-open.html
+++ b/n26/designsystem/templates/designsystem/demos/actions-square/10-nothing-open.html
@@ -1,4 +1,4 @@
 {# title: Nothing open #}
-{# note: The square is there whether or not anything is open — one that came and went would shift every card after it. The menu is the way to start something. #}
+{# note: The square is there whether or not anything is open — one that came and went would shift every card after it. The menu is the way to start something, and the gang's last few acts are printed under it whatever is open. #}
 {# layout: col #}
 <c-n26.actions-square :square="sample_square_empty" class="max-w-sm" />

--- a/n26/designsystem/templates/designsystem/demos/actions-square/50-no-history.html
+++ b/n26/designsystem/templates/designsystem/demos/actions-square/50-no-history.html
@@ -1,0 +1,4 @@
+{# title: Nothing done yet #}
+{# note: A gang whose story is empty says so in a sentence rather than drawing a heading over nothing. The way through to the history page stays, because the page holds the filters and the whole of it. #}
+{# layout: col #}
+<c-n26.actions-square :square="sample_square_no_history" class="max-w-sm" />

--- a/n26/designsystem/templates/designsystem/demos/model-card/60-founding-budget.html
+++ b/n26/designsystem/templates/designsystem/demos/model-card/60-founding-budget.html
@@ -1,0 +1,6 @@
+{# title: A founding allowance #}
+{# note: Some books give a model Trade Points of its own to spend as it joins the gang. What is left of them sits ahead of the rating and quieter than it, with a hover saying what the figure is. Drawn only while the gang's Found and equip gang action is open, and only for the owner — the gang and edit modes, never view. #}
+{# layout: full #}
+<div class="max-w-2xl">
+    <c-n26.model-card :card="model_card_founding" />
+</div>

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -101,7 +101,7 @@ class TestTheActionCardPage:
 
 
 class TestTheActionsSquarePage:
-    """Its props and all four states reach the gallery drawn."""
+    """Its props and all five states reach the gallery drawn."""
 
     def test_the_page_documents_the_props_declared_in_the_template(self, reader):
         page = reader.get("/n26/design/c/actions-square/").content.decode()
@@ -111,16 +111,30 @@ class TestTheActionsSquarePage:
         page = reader.get("/n26/design/c/actions-square/").content.decode()
         assert "Current action" in page
 
-    def test_all_four_demos_render_rather_than_falling_back(self, reader):
+    def test_all_five_demos_render_rather_than_falling_back(self, reader):
         page = reader.get("/n26/design/c/actions-square/").content.decode()
         assert "Nothing open" in page
         assert "The founding open" in page
         assert "A visit open" in page
         assert "Both open" in page
+        assert "Nothing done yet" in page
         # From the markup the demos rendered, not their titles.
         assert "No action is open." in page
         assert "Trading Post visit open" in page
         assert "Complete action" in page
+
+    def test_the_story_under_the_square_is_drawn(self, reader):
+        """The snapshot's own markup, and one of the sample sentences —
+        a demo that fell back to "No examples yet" would carry the
+        heading from no state at all."""
+        page = reader.get("/n26/design/c/actions-square/").content.decode()
+        assert "Recent history" in page
+        assert "Full history" in page
+        assert "hired Yolanda, a Ganger" in page
+
+    def test_a_gang_with_no_story_says_so(self, reader):
+        page = reader.get("/n26/design/c/actions-square/").content.decode()
+        assert "No history for this gang yet." in page
 
     def test_the_start_row_is_a_post_not_a_link(self, reader):
         """Starting an act must never be a link: a link is followed by
@@ -516,12 +530,14 @@ class TestTheModelCardsTooltips:
         assert 'title="Select' not in page
         assert 'title="From' not in page
         assert 'title="Granted' not in page
+        assert 'title="Trade Points' not in page
 
     def test_the_provenance_and_rating_bubbles_are_drawn(self, reader):
         page = reader.get("/n26/design/c/model-card/").content.decode()
         assert 'role="tooltip"' in page
         assert "From Leader" in page
         assert "Rating, including weapons and wargear" in page
+        assert "can spend while the Found and equip gang action is open" in page
 
     def test_both_kinds_of_open_choice_draw_their_way_in(self, reader):
         """The sample carries an open one-pick choice and a several-pick

--- a/n26/designsystem/views.py
+++ b/n26/designsystem/views.py
@@ -96,6 +96,7 @@ def component(request, slug):
             "unsafe_html": UNSAFE_HTML,
             "model_card": sampledata.model_card(),
             "model_card_editable": sampledata.model_card_editable(),
+            "model_card_founding": sampledata.model_card_founding(),
             "model_card_written": sampledata.model_card_written(),
             "needs_rich_text": needs_rich_text,
             # The icon gallery renders the registry rather than a written-out
@@ -193,6 +194,7 @@ def view_preview(request, slug):
             "demo_template": found.demos[0].template_name,
             "model_card": sampledata.model_card(),
             "model_card_editable": sampledata.model_card_editable(),
+            "model_card_founding": sampledata.model_card_founding(),
             "model_card_written": sampledata.model_card_written(),
             # The same test the component page makes: a view whose demo
             # draws an editor brings TinyMCE with it, and only then.

--- a/n26/tests/sandbox/test_founding_budget.py
+++ b/n26/tests/sandbox/test_founding_budget.py
@@ -924,11 +924,11 @@ class TestTheSeed:
 
 
 def sheet_of(gang):
-    """The gang sheet, drawn from a row of its own."""
+    """The gang sheet as its owner reads it, from a row of its own."""
     from n26.core.models import Gang
     from n26.core.render import render_gang
 
-    return render_gang(Gang.objects.get(pk=gang.pk))
+    return render_gang(Gang.objects.get(pk=gang.pk), for_owner=True)
 
 
 def card_for(gang, name):
@@ -1001,7 +1001,7 @@ class TestTheRosterReadInOneGo:
         def measure():
             fresh = Gang.objects.get(pk=gang.pk)
             with django_assert_num_queries(self.SHEET):
-                render_gang(fresh)
+                render_gang(fresh, for_owner=True)
 
         measure()
         for name in ("Kade", "Sull", "Nix"):
@@ -1010,9 +1010,9 @@ class TestTheRosterReadInOneGo:
 
     #: What drawing this gang's sheet reads. Pinned so it changes
     #: deliberately: the rows, the fold's own lookups, the gang's open
-    #: actions, the standard counter and the one sum of what has been
-    #: spent against the founding action.
-    SHEET = 33
+    #: actions, the campaign it is playing, the standard counter and the
+    #: one sum of what has been spent against the founding action.
+    SHEET = 35
 
     def test_the_allowances_are_two_of_those_reads(
         self, gang, hire_into, leader, django_assert_num_queries
@@ -1041,6 +1041,21 @@ class TestTheRosterReadInOneGo:
 
         with django_assert_num_queries(2):
             budgets_by_model(fresh, folds)
+
+    def test_a_reader_who_is_not_the_owner_pays_for_none_of_it(
+        self, gang, hire_into, leader, django_assert_num_queries
+    ):
+        """The figure is the owner's, so a stranger's read of the same
+        roster neither shows it nor spends the two reads it takes."""
+        from n26.core.models import Gang
+        from n26.core.render import render_gang
+
+        fresh = Gang.objects.get(pk=gang.pk)
+        with django_assert_num_queries(self.SHEET - 2):
+            sheet = render_gang(fresh)
+
+        assert all(not card.founding_budget for card in sheet.models)
+        assert all(card.trade_points_left is None for card in sheet.models)
 
     def test_a_gang_whose_books_grant_none_asks_nothing(
         self, outcast, player, make_profile, make_statline, django_assert_num_queries
@@ -1085,7 +1100,7 @@ class TestTheFigureOnTheGangPage:
     #: What the hover says, per model. The whole of it, because a
     #: substring of it would pass on a page that had drawn half a
     #: sentence.
-    HOVER = "Trade Points {} can spend while the Found and equip gang action is open."
+    HOVER = "Trade Points {} can spend while the Found and equip gang action is open"
 
     def page(self, gang):
         from django.urls import reverse

--- a/n26/tests/sandbox/test_founding_budget.py
+++ b/n26/tests/sandbox/test_founding_budget.py
@@ -921,3 +921,205 @@ class TestTheSeed:
         assign(rule, miniature=leader)
 
         assert reading(leader) == 5
+
+
+def sheet_of(gang):
+    """The gang sheet, drawn from a row of its own."""
+    from n26.core.models import Gang
+    from n26.core.render import render_gang
+
+    return render_gang(Gang.objects.get(pk=gang.pk))
+
+
+def card_for(gang, name):
+    return next(card for card in sheet_of(gang).models if card.name == name)
+
+
+class TestTheRosterReadInOneGo:
+    """Every model's allowance is worked out for the whole roster at once.
+
+    The reading is already in the fold the cards are drawn from, and what
+    has gone is one sum grouped by whoever spent it — so a gang sheet of
+    sixteen fighters is drawn for what one of two costs.
+    """
+
+    def test_a_budgeted_model_carries_its_figure(self, gang, leader):
+        card = card_for(gang, "Rasp")
+
+        assert card.founding_budget is True
+        assert card.trade_points_left == 5
+
+    def test_a_model_with_no_allowance_carries_none(self, gang, hire_into, leader):
+        hire_into(gang, ("Allies", "Bone Scrivener"), "Wren")
+        card = card_for(gang, "Wren")
+
+        assert card.founding_budget is False
+        assert card.trade_points_left is None
+
+    def test_what_one_has_spent_is_not_charged_to_another(
+        self, gang, hire_into, leader, kit, legacy_list
+    ):
+        champion = hire_into(gang, ("Venators", "Hunt Champion"), "Kade")
+        buy_at_founding(leader, line_for(browse(legacy_list, FOUNDING), "Flak plate"))
+
+        assert card_for(gang, "Rasp").trade_points_left == 2
+        assert card_for(gang, champion.name).trade_points_left == 4
+
+    def test_the_figure_goes_when_the_action_is_complete(self, gang, leader, player):
+        complete_action(gang, FOUNDING_KIND, actor=player)
+        card = card_for(gang, "Rasp")
+
+        assert card.founding_budget is False
+        assert card.trade_points_left is None
+
+    def test_spending_past_it_reads_below_nothing(
+        self, gang, hire_into, kit, legacy_list
+    ):
+        """Trade Points inform and only credits are refused, so a model
+        the owner meant to overspend reports what it is over by."""
+        hunter = hire_into(gang, ("Venators", "Hunter"), "Sull")
+        for _ in range(2):
+            buy_at_founding(
+                hunter, line_for(browse(legacy_list, FOUNDING), "Flak plate")
+            )
+
+        assert card_for(gang, "Sull").trade_points_left == -3
+
+    def test_the_cost_does_not_follow_the_roster(
+        self, gang, hire_into, leader, django_assert_num_queries
+    ):
+        """Two reads for the allowances however many models carry one:
+        the standard counter, asked once for the roster rather than once
+        a model, and what every model has spent under the founding
+        action. Which actions the gang has open is a third, and the sheet
+        pays it for the visit's figure whether or not anybody has an
+        allowance.
+        """
+        from n26.core.models import Gang
+        from n26.core.render import render_gang
+
+        def measure():
+            fresh = Gang.objects.get(pk=gang.pk)
+            with django_assert_num_queries(self.SHEET):
+                render_gang(fresh)
+
+        measure()
+        for name in ("Kade", "Sull", "Nix"):
+            hire_into(gang, ("Venators", "Hunt Champion"), name)
+        measure()
+
+    #: What drawing this gang's sheet reads. Pinned so it changes
+    #: deliberately: the rows, the fold's own lookups, the gang's open
+    #: actions, the standard counter and the one sum of what has been
+    #: spent against the founding action.
+    SHEET = 33
+
+    def test_the_allowances_are_two_of_those_reads(
+        self, gang, hire_into, leader, django_assert_num_queries
+    ):
+        """The standard counter, so a homebrew one of the same name is
+        not mistaken for it, and one sum of what the roster has spent.
+        Which actions the gang has open is not among them: the sheet asks
+        that for the visit's figure whether or not anybody has an
+        allowance."""
+        from n26.core.card import build_gang_card, build_modifier_index
+        from n26.core.effects import compute
+        from n26.core.founding import budgets_by_model
+        from n26.core.models import Gang
+
+        fresh = Gang.objects.get(pk=gang.pk)
+        card = build_gang_card(fresh)
+        index = build_modifier_index(
+            [
+                node.assignable
+                for member in card.members.values()
+                for node in member.all_nodes()
+            ]
+        )
+        folds = {pk: compute(member, index) for pk, member in card.members.items()}
+        fresh.open_actions()
+
+        with django_assert_num_queries(2):
+            budgets_by_model(fresh, folds)
+
+    def test_a_gang_whose_books_grant_none_asks_nothing(
+        self, outcast, player, make_profile, make_statline, django_assert_num_queries
+    ):
+        """No card names the counter, so there is nothing to look up —
+        not the gang's open actions, and not the ledger."""
+        from n26.core.card import build_gang_card, build_modifier_index
+        from n26.core.effects import compute
+        from n26.core.founding import budgets_by_model
+        from n26.core.models import Gang
+        from n26.library.models import GangType
+
+        plain = GangType.objects.create(name="Corpse Grinder Cult")
+        profile = make_profile("Cutter", price=45, gang_type=plain)
+        make_statline(profile)
+        theirs = found_gang("The Rust Sermon", plain, owner=player, budget=1000)
+        hire_with_option(theirs, profile, "Sull")
+
+        fresh = Gang.objects.get(pk=theirs.pk)
+        card = build_gang_card(fresh)
+        index = build_modifier_index(
+            [
+                node.assignable
+                for member in card.members.values()
+                for node in member.all_nodes()
+            ]
+        )
+        folds = {pk: compute(member, index) for pk, member in card.members.items()}
+
+        with django_assert_num_queries(0):
+            assert budgets_by_model(fresh, folds) == {}
+
+
+class TestTheFigureOnTheGangPage:
+    """The gang page prints what a model has left ahead of its rating.
+
+    An owner deciding who to spend on next reads it off the roster rather
+    than opening every fighter's screen. It is the owner's business, so a
+    reader who does not own the gang is not shown it.
+    """
+
+    #: What the hover says, per model. The whole of it, because a
+    #: substring of it would pass on a page that had drawn half a
+    #: sentence.
+    HOVER = "Trade Points {} can spend while the Found and equip gang action is open."
+
+    def page(self, gang):
+        from django.urls import reverse
+
+        return reverse("n26-gang", args=[gang.pk])
+
+    def body(self, client, gang, reader=None):
+        client.force_login(reader or gang.owner)
+        return client.get(self.page(gang)).content.decode()
+
+    def test_a_budgeted_model_shows_what_it_has_left(self, client, gang, leader):
+        assert ">5 TP<span" in self.body(client, gang)
+
+    def test_the_hover_says_what_the_figure_is(self, client, gang, leader):
+        assert self.HOVER.format("Rasp") in self.body(client, gang)
+
+    def test_spending_moves_it(self, client, gang, leader, kit, legacy_list):
+        buy_at_founding(leader, line_for(browse(legacy_list, FOUNDING), "Flak plate"))
+
+        assert ">2 TP<span" in self.body(client, gang)
+
+    def test_completing_the_action_takes_it_away(self, client, gang, leader, player):
+        complete_action(gang, FOUNDING_KIND, actor=player)
+
+        assert self.HOVER.format("Rasp") not in self.body(client, gang)
+
+    def test_a_model_with_no_allowance_shows_nothing(self, client, gang, hire_into):
+        """The ally is ranked Champion by its own book, and no gang's
+        list names it — so nothing on its card raises the counter."""
+        hire_into(gang, ("Allies", "Bone Scrivener"), "Wren")
+
+        assert self.HOVER.format("Wren") not in self.body(client, gang)
+
+    def test_a_reader_who_does_not_own_it_is_not_shown_it(self, client, gang, leader):
+        stranger = User.objects.create_user("a-stranger")
+
+        assert self.HOVER.format("Rasp") not in self.body(client, gang, reader=stranger)

--- a/n26/tests/sandbox/test_gang_history.py
+++ b/n26/tests/sandbox/test_gang_history.py
@@ -370,6 +370,89 @@ class TestTheCostDoesNotFollowTheLength:
             history.build(long, viewer=gang.owner)
 
 
+class TestASnapshotOfTheStory:
+    """A screen wanting the last few acts reads the last stretch of
+    events, never the whole story: a gang played for a season would
+    otherwise pay for every act it ever did to print five lines.
+
+    The sentences are the history page's own, so the two cannot describe
+    one act differently.
+    """
+
+    def _lengthen(self, gang, vex, acts):
+        for number in range(acts):
+            with edit(gang) as op:
+                op.rename(vex, f"Vex {number}")
+
+    def told(self, acts):
+        return ["".join(span.text for span in act.spans) for act in acts]
+
+    def test_the_newest_act_comes_first(self, gang, vex):
+        latest = history.latest(Gang.objects.get(pk=gang.pk), viewer=gang.owner)
+
+        assert self.told(latest)[0].startswith("hired Vex")
+
+    def test_it_gives_back_no_more_than_it_was_asked_for(self, gang, vex):
+        self._lengthen(gang, vex, 8)
+        latest = history.latest(Gang.objects.get(pk=gang.pk), limit=3)
+
+        assert len(latest) == 3
+
+    def test_they_are_the_acts_the_page_would_print_first(self, gang, vex):
+        self._lengthen(gang, vex, 4)
+        whole = Gang.objects.get(pk=gang.pk)
+        page = list(reversed(history.build(whole, viewer=gang.owner)))[:5]
+        latest = history.latest(whole, viewer=gang.owner)
+
+        assert self.told(latest) == self.told(page)
+
+    def test_a_gang_nothing_has_been_done_to_has_nothing_to_tell(
+        self, gang_type, owner
+    ):
+        """A row written without an operation behind it — the state a
+        screen has to draw something for rather than a heading over
+        nothing."""
+        bare = Gang.objects.create(
+            name="The Rust Sermon", owner=owner, gang_type=gang_type
+        )
+
+        assert history.latest(bare) == []
+
+    def test_models_are_named_rather_than_linked(self, gang, vex):
+        """The way through to a model is the roster, and the way through
+        to the whole story is the history page: knowing which models are
+        still on the roster is a query a snapshot need not spend."""
+        latest = history.latest(Gang.objects.get(pk=gang.pk), viewer=gang.owner)
+
+        assert any("Vex" in line for line in self.told(latest))
+        assert not any(span.href for act in latest for span in act.spans)
+
+    def test_the_cost_does_not_follow_the_length(
+        self, gang, vex, django_assert_num_queries
+    ):
+        """Two reads whatever the gang's age: the last stretch of events,
+        and the records those events name."""
+        self._lengthen(gang, vex, 5)
+        short = Gang.objects.get(pk=gang.pk)
+        with django_assert_num_queries(2):
+            history.latest(short, viewer=gang.owner)
+        self._lengthen(gang, vex, 60)
+        long = Gang.objects.get(pk=gang.pk)
+        with django_assert_num_queries(2):
+            history.latest(long, viewer=gang.owner)
+
+    def test_it_reads_only_the_last_stretch_of_events(self, gang, vex):
+        """The window is counted in events because acts are made of them.
+        Asked for more acts than the stretch holds, it gives what the
+        stretch tells and no more — where the whole story has them all."""
+        self._lengthen(gang, vex, history.SNAPSHOT_WINDOW + 20)
+        whole = Gang.objects.get(pk=gang.pk)
+
+        snapshot = history.latest(whole, limit=1000, viewer=gang.owner)
+        assert len(snapshot) <= history.SNAPSHOT_WINDOW
+        assert len(history.build(whole, viewer=gang.owner)) > len(snapshot)
+
+
 class TestThePageIsTheOwners:
     """The history says things the roster does not, so only the owner
     reads it — and every narrowing is an address."""


### PR DESCRIPTION
Two follow-ups to the n26 Actions square, part of the Trade Point budgets
work (slice 9 of the plan; after #2443, #2450 and #2451).

## Recent history in the square

The square told you what the gang had open but nothing about what had just
happened, so the answer to "where was I?" was always a click away on the
history page. It now prints the gang's last five acts underneath what is
open — each with a relative time, and a **Full history** link through to
the page.

The sentences are built by the history page's own builder, so the square
and the page cannot describe one act two different ways. A gang nothing
has been done to says so in a line rather than drawing a heading over
nothing.

Reading the whole story to print five lines of it would make an old gang's
page slower every week it is played, so `history.latest()` reads a bounded
window of the last events and tells whatever acts those make up — two
queries whatever the gang's age, where the full `build()` costs three. It
names models rather than linking them, which is the third query it saves;
the way through to a fighter is the roster below, and to the whole story
the link at the foot.

## Founding Trade Points on the model card

Some gang books (Venators, Outcast) give a fighter Trade Points of its own
to spend as it joins the gang — a Hunt Leader has 5, a Hunt Champion 4, a
Hunter 3. Until now the only place to see what was left of one was that
fighter's own equip screen, so deciding who to spend on next meant opening
every card in turn.

Each model card now carries the figure ahead of its rating and quieter
than it — `5 TP · 145¢` — with a hover saying what it is. Only while the
gang's Found and equip gang action is open, only where the books grant an
allowance, and only for the owner: what one of their fighters may still
spend is nobody else's business.

`render_gang` fills it from the fold it has just worked out, plus **one**
aggregate over `LedgerEntry.spent_by` for the whole roster
(`founding.budgets_by_model`) — so a sheet of sixteen fighters is drawn
for what one of two costs, and a gang whose books grant no allowance asks
for nothing at all, because nothing on any of its cards names the counter.

## Query budgets

Pinned, with the reasons in the tests:

- The Actions square is **3 reads**: which actions the gang has open, the
  last stretch of its events, and the records those events name. Flat as
  the roster grows and flat as the story grows — both pinned in
  `n26/core/test_views_founding_action.py`.
- The founding allowances are **2 reads** for the whole roster (the
  standard counter, and one sum of what has been spent), and **0** for a
  gang whose books grant none. A Venator gang sheet is pinned at 33
  queries and holds there from one budgeted fighter to four
  (`n26/tests/sandbox/test_founding_budget.py`).

## How to try it

Start the dev server (`./scripts/dev.sh`) and open a gang you own as a
staff user — the square is still staff-only while the actions are built
out: `/n26/gangs/<id>/`. The square draws the last five acts under the
open action, with the link through to the history page.

For the Trade Point figure the gang needs books that grant one. Press
**Create** on the `founding-budgets` seed on the Foundations page, found a
Venators gang, and hire a Hunt Leader, a Hunt Champion and a Hunter: their
cards read `5 TP · …¢`, `4 TP · …¢` and `3 TP · …¢` beside their ratings.
Buy something off their equipment list and the figures move; complete the
Found and equip gang action and they go.

Gallery pages: `/n26/design/c/actions-square/` (with a story, and the
empty state) and `/n26/design/c/model-card/` (**A founding allowance**).

## Tests

- `pytest n26 -n 4` — 5103 passed, 1 xfailed.
- New: `TestASnapshotOfTheStory` (`n26/tests/sandbox/test_gang_history.py`),
  `TestTheStoryUnderIt` and `TestWhatTheSquareCosts`
  (`n26/core/test_views_founding_action.py`), `TestTheRosterReadInOneGo`
  and `TestTheFigureOnTheGangPage`
  (`n26/tests/sandbox/test_founding_budget.py`).
- Browser pass on desktop and mobile against a real Venator gang, plus
  both gallery pages.

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh
