### PR TITLE
refactor: drop the CampaignType.assets catalogue; author Assets under their kind on the type page

### DIFF
--- a/n26/core/campaigns.py
+++ b/n26/core/campaigns.py
@@ -302,16 +302,27 @@ class CampaignOperation:
     def add_asset(self, asset, name=""):
         """Put one copy of a pooled asset into the pool, held by nobody.
 
-        Only an asset of a pooled kind. A held-one-each asset is every
-        member gang's own, given on joining, and has no pool to sit in —
-        so one arriving here is a caller's mistake, not a choice a screen
-        offers. Nothing changes for any gang: a copy nobody holds is the
-        campaign's own act, and only its log carries it.
+        Only an asset of a pooled kind of this campaign's type or of its
+        additions. A held-one-each asset is every member gang's own, given
+        on joining, and has no pool to sit in; an asset of another type is
+        not one this campaign deals in — either arriving here is a caller's
+        mistake, not a choice a screen offers. Nothing changes for any
+        gang: a copy nobody holds is the campaign's own act, and only its
+        log carries it.
         """
         if not asset.kind.is_pooled:
             raise ValueError(
                 f"{asset} is of the kind {asset.kind}, which every gang holds one "
                 "of. Only a pooled kind has copies to add."
+            )
+        if asset.kind.campaign_type_id not in (
+            self.campaign.campaign_type_id,
+            self.campaign.additions_id,
+        ):
+            raise ValueError(
+                f"{asset} is of the kind {asset.kind}, which belongs to "
+                f"{asset.kind.campaign_type}, not to this campaign's type or "
+                "its additions."
             )
         token = CampaignAsset.objects.create(
             campaign=self.campaign, asset=asset, name=(name or "").strip()

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -466,18 +466,18 @@ class BattleForm(forms.Form):
 class AddToPoolForm(forms.Form):
     """One copy of a pooled asset, to put into a campaign's pool.
 
-    The assets offered are the campaign's catalogue — what its type and
-    its additions offer, of the pooled kinds — so the form cannot put a
-    Settlement in the pool or an asset the campaign does not deal in. The
-    catalogue has no default for the same reason a gang picker has none:
-    a queryset built without one would accept anything.
+    The assets offered are the ones the campaign deals in — those of the
+    pooled kinds of its type and of its additions — so the form cannot
+    put a Settlement in the pool or an asset of another type. ``offered``
+    has no default for the same reason a gang picker has none: a queryset
+    built without one would accept anything.
     """
 
     asset = forms.ModelChoiceField(
         queryset=None,
         label="Asset",
         error_messages={
-            "invalid_choice": "That asset is not in this campaign's catalogue.",
+            "invalid_choice": "That asset is not one this campaign deals in.",
             "required": "Select an asset to add.",
         },
     )
@@ -488,9 +488,9 @@ class AddToPoolForm(forms.Form):
         help_text="Optional. Leave blank to use the asset's name.",
     )
 
-    def __init__(self, *args, catalogue, **kwargs):
+    def __init__(self, *args, offered, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["asset"].queryset = catalogue
+        self.fields["asset"].queryset = offered
 
 
 class GrantAssetForm(forms.Form):

--- a/n26/core/templates/n26/add_to_pool.html
+++ b/n26/core/templates/n26/add_to_pool.html
@@ -19,7 +19,7 @@ posts with no script and a redisplay after a failed submit keeps the pick.
 {% block content %}
     <c-n26.form-page action="{% url 'n26-campaign-pool-add' campaign.pk %}"
                      title="Add to the pool"
-                     lead="One copy of an asset from the campaign's catalogue. Nobody holds it until you grant it."
+                     lead="One copy of an asset the campaign deals in. Nobody holds it until you grant it."
                      :form="form"
                      submit_label="Add to pool"
                      cancel_url="{% url 'n26-campaign-pool' campaign.pk %}">
@@ -42,7 +42,7 @@ posts with no script and a redisplay after a failed submit keeps the pick.
         <c-n26.form-section title="Asset">
             {% if assets %}
                 <c-n26.radio-cards label="Asset *"
-                                   description="The pooled assets this campaign offers."
+                                   description="The pooled assets of this campaign's type and its additions."
                                    :form="form"
                                    name="asset">
                     {% for asset in assets %}
@@ -55,7 +55,7 @@ posts with no script and a redisplay after a failed submit keeps the pick.
                 </c-n26.radio-cards>
             {% else %}
                 <c-ui.alert variant="info" title="Nothing to add">
-                    {{ campaign.campaign_type }} offers no pooled assets yet.
+                    {{ campaign.campaign_type }} and this campaign's additions have no pooled assets yet.
                 </c-ui.alert>
             {% endif %}
         </c-n26.form-section>

--- a/n26/core/templates/n26/campaign_pool.html
+++ b/n26/core/templates/n26/campaign_pool.html
@@ -107,7 +107,7 @@ nothing back from a pool that already holds a copy.
         {% empty %}
             <p class="text-sm text-muted">
                 Nothing in the pool yet.
-                {% if yours %}Add an asset from the campaign type's catalogue.{% endif %}
+                {% if yours %}Add a copy of an asset the campaign deals in.{% endif %}
             </p>
         {% endfor %}
     </div>

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -571,24 +571,18 @@ def remove_battle(request, pk, battle_pk):
     )
 
 
-def _catalogue(campaign):
-    """The assets this campaign can put in its pool: what its type and its
-    additions offer, of the pooled kinds only.
+def _pooled_assets(campaign):
+    """The assets this campaign can put copies of in its pool: those of
+    the pooled kinds of its type and of its additions.
 
     A held-one-each asset is every member gang's own, given on joining,
     and has no pool to sit in. Archived assets are left out here, where a
     new copy would be made — archiving hides a thing from new grants and
     takes nothing back from a pool that already holds it.
     """
-    from django.db.models import Q
-
-    from n26.library.models import Asset, AssetKind
-
     return (
-        Asset.objects.unarchived()
-        .filter(kind__mode=AssetKind.Mode.POOLED)
-        .filter(Q(offered_by=campaign.campaign_type) | Q(offered_by=campaign.additions))
-        .distinct()
+        (campaign.campaign_type.pooled_assets() | campaign.additions.pooled_assets())
+        .unarchived()
         .select_related("kind")
         .order_by("kind__position", "kind__label_singular", "name")
     )
@@ -674,15 +668,15 @@ def campaign_pool(request, pk):
 @requires_flag(CAMPAIGNS)
 @login_required
 def add_to_pool(request, pk):
-    """Put one copy of an asset from the catalogue into the pool."""
+    """Put one copy of an asset the campaign deals in into the pool."""
     from n26.core.campaigns import campaign_operation
     from n26.core.forms import AddToPoolForm
 
     found = _own_campaign_or_404(request, pk)
-    catalogue = _catalogue(found)
+    offered = _pooled_assets(found)
 
     if request.method == "POST":
-        form = AddToPoolForm(request.POST, catalogue=catalogue)
+        form = AddToPoolForm(request.POST, offered=offered)
         if form.is_valid():
             with campaign_operation(found, actor=request.user) as act:
                 token = act.add_asset(
@@ -691,7 +685,7 @@ def add_to_pool(request, pk):
             messages.success(request, f"Added {token} to the pool.")
             return redirect("n26-campaign-pool", pk=found.pk)
     else:
-        form = AddToPoolForm(catalogue=catalogue)
+        form = AddToPoolForm(offered=offered)
 
     submitted = str(form["asset"].value() or "")
     return render(
@@ -713,7 +707,7 @@ def add_to_pool(request, pk):
                     ),
                     "checked": str(asset.pk) == submitted,
                 }
-                for asset in catalogue
+                for asset in offered
             ],
         },
     )

--- a/n26/library/admin.py
+++ b/n26/library/admin.py
@@ -81,8 +81,6 @@ class CampaignTypeAdmin(admin.ModelAdmin):
     list_filter = ["pack", "archived"]
     search_fields = ["name"]
     inlines = [AssetKindInline]
-    # A plain multi-select here would draw every asset in the library.
-    autocomplete_fields = ["assets"]
     list_select_related = ["pack"]
 
 

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -83,39 +83,22 @@ def create_gang_type(
 # --- Campaign types and assets ---------------------------------------------
 
 
-def create_campaign_type(
-    name, assets=(), qualifier="", library_author_help="", **kwargs
-):
-    """A kind of campaign, for a campaign to be founded on. ``assets`` is
-    the catalogue it offers; its asset kinds are added afterwards with
-    ``add_asset_kind``. Stored stripped, as a gang type's name is."""
+def create_campaign_type(name, qualifier="", library_author_help="", **kwargs):
+    """A kind of campaign, for a campaign to be founded on. Its asset
+    kinds are added afterwards with ``add_asset_kind``, and its assets
+    under those with ``create_asset``. Stored stripped, as a gang type's
+    name is."""
     from n26.library.models import CampaignType
 
     name = (name or "").strip()
     if not name:
         raise ValidationError("A campaign type needs a name.")
-    campaign_type = CampaignType.objects.create(
+    return CampaignType.objects.create(
         name=name,
         qualifier=qualifier,
         library_author_help=library_author_help,
         **kwargs,
     )
-    if assets:
-        campaign_type.assets.set(assets)
-    return campaign_type
-
-
-def set_assets(campaign_type, assets=None):
-    """The catalogue, replaced — the write ``revise`` refuses.
-
-    The list handed over is the whole statement: an asset it does not
-    name is no longer offered by this type. Nothing a campaign already
-    holds changes; this is what a campaign of the type can hand out from
-    now on. ``None`` says nothing and leaves the catalogue as it was.
-    """
-    if assets is not None:
-        campaign_type.assets.set(assets)
-    return campaign_type
 
 
 def add_asset_kind(
@@ -158,16 +141,15 @@ def remove_asset_kind(kind):
 
     Refused in words while any asset is of this kind: each of those
     would be left of no kind at all, and the database would refuse the
-    delete with nobody's name on it. Move or delete the assets first.
+    delete with nobody's name on it. An asset's kind is settled when it
+    is made, so the way clear is to delete the assets first.
     """
     count = kind.assets.count()
     if count:
         noun = "asset is" if count == 1 else "assets are"
         them = "it" if count == 1 else "them"
-        their = "its" if count == 1 else "their"
         raise ValidationError(
-            f"{count} {noun} of the kind {kind}. Delete {them}, or change "
-            f"{their} kind, before removing {kind}."
+            f"{count} {noun} of the kind {kind}. Delete {them} before removing {kind}."
         )
     kind.delete()
 
@@ -175,9 +157,20 @@ def remove_asset_kind(kind):
 def create_asset(
     name, kind, annotation="", income=0, qualifier="", library_author_help="", **kwargs
 ):
-    """One asset of one kind — a Settlement, the Old Ruins territory."""
+    """One asset of one kind — a Settlement, the Old Ruins territory.
+
+    An asset is one entry in its kind's campaign type's list, so it lands
+    in that type's pack unless told otherwise — a type in a campaign's
+    own pack keeps its assets there. A blank name is refused here rather
+    than drawn as an empty line on a campaign page.
+    """
     from n26.library.models import Asset
 
+    if "pack" not in kwargs and "pack_id" not in kwargs:
+        kwargs["pack_id"] = kind.pack_id
+    name = (name or "").strip()
+    if not name:
+        raise ValidationError("An asset needs a name.")
     return Asset.objects.create(
         name=name,
         kind=kind,

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -103,19 +103,21 @@ Assignable for the same reason a profile is: founding is a gang-hosted assignmen
 
 *A kind of campaign — Dominion, Law & Misrule — assigned to every gang that joins a campaign founded on it.*
 
-Fields of its own: its **asset kinds** (see below) and the **assets** it offers — its catalogue. An asset can be offered by several campaign types.
+Fields of its own: its **asset kinds** (see below). Under each kind sit the **assets** of that kind — the list of what a campaign of this type hands out. An asset belongs to one kind, and so to one campaign type; there is no separate list on the type.
 
 Assignable for the same reason a gang type is: joining a campaign is a gang-hosted assignment naming the type. That gives the built-ins every member gang arrives with — a Reputation counter with its opening value, a Settlement — something to be caused by, and gives campaign-wide modifiers a carrier every member's card can find. Its pricing fields stay at zero; nobody buys a campaign type.
 
 Shared types live in the system pack. The one that ships is **N26 core**, with Settlement (held one each) and Territory (pooled) as its kinds, a Settlement asset, and Reputation at 0 built in. An arbitrator's additions to one campaign — a counter, a kind, a label — go on a second campaign type in that campaign's own pack, layered on the shared one rather than copied from it.
 
-**Asset kind** — *a class of asset a campaign type deals in: Territory, Racket, Settlement.* A row on the campaign type, edited on its page: a label (singular and plural, the plural defaulting to an s), a **mode**, and a position. The mode is on the kind, not the asset, because a whole class behaves one way. **Held one each**: every gang is given one when it joins, and it is never staked (a Settlement, a home territory). **Pooled**: the campaign holds a pool of them and each has one holder at a time (a Territory, a Racket, a Relic). Two kinds of one type cannot share a label, and a kind cannot be removed while any asset is of it.
+**Asset kind** — *a class of asset a campaign type deals in: Territory, Racket, Settlement.* A row on the campaign type, edited on its page: a label (singular and plural, the plural defaulting to an s), a **mode**, and a position. Its assets are listed under it on the same page, and added there. The mode is on the kind, not the asset, because a whole class behaves one way. **Held one each**: every gang is given one when it joins, and it is never staked (a Settlement, a home territory). **Pooled**: the campaign holds a pool of them and each has one holder at a time (a Territory, a Racket, a Relic). Two kinds of one type cannot share a label, and a kind cannot be removed while any asset is of it.
 
 ### Asset
 
 *One thing a campaign deals in — a Settlement, the Old Ruins territory, a Racket — of one asset kind.*
 
-Fields of its own: its **kind** (which fixes the campaign type it belongs to and how it behaves) and an **income** figure. The income is printed on the card and never collected; nothing moves credits. What holding the asset does for its holder — Reputation while held, a special rule, a free hire — rides it as ordinary modifiers.
+One entry in the list of what a campaign type hands out. It is made on the type's page, under one of the type's kinds, and that is the only way it belongs to the type. Assets have no listing or create page of their own; an asset's own page, reached from the type's, is where its modifiers and the rest of its fields are edited.
+
+Fields of its own: its **kind** (settled when the asset is made, and fixing both the campaign type it belongs to and how it behaves) and an **income** figure. The income is printed on the card and never collected; nothing moves credits. What holding the asset does for its holder — Reputation while held, a special rule, a free hire — rides it as ordinary modifiers.
 
 Assignable so that an asset of a held-one-each kind can be built into its campaign type and arrive on every member gang, and so that an asset of either kind can carry modifiers. A pooled asset is never assigned: the campaign's token records who holds it.
 

--- a/n26/library/core_campaign.py
+++ b/n26/library/core_campaign.py
@@ -3,9 +3,9 @@
 Reputation is a counter every campaign type in the books tracks, so it
 ships in the system pack. The N26 core type declares the two asset kinds
 the core rules deal in — a Settlement every gang holds, and Territories
-held one at a time from a pool — and gives every member gang Reputation
-at 0 and a Settlement through its built-ins. See
-design/campaign-assets.md.
+held one at a time from a pool — with one Settlement asset under the
+Settlement kind, and gives every member gang Reputation at 0 and that
+Settlement through its built-ins. See design/campaign-assets.md.
 
 Everything is matched on its natural key and left alone if it is
 already there, so this can run against a database that has some of it,
@@ -85,10 +85,7 @@ def seed_core_campaign(apps):
         settlement = Asset.objects.create(
             pack=pack, name=SETTLEMENT, kind=kinds[SETTLEMENT]
         )
-        lines.append(f"created the {SETTLEMENT} asset")
-    if not campaign_type.assets.filter(pk=settlement.pk).exists():
-        campaign_type.assets.add(settlement)
-        lines.append(f"offered {SETTLEMENT} from {CAMPAIGN_TYPE}")
+        lines.append(f"created the {SETTLEMENT} asset under the {SETTLEMENT} kind")
 
     built_ins = campaign_type.built_ins
     if built_ins is None:

--- a/n26/library/migrations/0081_the_n26_core_campaign_type.py
+++ b/n26/library/migrations/0081_the_n26_core_campaign_type.py
@@ -1,9 +1,9 @@
 """The N26 core campaign type, its asset kinds, and Reputation.
 
 Reputation becomes a counter in the system pack; the N26 core type
-declares Settlement (held one each) and Territory (pooled), offers a
-Settlement asset, and gives every member gang Reputation at 0 and the
-Settlement through its built-ins. ``n26/library/core_campaign.py``
+declares Settlement (held one each) and Territory (pooled), has one
+Settlement asset under the Settlement kind, and gives every member gang
+Reputation at 0 and the Settlement through its built-ins. ``n26/library/core_campaign.py``
 holds the rows and matches each on its natural key, so a database that
 already has any of them is left as it stands.
 

--- a/n26/library/migrations/0082_an_asset_belongs_to_its_kinds_campaign_type.py
+++ b/n26/library/migrations/0082_an_asset_belongs_to_its_kinds_campaign_type.py
@@ -1,0 +1,42 @@
+"""An asset belongs to a campaign type through its kind, and nothing else.
+
+The campaign type's own list of assets goes. An asset names one kind
+and a kind names one campaign type, so the list said nothing the kind's
+column did not already say, and a second statement of one fact is a
+place for the two to disagree. There is no data to carry across: every
+asset a type listed was of one of that type's kinds, which is how it
+came to be listed, so ``CampaignType.assets`` — now read through the
+kinds — answers exactly as the table did.
+
+The asset's kind column also gets the words that say how it is settled;
+its shape is unchanged.
+
+Reversible: the table comes back empty, and the seed and the authoring
+pages no longer write to it.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0081_the_n26_core_campaign_type"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="campaigntype",
+            name="assets",
+        ),
+        migrations.AlterField(
+            model_name="asset",
+            name="kind",
+            field=models.ForeignKey(
+                help_text="Which kind this asset is one of. Settled when the asset is made on its campaign type's page, and never changed afterwards.",
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="assets",
+                to="library.assetkind",
+            ),
+        ),
+    ]

--- a/n26/library/models/campaign_type.py
+++ b/n26/library/models/campaign_type.py
@@ -2,10 +2,11 @@
 
 A **campaign type** is to a campaign what a gang type is to a gang: the
 authored thing it is founded on. It holds a built-in set (what every
-member gang gets), campaign-wide modifiers, its **asset kinds**, and the
-**assets** it offers (the catalogue). Shared types live in the system
-pack; an arbitrator's additions to one campaign live in that campaign's
-own pack as a second type layered on top. See design/campaign-assets.md.
+member gang gets), campaign-wide modifiers, and its **asset kinds**, each
+of which lists the **assets** of that kind. Shared types live in the
+system pack; an arbitrator's additions to one campaign live in that
+campaign's own pack as a second type layered on top. See
+design/campaign-assets.md.
 
 An **asset kind** is a row on the type with a label and a mode. The mode
 is on the kind rather than the asset because it is a whole class of
@@ -13,10 +14,13 @@ asset that behaves one way: a Settlement is given to every gang on
 joining and never staked; a Territory is a token in the campaign's pool
 with one holder at a time.
 
-An **asset** is one thing of one kind. It is assignable so that a
-held-one-each asset can be a built-in member and so that either mode
-can carry modifiers for what holding it does. A pooled asset is never
-assigned; the campaign's token records who holds it.
+An **asset** is one entry in a campaign type's list of what it hands
+out, filed under one of the type's kinds — that is the whole of how it
+belongs to the type, and it is authored on the type's page. It is
+assignable so that a held-one-each asset can be a built-in member and
+so that either mode can carry modifiers for what holding it does. A
+pooled asset is never assigned; the campaign's token records who holds
+it.
 """
 
 from django.db import models
@@ -41,21 +45,11 @@ class CampaignType(Content, Assignable):
     every member's card can find.
 
     It also declares its **asset kinds** — Territory, Racket, Settlement —
-    and lists the **assets** it offers. Its pricing fields stay at zero;
-    nobody buys a campaign type.
+    and under each kind lists the **assets** a campaign of this type hands
+    out. Its pricing fields stay at zero; nobody buys a campaign type.
     """
 
     family = Family.GANG
-
-    assets = models.ManyToManyField(
-        "library.Asset",
-        blank=True,
-        related_name="offered_by",
-        help_text=(
-            "The assets a campaign of this type can hand out. An asset can "
-            "be offered by several campaign types."
-        ),
-    )
 
     class Meta:
         verbose_name = "campaign type"
@@ -73,6 +67,23 @@ class CampaignType(Content, Assignable):
 
     def __str__(self):
         return self.name
+
+    @property
+    def assets(self):
+        """Every asset this type hands out: the assets of its kinds.
+
+        An asset belongs to one kind and the kind to one type, so this is
+        the whole relationship — there is no list on the type to keep in
+        step with it. Archived assets are included, as a plain read is;
+        a surface offering new copies narrows with ``unarchived()``.
+        """
+        return Asset.objects.filter(kind__campaign_type=self)
+
+    def pooled_assets(self):
+        """The assets a campaign of this type can put copies of in its
+        pool: those of its pooled kinds. A held-one-each asset is every
+        member gang's own and has no pool to sit in."""
+        return self.assets.filter(kind__mode=AssetKind.Mode.POOLED)
 
 
 class AssetKind(Content):
@@ -161,8 +172,10 @@ class Asset(Content, Assignable):
     """One thing a campaign deals in — a Settlement, the Old Ruins
     territory, a Racket — of one asset kind.
 
-    Its **income** is a figure drawn on the card; nothing collects it.
-    What holding it does for the holder rides it as ordinary modifiers.
+    An asset is one entry in the list of what its campaign type hands
+    out, and is added on that type's page under its kind. Its **income**
+    is a figure drawn on the card; nothing collects it. What holding it
+    does for the holder rides it as ordinary modifiers.
 
     Assignable so that an asset of a held-one-each kind can be built into
     its campaign type and arrive on every member gang, and so that an
@@ -176,7 +189,10 @@ class Asset(Content, Assignable):
         AssetKind,
         on_delete=models.PROTECT,
         related_name="assets",
-        help_text="Which asset kind this is. A kind belongs to one campaign type.",
+        help_text=(
+            "Which kind this asset is one of. Settled when the asset is made "
+            "on its campaign type's page, and never changed afterwards."
+        ),
     )
     income = models.PositiveIntegerField(
         default=0,

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -248,8 +248,9 @@ class Spec:
     deprecated: bool = False
     #: Whether the verb writes its row into the pack of the carrier it is
     #: handed, rather than the default pack. A part that is part of its
-    #: carrier — an asset kind of a campaign type — says so, and the form
-    #: checking what the row may reference judges by that pack.
+    #: carrier — an asset kind of a campaign type, an asset of a kind —
+    #: says so, and the form checking what the row may reference judges
+    #: by that pack.
     joins_carrier_pack: bool = False
 
     @property
@@ -1110,16 +1111,12 @@ def _build_registry():
             },
         ),
         # The campaign surface: the type a campaign is founded on, the
-        # kinds of asset it deals in, and the assets themselves.
+        # kinds of asset it deals in, and under each kind the assets
+        # themselves.
         Spec(
             authoring.create_campaign_type,
             {
                 "name": Text(source=(CampaignType, "name")),
-                "assets": Many(
-                    model=Asset,
-                    source=(CampaignType, "assets"),
-                    replaced_by=authoring.set_assets,
-                ),
                 "qualifier": Text(source=(CampaignType, "qualifier")),
                 "library_author_help": Text(
                     source=(CampaignType, "library_author_help"), long=True
@@ -1138,18 +1135,22 @@ def _build_registry():
             identity="label_singular",
             joins_carrier_pack=True,
         ),
+        # An asset is made on its campaign type's page, under one of the
+        # type's kinds: the kind is the carrier the form is handed, fixed
+        # from then on, and the asset joins the type's pack.
         Spec(
             authoring.create_asset,
             {
                 "name": Text(source=(Asset, "name")),
                 "annotation": Text(source=(Asset, "annotation")),
-                "kind": One(model=AssetKind, source=(Asset, "kind")),
+                "kind": One(model=AssetKind, source=(Asset, "kind"), fixed=True),
                 "income": Int(source=(Asset, "income")),
                 "qualifier": Text(source=(Asset, "qualifier")),
                 "library_author_help": Text(
                     source=(Asset, "library_author_help"), long=True
                 ),
             },
+            joins_carrier_pack=True,
         ),
         Spec(
             authoring.create_profile,

--- a/n26/library/templates/authoring/_editable_parts.html
+++ b/n26/library/templates/authoring/_editable_parts.html
@@ -5,28 +5,36 @@ no page of their own. Each form names its part in `part` and says in
 which form was clicked. Removing stays a page of its own, as it is for
 every part, because what the act reaches cannot be read off the row.
 
-Takes `section`, whose parts each carry an `edit_form`.
+A part may hold things of its own — the assets of an asset kind — which
+are listed and added under it, in the same box but outside its form,
+because a form cannot hold another form.
+
+Takes `section`, whose parts each carry an `edit_form` and maybe `under`.
 {% endcomment %}
 <div class="space-y-4">
     {% for part in section.parts %}
-        <form method="post"
-              class="rounded-box border border-box-border p-4"
-              id="part-{{ part.pk }}">
-            {% csrf_token %}
-            <input type="hidden" name="act" value="edit-part">
-            <input type="hidden" name="part" value="{{ part.pk }}">
-            <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-                <span class="font-medium">{{ part.label }}</span>
-                <span class="text-sm text-muted">{{ part.notes|join:" · " }}</span>
-            </div>
-            <div class="mt-4 grid gap-4 sm:grid-cols-2">{% include "authoring/_form.html" with form=part.edit_form %}</div>
-            <c-n26.form-actions submit_label="Save" size="sm" class="mt-4">
-                {% if part.remove_url %}
-                    <c-ui.button href="{{ part.remove_url }}" size="sm" variant="ghost">
-                        Remove
-                    </c-ui.button>
-                {% endif %}
-            </c-n26.form-actions>
-        </form>
+        <div class="rounded-box border border-box-border p-4"
+             id="part-{{ part.pk }}">
+            <form method="post">
+                {% csrf_token %}
+                <input type="hidden" name="act" value="edit-part">
+                <input type="hidden" name="part" value="{{ part.pk }}">
+                <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                    <span class="font-medium">{{ part.label }}</span>
+                    <span class="text-sm text-muted">{{ part.notes|join:" · " }}</span>
+                </div>
+                <div class="mt-4 grid gap-4 sm:grid-cols-2">{% include "authoring/_form.html" with form=part.edit_form %}</div>
+                <c-n26.form-actions submit_label="Save" size="sm" class="mt-4">
+                    {% if part.remove_url %}
+                        <c-ui.button href="{{ part.remove_url }}" size="sm" variant="ghost">
+                            Remove
+                        </c-ui.button>
+                    {% endif %}
+                </c-n26.form-actions>
+            </form>
+            {% if part.under %}
+                {% include "authoring/_under_part.html" with under=part.under %}
+            {% endif %}
+        </div>
     {% endfor %}
 </div>

--- a/n26/library/templates/authoring/_under_part.html
+++ b/n26/library/templates/authoring/_under_part.html
@@ -1,0 +1,42 @@
+{% comment %}
+The things one part holds under it, listed and added in place: the assets
+of one asset kind, on its campaign type's page. Each row's name leads to
+the thing's own page, where its modifiers and the rest of its fields are
+edited. The form under the list adds one more; it names the part it goes
+under in `part` and its act in `act`, so the view knows which block was
+clicked.
+
+Takes `under`: the rows, the add form, the part's pk, and the words for
+all three.
+{% endcomment %}
+<div class="mt-5 border-t border-box-border pt-4">
+    <h4 class="text-sm font-medium">{{ under.parts_label|capfirst }}</h4>
+    {% if under.rows %}
+        <c-ui.table class="mt-2">
+            <tbody>
+                {% for row in under.rows %}
+                    <tr>
+                        <td class="whitespace-nowrap">
+                            <c-n26.link href="{{ row.href }}">
+                                {{ row.label }}
+                            </c-n26.link>
+                        </td>
+                        <td class="w-full text-right text-muted">{{ row.notes|join:" · " }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </c-ui.table>
+    {% else %}
+        <c-ui.description>
+            {{ under.nothing_yet }}
+        </c-ui.description>
+    {% endif %}
+    <form method="post" class="mt-4">
+        {% csrf_token %}
+        <input type="hidden" name="act" value="{{ under.act }}">
+        <input type="hidden" name="part" value="{{ under.part_pk }}">
+        <p class="text-sm font-medium">Add {{ under.part_name }}</p>
+        <div class="mt-3 grid gap-4 sm:grid-cols-3">{% include "authoring/_form.html" with form=under.form %}</div>
+        <c-n26.form-actions submit_label="Add" size="sm" class="mt-4" />
+    </form>
+</div>

--- a/n26/library/templates/authoring/asset_kind_remove.html
+++ b/n26/library/templates/authoring/asset_kind_remove.html
@@ -6,8 +6,8 @@ reload, Back is a real way out, and it works with scripting switched
 off. Nothing here changes anything — the form's POST is the act.
 
 While any asset is of the kind the act is refused, so the page lists
-them: each is a way to the asset, where its kind is changed or the asset
-deleted.
+them: each is a way to the asset, where it can be deleted. An asset's
+kind is settled when it is made, so deleting is the only way clear.
 {% endcomment %}
 {% block head_title %}Remove {{ label }}{% endblock head_title %}
 {% block content %}
@@ -31,7 +31,7 @@ deleted.
         {% csrf_token %}
         {% if assets %}
             <c-ui.alert variant="warning" title="Assets are still of this kind">
-                You cannot remove it until you delete these assets, or change them to another kind:
+                You cannot remove it until you delete these assets:
                 <ul class="mt-2 list-disc pl-5">
                     {% for asset in assets %}
                         <li>

--- a/n26/library/templates/authoring/detail.html
+++ b/n26/library/templates/authoring/detail.html
@@ -23,9 +23,20 @@ thing twice, a line apart.
         <c-slot name="breadcrumb">
             <c-ui.breadcrumbs>
                 <c-ui.breadcrumbs.item href="{% url 'authoring-index' %}">Content library</c-ui.breadcrumbs.item>
-                <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' kind %}">
-                    {{ verbose_name_plural|capfirst }}
-                </c-ui.breadcrumbs.item>
+                {% comment %}
+                A kind made on its parent's page has no listing of its
+                own, so the trail runs through the parent's kind instead:
+                Content library, Campaign types, the type, the asset.
+                {% endcomment %}
+                {% if nested %}
+                    <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' parent.kind %}">
+                        {{ parent.verbose_name_plural|capfirst }}
+                    </c-ui.breadcrumbs.item>
+                {% else %}
+                    <c-ui.breadcrumbs.item href="{% url 'authoring-leaf' kind %}">
+                        {{ verbose_name_plural|capfirst }}
+                    </c-ui.breadcrumbs.item>
+                {% endif %}
                 {% comment %}
                 A kind filed under another names it here, which is the
                 only place some pages name it at all: a field settled

--- a/n26/library/templatetags/authoring_nav.py
+++ b/n26/library/templatetags/authoring_nav.py
@@ -42,8 +42,16 @@ def kinds_switcher(here="", menu_label="Switch kind", named=False):
 
     from n26.core.navigation import Switcher, SwitcherItem
     from n26.library.specs import specs
-    from n26.library.views import LEAF_KINDS, RETIRED_KINDS, _model_for
+    from n26.library.views import (
+        LEAF_KINDS,
+        NESTED_KINDS,
+        RETIRED_KINDS,
+        _model_for,
+    )
 
+    # A kind listed only on its parent's page has no listing to go to,
+    # so the switcher never offers it — from one of its rows the leading
+    # link is the library index, and the breadcrumb is the way up.
     items = sorted(
         (
             SwitcherItem(
@@ -54,7 +62,7 @@ def kinds_switcher(here="", menu_label="Switch kind", named=False):
                 current=kind == here,
             )
             for kind, verb in LEAF_KINDS.items()
-            if kind not in RETIRED_KINDS or kind == here
+            if kind not in NESTED_KINDS and (kind not in RETIRED_KINDS or kind == here)
         ),
         key=lambda item: item.label,
     )

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -86,6 +86,17 @@ LEAF_KINDS = {
 RETIRED_KINDS = frozenset({"affiliation"})
 
 
+#: Kinds made on another kind's page rather than from the menu. An asset
+#: is one entry in a campaign type's list of what it hands out, filed
+#: under one of the type's kinds, so it is added there, under that kind;
+#: a menu entry, a listing and a create page of its own would offer the
+#: same thing a second way, from a page that cannot say which kind. Each
+#: row keeps a page of its own — reached from the parent's — for its
+#: modifiers and the rest of its fields, and its breadcrumb runs through
+#: the parent's kind rather than a listing it does not have.
+NESTED_KINDS = frozenset({"asset"})
+
+
 #: Kinds whose page is a place you come back to: the thing, and the
 #: parts you add to it over time. ``kind -> the verb that adds a part``.
 def _describe_weapon_profile(profile):
@@ -164,19 +175,28 @@ def _describe_built_in(member):
 
 def _describe_asset_kind(kind):
     """One class of asset a campaign type deals in: what several are
-    called, how the kind behaves, and how many assets are of it — the
-    count being what an author has to clear before the kind can go.
+    called and how the kind behaves. Its assets are not counted here —
+    they are listed under it on the same page."""
+    return kind.label_singular, [kind.plural, kind.get_mode_display().lower()]
 
-    Reads the assets with ``.all()``, so a page that prefetched them
-    describes every kind of a type without a query per row.
+
+def _describe_asset(asset):
+    """One asset under its kind: the income figure its card prints, and
+    how many modifiers ride it — what those do is read on the asset's own
+    page, which the name leads to.
+
+    Reads the modifiers with ``.all()``, so a page that prefetched them
+    describes every asset of a type without a query per row.
     """
-    count = len(kind.assets.all())
-    notes = [kind.plural, kind.get_mode_display().lower()]
+    notes = []
+    if asset.income:
+        notes.append(f"income {asset.income}cr")
+    count = len(asset.modifiers.all())
     if count == 0:
-        notes.append("no assets yet")
+        notes.append("no modifiers")
     else:
-        notes.append(f"{count} asset" if count == 1 else f"{count} assets")
-    return kind.label_singular, notes
+        notes.append(f"{count} modifier" if count == 1 else f"{count} modifiers")
+    return _label_for(asset), notes
 
 
 def _describe_picklist_member(member):
@@ -365,13 +385,14 @@ DETAIL_KINDS = {
         "parts": "asset_kinds",
         "statline": False,
         "describe": _describe_asset_kind,
-        "parts_hint": lambda parts: parts.prefetch_related("assets"),
+        "parts_hint": lambda parts: parts.prefetch_related("assets__modifiers"),
         "parts_label": "asset kinds",
         "part_name": "asset kind",
         "parts_description": (
             "The classes of asset a campaign of this type deals in — "
             "Territory, Racket, Settlement. Each has a label a campaign page "
-            "prints, and a mode every asset of the kind follows."
+            "prints, and a mode every asset of the kind follows. The assets "
+            "themselves are listed under their kind, and added there."
         ),
         "nothing_yet": (
             "No asset kinds yet. A campaign of this type has nothing to hand "
@@ -380,6 +401,28 @@ DETAIL_KINDS = {
         # An asset kind has no page of its own: its four fields are
         # edited in place, on the row that lists it.
         "editable": True,
+        # Under each kind, the assets of it, and the form that adds one
+        # more. An asset is one entry in the type's list, so it is made
+        # here rather than from the menu: the kind is the carrier its form
+        # is handed, and the asset joins the type's pack.
+        "under_each": {
+            "act": "add-asset",
+            "verb": "create_asset",
+            "parts": "assets",
+            # The spec field the carrier answers, so the form does not ask
+            # it — the kind is settled by which block the author typed in.
+            "carrier_field": "kind",
+            # What the form asks here. The rest of an asset's fields are
+            # edited on its own page, which its name leads to.
+            "fields": ("name", "annotation", "income"),
+            "describe": _describe_asset,
+            "opens": lambda asset: reverse(
+                "authoring-detail", args=["asset", asset.pk]
+            ),
+            "parts_label": lambda kind: kind.plural,
+            "part_name": lambda kind: kind.label_singular,
+            "nothing_yet": lambda kind: f"No {kind.plural} yet.",
+        },
         # Taking a kind off is refused while any asset is of it, and the
         # refusal needs a page: a row's control cannot say what stands
         # in the way.
@@ -944,29 +987,20 @@ def _describe_gang_type(gang_type):
 
 def _describe_campaign_type(campaign_type):
     """A campaign type, as a listing needs to tell one from the next:
-    the kinds of asset it deals in and how many assets it offers.
+    the kinds of asset it deals in and how many assets it hands out.
 
-    Reads both sets with ``.all()``, so a listing that prefetched them
-    describes every type without a query per row.
+    Reads the kinds and their assets with ``.all()``, so a listing that
+    prefetched them describes every type without a query per row.
     """
-    kinds = [kind.plural for kind in campaign_type.asset_kinds.all()]
-    count = len(campaign_type.assets.all())
-    notes = [", ".join(kinds) if kinds else "no asset kinds yet"]
+    kinds = list(campaign_type.asset_kinds.all())
+    count = sum(len(kind.assets.all()) for kind in kinds)
+    notes = [
+        ", ".join(kind.plural for kind in kinds) if kinds else "no asset kinds yet"
+    ]
     if count == 0:
-        notes.append("offers no assets yet")
+        notes.append("no assets yet")
     else:
-        notes.append(
-            f"offers {count} asset" if count == 1 else f"offers {count} assets"
-        )
-    return notes
-
-
-def _describe_asset(asset):
-    """An asset: which kind of which campaign type it is, and the income
-    figure its card prints."""
-    notes = [f"{asset.kind} ({asset.kind.campaign_type})"]
-    if asset.income:
-        notes.append(f"income {asset.income}cr")
+        notes.append(f"{count} asset" if count == 1 else f"{count} assets")
     return notes
 
 
@@ -1056,7 +1090,6 @@ LEAF_DESCRIBE = {
     "profile": _describe_profile,
     "gang-type": _describe_gang_type,
     "campaign-type": _describe_campaign_type,
-    "asset": _describe_asset,
     "slot-type": _describe_slot_type,
     "pickable": _describe_pickable,
     "picklist": _describe_picklist,
@@ -1099,10 +1132,8 @@ LEAF_LISTING_HINTS = {
         "members"
     ),
     "slot": lambda rows: rows.select_related("slot_type", "picklist"),
-    # A campaign type says its kinds and counts its catalogue; an asset
-    # says which kind of which type it is.
-    "campaign-type": lambda rows: rows.prefetch_related("asset_kinds", "assets"),
-    "asset": lambda rows: rows.select_related("kind__campaign_type"),
+    # A campaign type says its kinds and counts the assets under them.
+    "campaign-type": lambda rows: rows.prefetch_related("asset_kinds__assets"),
 }
 
 
@@ -1196,7 +1227,7 @@ def index(request):
     qualities, the kit, the gang-scale picks."""
     grouped = {family: [] for family in Family}
     for kind, verb_name in LEAF_KINDS.items():
-        if kind in RETIRED_KINDS:
+        if kind in RETIRED_KINDS or kind in NESTED_KINDS:
             continue
         model = _model_for(specs()[verb_name])
         grouped[model.family].append(
@@ -1342,6 +1373,8 @@ def leaf(request, kind):
     author checks content against, so it holds no form — making one is
     a button, and changing one is the row itself.
     """
+    if kind in NESTED_KINDS:
+        raise Http404(f"{kind!r} is listed on its parent's page, not on its own")
     spec = _spec_for(kind)
     model = _model_for(spec)
     describe = LEAF_DESCRIBE.get(kind, _describe_row)
@@ -1500,7 +1533,7 @@ def _selected(rows, pks):
 @staff_member_required
 def create(request, kind):
     """The form that makes one more of a leaf kind, on its own page."""
-    if kind in RETIRED_KINDS:
+    if kind in RETIRED_KINDS or kind in NESTED_KINDS:
         raise Http404(f"No authoring page for {kind!r}")
     spec = _spec_for(kind)
     model = _model_for(spec)
@@ -1760,12 +1793,20 @@ DETAIL_RELATED = {
 
 
 def _parent_of(kind, thing):
-    """The thing this one is filed under, for the bar that says so."""
+    """The thing this one is filed under, for the bar that says so — and
+    the parent kind's plural, which a kind with no listing of its own
+    puts in its breadcrumb where its own listing would go."""
     filed_under = DETAIL_PARENTS.get(kind)
     if filed_under is None:
         return None
     parent_kind, attribute = filed_under
-    return {"kind": parent_kind, "thing": getattr(thing, attribute)}
+    return {
+        "kind": parent_kind,
+        "thing": getattr(thing, attribute),
+        "verbose_name_plural": _model_for(
+            _spec_for(parent_kind)
+        )._meta.verbose_name_plural,
+    }
 
 
 def _related_sections(kind, thing):
@@ -1844,11 +1885,12 @@ def detail(request, kind, pk):
         ),
         None,
     )
+    under_act = _under_act(sections)
     if (
         request.method == "POST"
         and act
         and with_modifiers
-        and act not in ("edit", "edit-part")
+        and act not in ("edit", "edit-part", under_act)
         and posted_to is None
     ):
         response, composer = _modifier_action(request, kind, thing, act)
@@ -1861,6 +1903,15 @@ def detail(request, kind, pk):
     edited = None
     if request.method == "POST" and act == "edit-part":
         response, edited = _edit_part(request, kind, thing, sections)
+        if response is not None:
+            return response
+
+    # A thing added under one part posts its own form back here too,
+    # naming the part it goes under. Refused, the bound form takes the
+    # place of that part's add form.
+    added = None
+    if request.method == "POST" and under_act and act == under_act:
+        response, added = _add_under_part(request, kind, thing, sections)
         if response is not None:
             return response
 
@@ -1887,9 +1938,10 @@ def detail(request, kind, pk):
                 edit_form.add_error(None, refused)
             except IntegrityError:
                 named = spec.identity
+                noun = model._meta.verbose_name
                 edit_form.add_error(
                     named,
-                    f"A {model._meta.verbose_name} named "
+                    f"{_article_for(noun).capitalize()} {noun} named "
                     f"“{edit_form.cleaned_data[named]}” already exists in this pack.",
                 )
             else:
@@ -1963,6 +2015,10 @@ def detail(request, kind, pk):
                         # A part edited in place carries its own form; the
                         # one just refused keeps the form it was refused on.
                         "edit_form": _part_edit_form(section, part_spec, part, edited),
+                        # The things filed under this part, and the form
+                        # that adds one more — for a kind whose parts hold
+                        # things of their own.
+                        "under": _under_part(section, part, added),
                     },
                 )
             )
@@ -2031,6 +2087,7 @@ def detail(request, kind, pk):
             "kind": kind,
             "thing": thing,
             "parent": _parent_of(kind, thing),
+            "nested": kind in NESTED_KINDS,
             "related_sections": _related_sections(kind, thing),
             "prose": said,
             "verbose_name": model._meta.verbose_name,
@@ -2096,6 +2153,112 @@ def _edit_part(request, kind, thing, sections):
         else:
             said, _ = section["describe"](part)
             messages.success(request, f"Saved {said}.")
+            return redirect("authoring-detail", kind=kind, pk=thing.pk), None
+    return None, (str(part.pk), form)
+
+
+def _under_act(sections):
+    """The act a form adding a thing under one of these sections' parts
+    posts, or blank where no section holds things under its parts."""
+    section = next((one for one in sections if one.get("under_each")), None)
+    return section["under_each"]["act"] if section else ""
+
+
+def _under_form(under, carrier, data=None):
+    """The form that adds one thing under ``carrier``: the spec-generated
+    create form for that kind, asking only what the block asks.
+
+    The carrier fills one spec field itself, so that field is taken off
+    rather than offered as a picker with one possible value, and the
+    fields the block does not ask are left to the thing's own page.
+    Prefixed by the carrier, because a page draws one of these per part
+    and two forms naming a field alike would post as one another.
+    """
+    spec = specs()[under["verb"]]
+    form = generate_form(spec)(
+        data, carrier=carrier, prefix=f"{under['act']}-{carrier.pk}"
+    )
+    for name in list(form.fields):
+        if name not in under["fields"]:
+            form.fields.pop(name)
+    return form
+
+
+def _under_part(section, part, added):
+    """What one part holds under it, drawn: the rows, each leading to its
+    own page, and the form that adds one more — the one just refused,
+    where this is the part it was refused under, else a fresh one.
+    Nothing for a section whose parts hold nothing."""
+    under = section.get("under_each")
+    if under is None:
+        return None
+
+    def worded(value):
+        return value(part) if callable(value) else value
+
+    rows = []
+    for row in getattr(part, under["parts"]).all():
+        label, notes = under["describe"](row)
+        rows.append(
+            {
+                "pk": row.pk,
+                "label": label,
+                "notes": notes,
+                "href": _opens_url(under["opens"], row),
+            }
+        )
+    if added is not None and added[0] == str(part.pk):
+        form = added[1]
+    else:
+        form = _under_form(under, part)
+    # No article before the name: the name is a label an author typed,
+    # and the a/an rule only holds for the app's own words. The carrier's
+    # pk rides along so the partial that draws this needs nothing else.
+    return {
+        "act": under["act"],
+        "part_pk": part.pk,
+        "rows": rows,
+        "form": form,
+        "parts_label": worded(under["parts_label"]),
+        "part_name": str(worded(under["part_name"])),
+        "nothing_yet": worded(under["nothing_yet"]),
+    }
+
+
+def _add_under_part(request, kind, thing, sections):
+    """Write one thing under one of ``thing``'s parts.
+
+    Returns ``(response, refused)`` as ``_edit_part`` does: a redirect
+    when the thing was made, or ``(None, (part pk, bound form))`` when
+    it was refused and the page should redraw with the form's errors in
+    place. A post naming a part this thing does not have is a mistyped
+    address rather than an author's mistake.
+    """
+    section = next((one for one in sections if one.get("under_each")), None)
+    if section is None:
+        raise Http404("Nothing on this page holds things under its parts")
+    under = section["under_each"]
+    spec = specs()[under["verb"]]
+    part = get_object_or_404(
+        getattr(thing, section["parts"]).all(), pk=request.POST.get("part", "")
+    )
+    form = _under_form(under, part, request.POST)
+    if form.is_valid():
+        try:
+            with transaction.atomic():
+                made = spec.verb(**{under["carrier_field"]: part}, **form.verb_data())
+        except ValidationError as refused:
+            form.add_error(None, refused)
+        except IntegrityError:
+            named = spec.identity
+            noun = spec.creates._meta.verbose_name
+            form.add_error(
+                named,
+                f"{_article_for(noun).capitalize()} {noun} named "
+                f"“{form.cleaned_data[named]}” already exists in this pack.",
+            )
+        else:
+            messages.success(request, f"Added {made} under {part}.")
             return redirect("authoring-detail", kind=kind, pk=thing.pk), None
     return None, (str(part.pk), form)
 
@@ -2661,9 +2824,16 @@ def thing_delete(request, kind, pk):
     model = _model_for(spec)
     thing = get_object_or_404(model, pk=pk)
     back = reverse("authoring-detail", args=[kind, pk])
+    # Read before the delete: a kind with no listing of its own goes back
+    # to the page it was made on, and the row is what names that page.
+    parent = _parent_of(kind, thing) if kind in NESTED_KINDS else None
 
     if request.method == "POST":
         if _deleting(request, thing):
+            if parent is not None:
+                return redirect(
+                    "authoring-detail", kind=parent["kind"], pk=parent["thing"].pk
+                )
             return redirect("authoring-leaf", kind=kind)
         return redirect(request.path)
 

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -22,7 +22,7 @@ import pytest
 from django.contrib.auth.models import User
 
 from n26.library.specs import specs
-from n26.library.views import LEAF_KINDS, RETIRED_KINDS
+from n26.library.views import LEAF_KINDS, NESTED_KINDS, RETIRED_KINDS
 
 pytestmark = pytest.mark.django_db
 
@@ -81,20 +81,26 @@ class TestTheMenuIsBackedBySpecs:
                 f"model the verb makes."
             )
 
-    @pytest.mark.parametrize("kind", sorted(LEAF_KINDS), ids=str)
+    @pytest.mark.parametrize(
+        "kind", sorted(k for k in LEAF_KINDS if k not in NESTED_KINDS), ids=str
+    )
     def test_every_leaf_page_renders(self, kind, author, client, default_pack):
         response = client.get(f"/n26/authoring/{kind}/")
         assert response.status_code == 200
 
     @pytest.mark.parametrize(
-        "kind", sorted(k for k in LEAF_KINDS if k not in RETIRED_KINDS), ids=str
+        "kind",
+        sorted(k for k in LEAF_KINDS if k not in RETIRED_KINDS | NESTED_KINDS),
+        ids=str,
     )
     def test_every_kind_has_a_create_page(self, kind, author, client, default_pack):
         response = client.get(f"/n26/authoring/{kind}/new/")
         assert response.status_code == 200
 
     @pytest.mark.parametrize(
-        "kind", sorted(k for k in LEAF_KINDS if k not in RETIRED_KINDS), ids=str
+        "kind",
+        sorted(k for k in LEAF_KINDS if k not in RETIRED_KINDS | NESTED_KINDS),
+        ids=str,
     )
     def test_no_switch_is_handed_a_value_javascript_cannot_read(
         self, kind, author, client, default_pack
@@ -107,7 +113,9 @@ class TestTheMenuIsBackedBySpecs:
         assert "switchInput(false, none)" not in body
         assert "switchInput(false, None)" not in body
 
-    @pytest.mark.parametrize("kind", sorted(LEAF_KINDS), ids=str)
+    @pytest.mark.parametrize(
+        "kind", sorted(k for k in LEAF_KINDS if k not in NESTED_KINDS), ids=str
+    )
     def test_every_leaf_page_renders_with_rows_in_it(
         self, kind, author, client, default_pack
     ):

--- a/n26/tests/sandbox/test_campaign_assets.py
+++ b/n26/tests/sandbox/test_campaign_assets.py
@@ -69,11 +69,11 @@ def core(default_pack):
 
 @pytest.fixture
 def old_ruins(core):
-    """A Territory in the core catalogue with the two boons a territory
-    can carry: Reputation while held, and a named rule for the gang."""
+    """A Territory under the core type's Territory kind, with the two boons
+    a territory can carry: Reputation while held, and a named rule for
+    the gang."""
     territory = core.asset_kinds.get(label_singular="Territory")
     asset = create_asset("Old Ruins", territory, income=30)
-    core.assets.add(asset)
     reputation = Counter.objects.get(name="Reputation")
     modifier(
         "Old Ruins: Reputation",
@@ -413,7 +413,47 @@ class TestThePoolPages:
             {"asset": str(settlement.pk), "name": ""},
         )
         body = response.content.decode()
-        assert "not in this campaign" in body and "catalogue" in body
+        assert "not one this campaign deals in" in body
+        assert campaign.pool.count() == 0
+
+    def test_the_add_form_offers_the_types_and_the_additions_pooled_assets(
+        self, client, campaign, old_ruins, arbitrator, core
+    ):
+        """What the form offers is read through the kinds: every pooled
+        asset of the campaign's type and of its additions, and nothing
+        of another type or of a held-one-each kind."""
+        from n26.library.authoring import add_asset_kind, create_campaign_type
+
+        racket = add_asset_kind(campaign.additions, "Racket", "pooled")
+        protection = create_asset("Protection", racket)
+        other = create_campaign_type("Law & Misrule")
+        elsewhere = create_asset(
+            "Somebody else's turf", add_asset_kind(other, "Turf", "pooled")
+        )
+        client.force_login(arbitrator)
+
+        body = client.get(
+            reverse("n26-campaign-pool-add", args=[campaign.pk])
+        ).content.decode()
+
+        assert "Old Ruins" in body
+        assert "Protection" in body
+        assert "Somebody else" not in body
+        settlement = Asset.objects.get(name="Settlement")
+        assert f'value="{settlement.pk}"' not in body
+        assert protection.pack == campaign.pack
+        assert elsewhere.kind.campaign_type == other
+
+    def test_an_asset_of_another_type_cannot_be_added_to_the_pool(
+        self, campaign, old_ruins
+    ):
+        from n26.library.authoring import add_asset_kind, create_campaign_type
+
+        other = create_campaign_type("Law & Misrule")
+        elsewhere = create_asset("Turf", add_asset_kind(other, "Turf", "pooled"))
+
+        with pytest.raises(ValueError, match="not to this campaign's type"):
+            add_to_pool(campaign, elsewhere)
         assert campaign.pool.count() == 0
 
     def test_the_arbitrator_grants_a_copy(

--- a/n26/tests/sandbox/test_campaign_types.py
+++ b/n26/tests/sandbox/test_campaign_types.py
@@ -1,12 +1,13 @@
 """Campaign types and assets — the library kinds a campaign is founded on.
 
 A campaign type declares the kinds of asset a campaign of it deals in,
-offers a catalogue of assets, and — being assignable, as a gang type is
-— carries built-ins that every member gang gets. An asset is one thing
-of one kind; its income is a figure on the card and its boons ride it
-as modifiers. The N26 core type ships with Settlement held one each,
-Territory pooled, and Reputation at 0 built in. See
-design/campaign-assets.md.
+lists under each kind the assets of it, and — being assignable, as a
+gang type is — carries built-ins that every member gang gets. An asset
+is one entry in that list: it belongs to one kind, and so to one type,
+and is authored on the type's page under its kind; its income is a
+figure on the card and its boons ride it as modifiers. The N26 core type
+ships with Settlement held one each, Territory pooled, and Reputation at
+0 built in. See design/campaign-assets.md.
 
 The same note settles one rule about packs: content in a pack nobody
 owns may never point at content in a pack somebody does. The library's
@@ -29,7 +30,6 @@ from n26.library.authoring import (
     ef_adds,
     modifier,
     remove_asset_kind,
-    set_assets,
     targets_gang,
 )
 from n26.library.core_campaign import seed_core_campaign
@@ -71,9 +71,10 @@ def owned(db):
     arbitrator = User.objects.create_user("arbitrator")
     pack = create_pack("Sump Rats", owner=arbitrator)
     campaign_type = create_campaign_type("Sump Rats campaign", pack=pack)
-    # No pack named: a kind joins its type's pack on its own.
+    # No pack named: a kind joins its type's pack on its own, and an
+    # asset its kind's.
     kind = add_asset_kind(campaign_type, "Rat hole", "pooled")
-    asset = create_asset("The Big Hole", kind, pack=pack)
+    asset = create_asset("The Big Hole", kind)
     counter = create_counter("Meat", pack=pack)
     return {
         "pack": pack,
@@ -85,8 +86,8 @@ def owned(db):
 
 
 class TestAuthoringACampaignType:
-    """The verbs build a type, its kinds and its catalogue, and refuse
-    the two mistakes an author can make in words."""
+    """The verbs build a type, its kinds and the assets under them, and
+    refuse the mistakes an author can make in words."""
 
     def test_a_campaign_type_declares_its_asset_kinds_in_order(self, dominion):
         kinds = list(dominion["type"].asset_kinds.all())
@@ -101,17 +102,35 @@ class TestAuthoringACampaignType:
         assert owned["kind"].pack == owned["pack"]
         assert dominion["territory"].pack == dominion["type"].pack
 
+    def test_an_asset_joins_its_kinds_pack(self, dominion, owned):
+        assert owned["asset"].pack == owned["pack"]
+        ruins = create_asset("Old Ruins", dominion["territory"])
+        assert ruins.pack == dominion["type"].pack
+
+    def test_an_asset_needs_a_name(self, dominion):
+        with pytest.raises(ValidationError, match="An asset needs a name"):
+            create_asset("  ", dominion["territory"])
+
     def test_two_kinds_of_one_type_cannot_share_a_label(self, dominion):
         with pytest.raises(ValidationError, match="already has an asset kind"):
             add_asset_kind(dominion["type"], "territory", "pooled")
 
-    def test_an_asset_is_of_one_kind_and_the_type_offers_it(self, dominion):
+    def test_an_asset_is_of_one_kind_and_so_in_its_types_list(self, dominion):
+        """The kind is the whole of how an asset belongs to a type: the
+        type's list of assets is read through its kinds, and there is no
+        second list to add the asset to."""
         ruins = create_asset("Old Ruins", dominion["territory"], income=10)
-        set_assets(dominion["type"], [ruins])
+        settlement = create_asset("Settlement", dominion["settlement"])
 
         assert ruins.campaign_type == dominion["type"]
-        assert list(dominion["type"].assets.all()) == [ruins]
-        assert list(ruins.offered_by.all()) == [dominion["type"]]
+        assert list(dominion["type"].assets) == [ruins, settlement]
+        assert list(dominion["type"].pooled_assets()) == [ruins]
+
+    def test_another_types_assets_are_not_in_the_list(self, dominion):
+        other = create_campaign_type("Law & Misrule")
+        create_asset("Turf", add_asset_kind(other, "Turf", "pooled"))
+
+        assert not dominion["type"].assets.exists()
 
     def test_a_kind_with_assets_of_it_cannot_be_removed(self, dominion):
         ruins = create_asset("Old Ruins", dominion["territory"])
@@ -176,7 +195,7 @@ class TestTheCoreCampaignType:
         ]
         settlement = Asset.objects.get(name="Settlement")
         assert settlement.kind.label_singular == "Settlement"
-        assert list(core.assets.all()) == [settlement]
+        assert list(core.assets) == [settlement]
 
         reputation = Counter.objects.get(name="Reputation")
         members = list(core.built_in_members)
@@ -187,8 +206,8 @@ class TestTheCoreCampaignType:
         assert core.built_ins.name == "N26 core built-ins"
         assert all(row.pack == default_pack for row in (core, settlement, reputation))
         # One line per row: the counter, the type, two kinds, the asset,
-        # its listing in the catalogue, the set, and two members.
-        assert len(lines) == 9
+        # the set, and two members.
+        assert len(lines) == 8
 
     def test_running_it_again_creates_nothing(self, default_pack):
         list(seed_core_campaign(apps))
@@ -227,14 +246,21 @@ class TestTheCoreCampaignType:
 
 
 class TestTheAuthoringPages:
-    """Both kinds have pages in the existing style: a listing, a create
-    page, and a page per row. The campaign type's page lists its asset
-    kinds and edits each in place."""
+    """A campaign type has pages in the existing style: a listing, a
+    create page, and a page per row. The type's page lists its asset kinds
+    and edits each in place, and under each kind lists the assets of it
+    and adds one more. An asset has no menu entry, listing or create page
+    of its own: it is one entry in the type's list, made on the type's
+    page, and keeps a page of its own for its modifiers."""
 
-    def test_the_menu_offers_both_kinds(self, author, client, default_pack):
+    def test_the_menu_offers_campaign_types_and_not_assets(
+        self, author, client, default_pack
+    ):
         body = client.get("/n26/authoring/").content.decode()
         assert 'href="/n26/authoring/campaign-type/"' in body
-        assert 'href="/n26/authoring/asset/"' in body
+        assert 'href="/n26/authoring/asset/"' not in body
+        assert client.get("/n26/authoring/asset/").status_code == 404
+        assert client.get("/n26/authoring/asset/new/").status_code == 404
 
     def test_creating_a_campaign_type_through_its_page(
         self, author, client, default_pack
@@ -258,7 +284,11 @@ class TestTheAuthoringPages:
         territory = dominion["territory"]
         assert f'name="part-{territory.pk}-label_singular"' in body
         assert 'value="Territory"' in body
-        assert "Territories · pooled · no assets yet" in body
+        assert "Territories · pooled" in body
+        assert "No Territories yet." in body
+        assert f'name="add-asset-{territory.pk}-name"' in body
+        assert f'name="add-asset-{territory.pk}-income"' in body
+        assert "Add Territory" in body
         assert "Comes with" in body
         assert "Modifiers" in body
         assert f"/n26/authoring/asset-kinds/{territory.pk}/remove/" in body
@@ -337,38 +367,151 @@ class TestTheAuthoringPages:
         assert done.url == f"/n26/authoring/campaign-type/{dominion['type'].pk}/"
         assert not AssetKind.objects.filter(pk=territory.pk).exists()
 
-    def test_creating_an_asset_through_its_page(self, author, client, dominion):
+    def test_the_type_page_adds_an_asset_under_a_kind(
+        self, author, client, dominion, default_pack
+    ):
+        territory = dominion["territory"]
+        page = f"/n26/authoring/campaign-type/{dominion['type'].pk}/"
         response = client.post(
-            "/n26/authoring/asset/new/",
+            page,
             {
-                "name": "Old Ruins",
-                "kind": str(dominion["territory"].pk),
-                "income": "10",
+                "act": "add-asset",
+                "part": str(territory.pk),
+                f"add-asset-{territory.pk}-name": "Old Ruins",
+                f"add-asset-{territory.pk}-income": "10",
             },
         )
 
         ruins = Asset.objects.get(name="Old Ruins")
         assert response.status_code == 302
-        assert ruins.kind == dominion["territory"]
+        assert response.url == page
+        assert ruins.kind == territory
         assert ruins.income == 10
+        assert ruins.pack == default_pack
+
+        body = client.get(page, follow=True).content.decode()
+        assert "Added Old Ruins under Territory." in body
+        assert f'href="/n26/authoring/asset/{ruins.pk}/"' in body
+        assert "income 10cr · no modifiers" in body
+
+    def test_an_asset_is_added_under_a_kind_of_this_type_only(
+        self, author, client, dominion, owned
+    ):
+        """The block an author types in settles the kind, so a post naming
+        a kind of another type is a mistyped address, not a choice."""
+        response = client.post(
+            f"/n26/authoring/campaign-type/{dominion['type'].pk}/",
+            {
+                "act": "add-asset",
+                "part": str(owned["kind"].pk),
+                f"add-asset-{owned['kind'].pk}-name": "Stray",
+            },
+        )
+
+        assert response.status_code == 404
+        assert not Asset.objects.filter(name="Stray").exists()
+
+    def test_adding_a_second_asset_of_one_name_is_refused_in_words(
+        self, author, client, dominion
+    ):
+        territory = dominion["territory"]
+        create_asset("Old Ruins", territory)
+        response = client.post(
+            f"/n26/authoring/campaign-type/{dominion['type'].pk}/",
+            {
+                "act": "add-asset",
+                "part": str(territory.pk),
+                f"add-asset-{territory.pk}-name": "old ruins",
+            },
+        )
+
+        assert response.status_code == 200
+        assert "An asset named “old ruins” already exists" in response.content.decode()
+        assert Asset.objects.filter(name__iexact="old ruins").count() == 1
+
+    def test_the_type_page_costs_the_same_however_many_assets_it_lists(
+        self, author, client, dominion
+    ):
+        """The assets under each kind and their modifier counts are loaded
+        with the kinds, so a type with a dozen assets draws for the same
+        number of queries as one with a single asset."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        page = f"/n26/authoring/campaign-type/{dominion['type'].pk}/"
+
+        def asset_with_a_boon(name):
+            asset = create_asset(name, dominion["territory"])
+            modifier(
+                f"{name} rule",
+                targets_gang(),
+                ef_adds(create_rule(f"{name} rule")),
+                attach_to=asset,
+            )
+
+        asset_with_a_boon("Old Ruins")
+        # The first visit pays for caches the process keeps warm afterwards;
+        # only the second and third are compared.
+        client.get(page)
+        with CaptureQueriesContext(connection) as one:
+            client.get(page)
+
+        for name in ("Collapsed Dome", "Sludge Sea", "Wastes", "Rogue Doc"):
+            asset_with_a_boon(name)
+        with CaptureQueriesContext(connection) as many:
+            client.get(page)
+
+        assert len(many) == len(one)
+
+    def test_an_assets_own_page_is_reached_from_the_type_and_fixes_its_kind(
+        self, author, client, dominion
+    ):
+        ruins = create_asset("Old Ruins", dominion["territory"], income=10)
 
         page = client.get(f"/n26/authoring/asset/{ruins.pk}/").content.decode()
-        # Filed under its campaign type, which the breadcrumb names.
-        assert f"/n26/authoring/campaign-type/{dominion['type'].pk}/" in page
+        # The trail runs through the type: Content library, Campaign
+        # types, Dominion, Old Ruins — there is no asset listing to name.
+        assert 'href="/n26/authoring/campaign-type/"' in page
+        assert f'href="/n26/authoring/campaign-type/{dominion["type"].pk}/"' in page
+        assert 'href="/n26/authoring/asset/"' not in page
+        # The kind was settled where the asset was made, so the edit form
+        # does not offer it; the rest of the fields are here.
+        assert 'name="edit-name"' in page
+        assert 'name="edit-income"' in page
+        assert 'name="edit-kind"' not in page
+        assert "Modifiers" in page
 
-    def test_the_asset_listing_says_kind_and_income(self, author, client, dominion):
-        create_asset("Old Ruins", dominion["territory"], income=10)
+        response = client.post(
+            f"/n26/authoring/asset/{ruins.pk}/",
+            {"act": "edit", "edit-name": "Older Ruins", "edit-income": "20"},
+        )
+        ruins.refresh_from_db()
+        assert response.status_code == 302
+        assert (ruins.name, ruins.income, ruins.kind) == (
+            "Older Ruins",
+            20,
+            dominion["territory"],
+        )
 
-        body = client.get("/n26/authoring/asset/").content.decode()
-        assert "Territory (Dominion)" in body
-        assert "income 10cr" in body
+    def test_deleting_an_asset_returns_to_its_types_page(
+        self, author, client, dominion
+    ):
+        ruins = create_asset("Old Ruins", dominion["territory"])
 
-    def test_the_type_listing_says_kinds_and_catalogue(self, author, client, dominion):
-        set_assets(dominion["type"], [create_asset("Old Ruins", dominion["territory"])])
+        response = client.post(f"/n26/authoring/asset/{ruins.pk}/delete/")
+
+        assert response.status_code == 302
+        assert response.url == f"/n26/authoring/campaign-type/{dominion['type'].pk}/"
+        assert not Asset.objects.filter(pk=ruins.pk).exists()
+
+    def test_the_type_listing_says_kinds_and_counts_assets(
+        self, author, client, dominion
+    ):
+        create_asset("Old Ruins", dominion["territory"])
 
         body = client.get("/n26/authoring/campaign-type/").content.decode()
         assert "Territories, Settlements" in body
-        assert "offers 1 asset" in body
+        assert "1 asset" in body
 
 
 class TestSystemContentNeverReferencesOwnedContent:
@@ -386,54 +529,75 @@ class TestSystemContentNeverReferencesOwnedContent:
         assert cross_pack_refusal(owned["pack"], owned["asset"]) is None
         assert "has an owner" in cross_pack_refusal(default_pack, owned["asset"])
 
-    def test_a_system_pack_form_refuses_an_owned_pack_reference(
-        self, author, client, default_pack, owned
+    def test_an_asset_added_on_a_system_type_is_system_content(
+        self, author, client, dominion, default_pack
     ):
-        response = client.post(
-            "/n26/authoring/asset/new/",
-            {"name": "Rat hole asset", "kind": str(owned["kind"].pk)},
-        )
-
-        assert response.status_code == 200
-        assert not Asset.objects.filter(name="Rat hole asset").exists()
-        body = response.content.decode()
-        assert "Rat hole (Sump Rats campaign) is in the Sump Rats pack" in body
-        assert "which has an owner" in body
-
-    def test_an_owned_pack_form_may_reference_system_content(
-        self, author, client, dominion, owned
-    ):
-        asset = owned["asset"]
-        response = client.post(
-            f"/n26/authoring/asset/{asset.pk}/",
-            {
-                "act": "edit",
-                "edit-name": asset.name,
-                "edit-kind": str(dominion["territory"].pk),
-                "edit-income": "0",
-            },
-        )
-
-        asset.refresh_from_db()
-        assert response.status_code == 302
-        assert asset.kind == dominion["territory"]
-        assert asset.pack == owned["pack"]
-
-    def test_a_system_types_catalogue_refuses_an_owned_asset(
-        self, author, client, dominion, owned
-    ):
-        response = client.post(
+        """An asset's only reference is its kind, and the type's page
+        offers only the type's own kinds — so an asset added there can
+        never point into a pack somebody owns, and lands in the type's."""
+        territory = dominion["territory"]
+        client.post(
             f"/n26/authoring/campaign-type/{dominion['type'].pk}/",
             {
-                "act": "edit",
-                "edit-name": "Dominion",
-                "edit-assets": [str(owned["asset"].pk)],
+                "act": "add-asset",
+                "part": str(territory.pk),
+                f"add-asset-{territory.pk}-name": "Old Ruins",
             },
         )
 
-        assert response.status_code == 200
+        ruins = Asset.objects.get(name="Old Ruins")
+        assert ruins.pack == default_pack
+        assert ruins.kind.pack == default_pack
+
+    def test_an_asset_added_on_an_owned_type_joins_its_pack(
+        self, author, client, owned
+    ):
+        kind = owned["kind"]
+        response = client.post(
+            f"/n26/authoring/campaign-type/{owned['type'].pk}/",
+            {
+                "act": "add-asset",
+                "part": str(kind.pk),
+                f"add-asset-{kind.pk}-name": "The Small Hole",
+                f"add-asset-{kind.pk}-income": "5",
+            },
+        )
+
+        made = Asset.objects.get(name="The Small Hole")
+        assert response.status_code == 302
+        assert made.kind == kind
+        assert made.pack == owned["pack"]
+
+    def test_attaching_an_owned_modifier_to_a_system_asset_is_refused(
+        self, author, client, dominion, owned
+    ):
+        ruins = create_asset("Old Ruins", dominion["territory"])
+        rule = create_rule("Rat pack", pack=owned["pack"])
+        owned_modifier = modifier(
+            "Rat pack rule", targets_gang(), ef_adds(rule), pack=owned["pack"]
+        )
+
+        response = client.post(
+            f"/n26/authoring/asset/{ruins.pk}/",
+            {"act": "attach", "modifier": str(owned_modifier.pk)},
+            follow=True,
+        )
+
         assert "which has an owner" in response.content.decode()
-        assert not dominion["type"].assets.exists()
+        assert not ruins.modifiers.exists()
+
+    def test_an_owned_asset_may_carry_a_system_modifier(self, author, client, owned):
+        system_modifier = modifier(
+            "Salvage rule", targets_gang(), ef_adds(create_rule("Salvage"))
+        )
+
+        response = client.post(
+            f"/n26/authoring/asset/{owned['asset'].pk}/",
+            {"act": "attach", "modifier": str(system_modifier.pk)},
+        )
+
+        assert response.status_code == 302
+        assert list(owned["asset"].modifiers.all()) == [system_modifier]
 
     def test_a_system_types_built_ins_refuse_an_owned_counter(
         self, author, client, dominion, owned


### PR DESCRIPTION
## Problem

A campaign type's assets were modelled twice. An `Asset` already names its `AssetKind`, and a kind names its `CampaignType`, so the kind fixes which type an asset belongs to. On top of that, `CampaignType.assets` was a many-to-many "catalogue" that had to be kept in step by hand: the seed added the Settlement to it, the type's edit form had an Assets multiselect, and the pool's add form read it. Two statements of one fact, and a place for them to disagree. Assets were also authored as a top-level library kind — their own menu entry, listing and create page — even though an asset means nothing apart from the type it belongs to.

The ruling (#2421, `design/campaign-assets.md`): an asset is one entry in a campaign type's list of what it hands out, and nothing else.

## Change

- **`CampaignType.assets` M2M dropped.** It is now a property reading through the kinds (`Asset.objects.filter(kind__campaign_type=self)`), with `pooled_assets()` for the pool. Migration `library.0082_an_asset_belongs_to_its_kinds_campaign_type` removes the table; there is no data to carry because every listed asset was already of one of that type's kinds (verified on a dev database). `authoring.set_assets` is gone and `create_campaign_type` no longer takes `assets`.
- **Assets are authored on the campaign type's page, under their kind.** Each asset-kind block on the type page lists the assets of that kind (name → the asset's own page, income, modifier count) and carries an "Add" form (name, annotation, income). The form reuses the existing editable-parts mechanism: `create_asset` is a part verb with `joins_carrier_pack=True`, the kind is the carrier, so the asset lands in the type's pack and the cross-pack guard in `forms.py` keeps holding. An asset's kind is fixed once made.
- **Assets leave the top-level authoring index, listing and create page.** `NESTED_KINDS = {"asset"}` in `views.py`: the index and the kinds switcher skip them, `/n26/authoring/asset/` and `/n26/authoring/asset/new/` are 404. The asset's own detail page stays (for its modifiers and the rest of its fields), reached from the type page, with the breadcrumb Content library › Campaign types › N26 core › Old Ruins. Deleting an asset returns to its type's page.
- **The pool add form reads through kinds**: the pooled, unarchived assets of the campaign's type and of its additions. `campaign_operation.add_asset` now also refuses an asset whose kind belongs to another type.
- Seed `core_campaign.py` creates the Settlement under the Settlement kind with no catalogue step; still idempotent. Admin drops the `assets` autocomplete. `concepts.md` Campaign type / Asset sections rewritten.

## How to try it

1. `./scripts/dev.sh`, sign in as staff, open `/n26/authoring/` — no Assets entry.
2. Open Campaign types › N26 core: each kind block lists its assets with an add form. Add a Territory "Old Ruins" with income 30; it appears under Territories and the success message names the kind.
3. Click Old Ruins: breadcrumb runs through Campaign types › N26 core; the edit form has no kind field; build a modifier on it.
4. Found a campaign on N26 core, join a gang, open Pool › Add to pool — Old Ruins is offered (the Settlement is not). Add a copy and grant it; the gang sheet's campaign block shows it.

## Tests

`pytest n26 -n 4`: 5213 passed, 1 xfailed. `pytest --ignore=n26 -n 4`: 4475 passed, 12 skipped. `./scripts/check_migrations.sh` clean. Browser pass done end to end (index, type page, add asset, asset page + modifier, found campaign, join, pool add, grant, gang sheet).

## Deploy note

`library.0082` drops a table. `migrate` runs in the entrypoint, so while the outgoing revision is still serving (tens of seconds) its `_catalogue` query, the campaign type listing's `prefetch_related("assets")` and the admin's `assets` autocomplete would 500 — all staff-only or behind the `campaigns` flag. If #2439–#2448 are already live in production and that window matters, split the `RemoveField` into a second deploy; otherwise this ships as one.

Part of #2421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
