### PR TITLE
fix: use one scroll container for n26 quick-switcher menus

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -72,10 +72,6 @@ def django_test_settings():
         "django.contrib.staticfiles.storage.StaticFilesStorage"
     )
 
-    # This prevents the banner query being fired in tests
-    for key in BANNER_CACHE_KEYS.values():
-        cache.set(key, False, None)
-
     # Optimize test performance
     # Disable DEBUG to avoid query tracking overhead
     settings.DEBUG = False
@@ -101,21 +97,33 @@ def django_test_settings():
 
 
 @pytest.fixture(autouse=True)
+def suppress_site_banner_queries():
+    """Keep banner queries out of unrelated tests, regardless of worker history.
+
+    Banner tests invalidate these entries and replace them with expiring
+    values. Reset them before each test so an expiry cannot add a query
+    halfway through a page's query-budget check. Tests of banners can still
+    invalidate the entries themselves.
+    """
+    for key in BANNER_CACHE_KEYS.values():
+        cache.set(key, False, None)
+
+
+@pytest.fixture(autouse=True)
 def clear_content_page_ref_cache():
     """Empty the per-title page-ref cache before every test.
 
     ``ContentPageRef.find_similar`` caches one entry per title in a process-local
     ``LocMemCache``, and it sits in the fighter-card render path. Nothing else
-    clears it — every other autouse fixture here is session-scoped — so its
-    contents at test start depend on which tests ran earlier *in the same xdist
-    worker*, and it keeps filling while a test runs.
+    clears it, so its contents at test start depend on which tests ran earlier
+    *in the same xdist worker*, and it keeps filling while a test runs.
 
     That makes query counts depend on worker history and on how many renders have
     already happened, which is what made the relative query-count tests in
     test_crew.py flaky on CI but not locally (#2114).
 
     Only this cache is cleared. The ``default`` cache deliberately holds the
-    ``BANNER_CACHE_KEYS`` entries from ``django_test_settings`` so the banner
+    ``BANNER_CACHE_KEYS`` entries from ``suppress_site_banner_queries`` so the banner
     query stays out of every test's count; clearing that here would put the
     query back.
     """

--- a/gyrinx/tests/test_context_processors.py
+++ b/gyrinx/tests/test_context_processors.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -6,7 +7,7 @@ from django.db import DatabaseError, InterfaceError, OperationalError
 from django.test import RequestFactory
 
 from gyrinx.context_processors import site_banner
-from gyrinx.site.models import BANNER_CACHE_KEYS, Banner
+from gyrinx.site.models import BANNER_CACHE_KEYS, BANNER_CACHE_TIMEOUT, Banner
 
 
 @pytest.fixture
@@ -17,6 +18,27 @@ def request_factory():
 def clear_banner_cache():
     for key in BANNER_CACHE_KEYS.values():
         cache.delete(key)
+
+
+@pytest.mark.django_db
+class TestBannerCacheIsolation:
+    @pytest.fixture(scope="class", autouse=True)
+    def prior_banner_cache(self):
+        # Seed before function fixtures, as a previous banner test would.
+        for key in BANNER_CACHE_KEYS.values():
+            cache.set(key, False, BANNER_CACHE_TIMEOUT)
+
+    @pytest.mark.parametrize("path", ["/", "/n26/gangs/"])
+    def test_banner_expiry_cannot_add_a_query(
+        self, path, request_factory, django_assert_num_queries
+    ):
+        request = request_factory.get(path)
+        request.session = {}
+        after_expiry = time.time() + BANNER_CACHE_TIMEOUT + 1
+        with patch("django.core.cache.backends.locmem.time") as clock:
+            clock.time.return_value = after_expiry
+            with django_assert_num_queries(0):
+                assert site_banner(request) == {"banner": None}
 
 
 @pytest.mark.django_db

--- a/n26/core/templates/cotton/n26/quick_switcher/index.html
+++ b/n26/core/templates/cotton/n26/quick_switcher/index.html
@@ -22,8 +22,9 @@ component must leave that root reachable. The kit writes offsets of its own on
 open, scroll and resize and they are wrong for a fixed box; those listeners are
 dropped and replaced, so a scroll that started inside the panel is not treated
 as the switcher leaving the window. Rewriting position:fixed mid-gesture
-cancels the list's own scroll on a phone. The panel itself is not a scroll
-box — overflow=hidden on the dropdown — so only the list of rows scrolls.
+can interrupt scrolling. The dropdown is the only scroll container; its
+search field stays pinned while the destinations scroll underneath it.
+Its height follows the visible viewport, including the on-screen keyboard.
 
 Focus lands in the filter box and never leaves it: Down and Up move a
 highlight, Enter clicks the highlighted row, Escape clears the filter before it
@@ -84,7 +85,6 @@ aria-activedescendant so the tinted row and the spoken one agree.
             </c-ui.button>
         {% endif %}
         <c-ui.dropdown align="{{ align }}"
-                       overflow="hidden"
                        min_width="min({{ min_width }}, calc(100vw - 1rem))">
             <c-slot name="trigger">
                 {% comment %}
@@ -135,6 +135,8 @@ aria-activedescendant so the tinted row and the spoken one agree.
                      gutter: 8,
                      tries: 0,
                      refit: null,
+                     touchY: null,
+                     touchX: null,
                      {% if hotkey %}chord: null,{% endif %}
                      register(el, facets) {
                          const row = { id: this.$id('n26-switcher') + '-option-' + this.items.length, el, ...facets };
@@ -198,6 +200,25 @@ aria-activedescendant so the tinted row and the spoken one agree.
                          const panel = this.$el.parentElement;
                          return !!(panel && node instanceof Node && panel.contains(node));
                      },
+                     // Keep native scrolling within the panel. At either
+                     // end, iOS can otherwise pan the page behind it.
+                     startTouch(event) {
+                         this.touchY = event.touches.length === 1 ? event.touches[0].clientY : null;
+                         this.touchX = event.touches.length === 1 ? event.touches[0].clientX : null;
+                     },
+                     containTouch(event) {
+                         if (this.touchY === null || event.touches.length !== 1) return;
+                         const touch = event.touches[0];
+                         const dy = touch.clientY - this.touchY;
+                         const dx = touch.clientX - this.touchX;
+                         this.touchY = touch.clientY;
+                         this.touchX = touch.clientX;
+                         if (Math.abs(dx) > Math.abs(dy)) return;
+                         const panel = this.$el.parentElement;
+                         const atTop = panel.scrollTop <= 0;
+                         const atBottom = panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 1;
+                         if ((dy > 0 && atTop) || (dy < 0 && atBottom)) event.preventDefault();
+                     },
                      fit() {
                          const panel = this.$el.parentElement;
                          // A panel still opening has no width to measure, and
@@ -219,8 +240,11 @@ aria-activedescendant so the tinted row and the spoken one agree.
                          }
                          this.tries = 0;
                          const gap = 4;
-                         const room = document.documentElement.clientWidth;
-                         const drop = document.documentElement.clientHeight;
+                         const viewport = window.visualViewport;
+                         const left = viewport ? viewport.offsetLeft : 0;
+                         const top = viewport ? viewport.offsetTop : 0;
+                         const room = viewport ? viewport.width : document.documentElement.clientWidth;
+                         const drop = viewport ? viewport.height : document.documentElement.clientHeight;
                          const anchor = panel.closest('[data-quick-switcher]').getBoundingClientRect();
                          // Fixed, so the window is the panel's containing
                          // block: the width it is offered does not depend on
@@ -232,6 +256,9 @@ aria-activedescendant so the tinted row and the spoken one agree.
                          // does not, and the difference is exactly a panel at
                          // full cap poking out by a scrollbar.
                          panel.style.maxWidth = room - 2 * this.gutter + 'px';
+                         // A minimum beats a maximum, including when pinch
+                         // zoom makes the visual viewport narrower.
+                         panel.style.minWidth = 'min(var(--dd-min), ' + (room - 2 * this.gutter) + 'px)';
                          panel.style.right = 'auto';
                          panel.style.bottom = 'auto';
                          panel.style.transform = '';
@@ -239,25 +266,31 @@ aria-activedescendant so the tinted row and the spoken one agree.
                          // window offers all the room the clamp could ever
                          // leave it, so the width read is the content's own
                          // and not an artefact of the previous placement.
-                         panel.style.left = this.gutter + 'px';
+                         panel.style.left = left + this.gutter + 'px';
                          panel.style.top = '0px';
                          const width = panel.offsetWidth;
                          const at = '{{ align }}' === 'end' ? anchor.right - width : anchor.left;
-                         panel.style.left = Math.max(this.gutter, Math.min(at, room - this.gutter - width)) + 'px';
-                         // Below the switcher, unless only above has the room.
+                         panel.style.left = Math.max(left + this.gutter, Math.min(at, left + room - this.gutter - width)) + 'px';
+                         // One scrollport, capped to the larger side of the
+                         // trigger. The keyboard shrinks the visual viewport
+                         // without changing documentElement.clientHeight.
+                         const below = Math.max(0, top + drop - this.gutter - anchor.bottom - gap);
+                         const above = Math.max(0, anchor.top - gap - top - this.gutter);
+                         const preferredHeight = 21.25 * parseFloat(getComputedStyle(document.documentElement).fontSize);
+                         const opensAbove = below < Math.min(panel.scrollHeight, preferredHeight) && above > below;
+                         const available = Math.min(drop - 2 * this.gutter, opensAbove ? above : below);
+                         panel.style.maxHeight = Math.max(0, Math.min(preferredHeight, available)) + 'px';
+                         panel.style.scrollPaddingTop = this.$refs.filterHeader.offsetHeight + 'px';
                          const height = panel.offsetHeight;
-                         const below = drop - anchor.bottom - gap;
-                         const above = anchor.top - gap;
-                         panel.style.top = (height > below && above > below
-                             ? Math.max(this.gutter, anchor.top - gap - height)
-                             : anchor.bottom + gap) + 'px';
+                         const y = opensAbove ? anchor.top - gap - height : anchor.bottom + gap;
+                         panel.style.top = Math.max(top + this.gutter, Math.min(y, top + drop - this.gutter - height)) + 'px';
                          panel.style.visibility = '';
                      },
                      init() {
                          this.$watch('dropdownMenu', open => {
                              this.query = '';
                              this.active = '';
-                             if (open) this.$nextTick(() => { this.$refs.filter.focus(); this.fit(); });
+                             if (open) this.$nextTick(() => { this.$refs.filter.focus({ preventScroll: true }); this.fit(); });
                          });
                          // A highlight the query has just hidden would send
                          // Enter to a row nobody can see.
@@ -282,6 +315,8 @@ aria-activedescendant so the tinted row and the spoken one agree.
                              window.removeEventListener('scroll', kit, true);
                              window.removeEventListener('resize', kit);
                          }
+                         window.visualViewport?.addEventListener('resize', this.refit);
+                         window.visualViewport?.addEventListener('scroll', this.refit);
                          window.addEventListener('resize', this.refit);
                          window.addEventListener('scroll', this.refit, true);
                          {% if hotkey %}
@@ -303,6 +338,8 @@ aria-activedescendant so the tinted row and the spoken one agree.
                          {% endif %}
                      },
                      destroy() {
+                         window.visualViewport?.removeEventListener('resize', this.refit);
+                         window.visualViewport?.removeEventListener('scroll', this.refit);
                          window.removeEventListener('resize', this.refit);
                          window.removeEventListener('scroll', this.refit, true);
                          {% if hotkey %}
@@ -310,6 +347,10 @@ aria-activedescendant so the tinted row and the spoken one agree.
                          {% endif %}
                      },
                  }"
+                 @touchstart.passive="startTouch($event)"
+                 @touchmove="containTouch($event)"
+                 @touchend="touchY = null; touchX = null"
+                 @touchcancel="touchY = null; touchX = null"
                  class="flex max-w-[calc(100vw-1rem)] flex-col">
                 {% comment %}
                 The filter box owns the arrow keys and never gives focus up:
@@ -319,7 +360,7 @@ aria-activedescendant so the tinted row and the spoken one agree.
                 outside the box, so the box has to say which list it is naming
                 a row in.
                 {% endcomment %}
-                <div class="border-b border-box-border p-2">
+                <div x-ref="filterHeader" class="sticky top-0 z-10 border-b border-box-border bg-white p-2 dark:bg-ink-900">
                     <c-ui.input type="search"
                                 size="sm"
                                 placeholder="{{ placeholder }}"
@@ -341,11 +382,7 @@ aria-activedescendant so the tinted row and the spoken one agree.
                 the overflow it leaves in the panel, so a list that fits gains
                 a scrollbar and one pixel of scroll.
                 {% endcomment %}
-                {% comment %}
-                overscroll-contain: reaching either end of this list must
-                not hand the gesture to the page underneath.
-                {% endcomment %}
-                <div :id="$id('n26-switcher') + '-list'" class="max-h-72 overflow-y-auto overscroll-contain">{{ slot }}</div>
+                <div :id="$id('n26-switcher') + '-list'">{{ slot }}</div>
                 {% comment %}
                 x-cloak, so a reader with no script never sees a line about a
                 filter they do not have.

--- a/n26/core/test_quick_switcher.py
+++ b/n26/core/test_quick_switcher.py
@@ -1,14 +1,19 @@
-"""What the quick switcher must put in the HTML, whatever else it draws.
+"""Quick-switcher HTML wiring and executable scroll/placement checks.
 
-No database: a component is a template and a set of props, and everything
-claimed here is decided before a request exists. The assertions are substrings
-that can only be there if the behaviour worked — a destination that is a real
-link, a current row that says so without relying on the tick, and a chevron
-that has a name of its own when there is nothing beside it to borrow one from.
+No database is needed: render the real Cotton component, check its public
+markup, and execute its Alpine methods with controlled touch and viewport
+inputs. Native browser scrolling still needs a browser check.
 """
 
+import html
+import json
 import re
+import shutil
 
+# Runs repository-owned JavaScript with Node, without a shell.
+import subprocess  # nosec B404
+
+import pytest
 from django.template import Context, Template
 from django_cotton.compiler_regex import CottonCompiler
 
@@ -216,22 +221,38 @@ class TestStayingOnTheScreen:
         assert "window.removeEventListener('scroll', kit, true)" in html
         assert "window.removeEventListener('resize', kit)" in html
 
-    def test_the_panel_is_not_a_second_scroll_box(self):
-        """The list of rows is the scroller. A second overflow-y-auto on
-        the dropdown around it hands a touch gesture to the page."""
-        # The noscript strip also hides overflow as a box; the kit panel
-        # is the half that must not be a second scroll container.
-        panel = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>").split(
-            "<noscript>"
-        )[0]
-        assert "max-h-[calc(100vh-4rem)]" in panel
-        assert "overflow-hidden" in panel
-        assert "overflow-y-auto overflow-x-hidden" not in panel
-        assert "overscroll-contain" in panel
-
-    def test_reaching_the_end_of_the_list_does_not_scroll_the_page(self):
+    def test_the_dropdown_is_the_only_scroll_container(self):
         html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")
-        assert "max-h-72 overflow-y-auto overscroll-contain" in html
+        menu = html.split("<noscript>")[0]
+        assert "overflow-y-auto overflow-x-hidden" in menu
+        assert "max-h-72" not in menu
+        assert "sticky top-0" in menu
+        assert "scrollPaddingTop" in menu
+        assert 'x-ref="filterHeader"' in menu
+
+    def test_touch_boundaries_are_contained_without_disabling_native_scrolling(self):
+        html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")
+        assert '@touchstart.passive="startTouch($event)"' in html
+        assert '@touchmove="containTouch($event)"' in html
+        assert '@touchcancel="touchY = null; touchX = null"' in html
+        assert "event.touches.length !== 1" in html
+        assert "event.preventDefault()" in html
+        assert "overscroll-contain" in html
+
+    def test_the_menu_fits_the_visible_viewport_when_the_keyboard_opens(self):
+        html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")
+        assert "viewport.height" in html
+        assert "viewport.offsetTop" in html
+        assert "panel.style.maxHeight" in html
+        for event in ("resize", "scroll"):
+            assert (
+                f"window.visualViewport?.addEventListener('{event}', this.refit)"
+                in html
+            )
+            assert (
+                f"window.visualViewport?.removeEventListener('{event}', this.refit)"
+                in html
+            )
 
     def test_the_scriptless_strip_gives_up_its_width_rather_than_overflow(self):
         html = render(f"<c-n26.quick-switcher>{ITEMS}</c-n26.quick-switcher>")
@@ -303,7 +324,7 @@ class TestMovingThroughItFromTheKeyboard:
         highlight moved to is often below the fold of it."""
         html = panel()
         assert "rows[to].el.scrollIntoView({ block: 'nearest' });" in html
-        assert "max-h-72 overflow-y-auto" in html
+        assert "overflow-y-auto overflow-x-hidden" in html
 
     def test_enter_presses_the_highlighted_row_s_own_link(self):
         """The same path the pointer takes: the panel's click handler closes
@@ -466,3 +487,96 @@ class TestTheDirectivesCompile:
                     "it, so the rest of the expression is commented out:\n"
                     f"{expr}"
                 )
+
+
+@pytest.mark.skipif(
+    not shutil.which("node"), reason="Node.js runs the component behaviour checks"
+)
+def test_scroll_boundaries_and_visible_viewport():
+    """Execute the rendered Alpine methods; CSS substring checks cannot
+    establish which gestures are cancelled or whether a menu fits."""
+    data = next(
+        html.unescape(match)
+        for match in re.findall(r'x-data="([^"]*)"', panel(), re.DOTALL)
+        if "containTouch(event)" in match
+    )
+    checks = r"""
+const assert = require('node:assert/strict');
+const scope = eval('(' + SOURCE + ')');
+const panel = {
+    style: {}, scrollTop: 0, clientHeight: 200, scrollHeight: 600,
+    get offsetWidth() { return Math.min(256, parseFloat(this.style.maxWidth) || 256) },
+    get offsetHeight() { return Math.min(this.scrollHeight, parseFloat(this.style.maxHeight) || 600) },
+    closest() { return {getBoundingClientRect: () => anchor} },
+};
+let anchor = {left: 100, right: 180, top: 200, bottom: 230};
+scope.$el = {parentElement: panel};
+scope.$refs = {filterHeader: {offsetHeight: 52}};
+global.document = {documentElement: {clientWidth: 390, clientHeight: 844}};
+global.getComputedStyle = () => ({fontSize: '16px'});
+global.window = {visualViewport: {offsetLeft: 0, offsetTop: 0, width: 390, height: 844}};
+
+function gesture(scrollTop, deltaY, deltaX = 0, fingers = 1) {
+    panel.scrollTop = scrollTop;
+    scope.startTouch({touches: [{clientX: 100, clientY: 100}]});
+    let cancelled = false;
+    scope.containTouch({
+        touches: Array.from({length: fingers}, () => ({clientX: 100 + deltaX, clientY: 100 + deltaY})),
+        preventDefault() { cancelled = true },
+    });
+    return cancelled;
+}
+assert.equal(gesture(0, 20), true, 'dragging past the top must not scroll the page');
+assert.equal(gesture(400, -20), true, 'dragging past the bottom must not scroll the page');
+assert.equal(gesture(0, -20), false, 'scroll down natively from the top');
+assert.equal(gesture(400, 20), false, 'scroll up natively from the bottom');
+assert.equal(gesture(200, -20), false, 'keep native scrolling and momentum within the menu');
+assert.equal(gesture(200, 20), false);
+assert.equal(gesture(0, 20, 40), false, 'leave horizontal gestures alone');
+assert.equal(gesture(0, 20, 0, 2), false, 'leave pinch zoom alone');
+assert.equal(gesture(0, 0), false, 'a tap is not a scroll');
+panel.scrollHeight = panel.clientHeight;
+assert.equal(gesture(0, 20), true, 'short and empty menus contain both directions');
+assert.equal(gesture(0, -20), true);
+panel.scrollHeight = 600;
+
+function fits() {
+    scope.fit();
+    const viewport = window.visualViewport || {offsetTop: 0, height: 844};
+    const top = parseFloat(panel.style.top);
+    assert.ok(top >= viewport.offsetTop + 8, 'menu starts inside the visible viewport');
+    assert.ok(top + panel.offsetHeight <= viewport.offsetTop + viewport.height - 8,
+        'menu ends inside the visible viewport');
+    assert.ok(panel.offsetHeight > 52, 'search and destinations remain reachable');
+    const left = parseFloat(panel.style.left);
+    const visible = window.visualViewport || {offsetLeft: 0, width: 390};
+    assert.ok(left >= visible.offsetLeft + 8);
+    assert.ok(left + panel.offsetWidth <= visible.offsetLeft + visible.width - 8);
+    assert.equal(panel.style.minWidth, 'min(var(--dd-min), ' + (visible.width - 16) + 'px)');
+}
+fits();
+assert.equal(panel.style.top, '234px');
+assert.equal(panel.style.scrollPaddingTop, '52px');
+anchor = {left: 100, right: 180, top: 720, bottom: 750};
+fits();
+assert.ok(parseFloat(panel.style.top) < anchor.top, 'flip above a low trigger');
+window.visualViewport = {offsetLeft: 0, offsetTop: 120, width: 390, height: 300};
+anchor = {left: 100, right: 180, top: 220, bottom: 250};
+fits();
+assert.ok(panel.offsetHeight < 200, 'the keyboard must shrink the scrollport');
+window.visualViewport = {offsetLeft: 50, offsetTop: 120, width: 195, height: 300};
+fits();
+window.visualViewport = null;
+fits();
+"""
+    result = subprocess.run(
+        [
+            shutil.which("node"),
+            "-e",
+            "const SOURCE = " + json.dumps(data) + ";\n" + checks,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr

--- a/n26/core/test_quick_switcher.py
+++ b/n26/core/test_quick_switcher.py
@@ -1,19 +1,11 @@
-"""Quick-switcher HTML wiring and executable scroll/placement checks.
+"""Quick-switcher markup and event wiring.
 
-No database is needed: render the real Cotton component, check its public
-markup, and execute its Alpine methods with controlled touch and viewport
-inputs. Native browser scrolling still needs a browser check.
+Render the real Cotton component and check the HTML it supplies. These
+checks do not exercise browser layout or native touch scrolling.
 """
 
-import html
-import json
 import re
-import shutil
 
-# Runs repository-owned JavaScript with Node, without a shell.
-import subprocess  # nosec B404
-
-import pytest
 from django.template import Context, Template
 from django_cotton.compiler_regex import CottonCompiler
 
@@ -487,96 +479,3 @@ class TestTheDirectivesCompile:
                     "it, so the rest of the expression is commented out:\n"
                     f"{expr}"
                 )
-
-
-@pytest.mark.skipif(
-    not shutil.which("node"), reason="Node.js runs the component behaviour checks"
-)
-def test_scroll_boundaries_and_visible_viewport():
-    """Execute the rendered Alpine methods; CSS substring checks cannot
-    establish which gestures are cancelled or whether a menu fits."""
-    data = next(
-        html.unescape(match)
-        for match in re.findall(r'x-data="([^"]*)"', panel(), re.DOTALL)
-        if "containTouch(event)" in match
-    )
-    checks = r"""
-const assert = require('node:assert/strict');
-const scope = eval('(' + SOURCE + ')');
-const panel = {
-    style: {}, scrollTop: 0, clientHeight: 200, scrollHeight: 600,
-    get offsetWidth() { return Math.min(256, parseFloat(this.style.maxWidth) || 256) },
-    get offsetHeight() { return Math.min(this.scrollHeight, parseFloat(this.style.maxHeight) || 600) },
-    closest() { return {getBoundingClientRect: () => anchor} },
-};
-let anchor = {left: 100, right: 180, top: 200, bottom: 230};
-scope.$el = {parentElement: panel};
-scope.$refs = {filterHeader: {offsetHeight: 52}};
-global.document = {documentElement: {clientWidth: 390, clientHeight: 844}};
-global.getComputedStyle = () => ({fontSize: '16px'});
-global.window = {visualViewport: {offsetLeft: 0, offsetTop: 0, width: 390, height: 844}};
-
-function gesture(scrollTop, deltaY, deltaX = 0, fingers = 1) {
-    panel.scrollTop = scrollTop;
-    scope.startTouch({touches: [{clientX: 100, clientY: 100}]});
-    let cancelled = false;
-    scope.containTouch({
-        touches: Array.from({length: fingers}, () => ({clientX: 100 + deltaX, clientY: 100 + deltaY})),
-        preventDefault() { cancelled = true },
-    });
-    return cancelled;
-}
-assert.equal(gesture(0, 20), true, 'dragging past the top must not scroll the page');
-assert.equal(gesture(400, -20), true, 'dragging past the bottom must not scroll the page');
-assert.equal(gesture(0, -20), false, 'scroll down natively from the top');
-assert.equal(gesture(400, 20), false, 'scroll up natively from the bottom');
-assert.equal(gesture(200, -20), false, 'keep native scrolling and momentum within the menu');
-assert.equal(gesture(200, 20), false);
-assert.equal(gesture(0, 20, 40), false, 'leave horizontal gestures alone');
-assert.equal(gesture(0, 20, 0, 2), false, 'leave pinch zoom alone');
-assert.equal(gesture(0, 0), false, 'a tap is not a scroll');
-panel.scrollHeight = panel.clientHeight;
-assert.equal(gesture(0, 20), true, 'short and empty menus contain both directions');
-assert.equal(gesture(0, -20), true);
-panel.scrollHeight = 600;
-
-function fits() {
-    scope.fit();
-    const viewport = window.visualViewport || {offsetTop: 0, height: 844};
-    const top = parseFloat(panel.style.top);
-    assert.ok(top >= viewport.offsetTop + 8, 'menu starts inside the visible viewport');
-    assert.ok(top + panel.offsetHeight <= viewport.offsetTop + viewport.height - 8,
-        'menu ends inside the visible viewport');
-    assert.ok(panel.offsetHeight > 52, 'search and destinations remain reachable');
-    const left = parseFloat(panel.style.left);
-    const visible = window.visualViewport || {offsetLeft: 0, width: 390};
-    assert.ok(left >= visible.offsetLeft + 8);
-    assert.ok(left + panel.offsetWidth <= visible.offsetLeft + visible.width - 8);
-    assert.equal(panel.style.minWidth, 'min(var(--dd-min), ' + (visible.width - 16) + 'px)');
-}
-fits();
-assert.equal(panel.style.top, '234px');
-assert.equal(panel.style.scrollPaddingTop, '52px');
-anchor = {left: 100, right: 180, top: 720, bottom: 750};
-fits();
-assert.ok(parseFloat(panel.style.top) < anchor.top, 'flip above a low trigger');
-window.visualViewport = {offsetLeft: 0, offsetTop: 120, width: 390, height: 300};
-anchor = {left: 100, right: 180, top: 220, bottom: 250};
-fits();
-assert.ok(panel.offsetHeight < 200, 'the keyboard must shrink the scrollport');
-window.visualViewport = {offsetLeft: 50, offsetTop: 120, width: 195, height: 300};
-fits();
-window.visualViewport = null;
-fits();
-"""
-    result = subprocess.run(
-        [
-            shutil.which("node"),
-            "-e",
-            "const SOURCE = " + json.dumps(data) + ";\n" + checks,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
The n26 “+N more” menu can pass phone scrolling to the page behind it. This changes the shared quick-switcher used by the Hire section picker and other tab strips:

- Use the dropdown as the single scroll container, with search pinned at the top. The inner list no longer has a separate scrollport.
- Contain outward touch gestures at both ends while preserving native scrolling within the menu, taps, horizontal gestures and pinch zoom.
- Fit the menu to the visual viewport, including keyboard and zoom changes. Keep keyboard highlights below the pinned search field.

The shared test setup also resets the site-banner cache before each test. Banner tests leave entries with a five-minute expiry; if one expires during a later page query-budget check, it adds a banner query and fails the check. Two clock-expiry regressions cover both editions.

Refs #2398

Validation:
- [x] Banner, Trade Points, quick-switcher and platform integration checks pass; both new cache-expiry regressions fail without the fix.
- [x] 100 Python component and design-system tests pass with four workers. These check rendered HTML and event wiring; they do not execute browser behaviour.
- [x] Browser checks at 390×844 and 390×320: last entries reachable, search pinned, page stationary during menu scrolling, filtering and keyboard selection work.
- [x] Formatters and template lint pass; independent code and copy review completed.
- [ ] Retest on a physical iPhone in Chrome. Desktop checks do not reproduce the original iOS gesture failure.

To try it on a phone: open Hire Fighters → All profiles, open “+N more” beside the current section, then swipe through the names and beyond each end. The names should scroll while the page stays still. Also test search, choosing a section, and opening the keyboard.
