### PR TITLE
fix: delete legacy affiliation assignments

### DIFF
--- a/n26/core/legacy_affiliation_assignments.py
+++ b/n26/core/legacy_affiliation_assignments.py
@@ -1,0 +1,353 @@
+"""Delete the last player assignments left by the Affiliation conversions.
+
+The conversions deliberately preserved two kinds of old row.  Variant's
+``None`` assignment was archived so an optional slot would still read as
+unanswered, and a doubled Outcast assignment was left as a spare when another
+assignment already settled the question.  Both still point at the retired
+Affiliation library rows and therefore keep those rows from being deleted.
+
+This is a deliberately narrow repair.  It recognises only the two shapes
+measured in production, proves that their books are empty and that nothing
+depends on them, then deletes the assignment together with its ledger entry
+and history events.  Every affected gang must reconcile; an archived assignment
+must render identically, while a live spare may remove only its own obsolete
+line from the gang sheet.
+"""
+
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.db import transaction
+
+from n26.core.capture import differences, gang_state
+
+ARCHIVED_NONE = "archived None"
+LIVE_SPARE = "live spare"
+
+
+class Refused(Exception):
+    """The repair found something other than the measured legacy shapes."""
+
+
+@dataclass(frozen=True)
+class LegacyAffiliationAssignments:
+    """Assignments safe to delete, grouped by their gang."""
+
+    #: ``(gang id, ((assignment id, classification), ...))``.
+    gangs: tuple = ()
+    problems: tuple = ()
+    nothing_here: bool = False
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    @property
+    def assignment_ids(self):
+        return tuple(pk for _, rows in self.gangs for pk, _ in rows)
+
+    def preview(self):
+        lines = []
+        if self.nothing_here:
+            lines.append("no legacy affiliation assignments remain")
+        for gang_id, rows in self.gangs:
+            counts = {
+                kind: sum(found == kind for _, found in rows)
+                for kind in (ARCHIVED_NONE, LIVE_SPARE)
+            }
+            parts = []
+            if counts[ARCHIVED_NONE]:
+                count = counts[ARCHIVED_NONE]
+                parts.append(
+                    f"{count} archived None assignment{'' if count == 1 else 's'}"
+                )
+            if counts[LIVE_SPARE]:
+                count = counts[LIVE_SPARE]
+                parts.append(
+                    f"{count} live spare assignment{'' if count == 1 else 's'}"
+                )
+            lines.append(f"gang {gang_id}: delete " + " and ".join(parts))
+        if self.gangs:
+            count = len(self.assignment_ids)
+            lines.append(
+                f"{count} assignment{'' if count == 1 else 's'} across "
+                f"{len(self.gangs)} gang{'' if len(self.gangs) == 1 else 's'}; "
+                "their zero-value ledger entries and history events are deleted too"
+            )
+        return lines
+
+
+def _problem(assignment, reason):
+    return f"assignment {assignment.pk} naming “{assignment.affiliation}” {reason}"
+
+
+def _has_unexpected_dependants(assignment):
+    """Relations whose cascade would delete anything except empty books."""
+    from n26.core.models import Assignment
+
+    checks = (
+        (assignment.children, "child assignments"),
+        (assignment.caused, "caused assignments"),
+        (assignment.picks, "picks"),
+        (assignment.assignment_sets, "model-card sets"),
+        (assignment.print_configs, "print configurations"),
+        (assignment.chosen_options, "chosen profile options"),
+    )
+    found = [label for manager, label in checks if manager.exists()]
+    for relation, label in (
+        ("founded", "a founded gang"),
+        ("member", "a model membership"),
+        ("profile_role", "a profile role"),
+        ("counter_value", "a counter value"),
+    ):
+        try:
+            getattr(assignment, relation)
+        except assignment._meta.get_field(relation).related_model.DoesNotExist:
+            pass
+        else:
+            found.append(label)
+    if Assignment.objects.filter(materialised_for=assignment).exists():
+        found.append("materialised assignments")
+    return found
+
+
+def _empty_books(assignment, *, allowed_events):
+    try:
+        entry = assignment.ledger_entry
+    except assignment._meta.get_field("ledger_entry").related_model.DoesNotExist:
+        return "has no ledger entry"
+    if (
+        entry.list_price,
+        entry.discount,
+        entry.paid,
+        entry.trade_points,
+        entry.rating_contribution,
+    ) != (0, 0, 0, 0, 0):
+        return "has a non-zero ledger entry"
+    if entry.reason != "granted" or entry.bought_from_id is not None:
+        return "does not have the zero-value granted ledger shape"
+
+    events = list(assignment.ledger_events.order_by("created", "id"))
+    if any(event.gang_id != assignment.gang_root_id for event in events):
+        return "has a history event pinned to another gang"
+    if tuple(event.kind for event in events) not in allowed_events:
+        return "does not have the measured granted/removed history"
+    if any(
+        (event.credits_delta, event.trade_points_delta, event.rating_delta) != (0, 0, 0)
+        for event in events
+    ):
+        return "has a non-zero history event"
+    return ""
+
+
+def _common_problem(assignment):
+    affiliation = assignment.affiliation
+    if affiliation.pack.slug != settings.DEFAULT_CONTENT_PACK_SLUG:
+        return "belongs to another content pack"
+    if affiliation.modifiers.exists():
+        return "names an affiliation that still carries modifiers"
+    if affiliation.built_ins_id is not None and affiliation.built_ins.members.exists():
+        return "names an affiliation whose built-in set is not empty"
+    if assignment.removes:
+        return "is a removal"
+    if (
+        assignment.gang_id is None
+        or assignment.miniature_id is not None
+        or assignment.parent_id is not None
+        or assignment.stash_id is not None
+        or assignment.gang_root_id != assignment.gang_id
+        or assignment.miniature_root_id is not None
+        or assignment.stash_root_id is not None
+    ):
+        return "is not hosted and rooted directly on one gang"
+    if assignment.caused_by_id is None or assignment.caused_by.archived:
+        return "does not name a live cause"
+    if assignment.caused_by.gang_root_id != assignment.gang_root_id:
+        return "does not share its cause's gang root"
+    if any(
+        (
+            assignment.chosen_for_id,
+            assignment.chosen_for_slot_id,
+            assignment.chosen_for_offer_id,
+            assignment.materialised_from_id,
+            assignment.materialised_for_id,
+        )
+    ):
+        return "still carries choice or materialisation provenance"
+    dependants = _has_unexpected_dependants(assignment)
+    if dependants:
+        return "still has " + ", ".join(dependants)
+    return ""
+
+
+def _archived_none_problem(assignment):
+    if not assignment.archived:
+        return "is a live None assignment"
+    if assignment.caused_by.gang_type_id is None:
+        return "was not caused by the gang-type assignment"
+    books = _empty_books(
+        assignment,
+        allowed_events=(("granted",), ("granted", "removed")),
+    )
+    if books:
+        return books
+    grant_modifiers = assignment.caused_by.gang_type.modifiers.filter(
+        adds_assignable__slot__name="Variant",
+        adds_assignable__slot__slot_type__name="Variant",
+        adds_assignable__slot__pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
+        targets_gang__isnull=False,
+    )
+    if grant_modifiers.count() != 1:
+        return "does not have one Variant-slot grant on its gang-type cause"
+    return ""
+
+
+def _live_spare_problem(assignment):
+    if assignment.archived:
+        return "is an archived non-None assignment"
+    if assignment.caused_by.hidden_id is None:
+        return "was not caused by the old “Affiliation” marker"
+    books = _empty_books(assignment, allowed_events=(("granted",),))
+    if books:
+        return books
+
+    from n26.core.models import Assignment
+
+    siblings = Assignment.objects.filter(
+        gang_root_id=assignment.gang_root_id,
+        gang_id=assignment.gang_root_id,
+        caused_by_id=assignment.caused_by_id,
+        chosen_for_id=assignment.caused_by_id,
+        chosen_for_slot__slot_type__name="Affiliation",
+        chosen_for_slot__name="Affiliation",
+        pickable__isnull=False,
+    )
+    matching_old = siblings.filter(
+        archived=True,
+        pickable__name=assignment.affiliation.name,
+    )
+    current = siblings.filter(archived=False)
+    if matching_old.count() != 1 or current.count() != 1:
+        return (
+            "does not have one archived converted pick of the same name and "
+            "one live pick settling the “Affiliation” slot"
+        )
+    return ""
+
+
+def find(gang_id=None):
+    """Read the exact legacy assignments that may be deleted."""
+    from n26.core.models import Assignment
+
+    rows = Assignment.objects.filter(affiliation__isnull=False)
+    if gang_id is not None:
+        rows = rows.filter(gang_root_id=gang_id)
+    rows = rows.select_related(
+        "affiliation__pack",
+        "affiliation__built_ins",
+        "caused_by",
+    ).order_by("gang_root_id", "created", "id")
+
+    problems = []
+    by_gang = {}
+    for assignment in rows:
+        problem = _common_problem(assignment)
+        classification = None
+        if not problem and assignment.affiliation.name == "None":
+            classification = ARCHIVED_NONE
+            problem = _archived_none_problem(assignment)
+        elif not problem:
+            classification = LIVE_SPARE
+            problem = _live_spare_problem(assignment)
+        if problem:
+            problems.append(_problem(assignment, problem))
+            continue
+        by_gang.setdefault(assignment.gang_root_id, []).append(
+            (assignment.pk, classification)
+        )
+
+    gangs = tuple(
+        (pk, tuple(assignments))
+        for pk, assignments in sorted(by_gang.items(), key=lambda item: item[0])
+    )
+    return LegacyAffiliationAssignments(
+        gangs=gangs,
+        problems=tuple(problems),
+        nothing_here=not gangs and not problems,
+    )
+
+
+def apply(plan):
+    """Delete the planned rows gang by gang, refusing an unsafe plan."""
+    if plan.problems:
+        raise Refused(
+            "The deletion cannot run because " + "; ".join(plan.problems) + "."
+        )
+    if plan.nothing_here:
+        return list(plan.preview())
+
+    report = list(plan.preview())
+    for gang_id, assignments in plan.gangs:
+        report.append(_delete_one(gang_id, assignments))
+    return report
+
+
+def _delete_one(gang_id, assignments):
+    from copy import deepcopy
+
+    from n26.core.models import Assignment, Gang
+    from n26.core.reconcile import check_gang
+
+    ids = tuple(pk for pk, _ in assignments)
+    with transaction.atomic():
+        gang = Gang.objects.select_for_update().get(pk=gang_id)
+        locked = list(
+            Assignment.objects.select_for_update().filter(pk__in=ids).order_by("pk")
+        )
+        standing = dict(find(gang_id).gangs)
+        if standing.get(gang_id) != assignments:
+            return (
+                f"gang {gang_id}: skipped — its affiliation assignments changed "
+                "since the plan was read; run the deletion again with a new plan"
+            )
+
+        before_problems = check_gang(gang)
+        if before_problems:
+            return (
+                f"gang {gang_id}: skipped — it did not reconcile before the "
+                "deletion: " + "; ".join(before_problems)
+            )
+        before = gang_state(gang)
+        expected = deepcopy(before)
+        kinds = dict(assignments)
+        for assignment in locked:
+            if kinds[assignment.pk] == LIVE_SPARE:
+                try:
+                    expected["rows"].remove(str(assignment.affiliation))
+                except ValueError:
+                    return (
+                        f"gang {gang_id}: skipped — live spare assignment "
+                        f"{assignment.pk} has no matching gang-sheet line"
+                    )
+        Assignment.objects.filter(pk__in=ids).delete()
+        gang.refresh_from_db()
+        after_problems = check_gang(gang)
+        changed = differences(expected, gang_state(gang))
+        if after_problems or changed:
+            transaction.set_rollback(True)
+            reasons = []
+            if after_problems:
+                reasons.append(
+                    "its books no longer reconcile: " + "; ".join(after_problems)
+                )
+            if changed:
+                reasons.append(
+                    "its pages would change beyond removing the live spare line: "
+                    + "; ".join(changed)
+                )
+            return f"gang {gang_id}: skipped — " + "; ".join(reasons)
+
+    count = len(ids)
+    return (
+        f"gang {gang_id}: deleted {count} legacy assignment{'' if count == 1 else 's'}"
+    )

--- a/n26/core/legacy_affiliation_assignments.py
+++ b/n26/core/legacy_affiliation_assignments.py
@@ -256,9 +256,11 @@ def find(gang_id=None):
         if not problem and assignment.affiliation.name == "None":
             classification = ARCHIVED_NONE
             problem = _archived_none_problem(assignment)
-        elif not problem:
+        elif not problem and assignment.affiliation.name == "Mutant":
             classification = LIVE_SPARE
             problem = _live_spare_problem(assignment)
+        elif not problem:
+            problem = "is not the measured live Mutant spare"
         if problem:
             problems.append(_problem(assignment, problem))
             continue
@@ -304,7 +306,13 @@ def _delete_one(gang_id, assignments):
         locked = list(
             Assignment.objects.select_for_update().filter(pk__in=ids).order_by("pk")
         )
-        standing = dict(find(gang_id).gangs)
+        current = find(gang_id)
+        standing = dict(current.gangs)
+        if current.problems:
+            return (
+                f"gang {gang_id}: skipped — its affiliation assignments no longer "
+                "pass the deletion safety checks: " + "; ".join(current.problems)
+            )
         if standing.get(gang_id) != assignments:
             return (
                 f"gang {gang_id}: skipped — its affiliation assignments changed "

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -60,6 +60,7 @@ __all__ = [
     "Operation",
     "backfill_built_ins",
     "delete_empty_affiliations",
+    "delete_legacy_affiliation_assignments",
     "delete_nameless_gang_type",
     "open_founding_actions",
     "rehost_gang_picks",
@@ -176,6 +177,10 @@ class Operation(models.TextChoices):
         "n26_open_founding_actions",
         "n26: the Found and equip gang action is opened on gangs that never had one",
     )
+    DELETE_LEGACY_AFFILIATION_ASSIGNMENTS = (
+        "n26_delete_legacy_affiliation_assignments",
+        "n26: legacy affiliation assignments are deleted",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -192,6 +197,7 @@ LOCK_KEYS = {
     Operation.REPOINT_CHAMPION_PICKS: 826_020_615,
     Operation.DELETE_EMPTY_AFFILIATIONS: 826_020_616,
     Operation.OPEN_FOUNDING_ACTIONS: 826_020_617,
+    Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS: 826_020_618,
 }
 
 
@@ -890,6 +896,57 @@ def delete_empty_affiliations(backfill_id, **said_by_whoever_enqueued_it):
     )
 
 
+@task
+def delete_legacy_affiliation_assignments(backfill_id, **said_by_whoever_enqueued_it):
+    """Delete the two measured player-data leftovers of the conversions."""
+    from n26.core.legacy_affiliation_assignments import Refused, apply, find
+
+    _run_recorded(
+        backfill_id,
+        Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS,
+        "Legacy affiliation assignment deletion",
+        lambda: apply(find()),
+        Refused,
+    )
+
+
+LEGACY_AFFILIATION_ASSIGNMENT_WORDS = {
+    "noun": "deletion",
+    "intro": (
+        "This deletes the player assignments left by the affiliation conversions. "
+        "Only archived None assignments replaced by an optional Variant slot and "
+        "live spare assignments whose converted affiliation pick has since changed "
+        "can be deleted. Every assignment must have a zero-value ledger entry, only "
+        "the expected zero-value history events, and no dependent data. Its ledger "
+        "entry and history events are deleted with it. Each affected gang must "
+        "reconcile. An archived assignment cannot change a page; a live spare may "
+        "remove only its own obsolete line. Otherwise the gang is left alone."
+    ),
+    "nothing_heading": "Nothing to delete",
+    "nothing_flash": "No legacy affiliation assignments remain.",
+    "nothing_words": "No legacy affiliation assignments remain.",
+    "refuses_heading": "The deletion cannot run",
+    "button": "Delete the legacy assignments",
+    "confirm": (
+        "Delete these assignments, their ledger entries and their history events? "
+        "This cannot be undone."
+    ),
+}
+
+
+def delete_legacy_affiliation_assignments_view(request):
+    """Preview the player-data deletion (GET), or record and enqueue it."""
+    from n26.core.legacy_affiliation_assignments import find
+
+    return _deletion_view(
+        request,
+        Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS,
+        find,
+        delete_legacy_affiliation_assignments,
+        LEGACY_AFFILIATION_ASSIGNMENT_WORDS,
+    )
+
+
 REHOST_WORDS = {
     "noun": "move",
     "intro": (
@@ -948,7 +1005,7 @@ EMPTY_AFFILIATION_WORDS = {
         "the new system. The deletion is rolled back if it would change "
         "any checked gang page. The deletion cannot run while any "
         "assignment still names an affiliation or anyone still holds an "
-        "affiliation offer. Run the related conversion first."
+        "affiliation offer. Run the legacy affiliation assignment deletion first."
     ),
     "nothing_heading": "Nothing to delete",
     "nothing_flash": "There was nothing selected for deletion.",
@@ -1677,6 +1734,23 @@ register_operation(
 
 register_operation(
     MaintenanceOperation(
+        operation=Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS.value,
+        name=Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS.label,
+        added=date(2026, 9, 4),
+        description=(
+            "Delete archived None assignments and live spare affiliation assignments "
+            "left by the conversions. Each assignment must have the expected "
+            "zero-value ledger entry and history events. Those records are deleted too, "
+            "and every affected gang must reconcile. Only a live spare's own "
+            "obsolete line may disappear from its gang sheet."
+        ),
+        view=delete_legacy_affiliation_assignments_view,
+        detail_template="admin/maintenance/n26/_delete_detail.html",
+    )
+)
+
+register_operation(
+    MaintenanceOperation(
         operation=Operation.DELETE_EMPTY_AFFILIATIONS.value,
         name=Operation.DELETE_EMPTY_AFFILIATIONS.label,
         added=date(2026, 8, 29),
@@ -1688,7 +1762,8 @@ register_operation(
             "gang page. The slot types named Affiliation, Clan House, "
             "Chaos God and Variant remain. The deletion cannot run while "
             "any assignment still names an affiliation or any affiliation "
-            "offer remains attached to a carrier."
+            "offer remains attached to a carrier; run the legacy affiliation "
+            "assignment deletion first."
         ),
         view=delete_empty_affiliations_view,
         detail_template="admin/maintenance/n26/_delete_detail.html",
@@ -1723,6 +1798,11 @@ task_routes = [
     TaskRoute(drop_duplicate_grants, ack_deadline=600),
     TaskRoute(rehost_gang_picks, ack_deadline=600, min_retry_delay=60),
     TaskRoute(repoint_champion_picks, ack_deadline=600, min_retry_delay=60),
+    TaskRoute(
+        delete_legacy_affiliation_assignments,
+        ack_deadline=600,
+        min_retry_delay=60,
+    ),
     TaskRoute(delete_empty_affiliations, ack_deadline=600, min_retry_delay=60),
     TaskRoute(open_founding_actions, ack_deadline=600),
 ]

--- a/n26/tests/sandbox/test_legacy_affiliation_assignments.py
+++ b/n26/tests/sandbox/test_legacy_affiliation_assignments.py
@@ -1,0 +1,216 @@
+"""The player-data repair that frees the retired Affiliation rows."""
+
+import pytest
+
+from n26.core.capture import gang_state
+from n26.core.legacy_affiliation_assignments import (
+    ARCHIVED_NONE,
+    LIVE_SPARE,
+    Refused,
+    apply,
+    find,
+)
+from n26.core.models import Assignment, LedgerEntry, LedgerEvent
+from n26.core.reconcile import assert_reconciled
+from n26.tests.sandbox.actions import (
+    assign,
+    create_affiliation,
+    create_gang_type,
+    create_hidden,
+    create_pickable,
+    create_picklist,
+    create_slot,
+    create_slot_type,
+    ef_adds,
+    found_gang,
+    modifier,
+    targets_gang_alone,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def legacy_world(default_pack, owner):
+    gang_type = create_gang_type("Legacy repair gang", starting_credits=1000)
+
+    variant_type = create_slot_type(
+        "Variant", plural_name="Variants", allows_repeats=False
+    )
+    variant_slot = create_slot(
+        "Variant",
+        variant_type,
+        create_picklist("Variants", variant_type),
+        assigned_to="gang",
+        min_picks=0,
+        max_picks=1,
+    )
+
+    affiliation_type = create_slot_type(
+        "Affiliation", plural_name="Affiliations", allows_repeats=False
+    )
+    mutant_pickable = create_pickable("Mutant", affiliation_type)
+    clanless_pickable = create_pickable("Clanless", affiliation_type)
+    affiliation_slot = create_slot(
+        "Affiliation",
+        affiliation_type,
+        create_picklist(
+            "Affiliations",
+            affiliation_type,
+            members=[mutant_pickable, clanless_pickable],
+        ),
+        assigned_to="gang",
+        min_picks=0,
+        max_picks=1,
+    )
+    modifier(
+        "Variants: the gang is asked its Variant",
+        targets_gang_alone(),
+        ef_adds(variant_slot),
+        carried_by=gang_type,
+    )
+
+    none_gang = found_gang("The None", gang_type, owner=owner, budget=1000)
+    none_cause = none_gang.founding
+    none = assign(
+        create_affiliation("None"),
+        gang=none_gang,
+        caused_by=none_cause,
+    )
+    none.archive()
+
+    spare_gang = found_gang("The Spare", gang_type, owner=owner, budget=1000)
+    marker = assign(
+        create_hidden("Affiliation"),
+        gang=spare_gang,
+        caused_by=spare_gang.founding,
+    )
+    mutant = assign(
+        create_affiliation("Mutant"),
+        gang=spare_gang,
+        caused_by=marker,
+    )
+    old_pick = assign(
+        mutant_pickable,
+        gang=spare_gang,
+        caused_by=marker,
+        chosen_for=marker,
+        chosen_for_slot=affiliation_slot,
+    )
+    old_pick.archive()
+    current_pick = assign(
+        clanless_pickable,
+        gang=spare_gang,
+        caused_by=marker,
+        chosen_for=marker,
+        chosen_for_slot=affiliation_slot,
+    )
+
+    assert_reconciled(none_gang)
+    assert_reconciled(spare_gang)
+    return none_gang, none, spare_gang, mutant, old_pick, current_pick
+
+
+def test_it_finds_only_the_two_measured_shapes(legacy_world):
+    none_gang, none, spare_gang, mutant, *_ = legacy_world
+
+    plan = find()
+
+    assert plan.ok and not plan.nothing_here
+    assert dict(plan.gangs) == {
+        none_gang.pk: ((none.pk, ARCHIVED_NONE),),
+        spare_gang.pk: ((mutant.pk, LIVE_SPARE),),
+    }
+    said = "\n".join(plan.preview())
+    assert "1 archived None assignment" in said
+    assert "1 live spare" in said
+    assert "ledger entries and history events are deleted too" in said
+
+
+def test_it_deletes_the_legacy_rows_and_their_empty_books_without_changing_pages(
+    legacy_world,
+):
+    none_gang, none, spare_gang, mutant, old_pick, current_pick = legacy_world
+    before = {gang.pk: gang_state(gang) for gang in (none_gang, spare_gang)}
+    deleted_ids = (none.pk, mutant.pk)
+    kept_event = current_pick.ledger_events.get().pk
+
+    report = apply(find())
+
+    assert any("deleted 1 legacy assignment" in line for line in report)
+    assert not Assignment.objects.filter(pk__in=deleted_ids).exists(), report
+    assert not LedgerEntry.objects.filter(assignment_id__in=deleted_ids).exists()
+    assert not LedgerEvent.objects.filter(assignment_id__in=deleted_ids).exists()
+    assert Assignment.objects.filter(pk__in=(old_pick.pk, current_pick.pk)).count() == 2
+    assert LedgerEvent.objects.filter(pk=kept_event).exists()
+    none_gang.refresh_from_db()
+    assert gang_state(none_gang) == before[none_gang.pk]
+    assert_reconciled(none_gang)
+    spare_gang.refresh_from_db()
+    after_spare = gang_state(spare_gang)
+    assert after_spare["rows"] == [
+        row for row in before[spare_gang.pk]["rows"] if row != "Mutant"
+    ]
+    assert {**after_spare, "rows": before[spare_gang.pk]["rows"]} == before[
+        spare_gang.pk
+    ]
+    assert_reconciled(spare_gang)
+    assert find().nothing_here
+    assert apply(find()) == ["no legacy affiliation assignments remain"]
+
+
+def test_it_refuses_a_non_zero_ledger_entry(legacy_world):
+    _, none, *_ = legacy_world
+    entry = none.ledger_entry
+    entry.paid = 1
+    entry.save(update_fields=["paid"])
+
+    plan = find()
+
+    assert not plan.ok
+    assert any("non-zero ledger entry" in problem for problem in plan.problems)
+    with pytest.raises(Refused, match="cannot run"):
+        apply(plan)
+
+
+def test_it_refuses_history_pinned_to_another_gang(legacy_world):
+    _, none, other_gang, *_ = legacy_world
+    event = none.ledger_events.get()
+    event.gang = other_gang
+    event.save(update_fields=["gang"])
+
+    plan = find()
+
+    assert not plan.ok
+    assert any("history event pinned to another gang" in p for p in plan.problems)
+
+
+def test_it_refuses_a_live_none_assignment(legacy_world):
+    _, none, *_ = legacy_world
+    none.unarchive()
+
+    plan = find()
+
+    assert not plan.ok
+    assert any("live None assignment" in problem for problem in plan.problems)
+
+
+def test_it_refuses_a_spare_without_one_current_converted_pick(legacy_world):
+    *_, current_pick = legacy_world
+    current_pick.archive()
+
+    plan = find()
+
+    assert not plan.ok
+    assert any("one live pick" in problem for problem in plan.problems)
+
+
+def test_a_changed_plan_is_skipped_without_deleting_anything(legacy_world):
+    _, none, *_ = legacy_world
+    plan = find()
+    none.unarchive()
+
+    report = apply(plan)
+
+    assert Assignment.objects.filter(pk=none.pk).exists()
+    assert any("changed since the plan was read" in line for line in report)

--- a/n26/tests/sandbox/test_legacy_affiliation_assignments.py
+++ b/n26/tests/sandbox/test_legacy_affiliation_assignments.py
@@ -205,6 +205,21 @@ def test_it_refuses_a_spare_without_one_current_converted_pick(legacy_world):
     assert any("one live pick" in problem for problem in plan.problems)
 
 
+def test_it_refuses_a_live_spare_with_an_unmeasured_name(legacy_world):
+    _, _, _, mutant, old_pick, _ = legacy_world
+    mutant.affiliation.name = "Aranthian"
+    mutant.affiliation.save(update_fields=["name"])
+    old_pick.pickable.name = "Aranthian"
+    old_pick.pickable.save(update_fields=["name"])
+
+    plan = find()
+
+    assert not plan.ok
+    assert any(
+        "not the measured live Mutant spare" in problem for problem in plan.problems
+    )
+
+
 def test_a_changed_plan_is_skipped_without_deleting_anything(legacy_world):
     _, none, *_ = legacy_world
     plan = find()
@@ -213,4 +228,19 @@ def test_a_changed_plan_is_skipped_without_deleting_anything(legacy_world):
     report = apply(plan)
 
     assert Assignment.objects.filter(pk=none.pk).exists()
-    assert any("changed since the plan was read" in line for line in report)
+    assert any("no longer pass the deletion safety checks" in line for line in report)
+
+
+def test_a_new_unsafe_assignment_after_preview_skips_the_gang(legacy_world):
+    _, _, spare_gang, mutant, *_ = legacy_world
+    plan = find(spare_gang.pk)
+    assign(
+        create_affiliation("Aranthian"),
+        gang=spare_gang,
+        caused_by=mutant.caused_by,
+    )
+
+    report = apply(plan)
+
+    assert Assignment.objects.filter(pk=mutant.pk).exists()
+    assert any("no longer pass the deletion safety checks" in line for line in report)

--- a/n26/tests/test_maintenance_console.py
+++ b/n26/tests/test_maintenance_console.py
@@ -29,6 +29,7 @@ from n26.maintenance import (
     convert_outcast_affiliation_view,
     convert_variant_view,
     delete_empty_affiliations_view,
+    delete_legacy_affiliation_assignments_view,
     delete_nameless_gang_type_view,
     open_founding_actions_view,
 )
@@ -597,6 +598,48 @@ class TestTheEmptyAffiliationDeletion:
         assert posted.status_code == 302
         assert not Backfill.objects.exists()
         assert Affiliation.objects.filter(pk=names["Mutant"].pk).exists()
+
+
+class TestTheLegacyAffiliationAssignmentDeletion:
+    def test_its_lock_is_unique_and_its_slug_is_permanent(self):
+        keys = list(LOCK_KEYS.values())
+        assert len(keys) == len(set(keys))
+        assert LOCK_KEYS[Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS] == 826_020_618
+        assert Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS.value == (
+            "n26_delete_legacy_affiliation_assignments"
+        )
+
+    def test_the_operation_is_registered_and_offered(self):
+        registered = {op.operation for op in operations()}
+
+        assert Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS.value in registered
+        found = resolve_operation(Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS.value)
+        assert found.name == Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS.label
+        assert found.view is delete_legacy_affiliation_assignments_view
+
+    def test_only_a_superuser_may_reach_it(self, client, staffer):
+        client.force_login(staffer)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_delete_legacy_affiliation_assignments")
+        )
+
+        assert response.status_code in (302, 403)
+
+    def test_get_shows_the_empty_plan_without_writing(
+        self, client, superuser, default_pack
+    ):
+        client.force_login(superuser)
+
+        response = client.get(
+            reverse("admin:maintenance_n26_delete_legacy_affiliation_assignments")
+        )
+
+        page = response.content.decode()
+        assert response.status_code == 200
+        assert "Nothing to delete" in page
+        assert "No legacy affiliation assignments remain" in page
+        assert not Backfill.objects.exists()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Add a maintenance operation that deletes the two affiliation-assignment shapes left by the Variant and Outcast conversions.
- Refuse unexpected hosts, dependencies, ledger values, history, or converted-pick relationships. Lock and recheck each gang, then roll it back if its books or page change beyond removing the one obsolete live spare line.
- Tell operators to run this repair before deleting the retired affiliation library rows.

## Production check

The read-only classifier accepts exactly the known 210 assignments across 194 gangs: 209 archived None assignments and one live Mutant spare. It reports no unexplained rows.

## Validation

- `pytest -q -n 0 n26/tests/sandbox/test_legacy_affiliation_assignments.py n26/tests/test_maintenance_console.py` — 76 passed after the review fixes
- Fresh PR CI at `b2c48b9fe` — all 11 checks passed, including the full suite
- Full suite before the rebase — 9,365 passed, 12 skipped, 1 xfailed
- Local maintenance page smoke test — HTTP 200