### PR TITLE
fix: n26 founding Trade Point budgets reach staff owners only while they are tested

### DIFF
--- a/n26/core/test_views_founding_budget.py
+++ b/n26/core/test_views_founding_budget.py
@@ -88,7 +88,9 @@ def venators(library):
 
 @pytest.fixture
 def tester(db):
-    return User.objects.create_user("player")
+    # Staff, because the founding budgets reach staff owners only while
+    # they are being tested; the non-staff owner has a class of their own.
+    return User.objects.create_user("player", is_staff=True)
 
 
 @pytest.fixture
@@ -335,6 +337,45 @@ class TestWhatTheScreenSays:
 
         assert response.context["founding_budget"] is None
         assert "Founding Trade Points" not in response.content.decode()
+
+
+class TestAnOwnerTheBudgetsDoNotReachYet:
+    """While the founding budgets are being tested they reach staff owners
+    only, the same readers as the Actions square that completes the
+    founding. Every other owner's screens are read exactly as they were
+    before budgets existed: no tally, list lines counting nothing, the
+    post-is-shut note in its old place, and a purchase naming no action."""
+
+    @pytest.fixture(autouse=True)
+    def signed_in_as_a_plain_owner(self, client, gang):
+        plain = User.objects.create_user("plain-owner")
+        gang.owner = plain
+        gang.save(update_fields=["owner"])
+        client.force_login(plain)
+
+    def test_the_tally_is_not_drawn(self, client, leader, legacy_list):
+        response = client.get(equip_url(leader, legacy_list))
+
+        assert response.context["founding_budget"] is None
+        assert "Founding Trade Points" not in response.content.decode()
+
+    def test_the_post_is_still_said_to_be_shut(self, client, leader, post):
+        response = client.get(equip_url(leader, post))
+
+        assert response.context["post_is_shut"] is True
+        assert "Not tracking TP" in response.content.decode()
+
+    def test_a_list_purchase_counts_nothing_and_names_no_action(
+        self, client, gang, leader, legacy_list
+    ):
+        client.post(
+            equip_url(leader, legacy_list), {"thing": key_of(wargear("Flak plate"))}
+        )
+
+        entry = bought(gang, "Flak plate").ledger_entry
+        assert entry.trade_points == 0
+        assert entry.action is None
+        assert entry.spent_by is None
 
 
 class TestGoingPastIt:

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -35,6 +35,7 @@ from n26.core.views.htmx import is_htmx, no_update, with_toasts
 from n26.core.views.permissions import (
     _own_gang_or_404,
     _own_miniature_or_404,
+    may_see_founding,
     trade_points_href,
 )
 
@@ -410,7 +411,7 @@ class Screen:
         return EquipHost.stash(self.gang, self.card, at=at)
 
 
-def _screen(gang, miniature=None, list_param=""):
+def _screen(gang, miniature=None, list_param="", budgets=True):
     """What an equip screen shows: card, collections, chosen list, view.
 
     ``miniature`` names whose screen this is; without one it is the
@@ -457,8 +458,9 @@ def _screen(gang, miniature=None, list_param=""):
         # screen against it, which the books call a combined figure — so
         # the terms are the founding ones and not each collection's. A
         # model without one is read exactly as it was before allowances
-        # existed, down to the queries.
-        budget = budget_for(gang, miniature, computed)
+        # existed, down to the queries — as is every model for a reader
+        # the feature does not reach (``budgets`` False).
+        budget = budget_for(gang, miniature, computed) if budgets else None
         terms = FOUNDING if budget is not None else None
         collections = buyable_lists(
             access.collection
@@ -552,7 +554,12 @@ def render_update(
     from n26.core.owned import possessions
     from n26.core.views.owned import accessorise_dialogs
 
-    screen = _screen(gang, miniature=miniature, list_param=list_param)
+    screen = _screen(
+        gang,
+        miniature=miniature,
+        list_param=list_param,
+        budgets=may_see_founding(gang, request.user),
+    )
     host = screen.host(at)
     held = possessions(host)
     refunds = not gang.credits_unlimited
@@ -856,7 +863,12 @@ def equip(request, pk):
 
     wanted = request.GET.get("list", "")
     everything = wanted == ALL_SCOPE
-    screen = _screen(gang, miniature=miniature, list_param=wanted)
+    screen = _screen(
+        gang,
+        miniature=miniature,
+        list_param=wanted,
+        budgets=may_see_founding(gang, request.user),
+    )
     collections, chosen, view = screen.collections, screen.chosen, screen.view
 
     # Which of the picker's section tabs the reader was on — client state

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -16,6 +16,7 @@ from n26.core.views.permissions import (
     _own_gang_or_404,
     link_campaign,
     may_see_actions_square,
+    may_see_founding,
     trade_points_href,
 )
 
@@ -257,10 +258,11 @@ def gang_sheet(request, pk):
     yours = gang.owner_id == getattr(request.user, "id", None)
     at = reverse("n26-gang", args=[gang.pk])
     card = build_gang_card(gang)
-    # for_owner puts the owner-only figures on the cards — what a model
-    # has left of its founding Trade Points — and is what keeps a
-    # stranger's read from paying for figures they are not shown.
-    sheet = render_gang(gang, card=card, for_owner=yours)
+    # for_owner puts the founding figures on the cards — what a model has
+    # left of its founding Trade Points — for the readers the feature
+    # reaches, and is what keeps everyone else's read from paying for
+    # figures they are not shown.
+    sheet = render_gang(gang, card=card, for_owner=may_see_founding(gang, request.user))
     dialog = None
     link_campaign(sheet.campaign, request.user)
     if yours:

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -71,6 +71,19 @@ def link_campaign(block, user):
     block.pool_href = reverse("n26-campaign-pool", args=[block.campaign_id])
 
 
+def may_see_founding(gang, user):
+    """Whether the reader is shown the founding Trade Point budgets.
+
+    The figures on the model cards, the allowance block on the equip
+    screen and the terms that make list lines count Trade Points are one
+    feature, and while it is being tested it reaches the same readers as
+    the Actions square that completes the founding: staff who own the
+    gang. Everyone else is read exactly as before budgets existed. The
+    two gates lift together.
+    """
+    return may_see_actions_square(gang, user)
+
+
 def may_see_actions_square(gang, user):
     """Whether the gang page draws its Actions square for this reader.
 

--- a/n26/tests/sandbox/test_founding_budget.py
+++ b/n26/tests/sandbox/test_founding_budget.py
@@ -53,7 +53,9 @@ FOUNDING_KIND = Action.Kind.FOUNDING
 
 @pytest.fixture
 def player():
-    return User.objects.create_user("tom")
+    # Staff, because the founding budgets reach staff owners only while
+    # they are being tested; the non-staff owner has tests of their own.
+    return User.objects.create_user("tom", is_staff=True)
 
 
 #: The entries each gang list holds, as ``(entry, the subtype naming its
@@ -1138,3 +1140,15 @@ class TestTheFigureOnTheGangPage:
         stranger = User.objects.create_user("a-stranger")
 
         assert self.HOVER.format("Rasp") not in self.body(client, gang, reader=stranger)
+
+    def test_an_owner_who_is_not_staff_is_not_shown_it_yet(self, client, gang, leader):
+        """The budgets reach staff owners only while they are being tested,
+        the same readers as the Actions square that completes the founding.
+        Every other owner reads their roster as it was before budgets."""
+        plain = User.objects.create_user("plain-owner")
+        gang.owner = plain
+        gang.save(update_fields=["owner"])
+
+        body = self.body(client, gang, reader=plain)
+        assert self.HOVER.format("Rasp") not in body
+        assert " TP<span" not in body


### PR DESCRIPTION
## Problem

The Foundations seeds are now pressed in production, so every owner of a Venator or Outcast gang sees founding Trade Point figures on their model cards and equip screens, while the Actions square that completes the founding is staff-only. Tom wants the budgets hidden until he has tested them more completely.

## Change

`may_see_founding(gang, user)` in `n26/core/views/permissions.py`: the same gate as the Actions square (staff who own the gang). It governs the whole feature as one unit: the figures on the model cards (`render_gang(for_owner=…)`), the allowance block on the equip screen, the `FOUNDING` terms that make list lines count Trade Points, and the action a purchase records. Every other owner is read exactly as before budgets existed, including the "Not tracking TP" note. The two gates lift together.

## Test plan

- [x] `pytest -n 4` on the founding budget (view + sandbox), founding action, equip, gang-equip and trade-points suites: 375 passed
- [x] New tests: a non-staff owner sees no tally and no card figure, list lines count nothing and a purchase names no action, the post-is-shut note is back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh