### PR TITLE
feat: rename the core CampaignType to "Territory campaign" and describe it on the set-up screen

### DIFF
--- a/n26/core/campaign_packs.py
+++ b/n26/core/campaign_packs.py
@@ -6,8 +6,8 @@ type (``CampaignOperation.found``); a gang that joins is assigned both
 types, with the shared type's built-ins landing caused by its carrier
 (``Operation.join_campaign``). Campaigns and memberships written before
 either existed have none of it, and this fills the gap: each campaign
-missing a type is put on the **N26 core** type, the one type every
-install has and the only thing a campaign could have been played as
+missing a type is put on the **Territory campaign** type, the one type
+every install has and the only thing a campaign could have been played as
 before there was a choice; each missing a pack or an additions type is
 given one, named for the campaign as founding names them; and each open
 membership missing a carrier is given it, with the type's built-ins
@@ -26,9 +26,9 @@ What an operation does beyond writing rows is not done here: no stored
 effect runs, and a weapon lands without its free firing lines. Nor are
 two shapes of built-in followed: an extra firing line, which needs a gun
 to land on, and a built-in with built-ins of its own. None of these is
-in the N26 core type, whose built-ins are a counter and an asset. Each
-is reported rather than half-written, and the propagation pass catches
-up whatever it can.
+in the Territory campaign type, whose built-ins are a counter and an
+asset. Each is reported rather than half-written, and the propagation pass
+catches up whatever it can.
 
 Everything is matched on what already stands and left alone if it is
 there, so running this twice changes nothing the second time. Written
@@ -41,7 +41,11 @@ from uuid import uuid4
 from django.conf import settings
 
 from n26.core.models.ledger import Reason
-from n26.library.core_campaign import CAMPAIGN_TYPE, seed_core_campaign
+from n26.library.core_campaign import (
+    CAMPAIGN_TYPE,
+    FORMER_NAME,
+    seed_core_campaign,
+)
 from n26.library.models.defaults import DEFAULT_ASSIGNABLE_FIELDS
 
 #: ``LedgerEvent.Kind.GRANTED``, by value: the history's word for a thing
@@ -107,16 +111,19 @@ def give_campaigns_their_packs(apps):
 
 
 def _core_type(apps):
-    """The N26 core campaign type, created along with the rest of the core
-    campaign content if a database lacks it."""
+    """The Territory campaign type, created along with the rest of the
+    core campaign content if a database lacks it. A database still holding
+    the type under its former name is not given a second one."""
     CampaignType = apps.get_model("library", "CampaignType")
 
     def find():
-        return CampaignType.objects.filter(
-            pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
-            name__iexact=CAMPAIGN_TYPE,
-            qualifier="",
-        ).first()
+        system = CampaignType.objects.filter(
+            pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG, qualifier=""
+        )
+        return (
+            system.filter(name__iexact=CAMPAIGN_TYPE).first()
+            or system.filter(name__iexact=FORMER_NAME).first()
+        )
 
     core = find()
     if core is None:

--- a/n26/core/campaigns.py
+++ b/n26/core/campaigns.py
@@ -28,10 +28,11 @@ so a campaign never exists without them::
 
     campaign = Campaign(name="Dust Falls", owner=arbitrator)
     with campaign_operation(campaign, actor=arbitrator) as act:
-        act.found(n26_core)
+        act.found(territory_campaign)
 """
 
 from contextlib import contextmanager
+from dataclasses import dataclass
 from uuid import uuid4
 
 from django.db import transaction
@@ -479,3 +480,88 @@ def campaign_operation(campaign, actor=None):
             ).first()
             campaign.refresh_from_db()
         yield CampaignOperation(campaign, actor=actor)
+
+
+# --- What a type gives, for the screen that offers it ------------------------
+
+
+@dataclass(frozen=True)
+class CampaignTypeSummary:
+    """One campaign type as the set-up screen offers it: what a campaign
+    of it is about, and what a gang that joins is given.
+
+    Built here rather than in the template because each line is a
+    sentence composed from several rows — a kind's label and its mode, a
+    built-in member and its opening value, a modifier's scope and effect
+    — and the words belong with the facts they are made from.
+
+    ``kinds`` is one sentence per asset kind, in the type's own order.
+    ``starts_with`` is one sentence for the whole built-in set, or empty
+    where the type builds nothing in. ``rules`` is one sentence per
+    campaign-wide modifier, in the words the authoring pages use.
+    """
+
+    pk: str
+    name: str
+    description: str
+    kinds: tuple[str, ...] = ()
+    starts_with: str = ""
+    rules: tuple[str, ...] = ()
+    checked: bool = False
+
+
+def summarise_campaign_type(campaign_type, checked=False):
+    """What founding a campaign on this type gives, in sentences.
+
+    Reads the type's kinds, its built-in members and its modifiers, each
+    once. Three or four queries per type; the screen offers a handful.
+    """
+    from n26.library.models.defaults import DEFAULT_ASSIGNABLE_FIELDS
+    from n26.library.prose import GANG, sentence_for
+    from n26.library.references import reading_sentences
+
+    kinds = tuple(_kind_sentence(kind) for kind in campaign_type.asset_kinds.all())
+    members = campaign_type.built_in_members.select_related(
+        *DEFAULT_ASSIGNABLE_FIELDS
+    ).order_by("position")
+    given = [_given(member) for member in members]
+    starts_with = f"Every gang starts with {_and(given)}." if given else ""
+    rules = tuple(
+        sentence_for(modifier, GANG, thing=campaign_type).text
+        for modifier in reading_sentences(campaign_type.modifiers.all())
+    )
+    return CampaignTypeSummary(
+        pk=str(campaign_type.pk),
+        name=str(campaign_type),
+        description=campaign_type.description,
+        kinds=kinds,
+        starts_with=starts_with,
+        rules=rules,
+        checked=checked,
+    )
+
+
+def _kind_sentence(kind):
+    """How assets of one kind behave, in one sentence: "one" rather than
+    an article, so the label needs no a/an."""
+    if kind.is_pooled:
+        return f"{kind.plural} change hands."
+    return f"Every gang gets one {kind.label_singular} and keeps it."
+
+
+def _given(member):
+    """One built-in member as a gang receives it: a counter with its
+    opening value, an asset by the one, anything else by name."""
+    thing = member.assignable
+    if member.counter_id is not None:
+        return f"{thing} at {member.amount}"
+    if member.asset_id is not None:
+        return f"one {thing}"
+    return str(thing)
+
+
+def _and(words):
+    words = list(words)
+    if len(words) == 1:
+        return words[0]
+    return f"{', '.join(words[:-1])} and {words[-1]}"

--- a/n26/core/forms.py
+++ b/n26/core/forms.py
@@ -373,11 +373,14 @@ class FoundCampaignForm(CampaignForm):
     # A campaign's own additions type lives in a pack the arbitrator owns
     # and is never offered here, or anywhere else.
     campaign_type = forms.ModelChoiceField(
-        queryset=CampaignType.objects.selectable().exclude(name__regex=r"^\s*$"),
+        queryset=CampaignType.objects.selectable()
+        .exclude(name__regex=r"^\s*$")
+        .select_related("built_ins")
+        .prefetch_related("asset_kinds"),
         label="Campaign type",
         help_text=(
-            "What the campaign runs on. Every gang that joins gets what the "
-            "type includes."
+            "The rules the campaign is played under. Each type sets what "
+            "the gangs fight over and what every gang starts with."
         ),
         error_messages={
             "invalid_choice": (
@@ -394,17 +397,16 @@ class FoundCampaignForm(CampaignForm):
         The same types the field validates against, said once, in the
         shape ``CreateGangForm.gang_type_choices`` uses: ``checked`` is
         worked out here so a redisplay after a failed submit keeps the
-        reader's pick. The line under the name is the type's own help,
-        which is the one thing the library says about a type to a reader.
+        reader's pick. Each card carries what founding on the type gives —
+        its description, its asset kinds, what every gang starts with, and
+        any campaign-wide rules — so the picker reads as choosing a
+        rulebook rather than a name.
         """
+        from n26.core.campaigns import summarise_campaign_type
+
         submitted = str(self["campaign_type"].value() or "")
         return [
-            {
-                "value": str(row.pk),
-                "label": str(row),
-                "description": row.library_author_help,
-                "checked": str(row.pk) == submitted,
-            }
+            summarise_campaign_type(row, checked=str(row.pk) == submitted)
             for row in self.fields["campaign_type"].queryset
         ]
 

--- a/n26/core/migrations/0048_existing_campaigns_get_a_type_a_pack_and_carriers.py
+++ b/n26/core/migrations/0048_existing_campaigns_get_a_type_a_pack_and_carriers.py
@@ -2,7 +2,7 @@
 additions; every gang playing one is given the two carriers with the
 type's built-ins landed.
 
-Campaigns written before types existed are put on the **N26 core** type,
+Campaigns written before types existed are put on the core campaign type,
 matched by name in the system pack without regard to case. It is the one
 type every install has, and the only thing a campaign could have been
 played as before there was a choice; an arbitrator who wants another

--- a/n26/core/migrations/0057_campaign_type_help_and_asset_event_labels.py
+++ b/n26/core/migrations/0057_campaign_type_help_and_asset_event_labels.py
@@ -1,0 +1,51 @@
+"""The words on a campaign's type and on the two asset-copy event kinds.
+
+Help text and choice labels only; no column changes shape and no row is
+touched. The event kinds' labels stop naming a pool: a campaign keeps
+copies of its assets, and the labels say so.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0083_the_core_campaign_type_is_the_territory_campaign"),
+        ("n26", "0056_a_roll_on_a_table_is_put_on_the_record"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="campaign",
+            name="campaign_type",
+            field=models.ForeignKey(
+                help_text="The campaign type this campaign was founded on. Every gang that joins is assigned this type and is given its built-ins.",
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="campaigns",
+                to="library.campaigntype",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="campaignevent",
+            name="kind",
+            field=models.CharField(
+                choices=[
+                    ("created", "Set up"),
+                    ("renamed", "Renamed"),
+                    ("budget_set", "Budget set"),
+                    ("summary_edited", "Summary edited"),
+                    ("archived", "Archived"),
+                    ("battle_recorded", "Battle recorded"),
+                    ("battle_removed", "Battle removed"),
+                    ("invited", "Invited somebody"),
+                    ("invite_accepted", "Invitation accepted"),
+                    ("invite_declined", "Invitation declined"),
+                    ("participant_removed", "Participant removed"),
+                    ("asset_added", "Asset copy added"),
+                    ("asset_dropped", "Asset copy dropped"),
+                ],
+                max_length=20,
+            ),
+        ),
+    ]

--- a/n26/core/models/campaign.py
+++ b/n26/core/models/campaign.py
@@ -67,7 +67,7 @@ class Campaign(Base, Owned, Archived):
         related_name="campaigns",
         help_text=(
             "The campaign type this campaign was founded on. Every gang that "
-            "joins gets this type and everything that comes with it."
+            "joins is assigned this type and is given its built-ins."
         ),
     )
     #: The arbitrator's own pack, created at founding. Holds the additions
@@ -152,10 +152,11 @@ class CampaignEvent(Base):
         INVITE_ACCEPTED = "invite_accepted", "Invitation accepted"
         INVITE_DECLINED = "invite_declined", "Invitation declined"
         PARTICIPANT_REMOVED = "participant_removed", "Participant removed"
-        # The pool changing with no gang touched. A grant or a taking
-        # away changes a gang, and is that gang's ledger event instead.
-        ASSET_ADDED = "asset_added", "Asset added to the pool"
-        ASSET_DROPPED = "asset_dropped", "Asset dropped from the pool"
+        # The campaign's copies changing with no gang touched. A grant or
+        # a taking away changes a gang, and is that gang's ledger event
+        # instead.
+        ASSET_ADDED = "asset_added", "Asset copy added"
+        ASSET_DROPPED = "asset_dropped", "Asset copy dropped"
 
     campaign = models.ForeignKey(
         "n26.Campaign",
@@ -301,9 +302,10 @@ class CampaignMembership(Base):
 
 
 class CampaignAsset(Base):
-    """One copy of a pooled asset in one campaign's pool, and who holds it.
+    """One copy of an asset that changes hands, kept by one campaign, and
+    who holds it.
 
-    A pooled asset is a **holding**, not a possession. The campaign owns
+    Such an asset is a **holding**, not a possession. The campaign owns
     the token; a gang only ever holds it, and the token says which gang
     that is. Nothing is assigned to the gang, no ledger entry is written,
     and the gang's rating never counts it — so granting, taking away and
@@ -356,9 +358,9 @@ class CampaignAsset(Base):
     class Meta:
         verbose_name = "campaign asset"
         verbose_name_plural = "campaign assets"
-        # Grouped by kind, as the pool page lists them, then by asset and
-        # by copy. The joins are paid on every read of a pool and nowhere
-        # else: nothing hot reads tokens in bulk.
+        # Grouped by kind, as the campaign's asset page lists them, then
+        # by asset and by copy. The joins are paid on every read of that
+        # page and nowhere else: nothing hot reads tokens in bulk.
         ordering = ["asset__kind__position", "asset__name", "name", "created"]
         indexes = [
             models.Index(fields=["campaign", "holder"], name="campaign_asset_pool_idx"),

--- a/n26/core/templates/cotton/n26/radio_cards/card.html
+++ b/n26/core/templates/cotton/n26/radio_cards/card.html
@@ -33,6 +33,10 @@ not read as a question.
     description's place. A greyed option with no reason reads as broken.
   flair — a badge after the label, sized in em by <c-n26.flair-link>. Optional.
   meta — a slot at the far end of the header: a price, a count. Optional.
+  slot — lines of detail under the description, for an option that is a
+    set of rules rather than a name. Phrasing content only: the whole card
+    is a <label>, so write <span class="block"> lines, never a list.
+    Optional.
 {% endcomment %}
 <c-vars
     name=""
@@ -77,6 +81,9 @@ accent border and tint match the kit's checkbox cards.
             <span class="block text-muted">{{ reason }}</span>
         {% elif description %}
             <span class="block {% if not wrap %}truncate{% endif %} text-muted">{{ description }}</span>
+        {% endif %}
+        {% if slot.strip %}
+            <span class="mt-2 block border-t border-box-border pt-2 text-sm">{{ slot }}</span>
         {% endif %}
         {% if example and not disabled %}
             {% comment %}

--- a/n26/core/templates/n26/campaign_log.html
+++ b/n26/core/templates/n26/campaign_log.html
@@ -1,0 +1,121 @@
+{% extends "n26/layouts/base.html" %}
+{% load navigation %}
+{% load humanize %}
+{% comment %}
+The campaign's whole log — everything done in it, newest first, a
+screenful at a time. The campaign's own page draws only the newest acts
+and this is where the rest are read.
+
+One line per act, in plain words, with the gang it happened to beneath
+it where a gang was involved. The full timestamp rides on each time as a
+title, so hovering shows the exact time without spending a column on
+it. Nothing here changes anything, so there are no controls.
+{% endcomment %}
+{% block head_title %}Log of {{ campaign.name }}{% endblock head_title %}
+{% comment %}
+The bar names the campaign through the switcher, as the campaign's own
+page does: the name is a link back to it, and the chevron beside it
+offers the reader's other campaigns.
+{% endcomment %}
+{% block nav_switcher %}
+    {% campaign_switcher campaign as campaign_switcher_ %}
+    <c-n26.quick-switcher.of :switcher="campaign_switcher_" hotkey="f" />
+{% endblock nav_switcher %}
+{% block nav_items %}
+    {% include 'n26/_nav.html' with here='campaigns' %}
+{% endblock %}
+{% block content %}
+    <div class="mx-auto flex w-full max-w-2xl flex-col gap-6">
+        <c-n26.page-header title="Log"
+                           lead="Everything done in {{ campaign.name }}, newest first.">
+            <c-slot name="breadcrumb">
+                <c-ui.breadcrumbs>
+                    <c-ui.breadcrumbs.item>
+                        <c-n26.user-link :user="campaign.owner"
+                                         tone="current"
+                                         href="{% url 'n26-dashboard' %}" />
+                    </c-ui.breadcrumbs.item>
+                    <c-ui.breadcrumbs.item href="{% url 'n26-campaigns' %}">Campaigns</c-ui.breadcrumbs.item>
+                    <c-ui.breadcrumbs.item href="{% url 'n26-campaign' campaign.pk %}">{{ campaign.name }}</c-ui.breadcrumbs.item>
+                    <c-ui.breadcrumbs.item :current="True">
+                        Log
+                    </c-ui.breadcrumbs.item>
+                </c-ui.breadcrumbs>
+            </c-slot>
+        </c-n26.page-header>
+        {% if days %}
+            <ol class="flex flex-col gap-5">
+                {% for day in days %}
+                    <li>
+                        <h2 class="mb-1 border-b border-box-border pb-1 text-sm font-medium text-muted">
+                            {{ day.date|naturalday:"j F Y"|capfirst }}
+                        </h2>
+                        <ol>
+                            {% for act in day.acts %}
+                                <li class="flex gap-3 border-b border-box-border/50 py-2 last:border-b-0">
+                                    <time datetime="{{ act.when|date:'c' }}"
+                                          title="{{ act.when }}"
+                                          class="w-11 shrink-0 pt-px text-right text-sm tabular-nums text-muted">
+                                        {{ act.when|time:"H:i" }}
+                                    </time>
+                                    <div class="min-w-0 flex-1">
+                                        <p class="text-base">
+                                            {% if act.actor %}<span class="font-medium">{{ act.actor }}</span>{% endif %}
+                                            {% for span in act.spans %}{% if span.href %}<c-n26.link href="{{ span.href }}" tone="current">{{ span.text }}</c-n26.link>{% else %}{{ span.text }}{% endif %}{% endfor %}
+                                        </p>
+                                        {% if act.gang_name %}<p class="text-sm text-muted">{{ act.gang_name }}</p>{% endif %}
+                                        {% if act.note %}<p class="text-sm text-muted">{{ act.note }}</p>{% endif %}
+                                        {% if act.subs %}
+                                            <ul class="mt-0.5 text-sm text-muted">
+                                                {% for sub in act.subs %}
+                                                    <li>
+                                                        {{ sub.name }}
+                                                        {% if sub.detail %}<span class="opacity-75">— {{ sub.detail }}</span>{% endif %}
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        {% endif %}
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        </ol>
+                    </li>
+                {% endfor %}
+            </ol>
+        {% else %}
+            <p class="text-muted">Nothing recorded yet. Every change to the campaign is added here.</p>
+        {% endif %}
+        {% comment %}
+        The ends are drawn as two cases rather than one with a computed
+        `disabled`: a component attribute takes a variable, not an
+        expression, so `not pages.next` would evaluate to nothing and
+        the control would draw as a live link with nowhere to go.
+        {% endcomment %}
+        {% if pages %}
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <c-ui.pagination>
+                    {% if pages.previous %}
+                        <c-ui.pagination.prev href="{{ pages.previous }}" />
+                    {% else %}
+                        <c-ui.pagination.prev :disabled="True" />
+                    {% endif %}
+                    {% for number in pages.numbers %}
+                        {% if number.elided %}
+                            <c-ui.pagination.ellipsis />
+                        {% else %}
+                            <c-ui.pagination.item href="{{ number.href }}" :current="number.current">
+                                {{ number.label }}
+                            </c-ui.pagination.item>
+                        {% endif %}
+                    {% endfor %}
+                    {% if pages.next %}
+                        <c-ui.pagination.next href="{{ pages.next }}" />
+                    {% else %}
+                        <c-ui.pagination.next :disabled="True" />
+                    {% endif %}
+                </c-ui.pagination>
+                <p class="text-sm text-muted">Page {{ pages.number }} of {{ pages.of }} · {{ total }} entr{{ total|pluralize:"y,ies" }}</p>
+            </div>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/n26/core/templates/n26/create_campaign.html
+++ b/n26/core/templates/n26/create_campaign.html
@@ -27,7 +27,7 @@ field draws as a plain textarea and no editor ever appears.
 {% block content %}
     <c-n26.form-page action="{% url 'n26-create-campaign' %}"
                      title="Set up a campaign"
-                     lead="What the campaign runs on, its name, and how much a gang should be worth."
+                     lead="The rules the campaign is played under, its name, and how much a gang should be worth."
                      :form="form"
                      submit_label="Set up campaign"
                      cancel_url="{% url 'n26-campaigns' %}">
@@ -50,18 +50,29 @@ field draws as a plain textarea and no editor ever appears.
         which the edit screen also draws. Native radios over a shared name,
         as the gang type cards are, so the form posts with no script and a
         redisplay after a failed submit keeps the reader's pick.
+
+        Each card carries the whole of what the type gives — its
+        description, its asset kinds, what every gang starts with, and any
+        campaign-wide rules — composed as sentences in Python. The card is a
+        label, so the lines are block spans rather than a list.
         {% endcomment %}
         <c-n26.form-section title="Campaign type">
             <c-n26.radio-cards label="Campaign type *"
-                               description="What the campaign runs on. Every gang that joins gets what the type includes."
+                               description="The rules the campaign is played under. Each type sets what the gangs fight over and what every gang starts with."
                                :form="form"
-                               name="campaign_type">
+                               name="campaign_type"
+                               min="24rem">
                 {% for type in campaign_types %}
                     <c-n26.radio-cards.card name="campaign_type"
-                                            value="{{ type.value }}"
-                                            label="{{ type.label }}"
+                                            value="{{ type.pk }}"
+                                            label="{{ type.name }}"
                                             description="{{ type.description }}"
-                                            :checked="type.checked" />
+                                            :checked="type.checked"
+                                            :wrap="True">
+                        {% for line in type.kinds %}<span class="block">{{ line }}</span>{% endfor %}
+                        {% if type.starts_with %}<span class="block">{{ type.starts_with }}</span>{% endif %}
+                        {% for rule in type.rules %}<span class="block">{{ rule }}</span>{% endfor %}
+                    </c-n26.radio-cards.card>
                 {% endfor %}
             </c-n26.radio-cards>
         </c-n26.form-section>

--- a/n26/core/test_radio_cards.py
+++ b/n26/core/test_radio_cards.py
@@ -66,3 +66,28 @@ class TestTheGridGivesEachCardRoomToShrink:
 
         assert "[&>*]:min-w-0" in html
         assert "min-w-0" in html
+
+
+class TestACardCanCarryLinesOfDetail:
+    """An option that is a set of rules needs more than one line under its
+    name. The body slot draws under the description, inside the label, so
+    a click on any line still selects the card."""
+
+    def test_the_body_is_drawn_after_the_description(self):
+        html = render(
+            '<c-n26.radio-cards.card name="type" value="1" '
+            'label="Territory campaign" description="Gangs fight for Territory." '
+            ':wrap="True">'
+            '<span class="block">Territories change hands.</span>'
+            "</c-n26.radio-cards.card>"
+        )
+
+        assert html.index("Gangs fight for Territory.") < html.index(
+            "Territories change hands."
+        )
+        assert html.index("Territories change hands.") < html.index("</label>")
+        assert "border-t" in html
+
+    def test_a_card_with_no_body_draws_no_divider(self):
+        html = render('<c-n26.radio-cards.card name="type" value="1" label="Escher" />')
+        assert "border-t" not in html

--- a/n26/core/views/__init__.py
+++ b/n26/core/views/__init__.py
@@ -21,6 +21,7 @@ from n26.core.views.campaigns import (
     answer_invitation,
     archive_campaign,
     campaign,
+    campaign_log,
     campaign_pool,
     campaigns,
     create_campaign,
@@ -69,6 +70,7 @@ from n26.core.views.skills import skills
 __all__ = [
     "accessorise_assignment",
     "campaign",
+    "campaign_log",
     "campaigns",
     "changelog",
     "changelog_entry",

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -32,6 +32,10 @@ BATTLES_ON_THE_PAGE = 10
 #: Enough to see what happened since last time without burying the page.
 LOG_ON_THE_PAGE = 10
 
+#: How many acts one screenful of the full log holds. The same as a gang's
+#: history page, which reads the same shape of act.
+LOG_PER_PAGE = 50
+
 
 @requires_flag(CAMPAIGNS)
 @login_required
@@ -239,6 +243,46 @@ def campaign(request, pk):
             "pool_size": pool_size,
             "pool_held": pool_held,
             "pool_unclaimed": pool_size - pool_held,
+        },
+    )
+
+
+@requires_flag(CAMPAIGNS)
+@login_required
+def campaign_log(request, pk):
+    """The whole of a campaign's log, newest first, a screenful at a time.
+
+    The campaign's own page cuts its log to the most recent acts; this is
+    where the rest are read. It opens for whoever the campaign's page opens
+    for — the arbitrator and the people they sent the address to — because
+    the log is the same story the page tells, told in full. Nothing here
+    changes anything, so nobody is offered a control.
+
+    Paged, because a campaign played for a year has more acts than one
+    page wants, and every act is built before the page is cut: acts fold
+    what rode with them, so they cannot be counted or cut by row.
+    """
+    from n26.core.history import campaign_history
+    from n26.core.views.gangs import _pages
+    from n26.core.views.history import by_day
+
+    found = _any_campaign_or_404(request, pk)
+    acts = campaign_history(found, viewer=request.user)
+    total = len(acts)
+    # Newest first before paging, so page one is the latest screenful
+    # rather than the founding.
+    page = Paginator(list(reversed(acts)), LOG_PER_PAGE).get_page(
+        request.GET.get("page")
+    )
+
+    return render(
+        request,
+        "n26/campaign_log.html",
+        {
+            "campaign": found,
+            "days": by_day(page.object_list),
+            "total": total,
+            "pages": _pages(request, page) if page.paginator.num_pages > 1 else None,
         },
     )
 

--- a/n26/core/views/history.py
+++ b/n26/core/views/history.py
@@ -92,7 +92,7 @@ def gang_history(request, pk):
         "n26/gang_history.html",
         {
             "gang": gang,
-            "days": _by_day(page.object_list),
+            "days": by_day(page.object_list),
             # What this screenful carries, and what the whole answer
             # holds, so the count can say "50 of 312".
             "shown": len(page.object_list),
@@ -107,8 +107,9 @@ def gang_history(request, pk):
     )
 
 
-def _by_day(acts):
-    """Already newest first: gathered under the local date each landed on."""
+def by_day(acts):
+    """Already newest first: gathered under the local date each landed on.
+    Shared with the campaign log, which reads the same shape of act."""
     days = []
     for act in acts:
         date = timezone.localtime(act.when).date()

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -1985,7 +1985,7 @@ def gang_sheet():
                     kind_label="Settlement",
                     name="Settlement",
                     provenance=Provenance(
-                        source="N26 core", source_kind="campaign type"
+                        source="Territory campaign", source_kind="campaign type"
                     ),
                 )
             ],
@@ -2000,7 +2000,7 @@ def gang_sheet():
                     href="#",
                     back="#",
                     provenance=Provenance(
-                        source="N26 core", source_kind="campaign type"
+                        source="Territory campaign", source_kind="campaign type"
                     ),
                 )
             ],

--- a/n26/designsystem/templates/designsystem/demos/radio-cards/40-detail.html
+++ b/n26/designsystem/templates/designsystem/demos/radio-cards/40-detail.html
@@ -1,0 +1,22 @@
+{# title: Lines of detail under the description #}
+{# note: The body slot draws under the description, inside the label, for an option that is a set of rules rather than a name. Block spans, never a list: the whole card is a label. #}
+{# layout: col #}
+<c-n26.radio-cards label="Campaign type" min="24rem">
+    <c-n26.radio-cards.card name="demo-campaign-type"
+                            value="territory"
+                            label="Territory campaign"
+                            description="The core rulebook's campaign: gangs fight for control of Territory."
+                            :wrap="True"
+                            :checked="True">
+        <span class="block">Every gang gets one Settlement and keeps it.</span>
+        <span class="block">Territories change hands.</span>
+        <span class="block">Every gang starts with Reputation at 0 and one Settlement.</span>
+    </c-n26.radio-cards.card>
+    <c-n26.radio-cards.card name="demo-campaign-type"
+                            value="rackets"
+                            label="Law and Misrule"
+                            description="Gangs pick a side and fight over Rackets."
+                            :wrap="True">
+        <span class="block">Rackets change hands.</span>
+    </c-n26.radio-cards.card>
+</c-n26.radio-cards>

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -164,10 +164,12 @@ class TestTheRadioCardsPage:
         assert "One of these" in page
         assert "No badges, no detail, and a wider card" in page
         assert "A sentence-long name wraps" in page
+        assert "Lines of detail under the description" in page
         # From the markup the demos rendered, not from their titles: a demo
         # directory the catalog cannot find yields "No examples yet" instead.
         assert 'name="demo-gang-type"' in page
         assert 'name="demo-purpose"' in page
+        assert 'name="demo-campaign-type"' in page
         assert 'name="demo-scope"' in page
 
 

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -83,11 +83,14 @@ def create_gang_type(
 # --- Campaign types and assets ---------------------------------------------
 
 
-def create_campaign_type(name, qualifier="", library_author_help="", **kwargs):
+def create_campaign_type(
+    name, qualifier="", description="", library_author_help="", **kwargs
+):
     """A kind of campaign, for a campaign to be founded on. Its asset
     kinds are added afterwards with ``add_asset_kind``, and its assets
     under those with ``create_asset``. Stored stripped, as a gang type's
-    name is."""
+    name is. The description is for the arbitrator founding on the type;
+    the author help is for whoever builds content against it."""
     from n26.library.models import CampaignType
 
     name = (name or "").strip()
@@ -96,6 +99,7 @@ def create_campaign_type(name, qualifier="", library_author_help="", **kwargs):
     return CampaignType.objects.create(
         name=name,
         qualifier=qualifier,
+        description=description,
         library_author_help=library_author_help,
         **kwargs,
     )

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -101,25 +101,25 @@ Assignable for the same reason a profile is: founding is a gang-hosted assignmen
 
 ### Campaign type
 
-*A kind of campaign — Dominion, Law & Misrule — assigned to every gang that joins a campaign founded on it.*
+*A kind of campaign — Territory campaign, Dominion, Law & Misrule — assigned to every gang that joins a campaign founded on it.*
 
-Fields of its own: its **asset kinds** (see below). Under each kind sit the **assets** of that kind — the list of what a campaign of this type hands out. An asset belongs to one kind, and so to one campaign type; there is no separate list on the type.
+Fields of its own: a **description** and its **asset kinds** (see below). The description is written for the arbitrator setting a campaign up: what the gangs fight over, what each starts with, how the campaign runs and how it ends. The set-up screen draws it on the type's card, beside sentences the app composes from the type's kinds, built-ins and modifiers. It is the one field on a campaign type a player reads; the author help stays for authors. Under each kind sit the **assets** of that kind — the list of what a campaign of this type hands out. An asset belongs to one kind, and so to one campaign type; there is no separate list on the type.
 
 Assignable for the same reason a gang type is: joining a campaign is a gang-hosted assignment naming the type. That gives the built-ins every member gang arrives with — a Reputation counter with its opening value, a Settlement — something to be caused by, and gives campaign-wide modifiers a carrier every member's card can find. Its pricing fields stay at zero; nobody buys a campaign type.
 
-Shared types live in the system pack. The one that ships is **N26 core**, with Settlement (held one each) and Territory (pooled) as its kinds, a Settlement asset, and Reputation at 0 built in. An arbitrator's additions to one campaign — a counter, a kind, a label — go on a second campaign type in that campaign's own pack, layered on the shared one rather than copied from it.
+Shared types live in the system pack. The one that ships is the **Territory campaign**, the core rulebook's own: gangs fight for control of Territory, every gang keeps a Settlement and starts with one Territory, and each Territory held gives a Boon. The campaign has three phases (Occupation, Downtime, Takeover) and ends with Triumphs. Its kinds are Settlement (held one each) and Territory (changes hands); it has a Settlement asset, and Reputation at 0 and the Settlement built in. An arbitrator's additions to one campaign — a counter, a kind, a label — go on a second campaign type in that campaign's own pack, layered on the shared one rather than copied from it.
 
-**Asset kind** — *a class of asset a campaign type deals in: Territory, Racket, Settlement.* A row on the campaign type, edited on its page: a label (singular and plural, the plural defaulting to an s), a **mode**, and a position. Its assets are listed under it on the same page, and added there. The mode is on the kind, not the asset, because a whole class behaves one way. **Held one each**: every gang is given one when it joins, and it is never staked (a Settlement, a home territory). **Pooled**: the campaign holds a pool of them and each has one holder at a time (a Territory, a Racket, a Relic). Two kinds of one type cannot share a label, and a kind cannot be removed while any asset is of it.
+**Asset kind** — *a class of asset a campaign type has: Territory, Racket, Settlement.* A row on the campaign type, edited on its page: a label (singular and plural, the plural defaulting to an s), a **mode**, and a position. Its assets are listed under it on the same page, and added there. The mode is on the kind, not the asset, because a whole class behaves one way. **Held one each**: every gang is given one when it joins and keeps it (a Settlement, a home territory). **Changes hands**: the campaign keeps the copies and each copy has one holder at a time (a Territory, a Racket, a Relic). Two kinds of one type cannot share a label, and a kind cannot be removed while any asset is of it.
 
 ### Asset
 
-*One thing a campaign deals in — a Settlement, the Old Ruins territory, a Racket — of one asset kind.*
+*One thing a campaign has — a Settlement, the Old Ruins territory, a Racket — of one asset kind.*
 
 One entry in the list of what a campaign type hands out. It is made on the type's page, under one of the type's kinds, and that is the only way it belongs to the type. Assets have no listing or create page of their own; an asset's own page, reached from the type's, is where its modifiers and the rest of its fields are edited.
 
 Fields of its own: its **kind** (settled when the asset is made, and fixing both the campaign type it belongs to and how it behaves) and an **income** figure. The income is printed on the card and never collected; nothing moves credits. What holding the asset does for its holder — Reputation while held, a special rule, a free hire — rides it as ordinary modifiers.
 
-Assignable so that an asset of a held-one-each kind can be built into its campaign type and arrive on every member gang, and so that an asset of either kind can carry modifiers. A pooled asset is never assigned: the campaign's token records who holds it.
+Assignable so that an asset of a held-one-each kind can be built into its campaign type and arrive on every member gang, and so that an asset of a kind that changes hands can carry modifiers too. An asset that changes hands is never assigned: the campaign's copy records who holds it.
 
 ### Hidden
 

--- a/n26/library/core_campaign.py
+++ b/n26/library/core_campaign.py
@@ -1,11 +1,15 @@
-"""The N26 core campaign type — the one campaign type every install has.
+"""The Territory campaign type — the one campaign type every install has.
 
-Reputation is a counter every campaign type in the books tracks, so it
-ships in the system pack. The N26 core type declares the two asset kinds
-the core rules deal in — a Settlement every gang holds, and Territories
-held one at a time from a pool — with one Settlement asset under the
-Settlement kind, and gives every member gang Reputation at 0 and that
-Settlement through its built-ins. See design/campaign-assets.md.
+The core rulebook's campaign is a fight over Territory: every gang keeps
+a Settlement, one Territory is drawn for it at the start, each Territory
+held gives its holder a Boon, and the campaign runs Occupation, Downtime
+and Takeover before Triumphs are awarded. Reputation is a counter every
+campaign type in the books tracks, so it ships in the system pack. The
+Territory campaign type declares the two asset kinds that campaign deals
+in — a Settlement every gang holds, and Territories that change hands —
+with one Settlement asset under the Settlement kind, and gives every
+member gang Reputation at 0 and that Settlement through its built-ins.
+See design/campaign-assets.md.
 
 Everything is matched on its natural key and left alone if it is
 already there, so this can run against a database that has some of it,
@@ -18,8 +22,11 @@ handed, so a migration can run it on historical ones.
 from django.conf import settings
 
 REPUTATION = "Reputation"
-CAMPAIGN_TYPE = "N26 core"
-#: ``(label, plural, mode, position)`` for each kind the core type deals in.
+CAMPAIGN_TYPE = "Territory campaign"
+#: What the type was called before it took the rulebook's own subject as
+#: its name. ``rename_core_campaign`` moves a row under this name across.
+FORMER_NAME = "N26 core"
+#: ``(label, plural, mode, position)`` for each kind the core type has.
 ASSET_KINDS = (
     ("Settlement", "Settlements", "held-one-each", 0),
     ("Territory", "Territories", "pooled", 1),
@@ -28,10 +35,32 @@ SETTLEMENT = "Settlement"
 #: Named as ``authoring.add_built_in`` would name it, so the set reads
 #: like every other type's on the authoring pages.
 BUILT_INS = f"{CAMPAIGN_TYPE} built-ins"
+FORMER_BUILT_INS = f"{FORMER_NAME} built-ins"
+
+#: What the arbitrator setting a campaign up reads. Our own words about
+#: the core rulebook's campaign, never the book's.
+DESCRIPTION = (
+    "The core rulebook's campaign: gangs fight for control of Territory. "
+    "Every gang keeps a Settlement it cannot lose and starts with one "
+    "Territory drawn from the campaign's table. Each Territory a gang "
+    "holds gives it a Boon, such as income, Reputation or equipment. The "
+    "campaign has three phases: Occupation, Downtime and Takeover. It ends "
+    "with Triumphs awarded for the most Territories, the highest Reputation, "
+    "the most battles fought, the most enemies taken out of action and the "
+    "highest Wealth."
+)
+#: What a content author reads on the authoring pages.
+LIBRARY_AUTHOR_HELP = (
+    "The campaign type from the core rulebook. Settlement is held one "
+    "each: every gang is given one when it joins and keeps it. Territory "
+    "changes hands. Add each Territory as an asset under that kind, with "
+    "its income figure and its Boons as modifiers. Reputation at 0 and the "
+    "Settlement are built in, so every gang that joins starts with both."
+)
 
 
 def seed_core_campaign(apps):
-    """Create what is missing of the N26 core campaign type, and return
+    """Create what is missing of the Territory campaign type, and return
     one line per row created, so a caller can say what happened."""
     lines = []
     ContentPack = apps.get_model("library", "ContentPack")
@@ -58,7 +87,9 @@ def seed_core_campaign(apps):
         pack=pack, name__iexact=CAMPAIGN_TYPE, qualifier=""
     ).first()
     if campaign_type is None:
-        campaign_type = CampaignType.objects.create(pack=pack, name=CAMPAIGN_TYPE)
+        fields = {"pack": pack, "name": CAMPAIGN_TYPE}
+        fields.update(_words_for(CampaignType))
+        campaign_type = CampaignType.objects.create(**fields)
         lines.append(f"created the {CAMPAIGN_TYPE} campaign type")
 
     kinds = {}
@@ -110,3 +141,72 @@ def seed_core_campaign(apps):
         )
         lines.append(f"built the {SETTLEMENT} into {CAMPAIGN_TYPE}")
     return lines
+
+
+def rename_core_campaign(apps):
+    """Move a system-pack type standing under the former name to the
+    current one, with its built-ins set, and give the type its words where
+    it has none. Returns one line per change, so a caller can say what
+    happened.
+
+    Nothing is renamed while a row already holds the current name: two
+    types cannot share it, and which of the two is the real one is a
+    question for a person. A type already renamed, or created under the
+    current name, only gains whichever of its two texts is still blank —
+    so this runs as often as it likes and never overwrites an author's
+    own words.
+    """
+    lines = []
+    ContentPack = apps.get_model("library", "ContentPack")
+    CampaignType = apps.get_model("library", "CampaignType")
+    DefaultAssignmentSet = apps.get_model("library", "DefaultAssignmentSet")
+
+    pack = ContentPack.objects.filter(slug=settings.DEFAULT_CONTENT_PACK_SLUG).first()
+    if pack is None:
+        return lines
+    types = CampaignType.objects.filter(pack=pack, qualifier="")
+    current = types.filter(name__iexact=CAMPAIGN_TYPE).first()
+    former = types.filter(name__iexact=FORMER_NAME).first()
+
+    if current is None and former is not None:
+        former.name = CAMPAIGN_TYPE
+        former.save(update_fields=["name"])
+        lines.append(f"renamed the {FORMER_NAME} campaign type to {CAMPAIGN_TYPE}")
+        current = former
+
+    if current is None:
+        return lines
+    # The set follows the type, whichever run renamed the type: a set
+    # still under the former name is renamed as long as the new name is
+    # free, so the authoring pages read it as the type's own.
+    built_ins = DefaultAssignmentSet.objects.filter(
+        pack=pack, name__iexact=FORMER_BUILT_INS
+    ).first()
+    taken = DefaultAssignmentSet.objects.filter(
+        pack=pack, name__iexact=BUILT_INS
+    ).exists()
+    if built_ins is not None and not taken:
+        built_ins.name = BUILT_INS
+        built_ins.save(update_fields=["name"])
+        lines.append(f"renamed the {FORMER_BUILT_INS} set to {BUILT_INS}")
+    changed = []
+    for field, words in _words_for(CampaignType).items():
+        if not getattr(current, field):
+            setattr(current, field, words)
+            changed.append(field)
+    if changed:
+        current.save(update_fields=changed)
+        lines.append(f"gave {CAMPAIGN_TYPE} its {' and '.join(changed)}")
+    return lines
+
+
+def _words_for(CampaignType):
+    """The type's two texts, keyed by field — only the fields this model
+    class has, so the seed can run on a historical class from before the
+    description existed."""
+    names = {field.name for field in CampaignType._meta.get_fields()}
+    words = {
+        "description": DESCRIPTION,
+        "library_author_help": LIBRARY_AUTHOR_HELP,
+    }
+    return {name: text for name, text in words.items() if name in names}

--- a/n26/library/migrations/0081_the_n26_core_campaign_type.py
+++ b/n26/library/migrations/0081_the_n26_core_campaign_type.py
@@ -1,11 +1,13 @@
-"""The N26 core campaign type, its asset kinds, and Reputation.
+"""The core campaign type, its asset kinds, and Reputation.
 
-Reputation becomes a counter in the system pack; the N26 core type
-declares Settlement (held one each) and Territory (pooled), has one
-Settlement asset under the Settlement kind, and gives every member gang
-Reputation at 0 and the Settlement through its built-ins. ``n26/library/core_campaign.py``
-holds the rows and matches each on its natural key, so a database that
-already has any of them is left as it stands.
+Reputation becomes a counter in the system pack; the core campaign type
+declares Settlement (held one each) and Territory (changes hands), has
+one Settlement asset under the Settlement kind, and gives every member
+gang Reputation at 0 and the Settlement through its built-ins.
+``n26/library/core_campaign.py`` holds the rows and matches each on its
+natural key, so a database that already has any of them is left as it
+stands. The type's name is whatever that module names it when this runs;
+a later migration settles it.
 
 Nothing is removed in reverse: a campaign founded on the type would be
 left standing on nothing.

--- a/n26/library/migrations/0083_the_core_campaign_type_is_the_territory_campaign.py
+++ b/n26/library/migrations/0083_the_core_campaign_type_is_the_territory_campaign.py
@@ -1,0 +1,60 @@
+"""The core campaign type is named for what the rulebook's campaign is
+about, and gains a description for the arbitrator founding on it.
+
+A campaign type gets a ``description``: words written for the player
+setting a campaign up, as distinct from ``library_author_help``, which
+is for content authors and never reaches a player. The set-up screen's
+card draws the description.
+
+The type every install has, created under a working name, becomes the
+**Territory campaign** — the core rulebook's own campaign, in which gangs
+fight for Territory. ``rename_core_campaign`` moves the row across by
+name, with its built-ins set, and fills in the description and author
+help where the type has none; a type already carrying either keeps its
+words. Everything is matched on what stands, so a database that has
+already been through this is left as it is.
+
+Reversible for the schema only: the description column goes, and the
+rename stands, because a campaign founded on the type names it and a
+name is nothing a reverse should take away.
+"""
+
+from django.db import migrations, models
+
+from n26.library.core_campaign import rename_core_campaign
+
+
+def rename(apps, schema_editor):
+    for line in rename_core_campaign(apps):
+        print(f"[core campaign] {line}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0082_an_asset_belongs_to_its_kinds_campaign_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="campaigntype",
+            name="description",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="What a campaign of this type is about, for the arbitrator setting one up: what the gangs fight over, what each starts with, how the campaign runs and how it ends. Shown on the set-up screen. Use your own words, not the book's.",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="assetkind",
+            name="mode",
+            field=models.CharField(
+                choices=[
+                    ("held-one-each", "Held one each"),
+                    ("pooled", "Changes hands"),
+                ],
+                help_text="Held one each: every gang is given one when it joins and keeps it. Changes hands: the campaign keeps the copies, and each copy has one holder at a time.",
+                max_length=20,
+            ),
+        ),
+        migrations.RunPython(rename, migrations.RunPython.noop),
+    ]

--- a/n26/library/models/campaign_type.py
+++ b/n26/library/models/campaign_type.py
@@ -11,16 +11,16 @@ design/campaign-assets.md.
 An **asset kind** is a row on the type with a label and a mode. The mode
 is on the kind rather than the asset because it is a whole class of
 asset that behaves one way: a Settlement is given to every gang on
-joining and never staked; a Territory is a token in the campaign's pool
+joining and never staked; a Territory is a token the campaign keeps,
 with one holder at a time.
 
 An **asset** is one entry in a campaign type's list of what it hands
 out, filed under one of the type's kinds — that is the whole of how it
 belongs to the type, and it is authored on the type's page. It is
 assignable so that a held-one-each asset can be a built-in member and
-so that either mode can carry modifiers for what holding it does. A
-pooled asset is never assigned; the campaign's token records who holds
-it.
+so that either mode can carry modifiers for what holding it does. An
+asset that changes hands is never assigned; the campaign's copy records
+who holds it.
 """
 
 from django.db import models
@@ -35,7 +35,7 @@ from n26.library.models.base import Content
 
 
 class CampaignType(Content, Assignable):
-    """A kind of campaign — Dominion, Law & Misrule — assigned to every
+    """A kind of campaign — Territory campaign, Dominion — assigned to every
     gang that joins a campaign founded on it.
 
     Assignable for the same reason a gang type is: joining a campaign is a
@@ -47,9 +47,24 @@ class CampaignType(Content, Assignable):
     It also declares its **asset kinds** — Territory, Racket, Settlement —
     and under each kind lists the **assets** a campaign of this type hands
     out. Its pricing fields stay at zero; nobody buys a campaign type.
+
+    The **description** is the one field here written for a player: the
+    arbitrator setting a campaign up reads it on the set-up screen. The
+    library author help stays for content authors, as on every other kind.
     """
 
     family = Family.GANG
+
+    description = models.TextField(
+        blank=True,
+        default="",
+        help_text=(
+            "What a campaign of this type is about, for the arbitrator "
+            "setting one up: what the gangs fight over, what each starts "
+            "with, how the campaign runs and how it ends. Shown on the "
+            "set-up screen. Use your own words, not the book's."
+        ),
+    )
 
     class Meta:
         verbose_name = "campaign type"
@@ -80,28 +95,29 @@ class CampaignType(Content, Assignable):
         return Asset.objects.filter(kind__campaign_type=self)
 
     def pooled_assets(self):
-        """The assets a campaign of this type can put copies of in its
-        pool: those of its pooled kinds. A held-one-each asset is every
-        member gang's own and has no pool to sit in."""
+        """The assets a campaign of this type can keep copies of: those of
+        its kinds that change hands. A held-one-each asset is every member
+        gang's own, and the campaign keeps no copies of it."""
         return self.assets.filter(kind__mode=AssetKind.Mode.POOLED)
 
 
 class AssetKind(Content):
-    """A class of asset a campaign type deals in — Territory, Racket,
+    """A class of asset a campaign type has — Territory, Racket,
     Settlement — with the label a campaign page prints and the mode that
     fixes how every asset of the kind behaves.
 
-    **Held one each** means every gang is given one when it joins and it
-    is never staked: a Settlement, a home territory. **Pooled** means the
-    campaign holds a pool of them and each one has one holder at a time:
-    a Territory, a Racket, a Relic.
+    **Held one each** means every gang is given one when it joins and
+    keeps it: a Settlement, a home territory. **Changes hands** means the
+    campaign keeps the copies and each copy has one holder at a time: a
+    Territory, a Racket, a Relic.
     """
 
     class Mode(models.TextChoices):
         #: Given to every gang on joining, never staked.
         HELD_ONE_EACH = "held-one-each", "Held one each"
-        #: A token in the campaign's pool, one holder at a time.
-        POOLED = "pooled", "Pooled"
+        #: A token the campaign keeps, with one holder at a time. The value
+        #: is what stored rows say and stays as it is.
+        POOLED = "pooled", "Changes hands"
 
     campaign_type = models.ForeignKey(
         CampaignType, on_delete=models.CASCADE, related_name="asset_kinds"
@@ -125,9 +141,9 @@ class AssetKind(Content):
         max_length=20,
         choices=Mode,
         help_text=(
-            "Held one each: every gang is given one when it joins, and it is "
-            "never staked. Pooled: the campaign holds a pool of them, and "
-            "each has one holder at a time."
+            "Held one each: every gang is given one when it joins and keeps "
+            "it. Changes hands: the campaign keeps the copies, and each copy "
+            "has one holder at a time."
         ),
     )
     position = models.PositiveIntegerField(
@@ -169,7 +185,7 @@ class AssetKind(Content):
 
 
 class Asset(Content, Assignable):
-    """One thing a campaign deals in — a Settlement, the Old Ruins
+    """One thing a campaign has — a Settlement, the Old Ruins
     territory, a Racket — of one asset kind.
 
     An asset is one entry in the list of what its campaign type hands
@@ -179,8 +195,8 @@ class Asset(Content, Assignable):
 
     Assignable so that an asset of a held-one-each kind can be built into
     its campaign type and arrive on every member gang, and so that an
-    asset of either kind can carry modifiers. A pooled asset is never
-    assigned: the campaign's token records who holds it.
+    asset of either kind can carry modifiers. An asset that changes hands
+    is never assigned: the campaign's copy records who holds it.
     """
 
     family = Family.BASE

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -1118,6 +1118,7 @@ def _build_registry():
             {
                 "name": Text(source=(CampaignType, "name")),
                 "qualifier": Text(source=(CampaignType, "qualifier")),
+                "description": Text(source=(CampaignType, "description"), long=True),
                 "library_author_help": Text(
                     source=(CampaignType, "library_author_help"), long=True
                 ),

--- a/n26/library/templates/authoring/asset_kind_remove.html
+++ b/n26/library/templates/authoring/asset_kind_remove.html
@@ -13,7 +13,7 @@ kind is settled when it is made, so deleting is the only way clear.
 {% block content %}
     <c-n26.form-page action="{% url 'authoring-asset-kind-remove' thing.pk %}"
                      title="Remove the {{ label }} asset kind?"
-                     lead="{{ campaign_type }} will no longer deal in {{ thing.plural }}."
+                     lead="Campaigns of the {{ campaign_type }} type will have no {{ thing.plural }}."
                      submit_label="Remove asset kind"
                      submit_variant="danger"
                      cancel_url="{{ back }}">
@@ -44,7 +44,7 @@ kind is settled when it is made, so deleting is the only way clear.
             </c-ui.alert>
         {% else %}
             <c-ui.alert variant="info" title="No assets are of this kind">
-                Removing it changes only what this campaign type deals in.
+                Removing it changes only which kinds of asset this campaign type has.
             </c-ui.alert>
         {% endif %}
     </c-n26.form-page>

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -174,8 +174,8 @@ def _describe_built_in(member):
 
 
 def _describe_asset_kind(kind):
-    """One class of asset a campaign type deals in: what several are
-    called and how the kind behaves. Its assets are not counted here —
+    """One class of asset a campaign type has: what several are called
+    and how the kind behaves. Its assets are not counted here —
     they are listed under it on the same page."""
     return kind.label_singular, [kind.plural, kind.get_mode_display().lower()]
 
@@ -389,14 +389,14 @@ DETAIL_KINDS = {
         "parts_label": "asset kinds",
         "part_name": "asset kind",
         "parts_description": (
-            "The classes of asset a campaign of this type deals in — "
-            "Territory, Racket, Settlement. Each has a label a campaign page "
-            "prints, and a mode every asset of the kind follows. The assets "
-            "themselves are listed under their kind, and added there."
+            "The kinds of asset a campaign of this type has — Territory, "
+            "Racket, Settlement. Each has a label a campaign page prints, and "
+            "a mode every asset of the kind follows. The assets themselves "
+            "are listed under their kind, and added there."
         ),
         "nothing_yet": (
-            "No asset kinds yet. A campaign of this type has nothing to hand "
-            "out until it has one."
+            "No asset kinds yet. Every asset belongs to a kind, so add one "
+            "before adding assets."
         ),
         # An asset kind has no page of its own: its four fields are
         # edited in place, on the row that lists it.
@@ -987,7 +987,7 @@ def _describe_gang_type(gang_type):
 
 def _describe_campaign_type(campaign_type):
     """A campaign type, as a listing needs to tell one from the next:
-    the kinds of asset it deals in and how many assets it hands out.
+    the kinds of asset it has and how many assets it hands out.
 
     Reads the kinds and their assets with ``.all()``, so a listing that
     prefetched them describes every type without a query per row.
@@ -3838,14 +3838,16 @@ def asset_kind_remove(request, pk):
     held = list(kind.assets.all())
 
     if request.method == "POST":
-        said = kind.plural
+        said = kind.label_singular
         try:
             with transaction.atomic():
                 authoring.remove_asset_kind(kind)
         except ValidationError as refused:
             messages.error(request, " ".join(refused.messages))
             return redirect(request.path)
-        messages.success(request, f"{campaign_type} no longer deals in {said}.")
+        messages.success(
+            request, f"Removed the {said} asset kind from {campaign_type}."
+        )
         return redirect(back)
 
     return render(

--- a/n26/tests/fixtures.py
+++ b/n26/tests/fixtures.py
@@ -89,11 +89,11 @@ def gang_type(db):
 @pytest.fixture
 def campaign_type(default_pack):
     """A bare campaign type in the system pack, for a campaign to be
-    founded on. Nothing built in: a suite that wants the N26 core shape —
+    founded on. Nothing built in: a suite that wants the Territory campaign shape —
     Reputation at 0, a Settlement — seeds it with ``seed_core_campaign``."""
     from n26.library.authoring import create_campaign_type
 
-    return create_campaign_type("N26 core")
+    return create_campaign_type("Territory campaign")
 
 
 #: The fixtures build exactly what the Foundations page creates — one

--- a/n26/tests/sandbox/test_campaign_assets.py
+++ b/n26/tests/sandbox/test_campaign_assets.py
@@ -61,10 +61,10 @@ def player():
 
 @pytest.fixture
 def core(default_pack):
-    """The N26 core type as it ships: Reputation at 0, a Settlement built
+    """The Territory campaign type as it ships: Reputation at 0, a Settlement built
     in, and Territory as its pooled kind."""
     seed_core_campaign(apps)
-    return CampaignType.objects.get(name="N26 core")
+    return CampaignType.objects.get(name="Territory campaign")
 
 
 @pytest.fixture

--- a/n26/tests/sandbox/test_campaign_battles.py
+++ b/n26/tests/sandbox/test_campaign_battles.py
@@ -28,7 +28,7 @@ def campaign(arbitrator, campaign_type):
 
 
 #: The log's first line, which founding writes before any test here acts.
-FOUNDED = "set the campaign up on N26 core"
+FOUNDED = "set the campaign up on Territory campaign"
 
 
 @pytest.fixture

--- a/n26/tests/sandbox/test_campaign_founding.py
+++ b/n26/tests/sandbox/test_campaign_founding.py
@@ -3,7 +3,7 @@
 A campaign is founded on a shared campaign type and owns, from that
 moment, a pack of its own with an empty additions type in it. A gang
 that joins is assigned both types, gang-hosted and granted, and the
-shared type's built-ins arrive caused by its carrier — on N26 core, a
+shared type's built-ins arrive caused by its carrier — on Territory campaign, a
 Settlement and a Reputation counter at 0. The gang sheet draws those
 under the campaign's name, credited to the type that brought them, and
 a staff edit to the shared type reaches every member gang by the same
@@ -48,11 +48,11 @@ def arbitrator():
 
 @pytest.fixture
 def core(default_pack):
-    """The N26 core type as it ships: Reputation at 0 and a Settlement
+    """The Territory campaign type as it ships: Reputation at 0 and a Settlement
     built in. The data migration that creates it never runs under the
     test settings, so the same code seeds it here."""
     seed_core_campaign(apps)
-    return CampaignType.objects.get(name="N26 core")
+    return CampaignType.objects.get(name="Territory campaign")
 
 
 @pytest.fixture
@@ -123,7 +123,7 @@ class TestFoundingACampaign:
     def test_the_log_opens_by_naming_the_type(self, campaign):
         assert [e.kind for e in campaign.events.all()] == [CampaignEvent.Kind.CREATED]
         assert sentences(campaign_history(campaign)) == [
-            "set the campaign up on N26 core"
+            "set the campaign up on Territory campaign"
         ]
 
     def test_a_campaign_is_founded_once(self, campaign, core, arbitrator):
@@ -183,16 +183,16 @@ class TestJoiningACampaign:
         ]
         assert sorted((sub.name, sub.kind) for sub in joined.subs) == [
             ("Dust Falls", "campaign type"),
-            ("N26 core", "campaign type"),
             ("Reputation", "counter"),
             ("Settlement", "asset"),
+            ("Territory campaign", "campaign type"),
         ]
         assert not any("gained" in line for line in sentences(acts))
 
     def test_the_campaigns_log_reads_the_same_act(self, membership, campaign):
         told = sentences(campaign_history(campaign))
         assert told == [
-            "set the campaign up on N26 core",
+            "set the campaign up on Territory campaign",
             "added the gang to Dust Falls",
         ]
 
@@ -223,10 +223,10 @@ class TestTheGangSheet:
                 line.provenance.source_kind,
             )
             for line in block.lines
-        ] == [("Settlement", "Settlement", "N26 core", "campaign type")]
+        ] == [("Settlement", "Settlement", "Territory campaign", "campaign type")]
         assert [
             (line.name, line.value, line.provenance.source) for line in block.counters
-        ] == [("Reputation", 0, "N26 core")]
+        ] == [("Reputation", 0, "Territory campaign")]
 
     def test_the_owner_can_tally_the_campaigns_counter_from_the_sheet(
         self, client, membership, gang
@@ -269,7 +269,7 @@ class TestTheGangSheet:
     def test_the_carriers_draw_no_line_among_the_gangs_own_rows(self, membership, gang):
         sheet = render_gang(gang)
         names = [row.name for row in sheet.rows]
-        assert "N26 core" not in names
+        assert "Territory campaign" not in names
         assert "Dust Falls" not in names
         assert "Settlement" not in names
 
@@ -282,7 +282,7 @@ class TestTheGangSheet:
         assert "Dust Falls" in body
         assert "Settlement" in body
         assert "Reputation" in body
-        assert "From N26 core (campaign type)" in body
+        assert "From Territory campaign (campaign type)" in body
 
 
 class TestEditingTheTypeReachesMemberGangs:

--- a/n26/tests/sandbox/test_campaign_membership.py
+++ b/n26/tests/sandbox/test_campaign_membership.py
@@ -40,7 +40,7 @@ def other_campaign(arbitrator, campaign_type):
 
 
 #: The log's first line, which founding writes before any test here acts.
-FOUNDED = "set the campaign up on N26 core"
+FOUNDED = "set the campaign up on Territory campaign"
 
 
 def sentences(acts):

--- a/n26/tests/sandbox/test_campaign_types.py
+++ b/n26/tests/sandbox/test_campaign_types.py
@@ -5,8 +5,8 @@ lists under each kind the assets of it, and — being assignable, as a
 gang type is — carries built-ins that every member gang gets. An asset
 is one entry in that list: it belongs to one kind, and so to one type,
 and is authored on the type's page under its kind; its income is a
-figure on the card and its boons ride it as modifiers. The N26 core type
-ships with Settlement held one each, Territory pooled, and Reputation at
+figure on the card and its boons ride it as modifiers. The Territory campaign type
+ships with Settlement held one each, Territory changing hands, and Reputation at
 0 built in. See design/campaign-assets.md.
 
 The same note settles one rule about packs: content in a pack nobody
@@ -32,7 +32,14 @@ from n26.library.authoring import (
     remove_asset_kind,
     targets_gang,
 )
-from n26.library.core_campaign import seed_core_campaign
+from n26.library.core_campaign import (
+    DESCRIPTION,
+    FORMER_BUILT_INS,
+    FORMER_NAME,
+    LIBRARY_AUTHOR_HELP,
+    rename_core_campaign,
+    seed_core_campaign,
+)
 from n26.library.forms import cross_pack_refusal
 from n26.library.models import (
     Asset,
@@ -176,7 +183,7 @@ class TestAuthoringACampaignType:
 
 
 class TestTheCoreCampaignType:
-    """What every install ships with: the N26 core type, its two kinds,
+    """What every install ships with: the Territory campaign type, its two kinds,
     a Settlement, and Reputation at 0 — created once, whatever the
     database already holds."""
 
@@ -185,7 +192,7 @@ class TestTheCoreCampaignType:
     ):
         lines = list(seed_core_campaign(apps))
 
-        core = CampaignType.objects.get(name="N26 core")
+        core = CampaignType.objects.get(name="Territory campaign")
         assert [
             (kind.label_singular, kind.plural, kind.mode)
             for kind in core.asset_kinds.all()
@@ -203,7 +210,7 @@ class TestTheCoreCampaignType:
             (reputation, 0),
             (settlement, 0),
         ]
-        assert core.built_ins.name == "N26 core built-ins"
+        assert core.built_ins.name == "Territory campaign built-ins"
         assert all(row.pack == default_pack for row in (core, settlement, reputation))
         # One line per row: the counter, the type, two kinds, the asset,
         # the set, and two members.
@@ -241,8 +248,83 @@ class TestTheCoreCampaignType:
         list(seed_core_campaign(apps))
 
         assert Counter.objects.filter(name__iexact="reputation").count() == 1
-        core = CampaignType.objects.get(name="N26 core")
+        core = CampaignType.objects.get(name="Territory campaign")
         assert core.built_in_members.filter(counter=existing).exists()
+
+    def test_it_gives_the_type_its_words_for_arbitrators_and_authors(
+        self, default_pack
+    ):
+        """The description is what the set-up screen's card draws; the
+        author help is what the authoring pages draw. Both are ours, about
+        the core rulebook's campaign, and never the book's own words."""
+        list(seed_core_campaign(apps))
+
+        core = CampaignType.objects.get(name="Territory campaign")
+        assert core.description == DESCRIPTION
+        assert core.library_author_help == LIBRARY_AUTHOR_HELP
+        assert "fight for control of Territory" in core.description
+        assert "Occupation, Downtime and Takeover" in core.description
+
+
+class TestRenamingTheCoreType:
+    """The type every install has was first created under a working name.
+    Renaming it moves the standing row across, built-ins set and all, so a
+    campaign founded on it keeps its type; a database that has already
+    been through this is left as it stands."""
+
+    def test_a_type_under_the_former_name_is_renamed_with_its_built_ins(
+        self, default_pack
+    ):
+        former = create_campaign_type(FORMER_NAME)
+        former.built_ins = DefaultAssignmentSet.objects.create(name=FORMER_BUILT_INS)
+        former.save()
+
+        lines = rename_core_campaign(apps)
+
+        former.refresh_from_db()
+        assert former.name == "Territory campaign"
+        assert former.built_ins.name == "Territory campaign built-ins"
+        assert former.description == DESCRIPTION
+        assert former.library_author_help == LIBRARY_AUTHOR_HELP
+        assert len(lines) == 3
+        assert rename_core_campaign(apps) == []
+
+    def test_a_type_already_renamed_keeps_an_authors_own_words(self, default_pack):
+        """Only a blank text is filled in: an author who has already
+        written the type's description keeps it across every run."""
+        theirs = create_campaign_type("Territory campaign", description="Ours.")
+
+        rename_core_campaign(apps)
+
+        theirs.refresh_from_db()
+        assert theirs.description == "Ours."
+        assert theirs.library_author_help == LIBRARY_AUTHOR_HELP
+
+    def test_the_built_ins_set_follows_a_type_already_renamed(self, default_pack):
+        """A type renamed by hand keeps a set under the former name; the
+        set is renamed on its own."""
+        renamed = create_campaign_type("Territory campaign")
+        renamed.built_ins = DefaultAssignmentSet.objects.create(name=FORMER_BUILT_INS)
+        renamed.save()
+
+        rename_core_campaign(apps)
+
+        renamed.built_ins.refresh_from_db()
+        assert renamed.built_ins.name == "Territory campaign built-ins"
+
+    def test_nothing_is_renamed_while_both_names_stand(self, default_pack):
+        """Two types cannot share the name, and which of the two is the
+        real one is a question for a person rather than a migration."""
+        create_campaign_type("Territory campaign")
+        former = create_campaign_type(FORMER_NAME)
+
+        rename_core_campaign(apps)
+
+        former.refresh_from_db()
+        assert former.name == FORMER_NAME
+
+    def test_a_database_with_no_system_pack_is_left_alone(self, db):
+        assert rename_core_campaign(apps) == []
 
 
 class TestTheAuthoringPages:
@@ -284,7 +366,7 @@ class TestTheAuthoringPages:
         territory = dominion["territory"]
         assert f'name="part-{territory.pk}-label_singular"' in body
         assert 'value="Territory"' in body
-        assert "Territories · pooled" in body
+        assert "Territories · changes hands" in body
         assert "No Territories yet." in body
         assert f'name="add-asset-{territory.pk}-name"' in body
         assert f'name="add-asset-{territory.pk}-income"' in body

--- a/n26/tests/test_campaign_invitations.py
+++ b/n26/tests/test_campaign_invitations.py
@@ -32,7 +32,7 @@ def campaign(arbitrator, campaign_type):
 
 
 #: The log's first line, which founding writes before any test here acts.
-FOUNDED = "set the campaign up on N26 core"
+FOUNDED = "set the campaign up on Territory campaign"
 
 
 def told(campaign):

--- a/n26/tests/test_views_campaigns.py
+++ b/n26/tests/test_views_campaigns.py
@@ -4,6 +4,8 @@ Here rather than beside the views because opening the flag means writing the
 site's own row, and only these tests may reach across to the platform.
 """
 
+from importlib import import_module
+
 import pytest
 from django.contrib.auth.models import Group, User
 
@@ -266,6 +268,48 @@ class TestSettingOneUp:
         assert f'value="{campaign_type.pk}"' in body
         assert f'value="{campaign.additions.pk}"' not in body
 
+    def test_each_card_says_what_founding_on_the_type_gives(
+        self, client, arbitrator, default_pack, open_to_everyone
+    ):
+        """The picker reads as choosing a rulebook: the type's description,
+        how each kind of asset behaves, and what every gang starts with."""
+        from django.apps import apps
+
+        from n26.library.core_campaign import seed_core_campaign
+
+        seed_core_campaign(apps)
+
+        body = client.get("/n26/campaigns/new/").content.decode()
+        assert "Territory campaign" in body
+        assert "gangs fight for control of Territory" in body
+        assert "Every gang gets one Settlement and keeps it." in body
+        assert "Territories change hands." in body
+        assert "Every gang starts with Reputation at 0 and one Settlement." in body
+
+    def test_a_campaign_wide_rule_is_drawn_on_the_card(
+        self, client, arbitrator, campaign_type, open_to_everyone
+    ):
+        """A modifier on the type reaches every member gang, so the card
+        says what it does in the words the authoring pages use. A type
+        with nothing built in says nothing about what a gang starts with."""
+        from n26.library.authoring import (
+            create_rule,
+            ef_adds,
+            modifier,
+            targets_gang,
+        )
+
+        modifier(
+            "Everyone is wanted",
+            targets_gang(),
+            ef_adds(create_rule("Wanted")),
+            attach_to=campaign_type,
+        )
+
+        body = client.get("/n26/campaigns/new/").content.decode()
+        assert "Wanted" in body
+        assert "Every gang starts with" not in body
+
     def test_a_campaign_without_a_type_is_refused(
         self, client, arbitrator, campaign_type, open_to_everyone
     ):
@@ -279,7 +323,7 @@ class TestSettingOneUp:
     def test_the_page_names_the_type(self, client, campaign, open_to_everyone):
         body = client.get(f"/n26/campaigns/{campaign.pk}/").content.decode()
         assert "Campaign type" in body
-        assert "N26 core" in body
+        assert "Territory campaign" in body
 
     def test_the_form_opens_with_a_thousand_credit_budget(
         self, client, arbitrator, open_to_everyone
@@ -451,7 +495,7 @@ class TestTheLogOnTheCampaignsPage:
         made = found_campaign("Quiet Start", campaign_type, owner=arbitrator)
         drawn = self.page(client, made)
         assert "Log" in drawn
-        assert "set the campaign up on N26 core" in drawn
+        assert "set the campaign up on Territory campaign" in drawn
         assert "Nothing yet." not in drawn
 
     def test_setting_one_up_writes_its_first_line(
@@ -462,7 +506,7 @@ class TestTheLogOnTheCampaignsPage:
         assert [event.kind for event in made.events.all()] == [
             CampaignEvent.Kind.CREATED
         ]
-        assert "set the campaign up on N26 core" in self.page(client, made)
+        assert "set the campaign up on Territory campaign" in self.page(client, made)
 
     def test_editing_writes_what_changed_and_the_page_says_it(
         self, client, campaign, open_to_everyone
@@ -550,6 +594,56 @@ class TestTheLogOnTheCampaignsPage:
             CampaignEvent.Kind.CREATED,
             CampaignEvent.Kind.ARCHIVED,
         ]
+
+
+class TestTheFullLog:
+    """The campaign's page draws only its newest acts; the log page draws
+    them all, newest first, a screenful at a time, for whoever the
+    campaign's page opens for."""
+
+    def rename(self, client, campaign, times):
+        for number in range(1, times + 1):
+            client.post(
+                f"/n26/campaigns/{campaign.pk}/edit/",
+                {"name": f"Dust Falls {number}", "budget": "1000", "summary": ""},
+            )
+
+    def test_every_act_is_drawn(self, client, campaign, open_to_everyone):
+        self.rename(client, campaign, 14)
+        drawn = client.get(f"/n26/campaigns/{campaign.pk}/log/").content.decode()
+        assert drawn.count("renamed the campaign") == 14
+        assert "set the campaign up on Territory campaign" in drawn
+        assert "earlier act" not in drawn
+
+    def test_the_newest_act_is_drawn_first(self, client, campaign, open_to_everyone):
+        self.rename(client, campaign, 1)
+        drawn = client.get(f"/n26/campaigns/{campaign.pk}/log/").content.decode()
+        assert drawn.index("renamed the campaign") < drawn.index("set the campaign up")
+
+    def test_a_long_log_is_paged(self, client, campaign, open_to_everyone, monkeypatch):
+        """Every other parameter rides along, and the last page ends with
+        the founding line."""
+        # By module rather than by dotted path: the views package exports
+        # a ``campaigns`` view under the submodule's own name.
+        monkeypatch.setattr(
+            import_module("n26.core.views.campaigns"), "LOG_PER_PAGE", 5
+        )
+        self.rename(client, campaign, 14)
+        first = client.get(f"/n26/campaigns/{campaign.pk}/log/").content.decode()
+        assert first.count("renamed the campaign") == 5
+        assert "Page 1 of 3" in first
+        assert "15 entries" in first
+        last = client.get(f"/n26/campaigns/{campaign.pk}/log/?page=3").content.decode()
+        assert "set the campaign up on Territory campaign" in last
+
+    def test_it_opens_for_a_reader_who_does_not_arbitrate(
+        self, client, campaign, open_to_everyone
+    ):
+        client.force_login(User.objects.create_user("reader"))
+        assert client.get(f"/n26/campaigns/{campaign.pk}/log/").status_code == 200
+
+    def test_it_is_shut_with_the_feature(self, client, campaign, shut):
+        assert client.get(f"/n26/campaigns/{campaign.pk}/log/").status_code == 404
 
 
 class TestTheRollOfGangs:

--- a/n26/urls.py
+++ b/n26/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
     path("campaigns/new/", views.create_campaign, name="n26-create-campaign"),
     # After campaigns/new/, which would otherwise resolve "new" as an id.
     path("campaigns/<str:pk>/", views.campaign, name="n26-campaign"),
+    # The whole log; the campaign's page draws only the newest acts.
+    path("campaigns/<str:pk>/log/", views.campaign_log, name="n26-campaign-log"),
     path(
         "campaigns/<str:pk>/edit/",
         views.edit_campaign,


### PR DESCRIPTION
## What changed

**The core campaign type is now called "Territory campaign".** The type every install ships with was seeded as "N26 core", which names the software rather than the game. The core rulebook's campaign chapter is about gangs fighting for control of Territory, so the type takes that as its name. A new library migration (`0083`) renames the existing row and its built-ins set in place — a campaign already founded on it keeps its type — and is safe to run again.

**A campaign type has a description written for the arbitrator.** `CampaignType.description` is a new field, edited on the type's authoring page. `library_author_help` was the only text on a type, and its contract says it never reaches a player; the founding form was drawing it anyway. The Territory campaign's description and author help are written in our own words from the rules: what the gangs fight over, what every gang starts with, what a Territory gives, the three phases, how it ends.

**The set-up screen says what each type gives.** Each card on `/n26/campaigns/new/` now carries the type's description, one sentence per asset kind ("Every gang gets one Settlement and keeps it." / "Territories change hands."), what every gang starts with from the type's built-ins ("Every gang starts with Reputation at 0 and one Settlement."), and one sentence per campaign-wide modifier. The sentences are composed in Python (`CampaignTypeSummary` / `summarise_campaign_type` in `n26/core/campaigns.py`), and the radio-card component gained a body slot to draw them.

**A full campaign log page.** The campaign page caps its log at ten and ends in "and N earlier acts" with nothing to click. `n26-campaign-log` (`/n26/campaigns/<pk>/log/`) draws the whole log, newest first, fifty acts a page, for whoever the campaign page opens for. The campaign page is not linked to it here — another change owns that template.

**Copy pass.** "What the campaign runs on. Every gang that joins gets what the type includes." is gone. Model help texts, the authoring page strings, the concepts reference and the choice label for the asset kind mode ("Pooled" → "Changes hands"; the stored value stays `pooled`) no longer say "pool", "runs on", "includes" or "deals in".

## How to try it

1. `manage migrate` — the migration prints what it renamed.
2. Open `/n26/campaigns/new/` and read the Territory campaign card.
3. Set a campaign up, then open `/n26/campaigns/<pk>/log/`.
4. Staff: open `/n26/authoring/campaign-type/` → Territory campaign, and read the new Description field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
