### PR TITLE
feat: show campaign templates on the campaigns index and at create time

### DIFF
--- a/n23/core/templates/core/campaign/campaign_new.html
+++ b/n23/core/templates/core/campaign/campaign_new.html
@@ -16,7 +16,7 @@
                         Based on <a href="{% url 'core:campaign' template_campaign.id %}" class="linked">{{ template_campaign.name }}</a>
                     </div>
                     <a href="{{ change_template_url }}"
-                       class="linked-secondary fs-7 flex-shrink-0">Change</a>
+                       class="linked-secondary fs-7 flex-shrink-0">Change template</a>
                 </div>
                 {% if template_contents %}
                     <div class="fs-7 text-secondary vstack gap-1">

--- a/n23/core/templates/core/campaign/campaign_new.html
+++ b/n23/core/templates/core/campaign/campaign_new.html
@@ -10,9 +10,13 @@
         <h1 class="h3">Create a new Campaign</h1>
         {% if template_campaign %}
             <c-box class="vstack gap-2">
-                <div>
-                    <i class="bi-stars" aria-hidden="true"></i>
-                    Based on <a href="{% url 'core:campaign' template_campaign.id %}" class="linked">{{ template_campaign.name }}</a>
+                <div class="d-flex align-items-start gap-2">
+                    <div class="flex-grow-1">
+                        <i class="bi-stars" aria-hidden="true"></i>
+                        Based on <a href="{% url 'core:campaign' template_campaign.id %}" class="linked">{{ template_campaign.name }}</a>
+                    </div>
+                    <a href="{{ change_template_url }}"
+                       class="linked-secondary fs-7 flex-shrink-0">Change</a>
                 </div>
                 {% if template_contents %}
                     <div class="fs-7 text-secondary vstack gap-1">
@@ -24,12 +28,13 @@
                         {% endfor %}
                     </div>
                 {% endif %}
-                <div class="fs-7">
-                    <a href="{% url 'core:campaigns-new' %}" class="linked-secondary">Start from scratch instead</a>
-                </div>
             </c-box>
+        {% elif has_template_campaigns %}
+            <div class="fs-7">
+                <a href="{{ change_template_url }}" class="linked">Start from a template instead</a>
+            </div>
         {% endif %}
-        <form action="{% url 'core:campaigns-new' %}{% if template_campaign %}?template={{ template_campaign.id }}{% endif %}"
+        <form action="{% url 'core:campaigns-new' %}?{% if template_campaign %}template={{ template_campaign.id }}{% else %}skip_template=1{% endif %}"
               method="post"
               class="vstack gap-3">
             {% csrf_token %}

--- a/n23/core/templates/core/campaign/campaign_new_template.html
+++ b/n23/core/templates/core/campaign/campaign_new_template.html
@@ -1,0 +1,70 @@
+{% extends "core/layouts/base.html" %}
+{% block head_title %}
+    Start from a template?
+{% endblock head_title %}
+{% block content %}
+    {% url 'core:campaigns' as campaigns_url %}
+    <c-breadcrumb>
+        <c-breadcrumb.user :user="request.user" />
+        <c-breadcrumb.item href="{{ campaigns_url }}">
+            Campaigns
+        </c-breadcrumb.item>
+        <c-breadcrumb.item>
+            New
+        </c-breadcrumb.item>
+    </c-breadcrumb>
+    <div class="col-12 col-xl-8 px-0 vstack gap-3">
+        <h1 class="h3">Start from a template?</h1>
+        <c-box>
+            <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-3">
+                <i class="bi-file-earmark fs-5 d-none d-sm-block" aria-hidden="true"></i>
+                <div>
+                    <div class="fw-medium">Empty campaign</div>
+                    <div class="text-secondary fs-7">Add your own assets, resources and attributes once it exists.</div>
+                </div>
+                <c-btn variant="primary"
+                       class="ms-sm-auto flex-shrink-0"
+                       href="{{ skip_url }}">
+                    Start from scratch <i class="bi-arrow-right"></i>
+                </c-btn>
+            </div>
+        </c-box>
+        <div class="d-flex align-items-center gap-3">
+            <hr class="flex-grow-1">
+            <span class="text-secondary fs-7">Or use a template</span>
+            <hr class="flex-grow-1">
+        </div>
+        <div class="vstack gap-2">
+            {% for campaign in template_campaigns %}
+                <c-box>
+                    <div class="d-flex flex-column flex-sm-row align-items-sm-start gap-3">
+                        <div class="flex-grow-1 overflow-hidden">
+                            <h2 class="h5 mb-1">{{ campaign.name }}</h2>
+                            {% if campaign.summary %}
+                                <div class="text-secondary">{{ campaign.summary|striptags|truncatewords:30 }}</div>
+                            {% endif %}
+                            {% if campaign.contents %}
+                                <div class="text-secondary fs-7 mt-2 vstack gap-1">
+                                    {% for group in campaign.contents %}
+                                        <div>
+                                            <span class="caps-label">{{ group.label }}</span>
+                                            {{ group.names|join:", " }}
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        <c-btn variant="primary"
+                               size="sm"
+                               class="flex-shrink-0"
+                               href="{{ campaign.use_url }}">
+                            Use this <i class="bi-arrow-right"></i>
+                        </c-btn>
+                    </div>
+                </c-box>
+            {% empty %}
+                <div class="text-secondary fs-7">No templates yet.</div>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock content %}

--- a/n23/core/templates/core/campaign/campaign_new_template.html
+++ b/n23/core/templates/core/campaign/campaign_new_template.html
@@ -20,7 +20,7 @@
                 <i class="bi-file-earmark fs-5 d-none d-sm-block" aria-hidden="true"></i>
                 <div>
                     <div class="fw-medium">Empty campaign</div>
-                    <div class="text-secondary fs-7">Add your own assets, resources and attributes once it exists.</div>
+                    <div class="text-secondary fs-7">Add your own assets, resources and attributes after you create it.</div>
                 </div>
                 <c-btn variant="primary"
                        class="ms-sm-auto flex-shrink-0"
@@ -58,12 +58,12 @@
                                size="sm"
                                class="flex-shrink-0"
                                href="{{ campaign.use_url }}">
-                            Use this <i class="bi-arrow-right"></i>
+                            Use this template <i class="bi-arrow-right"></i>
                         </c-btn>
                     </div>
                 </c-box>
             {% empty %}
-                <div class="text-secondary fs-7">No templates yet.</div>
+                <div class="text-secondary fs-7">No campaign templates yet.</div>
             {% endfor %}
         </div>
     </div>

--- a/n23/core/templates/core/campaign/campaigns.html
+++ b/n23/core/templates/core/campaign/campaigns.html
@@ -28,12 +28,25 @@
                 {% endfor %}
                 {% include "core/includes/pagination.html" %}
             </div>
-            {% if pinned_campaigns %}
+            {% if pinned_campaigns or template_campaigns %}
                 <div class="col-12 col-xl-4 order-1 order-xl-2 vstack gap-4">
-                    <div class="caps-label">Pinned</div>
-                    {% for campaign in pinned_campaigns %}
-                        {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
-                    {% endfor %}
+                    {% if pinned_campaigns %}
+                        <div class="caps-label">Pinned</div>
+                        {% for campaign in pinned_campaigns %}
+                            {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
+                        {% endfor %}
+                    {% endif %}
+                    {% if template_campaigns %}
+                        <div class="vstack gap-4">
+                            <div>
+                                <div class="caps-label">Templates</div>
+                                <div class="text-secondary fs-7">Start a campaign with assets and resources already set up.</div>
+                            </div>
+                            {% for campaign in template_campaigns %}
+                                {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/n23/core/templates/core/campaign/campaigns.html
+++ b/n23/core/templates/core/campaign/campaigns.html
@@ -15,56 +15,66 @@
                 {% endif %}
             </p>
         </div>
-        {% if template_campaigns %}
-            {% comment %}
-                Sits above the search bar at every width. Below xl the page is one
-                stacked column, so the block collapses to its header to keep the
-                campaign list within reach; `d-xl-block` beats `.collapse`'s
-                display:none, so at xl it is always open and the toggle is hidden.
-            {% endcomment %}
-            <div>
-                <c-btn variant="link"
-                       type="button"
-                       class="d-xl-none w-100 p-0 text-start text-decoration-none d-flex align-items-center"
-                       data-bs-toggle="collapse"
-                       data-bs-target="#campaign-templates"
-                       aria-expanded="false"
-                       aria-controls="campaign-templates">
-                    <span class="caps-label">Templates</span>
-                    <i class="bi-chevron-down ms-auto"
-                       data-gy-collapse-icon="campaign-templates"
-                       aria-hidden="true"></i>
-                </c-btn>
-                <div class="d-none d-xl-block caps-label">Templates</div>
-                <div class="collapse d-xl-block" id="campaign-templates">
-                    <div class="text-secondary fs-7 mt-1">Start a campaign with assets and resources already set up.</div>
-                    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-0">
-                        {% for campaign in template_campaigns %}
-                            <div class="col">{% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}</div>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-        <div class="grid">
-            {% url 'core:campaigns' as action %}
-            {% include "core/includes/campaigns_filter.html" with action=action status_choices=status_choices show_sort=True %}
-        </div>
+        {% comment %}
+            The search and the campaign list share one column; templates and pins
+            are its sibling column, so at xl they sit right-aligned beside the
+            list and below xl `order-1` lifts them above the search. The templates
+            block collapses to its header on that stacked layout to keep the list
+            within reach — `d-xl-block` beats `.collapse`'s display:none, so at xl
+            it is always open and the toggle is hidden.
+        {% endcomment %}
         <div class="row g-4">
             <div class="col-12 col-xl-8 order-2 order-xl-1 vstack gap-4">
-                {% for campaign in campaigns %}
-                    {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
-                {% empty %}
-                    <div class="py-2">No campaigns available.</div>
-                {% endfor %}
-                {% include "core/includes/pagination.html" %}
-            </div>
-            {% if pinned_campaigns %}
-                <div class="col-12 col-xl-4 order-1 order-xl-2 vstack gap-4">
-                    <div class="caps-label">Pinned</div>
-                    {% for campaign in pinned_campaigns %}
+                <div class="grid">
+                    {% url 'core:campaigns' as action %}
+                    {% include "core/includes/campaigns_filter.html" with action=action status_choices=status_choices show_sort=True %}
+                </div>
+                <div class="vstack gap-4">
+                    {% for campaign in campaigns %}
                         {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
+                    {% empty %}
+                        <div class="py-2">No campaigns available.</div>
                     {% endfor %}
+                    {% include "core/includes/pagination.html" %}
+                </div>
+            </div>
+            {% if template_campaigns or pinned_campaigns %}
+                <div class="col-12 col-xl-4 order-1 order-xl-2 vstack gap-4">
+                    {% if template_campaigns %}
+                        <div>
+                            <c-btn variant="link"
+                                   type="button"
+                                   class="d-xl-none w-100 p-0 text-start text-decoration-none d-flex align-items-center"
+                                   data-bs-toggle="collapse"
+                                   data-bs-target="#campaign-templates"
+                                   aria-expanded="false"
+                                   aria-controls="campaign-templates">
+                                <span class="caps-label">Start with a template <i class="bi-arrow-right" aria-hidden="true"></i></span>
+                                <i class="bi-chevron-down ms-auto"
+                                   data-gy-collapse-icon="campaign-templates"
+                                   aria-hidden="true"></i>
+                            </c-btn>
+                            <div class="d-none d-xl-block caps-label">
+                                Start with a template <i class="bi-arrow-right" aria-hidden="true"></i>
+                            </div>
+                            <div class="collapse d-xl-block" id="campaign-templates">
+                                <div class="text-secondary fs-7 mt-1">Each one comes with assets and resources already set up.</div>
+                                <div class="vstack gap-3 mt-3">
+                                    {% for campaign in template_campaigns %}
+                                        {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if pinned_campaigns %}
+                        <div class="vstack gap-4">
+                            <div class="caps-label">Pinned</div>
+                            {% for campaign in pinned_campaigns %}
+                                {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/n23/core/templates/core/campaign/campaigns.html
+++ b/n23/core/templates/core/campaign/campaigns.html
@@ -15,6 +15,37 @@
                 {% endif %}
             </p>
         </div>
+        {% if template_campaigns %}
+            {% comment %}
+                Sits above the search bar at every width. Below xl the page is one
+                stacked column, so the block collapses to its header to keep the
+                campaign list within reach; `d-xl-block` beats `.collapse`'s
+                display:none, so at xl it is always open and the toggle is hidden.
+            {% endcomment %}
+            <div>
+                <c-btn variant="link"
+                       type="button"
+                       class="d-xl-none w-100 p-0 text-start text-decoration-none d-flex align-items-center"
+                       data-bs-toggle="collapse"
+                       data-bs-target="#campaign-templates"
+                       aria-expanded="false"
+                       aria-controls="campaign-templates">
+                    <span class="caps-label">Templates</span>
+                    <i class="bi-chevron-down ms-auto"
+                       data-gy-collapse-icon="campaign-templates"
+                       aria-hidden="true"></i>
+                </c-btn>
+                <div class="d-none d-xl-block caps-label">Templates</div>
+                <div class="collapse d-xl-block" id="campaign-templates">
+                    <div class="text-secondary fs-7 mt-1">Start a campaign with assets and resources already set up.</div>
+                    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-0">
+                        {% for campaign in template_campaigns %}
+                            <div class="col">{% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}</div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
         <div class="grid">
             {% url 'core:campaigns' as action %}
             {% include "core/includes/campaigns_filter.html" with action=action status_choices=status_choices show_sort=True %}
@@ -28,25 +59,12 @@
                 {% endfor %}
                 {% include "core/includes/pagination.html" %}
             </div>
-            {% if pinned_campaigns or template_campaigns %}
+            {% if pinned_campaigns %}
                 <div class="col-12 col-xl-4 order-1 order-xl-2 vstack gap-4">
-                    {% if pinned_campaigns %}
-                        <div class="caps-label">Pinned</div>
-                        {% for campaign in pinned_campaigns %}
-                            {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
-                        {% endfor %}
-                    {% endif %}
-                    {% if template_campaigns %}
-                        <div class="vstack gap-4">
-                            <div>
-                                <div class="caps-label">Templates</div>
-                                <div class="text-secondary fs-7">Start a campaign with assets and resources already set up.</div>
-                            </div>
-                            {% for campaign in template_campaigns %}
-                                {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
-                            {% endfor %}
-                        </div>
-                    {% endif %}
+                    <div class="caps-label">Pinned</div>
+                    {% for campaign in pinned_campaigns %}
+                        {% include "core/campaign/includes/campaign_row.html" with campaign=campaign %}
+                    {% endfor %}
                 </div>
             {% endif %}
         </div>

--- a/n23/core/templates/core/campaign/includes/campaign_row.html
+++ b/n23/core/templates/core/campaign/includes/campaign_row.html
@@ -10,7 +10,13 @@ Expects `campaign` in context.{% endcomment %}
             <div>
                 <i class="bi-person"></i> <a href="{% url 'core:user' campaign.owner.username %}" class="linked">{{ campaign.owner }}</a>{% user_badge campaign.owner %}
             </div>
-            {% if not campaign.archived %}
+            {% if campaign.template %}
+                <div>
+                    <c-badge variant="info">
+                        Template
+                    </c-badge>
+                </div>
+            {% elif not campaign.archived %}
                 <div>{% include "core/campaign/includes/status.html" with campaign=campaign %}</div>
             {% endif %}
             <div class="text-secondary fs-7" title="Stars">

--- a/n23/core/tests/test_campaign_copy.py
+++ b/n23/core/tests/test_campaign_copy.py
@@ -1714,6 +1714,46 @@ def test_a_template_row_is_badged_as_one(client, user, template_campaign):
 
 
 @pytest.mark.django_db
+def test_the_templates_block_comes_before_the_search_bar(
+    client, user, template_campaign
+):
+    """It is a sibling of the filter and the list, not nested in the pinned column.
+
+    That position is what lets it collapse to one line above the search on a
+    narrow screen instead of pushing the campaign list down.
+    """
+    client.force_login(user)
+
+    content = client.get(reverse("core:campaigns")).content.decode()
+
+    assert content.index('id="campaign-templates"') < content.index('name="q"'), (
+        "the templates block must render before the search field"
+    )
+
+
+@pytest.mark.django_db
+def test_the_templates_block_has_a_collapse_toggle(client, user, template_campaign):
+    """The toggle is hidden by CSS at xl; the markup is always there."""
+    client.force_login(user)
+
+    content = client.get(reverse("core:campaigns")).content.decode()
+
+    assert 'data-bs-target="#campaign-templates"' in content
+    assert 'data-gy-collapse-icon="campaign-templates"' in content
+
+
+@pytest.mark.django_db
+def test_no_templates_means_no_block_at_all(client, user, make_campaign):
+    """An empty block above the search would be pure noise."""
+    make_campaign("An Ordinary Campaign")
+    client.force_login(user)
+
+    content = client.get(reverse("core:campaigns")).content.decode()
+
+    assert 'id="campaign-templates"' not in content
+
+
+@pytest.mark.django_db
 def test_interstitial_requires_login(client):
     response = client.get(reverse("core:campaigns-new-template"))
 

--- a/n23/core/tests/test_campaign_copy.py
+++ b/n23/core/tests/test_campaign_copy.py
@@ -1714,20 +1714,24 @@ def test_a_template_row_is_badged_as_one(client, user, template_campaign):
 
 
 @pytest.mark.django_db
-def test_the_templates_block_comes_before_the_search_bar(
+def test_the_templates_column_sorts_above_the_search_below_xl(
     client, user, template_campaign
 ):
-    """It is a sibling of the filter and the list, not nested in the pinned column.
+    """Templates are a sibling column of the one holding the search and the list.
 
-    That position is what lets it collapse to one line above the search on a
-    narrow screen instead of pushing the campaign list down.
+    Source order puts the search column first so it leads at xl; the flex
+    `order` utilities are what lift templates above it once the page stacks.
+    Asserting the classes is the only reachable proxy — the rest is pure CSS.
     """
     client.force_login(user)
 
     content = client.get(reverse("core:campaigns")).content.decode()
 
-    assert content.index('id="campaign-templates"') < content.index('name="q"'), (
-        "the templates block must render before the search field"
+    search_col = content.index("col-12 col-xl-8 order-2 order-xl-1")
+    templates_col = content.index("col-12 col-xl-4 order-1 order-xl-2")
+    assert search_col < templates_col, (
+        "the search and list column must come first in source, with the "
+        "templates column ordered above it below xl"
     )
 
 

--- a/n23/core/tests/test_campaign_copy.py
+++ b/n23/core/tests/test_campaign_copy.py
@@ -1632,6 +1632,87 @@ def test_interstitial_hides_archived_templates(client, user, template_campaign):
     assert list(response.context["template_campaigns"]) == []
 
 
+# --- Templates on the campaigns index ---
+
+
+@pytest.mark.django_db
+def test_campaigns_index_lists_templates(client, user, template_campaign):
+    """Templates are non-public, so the visibility filter never reaches them."""
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns"))
+
+    assert [c.id for c in response.context["template_campaigns"]] == [
+        template_campaign.id
+    ]
+    assert template_campaign.name in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_campaigns_index_lists_templates_for_anonymous_visitors(
+    client, template_campaign
+):
+    """Signed out too — the templates are curated content, not anyone's game."""
+    response = client.get(reverse("core:campaigns"))
+
+    assert [c.id for c in response.context["template_campaigns"]] == [
+        template_campaign.id
+    ]
+
+
+@pytest.mark.django_db
+def test_campaigns_index_hides_archived_templates(client, user, template_campaign):
+    template_campaign.archived = True
+    template_campaign.save()
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns"))
+
+    assert list(response.context["template_campaigns"]) == []
+
+
+@pytest.mark.django_db
+def test_a_public_template_is_not_listed_twice_on_the_page(
+    client, user, template_campaign
+):
+    """The sidebar is a template's one home, whatever its public flag says.
+
+    Campaign.public defaults to True, so a template created without thinking
+    about it would otherwise show in both the browse list and the sidebar.
+    """
+    assert template_campaign.public
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns") + "?my=0")
+
+    assert template_campaign.id not in [c.id for c in response.context["campaigns"]]
+    assert template_campaign.id in [
+        c.id for c in response.context["template_campaigns"]
+    ]
+
+
+@pytest.mark.django_db
+def test_the_owner_still_sees_their_own_template_in_their_list(
+    client, user, template_campaign
+):
+    """Excluding templates from browse must not hide one from whoever owns it."""
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns") + "?my=1")
+
+    assert template_campaign.id in [c.id for c in response.context["campaigns"]]
+
+
+@pytest.mark.django_db
+def test_a_template_row_is_badged_as_one(client, user, template_campaign):
+    """Otherwise a template is indistinguishable from a campaign someone plays."""
+    client.force_login(user)
+
+    content = client.get(reverse("core:campaigns")).content.decode()
+
+    assert "text-bg-info" in content
+
+
 @pytest.mark.django_db
 def test_interstitial_requires_login(client):
     response = client.get(reverse("core:campaigns-new-template"))

--- a/n23/core/tests/test_campaign_copy.py
+++ b/n23/core/tests/test_campaign_copy.py
@@ -1490,3 +1490,151 @@ def test_template_lost_mid_form_still_shows_field_errors(
     assert "That template is no longer available" in content
     assert "This field is required." in content
     assert response.context["form"].errors
+
+
+# --- Template interstitial ---
+
+
+@pytest.mark.django_db
+def test_new_campaign_redirects_to_the_template_interstitial(
+    client, user, template_campaign
+):
+    """A bare GET goes to the template step first, like /lists/new does."""
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new"))
+
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaigns-new-template")
+
+
+@pytest.mark.django_db
+def test_new_campaign_redirect_carries_a_typed_name(client, user, template_campaign):
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new") + "?name=Hive+War")
+
+    assert response.status_code == 302
+    assert response.url == reverse("core:campaigns-new-template") + "?name=Hive+War"
+
+
+@pytest.mark.django_db
+def test_new_campaign_skips_the_interstitial_when_there_are_no_templates(client, user):
+    """With nothing to offer, the detour would be a dead end."""
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new"))
+
+    assert response.status_code == 200
+    assert response.context["template_campaign"] is None
+
+
+@pytest.mark.django_db
+def test_skip_template_reaches_the_form(client, user, template_campaign):
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new") + "?skip_template=1")
+
+    assert response.status_code == 200
+    assert response.context["template_campaign"] is None
+
+
+@pytest.mark.django_db
+def test_choosing_a_template_bypasses_the_interstitial(client, user, template_campaign):
+    client.force_login(user)
+
+    response = client.get(
+        reverse("core:campaigns-new") + f"?template={template_campaign.id}"
+    )
+
+    assert response.status_code == 200
+    assert response.context["template_campaign"] == template_campaign
+
+
+@pytest.mark.django_db
+def test_start_from_scratch_link_does_not_bounce_back(client, user, template_campaign):
+    """The escape hatch must carry skip_template, or it loops to the interstitial."""
+    client.force_login(user)
+
+    interstitial = client.get(reverse("core:campaigns-new-template"))
+    skip_url = interstitial.context["skip_url"]
+
+    assert client.get(skip_url).status_code == 200
+
+
+@pytest.mark.django_db
+def test_posting_is_never_bounced_to_the_interstitial(client, user, template_campaign):
+    """The skip branch posts with no query string; the guard is GET-only."""
+    client.force_login(user)
+
+    client.post(
+        reverse("core:campaigns-new"),
+        {"name": "Posted Bare", "summary": "", "narrative": "", "budget": 1500},
+    )
+
+    campaign = Campaign.objects.get(name="Posted Bare")
+    assert not campaign.asset_types.exists()
+
+
+@pytest.mark.django_db
+def test_interstitial_offers_each_template_with_its_contents(
+    client, user, template_campaign
+):
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new-template"))
+    content = response.content.decode()
+
+    assert response.status_code == 200
+    assert [c.id for c in response.context["template_campaigns"]] == [
+        template_campaign.id
+    ]
+    assert template_campaign.name in content
+    # The contents summary is why this page exists rather than a list of names.
+    assert "Territories (1)" in content
+    assert "Meat" in content
+
+
+@pytest.mark.django_db
+def test_interstitial_use_link_starts_the_form_on_that_template(
+    client, user, template_campaign
+):
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new-template"))
+    use_url = response.context["template_campaigns"][0].use_url
+
+    followed = client.get(use_url)
+    assert followed.status_code == 200
+    assert followed.context["template_campaign"] == template_campaign
+
+
+@pytest.mark.django_db
+def test_interstitial_threads_a_name_onto_every_link(client, user, template_campaign):
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new-template") + "?name=Hive+War")
+
+    assert "name=Hive+War" in response.context["skip_url"]
+    assert "name=Hive+War" in response.context["template_campaigns"][0].use_url
+    carried = client.get(response.context["skip_url"])
+    assert carried.context["form"]["name"].value() == "Hive War"
+
+
+@pytest.mark.django_db
+def test_interstitial_hides_archived_templates(client, user, template_campaign):
+    template_campaign.archived = True
+    template_campaign.save()
+    client.force_login(user)
+
+    response = client.get(reverse("core:campaigns-new-template"))
+
+    assert list(response.context["template_campaigns"]) == []
+
+
+@pytest.mark.django_db
+def test_interstitial_requires_login(client):
+    response = client.get(reverse("core:campaigns-new-template"))
+
+    assert response.status_code == 302
+    assert "/accounts/login/" in response.url

--- a/n23/core/urls/campaign.py
+++ b/n23/core/urls/campaign.py
@@ -20,6 +20,11 @@ from ..views.campaign import views as campaign_views
 patterns = [
     path("campaigns/", campaign_views.Campaigns.as_view(), name="campaigns"),
     path("campaigns/new/", campaign_crud.new_campaign, name="campaigns-new"),
+    path(
+        "campaigns/new/template",
+        campaign_crud.new_campaign_template,
+        name="campaigns-new-template",
+    ),
     path("campaign/<id>", campaign_views.CampaignDetailView.as_view(), name="campaign"),
     path("campaign/<id>/edit/", campaign_crud.edit_campaign, name="campaign-edit"),
     path(

--- a/n23/core/views/campaign/crud.py
+++ b/n23/core/views/campaign/crud.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.http import urlencode
 
 from gyrinx import messages
 from gyrinx.analytics.models import EventVerb, log_event
@@ -42,6 +43,20 @@ def _get_template_campaign(request):
         raise Http404("No such template campaign.") from None
 
 
+def _available_template_campaigns():
+    """The template campaigns offered on the interstitial, in a stable order."""
+    return Campaign.objects.filter(template=True, archived=False).order_by("name")
+
+
+def _carried_campaign_name(raw):
+    """Normalise a campaign name carried through the template-selection flow:
+    strip whitespace and cap to the model field length so it can't bloat
+    redirect URLs (risking 414s) or exceed what the form would accept anyway.
+    """
+    max_length = Campaign._meta.get_field("name").max_length
+    return (raw or "").strip()[:max_length]
+
+
 def _resolve_template_campaign(request):
     """Resolve the requested template, tolerating one that vanished mid-form.
 
@@ -59,10 +74,66 @@ def _resolve_template_campaign(request):
 
 
 @login_required
+def new_campaign_template(request):
+    """
+    Offer the template campaigns before the new-campaign form is shown.
+
+    Each template links straight to ``campaigns-new?template=<id>``; the
+    "start from scratch" link carries ``skip_template=1``. Both bypass the
+    redirect in :func:`new_campaign`, so this page never posts anything and
+    needs no form of its own.
+
+    **Context**
+
+    ``template_campaigns``
+        The :model:`core.Campaign` templates on offer, each annotated with the
+        ``use_url`` that starts a campaign from it and the ``contents`` it would
+        copy over.
+    ``skip_url``
+        Where "start from scratch" goes.
+    ``name``
+        A campaign name carried in from a quick-create box, threaded onto every
+        outgoing link so it survives the detour.
+
+    **Template**
+
+    :template:`core/campaign/campaign_new_template.html`
+    """
+    name = _carried_campaign_name(request.GET.get("name"))
+    new_url = reverse("core:campaigns-new")
+
+    def _url(**params):
+        if name:
+            params["name"] = name
+        return f"{new_url}?{urlencode(params)}"
+
+    # A handful of curated templates, so the per-campaign contents summary is
+    # affordable here — it is the whole reason to show this page rather than a
+    # bare list of names.
+    template_campaigns = list(_available_template_campaigns())
+    for campaign in template_campaigns:
+        campaign.use_url = _url(template=str(campaign.id))
+        campaign.contents = describe_campaign_contents(campaign)
+
+    return render(
+        request,
+        "core/campaign/campaign_new_template.html",
+        {
+            "template_campaigns": template_campaigns,
+            "skip_url": _url(skip_template="1"),
+            "name": name,
+        },
+    )
+
+
+@login_required
 @transaction.atomic
 def new_campaign(request):
     """
     Create a new :model:`core.Campaign` owned by the current user.
+
+    Redirects to the template interstitial first unless a template has already
+    been chosen (``?template=<id>``) or declined (``?skip_template=1``).
 
     **Context**
 
@@ -72,6 +143,8 @@ def new_campaign(request):
         The template :model:`core.Campaign` this one is based on, from
         ``?template=<id>``, or None. Its assets, resources, attributes and
         Content Packs are copied over once the campaign is created.
+    ``change_template_url``
+        Back to the interstitial, to choose a different template or none.
     ``error_message``
         None or a string describing a form error.
 
@@ -79,6 +152,22 @@ def new_campaign(request):
 
     :template:`core/campaign/campaign_new.html`
     """
+    # Anyone who hasn't seen the interstitial yet gets sent there. GET only:
+    # the skip branch posts back here with no query string at all, and bouncing
+    # that would throw away everything they typed. And only when there is
+    # something to show — with no templates the detour is a dead end.
+    if (
+        request.method == "GET"
+        and request.GET.get("skip_template") != "1"
+        and not request.GET.get("template")
+        and _available_template_campaigns().exists()
+    ):
+        templates_url = reverse("core:campaigns-new-template")
+        carried_name = _carried_campaign_name(request.GET.get("name"))
+        if carried_name:
+            templates_url += "?" + urlencode({"name": carried_name})
+        return HttpResponseRedirect(templates_url)
+
     template_campaign, template_missing = _resolve_template_campaign(request)
     error_message = None
     if request.method == "POST":
@@ -157,6 +246,12 @@ def new_campaign(request):
                 describe_campaign_contents(template_campaign)
                 if template_campaign
                 else []
+            ),
+            "change_template_url": reverse("core:campaigns-new-template"),
+            # Only asked when no template is in play — that is the one branch
+            # offering a way back to the interstitial.
+            "has_template_campaigns": (
+                template_campaign is None and _available_template_campaigns().exists()
             ),
         },
     )

--- a/n23/core/views/campaign/views.py
+++ b/n23/core/views/campaign/views.py
@@ -47,13 +47,18 @@ class Campaigns(generic.ListView):
                 # Show campaigns where user is owner
                 queryset = queryset.filter(owner=self.request.user)
             else:
-                # Show public campaigns plus private campaigns the user participates in
-                queryset = queryset.filter(
-                    Q(public=True) | Q(lists__owner=self.request.user)
-                ).distinct()
+                # Show public campaigns plus private campaigns the user participates in.
+                # Templates are listed in their own sidebar block instead — a public
+                # one would otherwise appear twice on the same page. The owner branch
+                # above keeps them, so whoever owns a template still sees it.
+                queryset = (
+                    queryset.filter(Q(public=True) | Q(lists__owner=self.request.user))
+                    .exclude(template=True)
+                    .distinct()
+                )
         else:
             # For unauthenticated users, only show public campaigns
-            queryset = queryset.filter(public=True)
+            queryset = queryset.filter(public=True).exclude(template=True)
 
         # Apply "Participating only" filter
         show_participating = self.request.GET.get("participating", "0")
@@ -122,6 +127,18 @@ class Campaigns(generic.ListView):
             )
         else:
             context["pinned_campaigns"] = []
+
+        # Template campaigns for the sidebar. They are non-public, so the
+        # visibility filter above never reaches them and nothing else on the
+        # site links to one — this is the only place they are listed.
+        # Mirrors the main queryset so the shared row partial renders identically.
+        context["template_campaigns"] = (
+            Campaign.objects.filter(template=True, archived=False)
+            .select_related("owner", "owner__profile")
+            .prefetch_related("lists", "owner__badge_grants")
+            .annotate(star_count=Count("starred_by", distinct=True))
+            .order_by("name")
+        )
 
         return context
 


### PR DESCRIPTION
Template campaigns were effectively unreachable. All five in production (Ash Wastes, Dominion, Uprising, Underhells, Law and Misrule) are non-public, and the campaigns list filters on `public=True` without ever consulting `Campaign.template` — so nothing surfaced them. The only place they appeared by name was the copy-assets dropdown on a campaign you already owned, which is why the "Use this template" button on a template's own page was reachable only by someone handed the URL.

This fixes both halves: the moment you are choosing, and the moment you are browsing.

## 1. A template step before the create form

`/campaigns/new/` now redirects a bare GET to `/campaigns/new/template`, mirroring the step `/lists/new` has had all along. That page leads with "Empty campaign → Start from scratch", then lists each template with its summary and exactly what it would copy — the same contents summary the create form already shows once you have picked one. Choosing a template lands on the usual form with its "Based on ‹name›" box, now carrying a "Change template" link back.

The existing machinery is untouched: `?template=<id>`, `_get_template_campaign`, `_resolve_template_campaign` and `apply_campaign_template` all work as before. This is a front door onto a hallway that already worked. The "Use this template" button on a template's own detail page still goes straight to the form, since it already carries `?template=`.

Single-select, so the page needs no form of its own — each card is a plain link, and "start from scratch" carries the new `?skip_template=1`. Both bypass the redirect.

**Two things the guard has to get right,** both covered by tests:

- **It runs on GET only.** The skip branch posts back with no query string, and bouncing that would discard everything typed into the form.
- **It runs only when a template exists.** With none, the detour is a dead end, so installations without templates reach the form directly. This is also why the existing tests that GET `campaigns-new` (`test_csp_tinymce`, `test_campaign_status`) are unaffected.

`campaign_new.html`'s "Start from scratch instead" link pointed at bare `campaigns-new`, which under the guard would have bounced back to the interstitial. It is replaced by the "Change template" link, matching `list_new.html`.

## 2. Templates listed on the campaigns index

A "Templates" block in the sidebar that already holds "Pinned", reusing `campaign_row.html` so rows render identically. Signed-out visitors see it too — the campaign detail view has no login gate, so they can read a template before signing up.

Templates are **excluded from the browse branch** of the main list. `Campaign.public` defaults to `True`, so a template created without thinking about the flag would otherwise appear twice on one page. The owner branch (`?my=1`) keeps them, so whoever owns a template still sees it among their own.

A template row is badged "Template" in place of the status badge — Pre-Campaign on a template is noise, and without the badge a template is indistinguishable from a campaign someone is running.

## Testing

- 17 new tests in `test_campaign_copy.py`: the redirect, both bypasses, the GET-only guard, name threading, archived templates, login, the sidebar listing (signed in and out), the no-double-listing rule, the owner exemption, and the badge.
- Full suite green: 9834 passed, 12 skipped, 1 xfailed.
- Verified end to end against the running app, not just tests: submitted the create form from the template path and checked from outside the change that the new campaign received the template's asset type with both its assets, the resource type, and the `CampaignAction` recording which template it came from — matching what the card previewed.
- Screenshotted the interstitial, both create-form states and both campaigns-index states at desktop and mobile, light and dark, plus signed out.

## How to try it

1. `./scripts/dev.sh`, then sign in.
2. `/n23/campaigns/` — the Templates block is in the sidebar (top of the page on mobile).
3. Click "Create a new Campaign" — you land on the template step.
4. Pick a template, or take "Start from scratch". Both reach the create form; the template path shows what it copied, with "Change template" to go back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gy2aBqXaTEMDmKrwUXVwS
