### PR TITLE
fix: plainer founding Trade Points copy on the equip rail, model card and visit box

### DIFF
--- a/n26/core/templates/cotton/n26/model_card/index.html
+++ b/n26/core/templates/cotton/n26/model_card/index.html
@@ -82,7 +82,7 @@ control by the actions opens it.
                                     <c-n26.founding-mark class="size-3.5" />
                                     <span>{{ card.trade_points_left }} TP<span class="sr-only"> Trade Points left to spend while the gang is being founded</span></span>
                                 </span>
-                                <c-slot name="content">Trade Points {{ card.name }} can spend while the Found and equip gang action is open</c-slot>
+                                <c-slot name="content">Founding Trade Points {{ card.name }} has left to spend while the Found and equip gang action is open.</c-slot>
                             </c-ui.tooltip>
                             <span aria-hidden="true" class="text-muted">·</span>
                         </c-n26.model-card.mode>

--- a/n26/core/templates/n26/includes/founding_budget.html
+++ b/n26/core/templates/n26/includes/founding_budget.html
@@ -27,8 +27,9 @@ the page by id so the figures move without a reload.
         Founding Trade Points
     </p>
     <p class="mt-0.5 text-xs text-muted">
-        What {{ miniature.name }} can spend while the Found and equip gang action is
-        open. Everything on this page counts against it, including the equipment lists.
+        {{ miniature.name }} can spend these Trade Points while the Found and equip gang
+        action is open. Every purchase on this page counts against them, including
+        purchases from the equipment lists.
     </p>
     <c-n26.tally :facts="founding_budget.facts" class="mt-2 text-sm" />
 </div>

--- a/n26/core/templates/n26/includes/visit_open.html
+++ b/n26/core/templates/n26/includes/visit_open.html
@@ -9,7 +9,7 @@ comes off. Without an allowance the figure strip's TP already leads to the
 visit and this would say the same thing twice.
 
 Wants `visit_trade_points_left` (worked out in the view, so the figure is read
-once) and `trade_points_href`.
+once), `trade_points_href`, and `miniature` for the name in the sentence.
 {% endcomment %}
 <div class="self-start rounded-box border border-box-border p-3">
     <p class="text-sm font-medium text-ink-900 dark:text-ink-100">Trading Post visit</p>

--- a/n26/core/templates/n26/includes/visit_open.html
+++ b/n26/core/templates/n26/includes/visit_open.html
@@ -14,10 +14,10 @@ once) and `trade_points_href`.
 <div class="self-start rounded-box border border-box-border p-3">
     <p class="text-sm font-medium text-ink-900 dark:text-ink-100">Trading Post visit</p>
     <p class="mt-0.5 text-xs text-muted">
-        It's open, with
+        The visit is open with
         <span class="font-medium text-ink-900 dark:text-ink-100">{{ visit_trade_points_left }} TP</span>
-        left. What {{ miniature.name }} buys on this page counts against the
-        founding Trade Points, not against the visit.
+        left. Purchases on this page count against {{ miniature.name }}'s founding
+        Trade Points, not against the visit.
     </p>
     <c-ui.button size="xs"
                  variant="default"

--- a/n26/core/test_views_founding_budget.py
+++ b/n26/core/test_views_founding_budget.py
@@ -395,7 +395,7 @@ class TestBothPotsAtOnce:
     ):
         said = " ".join(client.get(equip_url(leader, post)).content.decode().split())
 
-        assert "counts against the founding Trade Points, not against the visit" in said
+        assert "founding Trade Points, not against the visit" in said
 
     def test_the_allowance_alone_draws_no_visit_block(
         self, client, leader, legacy_list

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -626,7 +626,7 @@ class TestTheModelCardsTooltips:
         assert 'role="tooltip"' in page
         assert "From Leader" in page
         assert "Rating, including weapons and wargear" in page
-        assert "can spend while the Found and equip gang action is open" in page
+        assert "has left to spend while the Found and equip gang action is open" in page
 
     def test_both_kinds_of_open_choice_draw_their_way_in(self, reader):
         """The sample carries an open one-pick choice and a several-pick

--- a/n26/designsystem/tests.py
+++ b/n26/designsystem/tests.py
@@ -174,7 +174,7 @@ class TestTheFoundingMarkPage:
         page = reader.get("/n26/design/c/founding-mark/").content.decode()
         assert "Available" in page
         assert "Remaining" in page
-        assert "counts against the" in page
+        assert "not against the visit" in page
         assert "Manage visit" in page
 
 

--- a/n26/tests/sandbox/test_founding_budget.py
+++ b/n26/tests/sandbox/test_founding_budget.py
@@ -1102,7 +1102,7 @@ class TestTheFigureOnTheGangPage:
     #: What the hover says, per model. The whole of it, because a
     #: substring of it would pass on a page that had drawn half a
     #: sentence.
-    HOVER = "Trade Points {} can spend while the Found and equip gang action is open"
+    HOVER = "Founding Trade Points {} has left to spend while the Found and equip gang action is open."
 
     def page(self, gang):
         from django.urls import reverse


### PR DESCRIPTION
Tom called the equip-rail help text ("What Leader 1 can spend while the Found and equip gang action is open.") sloppy microcopy. This rewrites the three founding-budget strings so each states the fact plainly.

- Equip rail: "{name} can spend these Trade Points while the Found and equip gang action is open. Every purchase on this page counts against them, including purchases from the equipment lists."
- Model card tooltip: "Founding Trade Points {name} has left to spend while the Found and equip gang action is open."
- Visit box beside the rail: "The visit is open with N TP left. Purchases on this page count against {name}'s founding Trade Points, not against the visit."

Tests that pinned the old wording are repinned. No behaviour change; all surfaces remain behind the `may_see_founding` staff gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh