### PR TITLE
feat: a Captured n26 model gets the Escape table; its results set Dead, Ransomed or In Recovery

### DIFF
--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -10,7 +10,7 @@ number of queries regardless of how many models or how much kit — see
 ``render_gang`` and the assertions in ``tests/sandbox/test_render.py``.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from django.utils.text import capfirst
 
@@ -592,6 +592,12 @@ def lift_landing(offer, landed, threshold=False):
     for group in offer.groups:
         for option in group.options:
             (first if option.key in landed else rest).append(option)
+    if not offer.takes_several and len(first) == 1:
+        # One pick, one landing: the radio opens on the result the roll
+        # landed on, so Save is the Add. Every other option, the None row
+        # included, opens clear.
+        first = [replace(first[0], is_current=True)]
+        rest = [replace(option, is_current=False) for option in rest]
     if not first:
         # Nothing on the list is where the roll landed — a full choice,
         # or a roll no result claims. A heading over nothing says less

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -306,6 +306,17 @@ rolls. The player rolls at the table and adds the result they rolled.
    the same hidden item. An entry added to the Allies list later needs
    it built in too.
 
+6. What a result does to the model's standing is a modifier on the
+   result too, and Foundations attaches these for you: Grievous Wound
+   and the 51–56 injuries put the model **In Recovery**, Critical Injury
+   marks it **Critically Injured**, Memorable Death marks it **Dead**,
+   and Captured marks it **Captured** and gives it an **Escape** choice —
+   a D6 table of its own (Executed, Ransomed, Daring Escape), each result
+   setting the status in turn. The card wears the status under the
+   model's name; the owner can set it by hand from the card's menu, and
+   Clean House on the gang's menu clears every Recovery at the end of a
+   cycle. Taking a result off the card does not undo the status.
+
 Removing one of those modifiers from a gang type removes the line from
 every card at once. Results players had already picked stay where they
 are, as plain lines the player can remove.

--- a/n26/library/standard_content.py
+++ b/n26/library/standard_content.py
@@ -1135,6 +1135,23 @@ LASTING_EFFECT_STATUSES = {
 #: than to the Doc: off the roster for good, which the app calls dead.
 DELEGATION_STATUSES = {"Critical Injury": "dead"}
 
+#: What happens to a captured model, rolled straight after the battle
+#: (core rules, the Wrap-up): a D6 band table of its own, under its own
+#: slot type, granted to the model by the Captured result itself.
+ESCAPE_SLOT_TYPE = "Escape"
+ESCAPE_TABLE = [
+    (1, 1, "Executed"),
+    (2, 4, "Ransomed"),
+    (5, 6, "Daring Escape"),
+]
+ESCAPE_STATUSES = {
+    "Executed": "dead",
+    "Ransomed": "ransomed",
+    "Daring Escape": "recovery",
+}
+#: The results that hand a model to the Escape table.
+CAPTURED_RESULTS = ("Captured",)
+
 
 def lasting_effect_status_modifiers():
     """A filter for the status modifiers the lasting-effect seed attaches,
@@ -1143,11 +1160,12 @@ def lasting_effect_status_modifiers():
     not make it look imported."""
     from django.db.models import Q
 
+    tables = [name for name, _, _, _, _ in LASTING_EFFECT_TABLES] + [ESCAPE_SLOT_TYPE]
     return Q(
-        op_sets_status__isnull=False,
-        library_pickable_set__slot_type__name__in=[
-            name for name, _, _, _, _ in LASTING_EFFECT_TABLES
-        ],
+        op_sets_status__isnull=False, library_pickable_set__slot_type__name__in=tables
+    ) | Q(
+        adds_assignable__slot__slot_type__name=ESCAPE_SLOT_TYPE,
+        library_pickable_set__slot_type__name__in=tables,
     )
 
 
@@ -1274,6 +1292,72 @@ def _create_lasting_effect_tables():
                     ),
                     status,
                 )
+    escape = _create_escape_table()
+    for index, (_, _, rows, _, _) in enumerate(LASTING_EFFECT_TABLES):
+        slot_type = SlotType.objects.get(name__iexact=LASTING_EFFECT_TABLES[index][0])
+        for _, _, result in rows:
+            if result in CAPTURED_RESULTS:
+                _grants_escape(
+                    _lasting_row(
+                        Pickable, result, _twin_qualifier(index, result), slot_type, {}
+                    ),
+                    escape,
+                )
+
+
+def _create_escape_table():
+    """The Escape table and the one-pick choice that draws from it.
+
+    Its own slot type, so nothing but an Escape result can settle it,
+    and one pick at most: a captured model rolls once. Returns the slot.
+    """
+    from n26.library.models import Pickable, Picklist, PicklistMember, Slot, SlotType
+
+    slot_type = SlotType.objects.filter(name__iexact=ESCAPE_SLOT_TYPE).first()
+    if slot_type is None:
+        slot_type = SlotType.objects.create(
+            name=ESCAPE_SLOT_TYPE, plural_name=ESCAPE_SLOT_TYPE
+        )
+    table = Picklist.objects.filter(
+        slot_type=slot_type, name__iexact=f"{ESCAPE_SLOT_TYPE} Table"
+    ).first()
+    if table is None:
+        table = Picklist.objects.create(
+            name=f"{ESCAPE_SLOT_TYPE} Table",
+            slot_type=slot_type,
+            dice="d6",
+            roll_selects="band",
+        )
+    for position, (low, high, result) in enumerate(ESCAPE_TABLE):
+        pickable = _lasting_row(Pickable, result, "", slot_type, {})
+        PicklistMember.objects.get_or_create(
+            picklist=table,
+            pickable=pickable,
+            defaults={"roll_low": low, "roll_high": high, "position": position},
+        )
+        _status_modifier(pickable, ESCAPE_STATUSES[result])
+    return _lasting_row(
+        Slot,
+        ESCAPE_SLOT_TYPE,
+        "",
+        slot_type,
+        {"picklist": table, "label": ESCAPE_SLOT_TYPE, "min_picks": 0, "max_picks": 1},
+    )
+
+
+def _grants_escape(pickable, slot):
+    """Attach "gives the model the Escape choice" to a Captured result,
+    once — found by name, as the status modifiers are."""
+    from n26.library.authoring import ef_adds, modifier, targets_model
+    from n26.library.models import Modifier
+
+    name = f"{pickable}: rolls on the {slot.choice_label} table"
+    if pickable.modifiers.filter(name=name).exists():
+        return
+    row = Modifier.objects.filter(name=name).first()
+    if row is None:
+        row = modifier(name, targets_model(), ef_adds(slot))
+    pickable.modifiers.add(row)
 
 
 def _status_modifier(pickable, status):
@@ -1300,8 +1384,10 @@ def _status_modifier(pickable, status):
 def _check_lasting_effect_tables():
     from n26.library.models import PicklistMember, Slot, SlotType
 
-    names = [name for name, _, _, _, _ in LASTING_EFFECT_TABLES]
-    members = sum(len(rows) for _, _, rows, _, _ in LASTING_EFFECT_TABLES)
+    names = [name for name, _, _, _, _ in LASTING_EFFECT_TABLES] + [ESCAPE_SLOT_TYPE]
+    members = sum(len(rows) for _, _, rows, _, _ in LASTING_EFFECT_TABLES) + len(
+        ESCAPE_TABLE
+    )
     present = _count(SlotType, name__in=names)
     present += _count(
         PicklistMember,

--- a/n26/tests/sandbox/test_escape.py
+++ b/n26/tests/sandbox/test_escape.py
@@ -1,0 +1,256 @@
+"""A captured model and the Escape table.
+
+The rules resolve a capture straight after the battle: the captured model
+rolls a D6 on the Escape table and is executed, ransomed, or escapes into
+Recovery (core rules, the Wrap-up). The app makes that one more roll
+table on the machinery the injury tables use: the Captured result carries
+a modifier that gives the model an Escape choice, so the card grows an
+Escape row with Roll the moment Captured is added; each Escape result
+sets the status when its pick lands.
+"""
+
+import re
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from n26.core.card import build_card, build_modifier_index
+from n26.core.effects import compute
+from n26.core.models import LedgerEvent, Miniature
+from n26.core.operations import operation
+from n26.core.reconcile import assert_reconciled
+from n26.core.render import option_key
+from n26.core.status import Status
+from n26.library.models import Picklist, Slot
+from n26.library.standard_content import STANDARD_CONTENT
+from n26.tests.sandbox.actions import (
+    create_profile,
+    ef_adds,
+    found_gang,
+    hire,
+    is_profile_type,
+    modifier,
+    targets_every_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def tables(default_pack):
+    STANDARD_CONTENT["lasting-effect-tables"].create()
+    return {
+        "injury": Picklist.objects.get(name="Lasting Injury Table"),
+        "damage": Picklist.objects.get(name="Lasting Damage Table"),
+        "escape": Picklist.objects.get(name="Escape Table"),
+        "injury_slot": Slot.objects.get(name="Lasting Injury"),
+        "damage_slot": Slot.objects.get(name="Lasting Damage"),
+        "escape_slot": Slot.objects.get(name="Escape"),
+    }
+
+
+@pytest.fixture
+def gang(gang_type, owner, fighter_type, vehicle_type, tables):
+    modifier(
+        "Fighters carry Lasting Injury",
+        targets_every_model(is_profile_type(fighter_type)),
+        ef_adds(tables["injury_slot"]),
+        carried_by=gang_type,
+    )
+    modifier(
+        "Vehicles carry Lasting Damage",
+        targets_every_model(is_profile_type(vehicle_type)),
+        ef_adds(tables["damage_slot"]),
+        carried_by=gang_type,
+    )
+    return found_gang("The Scar Crossing", gang_type, owner=owner, budget=1000)
+
+
+@pytest.fixture
+def krago(gang, gang_type, fighter_type):
+    profile = create_profile("Ganger", fighter_type, gang_type, price=50)
+    return hire(gang, profile, "Krago", paid=50)
+
+
+@pytest.fixture
+def rig(gang, gang_type, vehicle_type):
+    profile = create_profile("Cargo Rig", vehicle_type, gang_type, price=100)
+    return hire(gang, profile, "The Rig", paid=100)
+
+
+def computed_for(miniature):
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return compute(card, index)
+
+
+def choice_of(miniature, label):
+    return next(
+        (s for s in computed_for(miniature).choices if s.kind_label == label), None
+    )
+
+
+def result_named(table, name):
+    return next(m.pickable for m in table.members.all() if m.pickable.name == name)
+
+
+def add_result(miniature, label, table, name, roll=None):
+    slot = choice_of(miniature, label)
+    gang = miniature.membership.gang
+    with operation(gang, actor=gang.owner) as op:
+        return op.choose(
+            slot.anchor.assignment,
+            result_named(table, name),
+            slot=slot.slot,
+            miniature=miniature,
+            roll=roll,
+        )
+
+
+def fresh(miniature):
+    return Miniature.objects.get(pk=miniature.pk)
+
+
+class TestTheTableAsSeeded:
+    def test_the_escape_table_is_a_d6_band_table_of_three_results(self, tables):
+        table = tables["escape"]
+        assert table.dice == "d6"
+        assert [
+            (m.roll_low, m.roll_high, m.pickable.name)
+            for m in table.members.order_by("position")
+        ] == [(1, 1, "Executed"), (2, 4, "Ransomed"), (5, 6, "Daring Escape")]
+
+    def test_the_choice_takes_one_pick(self, tables):
+        assert (tables["escape_slot"].min_picks, tables["escape_slot"].max_picks) == (
+            0,
+            1,
+        )
+
+    def test_each_result_sets_a_status(self, tables):
+        from n26.library.standard_content import ESCAPE_STATUSES
+
+        for member in tables["escape"].members.select_related("pickable"):
+            carried = [
+                m.effect.status
+                for m in member.pickable.modifiers.all()
+                if m.op_sets_status_id is not None
+            ]
+            assert carried == [ESCAPE_STATUSES[member.pickable.name]]
+
+    def test_captured_on_both_tables_grants_the_escape_choice(self, tables):
+        for table in (tables["injury"], tables["damage"]):
+            captured = result_named(table, "Captured")
+            grants = [
+                m.effect.slot
+                for m in captured.modifiers.all()
+                if m.adds_assignable_id is not None
+            ]
+            assert grants == [tables["escape_slot"]]
+
+    def test_the_seed_runs_again_without_doubling(self, tables):
+        from n26.library.models import Modifier
+
+        before = Modifier.objects.count()
+        STANDARD_CONTENT["lasting-effect-tables"].create()
+        assert Modifier.objects.count() == before
+        present, total = STANDARD_CONTENT["lasting-effect-tables"].check()
+        assert present == total
+
+
+class TestACapturedModel:
+    def test_captured_puts_an_escape_row_on_the_card(self, gang, krago, tables):
+        assert choice_of(krago, "Escape") is None
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        assert fresh(krago).status == Status.CAPTURED
+        escape = choice_of(krago, "Escape")
+        assert escape is not None
+        assert escape.slot.picklist.dice == "d6"
+        assert_reconciled(gang)
+
+    def test_nobody_else_grows_an_escape_row(self, gang, krago, rig, tables):
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        assert choice_of(rig, "Escape") is None
+
+    def test_a_captured_vehicle_rolls_too(self, gang, rig, tables):
+        add_result(rig, "Lasting Damage", tables["damage"], "Captured")
+        assert choice_of(rig, "Escape") is not None
+
+    def test_executed_kills(self, gang, krago, tables):
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        add_result(krago, "Escape", tables["escape"], "Executed")
+        assert fresh(krago).status == Status.DEAD
+        assert_reconciled(gang)
+
+    def test_a_daring_escape_is_recovery(self, gang, krago, tables):
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        add_result(krago, "Escape", tables["escape"], "Daring Escape")
+        assert fresh(krago).status == Status.RECOVERY
+
+    def test_ransomed_waits_on_the_payment(self, gang, krago, tables):
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        add_result(krago, "Escape", tables["escape"], "Ransomed")
+        assert fresh(krago).status == Status.RANSOMED
+
+    def test_the_roll_the_pick_and_the_status_are_one_story(self, gang, krago, tables):
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        escape = choice_of(krago, "Escape")
+        with operation(gang, actor=gang.owner) as op:
+            rolled = op.roll(escape.slot, miniature=krago, rolled=1)
+        add_result(krago, "Escape", tables["escape"], "Executed", roll=rolled)
+        kinds = list(
+            LedgerEvent.objects.filter(gang=gang)
+            .order_by("created", "id")
+            .values_list("kind", flat=True)
+        )[-3:]
+        assert kinds == [
+            LedgerEvent.Kind.ROLLED,
+            LedgerEvent.Kind.GRANTED,
+            LedgerEvent.Kind.STATUS_SET,
+        ]
+
+
+class TestThePage:
+    def test_the_escape_row_offers_to_roll_a_d6(
+        self, client, owner, gang, krago, tables
+    ):
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        escape = choice_of(krago, "Escape")
+        address = reverse(
+            "n26-choose",
+            args=[
+                gang.pk,
+                f"{krago.pk}:{escape.anchor.assignment.pk}:{escape.identity.pk}",
+            ],
+        )
+        client.force_login(owner)
+        page = client.get(address).content.decode()
+        assert "Roll a D6" in page
+        assert "Executed" in page and "Daring Escape" in page
+
+        client.post(address, {"act": "enter", "rolled": "6"})
+        event = LedgerEvent.objects.get(kind=LedgerEvent.Kind.ROLLED)
+        page = client.get(f"{address}?roll={event.pk}").content.decode()
+        # One pick, so the page is radios with the landed row lifted and
+        # already checked — Save is the Add — rather than a several-pick
+        # list with an Add of its own.
+        assert "Landed on" in page
+        assert page.index("Landed on") < page.index("Daring Escape")
+        checked = re.search(r'<input[^>]*name="thing"[^>]*checked[^>]*>', page)
+        assert checked and "Daring Escape" not in checked.group(0)  # value is a key
+        key = re.search(r'value="([^"]+)"', checked.group(0)).group(1)
+        assert key == option_key(result_named(tables["escape"], "Daring Escape"))
+
+    def test_the_captured_card_says_what_to_do(
+        self, client, owner, gang, krago, tables
+    ):
+        add_result(krago, "Lasting Injuries", tables["injury"], "Captured")
+        client.force_login(owner)
+        page = client.get(reverse("n26-gang", args=[gang.pk])).content.decode()
+        assert "Captured" in page
+        assert ">Escape<" in page


### PR DESCRIPTION
Second of three PRs for a model's standing between battles in n26; stacked on #2476 (status). This one is **what happens to a captured model**: the Escape table, as one more roll table on the machinery the injury tables already use.

## The rule it follows

A model that rolls Captured (61–62 on Lasting Injury or Lasting Damage) rolls a D6 on the Escape table straight after the battle: 1 executed, 2–4 ransomed for D6×10 credits, 5–6 a daring escape into Recovery (`11-post-battle-and-post-cycle.md` › Being Captured; Escape Table). n26 keeps no lingering captive state — the roll resolves it there and then.

## What a player sees

- Add **Captured** (roll 61) and the card wears **Captured — Roll on the Escape table.** and grows an **Escape** row with Roll.
- Roll a D6 there. The landed result opens already checked, so Save is the Add. Executed marks the model **Dead**; Daring Escape puts them **In Recovery**; Ransomed marks them **Ransomed — Pay the ransom now, or they die.** The payment itself is the third PR.
- The history reads the roll, the pick and the status change as one story.

## The record

- Foundations seeds an "Escape" slot type, the D6 band table, and a one-pick Escape slot. The **Captured pickable** on both tables carries a modifier `ef_adds(escape slot)` reaching the model carrying it, which is what puts the Escape row on a captured card — the same grant mechanism as a gang type's standing grant, one level down. Each Escape result carries `op_sets_status`.
- Everything is content: no new model, no migration. The library clear recognises the seed's modifiers by what they do (a status effect or an Escape grant on a result of one of the tables), never by name.
- `render.lift_landing` now opens the landed radio checked on a one-pick table; before, a one-pick roll page opened on None.
- Recipe step 6 in `recipes.md` describes the statuses and the Escape table for authors.

**Prod:** one click of the Foundations button after deploy creates the Escape table and attaches the Captured grants and status effects (idempotent).

## Verified

- `pytest n26` green. New spec `n26/tests/sandbox/test_escape.py` (14 tests): the table as seeded; Captured on both tables grants the slot; the seed runs again without doubling and reports complete; a captured fighter grows the row and nobody else does; each result's status; roll → pick → status in one story; the page.
- Browser: Yolanda, enter 61 → Captured badge + Escape row → roll 5 → Daring Escape checked → Save → In Recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
