### PR TITLE
feat: gate the founding action and budgets on a founding FeatureFlag instead of is_staff

### DIFF
--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -2542,19 +2542,25 @@ class TestTheLibraryTabsQueryBudget:
     def test_it_costs_a_fixed_number(
         self, client, tester, fighter, house_list, stocked
     ):
+        from n26.tests.fixtures import admit_to_founding
+
+        # The founding flag's row stands, on the allowlist, and this owner
+        # is not on it: what an owner pays once the feature is being
+        # tried out, which is the flag row and their group membership.
+        admit_to_founding()
         client.force_login(tester)
 
         # The reader and their session, the gang, the fighter's card with
         # its options, the roster behind the header's count, which held
         # lists hold gear, the campaign's assets the gang holds, the
-        # drawer's one question about campaigns, whether the founding flag
-        # admits this owner —
+        # drawer's one question about campaigns, the founding flag's row
+        # and whether its group holds this owner —
         # the library: one query per gear kind, plus the guns' paid
         # rounds, each kind's offers and each restricted kind's use
         # lists — and a browse of each list held, which is what prices
         # the library's lines. A fixed number per list, never one per
         # item.
-        assert self.measure(client, f"{equip_url(fighter)}?list=all") == 53
+        assert self.measure(client, f"{equip_url(fighter)}?list=all") == 54
 
     def test_it_costs_the_same_however_much_it_holds(
         self, client, tester, fighter, house_list, stocked

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -2547,13 +2547,14 @@ class TestTheLibraryTabsQueryBudget:
         # The reader and their session, the gang, the fighter's card with
         # its options, the roster behind the header's count, which held
         # lists hold gear, the campaign's assets the gang holds, the
-        # drawer's one question about campaigns —
+        # drawer's one question about campaigns, whether the founding flag
+        # admits this owner —
         # the library: one query per gear kind, plus the guns' paid
         # rounds, each kind's offers and each restricted kind's use
         # lists — and a browse of each list held, which is what prices
         # the library's lines. A fixed number per list, never one per
         # item.
-        assert self.measure(client, f"{equip_url(fighter)}?list=all") == 52
+        assert self.measure(client, f"{equip_url(fighter)}?list=all") == 53
 
     def test_it_costs_the_same_however_much_it_holds(
         self, client, tester, fighter, house_list, stocked

--- a/n26/core/test_views_founding_action.py
+++ b/n26/core/test_views_founding_action.py
@@ -408,6 +408,21 @@ class TestTheSquareOnTheGangPage:
         body = client.get(sheet(gang)).content.decode()
         assert "Found and equip gang" not in body
         assert "Complete action" not in body
+
+    def test_the_flag_open_to_everyone_admits_no_reader_but_the_owner(
+        self, client, gang
+    ):
+        """Opening the flag widens who among owners sees their own square;
+        it never puts another gang's actions in front of a reader."""
+        from gyrinx.site.models import Availability, FeatureFlag
+
+        FeatureFlag.objects.filter(slug="founding").update(
+            availability=Availability.EVERYONE
+        )
+        client.force_login(User.objects.create_user("stranger"))
+        body = client.get(sheet(gang)).content.decode()
+        assert "Found and equip gang" not in body
+        assert 'value="start"' not in body
         assert "No action is open." not in body
 
     def test_an_owner_the_flag_does_not_admit_gets_no_square(self, client, gang):

--- a/n26/core/test_views_founding_action.py
+++ b/n26/core/test_views_founding_action.py
@@ -16,6 +16,7 @@ from django.urls import reverse
 from n26.core import history
 from n26.core.models import Action, Gang, LedgerEvent
 from n26.core.operations import Refusal, operation
+from n26.tests.fixtures import admit_to_founding
 
 pytestmark = pytest.mark.django_db
 
@@ -33,9 +34,11 @@ ONE_AT_A_TIME = "You can have only one of these actions open at a time."
 @pytest.fixture
 def tester(db):
     """The signed-in person these tests look at the app as."""
-    # Staff, because the square and its address are staff-only while the
-    # action is built out; the non-staff owner has tests of their own.
-    return User.objects.create_user("player", is_staff=True)
+    # On the founding flag's allowlist, because the square and its address
+    # reach the owners it admits; the owner it does not has tests of their own.
+    person = User.objects.create_user("player")
+    admit_to_founding(person)
+    return person
 
 
 @pytest.fixture
@@ -407,10 +410,10 @@ class TestTheSquareOnTheGangPage:
         assert "Complete action" not in body
         assert "No action is open." not in body
 
-    def test_an_owner_who_is_not_staff_gets_no_square_yet(self, client, gang):
-        """Staff-only while the action is built out: the owner reads the
-        gang page as it was before the square, and the open action stays
-        open behind it."""
+    def test_an_owner_the_flag_does_not_admit_gets_no_square(self, client, gang):
+        """Outside the founding flag's allowlist the owner reads the gang
+        page as it was before the square, and the open action stays open
+        behind it."""
         plain = User.objects.create_user("plain-player")
         gang.owner = plain
         gang.save(update_fields=["owner"])
@@ -722,7 +725,9 @@ class TestTheActsBehindIt:
         client.force_login(User.objects.create_user("stranger"))
         assert client.post(act_page(gang), {"act": "finish"}).status_code == 404
 
-    def test_an_owner_who_is_not_staff_cannot_reach_the_address(self, client, gang):
+    def test_an_owner_the_flag_does_not_admit_cannot_reach_the_address(
+        self, client, gang
+    ):
         plain = User.objects.create_user("plain-player")
         gang.owner = plain
         gang.save(update_fields=["owner"])

--- a/n26/core/test_views_founding_budget.py
+++ b/n26/core/test_views_founding_budget.py
@@ -24,6 +24,7 @@ from n26.library.authoring import (
     create_trading_post,
     create_wargear,
 )
+from n26.tests.fixtures import admit_to_founding
 
 pytestmark = pytest.mark.django_db
 
@@ -103,9 +104,11 @@ def venators(library):
 
 @pytest.fixture
 def tester(db):
-    # Staff, because the founding budgets reach staff owners only while
-    # they are being tested; the non-staff owner has a class of their own.
-    return User.objects.create_user("player", is_staff=True)
+    # On the founding flag's allowlist, because the budgets reach the
+    # owners it admits; the owner it does not has a class of their own.
+    person = User.objects.create_user("player")
+    admit_to_founding(person)
+    return person
 
 
 @pytest.fixture
@@ -444,10 +447,10 @@ class TestBothPotsAtOnce:
 
 
 class TestAnOwnerTheBudgetsDoNotReachYet:
-    """While the founding budgets are being tested they reach staff owners
-    only, the same readers as the Actions square that completes the
-    founding. Every other owner's screens are read exactly as they were
-    before budgets existed: no tally, list lines counting nothing, the
+    """The founding budgets reach the owners the founding flag admits, the
+    same readers as the Actions square that completes the founding. Every
+    other owner's screens are read exactly as they were before budgets
+    existed: no tally, list lines counting nothing, the
     post-is-shut note in its old place, and a purchase naming no action."""
 
     @pytest.fixture(autouse=True)
@@ -514,7 +517,7 @@ class TestTheWayIntoAVisitFromTheRail:
             not in client.get(equip_url(ganger, post)).content.decode()
         )
 
-    def test_a_staff_owner_gets_the_button_dead_and_the_reason(
+    def test_an_admitted_owner_gets_the_button_dead_and_the_reason(
         self, client, tester, ganger, post
     ):
         client.force_login(tester)

--- a/n26/core/test_views_trade_points.py
+++ b/n26/core/test_views_trade_points.py
@@ -17,20 +17,24 @@ from django.urls import reverse
 from n26.core.models import Gang, LedgerEvent
 from n26.core.operations import operation
 from n26.library.models import Subtype
+from n26.tests.fixtures import admit_to_founding
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
 def tester(db):
-    # Staff, because the Actions square is staff-only while the actions
-    # are built out. The Trade Points page itself is every owner's.
-    return User.objects.create_user("player", is_staff=True)
+    # On the founding flag's allowlist, because the Actions square reaches
+    # the owners it admits. The Trade Points page itself is every owner's.
+    person = User.objects.create_user("player")
+    admit_to_founding(person)
+    return person
 
 
 @pytest.fixture
 def player(db):
-    """An owner who is not staff: sees the stash line, never the square."""
+    """An owner the founding flag does not admit: sees the stash line, never
+    the square."""
     return User.objects.create_user("plain-player")
 
 
@@ -226,7 +230,8 @@ class TestTheActionsSquare:
 
     def test_the_stash_card_still_carries_it(self, client, tester, roster, gang):
         """The stash card keeps its Trading Post line for every owner while
-        the square is staff-only; a staff owner reads it in both places."""
+        the square reaches a named few; an admitted owner reads it in both
+        places."""
         client.force_login(tester)
         start(client, gang, roster["Vex"])
 
@@ -235,7 +240,7 @@ class TestTheActionsSquare:
         assert body.index("Trading Post visit open") < body.index(">Stash</span>")
         assert body.count("Trading Post visit open") == 2
 
-    def test_an_owner_who_is_not_staff_gets_the_stash_line_and_no_square(
+    def test_an_owner_the_flag_does_not_admit_gets_the_stash_line_and_no_square(
         self, client, player, roster, gang
     ):
         gang.owner = player

--- a/n26/core/views/equip.py
+++ b/n26/core/views/equip.py
@@ -861,6 +861,9 @@ def equip(request, pk):
 
     miniature = _own_miniature_or_404(request, pk)
     gang = miniature.gang
+    # Read once: the flag behind it is a query, and the screen and the
+    # note offering a visit ask the same question.
+    founding_seen = may_see_founding(gang, request.user)
 
     wanted = request.GET.get("list", "")
     everything = wanted == ALL_SCOPE
@@ -868,7 +871,7 @@ def equip(request, pk):
         gang,
         miniature=miniature,
         list_param=wanted,
-        budgets=may_see_founding(gang, request.user),
+        budgets=founding_seen,
     )
     collections, chosen, view = screen.collections, screen.chosen, screen.view
 
@@ -1050,7 +1053,7 @@ def equip(request, pk):
             # Asked only where the note offering one is drawn, so a page
             # that never mentions the post pays nothing to find out.
             "founding_blocks_visit": (
-                founding_blocks_visit(gang, may_see_founding(gang, request.user))
+                founding_blocks_visit(gang, founding_seen)
                 if picker["post_is_shut"]
                 else False
             ),

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -258,11 +258,14 @@ def gang_sheet(request, pk):
     yours = gang.owner_id == getattr(request.user, "id", None)
     at = reverse("n26-gang", args=[gang.pk])
     card = build_gang_card(gang)
+    # Read once for the page: the flag behind it is a query, and the
+    # cards, the stash card and the square all ask the same question.
+    founding_seen = may_see_founding(gang, request.user)
     # for_owner puts the founding figures on the cards — what a model has
     # left of its founding Trade Points — for the readers the feature
     # reaches, and is what keeps everyone else's read from paying for
     # figures they are not shown.
-    sheet = render_gang(gang, card=card, for_owner=may_see_founding(gang, request.user))
+    sheet = render_gang(gang, card=card, for_owner=founding_seen)
     dialog = None
     link_campaign(sheet.campaign, request.user)
     if yours:
@@ -298,12 +301,10 @@ def gang_sheet(request, pk):
             # Whether the stash card's way into a visit is shut for now.
             # Free where the square below was drawn: that read which
             # actions the gang has open, and the gang holds the reading.
-            "founding_blocks_visit": founding_blocks_visit(
-                gang, may_see_founding(gang, request.user)
-            ),
+            "founding_blocks_visit": founding_blocks_visit(gang, founding_seen),
             # The gang's own actions, which are the owner's to perform.
-            # Drawn for staff owners only while the actions are built out;
-            # every other reader gets no square. A fixed handful of
+            # Drawn for the owners the founding flag admits; every other
+            # reader gets no square. A fixed handful of
             # queries for the whole page, whatever the roster: the open
             # actions, and the last stretch of the gang's story with the
             # records it names. What a visit has left is already on the
@@ -317,7 +318,7 @@ def gang_sheet(request, pk):
                     history_at=reverse("n26-gang-history", args=[gang.pk]),
                     viewer=request.user,
                 )
-                if may_see_actions_square(gang, request.user)
+                if founding_seen
                 else None
             ),
             # Printing follows reading rather than owning, so a reader
@@ -1096,8 +1097,8 @@ def gang_founding_action(request, pk):
     from n26.core.operations import Refusal, operation
 
     gang = _own_gang_or_404(request, pk)
-    # The square that posts here is drawn for staff owners only while the
-    # action is built out, so the address is theirs alone too.
+    # The square that posts here is drawn for the owners the founding
+    # flag admits, so the address is theirs alone too.
     if not may_see_actions_square(gang, request.user):
         raise Http404
     at = reverse("n26-gang", args=[gang.pk])

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -76,10 +76,10 @@ def may_see_founding(gang, user):
 
     The figures on the model cards, the allowance block on the equip
     screen and the terms that make list lines count Trade Points are one
-    feature, and while it is being tested it reaches the same readers as
-    the Actions square that completes the founding: staff who own the
-    gang. Everyone else is read exactly as before budgets existed. The
-    two gates lift together.
+    feature, and it reaches the same readers as the Actions square that
+    completes the founding: owners the ``founding`` flag admits. Everyone
+    else is read exactly as before budgets existed. The two gates lift
+    together, by opening the flag.
     """
     return may_see_actions_square(gang, user)
 
@@ -87,17 +87,22 @@ def may_see_founding(gang, user):
 def may_see_actions_square(gang, user):
     """Whether the gang page draws its Actions square for this reader.
 
-    The square is shown to staff who own the gang while the actions it
-    holds are still being built out. Everyone else reads the gang page
-    as it was before the square existed: the Trading Post visit line
-    stays on the stash card for every owner.
+    The square is shown to the gang's owner where the ``founding`` flag
+    admits them — a named few while the actions are tried out, everyone
+    once it opens. Every other reader gets the gang page as it was before
+    the square existed: the Trading Post visit line stays on the stash
+    card for every owner.
+
+    Owning the gang is checked first, so a reader's flag is only looked up
+    on their own gang: one query per page for an owner, none for anyone
+    else. Callers that ask more than once on one page keep the first
+    reading (``n26.core.views.gangs.gang``).
     """
-    return bool(
-        user is not None
-        and user.is_authenticated
-        and user.is_staff
-        and gang.owner_id == user.pk
-    )
+    from n26.flags import FOUNDING, enabled
+
+    if user is None or not user.is_authenticated or gang.owner_id != user.pk:
+        return False
+    return enabled(FOUNDING, user)
 
 
 def _own_gang_or_404(request, pk):

--- a/n26/core/views/permissions.py
+++ b/n26/core/views/permissions.py
@@ -77,9 +77,10 @@ def may_see_founding(gang, user):
     The figures on the model cards, the allowance block on the equip
     screen and the terms that make list lines count Trade Points are one
     feature, and it reaches the same readers as the Actions square that
-    completes the founding: owners the ``founding`` flag admits. Everyone
-    else is read exactly as before budgets existed. The two gates lift
-    together, by opening the flag.
+    completes the founding: owners the ``founding`` flag admits. For
+    everyone else no figure is drawn, no list line counts Trade Points and
+    a purchase records no founding action. The two gates lift together,
+    by opening the flag.
     """
     return may_see_actions_square(gang, user)
 
@@ -89,14 +90,13 @@ def may_see_actions_square(gang, user):
 
     The square is shown to the gang's owner where the ``founding`` flag
     admits them — a named few while the actions are tried out, everyone
-    once it opens. Every other reader gets the gang page as it was before
-    the square existed: the Trading Post visit line stays on the stash
-    card for every owner.
+    once it opens. Every other reader gets no square; the Trading Post
+    visit line stays on the stash card for every owner.
 
-    Owning the gang is checked first, so a reader's flag is only looked up
-    on their own gang: one query per page for an owner, none for anyone
-    else. Callers that ask more than once on one page keep the first
-    reading (``n26.core.views.gangs.gang``).
+    Owning the gang is checked first, so the flag is only read for an
+    owner on their own gang: the flag row, and on the allowlist the
+    owner's membership of its group. Nobody else pays for it. A view that
+    needs the reading more than once takes it once and passes it on.
     """
     from n26.flags import FOUNDING, enabled
 

--- a/n26/flags.py
+++ b/n26/flags.py
@@ -23,6 +23,7 @@ from gyrinx.site.flags import enabled, register_flags, requires_flag, switched_o
 __all__ = [
     "BUILT_IN_PROPAGATION",
     "CAMPAIGNS",
+    "FOUNDING",
     "enabled",
     "requires_flag",
     "switched_on",
@@ -35,4 +36,10 @@ CAMPAIGNS = "campaigns"
 #: edits still file their passes; nothing runs them until it opens.
 BUILT_IN_PROPAGATION = "built-in-propagation"
 
-register_flags(CAMPAIGNS, BUILT_IN_PROPAGATION)
+#: Founding a gang as an action: the Actions square on the gang page, the
+#: founding Trade Point budgets on the cards and equip screens, and list
+#: lines counting Trade Points while the action is open. Shut, none of it
+#: is drawn, and purchases count against no founding budget.
+FOUNDING = "founding"
+
+register_flags(CAMPAIGNS, BUILT_IN_PROPAGATION, FOUNDING)

--- a/n26/tests/fixtures.py
+++ b/n26/tests/fixtures.py
@@ -1,5 +1,8 @@
 import pytest
+from django.contrib.auth.models import Group
 
+from gyrinx.site.models import Availability, FeatureFlag
+from n26.flags import FOUNDING
 from n26.library.models import (
     ContentPack,
     GangType,
@@ -13,6 +16,31 @@ from n26.library.models import (
     get_default_pack,
 )
 from n26.library.standard_content import MODEL_CHARACTERISTICS, MODEL_STATLINE
+
+FOUNDING_GROUP_NAME = "Founding preview"
+
+
+def admit_to_founding(*users):
+    """Put these accounts on the founding flag's allowlist, creating the
+    flag and its group where they do not exist yet.
+
+    The flag rows are seeded nowhere the test suite runs, so a test that
+    wants the Actions square or the founding budgets drawn creates the
+    row itself. It is opened on the allowlist rather than to everyone so
+    the tests keep an owner the flag does not reach.
+    """
+    group, _ = Group.objects.get_or_create(name=FOUNDING_GROUP_NAME)
+    FeatureFlag.objects.get_or_create(
+        slug=FOUNDING,
+        defaults={
+            "name": "Founding",
+            "availability": Availability.ALLOWLIST,
+            "group": group,
+        },
+    )
+    for user in users:
+        user.groups.add(group)
+    return group
 
 
 @pytest.fixture

--- a/n26/tests/sandbox/test_founding_budget.py
+++ b/n26/tests/sandbox/test_founding_budget.py
@@ -29,6 +29,7 @@ from n26.core.effects import compute
 from n26.core.founding import budget_for, budget_granted
 from n26.core.models import Action
 from n26.core.reconcile import assert_reconciled
+from n26.tests.fixtures import admit_to_founding
 from n26.tests.sandbox.actions import (
     add_entry,
     assign,
@@ -53,9 +54,11 @@ FOUNDING_KIND = Action.Kind.FOUNDING
 
 @pytest.fixture
 def player():
-    # Staff, because the founding budgets reach staff owners only while
-    # they are being tested; the non-staff owner has tests of their own.
-    return User.objects.create_user("tom", is_staff=True)
+    # On the founding flag's allowlist, because the budgets reach the
+    # owners it admits; the owner it does not has tests of their own.
+    person = User.objects.create_user("tom")
+    admit_to_founding(person)
+    return person
 
 
 #: The entries each gang list holds, as ``(entry, the subtype naming its
@@ -1153,10 +1156,12 @@ class TestTheFigureOnTheGangPage:
 
         assert self.HOVER.format("Rasp") not in self.body(client, gang, reader=stranger)
 
-    def test_an_owner_who_is_not_staff_is_not_shown_it_yet(self, client, gang, leader):
-        """The budgets reach staff owners only while they are being tested,
-        the same readers as the Actions square that completes the founding.
-        Every other owner reads their roster as it was before budgets."""
+    def test_an_owner_the_flag_does_not_admit_is_not_shown_it(
+        self, client, gang, leader
+    ):
+        """The budgets reach the owners the founding flag admits, the same
+        readers as the Actions square that completes the founding. Every
+        other owner reads their roster as it was before budgets."""
         plain = User.objects.create_user("plain-owner")
         gang.owner = plain
         gang.save(update_fields=["owner"])

--- a/n26/tests/test_flag_seam.py
+++ b/n26/tests/test_flag_seam.py
@@ -14,7 +14,7 @@ from django.contrib.auth.models import Group, User
 
 from gyrinx.site.flags import enabled, known_flags
 from gyrinx.site.models import Availability, FeatureFlag
-from n26.flags import BUILT_IN_PROPAGATION, CAMPAIGNS
+from n26.flags import BUILT_IN_PROPAGATION, CAMPAIGNS, FOUNDING
 
 pytestmark = [pytest.mark.django_db, pytest.mark.core]
 
@@ -31,6 +31,12 @@ class TestWhatThisEditionClaims:
         """The running side of propagation checks this flag; unclaimed,
         that check would raise instead of standing down."""
         assert BUILT_IN_PROPAGATION in known_flags()
+
+    def test_founding_is_registered(self):
+        """The gate on the Actions square and the founding budgets asks
+        for it on every owner's gang page; unclaimed, that ask would raise
+        instead of standing shut."""
+        assert FOUNDING in known_flags()
 
     def test_the_seam_answers_for_it(self):
         """A slug with no row is off — the same answer the platform gives,


### PR DESCRIPTION
The Actions square, the founding Trade Point budgets on cards and equip screens, and list lines counting Trade Points were shown to staff owners only. This puts them behind a `founding` feature flag instead, so the feature can be previewed by named accounts through the admin's allowlist and later opened to everyone, with no deploy either time.

- `n26/flags.py` registers the `founding` slug.
- `may_see_actions_square` / `may_see_founding` check ownership first, then `enabled(FOUNDING, user)`. The flag is only read for an owner on their own gang; the gang page and the equip page each read it once.
- No flag row is seeded. A registered slug with no row is off, so after deploy nobody sees the feature until the row exists. To preview: admin → Feature flags → add slug `founding`, availability Allowlist, attach a group holding the accounts to admit.
- Tests admit their owner through `admit_to_founding` in `n26/tests/fixtures.py`, which builds the row on the allowlist the way production will; the "owner outside the allowlist" tests replace the "non-staff owner" ones. A new test checks that opening the flag to everyone admits no reader but the owner.

Query cost: an owner's gang page and equip screens pay for the flag row and, on the allowlist, their group membership. The equip page's pinned budget for an owner goes from 52 to 54, measured with the flag row standing. Nobody but the owner pays anything. This read goes away with the gate once the feature is open to everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh