### PR TITLE
docs: require dedicated worktrees in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,10 +303,11 @@ titles, which should freely name model classes, functions and flags.
 ### Before Starting
 
 1. **Use a dedicated git worktree for every task that changes repository files.**
-   Before editing, create a worktree named `<agent-name>-<task>` with a `codex/`
-   branch, or reuse the worktree already assigned to the task. Do this
-   automatically without asking permission. Run edits, tests, and development
-   commands from that worktree. Leave the shared root checkout untouched,
+   Before editing, create a worktree named `<agent-name>-<task>` with a branch
+   prefix matching the agent: `claude/` for Claude, `codex/` for Codex, and the
+   equivalent for other agents. Reuse the worktree already assigned to the task
+   when one exists. Do this automatically without asking permission. Run edits,
+   tests, and development commands from that worktree. Leave the shared root checkout untouched,
    including other agents' uncommitted changes. Read-only investigation can use
    the current checkout. Work in the root checkout or on `main` only when
    explicitly requested or when the operation inherently requires it; explain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,15 @@ titles, which should freely name model classes, functions and flags.
 
 ### Before Starting
 
-1. Create a new branch for the task: `git checkout -b issue-NAME`
+1. **Use a dedicated git worktree for every task that changes repository files.**
+   Before editing, create a worktree named `<agent-name>-<task>` with a `codex/`
+   branch, or reuse the worktree already assigned to the task. Do this
+   automatically without asking permission. Run edits, tests, and development
+   commands from that worktree. Leave the shared root checkout untouched,
+   including other agents' uncommitted changes. Read-only investigation can use
+   the current checkout. Work in the root checkout or on `main` only when
+   explicitly requested or when the operation inherently requires it; explain
+   the reason before proceeding. Small changes are not an exception.
 2. **Start the dev server** (`./scripts/dev.sh`) near the start of any coding session —
    don't wait to be asked. Share the URL (per-worktree port, printed in the startup
    banner) so changes can be tested in the browser as they land.


### PR DESCRIPTION
## Summary

- Replace the branch-only instruction in `CLAUDE.md` with a requirement to create or reuse a dedicated worktree before changing repository files, without asking permission. Branch prefixes match the agent: `claude/` for Claude, `codex/` for Codex, and equivalent prefixes for other agents.
- Require edits, tests and development commands to run there, preserve the shared root checkout, and define exceptions for read-only work and operations that explicitly require the root checkout or `main`.

## Test plan

- [x] Reviewed the diff and ran `git diff --check`.
- [x] Applicable pre-commit hooks passed, including formatting and Markdown lint.
- Application tests and migration checks were not run because this change only updates agent instructions.
