### PR TITLE
fix: FoundingBudget sums spend across every Found and equip gang action

### DIFF
--- a/n26/core/founding.py
+++ b/n26/core/founding.py
@@ -13,13 +13,16 @@ the gang's Found and equip gang action is open. So it is kept the way
 everything else in this edition is kept: what a model may spend is a
 counter reading off its computed card, which content raises and no
 column stores, and what it has spent is the ledger's answer — every
-purchase that recorded the founding action, on that model. A refund
-returns to the same action because its event sits on the assignment the
-purchase made; a sale returns nothing, as it never returns Trade Points.
+purchase that recorded a Found and equip gang action of this gang, on
+that model. A refund returns to the same action because its event sits
+on the assignment the purchase made; a sale returns nothing, as it
+never returns Trade Points.
 
-Closing the action and starting it again gives a fresh figure, which is
-what an owner wants after hiring somebody new: spend is counted per
-action, so the old one's purchases stay on the old one.
+Closing the action and starting it again does not hand the figure back:
+spend is counted across every founding action the gang has opened, so
+what was bought the first time still sits on the allowance. A model
+hired after the first founding closed has spent nothing yet, and meets
+its figure whole.
 """
 
 from dataclasses import dataclass
@@ -82,8 +85,8 @@ class FoundingBudget:
     neither is a second copy of anything.
 
     ``action`` is the gang's open Found and equip gang action — the row
-    a purchase on this screen records, so that what has gone can be
-    summed back off it.
+    a purchase on this screen records. What has gone is every founding
+    action's spend, not only this one's.
     """
 
     action: object
@@ -124,10 +127,10 @@ def budget_for(gang, miniature, computed):
     homebrew one of the same name is not mistaken for it; which actions
     the gang has open — held on the gang, so a purchase on the same
     request reads it again for free — and what this model has already
-    spent under the founding one.
+    spent under every founding action.
     """
     from n26.core.models import Action
-    from n26.core.reconcile import trade_points_spent_by
+    from n26.core.reconcile import trade_points_spent_by_kind
 
     granted = budget_granted(computed)
     if granted <= 0:
@@ -138,7 +141,7 @@ def budget_for(gang, miniature, computed):
     return FoundingBudget(
         action=action,
         granted=granted,
-        spent=trade_points_spent_by(action, miniature),
+        spent=trade_points_spent_by_kind(gang, Action.Kind.FOUNDING, miniature),
     )
 
 
@@ -156,12 +159,12 @@ def budgets_by_model(gang, computed):
 
     A fixed cost for the whole roster rather than a query a fighter: the
     standard counter is asked for once, and what has gone is one sum
-    grouped by whoever spent it. A gang whose books grant no such
-    allowance pays for neither — nothing on any of its cards names the
-    counter.
+    grouped by whoever spent it, across every founding action the gang
+    has opened. A gang whose books grant no such allowance pays for
+    neither — nothing on any of its cards names the counter.
     """
     from n26.core.models import Action
-    from n26.core.reconcile import trade_points_spent_by_model
+    from n26.core.reconcile import trade_points_spent_by_model_for_kind
     from n26.library.standard_content import founding_budget_counter
 
     named = {
@@ -179,7 +182,9 @@ def budgets_by_model(gang, computed):
         return {}
     spent = {
         str(model_id): total
-        for model_id, total in trade_points_spent_by_model(action).items()
+        for model_id, total in trade_points_spent_by_model_for_kind(
+            gang, Action.Kind.FOUNDING
+        ).items()
     }
     budgets = {}
     for model_id, fold in named.items():

--- a/n26/core/reconcile.py
+++ b/n26/core/reconcile.py
@@ -178,6 +178,58 @@ def trade_points_spent_by_model(action):
     return {row[buyer]: row["total"] or 0 for row in spends}
 
 
+def trade_points_spent_by_kind(gang, kind, miniature):
+    """Every Trade Point one model spent against any action of this kind.
+
+    The same sum as :func:`trade_points_spent_by`, widened from one
+    action to every action of that kind the gang has opened. A founding
+    allowance is one allowance however many times the action is opened:
+    completing it and starting again does not hand the figure back.
+
+    Visit spend stays on :func:`trade_points_spent` — a visit that closed
+    loses what it had left, and the next one starts from what the
+    fighters brought.
+
+    One query.
+    """
+    from n26.core.models import LedgerEvent
+
+    return (
+        LedgerEvent.objects.filter(
+            assignment__ledger_entry__action__gang=gang,
+            assignment__ledger_entry__action__kind=kind,
+            assignment__ledger_entry__spent_by=miniature,
+        ).aggregate(total=Sum("trade_points_delta"))["total"]
+        or 0
+    )
+
+
+def trade_points_spent_by_model_for_kind(gang, kind):
+    """What every model has spent against any action of this kind.
+
+    The same sum as :func:`trade_points_spent_by_kind`, asked once for
+    the whole roster rather than once per model.
+
+    Purchases that recorded no buyer are left out rather than gathered
+    under a blank name — nobody's own allowance buys into the stash.
+
+    One query.
+    """
+    from n26.core.models import LedgerEvent
+
+    buyer = "assignment__ledger_entry__spent_by"
+    spends = (
+        LedgerEvent.objects.filter(
+            assignment__ledger_entry__action__gang=gang,
+            assignment__ledger_entry__action__kind=kind,
+            **{f"{buyer}__isnull": False},
+        )
+        .values(buyer)
+        .annotate(total=Sum("trade_points_delta"))
+    )
+    return {row[buyer]: row["total"] or 0 for row in spends}
+
+
 def trade_points_spent(gang):
     """What the gang's open Visit Trading Post action has spent.
 

--- a/n26/core/test_views_founding_budget.py
+++ b/n26/core/test_views_founding_budget.py
@@ -329,6 +329,23 @@ class TestWhatTheScreenSays:
         budget = client.get(equip_url(leader, legacy_list)).context["founding_budget"]
         assert (budget.granted, budget.spent, budget.remaining) == (5, 3, 2)
 
+    def test_starting_the_action_again_leaves_what_was_spent(
+        self, client, gang, tester, leader, legacy_list
+    ):
+        """Completing Found and equip gang and opening it again does not
+        hand the figure back: what this model already spent still sits
+        on the tally."""
+        client.post(
+            equip_url(leader, legacy_list), {"thing": key_of(wargear("Flak plate"))}
+        )
+        with operation(gang, actor=tester) as op:
+            op.close_action(gang.open_action(FOUNDING))
+        with operation(gang, actor=tester) as op:
+            op.open_action(FOUNDING)
+
+        budget = client.get(equip_url(leader, legacy_list)).context["founding_budget"]
+        assert (budget.granted, budget.spent, budget.remaining) == (5, 3, 2)
+
     def test_the_post_being_shut_is_not_mentioned(self, client, leader, post):
         """A model with an allowance has somewhere for its Trade Points to
         go, so there is nothing to tell it about the post."""

--- a/n26/tests/sandbox/test_founding_budget.py
+++ b/n26/tests/sandbox/test_founding_budget.py
@@ -12,12 +12,13 @@ Four claims, and each has a test below:
 * what a model may spend is content — a counter its gang type and its
   affiliation raise — so nothing in the code names a rank or a figure,
   and a model holding two ranks spends the better and not the sum;
-* what it has spent is what points back at the gang's Found and equip
-  gang action, on that model alone;
+* what it has spent is what points back at any of the gang's Found and
+  equip gang actions, on that model alone;
 * a refund returns to the action the purchase counted against, whenever
   it is taken, and a sale returns nothing;
-* completing the action and starting it again gives a fresh figure,
-  because spend is counted per action.
+* completing the action and starting it again remembers what was spent,
+  so the allowance is one allowance however many times the action is
+  opened.
 """
 
 import pytest
@@ -476,12 +477,12 @@ class TestGivingSomethingBack:
         gang.refresh_from_db()
         assert_reconciled(gang)
 
-    def test_a_refund_after_the_action_closed_counts_against_nothing_open(
+    def test_a_refund_after_the_action_closed_returns_to_the_allowance(
         self, gang, leader, legacy_list
     ):
         """The refund lands on the action the purchase counted against,
-        which is complete. Starting again therefore begins at nothing
-        spent rather than at points handed back into it."""
+        which is complete. Starting again still sees those points as
+        returned, because spend is counted across every founding action."""
         bought = buy_at_founding(
             leader, line_for(browse(legacy_list, FOUNDING), "Flak plate")
         )
@@ -497,9 +498,10 @@ class TestGivingSomethingBack:
 
 
 class TestFinishingAndStartingAgain:
-    """Spend is counted per action, so completing one and starting
-    another gives the model its figure back whole. That is how an owner
-    equips somebody hired after the founding was done."""
+    """Spend is counted across every founding action, so completing one
+    and starting another leaves what was bought sitting on the
+    allowance. A model hired after the first founding closed has spent
+    nothing yet, and meets its figure whole."""
 
     def test_a_completed_action_leaves_no_budget(self, gang, leader):
         complete_action(gang, FOUNDING_KIND)
@@ -514,14 +516,41 @@ class TestFinishingAndStartingAgain:
 
         assert reading(leader) == 5
 
-    def test_starting_again_begins_at_nothing_spent(self, gang, leader, legacy_list):
+    def test_starting_again_remembers_what_was_spent(self, gang, leader, legacy_list):
         buy_at_founding(leader, line_for(browse(legacy_list, FOUNDING), "Flak plate"))
         complete_action(gang, FOUNDING_KIND)
 
         start_action(gang, FOUNDING_KIND)
 
-        assert budget(leader).spent == 0
-        assert budget(leader).remaining == 5
+        assert budget(leader).spent == 3
+        assert budget(leader).remaining == 2
+
+    def test_a_later_purchase_adds_to_what_was_already_spent(
+        self, gang, leader, legacy_list
+    ):
+        buy_at_founding(leader, line_for(browse(legacy_list, FOUNDING), "Flak plate"))
+        complete_action(gang, FOUNDING_KIND)
+        start_action(gang, FOUNDING_KIND)
+
+        buy_at_founding(leader, line_for(browse(legacy_list, FOUNDING), "Mesh armour"))
+
+        assert budget(leader).spent == 4
+        assert budget(leader).remaining == 1
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_somebody_hired_after_the_founding_closed_starts_at_nothing_spent(
+        self, gang, leader, hire_into, legacy_list
+    ):
+        buy_at_founding(leader, line_for(browse(legacy_list, FOUNDING), "Flak plate"))
+        complete_action(gang, FOUNDING_KIND)
+        kel = hire_into(gang, ("Venators", "Hunt Champion"), "Kel")
+
+        start_action(gang, FOUNDING_KIND)
+
+        assert budget(leader).spent == 3
+        assert budget(kel).spent == 0
+        assert budget(kel).remaining == 4
 
     def test_the_earlier_actions_purchases_stay_on_it(self, gang, leader, legacy_list):
         first = buy_at_founding(
@@ -977,6 +1006,15 @@ class TestTheRosterReadInOneGo:
         assert card.founding_budget is False
         assert card.trade_points_left is None
 
+    def test_starting_again_leaves_what_was_spent_on_the_card(
+        self, gang, leader, player, legacy_list
+    ):
+        buy_at_founding(leader, line_for(browse(legacy_list, FOUNDING), "Flak plate"))
+        complete_action(gang, FOUNDING_KIND, actor=player)
+        start_action(gang, FOUNDING_KIND, actor=player)
+
+        assert card_for(gang, "Rasp").trade_points_left == 2
+
     def test_spending_past_it_reads_below_nothing(
         self, gang, hire_into, kit, legacy_list
     ):
@@ -995,7 +1033,7 @@ class TestTheRosterReadInOneGo:
     ):
         """Two reads for the allowances however many models carry one:
         the standard counter, asked once for the roster rather than once
-        a model, and what every model has spent under the founding
+        a model, and what every model has spent under every founding
         action. Which actions the gang has open is a third, and the sheet
         pays it for the visit's figure whether or not anybody has an
         allowance.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completing Found and equip gang and starting it again was handing every fighter a fresh personal Trade Points allowance. Spend was counted only against the current open action, so the previous founding's purchases vanished from the tally.

`FoundingBudget` now sums spend across every Found and equip gang action the gang has opened. Remaining carries over when the action is reopened. A fighter hired after the first founding closed still starts from a full figure, because they have spent nothing yet.

Visit Trading Post spend is unchanged: each visit is still its own pot, and unspent points are still lost when it closes.

## How to try it

1. Found a Venator gang, hire a Hunt Leader, and buy something with founding Trade Points (e.g. Flak plate at 3 TP).
2. Complete Found and equip gang, then start it again.
3. The leader's remaining founding TP should still be 2, not 5.
4. Hire a Hunt Champion after the first founding closed, then reopen: they should have a full 4 TP.

[Rasp still has 2 founding TP after completing and restarting Found and equip gang](https://cursor.com/agents/bc-48c33f08-b3c1-5807-8f29-39c99f68d48e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frasp-2tp-after-restart.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQCDVPQ4B/p1788714771678769?thread_ts=1788714771.678769&cid=C0BQCDVPQ4B)

<div><a href="https://cursor.com/agents/bc-48c33f08-b3c1-5807-8f29-39c99f68d48e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48c33f08-b3c1-5807-8f29-39c99f68d48e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

