### PR TITLE
feat: use Collections for gang and archetype hire lists

### DIFF
--- a/n26/core/hire.py
+++ b/n26/core/hire.py
@@ -18,12 +18,16 @@ otherwise-default selection, and a specific combination's card is a
 ``build_card_from_profile(profile, option=[...])`` away. Enumerating the
 combinations is exactly the explosion the groups exist to avoid.
 
-Not every fighter on offer is on a gang list. A collection the gang
-carries can list profiles too — a corruption's Aberrants and Chaos
-Spawn arrive that way — and it offers them at its own prices. Such a
-collection becomes a section of its own, built from the same entries by
-the same functions, with the collection's price standing in for the
-fighter's own (``Offer``, ``collection_offers``).
+The gang list itself is a collection the gang carries, and so is every
+other list of fighters it is offered — a corruption's Aberrants and Chaos
+Spawn arrive that way, at the corruption's own prices. A collection says
+which it is through its default section: named for the gang list's own
+taxonomy section, its fighters are the gang's list and file under the
+rank headings; named anything else, or not at all, they are a block of
+their own. Both are built from the same entries by the same functions,
+with the collection's price standing in for the fighter's own (``Offer``,
+``collection_offers``). A gang carrying no list of its own hires from its
+gang type's profiles.
 
 Query budget, as everywhere: previewing a whole gang list is a fixed
 number of queries whatever its length, and so is a gang's carried
@@ -186,20 +190,29 @@ class HireSection:
 class Offer:
     """One profile on the hire screen, and what put it there.
 
-    A plain listing on a gang's own list is an offer with no collection
-    behind it. A collection the gang carries offers its own entries: the entry
-    naming a profile prices it this collection's way, while a sweep
-    ("every profile homed in Corrupted Beasts") offers it at reference
-    like any listing.
+    Every offer here comes from a collection the gang carries, the gang's
+    own list among them: an entry naming a profile prices it that
+    collection's way, while a sweep ("every profile homed in Corrupted
+    Beasts") offers it at reference. A gang carrying no list of its own
+    is offered its gang type's fighter entries instead, and those offers
+    name no collection.
     """
 
     profile: object
     #: The curated entry that offered this, when one did. A swept profile
     #: has none, exactly as a swept line in a browse has none.
     entry: object = None
-    #: Which collection is offering. None for the gang's own list, whose
-    #: offers answer to no collection.
+    #: Which collection is offering. None where the gang type's own
+    #: fighter entries were the offer, which is what a gang with no list
+    #: of its own hires from.
     collection: object = None
+    #: The name of the offering collection's default section, or None
+    #: where it declares none. On this screen that name is where the
+    #: collection's fighters are filed: "Gang List" files them as the
+    #: gang's own list, under the rank headings; any other name is a
+    #: block of that name; no section at all is a block named after the
+    #: collection.
+    default_section: str | None = None
 
     @property
     def base(self):
@@ -371,9 +384,13 @@ def collection_offers(collections, *, include_staged=False):
     from n26.core import select
     from n26.library.models import CollectionEntry, CollectionSelector, Profile
 
-    ids = [collection.pk for collection in collections]
+    # A collection withdrawn, or not yet put live for this reader, offers
+    # nothing here — the same reading every discovery surface gives
+    # archived and staged content.
+    ids = set(visible_to(collections, include_staged=include_staged))
     if not ids:
         return []
+    collections = [collection for collection in collections if collection.pk in ids]
 
     # An archived entry is a line the list no longer offers, whoever is
     # looking; a staged one is a line it does not offer yet. A staged
@@ -384,17 +401,18 @@ def collection_offers(collections, *, include_staged=False):
     if not include_staged:
         listed = listed.live()
     entries = list(listed.order_by("position"))
-    sweeps = list(
-        CollectionSelector.objects.filter(
-            collection_id__in=ids,
-            of_kind=ContentType.objects.get_for_model(Profile),
-        )
-        .select_related("category")
-        .order_by("position")
-    )
+    # Selectors follow the same visibility rules as explicit entries.
+    swept = CollectionSelector.objects.filter(
+        collection_id__in=ids,
+        of_kind=ContentType.objects.get_for_model(Profile),
+    ).unarchived()
+    if not include_staged:
+        swept = swept.live()
+    sweeps = list(swept.select_related("category").order_by("position"))
     if not entries and not sweeps:
         return []
 
+    sections = default_sections(collections, include_staged=include_staged)
     wanted = Q(pk__in=[entry.profile_id for entry in entries])
     for sweep in sweeps:
         wanted |= sweep.as_selector().as_q(Profile)
@@ -413,7 +431,14 @@ def collection_offers(collections, *, include_staged=False):
             if profile.pk in taken:
                 continue
             taken.add(profile.pk)
-            offers.append(Offer(profile=profile, entry=entry, collection=collection))
+            offers.append(
+                Offer(
+                    profile=profile,
+                    entry=entry,
+                    collection=collection,
+                    default_section=sections.get(collection.pk),
+                )
+            )
         for sweep in sweeps:
             if sweep.collection_id != collection.pk:
                 continue
@@ -429,30 +454,165 @@ def collection_offers(collections, *, include_staged=False):
                     continue
                 if selector.matches(select.Matchable(thing=profile)):
                     taken.add(profile.pk)
-                    offers.append(Offer(profile=profile, collection=collection))
+                    offers.append(
+                        Offer(
+                            profile=profile,
+                            collection=collection,
+                            default_section=sections.get(collection.pk),
+                        )
+                    )
     return offers
 
 
-def collection_sections(offers, with_cards=True):
-    """One section per collection that offers fighters, named after it.
+def visible_to(collections, *, include_staged=False):
+    """Ids of unarchived collections visible to this reader."""
+    return [
+        collection.pk
+        for collection in collections
+        if not collection.archived and (include_staged or not collection.staged)
+    ]
 
-    The collection is the heading because the collection is the offer: a
-    reader knows these fighters by what brought them ("Genestealer Cult
-    Corrupted"), not by which gang type authored them. Inside, the
-    categories are the profiles' own homes, in taxonomy order, cheapest
-    first — the same shape every other section on this screen takes.
+
+def default_sections(collections, *, include_staged=False):
+    """Visible default section names keyed by collection id, in one query."""
+    from n26.library.models import CollectionSection
+
+    ids = visible_to(collections, include_staged=include_staged)
+    if not ids:
+        return {}
+    sections = CollectionSection.objects.filter(
+        collection_id__in=ids, is_default=True
+    ).unarchived()
+    if not include_staged:
+        sections = sections.live()
+    return {section.collection_id: section.name for section in sections}
+
+
+def gang_list_ids(collections, *, include_staged=False, include_archived=False):
+    """Identify fighter collections with a default section named Gang List.
+
+    Entries and selectors establish the collection's purpose even when
+    none currently offer a fighter. Discovery excludes hidden content;
+    the gang sheet includes staged and archived lists to keep them hidden.
+    """
+    from django.contrib.contenttypes.models import ContentType
+    from django.db.models import Exists, OuterRef
+
+    from n26.library.models import (
+        CollectionEntry,
+        CollectionSection,
+        CollectionSelector,
+        Profile,
+    )
+    from n26.library.standard_content import GANG_LIST_SECTION
+
+    ids = (
+        [
+            collection.pk
+            for collection in collections
+            if include_staged or not collection.staged
+        ]
+        if include_archived
+        else visible_to(collections, include_staged=include_staged)
+    )
+    if not ids:
+        return set()
+    holds_fighters = Exists(
+        CollectionEntry.objects.filter(
+            collection=OuterRef("collection"), profile__isnull=False
+        )
+    ) | Exists(
+        CollectionSelector.objects.filter(
+            collection=OuterRef("collection"),
+            of_kind=ContentType.objects.get_for_model(Profile),
+        )
+    )
+    sections = CollectionSection.objects.filter(
+        holds_fighters,
+        collection_id__in=ids,
+        is_default=True,
+        name__iexact=GANG_LIST_SECTION,
+    )
+    if not include_archived:
+        sections = sections.unarchived()
+    if not include_staged:
+        sections = sections.live()
+    return set(sections.values_list("collection_id", flat=True))
+
+
+def gang_scope_sections(
+    offers, gang_type, carried, *, with_cards=True, include_staged=False
+):
+    """Build the gang's hire list followed by additional fighter collections.
+
+    One visible gang-list collection replaces the gang-type fallback and
+    uses taxonomy headings. Multiple lists use their collection names.
+    Count carried lists even when all their entries are hidden: an empty
+    list must neither trigger the fallback nor combine with another list.
+    """
+    lists = gang_list_ids(carried, include_staged=include_staged)
+    own = [offer for offer in offers if offer.collection.pk in lists]
+    extra = [offer for offer in offers if offer.collection.pk not in lists]
+
+    if len(lists) > 1:
+        # No one list, so nothing stands as the list.
+        entries, extra = [], [*own, *extra]
+    elif lists:
+        entries = build_offer_entries(own, with_cards=with_cards)
+    else:
+        entries = build_hire_list(
+            gang_type, with_cards=with_cards, include_staged=include_staged
+        )
+
+    return _one_section_per_name(
+        [
+            *section_hire_list(entries),
+            *collection_sections(extra, with_cards=with_cards, gang_lists=lists),
+        ]
+    )
+
+
+def _one_section_per_name(sections):
+    """Merge matching section and category names, preserving first-seen order.
+
+    The picker identifies sections and categories by name. Duplicate
+    headings must share a block so every entry remains reachable.
+    """
+    merged = {}
+    for section in sections:
+        held = merged.get(section.name)
+        if held is None:
+            merged[section.name] = section
+            continue
+        by_name = {category.name: category for category in held.categories}
+        for category in section.categories:
+            standing = by_name.get(category.name)
+            if standing is None:
+                by_name[category.name] = category
+                held.categories.append(category)
+            else:
+                standing.entries = sorted(
+                    [*standing.entries, *category.entries], key=_entry_order
+                )
+    return list(merged.values())
+
+
+def collection_sections(offers, with_cards=True, gang_lists=frozenset()):
+    """Group extra offers by default section, or by collection name.
+
+    Multiple gang lists use their collection names to distinguish their
+    offers. Categories retain taxonomy order, with cheapest entries first.
     """
     grouped = {}
     for offer in offers:
-        grouped.setdefault(offer.collection.pk, (offer.collection, []))[1].append(offer)
-    sections = []
-    for collection, rows in grouped.values():
-        sections.append(
-            _section_of(
-                str(collection), build_offer_entries(rows, with_cards=with_cards)
-            )
-        )
-    return sections
+        named = offer.default_section
+        if named is None or offer.collection.pk in gang_lists:
+            named = str(offer.collection)
+        grouped.setdefault(named, []).append(offer)
+    return [
+        _section_of(name, build_offer_entries(rows, with_cards=with_cards))
+        for name, rows in grouped.items()
+    ]
 
 
 def preview_model_card(profile, option=None, base=None):

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -27,6 +27,7 @@ from n26.core.status import Status
 from n26.core.status import label_for as status_label
 from n26.library.models import (
     EMPTY_VALUE,
+    Collection,
     Counter,
     Hidden,
     Pickable,
@@ -2162,7 +2163,9 @@ def _provenance_within(card):
     return provenance_of
 
 
-def _gang_rows(gang_card, gang_computed, skipping=frozenset()):
+def _gang_rows(
+    gang_card, gang_computed, skipping=frozenset(), hidden_lists=frozenset()
+):
     """The gang's own rows as lines, same skipping rules as a model card:
     a Hidden draws nothing, a chosen thing is drawn as its choice's row,
     and counters have their own readings. Rules come back as their own list,
@@ -2171,6 +2174,11 @@ def _gang_rows(gang_card, gang_computed, skipping=frozenset()):
     ``skipping`` names nodes drawn elsewhere — what a campaign gave, which
     the sheet draws under the campaign's name rather than among the
     gang's own.
+
+    ``hidden_lists`` names the collections that are the gang's own hire
+    list. That list is what the hire screen *is*, stored or granted, so
+    it draws no line here: the sheet says the same whether a gang's list
+    is written down as a collection or left to its gang type.
 
     What a rule grants the gang folds in from ``ComputedGang`` the way a
     model card folds in its contributions — a named rule with the rules,
@@ -2199,6 +2207,11 @@ def _gang_rows(gang_card, gang_computed, skipping=frozenset()):
         if isinstance(node.assignable, (*DRAWS_NO_LINE, Counter)):
             if not _speaks_for_itself(node, asked_here):
                 continue
+        if (
+            isinstance(node.assignable, Collection)
+            and node.assignable.pk in hidden_lists
+        ):
+            continue
         if isinstance(node.assignable, Rule):
             rules.append(AssignableLine(name=node.name, provenance=provenance_of(node)))
             continue
@@ -2213,6 +2226,9 @@ def _gang_rows(gang_card, gang_computed, skipping=frozenset()):
                     )
                 )
         for contribution in gang_computed.collections:
+            granted = contribution.thing
+            if isinstance(granted, Collection) and granted.pk in hidden_lists:
+                continue
             if contribution.name not in {line.name for line in rows}:
                 rows.append(
                     AssignableLine(
@@ -2221,6 +2237,29 @@ def _gang_rows(gang_card, gang_computed, skipping=frozenset()):
                     )
                 )
     return rows, sorted(rules, key=lambda line: line.name)
+
+
+def _gang_lists_on(gang_card, gang_computed):
+    """The ids of the gang's own hire lists among the collections on its
+    card — stored or granted — so the sheet can leave their lines out.
+
+    Staged and archived lists stay hidden on the sheet, including after
+    archiving a list to restore gang-type hiring. One query for all lists.
+    """
+    from n26.core.hire import gang_list_ids
+
+    held = [
+        node.assignable
+        for node in gang_card.roots
+        if isinstance(node.assignable, Collection)
+    ]
+    if gang_computed:
+        held.extend(
+            contribution.thing
+            for contribution in gang_computed.collections
+            if isinstance(contribution.thing, Collection)
+        )
+    return gang_list_ids(held, include_staged=True, include_archived=True)
 
 
 def _campaign_keys(gang_card, membership):
@@ -2624,7 +2663,12 @@ def render_gang(gang, with_effects=True, *, card=None, for_owner=False):
     # fighter — and nothing at all for a gang whose books grant none, or
     # for a reader the figure is not for.
     budgets = budgets_by_model(gang, computed) if with_effects and for_owner else {}
-    gang_rows, gang_rules = _gang_rows(gang_card, gang_computed, campaign_keys)
+    gang_rows, gang_rules = _gang_rows(
+        gang_card,
+        gang_computed,
+        campaign_keys,
+        _gang_lists_on(gang_card, gang_computed),
+    )
     return GangSheet(
         name=gang.name,
         gang_type=gang.gang_type.name,

--- a/n26/core/views/hire.py
+++ b/n26/core/views/hire.py
@@ -397,9 +397,8 @@ def hire_fighter(request, pk):
     from n26.core.hire import (
         build_entries,
         build_hire_entry,
-        build_hire_list,
         collection_offers,
-        collection_sections,
+        gang_scope_sections,
         hireable_profiles,
         section_by_gang_type,
         section_hire_list,
@@ -423,6 +422,16 @@ def hire_fighter(request, pk):
     dialog = None
 
     @cache
+    def carried():
+        """The collections this gang carries, worked out once.
+
+        Read twice — for what they offer, and for whether any of them is
+        the gang's own list — and it costs a gang card, so the two never
+        build it twice.
+        """
+        return [access.collection for access in gang_collections(gang)]
+
+    @cache
     def offers():
         """What the collections this gang carries offer, worked out once.
 
@@ -431,10 +440,7 @@ def hire_fighter(request, pk):
         scope that draws no collection sections and a click naming no
         entry never build it at all.
         """
-        return collection_offers(
-            [access.collection for access in gang_collections(gang)],
-            include_staged=shown,
-        )
+        return collection_offers(carried(), include_staged=shown)
 
     if request.method == "POST" and "profile" in request.POST:
         form = HireFighterForm(request.POST)
@@ -615,16 +621,17 @@ def hire_fighter(request, pk):
         )
     else:
         # The gang's own list, then a section for each collection it
-        # carries that offers fighters. After the house's own sections
-        # because that is the order they were come by: the list a gang
-        # founds with is what it is, and a corruption's roster is
+        # carries that offers fighters besides. After the house's own
+        # sections because that is the order they were come by: the list a
+        # gang founds with is what it is, and a corruption's roster is
         # something it took on.
-        hire_list = [
-            *section_hire_list(
-                build_hire_list(gang.gang_type, with_cards=False, include_staged=shown)
-            ),
-            *collection_sections(offers(), with_cards=False),
-        ]
+        hire_list = gang_scope_sections(
+            offers(),
+            gang.gang_type,
+            carried(),
+            with_cards=False,
+            include_staged=shown,
+        )
     _link_cards(gang, hire_list)
     prices = [
         entry.base_price for section in hire_list for entry in section.all_entries()

--- a/n26/library/collections.md
+++ b/n26/library/collections.md
@@ -1,0 +1,82 @@
+# Collections
+
+A collection defines a list of content available to a gang or fighter. A house equipment list is the simplest example: it names the items a fighter can buy and any house-specific prices. You can give the same collection to several fighter entries, so you only maintain the list once.
+
+Giving a fighter an equipment collection adds a list to their equip page. It does not give them the equipment itself. The player still chooses and buys the items they want.
+
+Collections also provide the fighters on a hire list and the options for some choices. Start with an equipment list; the later sections explain how those other uses differ.
+
+## Creating an equipment list
+
+Suppose you want to write a house equipment list and make it available to the house's fighters. Create a collection in the content library and leave **Prices its entries** on. This enables the price and restriction fields you need for equipment.
+
+Use **Add an entry** to select an item from the library. Each entry puts that item on this list. Repeat for the other items the house offers.
+
+An entry can override the item's credit price and Trade Point price. Leave either blank to use the corresponding reference price. These overrides belong to the collection: changing a weapon's price here does not change its price on another house's list.
+
+The collection page's preview shows the resulting list and prices. You do not need to create sections for an equipment list; the equip page groups items by their existing library sections and categories.
+
+Once the entries are live, add the collection to a fighter entry's built-in items. Fighters hired from that entry will have the list on their equip page. Add the same collection to the other fighter entries that use it.
+
+For stash access, add a *gives* modifier to the gang type, naming the collection and using the scope **The gang carrying it**. That scope gives access to the stash only.
+
+## Restricting an entry
+
+Sometimes an item appears on a house list with a restriction, such as a heavy rock saw offered only to Forge-born. Put that restriction on the collection entry. You can restrict an entry by profile type, subtype or specific fighter entries.
+
+This restriction applies wherever that collection is used. Restrictions on the item itself still apply too. The listing marks unmet restrictions, but allows the player to buy the item.
+
+A rule can also grant access to a small collection. For example, to offer a familiar to Leaders and Champions, create a collection containing the familiar and give it through a modifier targeting those fighters. You do not need to add it to every house equipment list. Use **All models in the gang** when the modifier should give access across the gang, or **The model carrying it** for one model. The older **The gang carrying it and all models** scope is deprecated.
+
+## Preparing a collection for players
+
+You can stage entries from the authoring pages while you prepare them. Collections and their sections also support staging, but their authoring forms do not offer a staging control. Finish the entries and make them live before assigning a new collection to players.
+
+Collections and entries can be archived. An archived entry no longer appears in the listing.
+
+## Using a collection as a hire list
+
+To create a hire list, add entries for the fighters it offers, with price overrides where needed. Equipment collections each have their own tab; the hire page combines fighters from the gang's collections into one hire listing.
+
+A collection can have its own named sections. On the hire page, the collection's default section determines how the fighters are grouped. For a house's main hire list, add a section named **Gang List** and mark it as the default. The hire page then shows the collection's fighters under the usual rank headings. Capitalisation does not affect the section name's meaning. Then add the collection to the gang type's built-in items.
+
+Add that built-in last, after the entries are live. A collection becomes the gang's main list when it and its default Gang List section are live and the gang is assigned it. If all its entries are staged or archived, players see an empty hire list. A staged collection is hidden from players; staff and players with staged-content access can preview it. Until the gang has a main hire collection, it uses the fighter entries filed under its gang type.
+
+You can also offer extra fighters alongside the main list, such as those available through a corruption. Put them in a separate collection and assign it to the gang through a modifier on the corruption's pickable. Leave that collection without a default section to show the extra fighters *under its collection name*. To use a different heading, create a default section with that name.
+
+The hire page merges groups with the same heading, including categories with the same name inside those groups. Two additional collections with the same default section name therefore appear together. An additional collection can also join an existing hire section by using that section's name. This combines their displayed fighters; the collections remain separate to edit. Two main hire lists each appear under their collection name instead.
+
+| Behaviour | Equipment collections | Hire collections |
+| --- | --- | --- |
+| Browsing several collections | Each collection has its own tab. | Fighters from the gang's collections appear in one hire listing. |
+| Collection sections | Do not affect the equip page's layout. | The default section determines where the fighters appear. |
+| Matching section names | Do not combine collections. | Groups with the same heading merge, as do matching categories within them. |
+| Main list | No special main-list setting. | One collection with a **Gang List** default section uses the usual rank headings. Two main lists each appear under their collection name. |
+
+### Replacing the main list
+
+An archetype such as an Escher Chem Cult can replace the house's hire list. Create the archetype's collection with a default section named **Gang List**. On the archetype's pickable, add two modifiers with scope **The gang carrying it**: *takes something away* for the house list, and *gives* for the archetype's list.
+
+If you leave both lists assigned, the hire page shows them as separate groups named after their collections. See “Gang archetypes” in [Recipes](/n26/authoring/docs/recipes/) for the slot setup.
+
+## Sections for skills and powers
+
+Skill access is the reason collections need sections and placements. The same skill set can be Primary for one fighter and Secondary for another. The skills belong to a single collection; what changes is where their category appears for each fighter.
+
+The standard Skills & Powers collection automatically includes every skill and power. Skill sets and power families are library categories. Primary, Secondary and Other are sections within this collection.
+
+A **placement** is a modifier effect that puts a category in a collection section for the fighters it targets. If Agility is Primary for a fighter, add a placement to their fighter entry that puts the Agility category in Primary. Subtypes can add placements too, such as access to power families. This lets you build each fighter's skill access from the same collection.
+
+An *offers a choice* modifier can then use one of those sections. A choice of skill from Primary offers skills from the categories placed there for that fighter. The same mechanism supports choices of power or subtype; other choices, such as Chaos gods and gang archetypes, use picklists.
+
+Placements group content already in the collection; they do not add content to it. Categories without a placement go into the collection's default section, or under “Other” if none is set. A choice from the default section therefore includes unplaced categories too. If two placements assign the same category to different sections, the section with the lowest position wins.
+
+The skill selection page uses the fighter's placements to determine which collections and sections to show. You do not assign Skills & Powers as you would an equipment list. Unplaced sets appear only if the fighter's placements include the default section. Without any placements, the page has no skills to select.
+
+## The Trading Post
+
+The standard Trading Post is another collection, but it appears on every equip page without being assigned. It automatically includes weapons, wargear and weapon accessories with a Trade Point price. You can add an entry to override the price of an included item.
+
+During a trading trip, **Exclusive** items appear only if the collection has an explicit entry for them, marked **E**. Creating another collection called Trading Post does not replace the standard N26 Trading Post.
+
+As with any collection, its prices are separate from how the player pays. The purchase screen controls budgets and Trade Point spending, so the same collection can be browsed as an equipment list or a trading trip.

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -170,7 +170,17 @@ Both print on the card under their own headings. They arrive built in, given by 
 
 *A named list of content: an equipment list, a trading post, a menu.*
 
+See [Collections](/n26/authoring/docs/collections/) for how to create equipment lists, hire lists and skill access.
+
 One field of its own: **prices its entries** — turned off for a menu, where nothing is for sale and the entries are simply choices.
+
+On the hire screen, a collection of fighters is grouped according to its default section:
+
+- Default section named **Gang List**: the collection becomes the gang's main hire list, with fighters grouped under the usual rank headings. The collection appears on the hire screen and is hidden from the gang sheet. Capitalisation does not affect the section name's meaning.
+- Default section named anything else: fighters appear under that heading, after the gang's main list.
+- No default section: fighters appear under the collection's name. Use this for a corruption's extra fighters.
+
+A gang archetype replaces the house's collection with another whose default section is also named Gang List. A gang with no visible main hire collection hires from its gang type's fighter entries. If two main hire collections are assigned, each appears under its own collection name. This keeps their entries and prices separate.
 
 It contains things in two ways: manual **entries** (hand-picked items, optionally at this list's own price, and optionally narrowed to who *this list* offers the item to — the "(Forge-born only)" case) and **selectors** (rules like "every weapon", at their usual prices). An entry always beats a selector for the same item.
 

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -53,7 +53,8 @@ Once a gang carries that collection, its hire page shows a section named
 after the collection. The section lists exactly those fighters at the
 prices the collection states: the price written on an entry is the price
 the gang is charged. A gang without the corruption does not see that
-section.
+section. To show a different name, give the collection one section,
+marked default, with the name you want.
 
 **The Wyrd upgrade.** Create a "Wyrd" **subtype** carrying two modifiers:
 *offers a choice* of power from the right Wyrd Powers list, and *puts a
@@ -109,6 +110,79 @@ fighters' cards were given rules of their own. Everything the hidden
 item granted goes with it. Remove the corruption and it all comes back.
 Starting Skills and Skill Access live on the fighter entries, so they
 are not affected either way.
+
+## Gang archetypes
+
+Use this recipe when an archetype replaces a house's fighter list, such as an Escher Chem Cult. You will create a house hire collection, an archetype hire collection, and an optional choice on the gang. You will add modifiers to the archetype's pickable to replace the house's lists.
+
+Prepare the content using a test gang type and test gang before adding it to a house used by players. The Outcast **Archetype** is a separate choice; create a **Gang Archetype** slot type for this setup.
+
+### Create the house's hire collection
+
+Live content is available to players. Staged content is available only to staff and players with staged-content access. Prepare the new content as staged wherever the authoring pages offer that setting.
+
+1. Create a **collection** named "Escher Gang List". Leave **Prices its entries** on.
+2. Add a **section** named "Gang List" and mark it as the default. This name makes a fighter collection the main hire list. Capitalisation does not affect its meaning.
+3. Add an **entry** for every fighter available to an ordinary Escher gang. Select the existing fighter entries from the library. Leave the price override blank to use the fighter's reference price, or enter this list's price.
+4. Add the completed collection to your test gang type's **built-in items**. Found a test gang and check its hire page. It should offer exactly the listed fighters under their rank headings, at the listed prices.
+
+A gang without a visible main hire collection uses the fighter entries filed under its gang type. Once the gang has a live collection with a live default Gang List section, the collection determines which fighters appear on that main list. A fighter added to the house later also needs an entry in the collection.
+
+### Create each archetype's hire collection
+
+1. Create "Chem Cults Gang List" as a second **collection**, with **Prices its entries** on and a default section named "Gang List".
+2. Add an **entry** for every fighter the archetype hires. A fighter available on both lists needs an entry in each collection. Set any archetype-specific price on the entry in the archetype collection.
+3. Create a **slot type** named "Gang Archetype" and turn **Allows repeats** off. Create this once, then reuse it for every house and archetype in this setup.
+4. Create a **pickable** named "Chem Cults" belonging to that slot type.
+5. On the Chem Cults pickable, add a modifier with scope **The gang carrying it** and effect **Takes something away**. Select Escher Gang List.
+6. Add a second modifier to the pickable with the same scope and effect **Gives something**. Select Chem Cults Gang List.
+
+Add both modifiers to replace the house's hire collection. Giving the archetype list without taking the house list away leaves two main lists. The hire page then shows each under its collection name.
+
+Keep existing fighters filed under their current gang types while preparing the collections. Before filing archetype-only fighters under their house, check that the house's gangs have received their main hire collection. Otherwise, ordinary gangs without a main hire collection can hire those fighters through their gang type. Include those fighters only in the archetype's collection.
+
+### Add the optional choice to the gang
+
+Do this once per house. Further archetypes need a collection and pickable of their own, then a member in the house's existing picklist.
+
+1. Create a **picklist** named "Escher Gang Archetypes", using the Gang Archetype slot type. Add Chem Cults as a member. Include only archetypes available to Escher; other houses use their own picklists.
+2. Create a **slot** named "Escher Gang Archetype" using the Gang Archetype slot type and Escher Gang Archetypes picklist. Set **Label** to "Gang archetype", **Min picks** to 0, **Max picks** to 1, and **Assigned to** to **the gang**. Leave **Hidden** off.
+3. On the test gang type, add a modifier with scope **The gang carrying it** and effect **Gives something**. Select the Escher Gang Archetype slot. The gang sheet now has a Gang archetype choice.
+
+Leave the slot empty for an ordinary Escher gang. You do not need a pickable for this option.
+
+### Replace the equipment lists
+
+Skip this section if the archetype uses the house's existing equipment lists. Otherwise, create the archetype's equipment collection and add the items and prices it offers. For a fighter with its own list, such as a Chem Cult Death-Maiden, create that equipment collection too.
+
+Check the collections in the house fighters' built-in items and the collection available to the stash. These are the collections the modifiers must remove. If a fighter already has a separate house equipment list, remove that list for that fighter rather than leaving it alongside the replacement.
+
+Add the following pairs of modifiers to the archetype's pickable:
+
+1. **All fighters:** use scope **All models in the gang** for both modifiers. **Takes something away** names the house equipment collection; **Gives something** names the archetype's equipment collection.
+2. **The stash:** use scope **The gang carrying it** for both modifiers, with the same two equipment collections.
+3. **A fighter with its own list:** use scope **All models in the gang** for both modifiers. Add an **Is profile** condition and select the library fighter in **Profiles**, not its collection entry. **Takes something away** names the archetype's general equipment collection; **Gives something** names the fighter's equipment collection.
+
+The fighter and stash swaps need separate pairs. Changing only the gang's collection changes stash access and leaves the fighters' equipment lists unchanged. Fighters keep equipment they already own.
+
+### Check the content before making it available
+
+Entries can be staged from the authoring pages. Staff and players with staged-content access can preview them. Collections and their sections also support staging, although their authoring forms do not offer a staging control.
+
+**Put all required content live before adding the house collection to the real gang type.** Open **Staged content** from the library index and use **Put live** for this setup's new fighters, equipment, collection entries, pickables and picklist members. Review the list before using **Put everything live**, because it also releases other authors' staged work. Slots, picklists and modifiers have no staging control; test them before attaching them to a live gang type. A live main collection with all its entries staged or archived gives players an empty hire list. A staged collection is hidden from players without staged-content access, so it does not replace their gang-type fallback.
+
+Check these steps on your test gang:
+
+1. Leave Gang archetype empty. Check the house's fighters, prices, fighter equipment lists and stash equipment list.
+2. Select Chem Cults. Check that its fighters replace the house list and excluded fighters disappear. Fighters on both lists should use the archetype's prices.
+3. Hire a fighter whose price differs between the lists. Check the amount paid and the fighter's rating.
+4. If equipment lists change, check an ordinary fighter, a fighter with its own list, and the stash.
+5. Clear the archetype. Check that the house's hire and equipment lists return and hired fighters keep their equipment.
+6. Check the gang sheet. The archetype choice should appear; the main hire collections should not.
+
+When those checks pass, add the house collection to the real gang type's built-in items and add the modifier that gives its archetype slot. Check both a newly founded gang and an existing active gang. On each hire page, check the offered fighters and collection prices, then select the archetype and check the replacement. The main hire collection is hidden on the gang sheet, so that sheet cannot confirm access. If an existing gang has not updated, ask a maintainer to check the built-in update. Archived gangs need the maintainer's **Built-ins backfill** before they can rely on the new collection. Finish these checks before changing where archetype-only fighters are filed.
+
+If you archive the main hire collection, gangs can again hire fighters listed under their gang type. The collection stays hidden on the gang sheet. Check the gang type's fighter entries before using this fallback: it can include fighters that the collection excluded.
 
 ## A Gang Legacy
 

--- a/n26/library/views.py
+++ b/n26/library/views.py
@@ -1355,6 +1355,11 @@ DOCS = {
         "recipes.md",
         "Step-by-step walkthroughs of whole rulebook setups.",
     ),
+    "collections": (
+        "Collections",
+        "collections.md",
+        "How to create equipment lists, hire lists and skill access.",
+    ),
     "staged": (
         "Staged content",
         "staged.md",

--- a/n26/tests/sandbox/test_authoring_views.py
+++ b/n26/tests/sandbox/test_authoring_views.py
@@ -7037,6 +7037,30 @@ class TestTheDocumentation:
         assert "Recipes" in body
         assert "one card per kind, with its fields and behaviour" in body
 
+    def test_the_index_names_the_collections_page(self, author, client, default_pack):
+        body = client.get("/n26/authoring/docs/").content.decode()
+        assert "/n26/authoring/docs/collections/" in body
+        assert "Collections" in body
+
+    def test_an_author_reads_the_rendered_collections_page(
+        self, author, client, default_pack
+    ):
+        """The one page that explains the kind end to end, so it has to
+        reach every use a collection is put to."""
+        body = client.get("/n26/authoring/docs/collections/").content.decode()
+        for heading in [
+            "Creating an equipment list",
+            "Restricting an entry",
+            "Preparing a collection for players",
+            "Using a collection as a hire list",
+            "Replacing the main list",
+            "Sections for skills and powers",
+            "The Trading Post",
+        ]:
+            assert heading in body, heading
+        assert "## Sections" not in body
+        assert re.search(r"<h1[^>]*>\s*Collections", body)
+
     def test_the_library_index_points_at_the_documentation(
         self, author, client, default_pack
     ):

--- a/n26/tests/sandbox/test_gang_archetypes.py
+++ b/n26/tests/sandbox/test_gang_archetypes.py
@@ -1,0 +1,815 @@
+"""Collection-based gang hire lists and archetype swaps.
+
+Escher and Chem Cults use different fighter lists and prices. These tests
+cover choosing the archetype, hiring from its list, equipment-list swaps,
+visibility, section grouping, and gang-sheet rendering.
+
+Design: `design/collections.md`.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from n26.core.access import collections_for, gang_collections
+from n26.core.card import build_gang_card, build_modifier_index
+from n26.core.effects import compute_gang
+from n26.core.reconcile import assert_reconciled
+from n26.core.render import render_gang, roster
+from n26.core.render_text import render_gang_sheet
+from n26.core.views.equip import buyable_lists
+from n26.library.models import Profile
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    add_entry,
+    assign,
+    choose,
+    create_category,
+    create_collection,
+    create_gang_type,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_slot,
+    create_slot_type,
+    create_wargear,
+    ef_adds,
+    ef_removes,
+    found_gang,
+    hire,
+    is_profile,
+    modifier,
+    section_of,
+    targets_every_model,
+    targets_gang,
+    targets_gang_alone,
+)
+
+pytestmark = pytest.mark.django_db
+
+#: The house's fighter entries: what each is called, what it costs, and
+#: which of the gang list's headings it prints under. Pinned as a table
+#: so a reader can see at a glance which of them each list keeps.
+ESCHER = [
+    ("Queen", 145, "Leader"),
+    ("Matriarch", 120, "Champion"),
+    ("Death-Maiden", 115, "Champion"),
+    ("Gang Sister", 55, "Ganger"),
+    ("Chem Wytch", 60, "Ganger"),
+]
+
+#: Vanilla Escher's list. Chem Wytch is authored under the house — she is
+#: an Escher fighter, printed in the Escher pages — and simply is not on
+#: the list an ordinary Escher gang hires from.
+HOUSE_LIST = ["Queen", "Matriarch", "Death-Maiden", "Gang Sister"]
+
+#: The Chem Cults list. Two entries it shares with the house, one it
+#: alone offers, and two of the house's it drops.
+CHEM_LIST = ["Death-Maiden", "Gang Sister", "Chem Wytch"]
+
+#: What a Chem Cult pays for a Death-Maiden, where the house pays 115.
+CHEM_MAIDEN_PRICE = 130
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def headings(db):
+    """The gang list's own headings — Leader, Champion, Ganger — so the
+    sections a reader sees are the taxonomy's and not this test's."""
+    return {
+        name: create_category("Gang List", name, position=position)
+        for position, name in enumerate(["Leader", "Champion", "Ganger"])
+    }
+
+
+@pytest.fixture
+def escher(db):
+    return create_gang_type("Escher", starting_credits=1000)
+
+
+@pytest.fixture
+def equipment(db):
+    """Three equipment lists: the house's, the archetype's, and the one
+    the archetype gives its Death-Maidens alone.
+
+    Each holds a piece of gear, because a buying screen offers a
+    collection for what it contains: a list holding nothing to buy is
+    not somewhere to buy from, however it was come by.
+    """
+    made = {}
+    for key, name, gear in [
+        ("house", "Escher Equipment List", "Mesh armour"),
+        ("chem", "Chem Cults Equipment List", "Chem-thrower"),
+        ("maiden", "Chem Cults Death-Maiden Equipment List", "Chem-blade"),
+    ]:
+        collection = create_collection(name)
+        add_entry(collection, create_wargear(gear, price=20))
+        made[key] = collection
+    return made
+
+
+@pytest.fixture
+def profiles(escher, headings, person_type, make_statline, equipment):
+    """Every Escher fighter entry, each carrying the house equipment list
+    in its built-ins — the way a house list reaches a fighter."""
+    made = {}
+    for name, price, heading in ESCHER:
+        profile = create_profile(
+            name, person_type, escher, price=price, category=headings[heading]
+        )
+        make_statline(profile, movement=5, weapon_skill=3, toughness=3)
+        add_built_in(profile, equipment["house"])
+        made[name] = profile
+    return made
+
+
+@pytest.fixture
+def house_list(profiles):
+    """The gang list the house comes with: a collection of its fighter
+    entries whose default section is "Gang List", which is what files its
+    fighters as the gang's list rather than as a roster the gang took on."""
+    collection = create_collection("Escher Gang List")
+    section_of(collection, "Gang List", 0, is_default=True)
+    for name in HOUSE_LIST:
+        add_entry(collection, profiles[name])
+    return collection
+
+
+@pytest.fixture
+def chem_list(profiles):
+    """The Chem Cults list, which prices its Death-Maiden its own way."""
+    collection = create_collection("Chem Cults Gang List")
+    section_of(collection, "Gang List", 0, is_default=True)
+    for name in CHEM_LIST:
+        add_entry(
+            collection,
+            profiles[name],
+            **({"price_override": CHEM_MAIDEN_PRICE} if name == "Death-Maiden" else {}),
+        )
+    return collection
+
+
+@pytest.fixture
+def house(escher, house_list, equipment):
+    """What founding an Escher gang brings: its list of fighters and its
+    equipment list, both built into the gang type."""
+    add_built_in(escher, house_list)
+    modifier(
+        "Escher, the gang alone: adds Escher Equipment List",
+        targets_gang_alone(),
+        ef_adds(equipment["house"]),
+        carried_by=escher,
+    )
+    return escher
+
+
+@pytest.fixture
+def archetype_slot(db):
+    """The question a house asks: which archetype, or none. Optional, at
+    most one, and answered by the gang rather than by any one fighter."""
+    slot_type = create_slot_type("Gang Archetype", allows_repeats=False)
+    chem = create_pickable("Chem Cults", slot_type)
+    picklist = create_picklist("Escher Gang Archetypes", slot_type, members=[chem])
+    slot = create_slot(
+        "Gang Archetype",
+        slot_type,
+        picklist,
+        label="Gang Archetype",
+        min_picks=0,
+        max_picks=1,
+        assigned_to="gang",
+    )
+    return {"pickable": chem, "slot": slot}
+
+
+@pytest.fixture
+def chem_cults(house, archetype_slot, chem_list, house_list, equipment, profiles):
+    """The Chem Cults archetype, written out in full.
+
+    Eight rows, in three pairs and a pair: the list it hires from, the
+    list the gang itself buys from, the list its fighters buy from, and
+    the one its Death-Maidens buy from instead. Each pair takes one
+    collection away and gives another, which is the whole of an
+    archetype.
+    """
+    pickable = archetype_slot["pickable"]
+    modifier(
+        "Escher: the gang is asked its Gang Archetype",
+        targets_gang(),
+        ef_adds(archetype_slot["slot"]),
+        carried_by=house,
+    )
+    maiden = is_profile(profiles["Death-Maiden"])
+    for name, scope, effect in [
+        (
+            "the gang stops hiring from the Escher list",
+            targets_gang_alone(),
+            ef_removes(house_list),
+        ),
+        (
+            "the gang hires from the Chem Cults list",
+            targets_gang_alone(),
+            ef_adds(chem_list),
+        ),
+        (
+            "the gang stops buying from the Escher list",
+            targets_gang_alone(),
+            ef_removes(equipment["house"]),
+        ),
+        (
+            "the gang buys from the Chem Cults list",
+            targets_gang_alone(),
+            ef_adds(equipment["chem"]),
+        ),
+        (
+            "its fighters stop buying from the Escher list",
+            targets_every_model(),
+            ef_removes(equipment["house"]),
+        ),
+        (
+            "its fighters buy from the Chem Cults list",
+            targets_every_model(),
+            ef_adds(equipment["chem"]),
+        ),
+        (
+            "its Death-Maidens stop buying from the Chem Cults list",
+            targets_every_model(maiden),
+            ef_removes(equipment["chem"]),
+        ),
+        (
+            "its Death-Maidens buy from their own list",
+            targets_every_model(is_profile(profiles["Death-Maiden"])),
+            ef_adds(equipment["maiden"]),
+        ),
+    ]:
+        modifier(f"Chem Cults: {name}", scope, effect, carried_by=pickable)
+    return pickable
+
+
+@pytest.fixture
+def gang(house, owner):
+    return found_gang("The Ashen Choir", house, owner=owner, budget=2000)
+
+
+def hire_url(gang):
+    return reverse("n26-hire-fighter", args=[gang.pk])
+
+
+def screen(client, gang, owner):
+    client.force_login(owner)
+    return client.get(hire_url(gang))
+
+
+def offered(response):
+    """Every fighter the screen offers, by the heading it is filed under."""
+    return {
+        (section.name, category.name): [entry.name for entry in category.entries]
+        for section in response.context["hire_list"]
+        for category in section.categories
+    }
+
+
+def offered_names(response):
+    return sorted(
+        entry.name
+        for section in response.context["hire_list"]
+        for entry in section.all_entries()
+    )
+
+
+def sections_of(response):
+    return [section.name for section in response.context["hire_list"]]
+
+
+def row(response, name):
+    return next(
+        entry
+        for section in response.context["hire_list"]
+        for entry in section.all_entries()
+        if entry.name == name
+    )
+
+
+def take_the_archetype(gang, pickable):
+    """Answer the gang's own open question, as the picker's press does."""
+    card = build_gang_card(gang, with_statlines=False)
+    computed = compute_gang(
+        card, build_modifier_index([node.assignable for node in card.all_nodes()])
+    )
+    asked = next(
+        choice for choice in computed.choices if choice.kind_label == "Gang Archetype"
+    )
+    return choose(asked.anchor.assignment, pickable, slot=asked.slot)
+
+
+def lists_for(miniature):
+    """What this fighter may buy from, as the equip screen decides it.
+
+    Not every collection a fighter carries is somewhere to buy kit: a
+    gang list is a list of fighters, and the screens ask what a
+    collection *holds* rather than how it was come by. So the gang list
+    riding a member's card never offers itself as somewhere to buy kit.
+    """
+    return sorted(
+        str(collection)
+        for collection in buyable_lists(
+            access.collection for access in collections_for(miniature)
+        )
+    )
+
+
+def gang_lists_for(gang):
+    return sorted(access.name for access in gang_collections(gang))
+
+
+class TestTheListAGangCarries:
+    """A gang hires from the list it carries, and the screen draws that
+    list as its own — not as a section named after a collection."""
+
+    def test_the_house_list_arrives_with_the_gang_type(self, client, owner, gang):
+        response = screen(client, gang, owner)
+        assert offered_names(response) == sorted(HOUSE_LIST)
+
+    def test_its_fighters_sit_under_the_headings_the_taxonomy_gives(
+        self, client, owner, gang
+    ):
+        response = screen(client, gang, owner)
+        assert offered(response) == {
+            ("Gang List", "Leader"): ["Queen"],
+            ("Gang List", "Champion"): ["Death-Maiden", "Matriarch"],
+            ("Gang List", "Ganger"): ["Gang Sister"],
+        }
+        # The collection is not a heading anywhere on the screen: it is
+        # the list, so naming it would be naming the page.
+        assert "Escher Gang List" not in sections_of(response)
+        assert "Escher Gang List" not in response.content.decode()
+
+    def test_a_fighter_the_list_leaves_off_is_not_offered(self, client, owner, gang):
+        """Chem Wytch is an Escher profile and perfectly hireable. She is
+        simply not on this gang's list, which is what a list is for — and
+        is why an archetype's own fighters need no gang type of their own
+        to hide behind."""
+        response = screen(client, gang, owner)
+        assert "Chem Wytch" not in offered_names(response)
+
+    def test_a_list_that_offers_nothing_is_still_the_list(
+        self, client, owner, gang, house_list, profiles
+    ):
+        """Carrying an empty list means an empty list.
+
+        Archive every entry — or stage them while the next book is
+        written — and the list offers nobody. Falling back to the gang
+        type's profiles there would hand the gang the very fighters its
+        list exists to leave out, at prices the list never set.
+        """
+        for entry in house_list.entries.all():
+            entry.archive()
+
+        response = screen(client, gang, owner)
+        assert offered_names(response) == []
+        assert "Chem Wytch" not in response.content.decode()
+
+    def test_a_gang_type_with_no_list_of_its_own_offers_its_profiles(
+        self, client, owner, escher, profiles
+    ):
+        """Until a house's list is written down, its gang type's own
+        fighters are the list, so a house nobody has written down yet
+        hires from its gang type's fighter entries."""
+        plain = found_gang("The Unwritten", escher, owner=owner, budget=1000)
+        response = screen(client, plain, owner)
+        assert offered_names(response) == sorted(name for name, _, _ in ESCHER)
+
+
+class TestAnArchetypeSwapsTheList:
+    """Picking an archetype puts its list where the house's was."""
+
+    def test_the_archetypes_list_replaces_the_houses(
+        self, client, owner, gang, chem_cults
+    ):
+        take_the_archetype(gang, chem_cults)
+        response = screen(client, gang, owner)
+        assert offered_names(response) == sorted(CHEM_LIST)
+
+    def test_the_screen_reads_the_same_way_it_did(
+        self, client, owner, gang, chem_cults
+    ):
+        """The fighters change and the page does not: the same headings,
+        no section named after either collection."""
+        take_the_archetype(gang, chem_cults)
+        response = screen(client, gang, owner)
+        assert offered(response) == {
+            ("Gang List", "Champion"): ["Death-Maiden"],
+            # Cheapest first within a heading, as everywhere on this
+            # screen: a Gang Sister is 55 and a Chem Wytch 60.
+            ("Gang List", "Ganger"): ["Gang Sister", "Chem Wytch"],
+        }
+        assert "Chem Cults Gang List" not in sections_of(response)
+
+    def test_the_list_prices_its_own_rows(self, client, owner, gang, chem_cults):
+        """A Chem Cult's Death-Maiden costs what the Chem Cults list says,
+        not what the fighter is written at."""
+        take_the_archetype(gang, chem_cults)
+        response = screen(client, gang, owner)
+        assert row(response, "Death-Maiden").base_price == CHEM_MAIDEN_PRICE
+        assert f"{CHEM_MAIDEN_PRICE}¢" in response.content.decode()
+
+    def test_a_fighter_only_the_archetype_offers_can_be_hired(
+        self, client, owner, gang, chem_cults
+    ):
+        take_the_archetype(gang, chem_cults)
+        client.force_login(owner)
+        response = screen(client, gang, owner)
+        key = row(response, "Chem Wytch").key
+
+        client.post(hire_url(gang), {"profile": key, "name": "Sela"})
+
+        assert [str(member) for member in roster(gang)] == ["Sela"]
+        # At the archetype's price, not the fighter's own: the offer the
+        # row was made under is what the books record.
+        hired = next(member for member in roster(gang) if str(member) == "Sela")
+        assert hired.membership.ledger_entry.paid == 60
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_hiring_uses_the_archetypes_price_for_payment_and_rating(
+        self, client, owner, gang, chem_cults
+    ):
+        take_the_archetype(gang, chem_cults)
+        response = screen(client, gang, owner)
+        key = row(response, "Death-Maiden").key
+
+        response = client.post(hire_url(gang), {"profile": key, "name": "Ilyanna"})
+
+        assert response.status_code == 302
+        hired = next(member for member in roster(gang) if str(member) == "Ilyanna")
+        assert hired.membership.ledger_entry.paid == CHEM_MAIDEN_PRICE
+        gang.refresh_from_db()
+        assert gang.rating == CHEM_MAIDEN_PRICE
+        assert_reconciled(gang)
+
+    def test_a_gang_that_picks_nothing_keeps_the_house_list(
+        self, client, owner, gang, chem_cults, profiles
+    ):
+        """The archetype is written and unpicked, so the gang hires and
+        buys as any gang of its house does."""
+        response = screen(client, gang, owner)
+        assert offered_names(response) == sorted(HOUSE_LIST)
+
+        queen = hire(gang, profiles["Queen"], "Yara", paid=145)
+        assert lists_for(queen) == ["Escher Equipment List"]
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+
+class TestTwoListsAtOnce:
+    """A gang holding two gang lists has no one list, and the screen says
+    so rather than merging them."""
+
+    def test_each_stands_under_its_own_name(
+        self, client, owner, gang, chem_list, profiles
+    ):
+        """The author's likeliest slip: giving the archetype's list
+        without taking the house's away. Merged, Death-Maiden would sit
+        under one heading twice at two prices with nothing to tell the
+        rows apart, so instead each list is drawn under its own name.
+        """
+        assign(chem_list, gang=gang)
+
+        response = screen(client, gang, owner)
+        assert sections_of(response) == [
+            "Escher Gang List",
+            "Chem Cults Gang List",
+        ]
+        assert row(response, "Chem Wytch").base_price == 60
+
+    @pytest.mark.parametrize("entry_state", ["archived", "staged"])
+    def test_an_empty_second_list_still_uses_collection_headings(
+        self, client, owner, gang, chem_list, entry_state
+    ):
+        assign(chem_list, gang=gang)
+        chem_list.entries.update(**{entry_state: True})
+
+        response = screen(client, gang, owner)
+
+        assert sections_of(response) == ["Escher Gang List"]
+        assert offered_names(response) == sorted(HOUSE_LIST)
+
+    @pytest.mark.parametrize("collection_state", ["archived", "staged"])
+    def test_a_hidden_second_collection_does_not_change_the_live_list(
+        self, client, owner, gang, chem_list, collection_state
+    ):
+        assign(chem_list, gang=gang)
+        setattr(chem_list, collection_state, True)
+        chem_list.save(update_fields=[collection_state])
+
+        response = screen(client, gang, owner)
+
+        assert sections_of(response) == ["Gang List"]
+        assert offered_names(response) == sorted(HOUSE_LIST)
+
+
+class TestWhatElseAGangIsOffered:
+    """A collection of fighters that does not name the gang list is an
+    addition to whatever list the gang has, drawn as a block of its own."""
+
+    def test_a_roster_with_no_section_is_a_block_named_after_itself(
+        self, client, owner, gang, profiles
+    ):
+        """A roster authored with no sections at all, which is how every
+        corruption's roster is written."""
+        extra = create_collection("Genestealer Cult Corrupted")
+        add_entry(extra, profiles["Chem Wytch"], price_override=200)
+        assign(extra, gang=gang)
+
+        response = screen(client, gang, owner)
+        assert sections_of(response)[-1] == "Genestealer Cult Corrupted"
+        assert row(response, "Chem Wytch").base_price == 200
+        # And the gang's own list is untouched beneath it.
+        assert offered(response)[("Gang List", "Leader")] == ["Queen"]
+
+    def test_a_roster_naming_its_own_section_is_a_block_of_that_name(
+        self, client, owner, gang, profiles
+    ):
+        """An author may give the block a name other than the
+        collection's: the default section is what the screen reads."""
+        extra = create_collection("Genestealer Cult Corrupted Fighter Additions")
+        section_of(extra, "Genestealer Cult Corrupted", 0, is_default=True)
+        add_entry(extra, profiles["Chem Wytch"], price_override=200)
+        assign(extra, gang=gang)
+
+        response = screen(client, gang, owner)
+        assert sections_of(response)[-1] == "Genestealer Cult Corrupted"
+        assert "Fighter Additions" not in sections_of(response)
+
+
+class TestTheEquipmentListsFollow:
+    """An archetype changes what its gang buys from, fighter by fighter,
+    and the gang's own list for the stash along with them."""
+
+    @pytest.fixture
+    def hired(self, gang, profiles, chem_cults):
+        maiden = hire(gang, profiles["Death-Maiden"], "Ilyanna", paid=115)
+        sister = hire(gang, profiles["Gang Sister"], "Vasha", paid=55)
+        take_the_archetype(gang, chem_cults)
+        return gang, maiden, sister
+
+    def test_an_ordinary_fighter_buys_from_the_archetypes_list(self, hired):
+        _, _, sister = hired
+        assert lists_for(sister) == ["Chem Cults Equipment List"]
+
+    def test_a_fighter_the_archetype_names_buys_from_her_own(self, hired):
+        _, maiden, _ = hired
+        assert lists_for(maiden) == ["Chem Cults Death-Maiden Equipment List"]
+
+    def test_the_gang_itself_buys_from_the_archetypes_list(self, hired):
+        """The stash buys from the archetype's list too, which takes its
+        own pair of rows — a swap written for the fighters alone leaves
+        the gang still buying from the house list it no longer has."""
+        gang, _, _ = hired
+        assert [
+            str(collection)
+            for collection in buyable_lists(
+                access.collection for access in gang_collections(gang)
+            )
+        ] == ["Chem Cults Equipment List"]
+        # And what it hires from has moved with it.
+        assert "Chem Cults Gang List" in gang_lists_for(gang)
+        assert "Escher Gang List" not in gang_lists_for(gang)
+
+    def test_the_books_still_balance(self, hired):
+        gang, _, _ = hired
+        assert_reconciled(gang)
+
+
+class TestWhatTheScreenCosts:
+    """Reading the list off the gang's card costs a fixed number of
+    queries, however many fighters the list holds."""
+
+    def test_the_screen_costs_the_same_however_long_the_list_is(
+        self, client, owner, gang, house_list, profiles, person_type, headings
+    ):
+        client.force_login(owner)
+        # Once to warm whatever a first visit settles — the reading being
+        # taken is what a length costs, not what a cold cache does.
+        client.get(hire_url(gang))
+        with CaptureQueriesContext(connection) as short:
+            client.get(hire_url(gang))
+
+        for index in range(6):
+            extra = create_profile(
+                f"Sister {index}",
+                person_type,
+                gang.gang_type,
+                price=50,
+                category=headings["Ganger"],
+            )
+            add_entry(house_list, extra)
+
+        with CaptureQueriesContext(connection) as long:
+            response = client.get(hire_url(gang))
+
+        assert len(offered_names(response)) == len(HOUSE_LIST) + 6
+        assert len(long) == len(short)
+
+
+class TestAListNobodyMaySeeIsNotTheList:
+    """A gang list that is staged, or archived, is not a list this reader
+    hires from — so it must not switch the fallback off and leave them
+    with an empty tab. Staff, who see staged content, are offered from
+    it: that is how an author rehearses a house's list before it goes
+    live, while every player goes on hiring from the gang type."""
+
+    @staticmethod
+    def rehearsal(escher, profiles, owner):
+        """The house list authored the way the authoring pages author
+        everything: staged, with a staged section and staged entries —
+        and a gang of the house founded on top of it."""
+        collection = create_collection("Escher Gang List", staged=True)
+        section_of(collection, "Gang List", 0, is_default=True, staged=True)
+        for name in HOUSE_LIST:
+            add_entry(collection, profiles[name], staged=True)
+        add_built_in(escher, collection)
+        return found_gang("The Rehearsal", escher, owner=owner, budget=1000)
+
+    def test_a_player_still_hires_from_the_gang_type(
+        self, client, owner, escher, profiles, equipment
+    ):
+        gang = self.rehearsal(escher, profiles, owner)
+        response = screen(client, gang, owner)
+        assert offered_names(response) == sorted(name for name, _, _ in ESCHER)
+
+    def test_a_staff_reader_is_offered_from_the_staged_list(
+        self, client, escher, profiles, equipment
+    ):
+        staff = User.objects.create_user("author", is_staff=True)
+        gang = self.rehearsal(escher, profiles, staff)
+        response = screen(client, gang, staff)
+        assert offered_names(response) == sorted(HOUSE_LIST)
+
+    def test_an_archived_list_is_not_the_list_either(
+        self, client, owner, gang, house_list
+    ):
+        house_list.archive()
+        response = screen(client, gang, owner)
+        assert offered_names(response) == sorted(name for name, _, _ in ESCHER)
+
+
+class TestWhatCountsAsTheGangListsName:
+    """The default section's name is matched the way section names are
+    kept unique — without regard to case — and only on a collection that
+    holds fighters."""
+
+    def test_the_name_is_read_however_it_is_cased(
+        self, client, owner, escher, profiles
+    ):
+        collection = create_collection("Escher Gang List")
+        section_of(collection, "gang list", 0, is_default=True)
+        for name in HOUSE_LIST:
+            add_entry(collection, profiles[name])
+        add_built_in(escher, collection)
+        gang = found_gang("The Lower Case", escher, owner=owner, budget=1000)
+
+        response = screen(client, gang, owner)
+        assert offered_names(response) == sorted(HOUSE_LIST)
+        assert sections_of(response) == ["Gang List"]
+
+    def test_a_list_of_gear_by_that_name_is_nobodys_gang_list(
+        self, client, owner, escher, profiles
+    ):
+        """A gear list given the section name by mistake must not switch
+        the gang type's fighters off and leave an empty tab."""
+        gear = create_collection("Oddly named kit")
+        section_of(gear, "Gang List", 0, is_default=True)
+        add_entry(gear, create_wargear("Odd knife", price=10))
+        add_built_in(escher, gear)
+        gang = found_gang("The Unlucky", escher, owner=owner, budget=1000)
+
+        response = screen(client, gang, owner)
+        assert offered_names(response) == sorted(name for name, _, _ in ESCHER)
+
+
+class TestSectionsThatShareAName:
+    """Two sections reading alike would be one tab with half its rows
+    unreachable, so they become one section."""
+
+    def test_a_block_named_after_a_taxonomy_section_joins_it(
+        self, client, owner, gang, house_list, escher, person_type, make_statline
+    ):
+        """The house list reaches two taxonomy sections, and a carried
+        collection names the second as its own block. The block and the
+        section are one heading, holding both sets of rows."""
+        hanger = create_category("Hangers-on", "Shivver", position=0)
+        shivver = create_profile(
+            "Shivver", person_type, escher, price=80, category=hanger
+        )
+        make_statline(shivver, movement=5, weapon_skill=4, toughness=3)
+        add_entry(house_list, shivver)
+
+        extra = create_collection("A friend of the gang")
+        section_of(extra, "Hangers-on", 0, is_default=True)
+        hired_gun = create_profile(
+            "Hired gun", person_type, escher, price=95, category=hanger
+        )
+        make_statline(hired_gun, movement=5, weapon_skill=3, toughness=3)
+        add_entry(extra, hired_gun, price_override=200)
+        assign(extra, gang=gang)
+
+        response = screen(client, gang, owner)
+        names = sections_of(response)
+        assert names == ["Gang List", "Hangers-on"], names
+        merged = next(
+            section
+            for section in response.context["hire_list"]
+            if section.name == "Hangers-on"
+        )
+        headings = [category.name for category in merged.categories]
+        assert len(headings) == len(set(headings)), headings
+        # One heading, both the list's fighter and the collection's.
+        assert sorted(
+            entry.name
+            for section in response.context["hire_list"]
+            if section.name == "Hangers-on"
+            for entry in section.all_entries()
+        ) == ["Hired gun", "Shivver"]
+        assert row(response, "Hired gun").base_price == 200
+
+
+class TestTheGangSheetDrawsNoLineForTheList:
+    """The gang's hire list is what the hire screen *is*, so it draws no
+    line on the gang sheet: a gang whose house gains a written-down list,
+    or whose archetype swaps one for another, draws the same rows
+    either way. Its equipment list, which is somewhere to buy from, keeps
+    its line."""
+
+    def test_a_carried_list_is_not_a_row_on_the_sheet(self, gang):
+        names = [line.name for line in render_gang(gang).rows]
+        assert "Escher Gang List" not in names
+        assert "Escher Equipment List" in names
+
+    def test_nor_is_the_list_an_archetype_gives(self, gang, chem_cults):
+        take_the_archetype(gang, chem_cults)
+        names = [line.name for line in render_gang(gang).rows]
+        assert "Chem Cults Gang List" not in names
+        assert "Escher Gang List" not in names
+
+    def test_the_text_sheet_says_nothing_of_it_either(self, gang):
+        text = render_gang_sheet(render_gang(gang))
+        assert "Gang List" not in text
+
+    @pytest.mark.parametrize("with_effects", [True, False])
+    def test_an_archived_list_stays_hidden_when_hiring_falls_back(
+        self, client, owner, gang, house_list, with_effects
+    ):
+        house_list.archive()
+
+        sheet = render_gang(gang, with_effects=with_effects)
+        assert "Escher Gang List" not in [line.name for line in sheet.rows]
+        assert "Escher Gang List" not in render_gang_sheet(sheet)
+        if with_effects:
+            assert "Escher Equipment List" in [line.name for line in sheet.rows]
+        assert offered_names(screen(client, gang, owner)) == sorted(
+            name for name, _, _ in ESCHER
+        )
+
+    def test_an_archived_granted_list_stays_hidden(self, gang, chem_cults, chem_list):
+        take_the_archetype(gang, chem_cults)
+        chem_list.archive()
+
+        sheet = render_gang(gang)
+
+        assert "Chem Cults Gang List" not in [line.name for line in sheet.rows]
+        assert "Chem Cults Gang List" not in render_gang_sheet(sheet)
+
+    def test_a_list_with_an_archived_default_section_stays_hidden(
+        self, gang, house_list
+    ):
+        house_list.sections.get(is_default=True).archive()
+
+        assert "Escher Gang List" not in [line.name for line in render_gang(gang).rows]
+
+
+class TestASweepThatWasWithdrawn:
+    """A sweep is content like the entries beside it: archived, it
+    gathers nobody, and staged, it gathers nobody for a player."""
+
+    def test_an_archived_sweep_offers_none_of_its_fighters(
+        self, client, owner, gang, profiles, headings
+    ):
+        swept = create_collection(
+            "Corrupted beasts", contains=[(Profile, headings["Ganger"])]
+        )
+        section_of(swept, "Corrupted beasts", 0, is_default=True)
+        assign(swept, gang=gang)
+
+        response = screen(client, gang, owner)
+        assert "Corrupted beasts" in sections_of(response)
+
+        swept.selectors.get().archive()
+        response = screen(client, gang, owner)
+        assert "Corrupted beasts" not in sections_of(response)


### PR DESCRIPTION
The n26 hire page can use a carried `Collection` as the gang's main fighter list. This lets an archetype replace the house list, omit fighters, and set its own prices using the existing remove/give modifiers.

A fighter collection with a default section named **Gang List** supplies the main list under the fighters' rank headings. Gangs without a visible main collection keep hiring from their gang type's profiles. An empty live list stays empty; it does not restore excluded fighters through the fallback. If two main lists are carried, each appears under its collection name.

Collection offers respect staging and archiving. Main hire collections stay hidden on the gang sheet, including after archiving a collection to restore fallback hiring. Additional fighter collections continue to use their own headings, with matching sections and categories merged.

The recipe gives the complete authoring sequence: both hire collections, the shared slot type, per-house picklist and optional gang slot, remove/give modifiers, fighter and stash equipment swaps, publishing staged content, and checks on new and existing gangs. This PR adds no migrations, authored house lists, or content backfill. Existing gangs keep the current hire list until a main collection is authored and assigned.

Validation:

- Full suite: **10,349 passed, 12 skipped, 1 expected failure** (`pytest -n 4`).
- Author documentation tests: **14 passed** after completing the recipe.
- Formatting and pre-commit checks.
- Browser check on an isolated content mirror: house list → archetype list → house list, hiring at the archetype's overridden price, and ledger reconciliation.
- Fallback output compared with the original renderer across all 22 gang types in the local mirror.

To try it, follow **Gang archetypes** in `/n26/authoring/docs/recipes/`. The collection reference is at `/n26/authoring/docs/collections/`.
