### PR TITLE
fix: offer Refund for a purchase that paid Trade Points on a gang with no credit budget

### DIFF
--- a/n26/core/card.py
+++ b/n26/core/card.py
@@ -125,10 +125,36 @@ class Node:
             return bool(entry.paid or entry.trade_points or entry.rating_contribution)
         return bool(self.rating)
 
+    @property
+    def paid_trade_points(self):
+        """Whether a founding allowance paid for this line.
+
+        The question a gang with no credit budget asks before offering a
+        refund. Credits mean nothing to such a gang, so what a refund
+        gives it back is its models' Trade Points and nothing else — and
+        a line none of them paid for has nothing to return.
+
+        Asked of everything hanging off the line too, because a refund
+        takes the whole of it: a gun bought in credits, carrying
+        ammunition an allowance paid for, still has points behind it.
+
+        Free, whatever it walks — the card is in memory and each entry
+        arrived with its assignment. A card built from the library alone
+        keeps no ledger and so has nothing to return.
+        """
+        return any(_paid_trade_points(node) for node in self.walk())
+
     def walk(self):
         yield self
         for child in self.children:
             yield from child.walk()
+
+
+def _paid_trade_points(node):
+    """Whether Trade Points were handed over for this one line."""
+    assignment = node.assignment
+    entry = getattr(assignment, "ledger_entry", None) if assignment else None
+    return entry is not None and bool(entry.trade_points)
 
 
 def node_for(assignment):

--- a/n26/core/listing.py
+++ b/n26/core/listing.py
@@ -397,10 +397,11 @@ def copy_row(copy, refunds=True):
     Takes an :class:`n26.core.owned.OwnedThing`, which already knows where
     each of its controls leads; this says what each of them means.
 
-    ``refunds`` is whether Refund is offered at all. A gang founded
-    without a budget never paid credits, so there is nothing a refund
-    could give back — its rows offer Remove alone, exactly as its
-    fighter cards offer Delete without Refund.
+    ``refunds`` is whether the gang refunds in credits at all. A gang
+    founded without a budget has no credits to give back, so its copies
+    offer Remove alone — unless this particular one took Trade Points out
+    of its buyer's founding allowance, which a refund does return. That
+    is what ``paid_trade_points`` on the copy says, and either is enough.
     """
     return OwnedCopyRow(
         id=copy.id,
@@ -434,7 +435,7 @@ def copy_row(copy, refunds=True):
                     ),
                     *(
                         (Action("Refund", LINK, part.refund_href, SECONDARY),)
-                        if refunds
+                        if refunds or part.paid_trade_points
                         else ()
                     ),
                     Action("Remove", LINK, part.remove_href, DANGER),
@@ -470,7 +471,7 @@ def copy_row(copy, refunds=True):
             Action("Reassign", LINK, copy.reassign_href, SECONDARY),
             *(
                 (Action("Refund", LINK, copy.refund_href, SECONDARY),)
-                if refunds
+                if refunds or copy.paid_trade_points
                 else ()
             ),
             Action("Delete", LINK, copy.remove_href, DANGER),
@@ -526,8 +527,9 @@ def build_catalogue(view, owned, name=None, refunds=True, expanded_key=""):
     keyed the way rows are keyed — so the join is one dictionary read per
     row, however much the fighter is carrying and however long the list.
 
-    ``refunds`` rides down to every owned copy: a gang with no budget is
-    offered no Refund anywhere in the catalogue.
+    ``refunds`` rides down to every owned copy: a gang with no budget
+    refunds no credits, so a copy is offered Refund only where it took
+    Trade Points out of a founding allowance.
 
     Sections keep the order and the shape the browse gave them, with one
     substitution: a section the content left unnamed is called

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -126,6 +126,10 @@ def refund_of(assignment):
     refunded on this one. That is a different number from a sale's, which
     is half of what the thing is *worth*, and the two part company the
     moment anything is discounted or given away.
+
+    Credits alone. What the same purchases took out of a model's founding
+    allowance is :func:`trade_points_refund_of`, and one purchase may have
+    taken both.
     """
     rows = [row for row in [assignment, *subtree(assignment)] if not row.archived]
     paid = sum(
@@ -134,6 +138,52 @@ def refund_of(assignment):
         if (entry := getattr(row, "ledger_entry", None)) is not None
     )
     return rows, paid
+
+
+def trade_points_in(assignments):
+    """The Trade Points these assignments were bought with.
+
+    Takes what :func:`refund_of` already gathered, so a screen wanting
+    both figures walks the subtree once.
+    """
+    return sum(
+        entry.trade_points
+        for assignment in assignments
+        if (entry := getattr(assignment, "ledger_entry", None)) is not None
+    )
+
+
+def trade_points_refund_of(assignment):
+    """The Trade Points refunding this would give back.
+
+    The other half of :func:`refund_of`, over the same assignments. A
+    purchase made while the gang's Found and equip gang action was open
+    came off the buyer's founding allowance, and undoing it puts them
+    back.
+
+    A gang founded with no credit budget hands over nothing else, so this
+    is the whole of what a refund of one of its purchases returns — which
+    is why a screen asks it before deciding whether to offer the act.
+    """
+    return trade_points_in(refund_of(assignment)[0])
+
+
+def trade_points_carried_by(miniature):
+    """The Trade Points still riding on everything this model holds.
+
+    The same total a full refund of the model would give back — its hire,
+    what the hire brought, and every piece of kit bought since — asked as
+    one query rather than a walk per line, because the screens that ask
+    it only want to know whether to offer the act.
+    """
+    from django.db.models import Sum
+
+    return (
+        Assignment.objects.filter(miniature_root=miniature, archived=False).aggregate(
+            total=Sum("ledger_entry__trade_points")
+        )["total"]
+        or 0
+    )
 
 
 class Refusal(Exception):
@@ -1034,16 +1084,20 @@ class Operation:
         """Take something back and return what was paid for it.
 
         Removal and refund are deliberately different acts: ``remove``
-        archives and keeps the money spent; this archives the same subtree
-        *and* gives the credits back. ``sell`` is the third of them, and
-        returns half of what the thing is worth rather than what was paid.
+        archives and keeps what was spent; this archives the same subtree
+        *and* gives it back. ``sell`` is the third of them, and returns
+        half of what the thing is worth rather than what was paid.
+
+        Credits and Trade Points both count as having been paid, so a
+        purchase that took nothing but Trade Points is refunded like any
+        other. Only a line nobody handed anything over for is simply
+        removed.
 
         Each refunded line's entry is settled to zero with a matching
         event, so folding the events still reproduces the entry and the
-        gang's recomputed credits rise by exactly what was returned. Lines
-        nobody paid for are simply removed. Trade Points come back the
-        same way, and a refund taken on the same trip as the purchase
-        puts them back in the allowance; once a new allowance is set,
+        gang's recomputed credits rise by exactly what was returned. A
+        refund taken on the same trip as the purchase puts the Trade
+        Points back in the allowance; once a new allowance is set,
         neither the spending nor its undoing counts any more — the trip
         a refund belongs to is the trip the purchase belonged to, not
         whenever the owner got round to handing it back.
@@ -1061,7 +1115,7 @@ class Operation:
             target.save(update_fields=["archived", "archived_at", "modified"])
 
             entry = getattr(target, "ledger_entry", None)
-            if entry is None or entry.paid == 0:
+            if entry is None or not (entry.paid or entry.trade_points):
                 self.event(target, LedgerEvent.Kind.REMOVED, note=note)
                 continue
             self.event(

--- a/n26/core/owned.py
+++ b/n26/core/owned.py
@@ -151,6 +151,10 @@ class OwnedPart:
     sell_href: str
     refund_href: str
     remove_href: str
+    #: Whether a founding allowance paid for this copy or anything hung
+    #: off it. A gang with no credit budget refunds nothing else, so this
+    #: is what says whether the act is worth offering there.
+    paid_trade_points: bool = False
     #: Where to go to take this off and leave the fighter holding it.
     #: Empty for a firing line, and for a sight the gun came with.
     detach_href: str = ""
@@ -176,6 +180,10 @@ class OwnedThing:
     reassign_href: str
     refund_href: str
     remove_href: str
+    #: Whether a founding allowance paid for this copy or anything hung
+    #: off it. A gang with no credit budget refunds nothing else, so this
+    #: is what says whether the act is worth offering there.
+    paid_trade_points: bool = False
     #: Where to go to bolt something onto this. Only a weapon has one:
     #: an accessory hangs off the gun it changes, so nothing else on a
     #: card is somewhere to fit one.
@@ -274,6 +282,7 @@ def _parts_of(node, at, *, can_refit=False):
                 sell_href=with_query(at, sell=pk),
                 refund_href=with_query(at, refund=pk),
                 remove_href=with_query(at, remove=pk),
+                paid_trade_points=child.paid_trade_points,
                 detach_href=with_query(at, detach=pk) if unbolt else "",
                 fit_href=(with_query(at, fit=pk) if unbolt and can_refit else ""),
             )
@@ -355,6 +364,7 @@ def possessions(host: EquipHost):
                 reassign_href=with_query(at, reassign=pk),
                 refund_href=with_query(at, refund=pk),
                 remove_href=with_query(at, remove=pk),
+                paid_trade_points=node.paid_trade_points,
                 accessorise_href=(
                     with_query(at, accessorise=pk)
                     if isinstance(node.assignable, Weapon)

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -875,6 +875,10 @@ class StashLine:
     id: str = ""
     #: An accessory moves onto a weapon rather than a model.
     is_accessory: bool = False
+    #: Whether a founding allowance paid for this line or anything hung
+    #: off it. A gang with no credit budget refunds nothing else, so this
+    #: is what says whether the act is worth offering there.
+    paid_trade_points: bool = False
     #: What can happen to this line, each a link to a dialog on the page
     #: that drew it — see ``n26.core.views.owned.link_stash_actions``.
     #: Empty is a name with nothing to click, which is what a print-out
@@ -2531,6 +2535,7 @@ def stash_lines(gang_card):
             provenance=stash_provenance(node),
             id=str(node.assignment.pk) if node.assignment is not None else "",
             is_accessory=isinstance(node.assignable, WeaponAccessory),
+            paid_trade_points=node.paid_trade_points,
         )
         for node in gang_card.stash_roots
         # No row of its own is the kind's whole contract — a chosen

--- a/n26/core/templates/cotton/n26/owned_dialog.html
+++ b/n26/core/templates/cotton/n26/owned_dialog.html
@@ -93,10 +93,7 @@ itself.
             gang, undoing the purchase.
         {% else %}
             It and anything attached to it are permanently removed from the gang.
-            No credits are returned.
-            {% if dialog.can_refund %}
-                Use Refund instead to recover the amount paid.
-            {% endif %}
+            {{ dialog.remove_note }}
         {% endif %}
     </c-slot>
 

--- a/n26/core/templates/n26/fighter_edit.html
+++ b/n26/core/templates/n26/fighter_edit.html
@@ -100,7 +100,7 @@ is named by the page's own heading directly below.
                         Clone model
                     </c-ui.dropdown.item>
                 {% endif %}
-                {% if not gang.credits_unlimited %}
+                {% if may_refund %}
                     <c-ui.dropdown.item href="{% url 'n26-gang' gang.pk %}?refund={{ miniature.pk }}">
                         Refund
                     </c-ui.dropdown.item>

--- a/n26/core/templates/n26/gang_sheet.html
+++ b/n26/core/templates/n26/gang_sheet.html
@@ -326,7 +326,7 @@ that said it twice would be spending the width the name needs.
                 {% if leaving.stashable %}
                     <c-slot name="actions">
                         <c-ui.button type="submit" name="kit" value="stash" size="md">
-                            Stash their kit, then delete
+                            {{ leaving.stash_label }}
                         </c-ui.button>
                     </c-slot>
                 {% endif %}
@@ -335,7 +335,7 @@ that said it twice would be spending the width the name needs.
             <c-n26.dialog title="Refund {{ leaving.miniature.name }}?"
                           action="{% url 'n26-refund-fighter' leaving.miniature.pk %}"
                           cancel_url="{% url 'n26-gang' gang.pk %}"
-                          submit_label="Refund everything — {{ leaving.full_paid }}¢">
+                          submit_label="Refund everything — {{ leaving.full_returned }}">
                 <c-slot name="lead">
                     What was actually paid comes back — free and granted
                     things return nothing. They leave the roster with
@@ -345,7 +345,7 @@ that said it twice would be spending the width the name needs.
                 {% if leaving.stashable %}
                     <c-slot name="actions">
                         <c-ui.button type="submit" name="kit" value="stash" size="md">
-                            Stash kit, refund {{ leaving.fighter_paid }}¢
+                            {{ leaving.stash_label }}
                         </c-ui.button>
                     </c-slot>
                 {% endif %}

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1625,7 +1625,9 @@ def test_a_gang_with_no_budget_is_offered_no_refund(
     ).content.decode()
     assert "Delete" in asked
     assert "Refund" not in asked
-    assert "No credits are returned." in asked
+    # Not "no credits are returned": this gang counts none either way, so
+    # the sentence says the plain thing instead of naming money.
+    assert "Nothing comes back." in asked
 
 
 @pytest.fixture

--- a/n26/core/test_views_equip.py
+++ b/n26/core/test_views_equip.py
@@ -1522,7 +1522,7 @@ def test_a_refund_names_what_was_paid_and_not_its_rating(
     ).content.decode()
     copy = " ".join(body.split())
 
-    assert "5¢ comes back — the amount paid, not its rating." in copy
+    assert "You get 5¢ back — the amount paid, not its rating." in copy
     assert (
         "It and anything attached to it are removed from the gang, undoing the purchase."
         in copy

--- a/n26/core/test_views_founding_budget.py
+++ b/n26/core/test_views_founding_budget.py
@@ -15,6 +15,7 @@ database.
 
 import pytest
 from django.contrib.auth.models import User
+from django.contrib.messages import get_messages
 from django.urls import reverse
 
 from n26.core.models import Action, Assignment, Gang
@@ -753,3 +754,180 @@ class TestTheQueryBudget:
         assert len(self.reads_counter(asked)) == 1
         assert len(self.reads_actions(asked)) == 1
         assert self.reads_spend(asked) == []
+
+
+def acts_on(response, assignment):
+    """The labels in one held copy's more-menu, off the drawn catalogue.
+
+    None where the screen draws no copy for that assignment at all.
+    """
+    for row in response.context["catalogue"].all_rows():
+        for copy in getattr(row, "copies", ()):
+            if copy.id == str(assignment.pk):
+                return [act.label for act in copy.more]
+    return None
+
+
+class TestAGangFoundedWithNoBudget:
+    """Credits are not all a founding purchase spends.
+
+    A gang founded with the budget box left blank counts no credits, so a
+    refund gives it none back and every surface offers Delete in place of
+    Refund. Its models still have founding allowances, though, and a
+    purchase that took Trade Points out of one is undone by handing them
+    back — which only a refund does.
+    """
+
+    @pytest.fixture
+    def gang(self, venators, tester):
+        """Founded the way the create screen founds one when the owner
+        says they will spend as much as they like."""
+        gang = Gang.objects.create(
+            name="The Long Hunt",
+            owner=tester,
+            gang_type=venators,
+            starting_credits=None,
+            credits=0,
+        )
+        with operation(gang, actor=tester) as op:
+            op.found(venators)
+        return gang
+
+    @pytest.fixture(autouse=True)
+    def signed_in(self, client, tester):
+        client.force_login(tester)
+
+    @pytest.fixture
+    def plate(self, client, gang, leader, legacy_list):
+        """Flak plate, off the leader's founding allowance: 3 Trade
+        Points, and credits this gang does not count."""
+        client.post(
+            equip_url(leader, legacy_list), {"thing": key_of(wargear("Flak plate"))}
+        )
+        return bought(gang, "Flak plate")
+
+    @pytest.fixture
+    def banner(self, client, gang, leader, legacy_list):
+        """The Exclusive line, which carries no Trade Point figure, so
+        no allowance paid anything for it."""
+        client.post(
+            equip_url(leader, legacy_list), {"thing": key_of(wargear("Hunt banner"))}
+        )
+        return bought(gang, "Hunt banner")
+
+    def test_the_equip_page_offers_a_refund_for_the_copy(
+        self, client, leader, legacy_list, plate
+    ):
+        response = client.get(equip_url(leader, legacy_list))
+
+        assert "Refund" in acts_on(response, plate)
+
+    def test_a_copy_no_allowance_paid_for_is_offered_removal_alone(
+        self, client, leader, legacy_list, banner
+    ):
+        response = client.get(equip_url(leader, legacy_list))
+
+        acts = acts_on(response, banner)
+        assert "Refund" not in acts
+        assert "Delete" in acts
+
+    def test_the_dialog_for_the_copy_is_a_refund_and_not_a_removal(
+        self, client, leader, legacy_list, plate
+    ):
+        response = client.get(f"{equip_url(leader, legacy_list)}&refund={plate.pk}")
+
+        dialog = response.context["dialog"]
+        assert dialog["kind"] == "refund"
+        assert dialog["trade_points"] == 3
+        # No credits figure: this gang counts none, so promising one
+        # would name a number that never moves.
+        assert dialog["proceeds"] == 0
+        assert dialog["sum"] == (
+            "You get 3 Trade Points back — the amount paid, not its rating."
+        )
+
+    def test_the_dialog_for_a_copy_no_allowance_paid_for_asks_to_remove(
+        self, client, leader, legacy_list, banner
+    ):
+        response = client.get(f"{equip_url(leader, legacy_list)}&refund={banner.pk}")
+
+        dialog = response.context["dialog"]
+        assert dialog["kind"] == "remove"
+        assert dialog["can_refund"] is False
+
+    def test_refunding_the_copy_returns_the_trade_points(
+        self, client, leader, legacy_list, plate
+    ):
+        before = client.get(equip_url(leader, legacy_list)).context["founding_budget"]
+        assert (before.spent, before.remaining) == (3, 2)
+
+        response = client.post(reverse("n26-refund", args=[plate.pk]))
+
+        after = client.get(equip_url(leader, legacy_list)).context["founding_budget"]
+        assert (after.spent, after.remaining) == (0, 5)
+        assert [str(message) for message in get_messages(response.wsgi_request)] == [
+            "Refunded Flak plate — 3 Trade Points back."
+        ]
+
+    def test_removing_the_copy_leaves_the_trade_points_spent(
+        self, client, leader, legacy_list, plate
+    ):
+        """Removal keeps its meaning: the thing goes and nothing comes
+        back."""
+        client.post(reverse("n26-remove", args=[plate.pk]))
+
+        after = client.get(equip_url(leader, legacy_list)).context["founding_budget"]
+        assert (after.spent, after.remaining) == (3, 2)
+
+    def test_the_edit_menu_offers_a_refund_of_the_model(self, client, leader, plate):
+        body = client.get(
+            reverse("n26-edit-fighter", args=[leader.pk])
+        ).content.decode()
+
+        assert f"?refund={leader.pk}" in body
+
+    def test_a_model_no_allowance_paid_for_is_offered_deletion_alone(
+        self, client, ganger
+    ):
+        body = client.get(
+            reverse("n26-edit-fighter", args=[ganger.pk])
+        ).content.decode()
+
+        assert f"?refund={ganger.pk}" not in body
+        assert f"?delete={ganger.pk}" in body
+
+    def test_the_model_dialog_promises_the_trade_points(
+        self, client, gang, leader, plate
+    ):
+        url = reverse("n26-gang", args=[gang.pk])
+
+        leaving = client.get(f"{url}?refund={leader.pk}").context["leaving"]
+
+        assert leaving["kind"] == "refund"
+        assert leaving["full_returned"] == "3 Trade Points"
+        # Stashing the plate keeps its Trade Points spent and the hire
+        # itself returns nothing this gang counts, so the second button
+        # names no figure rather than promising a zero.
+        assert leaving["stash_label"] == "Stash their kit, then refund"
+
+    def test_refunding_the_model_returns_their_trade_points(
+        self, client, gang, leader, plate
+    ):
+        from n26.core.reconcile import trade_points_spent_for
+
+        response = client.post(reverse("n26-refund-fighter", args=[leader.pk]))
+
+        assert trade_points_spent_for(gang.open_action(FOUNDING)) == 0
+        # The last of them: the purchase this undoes left one of its own,
+        # and nothing has drawn a page to read them off since.
+        said = [str(message) for message in get_messages(response.wsgi_request)]
+        assert said[-1] == "Refunded Rasp — 3 Trade Points back."
+
+    def test_deleting_the_model_leaves_the_trade_points_spent(
+        self, client, gang, leader, plate
+    ):
+        from n26.core.reconcile import trade_points_spent_for
+
+        client.post(reverse("n26-delete-fighter", args=[leader.pk]))
+
+        assert trade_points_spent_for(gang.open_action(FOUNDING)) == 3

--- a/n26/core/test_views_founding_budget.py
+++ b/n26/core/test_views_founding_budget.py
@@ -853,7 +853,24 @@ class TestAGangFoundedWithNoBudget:
 
         dialog = response.context["dialog"]
         assert dialog["kind"] == "remove"
-        assert dialog["can_refund"] is False
+        # Nothing to point the reader at: this gang counts no credits and
+        # no allowance paid for the banner.
+        assert dialog["remove_note"] == "Nothing comes back."
+
+    def test_the_removal_panel_points_at_the_trade_points_and_not_at_credits(
+        self, client, leader, legacy_list, plate
+    ):
+        """The reader is deciding between Delete and Refund. Telling them
+        to recover the amount paid would name money this gang has none
+        of, so the sentence names what Refund would actually give."""
+        response = client.get(f"{equip_url(leader, legacy_list)}&remove={plate.pk}")
+
+        note = response.context["dialog"]["remove_note"]
+        assert note == (
+            "Nothing comes back. Use Refund instead to get 3 Trade Points back."
+        )
+        assert "amount paid" not in note
+        assert "¢" not in note
 
     def test_refunding_the_copy_returns_the_trade_points(
         self, client, leader, legacy_list, plate
@@ -922,6 +939,22 @@ class TestAGangFoundedWithNoBudget:
         # and nothing has drawn a page to read them off since.
         said = [str(message) for message in get_messages(response.wsgi_request)]
         assert said[-1] == "Refunded Rasp — 3 Trade Points back."
+
+    def test_refunding_the_model_but_stashing_the_kit_returns_nothing(
+        self, client, gang, leader, plate
+    ):
+        """Stashing keeps what was paid for the kit, so a model whose
+        only Trade Points rode the kit hands nothing back. The message
+        says what happened rather than promising a zero back."""
+        from n26.core.reconcile import trade_points_spent_for
+
+        response = client.post(
+            reverse("n26-refund-fighter", args=[leader.pk]), {"kit": "stash"}
+        )
+
+        assert trade_points_spent_for(gang.open_action(FOUNDING)) == 3
+        said = [str(message) for message in get_messages(response.wsgi_request)]
+        assert said[-1] == "Deleted Rasp. Their kit is in the stash (1 line)."
 
     def test_deleting_the_model_leaves_the_trade_points_spent(
         self, client, gang, leader, plate

--- a/n26/core/views/edit.py
+++ b/n26/core/views/edit.py
@@ -373,7 +373,7 @@ def edit_fighter(request, pk):
         statline_override_form_for,
     )
     from n26.core.images import MAX_PX, PORTRAIT
-    from n26.core.operations import Refusal, operation
+    from n26.core.operations import Refusal, operation, trade_points_carried_by
     from n26.core.owned import DIALOGS, EquipHost
     from n26.core.render import build_model_card, roster, summarise_roster
     from n26.core.views.choose import link_slots
@@ -714,6 +714,14 @@ def edit_fighter(request, pk):
             # Copying the owner carries both across; the child has no
             # independent purchase to copy on its own.
             "may_clone": miniature.membership.caused_by_id is None,
+            # Whether the menu offers Refund beside Delete. A gang founded
+            # without a budget refunds no credits, so the act is worth
+            # offering only where a founding allowance paid for something
+            # this model still carries. One query, and only for such a
+            # gang — everybody else knows the answer already.
+            "may_refund": (
+                not gang.credits_unlimited or trade_points_carried_by(miniature) > 0
+            ),
             # The role beside the name: the rank the profile is filed
             # under, which is what a reader checking "which of my models
             # is this" wants said once at the top. The bare name — the

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -684,7 +684,7 @@ def _dismiss(request, pk, kind):
         trade_points_carried_by,
         trade_points_in,
     )
-    from n26.core.views.owned import refund_words
+    from n26.core.views.owned import refund_words, refunded_credits
     from n26.core.views.permissions import _own_miniature_or_404
 
     miniature = _own_miniature_or_404(request, pk)
@@ -748,7 +748,11 @@ def _dismiss(request, pk, kind):
         trade_points=points_back,
     )
     stashed = f" Their kit is in the stash ({moved} line{'s' if moved != 1 else ''})."
-    if kind == "refund":
+    # What came back, worked out after the stash move rather than before
+    # it: kit put in the stash keeps what was paid for it, so a departure
+    # that stashed everything the allowance bought returns nothing, and a
+    # refund is what the deletion it turned out to be says it is.
+    if kind == "refund" and (refunded_credits(gang, paid_back) or points_back):
         messages.success(
             request,
             f"Refunded {was} — {refund_words(gang, paid_back, points_back)} back."

--- a/n26/core/views/gangs.py
+++ b/n26/core/views/gangs.py
@@ -394,10 +394,6 @@ def gang_sheet(request, pk):
                 gang, marking or ransoming, status_back
             ),
             "dialog": dialog,
-            # A gang founded without a budget never spent credits, so
-            # there is nothing a refund could give back: its cards offer
-            # Delete alone.
-            "budgeted": gang.starting_credits is not None,
         },
     )
 
@@ -581,8 +577,14 @@ def _leaving(request, gang):
     lines a stash disposal would move — only lines money was paid for,
     because a built-in knife moved to the stash is clutter the next hire
     re-arms for free.
+
+    Trade Points are counted beside the credits because a refund gives
+    both back. A gang founded without a budget returns nothing else, so
+    the points are also what decides whether the question is a refund at
+    all.
     """
-    from n26.core.operations import refund_of, subtree
+    from n26.core.operations import refund_of, trade_points_in
+    from n26.core.views.owned import refund_words
 
     for kind in ("delete", "refund"):
         miniature = _fighter_named(request, gang, kind)
@@ -591,25 +593,58 @@ def _leaving(request, gang):
     else:
         return None
 
-    # A gang founded without a budget never spent credits, so there is
+    membership = miniature.membership
+    hire, fighter_paid = refund_of(membership)
+    fighter_points = trade_points_in(hire)
+    in_hire = {held.pk for held in hire}
+    extra_paid = extra_points = stashable = 0
+    for root in _kit_roots(miniature):
+        held, paid = refund_of(root)
+        if paid > 0:
+            stashable += 1
+        if root.pk not in in_hire:
+            extra_paid += paid
+            extra_points += trade_points_in(held)
+
+    full_points = fighter_points + extra_points
+    # A gang founded without a budget pays no credits, so unless a
+    # founding allowance paid for something this model carries there is
     # nothing to give back: a refund asked of it is a deletion, and the
     # dialog says so rather than offering 0¢.
-    if kind == "refund" and gang.starting_credits is None:
+    if kind == "refund" and gang.starting_credits is None and not full_points:
         kind = "delete"
 
-    membership = miniature.membership
-    in_hire = {membership.pk, *(row.pk for row in subtree(membership))}
-    roots = _kit_roots(miniature)
-    _, fighter_paid = refund_of(membership)
-    extra_paid = sum(refund_of(root)[1] for root in roots if root.pk not in in_hire)
-    stashable = sum(1 for root in roots if refund_of(root)[1] > 0)
     return {
         "kind": kind,
         "miniature": miniature,
-        "full_paid": fighter_paid + extra_paid,
-        "fighter_paid": fighter_paid,
+        # What the whole departure hands back, credits and Trade Points
+        # together: a figure naming only the credits would promise
+        # nothing to a gang that counts none.
+        "full_returned": refund_words(gang, fighter_paid + extra_paid, full_points),
+        # And what the model alone hands back, for the button that
+        # stashes the kit first.
+        "stash_label": _stash_label(gang, kind, fighter_paid, fighter_points),
         "stashable": stashable,
     }
+
+
+def _stash_label(gang, kind, paid, trade_points):
+    """The second button on a leaving dialog: put the kit in the stash
+    first, then do the thing.
+
+    It names what the model alone hands back, where that is something.
+    Where it is nothing — a hire that was free, or a gang whose credits
+    count for nothing and whose allowance paid only for the kit being
+    stashed — a figure would promise a zero, so the button says what it
+    does and leaves the arithmetic out.
+    """
+    from n26.core.views.owned import refund_words, refunded_credits
+
+    if kind != "refund":
+        return "Stash their kit, then delete"
+    if refunded_credits(gang, paid) or trade_points:
+        return f"Stash kit, refund {refund_words(gang, paid, trade_points)}"
+    return "Stash their kit, then refund"
 
 
 @login_required
@@ -641,15 +676,28 @@ def _dismiss(request, pk, kind):
     fighter is still there afterwards and the sheet says why.
     """
     from n26.analytics import EventVerb, N26Noun, record
-    from n26.core.operations import Refusal, operation, refund_of, subtree
+    from n26.core.operations import (
+        Refusal,
+        operation,
+        refund_of,
+        subtree,
+        trade_points_carried_by,
+        trade_points_in,
+    )
+    from n26.core.views.owned import refund_words
     from n26.core.views.permissions import _own_miniature_or_404
 
     miniature = _own_miniature_or_404(request, pk)
     membership = miniature.membership
     gang = membership.gang
-    # No budget, no refund: the gang never spent credits, so the act
-    # behind either address is the same deletion the dialog promised.
-    if kind == "refund" and gang.starting_credits is None:
+    # No budget and no founding allowance spent on this model: nothing
+    # comes back either way, so the act behind either address is the same
+    # deletion the dialog promised.
+    if (
+        kind == "refund"
+        and gang.starting_credits is None
+        and not trade_points_carried_by(miniature)
+    ):
         kind = "delete"
     sheet_url = reverse("n26-gang", args=[gang.pk])
     if request.method != "POST":
@@ -672,11 +720,14 @@ def _dismiss(request, pk, kind):
             remaining = [
                 root for root in _kit_roots(miniature) if root.pk not in in_hire
             ]
-            paid_back = 0
+            paid_back = points_back = 0
             if kind == "refund":
-                paid_back = refund_of(membership)[1] + sum(
-                    refund_of(root)[1] for root in remaining
-                )
+                hire, paid_back = refund_of(membership)
+                points_back = trade_points_in(hire)
+                for root in remaining:
+                    held, paid = refund_of(root)
+                    paid_back += paid
+                    points_back += trade_points_in(held)
             act = op.refund if kind == "refund" else op.remove
             act(membership)
             for root in remaining:
@@ -694,12 +745,14 @@ def _dismiss(request, pk, kind):
         kind=kind,
         kit="stash" if stash_kit else "with",
         refunded=paid_back,
+        trade_points=points_back,
     )
     stashed = f" Their kit is in the stash ({moved} line{'s' if moved != 1 else ''})."
     if kind == "refund":
         messages.success(
             request,
-            f"Refunded {was} — {paid_back}¢ back." + (stashed if moved else ""),
+            f"Refunded {was} — {refund_words(gang, paid_back, points_back)} back."
+            + (stashed if moved else ""),
         )
     else:
         messages.success(request, f"Deleted {was}." + (stashed if moved else ""))

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -40,7 +40,8 @@ The acts are deliberately distinct, and the ledger says which happened:
     because which model holds a thing and which gun it is bolted to are
     not one question, however much they are one act.
 ``refund``
-    Undoing the purchase: every credit that was paid comes back. The amount
+    Undoing the purchase: everything that was handed over comes back —
+    credits, and the Trade Points a founding allowance paid. The amount
     paid and the rating part company at the first discount, which is why
     this is not a sale.
 ``remove``
@@ -249,6 +250,34 @@ def _asked(request):
 ROUTES = {"fit": "reassign", "detach": "reassign"}
 
 
+def refunded_credits(gang, paid):
+    """What a refund of something bought for ``paid`` puts back in this
+    gang's pocket.
+
+    Nothing, where the gang was founded with no budget: it counts no
+    credits — its number is its rating — so the ledger's figure is a
+    number nobody watching the gang would see move.
+    """
+    return 0 if gang.credits_unlimited else paid
+
+
+def refund_words(gang, paid, trade_points):
+    """What a refund hands back, as a phrase to drop into a sentence.
+
+    Both figures where both moved, and the one that did otherwise. A gang
+    spending its models' founding allowances and nothing else is told
+    about the Trade Points alone, because naming a sum of money would
+    promise it a figure that never moves.
+    """
+    from django.template.defaultfilters import pluralize
+
+    credits = refunded_credits(gang, paid)
+    if not trade_points:
+        return f"{credits}¢"
+    points = f"{trade_points} Trade Point{pluralize(trade_points)}"
+    return f"{credits}¢ and {points}" if credits else points
+
+
 def _panel(request, assignment, kind, at):
     """What every one of these dialogs says, whatever it is asking."""
     return {
@@ -356,6 +385,7 @@ def owned_dialog(request, host: EquipHost):
         detachable_children,
         refund_of,
         sale_of,
+        trade_points_in,
     )
 
     kind, named = _asked(request)
@@ -363,15 +393,25 @@ def owned_dialog(request, host: EquipHost):
         return None
 
     gang = host.gang
-    # A gang founded without a budget never paid credits, so there is
-    # nothing a refund could give back: a refund address asks the remove
-    # question instead, exactly as the fighter-level flow answers.
-    if kind == "refund" and gang.credits_unlimited:
-        kind = "remove"
-
     assignment = _held(host, named)
     if assignment is None:
         return None
+
+    # What a refund of this would hand back, asked once and only where
+    # the answer decides something: what the refund panel promises, and
+    # whether a gang that returns no credits has Trade Points to return
+    # instead. A gang with a budget always offers the act, so its remove
+    # panel settles that without asking.
+    asks_figures = kind == "refund" or (kind == "remove" and gang.credits_unlimited)
+    refunding, paid = refund_of(assignment) if asks_figures else ((), 0)
+    points = trade_points_in(refunding)
+    # A gang founded without a budget pays no credits, so a refund of a
+    # purchase it made in credits alone would give nothing back: that
+    # address asks the remove question instead, exactly as the
+    # fighter-level flow answers. Points off a founding allowance are a
+    # different matter — those come back.
+    if kind == "refund" and gang.credits_unlimited and not points:
+        kind = "remove"
 
     name = str(assignment.assignable)
     # A part is what hangs off something else — ammo in a gun, a sight
@@ -380,7 +420,7 @@ def owned_dialog(request, host: EquipHost):
     is_part = assignment.parent_id is not None
     dialog = _panel(request, assignment, kind, host.at) | {
         "stash_host": host.is_stash,
-        "can_refund": not gang.credits_unlimited,
+        "can_refund": not gang.credits_unlimited or bool(points),
     }
 
     if kind == "sell":
@@ -531,16 +571,21 @@ def owned_dialog(request, host: EquipHost):
         }
 
     if kind == "refund":
-        _, paid = refund_of(assignment)
-        # The figure is what the ledger says was handed over, which is not
-        # on the page anywhere and is not the price the listing quotes —
-        # so the sentence says which number it is as well as what it is.
+        # The figures are what the ledger says was handed over, which is
+        # not on the page anywhere and is not the price the listing
+        # quotes — so the sentence says which numbers they are as well as
+        # what they are. Trade Points are named where any moved: a gang
+        # spending its founding allowance is being handed back the only
+        # thing it paid.
+        credits = refunded_credits(gang, paid)
         return dialog | {
             "title": f"Refund {name}?",
-            "proceeds": paid,
+            "proceeds": credits,
+            "trade_points": points,
             "sum": (
-                f"{paid}¢ comes back — the amount paid, not its rating."
-                if paid
+                f"You get {refund_words(gang, paid, points)} back — the amount "
+                "paid, not its rating."
+                if credits or points
                 else "Nothing was paid for this, so nothing comes back."
             ),
             "submit_label": "Refund",
@@ -555,7 +600,13 @@ def owned_dialog(request, host: EquipHost):
 
 
 def link_stash_actions(sheet, at, *, refunds=True):
-    """Add dialog links without querying; print and read-only sheets stay plain."""
+    """Add dialog links without querying; print and read-only sheets stay plain.
+
+    ``refunds`` is whether the gang refunds in credits at all. A gang
+    founded without a budget has none to give back, so a stash line is
+    offered Refund only where a founding allowance paid for it — the line
+    already says which, off the card the sheet was drawn from.
+    """
     from n26.core.listing import DANGER, LINK, SECONDARY, Action
 
     for line in sheet.stash:
@@ -570,7 +621,7 @@ def link_stash_actions(sheet, at, *, refunds=True):
             ),
             Action("Sell", LINK, with_query(at, sell=line.id), DANGER),
         ]
-        if refunds:
+        if refunds or line.paid_trade_points:
             menu.append(
                 Action("Refund", LINK, with_query(at, refund=line.id), SECONDARY)
             )
@@ -586,8 +637,10 @@ def link_possession_actions(model_card, host, *, refunds=True):
     with no assignment — granted gear, a hire preview — stays a name
     with nothing to click.
 
-    ``refunds`` is whether Refund is offered at all, the same flag the
-    listing takes: a gang founded without a budget never paid credits.
+    ``refunds`` is whether the gang refunds in credits at all, the same
+    flag the listing takes: a gang founded without a budget has none to
+    give back, and each copy says for itself whether a founding allowance
+    paid for it.
     """
     from dataclasses import replace
 
@@ -1144,25 +1197,27 @@ def remove_assignment(request, pk):
 @login_required
 @require_POST
 def refund_assignment(request, pk):
-    """Undo the purchase: it archives, and every credit paid comes back.
+    """Undo the purchase: it archives, and what was paid comes back.
 
-    What was *paid*, not its rating — see ``Operation.refund``. The
-    figure is read before the write, because afterwards every entry in
-    the subtree has been settled to zero and there is nothing left to add
-    up.
+    Credits, and the Trade Points a founding allowance paid. What was
+    *paid*, not its rating — see ``Operation.refund``. The figures are
+    read before the write, because afterwards every entry in the subtree
+    has been settled to zero and there is nothing left to add up.
     """
     from n26.analytics import EventVerb, N26Noun, record
-    from n26.core.operations import Refusal, operation, refund_of
+    from n26.core.operations import Refusal, operation, refund_of, trade_points_in
 
     assignment = _possession_or_404(request, pk)
     gang = assignment.gang_root
-    # No budget, no refund: the money never left a budget, so the act
+    refunding, paid = refund_of(assignment)
+    points = trade_points_in(refunding)
+    # A gang with no budget pays no credits, so unless a founding
+    # allowance paid for this there is nothing to give back: the act
     # behind this address is the removal the dialog promised.
-    if gang.credits_unlimited:
+    if gang.credits_unlimited and not points:
         return remove_assignment(request, pk)
     miniature = assignment.miniature_root
     name = str(assignment.assignable)
-    _, paid = refund_of(assignment)
     back = _back_to(request, assignment, gang)
     touched = _row_behind(assignment)
 
@@ -1186,8 +1241,11 @@ def refund_assignment(request, pk):
         thing=name,
         action="refund",
         refunded=paid,
+        trade_points=points,
     )
-    messages.success(request, f"Refunded {name} — {paid}¢ back.")
+    messages.success(
+        request, f"Refunded {name} — {refund_words(gang, paid, points)} back."
+    )
     return _acted(request, touched, gang, back)
 
 

--- a/n26/core/views/owned.py
+++ b/n26/core/views/owned.py
@@ -278,6 +278,26 @@ def refund_words(gang, paid, trade_points):
     return f"{credits}¢ and {points}" if credits else points
 
 
+def removal_words(gang, paid, trade_points):
+    """The sentence under a removal: what it hands back, and what Refund
+    would hand back instead.
+
+    A gang with a budget hears about credits, which is what its removals
+    keep spent. A gang counting none hears what it would actually get —
+    its models' founding Trade Points — because "the amount paid" would
+    name money it has none of, and where no allowance paid for the thing
+    there is nothing to point it at.
+    """
+    if not gang.credits_unlimited:
+        return "No credits are returned. Use Refund instead to recover the amount paid."
+    if trade_points:
+        return (
+            "Nothing comes back. Use Refund instead to get "
+            f"{refund_words(gang, paid, trade_points)} back."
+        )
+    return "Nothing comes back."
+
+
 def _panel(request, assignment, kind, at):
     """What every one of these dialogs says, whatever it is asking."""
     return {
@@ -420,7 +440,10 @@ def owned_dialog(request, host: EquipHost):
     is_part = assignment.parent_id is not None
     dialog = _panel(request, assignment, kind, host.at) | {
         "stash_host": host.is_stash,
-        "can_refund": not gang.credits_unlimited or bool(points),
+        # The removal panel's own sentence, worked out where the figures
+        # are already in hand rather than by the template asking whether
+        # this gang has a budget.
+        "remove_note": removal_words(gang, paid, points),
     }
 
     if kind == "sell":

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -2829,7 +2829,7 @@ def owned_context():
             "kind": "refund",
             "title": "Refund Meltagun?",
             "proceeds": 120,
-            "sum": "120¢ comes back — what was paid for it, not what it is worth.",
+            "sum": "You get 120¢ back — the amount paid, not its rating.",
             "submit_label": "Refund",
             "submit_variant": "danger",
         },

--- a/n26/designsystem/sampledata.py
+++ b/n26/designsystem/sampledata.py
@@ -2883,6 +2883,10 @@ def owned_context():
             **named,
             "kind": "remove",
             "title": "Delete Meltagun?",
+            "remove_note": (
+                "No credits are returned. Use Refund instead to recover the "
+                "amount paid."
+            ),
             "submit_label": "Delete",
             "submit_variant": "danger",
         },

--- a/n26/tests/sandbox/test_founding_budget.py
+++ b/n26/tests/sandbox/test_founding_budget.py
@@ -463,6 +463,33 @@ class TestGivingSomethingBack:
         gang.refresh_from_db()
         assert_reconciled(gang)
 
+    def test_a_purchase_that_paid_only_trade_points_is_refunded_all_the_same(
+        self, gang, leader, legacy_list
+    ):
+        """What decides between a refund and a plain removal is whether
+        anything was handed over, and Trade Points are something. A gang
+        founded with no credit budget hands over nothing else, so treating
+        a nought in the credits column as nothing paid would leave its
+        allowance spent for good."""
+        from n26.core.models import LedgerEvent
+
+        bought = buy_at_founding(
+            leader, line_for(browse(legacy_list, FOUNDING), "Flak plate"), paid=0
+        )
+        assert bought.ledger_entry.paid == 0
+
+        refund(bought)
+
+        event = LedgerEvent.objects.get(
+            assignment=bought, kind=LedgerEvent.Kind.REFUNDED
+        )
+        assert event.trade_points_delta == -3
+        assert event.credits_delta == 0
+        assert budget(leader).spent == 0
+        assert budget(leader).remaining == 5
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
     def test_a_sale_returns_no_trade_points(self, gang, leader, legacy_list):
         """Selling is not undoing: the credits come back at half, and the
         Trade Points stay spent."""


### PR DESCRIPTION
A user reported that on a Venator gang there was no way to refund spent Trade Points during founding, so an overspend could never be undone. True: a gang founded with the credits box left blank ("spend as much as you like") had every Refund control replaced by Delete, because no credits were paid. Delete archives the item and hands nothing back, so Trade Points spent against the Found and equip gang action stayed spent forever. All 13 founding purchases in production so far are on such gangs; one has already been deleted this way.

The rule is now: a purchase is refundable if it paid credits **or** Trade Points, and Refund returns both. Delete keeps its meaning.

- `Operation.refund` settles an entry that paid Trade Points but no credits instead of falling through to a plain removal.
- The equip page's held items, the stash lines, the item dialog, the fighter-level Refund dialogs and the fighter edit menu offer Refund when the purchase paid Trade Points, using the already-prefetched ledger entry (no per-line queries; one aggregate for an unbudgeted gang's fighter dialogs).
- Messages and labels name what actually comes back ("3 Trade Points back", "40¢ and 3 Trade Points back") and never promise credits to a gang that counts none.

Tests: thirteen new, covering the six surfaces on an unbudgeted gang plus an operations-level check that a Trade-Points-only refund writes the negative delta. Full n26 suite green locally; no query pin moved.

Out of scope: the purchase message on an unbudgeted gang still names the credits ("40¢ and 3 TP"), the same inconsistency on the buy path. The one purchase already deleted in production keeps its lost point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je6KzMph3ccnUVutCSKWDh