### PR TITLE
feat: add Pickable.rating_contribution so a pick can raise a model's rating

### DIFF
--- a/.claude/notes/issue-2313-plan.md
+++ b/.claude/notes/issue-2313-plan.md
@@ -1,0 +1,336 @@
+# Spyrer suit evolution and tiered augmentations in n26
+
+Plan for 2313. Written against the worktree `heron-8e7b-spyrer-tiers`, off
+main 5d7440c15. Rules paraphrased from the local Spyre Hunting Party
+reference; nothing quoted.
+
+Decisions taken before planning (Tom, 2026-09-06): the default is a
+cumulative ladder as printed; a player may switch or step back freely (inform,
+never police); the Power Boost table belongs to this issue, not 706; the shape
+must leave room for paid ladders later without repeating n23's
+`ContentEquipmentUpgrade`.
+
+## What the rules ask for
+
+A Spyrer's rig counts kills. **Suit Evolution** is a post-battle act: with
+Kill Count at four or more, spend four, then either clear every glitch
+(Glitch Count to zero, and the penalties they caused with it) or roll D6 on
+the **Power Boost** table and raise the model's credit value by what the
+table says. Repeatable while four remain.
+
+Power Boost: 1 raises WS or BS (ceiling 2+, +20); 2 Initiative (2+, +10);
+3 Movement (8", +10); 4 armour save (2+, +15); 5-6 **Hunting Rig
+Augmentation** — pick one weapon or piece of wargear the Spyrer carries and
+raise its Augmentation level by one (+20). A result that would push a
+characteristic past its ceiling is taken as an augmentation instead.
+
+Each Spyrer item prints its own Tier 1/2/3 lines: a weapon characteristic set
+to a value, a trait added, removed or swapped for the next value up, a
+characteristic of the wearer raised, an armour save improved, and twice a
+choice between two characteristics. Some items have two tiers, some three. A
+Hunt Master's **Experienced Hunter** gives one free level on hire, and the
+glitch result **System Downgrade** takes one back.
+
+## 1. How to represent a ladder
+
+**(a) A new library kind** — an `Augmentation` model with ordered rungs
+pointing at the item. Cost: a new model, a union FK over weapon and wargear,
+a column on `Assignment` plus a line in `ASSIGNABLE_FIELDS`
+(`n26/core/models/assignment.py:41-61`, enforced at boot by `n26.E001`), a
+`Spec`, a generated form, two registries in `n26/library/views.py`, a page in
+`concepts.md`, migrations in both apps, and new prefetch paths in
+`build_modifier_index` (`n26/core/card.py:938-1000`) — miss one and `compute`
+lazy-queries, which it must not. It buys nothing the choice machinery lacks.
+
+**(c) Rungs hosted under the item through `Assignment.parent`** — attractive
+because `targets_attached_weapon()` would reach the weapon exactly. It does
+not work as built: `reconcile_defaults` hosts what a carrier brings
+*alongside* the carrier, not under it (`n26/core/operations.py:1762`), and
+`n26/tests/sandbox/test_dustback_helamite.py:270` pins the consequence — that
+scope reaches nothing when a thing is brought *by* an item rather than bolted
+*to* one. Making it work means changing where built-ins land.
+
+**(b) Slots and picks — recommended.** Per augmentable item:
+
+- one `Picklist` of slot type **Augmentation** holding that item's tiers as
+  `Pickable`s at positions 1..3;
+- one `Slot` (label naming the item, `min_picks=0`, `max_picks` = the number
+  of tiers, `assigned_to=bearer`), built into the item with `add_built_in`,
+  so it appears when the item is carried and goes when the item goes.
+
+A level is **one pick per rung, stacking**: at level 2 the model holds two
+picks against that slot, and the level is the count of live picks — computed,
+never stored. This matches the book's verb and keeps authoring one-to-one
+with the printed lines; the alternative (one pick naming the level reached)
+forces every rung's modifiers to be restated on the tier above it.
+
+Each item gets **its own picklist and its own pickables** — "Tier 1 — Orrus
+bolt launcher" is not "Tier 1 — Jakara rig". Picks land on the model, so a
+shared "Tier 1" across items would collapse four augmented items into one
+reading.
+
+**How a tier's effects land.** Not `targets_attached_weapon()`, per above.
+Name the item outright, as the Helamite claws do
+(`n26/tests/sandbox/test_dustback_helamite.py:291-300`):
+
+- weapon characteristics: `targets_weapons(is_one_of(bolt_launcher))` +
+  `ef_changes_stat(lethality, mode="set", amount=2)`. `ChangesStat.accepts`
+  admits weapon profiles as readily as models
+  (`n26/library/models/modifier.py:1662`), proven at
+  `n26/tests/sandbox/test_weapon_category_scope.py:161-183`. **Mind the
+  vocabulary**: the seeded weapon shape is SR / LR / Str / AP / L
+  (`n26/library/standard_content.py:36-68`), so the book's "Damage" is
+  **Lethality**, and AP is inverted, so improve-by-1 takes -1 to -2.
+- trait swaps: `ef_removes(rapid_fire_1)` plus `ef_adds(rapid_fire_2)` — a
+  modifier holds one effect, so a swap is two modifiers on the pickable.
+  Additions settle before removals within a round
+  (`n26/core/effects.py:1058-1076`) and traits fold by display string
+  (`effects.py:172-179`), so the pair is safe. "Remove Scarce" is the removal
+  alone; "add Parry" the addition alone.
+- the wearer: `targets_model()` + `ef_changes_stat(...)`. Armour save is a
+  real characteristic (`Sv`, target and inverted,
+  `n26/library/standard_content.py:45`), so "to 4+" is mode `set` amount 4,
+  "+1" is mode `improve`.
+- field armour saves are not characteristics: author them as a named `Rule`
+  with an annotation and swap the pair, exactly as with a trait.
+- **some printed lines have no column to land on.** The weapon shape has no
+  Ammo and no accuracy modifiers, so "Ammo to 2+" and "improve the long range
+  accuracy to -" become trait swaps (Ammo already rides as a trait
+  annotation) or a named line with nothing computed. Settle these item by
+  item while authoring.
+
+**A two-way tier** (Malcadon rig T1: BS or WS) needs no `OffersChoice` — list
+both as separate pickables. The same trick covers Power Boost result 1:
+`Picklist.landing` returns *every* member whose band holds the roll
+(`n26/library/models/slots.py:348-365`), so two members banded 1-1 both come
+up and the player takes one.
+
+**Ceilings are informed, never enforced.** `ChangesStat` has no cap field
+(`modifier.py:1634-1664`) and `apply_changes` does not clamp
+(`n26/core/render.py:1193-1225`). That is the right call: turning a capped
+result into an augmentation is the player's act, not the app's.
+
+## 2. Runtime model
+
+"This item is at level 2" is two live `Assignment`s whose `chosen_for_slot`
+is that item's slot. Nothing new is stored, and the card already draws the
+slot as a `ChoiceLine` (`n26/core/render.py:387`, filled
+`n26/core/effects.py:1597-1660`).
+
+**Money.** The +20 belongs to the Power Boost result, not the rung — see §4.
+Rung pickables are priced zero; Power Boost pickables carry 20/10/10/15/20.
+`_choose_for_slot` hardcodes `paid=0` and lets `rating` fall through to zero
+(`n26/core/operations.py:2190-2198` with `:358-366`), pinned by
+`n26/tests/sandbox/test_slots_and_picks.py:207-218`. It already **forwards
+`rating` in `**kwargs`**, so the change is to default it from the pickable's
+own reference price. `op.select` is the in-house precedent for a free
+acquisition that still adds rating (`operations.py:2374-2381`:
+`paid=0, rating=price_of(thing).credits, reason=Reason.REWARD`).
+
+**Ledger.** No new event kind. The pick writes the ordinary entry and event
+through `assign` (`operations.py:284-396`) with `rating_contribution=20` and
+`paid=0`; `Operation.settle` repins the model and the gang
+(`operations.py:2516-2538`) and rating recomputes from the ledger. The roll
+is already recorded as `ROLLED` (`operations.py:2383-2422`) and the Kill
+Count spend as `TALLIED`. Removing a pick archives it and its rating stops
+counting; no money comes back, because none went out.
+
+## 3. Suit Evolution: mostly content, one small act
+
+The Escape table is the precedent and it is **content only** — no code was
+written for it (`n26/library/standard_content.py:1308-1345`, proven end to
+end by `n26/tests/sandbox/test_escape.py`). Power Boost is the same shape,
+and `SPYRER_GLITCH_TABLE` already sits where the new table goes
+(`standard_content.py:1076-1099`, listed at `:1181-1187`).
+
+**Power Boost, authored:** slot type *Power Boost* (repeats allowed), one
+picklist with `dice="d6"`, `roll_selects="band"`, six bands over five
+results with two members on band 1, one `Slot` (`max_picks` generous — this
+repeats across a campaign) attached to the Spyrer subtype the way the glitch
+table is (`n26/library/recipes.md:250-303`, step 4). Each result pickable
+carries:
+
+- its computed effect — `targets_model()` + `ef_changes_stat(...)` for 1-4;
+- `op_changes_counter(kill_count, mode="subtract", amount=4)`, a **stored**
+  effect that runs once when the pick lands
+  (`n26/library/models/modifier.py:1522-1556`, driven by
+  `_run_stored_effects`, `operations.py:398-414`);
+- its price, which becomes the rating once §2's change is in.
+
+So the whole rolled half is: the player opens the existing choose page
+(`n26/core/views/choose.py`, `/gangs/<gang>/choose/<key>/`), clicks Roll,
+takes a result. The spend, the stat change and the +20 all fall out. Do not
+build a second picker.
+
+**Do not gate the slot on the counter.** `counter_at_least(kill_count, 4)` on
+the scope would hide the slot below four — and would take every pick already
+made with it, because a pick whose slot has gone is excluded as an orphan
+(`n26/core/effects.py:100-110`). Grant the slot unconditionally to Spyrers
+and say the threshold in words. Inform, never police, and here it is also the
+only safe option.
+
+**Results 5-6** carry the spend and the +20 but no stat change. What follows
+is the player raising one item's level, which is the ordinary choose page for
+that item's augmentation slot. The Power Boost result's line should say so.
+
+**A capped result** is substituted by the player: `_choose_for_slot`
+deliberately does not check the pick against the band it landed on
+(`operations.py:2135-2139`) because the rules substitute results. Print each
+ceiling in the picklist member's `label_override` (list wording, so it never
+rides the card) with a note saying what the rules do.
+
+**Clear glitches is the one bespoke act.** It spends four Kill Count, zeroes
+Glitch Count, and takes back the glitch picks carrying penalties. A per-model
+view in the shape of `mark_fighter` (`n26/core/views/gangs.py:701-747`): a
+dialog on the gang sheet keyed by a query parameter (`?evolve=<pk>`, beside
+`?status=`), POST to its own route next to `n26-mark-fighter`
+(`n26/urls.py:185`), inside one `operation(gang, actor=request.user)` calling
+`op.tally` twice and `op.remove` on each live glitch pick. Registration is
+the view, the `path()`, and the import plus `__all__` entry in
+`n26/core/views/__init__.py`.
+
+## 4. Switching, stepping back, refunds
+
+Rungs are free, so switching or stepping back moves no money. What was
+charged is the Power Boost result, which stays on the card as a line worth
+20. Taking a rung back uses the verbs already there —
+`rechoose_assignment` and `remove_assignment`
+(`n26/core/views/owned.py:952, 1103`). `remove` archives and writes a
+`REMOVED` event with no deltas (`operations.py:1010-1031`), so the rating
+simply stops counting; `refund_of` pays back what was **paid**
+(`operations.py:116-136`), which for a free pick is nothing. That is
+"refunds follow the purchase" applied honestly: to lose the 20 the owner
+removes the Power Boost result itself, which has its own verb. Note that the
+Kill Count spend is a stored effect and is never undone — correct, since the
+rules spent it.
+
+Words on the augmentation choice: *The rules gain these one level at a time
+through Suit Evolution. You can change it here.* The picker marks levels
+already held.
+
+**System Downgrade** lowers a level. Ship it as a result with no computed
+effect and have the player take a rung back by hand, with the flow saying so;
+an effect that retracts a pick is a later, general piece of work. Note also
+that the seeded glitch table (`standard_content.py:1078-1099`) is an earlier
+printing — no System Downgrade, Jammed Articulation, Disrupted Ammo Cables,
+Cracked Power Cell or Reduced Power Distribution, which the text we hold puts
+at 51-55. A content correction, not this issue's code.
+
+**Rejected alternative:** pricing rungs cumulatively (20/40/60) so a step down
+refunds itself. It double-counts against the boost line, makes the Hunt
+Master's free level a special case, and spends the `price` field that a paid
+ladder will want to mean a real purchase.
+
+## 5. Experienced Hunter
+
+A slot member can name a starting pick and the pick is written with it
+(`operations.py:1811-1814`), but the free level is on an item the player
+chooses at hire, so no built-in can name it.
+
+Because rungs are free, nothing needs building. The slots are already open on
+everything the Hunt Master carries and raising one takes nothing. All that is
+wanted is that the card says so: the named `Rule` "Experienced Hunter" on the
+profile, and one sentence in the augmentation choice's help. That is the
+payoff of putting the money on the boost rather than the rung.
+
+## 6. Paid ladders later
+
+The minimal extension: a field on `Slot` saying its picks are bought, one
+branch in `_choose_for_slot` taking the credits path, and rung pickables
+carrying a real price. Ordering, levels, the card line, removal and refund
+already exist.
+
+Do not build now: no per-position price table, no cumulative-versus-
+independent mode. n23's `ContentEquipmentUpgrade`
+(`n23/content/models/equipment.py:627`) puts position and price on the rung
+and the mode on the parent, so nothing can read a rung without first knowing
+the parent's mode. Here the mode is not a field at all: a ladder is a slot
+whose picklist is ordered and whose `max_picks` exceeds one; a set of
+independent add-ons is the same shape without the order.
+
+## 7. Content authoring
+
+Per item: one picklist, two or three pickables, one slot, one built-in
+attachment, and one or two modifiers per tier — roughly 22 items, plus the
+Power Boost table. All through the existing authoring pages and verbs, so
+`concepts.md` needs nothing new.
+
+Ingest stays out of it: `n26/design/ingest.md` already rules upgrade ladders
+hand-authored and out of the sheets, and the importer resolves weapon names
+rather than creating them, so hand-author first. Write the walkthrough into
+`n26/library/recipes.md` once the shape is agreed, in the register of the
+Lasting Injury section beside it.
+
+**Migrations:** none for the content shape. Leaves today are `library` 0089
+and `n26` core 0062, with library 0090-0092 in flight on open PRs 2483 and
+2485. Number last, repoint, and say so on the PR.
+
+## 8. Work breakdown
+
+Small and stacked (`gh stack`). n26 tests use `n26/tests/fixtures.py` and the
+verbs in `n26/tests/sandbox/actions.py` — **not** the platform fixtures in
+`gyrinx/conftest.py`, which `n26/tests/CLAUDE.md` forbids here. Every sandbox
+test ends with `assert_reconciled(gang)`.
+
+1. **A pick carries a rating.** `_choose_for_slot` defaults `rating` from the
+   pickable's reference price, `Reason.REWARD`. Tests in
+   `test_slots_and_picks.py`: a priced pickable moves the model's and the
+   gang's rating, a free one does not, reconcile stays honest. Plus a guard
+   that no shipped pickable is priced.
+2. **The augmentation shape, content only.** New suite
+   `n26/tests/sandbox/test_spyrer_augmentations.py`: build the Orrus bolt
+   launcher and the Jakara rig from the book, hire a Spyrer, take Tier 1 then
+   Tier 2, assert the card shows Lethality 2, AP -2, Rapid Fire (2) in place
+   of Rapid Fire (1), and Strength up on the wearer. If the scopes hold this
+   ships no production code — which is the point of it.
+3. **The Power Boost table.** Seeded in `standard_content.py` beside the
+   glitch table, the slot attached to the Spyrer subtype, the stored spend on
+   each result. Tests with loaded dice: band 1 offers two members, four Kill
+   Count goes, the rating moves by the table's figure, a capped result can be
+   substituted, and the slot survives the count dropping below four.
+4. **Clear glitches.** Route, dialog, the two tallies and the removals.
+   Tests: the count zeroes, the penalty picks go, the history reads.
+5. **Words and drawing.** The note on the augmentation choice, the Hunt
+   Master sentence, `recipes.md`, a gallery sample. Copywriter pass.
+
+A feature flag is probably unnecessary — nothing draws until the content
+exists — but `n26/flags.py` is one line if 3 and 4 must land ahead of it.
+
+## 9. Risks
+
+- **Orphan picks.** Anything that makes a slot conditional can retract picks
+  already made (`effects.py:100-110`). Grant the slots unconditionally. This
+  is the trap most likely to be walked into.
+- **Render cost.** Four augmentation slots on a Spyrer are four more choice
+  lines and up to twelve rung picks. `compute` is O(nodes × modifiers ×
+  rounds) and runs once per card per render (`n26/core/render.py:2525`), with
+  no cache between requests. Take the query budget before and after using the
+  existing budget assertions (e.g.
+  `n26/tests/sandbox/test_gang_legacy.py:691-708`).
+- **Rating on picks is a shared path.** Any priced pickable in prod would
+  move a gang's rating on deploy. Check with `manage prodshell` before
+  merging 1, and reconcile after.
+- **Identity by display string.** Twenty items each with a "Tier 1": names
+  are unique per pack, so the item belongs in the name or in the
+  author-facing `qualifier`; the card prints the name alone.
+- **Concurrent clicks.** `_choose_for_slot` runs under the gang's lock and
+  one standing pick per roll is enforced there
+  (`operations.py:2146-2153`), but `max_picks` is the picker's ceiling rather
+  than the database's, so a race can overshoot by one. Tolerable here.
+- **Migration numbering** against the open PRs above; collisions never
+  conflict in git.
+- **The seeded glitch table predates the printing we hold** (§4).
+
+## 10. For Tom
+
+1. Money on the boost or on the rung? This decides item 1 and the refund
+   words. Recommendation: the boost.
+2. *(Decided 2026-09-06: an owner may switch or step back freely; the app
+   informs, never polices.)* Confirm the wording in §4 says enough.
+3. Is the Hunt Master's free level just a note, or should the app open
+   something for it?
+4. Which printing of the glitch table is canon, and is correcting the seeded
+   one part of this issue?
+5. Should an item's augmentation choice draw under that item on the card, or
+   among the model's other choices? The second is free today; the first is a
+   change to `WeaponLine` (`n26/core/render.py:280-303`).

--- a/.claude/notes/issue-2313-plan.md
+++ b/.claude/notes/issue-2313-plan.md
@@ -118,14 +118,34 @@ slot as a `ChoiceLine` (`n26/core/render.py:387`, filled
 `n26/core/effects.py:1597-1660`).
 
 **Money.** The +20 belongs to the Power Boost result, not the rung — see §4.
-Rung pickables are priced zero; Power Boost pickables carry 20/10/10/15/20.
-`_choose_for_slot` hardcodes `paid=0` and lets `rating` fall through to zero
-(`n26/core/operations.py:2190-2198` with `:358-366`), pinned by
-`n26/tests/sandbox/test_slots_and_picks.py:207-218`. It already **forwards
-`rating` in `**kwargs`**, so the change is to default it from the pickable's
-own reference price. `op.select` is the in-house precedent for a free
-acquisition that still adds rating (`operations.py:2374-2381`:
-`paid=0, rating=price_of(thing).credits, reason=Reason.REWARD`).
+It is **rating, not money**: the gang spends no credits, so nothing is bought
+and nothing is refundable. Tom's line (2026-09-06, via merlin-a986's
+Gene-smithing assessment): *if the gang pays, it is a purchase and belongs in
+a collection; if credit value moves but money does not, it is rating on the
+pick.* So **`Pickable.price` stays untouched and unread** — that field means
+"what a catalogue asks for this", picks are in no catalogue, and reading it
+is how the next person justifies wiring charging behind it.
+
+Instead, a small dedicated field on `Pickable` saying what it is: the credit
+value this pick adds to its holder's rating (name to settle in PR 1; not
+`price`). Default 0. The choose view passes it explicitly —
+`op.choose(..., rating=pickable.<field>)` — which works today with no change
+to `operations.py`: `choose` and `_choose_for_slot` forward `**kwargs` to
+`assign` (`n26/core/operations.py:2010, 2106`), and `assign` takes `rating`
+independently of `paid` (`:284-366`), writing `LedgerEntry(list_price=0,
+paid=0, rating_contribution=20)`. Reconcile holds: `check_entry` only ties
+`paid` to `list_price - discount` (`n26/core/reconcile.py:22-40`). Do **not**
+default it silently inside `_choose_for_slot`: every pick writes rating 0
+today and `n26/library/concepts.md:240` says so in words ("A pick is free and
+adds nothing to any rating"); that sentence and the authoring page change
+deliberately in the same PR. `op.select` (`operations.py:2374-2381`) is the
+in-house precedent for `paid=0` with a real rating.
+
+Nothing becomes sellable or refundable: `Pickable` is `Family.CHOICE` and
+the owned-assignment acts require `Family.GEAR` (`_possession_or_404`), so
+sell / refund / reassign 404 by construction. Removal already does the right
+thing (`Operation.remove` archives; `sum_rating` skips archived,
+`reconcile.py:45-62`).
 
 **Ledger.** No new event kind. The pick writes the ordinary entry and event
 through `assign` (`operations.py:284-396`) with `rating_contribution=20` and
@@ -216,10 +236,9 @@ printing — no System Downgrade, Jammed Articulation, Disrupted Ammo Cables,
 Cracked Power Cell or Reduced Power Distribution, which the text we hold puts
 at 51-55. A content correction, not this issue's code.
 
-**Rejected alternative:** pricing rungs cumulatively (20/40/60) so a step down
-refunds itself. It double-counts against the boost line, makes the Hunt
-Master's free level a special case, and spends the `price` field that a paid
-ladder will want to mean a real purchase.
+**Rejected alternative:** rating the rungs cumulatively (20/40/60) so a step
+down settles itself. It double-counts against the boost line and makes the
+Hunt Master's free level a special case.
 
 ## 5. Experienced Hunter
 
@@ -235,10 +254,13 @@ payoff of putting the money on the boost rather than the rung.
 
 ## 6. Paid ladders later
 
-The minimal extension: a field on `Slot` saying its picks are bought, one
-branch in `_choose_for_slot` taking the credits path, and rung pickables
-carrying a real price. Ordering, levels, the card line, removal and refund
-already exist.
+The dividing line is **money, not rating**. When the gang genuinely pays for
+a rung, that is a purchase, and purchases belong in a **collection**: the
+rung is offered through a priced entry and bought through the ordinary equip
+path, with its confirm step, refund and ledger already there. Do not reach
+for the rating field in §2 to fake it — "set the rating and skip the
+collection" leaves the credits in the gang's pocket, which is the wrong
+answer. Ordering, levels and the card line carry over unchanged.
 
 Do not build now: no per-position price table, no cumulative-versus-
 independent mode. n23's `ContentEquipmentUpgrade`
@@ -261,9 +283,10 @@ rather than creating them, so hand-author first. Write the walkthrough into
 `n26/library/recipes.md` once the shape is agreed, in the register of the
 Lasting Injury section beside it.
 
-**Migrations:** none for the content shape. Leaves today are `library` 0089
-and `n26` core 0062, with library 0090-0092 in flight on open PRs 2483 and
-2485. Number last, repoint, and say so on the PR.
+**Migrations:** one, for PR 1's rating field on `Pickable` (`library`).
+Leaves at planning time were `library` 0089 and `n26` core 0062, with
+library 0090-0094 in flight on open PRs (2483, 2485, 2496). Number last,
+repoint, and say so on the PR.
 
 ## 8. Work breakdown
 
@@ -272,11 +295,18 @@ verbs in `n26/tests/sandbox/actions.py` — **not** the platform fixtures in
 `gyrinx/conftest.py`, which `n26/tests/CLAUDE.md` forbids here. Every sandbox
 test ends with `assert_reconciled(gang)`.
 
-1. **A pick carries a rating.** `_choose_for_slot` defaults `rating` from the
-   pickable's reference price, `Reason.REWARD`. Tests in
-   `test_slots_and_picks.py`: a priced pickable moves the model's and the
-   gang's rating, a free one does not, reconcile stays honest. Plus a guard
-   that no shipped pickable is priced.
+1. **A pick may carry a rating.** New field on `Pickable` (library
+   migration, one column, default 0; **not** `price`). Name it and word its
+   help text so it cannot be read as a price: *what holding this adds to the
+   model's credit value, when nothing was paid for it.* Check `gh pr list`
+   for open `library` migrations before numbering and again before merging,
+   and post the number in the board's `migrations` room. Exposed on the
+   Pickable authoring page, passed explicitly as `rating=` by the choose view
+   with `Reason.REWARD`. Update `concepts.md` §Picks and the authoring help
+   in the same PR. Tests in `test_slots_and_picks.py`: a rated pickable moves
+   the model's and the gang's rating, an unrated one does not, un-picking and
+   switching drop it with no credit movement, reconcile stays honest, and
+   sell/refund on a pick still 404.
 2. **The augmentation shape, content only.** New suite
    `n26/tests/sandbox/test_spyrer_augmentations.py`: build the Orrus bolt
    launcher and the Jakara rig from the book, hire a Spyrer, take Tier 1 then
@@ -307,9 +337,10 @@ exists — but `n26/flags.py` is one line if 3 and 4 must land ahead of it.
   no cache between requests. Take the query budget before and after using the
   existing budget assertions (e.g.
   `n26/tests/sandbox/test_gang_legacy.py:691-708`).
-- **Rating on picks is a shared path.** Any priced pickable in prod would
-  move a gang's rating on deploy. Check with `manage prodshell` before
-  merging 1, and reconcile after.
+- **Rating on picks is a shared path.** The new field defaults to 0, so no
+  existing pick changes value on deploy; still, reconcile prod after PR 1
+  lands, and keep the field off `price` so nothing already in prod is read
+  as a rating by accident.
 - **Identity by display string.** Twenty items each with a "Tier 1": names
   are unique per pack, so the item belongs in the name or in the
   author-facing `qualifier`; the card prints the name alone.
@@ -323,8 +354,15 @@ exists — but `n26/flags.py` is one line if 3 and 4 must land ahead of it.
 
 ## 10. For Tom
 
-1. Money on the boost or on the rung? This decides item 1 and the refund
-   words. Recommendation: the boost.
+1. *(Decided 2026-09-06: `Pickable.price` is not hooked up for picks.)*
+   Two ways left for the Power Boost's +20 to reach the card: **(i)** a
+   dedicated rating field on `Pickable`, rating-not-money, as §2 now says —
+   nearly free, one column, one deliberate change to the "picks add nothing
+   to rating" rule; or **(ii)** no rating at all: the result prints its
+   credit figure in words and the gang's rating does not move. (i) is what
+   the rules mean by "increase their credit cost"; (ii) is zero code and
+   zero doctrine change. Recommendation: (i). Either way the rung stays
+   free.
 2. *(Decided 2026-09-06: an owner may switch or step back freely; the app
    informs, never polices.)* Confirm the wording in §4 says enough.
 3. Is the Hunt Master's free level just a note, or should the app open

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -2188,6 +2188,13 @@ class Operation:
         writing a second pick. Which row the roll landed on is not
         checked: the rules substitute results ("counts as Out Cold"),
         and the record shows the roll beside whatever was picked.
+
+        A pick is never paid for, but it may carry a rating: a Power
+        Boost result raises the Spyrer's value by the amount the table
+        prints. The pickable says what it adds (``rating_contribution``,
+        0 for almost every pickable) and the pick is written with that
+        as its rating and nothing paid — so removing the pick drops the
+        rating and moves no credits. An explicit ``rating`` wins.
         """
         from n26.library.models import Pickable, Slot
 
@@ -2241,6 +2248,8 @@ class Operation:
                     "That roll was made for a different card. "
                     "Roll again for this choice."
                 )
+        if kwargs.get("rating") is None:
+            kwargs["rating"] = chosen.rating_contribution
         return self.assign(
             chosen,
             caused_by=anchor,

--- a/n26/core/operations.py
+++ b/n26/core/operations.py
@@ -2194,7 +2194,8 @@ class Operation:
         prints. The pickable says what it adds (``rating_contribution``,
         0 for almost every pickable) and the pick is written with that
         as its rating and nothing paid — so removing the pick drops the
-        rating and moves no credits. An explicit ``rating`` wins.
+        rating and moves no credits. A pick the gang holds adds nothing:
+        rating is what the models are worth. An explicit ``rating`` wins.
         """
         from n26.library.models import Pickable, Slot
 
@@ -2249,7 +2250,12 @@ class Operation:
                     "Roll again for this choice."
                 )
         if kwargs.get("rating") is None:
-            kwargs["rating"] = chosen.rating_contribution
+            # Rating is what the models are worth, and a gang-hosted
+            # assignment carries none of its own: a pick the gang holds
+            # adds nothing, whatever its pickable says.
+            kwargs["rating"] = (
+                0 if kwargs.get("gang") is not None else chosen.rating_contribution
+            )
         return self.assign(
             chosen,
             caused_by=anchor,

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -792,8 +792,9 @@ def create_pickable(
     the set it names.
 
     ``rating_contribution`` is what holding the pick adds to the model's
-    rating, in credits: a Power Boost result adds 20. A pick is never
-    paid for, so this is a rating, not a price.
+    rating, in credits: a Power Boost result adds 20. A pick the gang
+    holds adds nothing. A pick is never paid for, so this is a rating,
+    not a price.
     """
     from n26.library.models import Pickable
 

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -779,6 +779,7 @@ def create_pickable(
     qualifier="",
     library_author_help="",
     category=None,
+    rating_contribution=0,
     **kwargs,
 ):
     """One pickable a choice offers; ``effects`` are (scope, effect) pairs.
@@ -789,6 +790,10 @@ def create_pickable(
     decisions: a rule placing "the chosen set" reads it to learn which
     category the pick means, which is how a Skill Tree pick stands for
     the set it names.
+
+    ``rating_contribution`` is what holding the pick adds to the model's
+    rating, in credits: a Power Boost result adds 20. A pick is never
+    paid for, so this is a rating, not a price.
     """
     from n26.library.models import Pickable
 
@@ -798,6 +803,7 @@ def create_pickable(
         qualifier=qualifier,
         library_author_help=library_author_help,
         category=category,
+        rating_contribution=rating_contribution,
         **kwargs,
     )
     for scope, effect in effects:

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -237,7 +237,7 @@ One specific, named use of a slot type. Assigning one to a model or gang — bui
 
 *Not a type: the assignment that settles a choice.*
 
-The pick is an ordinary assignment: the pickable, hosted where the slot says it lands, caused by the slot's own assignment and pointing back at it. So removing the slot removes the pick and everything the pickable gave. Two slots of one slot type on one holder stay independent, even where one thing opened both. Nothing is worked out from what kind of thing was chosen. A pick is free and adds nothing to any rating.
+The pick is an ordinary assignment: the pickable, hosted where the slot says it lands, caused by the slot's own assignment and pointing back at it. So removing the slot removes the pick and everything the pickable gave. Two slots of one slot type on one holder stay independent, even where one thing opened both. Nothing is worked out from what kind of thing was chosen. A pick is never paid for: no credits move, and there is nothing to refund or sell. A pickable may still carry a rating contribution — a Spyrer's Power Boost result raises the model's value by the amount the table prints — and the pick carries that as its rating. Removing the pick removes that rating too. Most pickables add 0.
 
 A pick the gang holds is broadcast (but not displayed) to every member: a rule reaching "models with the Cawdor legacy" reaches them all, including the fighter who made the pick. A pickable that carries the *draws the pick on the card* effect is displayed after all, on the cards its scope reaches. See below.
 

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -203,7 +203,7 @@ A slot type puts a name on one or more slots, and groups pickables. It is not an
 
 *A value that goes into a slot.*
 
-Fields of its own: the **slot type** it belongs to, and an optional **linked category** — plus the shared assignable set, so whatever the pickable means is carried as ordinary modifiers.
+Fields of its own: the **slot type** it belongs to, an optional **linked category**, and a **rating contribution** (credits the pick adds to the model's rating; 0 for most pickables, and nothing for a pick the gang holds) — plus the shared assignable set, so whatever the pickable means is carried as ordinary modifiers.
 
 One thing offered in a slot: a specific value, of a particular slot type, that carries behaviour as ordinary modifiers. It never draws a line of its own: it appears under its slot's choice line when chosen. Without its slot it shows nothing and does nothing, so it arrives chosen, given, or as a slot's starting value, never as a bare built-in. The authoring form does not accept one. Reach: whatever its own modifiers say, from wherever the pick landed.
 
@@ -237,7 +237,7 @@ One specific, named use of a slot type. Assigning one to a model or gang — bui
 
 *Not a type: the assignment that settles a choice.*
 
-The pick is an ordinary assignment: the pickable, hosted where the slot says it lands, caused by the slot's own assignment and pointing back at it. So removing the slot removes the pick and everything the pickable gave. Two slots of one slot type on one holder stay independent, even where one thing opened both. Nothing is worked out from what kind of thing was chosen. A pick is never paid for: no credits move, and there is nothing to refund or sell. A pickable may still carry a rating contribution — a Spyrer's Power Boost result raises the model's value by the amount the table prints — and the pick carries that as its rating. Removing the pick removes that rating too. Most pickables add 0.
+The pick is an ordinary assignment: the pickable, hosted where the slot says it lands, caused by the slot's own assignment and pointing back at it. So removing the slot removes the pick and everything the pickable gave. Two slots of one slot type on one holder stay independent, even where one thing opened both. Nothing is worked out from what kind of thing was chosen. A pick is never paid for: no credits move, and there is nothing to refund or sell. A pickable may still carry a rating contribution — a Spyrer's Power Boost result raises the model's value by the amount the table prints — and the pick carries that as its rating. Removing the pick removes that rating too. A pick the gang holds adds nothing, whatever its pickable says. Most pickables add 0.
 
 A pick the gang holds is broadcast (but not displayed) to every member: a rule reaching "models with the Cawdor legacy" reaches them all, including the fighter who made the pick. A pickable that carries the *draws the pick on the card* effect is displayed after all, on the cards its scope reaches. See below.
 

--- a/n26/library/migrations/0094_a_pick_may_add_to_rating.py
+++ b/n26/library/migrations/0094_a_pick_may_add_to_rating.py
@@ -1,0 +1,29 @@
+"""A pick may add to its holder's rating.
+
+A pick is never paid for — no credits move, nothing is refunded or sold —
+but a rolled result can still raise a model's value: a Spyrer's Power
+Boost adds the amount the table prints. The pickable now says what it
+adds, and the pick is written with that as its rating contribution and
+nothing paid. Every existing pickable adds 0, so no gang's rating moves.
+
+Reversible: the field goes, and the values with it.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0093_a_stat_has_a_minimum_and_a_maximum"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pickable",
+            name="rating_contribution",
+            field=models.IntegerField(
+                default=0,
+                help_text="Credits this pick adds to the model's rating. A pick is never paid for, so this is a rating, not a price. Leave at 0 unless the rules raise the model's value, as a Spyrer's Power Boost does.",
+            ),
+        ),
+    ]

--- a/n26/library/migrations/0094_a_pick_may_add_to_rating.py
+++ b/n26/library/migrations/0094_a_pick_may_add_to_rating.py
@@ -2,7 +2,7 @@
 
 A pick is never paid for — no credits move, nothing is refunded or sold —
 but a rolled result can still raise a model's value: a Spyrer's Power
-Boost adds the amount the table prints. The pickable now says what it
+Boost adds the amount the table prints. The pickable says what it
 adds, and the pick is written with that as its rating contribution and
 nothing paid. Every existing pickable adds 0, so no gang's rating moves.
 
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
             name="rating_contribution",
             field=models.IntegerField(
                 default=0,
-                help_text="Credits this pick adds to the model's rating. A pick is never paid for, so this is a rating, not a price. Leave at 0 unless the rules raise the model's value, as a Spyrer's Power Boost does.",
+                help_text="Credits this pick adds to the model's rating. A pick the gang holds adds nothing. A pick is never paid for, so this is a rating, not a price. Leave at 0 unless the rules raise the model's value, as a Spyrer's Power Boost does.",
             ),
         ),
     ]

--- a/n26/library/models/slots.py
+++ b/n26/library/models/slots.py
@@ -143,20 +143,15 @@ class Pickable(Content, Assignable):
             "for pickables that work by their own modifiers."
         ),
     )
-    # Rating, never price. A pick is not bought: nothing leaves the
-    # gang's credits, so there is nothing to refund and nothing to sell.
-    # What a rolled result adds to a model's value — a Spyrer's Power
-    # Boost — still has to reach the card, and this is how: the pick is
-    # written with this as its rating contribution and no payment. A
-    # pick that is bought for credits is a purchase, and belongs in a
-    # collection, not here.
+    # Rating, never price: a pick is not bought, so nothing is refunded
+    # or sold. A pick bought for credits is a collection purchase, not this.
     rating_contribution = models.IntegerField(
         default=0,
         help_text=(
-            "Credits this pick adds to the model's rating. A pick is never "
-            "paid for, so this is a rating, not a price. Leave at 0 unless "
-            "the rules raise the model's value, as a Spyrer's Power Boost "
-            "does."
+            "Credits this pick adds to the model's rating. A pick the gang "
+            "holds adds nothing. A pick is never paid for, so this is a "
+            "rating, not a price. Leave at 0 unless the rules raise the "
+            "model's value, as a Spyrer's Power Boost does."
         ),
     )
 

--- a/n26/library/models/slots.py
+++ b/n26/library/models/slots.py
@@ -143,6 +143,22 @@ class Pickable(Content, Assignable):
             "for pickables that work by their own modifiers."
         ),
     )
+    # Rating, never price. A pick is not bought: nothing leaves the
+    # gang's credits, so there is nothing to refund and nothing to sell.
+    # What a rolled result adds to a model's value — a Spyrer's Power
+    # Boost — still has to reach the card, and this is how: the pick is
+    # written with this as its rating contribution and no payment. A
+    # pick that is bought for credits is a purchase, and belongs in a
+    # collection, not here.
+    rating_contribution = models.IntegerField(
+        default=0,
+        help_text=(
+            "Credits this pick adds to the model's rating. A pick is never "
+            "paid for, so this is a rating, not a price. Leave at 0 unless "
+            "the rules raise the model's value, as a Spyrer's Power Boost "
+            "does."
+        ),
+    )
 
     class Meta:
         verbose_name = "pickable"

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -144,8 +144,8 @@ slot type. This one is written out because it uses all of them.
 A fighter hired from an entry carrying the slot arrives with an open
 "Gang Legacy" line on their card. Clicking it shows that picklist.
 Picking a legacy opens the legacy's equipment list on the fighter's
-equip page and changes nothing else. The pick is free and adds nothing
-to the gang's rating.
+equip page and changes nothing else. The pick is not paid for, and a
+legacy pickable adds nothing to the gang's rating.
 
 A picklist with one pickable is still a choice: the line stays open
 until the player picks, and nothing is picked for them.

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -1040,6 +1040,7 @@ def _build_registry():
                     model=Category, source=(Pickable, "category"), optional=True
                 ),
                 "qualifier": Text(source=(Pickable, "qualifier")),
+                "rating_contribution": Int(source=(Pickable, "rating_contribution")),
                 "library_author_help": Text(
                     source=(Pickable, "library_author_help"), long=True
                 ),

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -2310,3 +2310,156 @@ class TestAChoiceThatAllowsRepeatsOnScreen:
             for line in card.questions
             if line.kind_label == "Lasting Injuries"
         )
+
+
+# --- A pick that adds to rating ---------------------------------------------
+
+
+class TestAPickMayAddToRating:
+    """A pick is never paid for, but a pickable may say what holding it
+    adds to the model's rating — a Spyrer's Power Boost raises the
+    model's value by the amount the table prints. The pick is written
+    with that as its rating and nothing paid, so taking it back drops
+    the rating and moves no credits, and the owned-assignment acts
+    (sell, refund, reassign, remove) do not resolve for it at all."""
+
+    @pytest.fixture
+    def boost(self, default_pack):
+        return create_slot_type("Power Boost", allows_repeats=True)
+
+    @pytest.fixture
+    def results(self, boost):
+        return {
+            "Combat Neuroware": create_pickable(
+                "Combat Neuroware", boost, rating_contribution=20
+            ),
+            "Improved Motive Power": create_pickable(
+                "Improved Motive Power", boost, rating_contribution=10
+            ),
+            "Nothing Happens": create_pickable("Nothing Happens", boost),
+        }
+
+    @pytest.fixture
+    def power_boost_slot(self, boost, results):
+        table = create_picklist("Power Boost", boost, members=list(results.values()))
+        return create_slot("Power Boost", boost, table, min_picks=0, max_picks=3)
+
+    @pytest.fixture
+    def spyrer(self, person_type, gang_type, power_boost_slot):
+        profile = create_profile("Spyrer", person_type, gang_type, price=200)
+        add_built_in(profile, power_boost_slot)
+        return profile
+
+    @pytest.fixture
+    def boosted_spyrer(self, person_type, gang_type, power_boost_slot, results):
+        """Hired already holding one result: a slot's starting pick
+        carries its rating like a clicked one."""
+        profile = create_profile("Boosted Spyrer", person_type, gang_type, price=200)
+        add_built_in(
+            profile, power_boost_slot, default_pickable=results["Combat Neuroware"]
+        )
+        return profile
+
+    def _boost_slot(self, miniature):
+        return next(
+            line for line in choices_of(miniature) if line.kind_label == "Power Boost"
+        )
+
+    def test_the_pick_adds_its_rating_and_costs_no_credits(self, gang, spyrer, results):
+        orrus = hire(gang, spyrer, "Orrus", paid=200)
+        gang.refresh_from_db()
+        credits_before, rating_before = gang.credits, gang.rating
+
+        pick = choose(
+            self._boost_slot(orrus).anchor.assignment, results["Combat Neuroware"]
+        )
+
+        gang.refresh_from_db()
+        orrus.refresh_from_db()
+        assert gang.credits == credits_before
+        assert gang.rating == rating_before + 20
+        assert orrus.rating == 220
+        entry = pick.ledger_entry
+        assert (entry.paid, entry.list_price, entry.rating_contribution) == (0, 0, 20)
+        assert_reconciled(gang)
+
+    def test_a_pickable_that_adds_nothing_still_adds_nothing(
+        self, gang, spyrer, results
+    ):
+        orrus = hire(gang, spyrer, "Orrus", paid=200)
+        gang.refresh_from_db()
+        before = gang.rating
+
+        choose(self._boost_slot(orrus).anchor.assignment, results["Nothing Happens"])
+
+        gang.refresh_from_db()
+        assert gang.rating == before
+        assert_reconciled(gang)
+
+    def test_picks_stack_and_each_adds_its_own(self, gang, spyrer, results):
+        orrus = hire(gang, spyrer, "Orrus", paid=200)
+        anchor = self._boost_slot(orrus).anchor.assignment
+
+        choose(anchor, results["Combat Neuroware"])
+        choose(anchor, results["Improved Motive Power"])
+
+        orrus.refresh_from_db()
+        gang.refresh_from_db()
+        assert orrus.rating == 230
+        assert_reconciled(gang)
+
+    def test_taking_the_pick_back_drops_the_rating_and_returns_no_credits(
+        self, gang, spyrer, results
+    ):
+        orrus = hire(gang, spyrer, "Orrus", paid=200)
+        pick = choose(
+            self._boost_slot(orrus).anchor.assignment, results["Combat Neuroware"]
+        )
+        gang.refresh_from_db()
+        credits_before = gang.credits
+
+        remove(pick)
+
+        gang.refresh_from_db()
+        orrus.refresh_from_db()
+        assert gang.credits == credits_before
+        assert orrus.rating == 200
+        assert_reconciled(gang)
+
+    def test_a_starting_pick_carries_its_rating_too(self, gang, boosted_spyrer):
+        orrus = hire(gang, boosted_spyrer, "Orrus", paid=200)
+
+        orrus.refresh_from_db()
+        assert orrus.rating == 220
+        assert self._boost_slot(orrus).chosen_name == "Combat Neuroware"
+        assert_reconciled(gang)
+
+    def test_an_explicit_rating_wins(self, gang, spyrer, results):
+        orrus = hire(gang, spyrer, "Orrus", paid=200)
+
+        pick = choose(
+            self._boost_slot(orrus).anchor.assignment,
+            results["Combat Neuroware"],
+            rating=5,
+        )
+
+        assert pick.ledger_entry.rating_contribution == 5
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+
+    def test_a_pick_is_not_a_possession_so_no_money_act_resolves_for_it(
+        self, client, owner, gang, spyrer, results
+    ):
+        """Rating is not money: a pick cannot be sold, refunded or moved
+        through the acts that serve kit. Those addresses 404 for it, as
+        they do for the assignment naming the model itself."""
+        from django.urls import reverse
+
+        orrus = hire(gang, spyrer, "Orrus", paid=200)
+        pick = choose(
+            self._boost_slot(orrus).anchor.assignment, results["Combat Neuroware"]
+        )
+        client.force_login(owner)
+
+        for route in ("n26-sell", "n26-refund", "n26-reassign", "n26-remove"):
+            assert client.post(reverse(route, args=[pick.pk])).status_code == 404, route

--- a/n26/tests/sandbox/test_slots_and_picks.py
+++ b/n26/tests/sandbox/test_slots_and_picks.py
@@ -2365,7 +2365,7 @@ class TestAPickMayAddToRating:
             line for line in choices_of(miniature) if line.kind_label == "Power Boost"
         )
 
-    def test_the_pick_adds_its_rating_and_costs_no_credits(self, gang, spyrer, results):
+    def test_the_pick_adds_its_rating_and_moves_no_credits(self, gang, spyrer, results):
         orrus = hire(gang, spyrer, "Orrus", paid=200)
         gang.refresh_from_db()
         credits_before, rating_before = gang.credits, gang.rating
@@ -2432,6 +2432,33 @@ class TestAPickMayAddToRating:
         orrus.refresh_from_db()
         assert orrus.rating == 220
         assert self._boost_slot(orrus).chosen_name == "Combat Neuroware"
+        assert_reconciled(gang)
+
+    def test_a_pick_the_gang_holds_adds_nothing(
+        self, gang, person_type, gang_type, boost, results
+    ):
+        """Rating is what the models are worth; a gang-hosted assignment
+        carries none of its own, and a pick landing on the gang is no
+        exception, whatever its pickable says."""
+        table = create_picklist("Gang Boost", boost, members=list(results.values()))
+        gang_slot = create_slot(
+            "Gang Boost", boost, table, min_picks=0, max_picks=1, assigned_to="gang"
+        )
+        profile = create_profile("Rig Master", person_type, gang_type, price=200)
+        add_built_in(profile, gang_slot)
+        master = hire(gang, profile, "Orrus", paid=200)
+        gang.refresh_from_db()
+        before = gang.rating
+        anchor = next(
+            line for line in choices_of(master) if line.kind_label == "Gang Boost"
+        ).anchor.assignment
+
+        pick = choose(anchor, results["Combat Neuroware"])
+
+        gang.refresh_from_db()
+        assert pick.gang_id == gang.pk and pick.miniature_id is None
+        assert pick.ledger_entry.rating_contribution == 0
+        assert gang.rating == before
         assert_reconciled(gang)
 
     def test_an_explicit_rating_wins(self, gang, spyrer, results):


### PR DESCRIPTION
## Summary

- A pick is never paid for, but a rolled result can still raise a model's value: a Spyrer's Power Boost adds the amount the table prints. `Pickable` gains `rating_contribution` (credits, default 0), and `Operation._choose_for_slot` writes the pick with that as its rating and nothing paid. Removing the pick drops the rating and moves no credits; a pick still cannot be sold, refunded or reassigned.
- `Pickable.price` is deliberately not read for picks. Money moving means a purchase and belongs in a collection; credit value moving with no money is a rating on the pick. The field's help text says so.
- The field is on the pickable authoring form (via the `create_pickable` spec), and `n26/library/concepts.md` and `recipes.md` no longer say a pick adds nothing to rating.

This is the first PR of the Spyrer suit evolution plan (`.claude/notes/issue-2313-plan.md`, also in this PR). Nothing in shipped content sets the field yet, so no gang's rating changes on deploy.

**Migration:** `library` 0094 on 0093. merlin-a986's category-row field is taking 0095 behind this one; agreed on the board.

## Test plan

- [x] `pytest -n 4 n26` — 5811 passed, 1 xfailed
- [x] New tests in `n26/tests/sandbox/test_slots_and_picks.py::TestAPickMayAddToRating`: rating moves with the pick and reconciles; two picks stack; removal drops the rating and returns no credits; a slot's starting pick carries its rating; an explicit `rating=` wins; sell/refund/reassign/remove 404 for a pick
- [x] `manage makemigrations --check` clean; `check_migrations.sh` passes
- [x] Generated pickable form renders the field with its help text
- [ ] Authoring page `/n26/authoring/slot-type/<id>/` shows the new field on the pickable form (manual)

Refs #2313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kd7cthXUJ4wRCY14ZC1qM
