### PR TITLE
feat: let AddsAssignable give a hidden Slot with its starting pick (with_pick)

### DIFF
--- a/n26/core/card.py
+++ b/n26/core/card.py
@@ -1026,6 +1026,9 @@ def build_modifier_index(assignables, max_depth=3):
         "requires_companions__of",
         *(f"allows_at_most__{name}" for name in COUNTABLE_FIELDS),
         *(f"adds_assignable__{name}" for name in GRANTABLE_FIELDS),
+        # A granted slot's starting pick, dealt onto the card beside the
+        # slot — and a carrier in its own right, so it joins the frontier.
+        "adds_assignable__with_pick",
         *(f"removes_assignable__{name}" for name in GRANTABLE_FIELDS),
         "changes_stat__stat",
         "contributes_to_counter__counter",
@@ -1101,6 +1104,11 @@ def build_modifier_index(assignables, max_depth=3):
                     granted_thing = getattr(modifier.effect, "thing", None)
                     if granted_thing is not None:
                         granted.append(granted_thing)
+                    # The pick a granted slot arrives with runs its own
+                    # modifiers too; without this, they would never load.
+                    with_pick = getattr(modifier.effect, "with_pick", None)
+                    if with_pick is not None:
+                        granted.append(with_pick)
         frontier = granted
 
     return index

--- a/n26/core/effects.py
+++ b/n26/core/effects.py
@@ -581,6 +581,13 @@ class ComputedCard:
     #: Named special rules granted computedly — a gang type's "all our
     #: fighters may…", reaching each member through the broadcast.
     rules: list[Contribution] = field(default_factory=list)
+    #: Picks a grant dealt onto the card beside the slot they settle — a
+    #: Clan House choice that makes the gang count as a Goliath gang.
+    #: Facts, not lines: a granted slot is hidden, so nothing draws them,
+    #: but a condition asking "has picked Goliath" sees them exactly as
+    #: it sees a written pick. Their source is the slot, so they go the
+    #: moment it does.
+    picks: list[Contribution] = field(default_factory=list)
     #: Where skill sets and power families sit for this fighter — see
     #: ``CategoryPlacement``.
     placements: list[CategoryPlacement] = field(default_factory=list)
@@ -696,6 +703,7 @@ def compute(card, index):
     followed through the chain in one pass at the end — see ``_retract``
     and the module docstring.
     """
+    from n26.library.models import Pickable
     from n26.library.models.modifier import (
         AddsAssignable,
         AllowsAtMost,
@@ -819,11 +827,24 @@ def compute(card, index):
     # modifiers run once however many ways it reaches the card.
     # A grant whose scope keeps it the gang's alone never echoes: it
     # prints on the gang's card and touches no fighter.
+    from_the_gang = _from_the_gang(card, index)
     echoed = [
         contribution
-        for contribution in _from_the_gang(card, index)
+        for contribution in from_the_gang
         if contribution.echoes and ModifierIndex.key(contribution.thing) not in seen
     ]
+    # A pick the gang holds is a fact about every member, whichever way it
+    # arrived: a written gang pick already rides each card as a broadcast
+    # line and counts there, and a granted one must count the same. Read
+    # off the gang's whole grant list rather than the echoed part, because
+    # a grant kept the gang's alone still says what the gang *is* — a
+    # Clan House Goliath Outcast gang's fighters pass "has picked Goliath"
+    # exactly as a Goliath gang's do.
+    guest_picks = tuple(
+        contribution.thing
+        for contribution in from_the_gang
+        if isinstance(contribution.thing, Pickable)
+    )
     for contribution in echoed:
         seen.add(ModifierIndex.key(contribution.thing))
         # The gang's guest keeps the line it stands on: the gang wrote
@@ -842,7 +863,8 @@ def compute(card, index):
     edits = _own_removals(card)
     round_no = 0
     while (pending or edits) and round_no <= MAX_CHAIN_DEPTH:
-        facts = _Facts(card, computed)  # the snapshot every scope in this round sees
+        # The snapshot every scope in this round sees.
+        facts = _Facts(card, computed, guest_picks)
         adds, removes = [], []
         # The owner's removals settle with round 0, the reach an
         # unconditional content removal has.
@@ -970,6 +992,39 @@ def compute(card, index):
                             pending.extend(
                                 steps_for(thing, True, round_no, root_key=step.root_key)
                             )
+                        if effect.with_pick_id is not None:
+                            # The pick a granted slot arrives settled on.
+                            # Dealt as a second addition whose source is
+                            # the *slot*, not the carrier: the retraction
+                            # cascade then takes the pick the moment the
+                            # slot goes, whether a removal named the slot
+                            # or the carrier itself was taken away. A
+                            # carrier in its own right too, so what the
+                            # pick gives runs from here.
+                            pick = effect.with_pick
+                            adds.append(
+                                (
+                                    target,
+                                    Contribution(
+                                        thing=pick,
+                                        source=str(thing),
+                                        source_kind=kind_of(thing),
+                                        echoes=getattr(scope, "echoes", True),
+                                        root_key=step.root_key,
+                                    ),
+                                    step.node,
+                                    thing_key,
+                                )
+                            )
+                            step.granted = (*step.granted, str(pick))
+                            pick_key = ModifierIndex.key(pick)
+                            if pick_key not in seen:
+                                seen.add(pick_key)
+                                pending.extend(
+                                    steps_for(
+                                        pick, True, round_no, root_key=step.root_key
+                                    )
+                                )
                     elif isinstance(effect, RemovesAssignable):
                         removes.append(
                             (
@@ -1226,6 +1281,10 @@ class ComputedGang:
     choices: list = field(default_factory=list)
     rules: list = field(default_factory=list)
     collections: list = field(default_factory=list)
+    #: Picks a grant dealt onto the gang beside a hidden slot — what a
+    #: gang-scoped "has picked" condition reads, and what every member's
+    #: facts inherit.
+    picks: list = field(default_factory=list)
     counters: list = field(default_factory=list)
     #: Empty today — placements land on models — but present so anything
     #: reading placements (``n26.core.browse.offered_by`` shaping a gang-level
@@ -1311,6 +1370,7 @@ def compute_gang(gang_card, index):
         choices=computed.choices,
         rules=computed.rules,
         collections=computed.collections,
+        picks=computed.picks,
         counters=counter_readings(gang_card, computed),
         placements=computed.placements,
         effects=computed.stored_effects,
@@ -1514,7 +1574,7 @@ class _Facts:
     settled by earlier rounds. Built once per round, so every question in
     the round sees the same world."""
 
-    def __init__(self, card, computed):
+    def __init__(self, card, computed, guest_picks=()):
         from n26.core import select
 
         self._select = select
@@ -1523,9 +1583,15 @@ class _Facts:
         # Counter contributions are part of what a threshold reads, and
         # they settle round by round like everything else here: a
         # contribution made in one round is asked about from the next.
+        # Granted picks settle the same way, and the gang's granted picks
+        # (``guest_picks``) are facts about the member from the start.
         self._model = (
             card.model_matchable()
-            .also(*(contribution.thing for contribution in computed.subtypes))
+            .also(
+                *(contribution.thing for contribution in computed.subtypes),
+                *(contribution.thing for contribution in computed.picks),
+                *guest_picks,
+            )
             .counting(counter_totals(computed))
         )
 
@@ -1733,7 +1799,7 @@ def _bucket(computed, target, thing):
     (``card_row`` — subtypes, skills, powers, rules, collections, and
     the ComputedCard's buckets carry the same names), granted equipment,
     or a weapon's traits."""
-    from n26.library.models import Wargear, Weapon
+    from n26.library.models import Pickable, Wargear, Weapon
 
     if target.kind == WEAPON_PROFILE:
         return computed.weapons[target.node.key], "traits"
@@ -1742,6 +1808,10 @@ def _bucket(computed, target, thing):
         return computed, row
     if isinstance(thing, (Weapon, Wargear)):
         return computed, "granted_gear"
+    if isinstance(thing, Pickable):
+        # A granted pick draws no line — its slot is hidden — but it is a
+        # fact the next round's conditions read, so it is kept.
+        return computed, "picks"
     return None, None
 
 

--- a/n26/library/authoring.py
+++ b/n26/library/authoring.py
@@ -1930,7 +1930,9 @@ def targets_gang():
 
 def targets_gang_alone():
     """The gang carrying it: applied only to the gang, and what it gives
-    the gang does not reach the models."""
+    the gang does not reach the models. A pick given with a slot is the
+    exception: what the gang has picked is a fact about every model in
+    it, whichever way the pick arrived."""
     from n26.library.models import TargetsGang
 
     return TargetsGang.objects.create(echoes=False)
@@ -1939,9 +1941,15 @@ def targets_gang_alone():
 # --- Effects: what a modifier does (ef_ at read, op_ at purchase) -----------
 
 
-def ef_adds(thing):
+def ef_adds(thing, with_pick=None):
     """Grants the target a subtype, skill, trait, collection, rule, weapon
     or wargear — or a further choice, which is how one pick opens the next.
+
+    ``with_pick`` is the pick a granted slot arrives settled on —
+    ``ef_adds(supertype_slot, with_pick=goliath)`` for a Clan House
+    choice that makes the gang count as a Goliath gang. The pick lasts
+    exactly as long as the slot. Only a hidden slot may carry one: a
+    granted pick has no assignment of its own to remove.
 
     Granted weapons and wargear add zero rating and are removed when
     their source is removed. Their modifiers apply. Weapons include free
@@ -1958,7 +1966,13 @@ def ef_adds(thing):
     """
     from n26.library.models import AddsAssignable
 
-    return AddsAssignable.objects.create(**_assignable_kwarg(thing))
+    grant = AddsAssignable(**_assignable_kwarg(thing), with_pick=with_pick)
+    if with_pick is not None:
+        # The pick has to belong to a hidden slot of its own type, and
+        # only the row knows both ends — so the row says it, once.
+        grant.clean()
+    grant.save()
+    return grant
 
 
 def ef_removes(thing):

--- a/n26/library/concepts.md
+++ b/n26/library/concepts.md
@@ -79,6 +79,10 @@ The relationships after one hire, spelled out:
 
 Do not author a new kind for this. Create a **slot type** (Affiliation, Chaos God, Variant, or a new name), its **pickables**, a **picklist**, and a **slot** assigned to the gang. Grant that slot from a hidden built into the gang type, or from the gang type itself. Attach ordinary modifiers to each pickable to define its effects. For example, a pickable can open equipment lists to some ranks, or grant another slot while the pick remains assigned.
 
+A choice can arrive already made. Built into a gang type, a slot takes a **starting pick**. A modifier that gives a hidden slot can give it **with a pick**: the pick arrives with the slot, counts as picked wherever a condition asks "has picked", and goes when the slot goes. Only a hidden slot can be given this way, because a given pick has no Remove control of its own. This is how one gang-level choice settles another: picking a Clan House for an Outcast gang gives the gang's hidden Gang supertype slot with that House already picked, so the gang counts as a gang of that House wherever a rule asks.
+
+A pick the gang holds is a fact about every model in it, whether the pick was written or given. A condition on a model that asks "has picked Goliath" is true of every member of a gang that has picked Goliath, even when the grant is the gang's alone.
+
 The slot type's name is the word the card and the history use. The slot's label is the wording of the choice on one card. See **Slot type** below.
 
 ### Rule (special rule)
@@ -252,6 +256,8 @@ One specific, named use of a slot type. Assigning one to a model or gang — bui
 The pick is an ordinary assignment: the pickable, hosted where the slot says it lands, caused by the slot's own assignment and pointing back at it. So removing the slot removes the pick and everything the pickable gave. Two slots of one slot type on one holder stay independent, even where one thing opened both. Nothing is worked out from what kind of thing was chosen. A pick is never paid for: no credits move, and there is nothing to refund or sell. A pickable may still carry a rating contribution — a Spyrer's Power Boost result raises the model's value by the amount the table prints — and the pick carries that as its rating. Removing the pick removes that rating too. A pick the gang holds adds nothing, whatever its pickable says. Most pickables add 0.
 
 A pick the gang holds is broadcast (but not displayed) to every member: a rule reaching "models with the Cawdor legacy" reaches them all, including the fighter who made the pick. A pickable that carries the *draws the pick on the card* effect is displayed after all, on the cards its scope reaches. See below.
+
+A pick can also arrive with a slot a modifier gives (*gives* a hidden slot **with a pick**). That pick is not an assignment: it is worked out when the card is read, draws no line, and the player cannot change or remove it. It counts as picked wherever a condition asks, on the holder and, for a slot the gang holds, on every member. It goes when the slot goes. Only a hidden slot can be given this way.
 
 Where the slot type does not allow repeats, the picker marks the pickables already picked for another slot, and the card notes when one pickable is picked for two (no page prints these notes yet). Marks and notes, never locks: the narrowing informs, and an owner may still hand over a pickable no picklist offered.
 

--- a/n26/library/forms.py
+++ b/n26/library/forms.py
@@ -569,9 +569,35 @@ class GeneratedForm(forms.Form):
         # An ask typed for one kind must not survive switching to a
         # kind that never asked — the value only means what the chosen
         # kind says it means.
+        asks = {}
         for ask_name, options in self.union_asks.get(name, {}).items():
             if chosen not in options:
                 cleaned[ask_name] = None
+            elif cleaned.get(ask_name) is not None:
+                asks[ask_name] = cleaned[ask_name]
+        if asks and not isinstance(picked, PendingCreate):
+            self._refuse_as_the_row_would(name, kind, chosen, picked, asks)
+
+    def _refuse_as_the_row_would(self, name, kind, chosen, picked, asks):
+        """An ask the chosen kind declares is judged by the row it is
+        written into, before the verb runs.
+
+        The through row's own ``clean`` knows both ends — a starting
+        pick belongs to a hidden slot of its own type — and the verb
+        raises what it says. Asking the row here puts that refusal on
+        the ask's field instead of letting it surface as a failed
+        request. A newly named thing is not judged: it does not exist
+        yet, and the verb creates it as the kind's plain default.
+        """
+        try:
+            kind.through(**{chosen: picked}, **asks).clean()
+        except ValidationError as refused:
+            picker = f"{name}_{chosen}"
+            if not hasattr(refused, "error_dict"):
+                self.add_error(picker, refused)
+                return
+            for field, errors in refused.error_dict.items():
+                self.add_error(field if field in self.fields else picker, errors)
 
     def verb_data(self):
         """The spec-field values a valid form holds, ready for the verb:

--- a/n26/library/forms.py
+++ b/n26/library/forms.py
@@ -364,6 +364,12 @@ def _initial_from(spec, row):
             if chosen is not None:
                 initial[f"{name}_kind"] = chosen
                 initial[f"{name}_{chosen}"] = getattr(row, chosen)
+            # The asks the chosen kind declares ride the same row, so an
+            # edit opens on them too — otherwise saving a grant without
+            # touching its pick would silently drop the pick.
+            for ask_name, options in _union_asks(kind).items():
+                if chosen in options and getattr(row, ask_name, None) is not None:
+                    initial[ask_name] = getattr(row, ask_name)
         elif isinstance(kind, Choice) and kind.reads is not None:
             initial[name] = kind.reads(row)
         elif not hasattr(row, name):

--- a/n26/library/migrations/0097_a_grant_may_carry_its_pick.py
+++ b/n26/library/migrations/0097_a_grant_may_carry_its_pick.py
@@ -1,0 +1,55 @@
+"""A grant of a slot may carry the pick the slot arrives settled on.
+
+``AddsAssignable.with_pick`` is the grant-side twin of
+``DefaultAssignment.default_pickable``: "gives this slot, already
+settled on this pick". The pick is dealt onto the card beside the slot
+and goes the moment the slot does. It is how one gang-level choice
+settles another — a Clan House pick on an Outcast gang gives the hidden
+Gang supertype slot with that House already picked, so the gang counts
+as a gang of that House wherever a rule asks.
+
+The constraint says what the database can: a pick needs a slot beside
+it. That the pick belongs to the slot's type, and that the slot is
+hidden, only the row knows, and ``clean()`` says.
+
+Reversible: the column and the constraint go.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("library", "0093_a_stat_has_a_minimum_and_a_maximum"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="addsassignable",
+            name="with_pick",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "The pick a granted slot arrives settled on. Only for a "
+                    "hidden slot; leave blank for anything else."
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="library.pickable",
+                verbose_name="pick given with the slot",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="addsassignable",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    ("with_pick__isnull", True),
+                    ("slot__isnull", False),
+                    _connector="OR",
+                ),
+                name="adds_assignable_pick_belongs_to_a_slot",
+            ),
+        ),
+    ]

--- a/n26/library/migrations/0097_a_grant_may_carry_its_pick.py
+++ b/n26/library/migrations/0097_a_grant_may_carry_its_pick.py
@@ -21,7 +21,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("library", "0093_a_stat_has_a_minimum_and_a_maximum"),
+        ("library", "0096_a_price_may_be_below_zero"),
     ]
 
     operations = [

--- a/n26/library/migrations/0102_a_grant_may_carry_its_pick.py
+++ b/n26/library/migrations/0102_a_grant_may_carry_its_pick.py
@@ -21,7 +21,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("library", "0096_a_price_may_be_below_zero"),
+        ("library", "0101_modifiers_can_grant_wargear"),
     ]
 
     operations = [

--- a/n26/library/models/modifier.py
+++ b/n26/library/models/modifier.py
@@ -805,7 +805,9 @@ class TargetsGang(models.Model):
     #: it does to every fighter. Off, the grant is the gang's alone:
     #: it prints on the gang's card and touches no fighter. Stored
     #: assignments the gang holds (a pick made for it) ride regardless —
-    #: that is assignment-level broadcast, not this modifier's.
+    #: that is assignment-level broadcast, not this modifier's. A pick
+    #: given with a slot counts the same way: what the gang has picked is
+    #: a fact about every member, however the pick arrived.
     echoes = models.BooleanField(
         default=True,
         help_text=(
@@ -972,7 +974,29 @@ class AddsAssignable(AssignableChoice):
 
     Naming a hidden carrier gives a *bundle*: it draws no row, so what
     arrives is everything it in turn does.
+
+    A granted slot may arrive already settled: ``with_pick`` names the
+    pick it comes with. The pick stays as long as the slot does. Only a
+    hidden slot may carry one, because a granted pick has no assignment
+    of its own to remove.
     """
+
+    #: The key ``Slot.ATTACHMENT_ASKS`` uses to say what granting it
+    #: asks for beyond the slot itself (library/offers.py).
+    attachment_context = "grant"
+
+    with_pick = models.ForeignKey(
+        "library.Pickable",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="+",
+        verbose_name="pick given with the slot",
+        help_text=(
+            "The pick a granted slot arrives settled on. Only for a hidden "
+            "slot; leave blank for anything else."
+        ),
+    )
 
     class Meta:
         verbose_name = "adds assignable"
@@ -982,10 +1006,56 @@ class AddsAssignable(AssignableChoice):
                 condition=exactly_one_of(GRANTABLE_FIELDS),
                 name="adds_assignable_exactly_one",
             ),
+            models.CheckConstraint(
+                condition=(
+                    models.Q(with_pick__isnull=True) | models.Q(slot__isnull=False)
+                ),
+                name="adds_assignable_pick_belongs_to_a_slot",
+            ),
         ]
 
     def __str__(self):
+        if self.with_pick_id is not None:
+            return f"adds {super().__str__()} with {self.with_pick}"
         return f"adds {super().__str__()}"
+
+    def clean(self):
+        """A starting pick belongs to a hidden slot of its own type.
+
+        Only this row knows both ends, so the database can say that a
+        pick needs a slot and nothing more.
+        """
+        super().clean()
+        if self.with_pick_id is None:
+            return
+        if self.slot_id is None:
+            raise ValidationError(
+                {
+                    "with_pick": (
+                        "A starting pick belongs to a slot. Identify the "
+                        "slot for this pick."
+                    )
+                }
+            )
+        if self.with_pick.slot_type_id != self.slot.slot_type_id:
+            raise ValidationError(
+                {
+                    "with_pick": (
+                        f"{self.with_pick} belongs to {self.with_pick.slot_type}, "
+                        f"and {self.slot} offers {self.slot.slot_type} pickables."
+                    )
+                }
+            )
+        if not self.slot.hidden:
+            raise ValidationError(
+                {
+                    "with_pick": (
+                        f"Only a hidden slot can be given with its pick. "
+                        f"{self.slot} is shown on the card, so a pick given "
+                        "with it would have no Remove control."
+                    )
+                }
+            )
 
 
 class RemovesAssignable(AssignableChoice):

--- a/n26/library/models/slots.py
+++ b/n26/library/models/slots.py
@@ -522,11 +522,13 @@ class Slot(Content, Assignable):
 
     #: Building a slot in is what carries its starting pick — the
     #: Ironhead Squats profile arriving with the Squats legacy already
-    #: chosen — so that is what attaching one asks for. Restated with the
+    #: chosen — so that is what attaching one asks for, and a grant of a
+    #: slot asks the same question of its own row. Restated with the
     #: inherited entry ask, because declaring these replaces rather than
     #: merges (library/offers.py).
     ATTACHMENT_ASKS = {
         "built-in": ("default_pickable",),
+        "grant": ("with_pick",),
         "entry": ("price_override", "trade_point_override"),
     }
 

--- a/n26/library/offers.py
+++ b/n26/library/offers.py
@@ -5,7 +5,8 @@ computed from them here; no form ever knows a kind by name.
 
 **Attachment asks.** When a row is named by a through row — built into
 a profile (``DefaultAssignment``), listed in a collection
-(``CollectionEntry``) — the through row sometimes carries values that
+(``CollectionEntry``), given by a modifier (``AddsAssignable``) — the
+through row sometimes carries values that
 only make sense for some kinds: a counter's opening value, an entry's
 price override. Which of those apply is the *kind's* knowledge, declared
 in ``ATTACHMENT_ASKS`` on the assignable class, keyed by the through
@@ -44,11 +45,11 @@ class Ask:
 def attachment_contexts():
     """Every through row that attaches assignables, by its context key —
     what the declarations on the kinds are checked against."""
-    from n26.library.models import CollectionEntry, DefaultAssignment
+    from n26.library.models import AddsAssignable, CollectionEntry, DefaultAssignment
 
     return {
         through.attachment_context: through
-        for through in (DefaultAssignment, CollectionEntry)
+        for through in (DefaultAssignment, CollectionEntry, AddsAssignable)
     }
 
 

--- a/n26/library/prose.py
+++ b/n26/library/prose.py
@@ -330,6 +330,12 @@ def _says_adds(effect, parts):
     who, thing = parts.who, effect.thing
     chain = parts.chain.get(_identity(thing), ())
     tail = f" — which itself gives {_and_then(chain)}" if chain else ""
+    # A slot given with its pick: the choice arrives already made.
+    settled = (
+        f", with {effect.with_pick} already picked"
+        if effect.with_pick_id is not None
+        else ""
+    )
     hint = (
         "Applies while the item carrying this modifier is assigned, and "
         "goes with it. Free — adds nothing to any rating."
@@ -339,11 +345,14 @@ def _says_adds(effect, parts):
     if parts.target == GANG_TARGET:
         landing = _ON_THE_GANG.get(type(thing)._meta.model_name, "held by the gang")
         return (
-            f"the gang gains {_gained(thing)}, {landing}{tail}.",
+            f"the gang gains {_gained(thing)}{settled}, {landing}{tail}.",
             f"{hint} {_GANG_REACH}",
         )
     verb = _agrees(who, "gains", "gain")
-    return f"{who.subject} {verb} {_gained(thing)}{_while(who)}{tail}.", hint
+    return (
+        f"{who.subject} {verb} {_gained(thing)}{settled}{_while(who)}{tail}.",
+        hint,
+    )
 
 
 @_renders("removes_assignable")
@@ -1177,6 +1186,7 @@ def _referenced_by(edges):
     said = [
         *_built_into(edges),
         *_started_with(edges),
+        *_granted_with_a_pick(edges),
         *_listed(edges),
         *_granted(edges),
         *_brought(edges),
@@ -1323,8 +1333,40 @@ def _started_with(edges):
     ]
 
 
+def _granted_with_a_pick(edges):
+    """The granted slots this arrives already settling — a grant with a
+    starting pick.
+
+    The grant-side twin of :func:`_started_with`: nothing gives the
+    pickable in its own right, it comes with the slot the grant hands
+    over, and it goes when that slot does. Read off the grant's own
+    ``with_pick`` column, never as "given by" — the grant gives the slot.
+    """
+    return [
+        Sentence(
+            text=f"Chosen from the start for {_named(reference.row.slot)}.",
+            hint=(
+                "Arrives already picked, with a slot that a modifier gives. "
+                "Players cannot change it. Goes when the slot does."
+            ),
+            key=_identity(reference.row.slot),
+        )
+        for reference in of_kind(
+            edges.references, "library.addsassignable", "with_pick"
+        )
+        if reference.row.slot_id is not None
+    ]
+
+
 def _granted(edges):
-    """Who gives it and who takes it away — the modifier routes."""
+    """Who gives it and who takes it away — the modifier routes.
+
+    Only the columns that name the thing given or taken: a grant also
+    names the pick a slot arrives with, and that is a route of its own
+    (:func:`_granted_with_a_pick`), not "given by".
+    """
+    from n26.library.models.modifier import GRANTABLE_FIELDS
+
     routes = [
         ("library.addsassignable", "Given", " to the gang", _GIVEN_HINT),
         ("library.removesassignable", "Taken away", " from the gang", _TAKEN_HINT),
@@ -1332,6 +1374,8 @@ def _granted(edges):
     said = []
     for label, verb, of_the_gang, hint in routes:
         for reference in of_kind(edges.references, label):
+            if reference.field not in GRANTABLE_FIELDS:
+                continue
             modifier = _modifier_of(reference.row)
             if modifier is None:
                 continue

--- a/n26/library/recipes.md
+++ b/n26/library/recipes.md
@@ -202,6 +202,47 @@ When those checks pass, add the house collection to the real gang type's built-i
 
 If you archive the main hire collection, gangs can again hire fighters listed under their gang type. The collection stays hidden on the gang sheet. Check the gang type's fighter entries before using this fallback: it can include fighters that the collection excluded.
 
+## A Clan House Outcast gang
+
+An Outcast gang chooses one of the six Clan Houses when it is created,
+and for campaign purposes counts as a gang of that House. Two gang-level
+choices are involved: the Clan House the Outcast player picks, and the
+hidden **Gang supertype** slot every gang carries. A Clan House gang
+type arrives with its supertype already picked. The Clan House pick
+fills the supertype slot.
+
+1. Create a **slot type** named "Gang supertype" and a **pickable** for
+   each House — Goliath, Escher, Orlock, Van Saar, Delaque, Cawdor.
+   These pickables carry no modifiers of their own. A rule reaches them
+   through the *has pickable* condition instead.
+2. Add a **picklist** of the six, and a **slot** named "Gang supertype",
+   taking 1 pick, assigned to the gang, with *hidden* turned on. Hidden
+   means the gang sheet never prints a "Gang supertype" line.
+3. Build that slot into every gang type. On each Clan House gang type,
+   name the matching House as the **starting pick**. On Outcast,
+   Enforcers and the rest, build it in with no starting pick.
+4. The Clan House choice is its own slot type, with its own pickables
+   carrying the equipment access and the rest of what the choice gives.
+   On each "Clan House: X" pickable, add a **modifier**: targets the gang
+   alone, *gives* the Gang supertype slot, **with X picked**. The pick
+   control appears once you choose a slot as the kind, and only a hidden
+   slot can take one.
+
+A Goliath gang and a Clan House Goliath Outcast gang now both have
+Goliath picked for their Gang supertype. A rule written as *targets
+every model, where it has picked Goliath* reaches every fighter in both.
+Taking the Clan House pick back takes the supertype pick with it, and
+the rule stops applying.
+
+One step is not yet possible: a condition on the gang itself (*targets
+the gang, where it has picked Goliath*). Until the gang scope takes
+conditions, a rule meant for the gang alone has to be written on the
+model scope and reach the gang's fighters instead.
+
+Nothing new shows on the gang sheet. The given pick is a fact about the
+gang, not a line: it adds nothing to the rating and does not appear in
+the history.
+
 ## A Gang Legacy
 
 > Draft, for review. The steps below are the authoring steps. Everything

--- a/n26/library/references.py
+++ b/n26/library/references.py
@@ -36,7 +36,7 @@ READ_WITH = {
     "library.option": ("default_set", "profile", "wargear"),
     # The slot rides along for the same reason: a grant naming a starting
     # pick is read as "chosen from the start for that choice".
-    "library.addsassignable": ("modifier", "slot"),
+    "library.addsassignable": ("modifier", "slot", "with_pick"),
     "library.removesassignable": ("modifier",),
     "library.offerschoice": ("modifier", "from_section__collection"),
     "library.placescategory": ("modifier", "section__collection", "category"),

--- a/n26/library/references.py
+++ b/n26/library/references.py
@@ -34,7 +34,9 @@ READ_WITH = {
     "library.defaultassignment": ("default_set", "slot"),
     "library.picklistmember": ("picklist", "pickable"),
     "library.option": ("default_set", "profile", "wargear"),
-    "library.addsassignable": ("modifier",),
+    # The slot rides along for the same reason: a grant naming a starting
+    # pick is read as "chosen from the start for that choice".
+    "library.addsassignable": ("modifier", "slot"),
     "library.removesassignable": ("modifier",),
     "library.offerschoice": ("modifier", "from_section__collection"),
     "library.placescategory": ("modifier", "section__collection", "category"),

--- a/n26/library/specs.py
+++ b/n26/library/specs.py
@@ -304,6 +304,13 @@ class Spec:
                 kwargs[name] = kind.coerce(value)
             else:
                 kwargs[name] = value
+        # What a union's kinds ask for beyond the pick — a slot's starting
+        # pick — rides the same data (``GeneratedForm.verb_data``). It is
+        # not a spec field, and the verb takes it by name, so it is handed
+        # on wherever the verb has a parameter for it.
+        for name, value in data.items():
+            if name not in self.fields and name in signature.parameters:
+                kwargs[name] = value
         return self.verb(*args, **kwargs)
 
 
@@ -342,6 +349,7 @@ def _build_registry():
     from n26.library import authoring
     from n26.library.income import INCOME_HELP
     from n26.library.models import (
+        AddsAssignable,
         Affiliation,
         AllowsAtMost,
         Asset,
@@ -564,22 +572,29 @@ def _build_registry():
             authoring.targets_gang_alone,
             {},
             label="The gang carrying it",
-            blurb="Applied only to the gang; does not reach the models.",
+            blurb=(
+                "Applied only to the gang; does not reach the models. A pick "
+                "given with a slot is still a fact about every model in the gang."
+            ),
             example=(
                 "A rule that prints on the gang sheet without touching the "
                 "fighters, or a gang-level counter."
             ),
         ),
         # -- effects, worked out at read time --------------------------
+        # What granting each kind asks for beyond the thing itself — a
+        # slot's starting pick — comes from the kind's own ATTACHMENT_ASKS,
+        # resolved through the union, so the pick control is drawn only
+        # when the chosen kind is a slot.
         Spec(
             authoring.ef_adds,
-            {"thing": Union(over=dict(GRANTABLE_FIELDS))},
+            {"thing": Union(over=dict(GRANTABLE_FIELDS), through=AddsAssignable)},
             label="Gives something",
             blurb=(
                 "The target gains a subtype, skill, power, rule, trait, "
                 "list, weapon or wargear — or a hidden item, which brings whatever "
                 "it gives. For as long as the item carrying this modifier "
-                "stays."
+                "stays. A hidden slot can be given with its pick already made."
             ),
             example=(
                 "The Cutter grants Mounted; Mounted grants Nerves of "

--- a/n26/tests/sandbox/test_a_grant_may_carry_its_pick.py
+++ b/n26/tests/sandbox/test_a_grant_may_carry_its_pick.py
@@ -573,6 +573,71 @@ class TestTheComposer:
         assert grant.slot == supertype_slot
         assert grant.with_pick == houses["Goliath"]
 
+    def test_a_pick_of_another_type_is_refused_on_its_field(
+        self, supertype_slot, default_pack
+    ):
+        """The row's own refusal lands on the pick control, so the page
+        redraws with it instead of failing the request."""
+        from n26.library.forms import generate_form
+        from n26.library.specs import specs
+
+        other = create_slot_type("Legacy", plural_name="Legacies")
+        stranger = create_pickable("Cawdor", other)
+        form = generate_form(specs()["ef_adds"])(
+            {
+                "thing_kind": "slot",
+                "thing_slot": str(supertype_slot.pk),
+                "with_pick": str(stranger.pk),
+            }
+        )
+
+        assert not form.is_valid()
+        (error,) = form.errors["with_pick"]
+        assert "offers Gang supertype pickables" in error
+
+    def test_a_pick_beside_a_shown_slot_is_refused_on_its_field(
+        self, shown_slot, houses
+    ):
+        from n26.library.forms import generate_form
+        from n26.library.specs import specs
+
+        form = generate_form(specs()["ef_adds"])(
+            {
+                "thing_kind": "slot",
+                "thing_slot": str(shown_slot.pk),
+                "with_pick": str(houses["Goliath"].pk),
+            }
+        )
+
+        assert not form.is_valid()
+        (error,) = form.errors["with_pick"]
+        assert "Only a hidden slot can be given with its pick" in error
+
+    def test_the_composer_page_redraws_a_refused_pick(self, client, shown_slot, houses):
+        """The modifier views catch a duplicate name and nothing else, so
+        the form has to hold the refusal itself for the page to show it."""
+        from n26.library.models import Modifier
+
+        client.force_login(User.objects.create_user("author", is_staff=True))
+        response = client.post(
+            "/n26/authoring/modifiers/new/",
+            {
+                "scope_kind": "targets_gang",
+                "effect_kind": "ef_adds",
+                "what-thing_kind": "slot",
+                "what-thing_slot": str(shown_slot.pk),
+                "what-with_pick": str(houses["Goliath"].pk),
+                "conditions-TOTAL_FORMS": "0",
+                "conditions-INITIAL_FORMS": "0",
+            },
+        )
+
+        assert response.status_code == 200
+        assert "Only a hidden slot can be given with its pick" in (
+            response.content.decode()
+        )
+        assert Modifier.objects.count() == 0
+
     def test_editing_a_grant_opens_on_its_pick(self, supertype_slot, houses):
         from n26.library.forms import generate_form
         from n26.library.specs import specs

--- a/n26/tests/sandbox/test_a_grant_may_carry_its_pick.py
+++ b/n26/tests/sandbox/test_a_grant_may_carry_its_pick.py
@@ -1,0 +1,585 @@
+"""A grant of a slot may carry the pick the slot arrives settled on.
+
+The Clan House Outcast case (design/house-and-territory-tables.md): an
+Outcast gang picks a Clan House, and for campaign purposes counts as a
+gang of that House. Every gang carries a hidden Gang supertype slot;
+Clan House gang types build it in with a starting pick, and the Outcast
+gang's Clan House pick *gives* the same slot with the House already
+picked. ``ef_adds(slot, with_pick=…)`` is the grant-side twin of a
+built-in's starting pick.
+
+What this file holds still: the given pick is a fact a "has picked"
+condition reads, on the bearer and on every member of a gang that holds
+it; it is not a line, opens no choice and is worth nothing; it stands on
+the slot, so it goes the moment the slot does; it runs its own
+modifiers; and a pick is refused without a slot, with a slot of another
+type, or with a slot that is shown on the card.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, connection, transaction
+from django.test.utils import CaptureQueriesContext
+
+from n26.core.card import build_card, build_gang_card, build_modifier_index
+from n26.core.effects import compute, compute_gang
+from n26.core.models import Assignment
+from n26.core.reconcile import assert_reconciled
+from n26.core.render import build_model_card, render_gang
+from n26.library.models import AddsAssignable
+from n26.library.prose import prose_for, sentence_for
+from n26.tests.sandbox.actions import (
+    add_built_in,
+    assign,
+    choose,
+    create_gang_type,
+    create_hidden,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_rule,
+    create_slot,
+    create_slot_type,
+    create_wargear,
+    ef_adds,
+    ef_removes,
+    found_gang,
+    has_pickable,
+    hire,
+    modifier,
+    remove,
+    targets_every_model,
+    targets_gang,
+    targets_gang_alone,
+    targets_model,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+# --- The supertype: a hidden gang-level choice with marker pickables --------
+
+
+@pytest.fixture
+def owner(db):
+    return User.objects.create_user("player")
+
+
+@pytest.fixture
+def supertype(default_pack):
+    return create_slot_type(
+        "Gang supertype", plural_name="Gang supertypes", allows_repeats=False
+    )
+
+
+@pytest.fixture
+def houses(supertype):
+    """Markers carrying no modifiers of their own; rules key on them."""
+    return {name: create_pickable(name, supertype) for name in ("Goliath", "Escher")}
+
+
+@pytest.fixture
+def supertypes(supertype, houses):
+    return create_picklist("Gang supertypes", supertype, members=list(houses.values()))
+
+
+@pytest.fixture
+def supertype_slot(supertype, supertypes):
+    """Hidden: the sheet never prints a "Gang supertype" line."""
+    return create_slot(
+        "Gang supertype", supertype, supertypes, assigned_to="gang", hidden=True
+    )
+
+
+@pytest.fixture
+def shown_slot(supertype, supertypes):
+    """The same choice, shown — what a grant may not carry a pick for."""
+    return create_slot("Shown supertype", supertype, supertypes, assigned_to="gang")
+
+
+@pytest.fixture
+def gang_type(default_pack):
+    return create_gang_type("Outcasts")
+
+
+@pytest.fixture
+def goliath_rule(gang_type, houses):
+    """A rule for every fighter of a gang that has picked Goliath — the
+    shape a journal's "Goliath Controlled" boon takes on a model."""
+    rule = create_rule("Goliath Controlled")
+    modifier(
+        "Outcasts: Goliath Controlled",
+        targets_every_model(has_pickable(houses["Goliath"])),
+        ef_adds(rule),
+        carried_by=gang_type,
+    )
+    return rule
+
+
+@pytest.fixture
+def clan_house(default_pack, supertype_slot, houses):
+    """The Outcast choice: its own slot type, its own pickables. Picking
+    Goliath gives the gang's supertype slot with Goliath already picked."""
+    slot_type = create_slot_type("Clan House")
+    goliath = create_pickable("Clan House: Goliath", slot_type)
+    modifier(
+        "Clan House: Goliath — the gang counts as Goliath",
+        targets_gang_alone(),
+        ef_adds(supertype_slot, with_pick=houses["Goliath"]),
+        carried_by=goliath,
+    )
+    clan_houses = create_picklist("Clan Houses", slot_type, members=[goliath])
+    slot = create_slot("Clan House", slot_type, clan_houses, assigned_to="gang")
+    return slot, goliath
+
+
+@pytest.fixture
+def leader(person_type, gang_type, clan_house):
+    slot, _ = clan_house
+    profile = create_profile("Outcast Leader", person_type, gang_type, price=120)
+    add_built_in(profile, slot)
+    return profile
+
+
+@pytest.fixture
+def scav(person_type, gang_type):
+    return create_profile("Scav", person_type, gang_type, price=40)
+
+
+@pytest.fixture
+def gang(owner, gang_type):
+    return found_gang("The Forgotten", gang_type, owner=owner, budget=1000)
+
+
+def card_of(miniature):
+    card = build_card(miniature, with_statlines=True)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return card, compute(card, index)
+
+
+def drawn_card(miniature):
+    card, computed = card_of(miniature)
+    return build_model_card(miniature, card=card, computed=computed)
+
+
+def gang_computed(gang):
+    card = build_gang_card(gang)
+    index = build_modifier_index([node.assignable for node in card.all_nodes()])
+    return compute_gang(card, index)
+
+
+def names(contributions):
+    return [contribution.name for contribution in contributions]
+
+
+def pick_clan_house(gang, boss, clan_house):
+    _, goliath = clan_house
+    (slot,) = [s for s in card_of(boss)[1].choices if s.kind_label == "Clan House"]
+    choose(slot.anchor.assignment, goliath)
+
+
+# --- On a model ------------------------------------------------------------
+
+
+class TestAGrantCarriesItsPickOntoTheBearer:
+    """The simplest shape: kit on a fighter gives a hidden slot with its
+    pick. The pick is a fact about the fighter and nothing more — no
+    line, no open choice, no rating."""
+
+    @pytest.fixture
+    def badge_slot(self, supertype, supertypes):
+        return create_slot("Own supertype", supertype, supertypes, hidden=True)
+
+    @pytest.fixture
+    def badge(self, badge_slot, houses):
+        gear = create_wargear("Goliath badge")
+        modifier(
+            "Goliath badge: counts as Goliath",
+            targets_model(),
+            ef_adds(badge_slot, with_pick=houses["Goliath"]),
+            carried_by=gear,
+        )
+        return gear
+
+    def test_the_pick_is_a_fact_a_condition_reads(
+        self, gang, scav, badge, goliath_rule
+    ):
+        rat = hire(gang, scav, "Rat", paid=40)
+        assign(badge, miniature=rat)
+
+        _, computed = card_of(rat)
+
+        assert names(computed.picks) == ["Goliath"]
+        assert names(computed.rules) == ["Goliath Controlled"]
+
+    def test_it_opens_no_choice_and_draws_no_line(self, gang, scav, badge):
+        rat = hire(gang, scav, "Rat", paid=40)
+        assign(badge, miniature=rat)
+
+        _, computed = card_of(rat)
+        drawn = drawn_card(rat)
+
+        assert computed.choices == []
+        assert drawn.choices == []
+        assert [line.name for line in drawn.equipment] == ["Goliath badge"]
+        assert drawn.remarks == []
+
+    def test_it_is_worth_nothing(self, gang, scav, badge):
+        rat = hire(gang, scav, "Rat", paid=40)
+        before = gang.rating
+
+        assign(badge, miniature=rat)
+
+        gang.refresh_from_db()
+        assert gang.rating == before
+        assert_reconciled(gang)
+
+    def test_a_fighter_without_the_grant_is_not_reached(
+        self, gang, scav, badge, goliath_rule
+    ):
+        rat = hire(gang, scav, "Rat", paid=40)
+        other = hire(gang, scav, "Other", paid=40)
+        assign(badge, miniature=rat)
+
+        assert names(card_of(other)[1].rules) == []
+        assert names(card_of(other)[1].picks) == []
+
+    def test_the_granted_pick_gives_in_turn(self, gang, scav, badge, houses):
+        """The pick runs its own modifiers: the index follows the grant
+        to the pick, or nothing it gives would ever load."""
+        modifier(
+            "Goliath: muscle",
+            targets_model(),
+            ef_adds(create_rule("Goliath Muscle")),
+            carried_by=houses["Goliath"],
+        )
+        rat = hire(gang, scav, "Rat", paid=40)
+        assign(badge, miniature=rat)
+
+        assert names(card_of(rat)[1].rules) == ["Goliath Muscle"]
+
+    def test_removing_the_carrier_takes_the_pick(self, gang, scav, badge, goliath_rule):
+        rat = hire(gang, scav, "Rat", paid=40)
+        given = assign(badge, miniature=rat)
+
+        remove(given)
+
+        _, computed = card_of(rat)
+        assert names(computed.picks) == []
+        assert names(computed.rules) == []
+        assert_reconciled(gang)
+
+    def test_a_removal_naming_the_slot_takes_the_pick(
+        self, gang, scav, badge, badge_slot, goliath_rule
+    ):
+        """The pick stands on the slot, not on the carrier: take the slot
+        away and the pick goes with it, while the carrier stays.
+
+        Only the pick is asserted on. A rule a later round granted on the
+        strength of the pick is settled the way every chain is — the
+        removal's consequences are followed once, after the rounds — so
+        on the bearer's own card it stands in the same read, exactly as a
+        rule conditioned on a subtype a removed hidden gave would.
+        """
+        stripped = create_wargear("Anonymity")
+        modifier(
+            "Anonymity: no supertype",
+            targets_model(),
+            ef_removes(badge_slot),
+            carried_by=stripped,
+        )
+        rat = hire(gang, scav, "Rat", paid=40)
+        assign(badge, miniature=rat)
+        assign(stripped, miniature=rat)
+
+        _, computed = card_of(rat)
+
+        assert names(computed.picks) == []
+        assert sorted(line.name for line in drawn_card(rat).equipment) == [
+            "Anonymity",
+            "Goliath badge",
+        ]
+
+
+# --- On the gang -----------------------------------------------------------
+
+
+class TestAGangHoldsAGrantedPick:
+    """The Outcast case. The Clan House pick is the gang's; what it gives
+    lands on the gang; and a pick the gang holds is a fact about every
+    member, whether written or given, and whether or not the grant
+    echoes."""
+
+    def test_the_pick_lands_on_the_gang(self, gang, leader, clan_house):
+        boss = hire(gang, leader, "Boss", paid=120)
+
+        assert names(gang_computed(gang).picks) == []
+        pick_clan_house(gang, boss, clan_house)
+
+        assert names(gang_computed(gang).picks) == ["Goliath"]
+
+    def test_every_member_counts_as_goliath(
+        self, gang, leader, scav, clan_house, goliath_rule
+    ):
+        """The grant is the gang's alone — it echoes nothing — and the
+        fighters still pass "has picked Goliath", exactly as the members
+        of a gang whose founding wrote the pick down would."""
+        boss = hire(gang, leader, "Boss", paid=120)
+        rat = hire(gang, scav, "Rat", paid=40)
+        assert names(card_of(boss)[1].rules) == []
+        assert names(card_of(rat)[1].rules) == []
+
+        pick_clan_house(gang, boss, clan_house)
+
+        assert names(card_of(boss)[1].rules) == ["Goliath Controlled"]
+        assert names(card_of(rat)[1].rules) == ["Goliath Controlled"]
+        late = hire(gang, scav, "Late", paid=40)
+        assert names(card_of(late)[1].rules) == ["Goliath Controlled"]
+        assert_reconciled(gang)
+
+    def test_the_gang_alone_grant_does_not_echo_the_pick_itself(
+        self, gang, leader, scav, clan_house
+    ):
+        """The fact reaches the members; the pick's own guest list does
+        not, because the grant said the gang alone."""
+        boss = hire(gang, leader, "Boss", paid=120)
+        rat = hire(gang, scav, "Rat", paid=40)
+        pick_clan_house(gang, boss, clan_house)
+
+        _, computed = card_of(rat)
+
+        assert names(computed.picks) == []
+        assert names(computed.echoed) == []
+
+    def test_the_sheet_draws_no_supertype_line(self, gang, leader, clan_house):
+        boss = hire(gang, leader, "Boss", paid=120)
+        pick_clan_house(gang, boss, clan_house)
+
+        sheet = render_gang(gang)
+
+        # The Clan House question is the Leader's; the gang's own card
+        # asks nothing, and no line anywhere names the supertype.
+        assert sheet.choices == []
+        (boss_card,) = sheet.models
+        assert [line.kind_label for line in boss_card.questions] == ["Clan House"]
+        assert "supertype" not in str(sheet.rows).lower()
+        assert "supertype" not in str(sheet.rules).lower()
+        assert "supertype" not in str(boss_card.equipment).lower()
+
+    def test_it_is_worth_nothing(self, gang, leader, clan_house):
+        boss = hire(gang, leader, "Boss", paid=120)
+        before = gang.rating
+
+        pick_clan_house(gang, boss, clan_house)
+
+        gang.refresh_from_db()
+        assert gang.rating == before
+        assert_reconciled(gang)
+
+    def test_taking_the_clan_house_pick_back_takes_the_supertype(
+        self, gang, leader, scav, clan_house, goliath_rule
+    ):
+        _, goliath = clan_house
+        boss = hire(gang, leader, "Boss", paid=120)
+        rat = hire(gang, scav, "Rat", paid=40)
+        pick_clan_house(gang, boss, clan_house)
+
+        remove(Assignment.objects.get(pickable=goliath, archived=False))
+
+        assert names(gang_computed(gang).picks) == []
+        assert names(card_of(boss)[1].rules) == []
+        assert names(card_of(rat)[1].rules) == []
+        assert_reconciled(gang)
+
+    def test_a_removal_naming_the_slot_takes_the_pick(
+        self, gang, leader, scav, clan_house, supertype_slot, goliath_rule
+    ):
+        boss = hire(gang, leader, "Boss", paid=120)
+        rat = hire(gang, scav, "Rat", paid=40)
+        pick_clan_house(gang, boss, clan_house)
+        outlawed = create_hidden(
+            "Outlawed", effects=[(targets_gang_alone(), ef_removes(supertype_slot))]
+        )
+
+        assign(outlawed, gang=gang)
+
+        assert names(gang_computed(gang).picks) == []
+        assert names(card_of(rat)[1].rules) == []
+
+    def test_a_grant_that_echoes_runs_the_picks_own_modifiers_on_everyone(
+        self, gang, gang_type, scav, supertype_slot, houses
+    ):
+        """Scoped to the gang and everyone, the pick rides the members'
+        cards as the gang's guest and what it gives reaches them."""
+        modifier(
+            "Goliath: muscle",
+            targets_every_model(),
+            ef_adds(create_rule("Goliath Muscle")),
+            carried_by=houses["Goliath"],
+        )
+        marker = create_hidden(
+            "Founded Goliath",
+            effects=[
+                (targets_gang(), ef_adds(supertype_slot, with_pick=houses["Goliath"]))
+            ],
+        )
+        rat = hire(gang, scav, "Rat", paid=40)
+
+        assign(marker, gang=gang)
+
+        _, computed = card_of(rat)
+        assert names(computed.rules) == ["Goliath Muscle"]
+        assert names(computed.echoed) == ["Gang supertype", "Goliath"]
+
+    def test_the_sheet_reads_flat_however_many_members(
+        self, gang, leader, scav, clan_house, goliath_rule
+    ):
+        """Two prefetch paths join the budget — the pick, and what it
+        carries — and neither grows with the roster."""
+        boss = hire(gang, leader, "Boss", paid=120)
+        pick_clan_house(gang, boss, clan_house)
+        with CaptureQueriesContext(connection) as few:
+            render_gang(gang)
+
+        for name in ("Rat", "Cat", "Bat"):
+            hire(gang, scav, name, paid=40)
+        with CaptureQueriesContext(connection) as more:
+            render_gang(gang)
+
+        assert len(more) <= len(few)
+
+
+# --- Refusals ---------------------------------------------------------------
+
+
+class TestWhatAGrantMayNotCarry:
+    """A pick belongs to a hidden slot of its own type. Each refusal is
+    said in words by the verb, by the row, and — where the database can
+    say it — by a constraint."""
+
+    def test_a_pick_with_no_slot(self, houses, default_pack):
+        with pytest.raises(ValidationError, match="belongs to a slot"):
+            ef_adds(create_rule("Loud"), with_pick=houses["Goliath"])
+
+    def test_a_pick_of_another_type(self, supertype_slot, clan_house):
+        _, goliath_house = clan_house
+        with pytest.raises(ValidationError, match="offers Gang supertype pickables"):
+            ef_adds(supertype_slot, with_pick=goliath_house)
+
+    def test_a_pick_for_a_slot_that_is_shown(self, shown_slot, houses):
+        with pytest.raises(ValidationError, match="shown on the card"):
+            ef_adds(shown_slot, with_pick=houses["Goliath"])
+
+    def test_the_row_says_the_same(
+        self, shown_slot, supertype_slot, houses, clan_house
+    ):
+        _, goliath_house = clan_house
+        with pytest.raises(ValidationError, match="belongs to a slot"):
+            AddsAssignable(with_pick=houses["Goliath"]).clean()
+        with pytest.raises(ValidationError, match="offers Gang supertype pickables"):
+            AddsAssignable(slot=supertype_slot, with_pick=goliath_house).clean()
+        with pytest.raises(ValidationError, match="shown on the card"):
+            AddsAssignable(slot=shown_slot, with_pick=houses["Goliath"]).clean()
+
+    def test_the_database_refuses_a_pick_with_no_slot(self, houses, default_pack):
+        rule = create_rule("Loud")
+        with pytest.raises(IntegrityError), transaction.atomic():
+            AddsAssignable.objects.create(rule=rule, with_pick=houses["Goliath"])
+
+    def test_the_plain_grant_is_unchanged(self, default_pack):
+        grant = ef_adds(create_rule("Quiet"))
+        assert grant.with_pick is None
+        assert str(grant) == "adds Quiet"
+
+
+# --- What the authoring pages say ------------------------------------------
+
+
+class TestWhatTheAuthoringPagesSay:
+    def texts(self, said):
+        return [sentence.text for sentence in said]
+
+    def test_the_pickable_says_it_is_chosen_from_the_start_never_given(
+        self, clan_house, houses
+    ):
+        said = self.texts(prose_for(houses["Goliath"]).referenced_by)
+
+        assert "Chosen from the start for the Gang supertype slot." in said
+        assert not any(text.startswith("Given") for text in said)
+
+    def test_the_slot_is_still_given(self, clan_house, supertype_slot):
+        said = self.texts(prose_for(supertype_slot).referenced_by)
+
+        assert any(text.startswith("Given to the gang by") for text in said)
+
+    def test_the_grant_names_its_pick(self, clan_house, houses, supertype_slot):
+        _, goliath_house = clan_house
+        (row,) = goliath_house.modifiers.all()
+
+        sentence = sentence_for(row, carriage=None)
+
+        assert "Gang supertype" in sentence.text
+        assert "with Goliath already picked" in sentence.text
+
+
+class TestTheComposer:
+    """The pick control rides the grant form because the slot declares
+    it, drawn only when the kind chosen is a slot (library/offers.py)."""
+
+    def test_the_form_asks_for_a_pick_beside_a_slot(self, default_pack):
+        from n26.library.forms import generate_form
+        from n26.library.specs import specs
+
+        form = generate_form(specs()["ef_adds"])()
+
+        assert "with_pick" in form.fields
+        attrs = form.fields["with_pick"].widget.attrs
+        assert attrs["data-union-of"] == "thing"
+        assert attrs["data-union-member"] == "slot"
+
+    def test_a_pick_typed_for_another_kind_is_dropped(self, houses, default_pack):
+        from n26.library.forms import generate_form
+        from n26.library.specs import specs
+
+        rule = create_rule("Loud")
+        form = generate_form(specs()["ef_adds"])(
+            {
+                "thing_kind": "rule",
+                "thing_rule": str(rule.pk),
+                "with_pick": str(houses["Goliath"].pk),
+            }
+        )
+
+        assert form.is_valid(), form.errors
+        grant = form.compile()
+        assert grant.rule == rule
+        assert grant.with_pick is None
+
+    def test_a_pick_beside_a_slot_is_kept(self, supertype_slot, houses):
+        from n26.library.forms import generate_form
+        from n26.library.specs import specs
+
+        form = generate_form(specs()["ef_adds"])(
+            {
+                "thing_kind": "slot",
+                "thing_slot": str(supertype_slot.pk),
+                "with_pick": str(houses["Goliath"].pk),
+            }
+        )
+
+        assert form.is_valid(), form.errors
+        grant = form.compile()
+        assert grant.slot == supertype_slot
+        assert grant.with_pick == houses["Goliath"]
+
+    def test_editing_a_grant_opens_on_its_pick(self, supertype_slot, houses):
+        from n26.library.forms import generate_form
+        from n26.library.specs import specs
+
+        grant = ef_adds(supertype_slot, with_pick=houses["Goliath"])
+
+        form = generate_form(specs()["ef_adds"]).opened_on(grant)
+
+        assert form.initial["thing_kind"] == "slot"
+        assert form.initial["with_pick"] == houses["Goliath"]


### PR DESCRIPTION
## Summary

A modifier that gives a hidden slot can now name the pick the slot arrives settled on. This is slice 1a of the territory-tables programme (`n26/design/house-and-territory-tables.md`, final section): it is the mechanism by which an Outcast gang's Clan House pick makes the gang count as a Goliath gang, without the two choices sharing pickables.

- **`AddsAssignable.with_pick`** (n26/library/models/modifier.py) is a nullable link to a `Pickable`, valid only beside `slot`: "gives this slot, already settled on this pick". It is the grant-side twin of `DefaultAssignment.default_pickable`. A pick with no slot is refused by a database constraint; a pick of another slot type, or beside a slot that is shown on the card, is refused in words. Only a hidden slot may carry one, because a given pick has no assignment of its own for a player to remove.
- **The effects engine deals the pick as a fact, not a line.** In `n26/core/effects.py` the grant branch adds the pick as a second computed addition whose *source is the slot*, so the existing retraction cascade drops the pick the moment the slot goes, whether a removal named the slot or the carrier was taken away. `ComputedCard` and `ComputedGang` gain a `picks` bucket. The facts a scope asks against now include the card's own computed picks and every pick the gang holds by grant, read off the gang's whole grant list rather than the echoed part, so fighters of a gang that has *picked* Goliath match "has picked Goliath" exactly as fighters of a gang whose founding wrote the pick down do, even when the grant is the gang's alone. Hidden slots draw nothing, so nothing new renders and the rating does not move.
- **The modifier index follows the pick** (`n26/core/card.py`), so a pickable given this way runs its own modifiers.
- **Authoring.** `ef_adds(thing, with_pick=None)`; the slot declares `"grant": ("with_pick",)` in `Slot.ATTACHMENT_ASKS`, so the modifier composer draws the pick control only when the kind chosen is a slot, the same way a built-in's starting pick appears. `Spec.compile` forwards union asks that are verb parameters (the composer previously would have dropped them), and editing a grant opens on its pick. The pickable's authoring page says "Chosen from the start for the Gang supertype slot." and never "Given by"; the grant's sentence reads "the gang gains Gang supertype, with Goliath already picked, held by the gang."
- **Docs.** `n26/library/concepts.md` (gang-level choice, Picks) and a new "A Clan House Outcast gang" recipe in `n26/library/recipes.md`. The recipe says plainly that a condition on the gang scope is not yet possible (that is slice 1b).

## Migration

`n26/library/migrations/0102_a_grant_may_carry_its_pick.py` adds the column and the constraint. It depends on `0101_modifiers_can_grant_wargear`, main's leaf now that #2513 has landed (the file was 0097 on 0096 until then); the whole stack is rebased onto main, `manage makemigrations --check` passes, and the path migrates cleanly on a fork of the content database.

## Test plan

- [x] `pytest n26 -n 4`: 5916 passed, 1 xfailed
- [x] New `n26/tests/sandbox/test_a_grant_may_carry_its_pick.py` (32 tests): the pick is a fact `HasPickable` reads on the bearer; it opens no choice, draws no line and is worth nothing; a gang-hosted Clan House pick reaches every member including one hired later; a gang-alone grant does not echo the pick's own guest list; the gang sheet draws no supertype line; taking the Clan House pick back, or a removal naming the slot, drops the pick; the granted pick's own grants arrive; the three refusals (verb, row, database); the authoring prose; the composer form draws and keeps the pick control only for a slot and reopens on it; a pick of another slot type, or beside a shown slot, is refused on the pick's field and the composer page redraws with it (review fix — the views catch only a duplicate name); the sheet's query count is flat as members are added
- [x] `n26/tests/sandbox/test_built_in_offers.py` passes with the new `"grant"` attachment context
- [x] `manage check`, `manage makemigrations --check`, `./scripts/fmt.sh`
- [x] copywriter and code-reviewer agents run over the diff; findings applied. Review round 2026-09-09: Copilot's `READ_WITH` finding (load `with_pick` with the grant) and the reviewer's composer-refusal finding both fixed in this PR

## How to try it

1. `./scripts/dev.sh`, sign in as staff (mint a session cookie, see CLAUDE.md).
2. On `/n26/authoring/`, create a slot type "Gang supertype", a pickable "Goliath", a picklist, and a slot "Gang supertype" with *hidden* on and *assigned to* the gang.
3. Open any pickable or hidden item, add a modifier: scope *The gang carrying it*, effect *Gives something*, kind *slot*, choose the slot. A **Pick given with the slot** control appears once the kind is a slot; choose Goliath. Choosing a slot that is not hidden refuses with "Only a hidden slot can be given with its pick."
4. Open the Goliath pickable's page: under how anyone comes to have it, "Chosen from the start for the Gang supertype slot."
5. Give a gang the carrier. Its sheet shows no new line, and a modifier scoped *every model, where it has picked Goliath* now reaches every fighter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTc5N9DniP5LSspvHpDANs



