### PR TITLE
feat: seed the Gang supertype and the Underhive Journal territories as a maintenance operation

### DIFF
--- a/n26/core/campaigns.py
+++ b/n26/core/campaigns.py
@@ -404,8 +404,16 @@ class CampaignOperation:
                     "table built into the campaign can be rolled on for its pool."
                 )
         elif table.pk not in {
-            held.pk for held in tables_held_by(membership.gang, self.campaign)
+            held.pk
+            for held in tables_held_by(
+                membership.gang,
+                self.campaign,
+                include_staged=sees_staged(self.actor),
+            )
         }:
+            # A staged table the gang holds is one the roller may use only
+            # if they may see staged content: the roll is where a Territory
+            # is newly chosen for the campaign.
             raise Refusal(
                 f"{membership.gang.name} cannot roll on {table}. Only a gang "
                 "that holds that table can."
@@ -1026,7 +1034,7 @@ def tables_in_play(campaign, *, include_staged=False):
     return tables if include_staged else tables.live()
 
 
-def tables_on(card, computed, withdrawn=frozenset()):
+def tables_on(card, computed, withdrawn=frozenset(), *, include_staged=False):
     """The asset tables a gang may roll on, read off its card: the stored
     assignments naming one and the tables a grant dealt onto it, each
     once, in the order they stand. Query-free, so a page that has the
@@ -1036,6 +1044,13 @@ def tables_on(card, computed, withdrawn=frozenset()):
     cards. A copy given through a built-in member the arbitrator has
     since closed stays on the gang — nothing is taken back — but the
     offer is withdrawn, so it is not a table the gang may roll on.
+
+    ``include_staged`` is whether the reader may see staged content
+    (``n26.library.staged.sees_staged``). A staged table a pick gives
+    reaches the gang's card like any grant, but rolling on it is where
+    a Territory is newly chosen for the campaign, so a reader who may
+    not see staged content is not offered it — and, as at every other
+    discovery surface, the default holds staged content back.
     """
     from n26.library.models import AssetTable
 
@@ -1049,7 +1064,7 @@ def tables_on(card, computed, withdrawn=frozenset()):
         held.setdefault(node.assignable.pk, node.assignable)
     for contribution in computed.tables:
         held.setdefault(contribution.thing.pk, contribution.thing)
-    return list(held.values())
+    return [table for table in held.values() if include_staged or not table.staged]
 
 
 def withdrawn_members(*cards):
@@ -1075,18 +1090,20 @@ def withdrawn_members(*cards):
     )
 
 
-def tables_held_by(gang, campaign):
+def tables_held_by(gang, campaign, *, include_staged=False):
     """The asset tables one gang may roll on in this campaign — its
     starting territory's tables. Builds the gang's card and computes it,
     so this is for an act on one gang; a page listing several reads
     ``tables_on`` off cards it already has and asks :func:`foreign_tables`
-    once for all of them."""
+    once for all of them. ``include_staged`` is as for ``tables_on``."""
     from n26.core.card import build_gang_card, build_modifier_index, carriers
     from n26.core.effects import compute
 
     card = build_gang_card(gang, with_statlines=False)
     computed = compute(card, build_modifier_index(carriers(card)))
-    held = tables_on(card, computed, withdrawn_members(card))
+    held = tables_on(
+        card, computed, withdrawn_members(card), include_staged=include_staged
+    )
     foreign = foreign_tables(campaign, held)
     return [table for table in held if table.pk not in foreign]
 

--- a/n26/core/history.py
+++ b/n26/core/history.py
@@ -243,6 +243,9 @@ def _rows_for(events):
             "stash",
             # A pick says its kind through the question it answered.
             "chosen_for_slot__slot_type",
+            # A pick of a hidden slot is not told; the slot is read off
+            # the pick, or off the assignment it was chosen for.
+            "chosen_for__slot",
         )
     )
     return {row.pk: row for row in fetched}
@@ -536,6 +539,11 @@ def _machinery(e, row):
     line is the exception in every event it has — bought in the story,
     it must also leave in it — so the test is what its record says was
     ever priced, not what this one event moved.
+
+    A hidden slot asks nothing and draws nothing, and the pick that
+    settles it is a classification, never a choice the player saw — the
+    Gang supertype built into a Clan House gang type — so neither the
+    slot nor its pick is told.
     """
     if row is None:
         return False
@@ -543,10 +551,24 @@ def _machinery(e, row):
         return True
     if row.hidden_id is not None or row.asset_table_id is not None:
         return True
+    if row.slot_id is not None and row.slot.hidden:
+        return True
+    if row.pickable_id is not None and _settles_a_hidden_slot(row):
+        return True
     if row.weapon_profile_id is None:
         return False
     entry = getattr(row, "ledger_entry", None)
     return entry is None or entry.list_price == 0
+
+
+def _settles_a_hidden_slot(pick):
+    """Whether this pick settles a hidden slot: the slot it names, or,
+    for a pick written before picks named their slot, the slot of the
+    assignment it was chosen for. Both are loaded with the record."""
+    slot = pick.chosen_for_slot
+    if slot is None and pick.chosen_for is not None:
+        slot = pick.chosen_for.slot
+    return slot is not None and slot.hidden
 
 
 def _one_edit_of_what_a_model_is(standing):

--- a/n26/core/render.py
+++ b/n26/core/render.py
@@ -2923,6 +2923,9 @@ def render_campaign(campaign, viewer=None):
     # Tables given through a member the arbitrator has since closed stay
     # on the gangs and are not offered: one query for every card at once.
     withdrawn = withdrawn_members(*cards.values())
+    # A staged table is offered to roll on only to a reader who may see
+    # staged content: the roll is where a Territory is newly chosen.
+    shown_staged = sees_staged(viewer)
     for membership in memberships:
         card = cards[membership.gang_id]
         computed = compute(card, index)
@@ -2933,7 +2936,11 @@ def render_campaign(campaign, viewer=None):
         # the card already computed: which tables its starting roll may
         # be made on.
         held_tables[membership.pk] = [
-            table for table in tables_on(card, computed, withdrawn) if table.dice
+            table
+            for table in tables_on(
+                card, computed, withdrawn, include_staged=shown_staged
+            )
+            if table.dice
         ]
         # What the gang has picked for each choice it is asked, by the
         # choice's label. A label is a gang-level slot the arbitrator built
@@ -3019,9 +3026,7 @@ def render_campaign(campaign, viewer=None):
     # The rolled tables the campaign itself holds, by asset type: what the
     # pool of each type is generated from. One query for the whole page.
     in_play = {}
-    for table in tables_in_play(campaign, include_staged=sees_staged(viewer)).order_by(
-        "name"
-    ):
+    for table in tables_in_play(campaign, include_staged=shown_staged).order_by("name"):
         if table.dice:
             in_play.setdefault(table.asset_type_id, []).append(_held_table(table))
     tables = {

--- a/n26/core/templates/admin/maintenance/n26/_seed_journal_content_detail.html
+++ b/n26/core/templates/admin/maintenance/n26/_seed_journal_content_detail.html
@@ -1,0 +1,31 @@
+{% comment %}
+    The summary of one journal content seed run, on the Backfill detail
+    page: what it set out to create, and — once it has finished — what it
+    created. The seed is one transaction, so a run still working has
+    created nothing yet, and a run that fails leaves nothing behind.
+{% endcomment %}
+{% if backfill.summary.report %}
+    <h2>What it did</h2>
+    <ul>
+        {% for line in backfill.summary.report %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+    {% if backfill.summary.seconds is not None %}
+        <p>Took {{ backfill.summary.seconds }} second{{ backfill.summary.seconds|pluralize }}.</p>
+    {% endif %}
+{% elif backfill.summary.preview %}
+    <h2>What it is doing</h2>
+    <p>
+        These are the rows it set out to create. The seed is one transaction,
+        so a run still working has created nothing yet, and a run that fails or
+        is interrupted leaves nothing behind.
+    </p>
+    <ul>
+        {% for line in backfill.summary.preview %}<li>{{ line }}</li>{% endfor %}
+    </ul>
+{% endif %}
+{% if backfill.summary.warning %}
+    <p>{{ backfill.summary.warning }}</p>
+{% endif %}
+{% if backfill.summary.attempts %}
+    <p>Started {{ backfill.summary.attempts }} time{{ backfill.summary.attempts|pluralize }}.</p>
+{% endif %}

--- a/n26/core/templates/admin/maintenance/n26/seed_journal_content.html
+++ b/n26/core/templates/admin/maintenance/n26/seed_journal_content.html
@@ -1,0 +1,81 @@
+{% extends "admin/base_site.html" %}
+{% comment %}
+The journal content seed's console page: what the seed would create or
+skip, an apply button, and the recent runs. The preview is the seed run
+and rolled back, so it is exactly what a run would do.
+Context from seed_journal_content_view (n26/maintenance.py): title,
+preview, nothing_to_do, problem, apply_url, recent.
+{% endcomment %}
+{% block title %}
+    {{ title }} | {{ site_title|default:_("Django site admin") }}
+{% endblock title %}
+{% block extrahead %}
+    {{ block.super }}
+    <style>
+    .mt-plan { font-family: monospace; line-height: 1.6; }
+    .mt-form { margin-top: 2rem; }
+    .mt-table { width: 100%; margin-top: 1rem; }
+    .mt-problems { color: var(--error-fg, #ba2121); }
+    </style>
+{% endblock extrahead %}
+{% block content %}
+    <p>
+        <a href="{% url 'admin:maintenance_index' %}">← Back to Maintenance</a>
+    </p>
+    <h1>{{ title }}</h1>
+    <p>
+        This creates library rows only. For the Gang supertype: a slot type,
+        six pickables, a picklist and a hidden slot, plus a built-in member on
+        each Clan House gang type and a modifier on each Outcast Clan House
+        pickable. For the two journals: twelve Territories, their boons and
+        their two tables. Rows already there are left as they are. The journal
+        rows are staged, so players do not see them until an author puts them
+        live. Gangs already founded get their supertype pick from the
+        propagation pass this files.
+    </p>
+    {% if problem %}
+        <h2 class="mt-problems">The preview cannot run</h2>
+        <p class="mt-problems">{{ problem }}</p>
+        <p>Nothing can be created while this stands.</p>
+    {% elif nothing_to_do %}
+        <h2>Nothing to create</h2>
+        <p>Every row this seed creates is already there.</p>
+        <ul class="mt-plan">
+            {% for line in preview|slice:"1:" %}<li>{{ line }}</li>{% endfor %}
+        </ul>
+    {% else %}
+        <h2>What it would do</h2>
+        <ul class="mt-plan">
+            {% for line in preview %}<li>{{ line }}</li>{% endfor %}
+        </ul>
+        <form method="post"
+              class="mt-form"
+              onsubmit="return confirm('Create the Gang supertype and the journal territories? Rows already there are left as they are.')">
+            {% csrf_token %}
+            <button type="submit" class="button default">Create the missing rows</button>
+        </form>
+    {% endif %}
+    {% if recent %}
+        <h2>Recent runs</h2>
+        <table class="mt-table">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Status</th>
+                    <th>Triggered by</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for run in recent %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'admin:maintenance_backfill_detail' run.id %}">{{ run.created }}</a>
+                        </td>
+                        <td>{{ run.get_status_display }}</td>
+                        <td>{{ run.triggered_by|default:"—" }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock content %}

--- a/n26/core/views/campaigns.py
+++ b/n26/core/views/campaigns.py
@@ -452,7 +452,9 @@ def roll_starting_asset(request, pk, gang_pk):
         return redirect(again)
     held = [
         table.pk
-        for table in tables_held_by(membership.gang, found)
+        for table in tables_held_by(
+            membership.gang, found, include_staged=sees_staged(request.user)
+        )
         if table.dice and table.asset_type_id == asset_type.pk
     ]
     form = RollAssetForm(request.POST, tables=AssetTable.objects.filter(pk__in=held))

--- a/n26/library/gang_supertypes.py
+++ b/n26/library/gang_supertypes.py
@@ -1,0 +1,223 @@
+"""The Gang supertype — which House a gang belongs to, as a hidden pick.
+
+A journal's territory boon applies "if the Territory is held by a Goliath
+gang", and an Outcast gang that chose House Goliath counts as one
+(design/house-and-territory-tables.md). The fact a rule reads is a pick
+on the gang: a hidden **Gang supertype** slot, drawing from a picklist of
+six marker pickables — Goliath, Escher, Orlock, Van Saar, Delaque and
+Cawdor — that carry no boon logic of their own. A rule keys on the pick
+(``targets_gang_alone(has_gang_pickable(goliath))``) rather than hanging
+off it.
+
+A gang gets its supertype two ways, and this seed writes both:
+
+* Each Clan House gang type builds the slot in with its own House as the
+  starting pick, so founding a Goliath gang writes the pick, and built-in
+  propagation gives it to every Goliath gang already founded.
+* Each Outcast Clan House pickable — House Goliath and the rest, on the
+  Outcast gang's own Clan House slot — carries a modifier that gives the
+  gang the supertype slot with the matching pick, so a Clan House Goliath
+  Outcast gang matches "has picked Goliath" as a Goliath gang does.
+
+Nothing here is staged: the slot is hidden, so the supertype is invisible
+to players by construction.
+
+The Venator Gang Legacy picks already hold the bare names Goliath, Escher
+and the rest, and a pickable's name is unique in its pack whatever its
+slot type, so the six markers carry the qualifier "Gang supertype" —
+author-facing only; the name a condition prints is the bare House.
+
+Everything is matched on its natural key — pack and name — and left
+alone if it is already there, so this can run against a database that
+has some of it, and running it twice changes nothing the second time.
+It runs through the authoring verbs, which file the propagation pass a
+built-in member is owed, so it works on live model classes only: run it
+as a maintenance operation after a deploy, never from a migration.
+"""
+
+from dataclasses import dataclass, field
+
+from django.conf import settings
+
+SLOT_TYPE = "Gang supertype"
+SLOT_TYPE_PLURAL = "Gang supertypes"
+PICKLIST = "Gang supertypes"
+SLOT = "Gang supertype"
+#: The six Clan Houses, each the name of a gang type and of its marker
+#: pickable, in the order the rules list them.
+HOUSES = ("Goliath", "Escher", "Orlock", "Van Saar", "Delaque", "Cawdor")
+#: The Outcast gang's Clan House choice: a slot type whose name carries
+#: this word, and one pickable per House named as below.
+CLAN_HOUSE = "Clan"
+
+
+@dataclass
+class Outcome:
+    """What a seed did, in words: one line per row it created, and one per
+    row it looked for and left alone or could not find. Kept apart so a
+    rerun that creates nothing can say so, whatever it skipped."""
+
+    created: list = field(default_factory=list)
+    skipped: list = field(default_factory=list)
+
+    def extend(self, other):
+        self.created.extend(other.created)
+        self.skipped.extend(other.skipped)
+
+    @property
+    def lines(self):
+        return [*self.created, *self.skipped]
+
+
+def clan_house_pickable_name(house):
+    """What the Outcast Clan House pickable for this House is called."""
+    return f"House {house}"
+
+
+def supertype_pick(house):
+    """The marker pickable for this House, or None where the seed has not run."""
+    from n26.library.models import Pickable
+
+    return Pickable.objects.filter(
+        pack__slug=settings.DEFAULT_CONTENT_PACK_SLUG,
+        slot_type__name__iexact=SLOT_TYPE,
+        name__iexact=house,
+    ).first()
+
+
+def seed_gang_supertypes():
+    """Create what is missing of the Gang supertype, and return
+    ``(outcome, picks)``: what was created and what was skipped, in
+    words, and the six marker pickables by House name, so the journal
+    seed can key its boons on them.
+
+    A gang type or an Outcast Clan House pickable that is not there is
+    skipped and named on the record — a fresh database has neither, and
+    this creates no gang list content of its own.
+    """
+    from n26.library.authoring import (
+        add_built_in,
+        add_picklist_member,
+        create_pickable,
+        create_picklist,
+        create_slot,
+        create_slot_type,
+        ef_adds,
+        modifier,
+        targets_gang_alone,
+    )
+    from n26.library.models import (
+        DefaultAssignment,
+        GangType,
+        Pickable,
+        Picklist,
+        Slot,
+        SlotType,
+    )
+    from n26.library.models.pack import get_default_pack
+
+    outcome = Outcome()
+    lines = outcome.created
+    pack = get_default_pack()
+    in_pack = {"pack": pack}
+
+    slot_type = SlotType.objects.filter(pack=pack, name__iexact=SLOT_TYPE).first()
+    if slot_type is None:
+        slot_type = create_slot_type(
+            SLOT_TYPE,
+            plural_name=SLOT_TYPE_PLURAL,
+            allows_repeats=False,
+            **in_pack,
+        )
+        lines.append(f"created the {SLOT_TYPE} slot type")
+
+    picks = {}
+    for house in HOUSES:
+        pick = Pickable.objects.filter(
+            pack=pack, slot_type=slot_type, name__iexact=house
+        ).first()
+        if pick is None:
+            pick = create_pickable(house, slot_type, qualifier=SLOT_TYPE, **in_pack)
+            lines.append(f"created the {house} pickable")
+        picks[house] = pick
+
+    picklist = Picklist.objects.filter(pack=pack, name__iexact=PICKLIST).first()
+    if picklist is None:
+        picklist = create_picklist(PICKLIST, slot_type, **in_pack)
+        lines.append(f"created the {PICKLIST} picklist")
+    for house in HOUSES:
+        if not picklist.members.filter(pickable=picks[house]).exists():
+            add_picklist_member(picklist, picks[house], **in_pack)
+            lines.append(f"listed {house} on {PICKLIST}")
+
+    slot = Slot.objects.filter(pack=pack, name__iexact=SLOT, qualifier="").first()
+    if slot is None:
+        slot = create_slot(
+            SLOT,
+            slot_type,
+            picklist,
+            min_picks=1,
+            max_picks=1,
+            assigned_to="gang",
+            hidden=True,
+            **in_pack,
+        )
+        lines.append(f"created the hidden {SLOT} slot")
+
+    for house in HOUSES:
+        gang_type = GangType.objects.filter(
+            pack=pack, name__iexact=house, qualifier="", archived=False
+        ).first()
+        if gang_type is None:
+            outcome.skipped.append(f"skipped {house}: no gang type of that name")
+            continue
+        # Archived members count: an author who took the slot out of a
+        # type's built-ins on purpose is not overruled by a rerun.
+        member = None
+        if gang_type.built_ins_id is not None:
+            member = DefaultAssignment.objects.filter(
+                default_set_id=gang_type.built_ins_id, slot=slot
+            ).first()
+        if member is None:
+            add_built_in(gang_type, slot, default_pickable=picks[house], **in_pack)
+            lines.append(f"built the {SLOT} slot into {house}, picked {house}")
+        elif member.archived:
+            outcome.skipped.append(
+                f"skipped {house}: its built-in {SLOT} slot member is archived, "
+                "so it was left as it is"
+            )
+        elif member.default_pickable_id != picks[house].pk:
+            outcome.skipped.append(
+                f"skipped {house}: its built-in {SLOT} slot starts on "
+                f"{member.default_pickable}, not {house}, so it was left as it is"
+            )
+
+    for house in HOUSES:
+        clan_pick = Pickable.objects.filter(
+            pack=pack,
+            slot_type__name__icontains=CLAN_HOUSE,
+            name__iexact=clan_house_pickable_name(house),
+            qualifier="",
+            archived=False,
+        ).first()
+        if clan_pick is None:
+            outcome.skipped.append(
+                f"skipped {clan_house_pickable_name(house)}: no Outcast Clan House "
+                "pickable of that name"
+            )
+            continue
+        given = clan_pick.modifiers.filter(
+            adds_assignable__slot=slot, adds_assignable__with_pick=picks[house]
+        ).exists()
+        if given:
+            continue
+        modifier(
+            f"{clan_pick.name}: gives the {SLOT} slot, picked {house}",
+            targets_gang_alone(),
+            ef_adds(slot, with_pick=picks[house]),
+            attach_to=clan_pick,
+            **in_pack,
+        )
+        lines.append(f"{clan_pick.name} now gives the {SLOT} slot, picked {house}")
+
+    return outcome, picks

--- a/n26/library/journal_content.py
+++ b/n26/library/journal_content.py
@@ -1,0 +1,285 @@
+"""The Underhive Journal territories — House of Chains and House of Blades.
+
+Each journal adds a D6 table of six Territories that a gang of its House
+may roll its starting Territory on (design/house-and-territory-tables.md).
+Every Territory has an income figure and a House Controlled boon that
+applies only while a gang of that House holds it; each also has a
+battlefield effect, which is out of scope and stored nowhere.
+
+What the seed writes, all in the system pack and all ``staged`` until an
+author puts it live:
+
+* Twelve ``Asset`` rows under the Territory asset type of the Territory
+  campaign type, each with its income as an Income contribution
+  (``n26/library/income.py``).
+* The House Controlled boon on each. Where the book's boon is more income,
+  it is a second Income contribution scoped to gangs that have picked the
+  House. Anything else is a ``Rule`` named "Goliath Controlled" or "Escher
+  Controlled", annotated with the Territory's name, given to the gang
+  alone under the same condition — the name only, never the rule's text.
+  A boon that replaces the income boon ("instead of gaining the Income
+  Boon") is stored as the plain income and the rule together; making the
+  two an either/or is a choice the app does not offer yet.
+* Two ``AssetTable`` rows, Goliath Territories and Escher Territories, a
+  D6 each with six entries on bands 1–1 to 6–6 in the book's order. They
+  are House tables, not built into the campaign type: each is given by a
+  modifier on the matching Gang supertype pickable
+  (``n26/library/gang_supertypes.py``) — the gang alone gains the table —
+  so every gang of that House holds it, Clan House Outcasts included, and
+  no other gang does until an arbitrator opens it. The supertype
+  pickables are markers that carry no boon logic; a table grant is how a
+  House table reaches its gangs, and is the one modifier they carry.
+
+Everything is matched on its natural key and left alone if it is already
+there, so this can run against a database that has some of it, and
+running it twice changes nothing the second time. Names and numbers are
+the book's; nothing else is. Written through the authoring verbs, so it
+runs on live model classes only: as a maintenance operation after a
+deploy, never from a migration.
+"""
+
+from dataclasses import dataclass
+
+from django.apps import apps
+from django.conf import settings
+from django.db import transaction
+
+from n26.library.core_campaign import CAMPAIGN_TYPE, seed_core_campaign
+from n26.library.gang_supertypes import SLOT, Outcome, seed_gang_supertypes
+from n26.library.territory_table import TERRITORY
+
+#: The stored value of ``Dice.D6``.
+DICE = "d6"
+
+
+@dataclass(frozen=True)
+class Territory:
+    """One journal Territory: its name, its income figure, and its House
+    Controlled boon — ``more_income`` where the boon is more credits when
+    collecting income, otherwise a rule named after the House. ``instead``
+    marks a boon the book offers in place of the income boon; it is stored
+    alongside the income for now."""
+
+    name: str
+    income: int
+    more_income: int = 0
+    instead: bool = False
+
+
+#: Each journal's table: the House it belongs to, the table's name, and
+#: its six Territories in the book's order, rolls 1 to 6.
+JOURNALS = (
+    (
+        "Goliath",
+        "Goliath Territories",
+        (
+            Territory("Slug House", 20),
+            Territory("Flesh-makers Theatre", 15, instead=True),
+            Territory("Fight Arena", 15),
+            Territory("Amneo-vats", 15, more_income=10),
+            Territory("Feasting Hall", 20),
+            Territory("Badzone Smelter", 20),
+        ),
+    ),
+    (
+        "Escher",
+        "Escher Territories",
+        (
+            Territory("Phelynx Pen", 20),
+            Territory("Bio-lab", 15),
+            Territory("Wyld Den", 15, instead=True),
+            Territory("Rogue Las Factoria", 20, instead=True),
+            Territory("Chem Arena", 15, instead=True),
+            Territory("Shivver Den", 15),
+        ),
+    ),
+)
+
+NOTHING_TO_DO = "Nothing to do: every row is already there."
+
+
+def controlled_rule_name(house):
+    """ "Goliath Controlled" — the name every one of a House's boon rules
+    shares; the Territory's name is the annotation."""
+    return f"{house} Controlled"
+
+
+def seed_journal_content():
+    """Create what is missing of the two journals' territories and tables,
+    and return an ``Outcome``: what was created and what was skipped, in
+    words.
+
+    The Territory campaign type and the Gang supertype are created first
+    where they are missing, so this runs on a fresh database as readily
+    as on one that has them; their lines are returned too. A House whose
+    supertype pickable cannot be found still gets its territories and
+    table, but no grant, and is named on the record.
+    """
+    from n26.library.authoring import (
+        add_asset_table_entry,
+        create_asset,
+        create_rule,
+        ef_adds,
+        ef_contributes_to_counter,
+        has_gang_pickable,
+        modifier,
+        targets_gang_alone,
+    )
+    from n26.library.income import ensure_income_counter
+    from n26.library.models import (
+        Asset,
+        AssetTable,
+        CampaignType,
+        ContentPack,
+        Modifier,
+        Rule,
+    )
+
+    outcome = Outcome(created=seed_core_campaign(apps))
+    supertypes, picks = seed_gang_supertypes()
+    outcome.extend(supertypes)
+    lines = outcome.created
+
+    pack = ContentPack.objects.get(slug=settings.DEFAULT_CONTENT_PACK_SLUG)
+    campaign_type = CampaignType.objects.get(
+        pack=pack, name__iexact=CAMPAIGN_TYPE, qualifier=""
+    )
+    territory = campaign_type.asset_types.get(label_singular__iexact=TERRITORY)
+    income = ensure_income_counter()
+    staged = {"pack": pack, "staged": True}
+
+    def modifier_missing(name):
+        return not Modifier.objects.filter(pack=pack, name__iexact=name).exists()
+
+    for house, table_name, territories in JOURNALS:
+        pick = picks.get(house)
+        if pick is None:
+            outcome.skipped.append(
+                f"skipped the {house} Controlled boons and the {table_name} "
+                f"grant: no {SLOT} pickable named {house}"
+            )
+
+        table = AssetTable.objects.filter(
+            pack=pack, name__iexact=table_name, qualifier=""
+        ).first()
+        if table is None:
+            # Written directly rather than through create_asset_table,
+            # which builds a table into its campaign type: this one is
+            # the House's, given by the pick below.
+            table = AssetTable.objects.create(
+                name=table_name, asset_type=territory, dice=DICE, **staged
+            )
+            lines.append(f"created the {table_name} table, staged")
+
+        for position, entry in enumerate(territories):
+            asset = Asset.objects.filter(
+                pack=pack, name__iexact=entry.name, qualifier=""
+            ).first()
+            if asset is None:
+                asset = create_asset(
+                    entry.name, territory, income=entry.income, **staged
+                )
+                lines.append(
+                    f"created the {entry.name} {TERRITORY} with income "
+                    f"{entry.income}, staged"
+                )
+            elif asset.asset_type_id != territory.pk:
+                outcome.skipped.append(
+                    f"skipped {entry.name}: an asset of that name already stands "
+                    "under another asset type, so no boon or entry was made for it"
+                )
+                continue
+
+            roll = position + 1
+            if not table.entries.filter(asset=asset).exists():
+                add_asset_table_entry(
+                    table, asset, position=position, roll_low=roll, **staged
+                )
+                lines.append(
+                    f"added {entry.name} to the {table_name} table on {roll}-{roll}"
+                )
+
+            if pick is None:
+                continue
+            boon = f"{entry.name}: {house} Controlled"
+            if entry.more_income:
+                if modifier_missing(boon):
+                    modifier(
+                        boon,
+                        targets_gang_alone(has_gang_pickable(pick)),
+                        ef_contributes_to_counter(income, entry.more_income),
+                        attach_to=asset,
+                        pack=pack,
+                    )
+                    lines.append(
+                        f"{entry.name}: {entry.more_income} more income for "
+                        f"gangs that have picked {house}"
+                    )
+            else:
+                rule = Rule.objects.filter(
+                    pack=pack,
+                    name__iexact=controlled_rule_name(house),
+                    annotation__iexact=entry.name,
+                    qualifier="",
+                ).first()
+                if rule is None:
+                    rule = create_rule(
+                        controlled_rule_name(house), annotation=entry.name, **staged
+                    )
+                    lines.append(f"created the rule {rule}, staged")
+                if modifier_missing(boon):
+                    modifier(
+                        boon,
+                        targets_gang_alone(has_gang_pickable(pick)),
+                        ef_adds(rule),
+                        attach_to=asset,
+                        pack=pack,
+                    )
+                    line = f"{entry.name}: the {rule} rule for gangs that have picked {house}"
+                    if entry.instead:
+                        # The book offers this boon in place of the income
+                        # boon. Both are stored; the either/or is not
+                        # offered yet, so a holder reads both for now.
+                        line += " (the book offers it instead of the income)"
+                    lines.append(line)
+
+        if pick is None:
+            continue
+        if not pick.modifiers.filter(adds_assignable__asset_table=table).exists():
+            modifier(
+                f"{house}: gives the {table_name} table",
+                targets_gang_alone(),
+                ef_adds(table),
+                attach_to=pick,
+                pack=pack,
+            )
+            lines.append(f"{house} gangs now hold the {table_name} table")
+
+    return outcome
+
+
+def seed_all():
+    """The whole seed as one transaction, reported in words: what it
+    created, then what it skipped — or, where it created nothing, a first
+    line saying there was nothing to do, then what it skipped."""
+    with transaction.atomic():
+        outcome = seed_journal_content()
+    if outcome.created:
+        return outcome.lines
+    return [NOTHING_TO_DO, *outcome.skipped]
+
+
+class _RolledBack(Exception):
+    """Carries a dry run's lines out of the transaction it rolls back."""
+
+
+def preview():
+    """What ``seed_all`` would do, without doing it: the seed runs inside
+    a transaction that is rolled back, so the lines are exactly the run's
+    own and nothing is written — not even the propagation filings, whose
+    messages publish only on commit."""
+    try:
+        with transaction.atomic():
+            raise _RolledBack(seed_all())
+    except _RolledBack as rolled_back:
+        return rolled_back.args[0]

--- a/n26/library/tables.py
+++ b/n26/library/tables.py
@@ -17,6 +17,11 @@ campaign's own pack under a shared asset type is given by that
 campaign's additions type, so one campaign's table never reaches every
 campaign founded on the shared type.
 
+A table a modifier gives — a journal's House table, given by the Gang
+supertype pick — is that House's, not every gang's, and is never built
+in by the rule: ``is_granted`` tells the two apart, and both passes below
+leave a granted table alone.
+
 ``authoring.create_asset_table`` applies the rule to live models and
 files the propagation pass. ``give_back`` puts an unarchived table back.
 ``build_in_missing`` applies the rule to whatever is already there,
@@ -25,10 +30,23 @@ migration can run it on historical ones.
 """
 
 from django.apps import apps as live_models
+from django.core.exceptions import FieldError
 from django.db import transaction
 from django.db.models import Max
 
 from n26.library.possessions import _built_ins_of, giver_of
+
+
+def is_granted(table, apps):
+    """Whether a modifier gives this table — in which case it is one
+    House's and is not built into a campaign type. Written against the
+    classes handed in; a historical state from before a grant could name
+    a table has no such grant."""
+    try:
+        AddsAssignable = apps.get_model("library", "AddsAssignable")
+        return AddsAssignable.objects.filter(asset_table=table).exists()
+    except LookupError, FieldError:
+        return False
 
 
 @transaction.atomic
@@ -58,6 +76,8 @@ def give_back(table):
         file_propagation_task(member.default_set)
     if revived:
         return
+    if is_granted(table, live_models):
+        return
     giver = giver_of(table, live_models)
     if giver is not None:
         add_built_in(giver, table, pack=table.pack)
@@ -69,8 +89,9 @@ def build_in_missing(apps, campaign_type=None):
 
     Idempotent: a table already given is left alone, so this can run over
     a database that has some of it. Archived tables are skipped — an
-    archived table is one taken out on purpose. ``campaign_type``
-    narrows to the tables of one type's asset types, for the seed.
+    archived table is one taken out on purpose — and so are tables a
+    modifier gives, which are one House's. ``campaign_type`` narrows to
+    the tables of one type's asset types, for the seed.
 
     Members are written directly rather than through the authoring verb,
     because the classes handed in may be historical ones; the caller
@@ -92,7 +113,7 @@ def build_in_missing(apps, campaign_type=None):
     givers = {}
     for table in tables.order_by("name"):
         giver = giver_of(table, apps)
-        if giver is None:
+        if giver is None or is_granted(table, apps):
             continue
         giver = givers.setdefault(giver.pk, giver)
         built_ins = _built_ins_of(giver, DefaultAssignmentSet)

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -49,7 +49,11 @@ from contextlib import contextmanager
 from datetime import date, timedelta
 
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import (
+    MultipleObjectsReturned,
+    ObjectDoesNotExist,
+    ValidationError,
+)
 from django.db import connection, models, transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -75,6 +79,7 @@ __all__ = [
     "rehost_gang_picks",
     "repair_doubled_refunds",
     "repoint_champion_picks",
+    "seed_journal_content",
     "PlanRefused",
     "run_batched",
     "run_per_gang",
@@ -201,6 +206,10 @@ class Operation(models.TextChoices):
         "n26_delete_legacy_affiliation_assignments",
         "n26: legacy affiliation assignments are deleted",
     )
+    SEED_JOURNAL_CONTENT = (
+        "n26_seed_journal_content",
+        "n26: the Gang supertype and the Underhive Journal territories are created",
+    )
 
 
 #: See the note on locks above: one per operation, never shared.
@@ -218,6 +227,7 @@ LOCK_KEYS = {
     Operation.DELETE_EMPTY_AFFILIATIONS: 826_020_616,
     Operation.OPEN_FOUNDING_ACTIONS: 826_020_617,
     Operation.DELETE_LEGACY_AFFILIATION_ASSIGNMENTS: 826_020_618,
+    Operation.SEED_JOURNAL_CONTENT: 826_020_619,
 }
 
 
@@ -1927,6 +1937,109 @@ register_operation(
     )
 )
 
+
+@task
+def seed_journal_content(backfill_id, **said_by_whoever_enqueued_it):
+    """Create the Gang supertype and the two Underhive Journals' territories
+    and tables, once, and record what was created.
+
+    Library-only work in one transaction under the runner discipline:
+    every row is matched on its name and pack and left alone where it
+    stands, so a rerun creates nothing and says so. The built-in members
+    it adds file the propagation pass that gives gangs already founded
+    their supertype pick.
+    """
+    from n26.library.journal_content import seed_all
+
+    _run_recorded(
+        backfill_id,
+        Operation.SEED_JOURNAL_CONTENT,
+        "Journal content seed",
+        seed_all,
+        (),
+    )
+
+
+def seed_journal_content_view(request):
+    """Say what the seed would create (GET), or record a run and enqueue it.
+
+    The preview is the seed itself, run and rolled back, so it lists
+    exactly the rows a run would create or skip. A seed with nothing to
+    do records no run.
+    """
+    from n26.library.journal_content import NOTHING_TO_DO, preview
+
+    operation = Operation.SEED_JOURNAL_CONTENT
+    address = reverse(f"admin:maintenance_{operation.value}")
+    if request.method == "POST":
+        running = running_guard(operation)
+        if running is not None:
+            messages.warning(request, "That seed is already running.")
+            return HttpResponseRedirect(
+                reverse("admin:maintenance_backfill_detail", args=[running.id])
+            )
+        lines = preview()
+        if lines[0] == NOTHING_TO_DO:
+            messages.info(request, NOTHING_TO_DO)
+            return HttpResponseRedirect(address)
+        backfill = Backfill.objects.create(
+            operation=operation,
+            triggered_by=request.user,
+            status=Backfill.Status.RUNNING,
+            summary={"preview": lines, "attempts": 0},
+        )
+        seed_journal_content.enqueue(backfill_id=str(backfill.id))
+        messages.success(
+            request, "The seed is running. This page shows what it creates."
+        )
+        return HttpResponseRedirect(
+            reverse("admin:maintenance_backfill_detail", args=[backfill.id])
+        )
+    problem = ""
+    try:
+        lines = preview()
+    except (ObjectDoesNotExist, MultipleObjectsReturned, ValidationError) as broke:
+        # A library shape the seed does not expect — two Territory asset
+        # types, say — is shown on the page in words rather than as an
+        # error page, so the operation stays reachable.
+        lines, problem = [], str(broke)
+    context = page_context(
+        request,
+        operation.label,
+        preview=lines,
+        nothing_to_do=bool(lines) and lines[0] == NOTHING_TO_DO,
+        problem=problem,
+        apply_url=address,
+        recent=Backfill.objects.filter(operation=operation)[:10],
+    )
+    return render(request, "admin/maintenance/n26/seed_journal_content.html", context)
+
+
+register_operation(
+    MaintenanceOperation(
+        operation=Operation.SEED_JOURNAL_CONTENT.value,
+        name=Operation.SEED_JOURNAL_CONTENT.label,
+        added=date(2026, 9, 7),
+        description=(
+            "Create the Gang supertype: a hidden gang-level slot with six "
+            "marker pickables, Goliath to Cawdor. It is built into each Clan "
+            "House gang type with that House picked, and Clan House Outcast "
+            "gangs are given it by their Clan House pickable. Create the two "
+            "Underhive Journals' territories as well: twelve Territories "
+            "under the Territory campaign type, each with its income and its "
+            "House Controlled boon, and the Goliath Territories and Escher "
+            "Territories tables, each given to the gangs of its House. The "
+            "journal rows are staged until an author puts them live. Every "
+            "row is matched by name, so running this again creates nothing. "
+            "No money moves; the propagation pass gives gangs already "
+            "founded their supertype pick."
+        ),
+        view=seed_journal_content_view,
+        detail_template="admin/maintenance/n26/_seed_journal_content_detail.html",
+    )
+)
+
+
 #: Declared for the task registry, which reads this from ``n26/core/tasks.py``.
 #: The deadline is the longest Pub/Sub allows, because a repair holds one
 #: transaction for as long as proving what it touched takes. It is also
@@ -1962,6 +2075,7 @@ task_routes = [
     ),
     TaskRoute(delete_empty_affiliations, ack_deadline=600, min_retry_delay=60),
     TaskRoute(open_founding_actions, ack_deadline=600),
+    TaskRoute(seed_journal_content, ack_deadline=600, min_retry_delay=60),
 ]
 
 

--- a/n26/maintenance.py
+++ b/n26/maintenance.py
@@ -1978,7 +1978,13 @@ def seed_journal_content_view(request):
             return HttpResponseRedirect(
                 reverse("admin:maintenance_backfill_detail", args=[running.id])
             )
-        lines = preview()
+        try:
+            lines = preview()
+        except (ObjectDoesNotExist, MultipleObjectsReturned, ValidationError) as broke:
+            # The same library shape the GET shows in words: a POST made by
+            # hand against it gets the message, not an error page.
+            messages.error(request, f"The seed cannot run: {broke}")
+            return HttpResponseRedirect(address)
         if lines[0] == NOTHING_TO_DO:
             messages.info(request, NOTHING_TO_DO)
             return HttpResponseRedirect(address)

--- a/n26/tests/sandbox/test_journal_content.py
+++ b/n26/tests/sandbox/test_journal_content.py
@@ -1,0 +1,811 @@
+"""The journal content seed: the Gang supertype and the two Underhive
+Journals' territories, created once, as a maintenance operation.
+
+The rules (design/house-and-territory-tables.md): a Goliath gang may roll
+its starting Territory on the House of Chains table, an Escher gang on
+the House of Blades table, and each of those Territories carries a House
+Controlled boon that applies only while a gang of that House holds it —
+a Clan House Outcast gang of that House included. The fact all of that
+reads is a hidden Gang supertype pick on the gang; the content that
+writes it, and the journals' territories, tables and boons, is one seed
+(``n26/library/gang_supertypes.py``, ``n26/library/journal_content.py``)
+run from the maintenance console on the tasks framework.
+
+What this file holds still: the seed creates every row exactly once and
+a rerun creates nothing and says so; a gang type or Outcast pick that is
+not there is skipped and said; a Goliath gang founded after the seed has
+the pick, one founded before catches up by propagation, a Clan House
+Goliath Outcast gang has it once House Goliath is picked, and an Escher
+gang and a Clanless Outcast never do; a journal territory's income and
+boons reach the holder the condition names; the House table reaches a
+gang through its pick and its starting-roll dialog offers it, while a
+reader who may not see staged content is not offered a staged table;
+both D6 tables cover every roll once; the House tables are never built
+into the campaign type; and the console previews, enqueues, records and
+stands down on a redelivery.
+"""
+
+import pytest
+from django.apps import apps
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from gyrinx.maintenance.models import Backfill
+from gyrinx.site.models import Availability, FeatureFlag
+from n26.core import select
+from n26.core.campaigns import tables_held_by
+from n26.core.card import build_card, build_gang_card, build_modifier_index, carriers
+from n26.core.effects import _Facts, compute, compute_gang
+from n26.core.models import BuiltInPropagationTask, CampaignAsset
+from n26.core.operations import Refusal
+from n26.core.reconcile import assert_reconciled
+from n26.core.render import render_campaign, render_gang
+from n26.flags import BUILT_IN_PROPAGATION, CAMPAIGNS
+from n26.library.core_campaign import CAMPAIGN_TYPE, seed_core_campaign
+from n26.library.gang_supertypes import (
+    HOUSES,
+    PICKLIST,
+    SLOT,
+    SLOT_TYPE,
+    clan_house_pickable_name,
+    seed_gang_supertypes,
+    supertype_pick,
+)
+from n26.library.income import INCOME, income_of
+from n26.library.journal_content import (
+    JOURNALS,
+    NOTHING_TO_DO,
+    controlled_rule_name,
+    preview,
+    seed_all,
+)
+from n26.library.models import (
+    Asset,
+    AssetTable,
+    AssetTableEntry,
+    CampaignType,
+    DefaultAssignment,
+    Modifier,
+    Pickable,
+    Picklist,
+    Rule,
+    Slot,
+    SlotType,
+)
+from n26.library.tables import build_in_missing
+from n26.library.territory_table import TABLE, seed_territory_table
+from n26.maintenance import Operation, seed_journal_content
+from n26.tests.sandbox.actions import (
+    add_asset,
+    add_built_in,
+    assign_asset,
+    choose,
+    create_gang_type,
+    create_pickable,
+    create_picklist,
+    create_profile,
+    create_slot,
+    create_slot_type,
+    found_campaign,
+    found_gang,
+    hire,
+    join_campaign,
+    open_table,
+    roll_asset,
+)
+
+pytestmark = pytest.mark.django_db
+
+GOLIATH_TABLE = JOURNALS[0][1]
+ESCHER_TABLE = JOURNALS[1][1]
+
+
+# --- The world the seed runs in --------------------------------------------
+
+
+@pytest.fixture
+def arbitrator(db):
+    return User.objects.create_user("arbitrator")
+
+
+@pytest.fixture
+def staff_arbitrator(db):
+    return User.objects.create_user("author", is_staff=True)
+
+
+@pytest.fixture
+def superuser(db):
+    return User.objects.create_superuser("boss", "boss@example.com", "password")
+
+
+@pytest.fixture
+def campaigns_open(db):
+    return FeatureFlag.objects.create(
+        slug=CAMPAIGNS, name="Campaigns", availability=Availability.EVERYONE
+    )
+
+
+@pytest.fixture
+def propagating(db):
+    return FeatureFlag.objects.create(
+        slug=BUILT_IN_PROPAGATION,
+        name="Built-in propagation",
+        availability=Availability.EVERYONE,
+    )
+
+
+@pytest.fixture
+def core(default_pack):
+    """The Territory campaign type as it ships, with the Territory
+    Selection Table built in."""
+    seed_core_campaign(apps)
+    seed_territory_table(apps)
+    return CampaignType.objects.get(name=CAMPAIGN_TYPE)
+
+
+@pytest.fixture
+def gang_types(default_pack):
+    """The six Clan House gang types and Outcast, as the system pack has
+    them, with no supertype built in yet."""
+    made = {house: create_gang_type(house) for house in HOUSES}
+    made["Outcast"] = create_gang_type("Outcast")
+    return made
+
+
+@pytest.fixture
+def clan_house(default_pack, gang_types, person_type):
+    """The Outcast gang's Clan House choice as it stands in the system
+    pack: its own slot type and pickables, House Goliath among them, on
+    a visible gang-level slot built into the Outcast Leader."""
+    slot_type = create_slot_type("Clan House")
+    picks = {
+        house: create_pickable(clan_house_pickable_name(house), slot_type)
+        for house in HOUSES
+    }
+    picklist = create_picklist("Clan House", slot_type, members=list(picks.values()))
+    slot = create_slot("Clan House", slot_type, picklist, assigned_to="gang")
+    leader = create_profile(
+        "Outcast Leader", person_type, gang_types["Outcast"], price=120
+    )
+    add_built_in(leader, slot)
+    return {"slot": slot, "picks": picks, "leader": leader}
+
+
+@pytest.fixture
+def seeded(core, gang_types, clan_house):
+    """The whole seed, run once over a world with everything it looks for.
+    The gang types in hand are read again afterwards: the seed founds
+    each type's built-ins set on a copy of its own."""
+    lines = seed_all()
+    for gang_type in gang_types.values():
+        gang_type.refresh_from_db()
+    return lines
+
+
+def gang_facts(gang):
+    """The gang as its own scopes see it: stored facts with the computed
+    grants — a pick a grant dealt included — layered on."""
+    card = build_gang_card(gang)
+    index = build_modifier_index(carriers(card))
+    return _Facts(card, compute(card, index)).model()
+
+
+def has_picked(gang, house):
+    return select.Has(supertype_pick(house)).matches(gang_facts(gang))
+
+
+def gang_rules(gang):
+    """The rules on the gang's own card, the campaign assets it holds
+    among the carriers."""
+    card = build_gang_card(gang)
+    index = build_modifier_index(carriers(card))
+    return [contribution.thing for contribution in compute_gang(card, index).rules]
+
+
+def income_reading(gang):
+    block = render_gang(gang).campaign
+    return next(line.value for line in block.counters if line.name == INCOME)
+
+
+def created_lines(lines):
+    return [line for line in lines if not line.startswith("skipped")]
+
+
+# --- What the seed creates -------------------------------------------------
+
+
+class TestTheSeedCreatesEverythingOnce:
+    """Every row the programme needs, in the system pack, matched by name
+    and pack; a second run creates nothing and says so."""
+
+    def test_the_supertype_is_one_slot_type_six_markers_one_list_one_hidden_slot(
+        self, seeded, default_pack
+    ):
+        (slot_type,) = SlotType.objects.filter(name=SLOT_TYPE)
+        assert slot_type.pack == default_pack
+        assert not slot_type.allows_repeats
+        picks = Pickable.objects.filter(slot_type=slot_type).order_by("name")
+        assert sorted(p.name for p in picks) == sorted(HOUSES)
+        # The Venator Gang Legacy picks hold the bare names in the pack,
+        # so the markers are told apart by an author-facing qualifier.
+        assert {p.qualifier for p in picks} == {SLOT_TYPE}
+        # Markers: the Goliath and Escher picks carry their House table's
+        # grant and nothing else; the other four carry nothing.
+        by_name = {p.name: p for p in picks}
+        for house in ("Orlock", "Van Saar", "Delaque", "Cawdor"):
+            assert by_name[house].modifiers.count() == 0
+        for house, table_name in (("Goliath", GOLIATH_TABLE), ("Escher", ESCHER_TABLE)):
+            (grant,) = by_name[house].modifiers.all()
+            assert grant.adds_assignable.asset_table.name == table_name
+            assert grant.targets_gang.echoes is False
+        (picklist,) = Picklist.objects.filter(name=PICKLIST)
+        assert [m.pickable.name for m in picklist.members.order_by("position")] == list(
+            HOUSES
+        )
+        (slot,) = Slot.objects.filter(name=SLOT)
+        assert (slot.hidden, slot.min_picks, slot.max_picks, slot.assigned_to) == (
+            True,
+            1,
+            1,
+            "gang",
+        )
+        assert slot.picklist == picklist
+
+    def test_each_clan_house_gang_type_builds_the_slot_in_with_its_house_picked(
+        self, seeded, gang_types
+    ):
+        slot = Slot.objects.get(name=SLOT)
+        for house in HOUSES:
+            gang_type = gang_types[house]
+            (member,) = DefaultAssignment.objects.filter(
+                default_set=gang_type.built_ins, slot=slot, archived=False
+            )
+            assert member.default_pickable == supertype_pick(house)
+        assert gang_types["Outcast"].built_ins is None
+
+    def test_each_outcast_clan_house_pick_gives_the_slot_with_its_house_picked(
+        self, seeded, clan_house
+    ):
+        slot = Slot.objects.get(name=SLOT)
+        for house in HOUSES:
+            clan_pick = clan_house["picks"][house]
+            (grant,) = clan_pick.modifiers.filter(adds_assignable__slot=slot)
+            assert grant.adds_assignable.with_pick == supertype_pick(house)
+            assert grant.targets_gang.echoes is False
+
+    def test_twelve_staged_territories_with_the_books_income(self, seeded, core):
+        territory = core.asset_types.get(label_singular="Territory")
+        for _house, _table, territories in JOURNALS:
+            for entry in territories:
+                asset = Asset.objects.get(name=entry.name)
+                assert asset.asset_type == territory
+                assert asset.staged
+                assert income_of(asset) == entry.income
+
+    def test_the_house_controlled_boons_are_income_or_a_named_rule(self, seeded):
+        for house, _table, territories in JOURNALS:
+            pick = supertype_pick(house)
+            for entry in territories:
+                asset = Asset.objects.get(name=entry.name)
+                (boon,) = [
+                    m for m in asset.modifiers.all() if m.targets_gang.is_conditional
+                ]
+                (condition,) = boon.targets_gang.has_gang_pickable.all()
+                assert list(condition.pickables.all()) == [pick]
+                assert boon.targets_gang.echoes is False
+                if entry.more_income:
+                    assert boon.contributes_to_counter.amount == entry.more_income
+                    assert boon.contributes_to_counter.counter.name == INCOME
+                else:
+                    rule = boon.adds_assignable.rule
+                    assert rule.name == controlled_rule_name(house)
+                    assert rule.annotation == entry.name
+                    assert rule.staged
+        assert Rule.objects.filter(name__endswith="Controlled").count() == 11
+
+    def test_two_staged_d6_tables_in_the_books_order(self, seeded):
+        for _house, table_name, territories in JOURNALS:
+            table = AssetTable.objects.get(name=table_name)
+            assert table.staged
+            assert table.dice == "d6"
+            entries = list(table.entries.select_related("asset").order_by("position"))
+            assert [(e.roll_low, e.roll_high, e.asset.name) for e in entries] == [
+                (roll, roll, entry.name)
+                for roll, entry in enumerate(territories, start=1)
+            ]
+            assert all(e.staged for e in entries)
+
+    def test_the_house_tables_are_not_built_into_the_campaign_type(self, seeded, core):
+        given = [m.assignable.name for m in core.built_in_members]
+        assert TABLE in given
+        assert GOLIATH_TABLE not in given and ESCHER_TABLE not in given
+
+    def test_a_later_built_in_pass_leaves_the_house_tables_alone(self, seeded, core):
+        """The rule that builds a table into its campaign type runs again
+        whenever the Territory Selection Table is seeded; a table a pick
+        gives is one House's and must not be swept up by it."""
+        assert build_in_missing(apps, core) == []
+        seed_territory_table(apps)
+        assert not DefaultAssignment.objects.filter(
+            asset_table__name__in=[GOLIATH_TABLE, ESCHER_TABLE]
+        ).exists()
+
+    def test_running_it_again_creates_nothing_and_says_so(self, seeded):
+        before = {
+            model: model.objects.count()
+            for model in (
+                SlotType,
+                Pickable,
+                Picklist,
+                Slot,
+                DefaultAssignment,
+                Asset,
+                AssetTable,
+                AssetTableEntry,
+                Rule,
+                Modifier,
+            )
+        }
+
+        again = seed_all()
+
+        assert again == [NOTHING_TO_DO]
+        assert before == {model: model.objects.count() for model in before}
+
+    def test_the_first_run_says_what_it_made(self, seeded):
+        assert f"created the {SLOT_TYPE} slot type" in seeded
+        assert f"built the {SLOT} slot into Goliath, picked Goliath" in seeded
+        assert f"House Goliath now gives the {SLOT} slot, picked Goliath" in seeded
+        assert "created the Slug House Territory with income 20, staged" in seeded
+        assert "Amneo-vats: 10 more income for gangs that have picked Goliath" in seeded
+        assert f"Goliath gangs now hold the {GOLIATH_TABLE} table" in seeded
+        assert not any(line.startswith("skipped") for line in seeded)
+
+    def test_the_preview_says_the_same_and_writes_nothing(
+        self, core, gang_types, clan_house, task_queue
+    ):
+        """Rolled back whole — the propagation filings the built-in members
+        make included, whose messages would otherwise have a scheduled
+        sweep reconcile every Clan House gang from a page load."""
+        # The Clan House fixture filed its own passes; only new filings count.
+        filed = BuiltInPropagationTask.objects.count()
+        with task_queue.capture():
+            lines = preview()
+
+        assert f"created the {SLOT_TYPE} slot type" in lines
+        assert not SlotType.objects.filter(name=SLOT_TYPE).exists()
+        assert not AssetTable.objects.filter(name=GOLIATH_TABLE).exists()
+        assert not Asset.objects.filter(staged=True).exists()
+        assert BuiltInPropagationTask.objects.count() == filed
+        assert task_queue.pending() == 0
+
+        assert seed_all() == lines
+        assert BuiltInPropagationTask.objects.count() == filed + 6
+
+    def test_a_missing_gang_type_or_outcast_pick_is_skipped_and_said(self, core):
+        """A fresh database has no gang lists; the seed creates none, and
+        says which built-ins and grants it could not write."""
+        lines = seed_all()
+
+        assert "skipped Goliath: no gang type of that name" in lines
+        assert (
+            "skipped House Goliath: no Outcast Clan House pickable of that name"
+            in lines
+        )
+        assert AssetTable.objects.filter(name=GOLIATH_TABLE).exists()
+        # The skips are said on every run, but they are not work: a rerun
+        # still reports nothing to do.
+        again = seed_all()
+        assert again[0] == NOTHING_TO_DO
+        assert created_lines(again[1:]) == []
+
+    def test_an_archived_built_in_member_is_left_archived(self, seeded, gang_types):
+        """An author who took the slot out of a type's built-ins is not
+        overruled by a rerun: the archived member is found, and said."""
+        slot = Slot.objects.get(name=SLOT)
+        member = DefaultAssignment.objects.get(
+            default_set=gang_types["Goliath"].built_ins, slot=slot
+        )
+        member.archive()
+
+        again = seed_all()
+
+        assert again[0] == NOTHING_TO_DO
+        assert any(line.startswith("skipped Goliath: its built-in") for line in again)
+        assert (
+            DefaultAssignment.objects.filter(
+                default_set=gang_types["Goliath"].built_ins, slot=slot
+            ).count()
+            == 1
+        )
+
+    def test_the_supertype_alone_can_be_seeded(self, gang_types):
+        outcome, picks = seed_gang_supertypes()
+        assert set(picks) == set(HOUSES)
+        assert f"created the {SLOT_TYPE} slot type" in outcome.created
+        assert len(outcome.skipped) == 6  # the Outcast picks are not there
+
+
+# --- Who has a supertype --------------------------------------------------
+
+
+class TestWhoHasASupertype:
+    """A Goliath gang has picked Goliath however it came to be one: founded
+    on the type after the seed, founded before and caught up, or an
+    Outcast gang that chose House Goliath. An Escher gang and a Clanless
+    Outcast have not."""
+
+    def test_a_goliath_gang_founded_after_the_seed_has_the_pick(
+        self, seeded, gang_types, owner
+    ):
+        gang = found_gang("Irontooth", gang_types["Goliath"], owner=owner, budget=1000)
+
+        assert has_picked(gang, "Goliath")
+        assert not has_picked(gang, "Escher")
+        (pick,) = gang.assignments.filter(pickable__isnull=False, archived=False)
+        assert pick.pickable == supertype_pick("Goliath")
+        assert SLOT_TYPE not in str(render_gang(gang).rows)
+        gang.refresh_from_db()
+        assert gang.rating == 0
+        assert_reconciled(gang)
+
+    def test_a_goliath_gang_founded_before_the_seed_catches_up(
+        self, core, gang_types, clan_house, owner, propagating, task_queue
+    ):
+        gang = found_gang("Old Guard", gang_types["Goliath"], owner=owner, budget=1000)
+        assert not gang.assignments.filter(pickable__isnull=False).exists()
+
+        with task_queue.capture():
+            seed_all()
+        assert not has_picked(gang, "Goliath")
+        task_queue.deliver_all()
+
+        assert has_picked(gang, "Goliath")
+        gang.refresh_from_db()
+        assert gang.rating == 0
+        assert_reconciled(gang)
+
+    def test_a_clan_house_goliath_outcast_gang_counts_as_goliath(
+        self, seeded, gang_types, clan_house, owner
+    ):
+        gang = found_gang(
+            "The Cast Out", gang_types["Outcast"], owner=owner, budget=1000
+        )
+        boss = hire(gang, clan_house["leader"], "Boss")
+        assert not has_picked(gang, "Goliath")
+
+        card = build_card(boss, with_statlines=True)
+        computed = compute(
+            card, build_modifier_index([n.assignable for n in card.all_nodes()])
+        )
+        (choice,) = [c for c in computed.choices if c.kind_label == "Clan House"]
+        choose(choice.anchor.assignment, clan_house["picks"]["Goliath"])
+
+        assert has_picked(gang, "Goliath")
+        assert not has_picked(gang, "Escher")
+        # Dealt by the grant, not written: the gang's only stored pick is
+        # the Clan House one.
+        assert not gang.assignments.filter(
+            pickable=supertype_pick("Goliath"), archived=False
+        ).exists()
+        gang.refresh_from_db()
+        assert_reconciled(gang)
+        assert boss.gang == gang
+
+    def test_an_escher_gang_and_a_clanless_outcast_are_not_goliath(
+        self, seeded, gang_types, clan_house, owner
+    ):
+        roses = found_gang("Wild Roses", gang_types["Escher"], owner=owner, budget=1000)
+        clanless = found_gang(
+            "The Nobodies", gang_types["Outcast"], owner=owner, budget=1000
+        )
+        hire(clanless, clan_house["leader"], "Boss")
+
+        assert has_picked(roses, "Escher") and not has_picked(roses, "Goliath")
+        assert not has_picked(clanless, "Goliath")
+        assert not has_picked(clanless, "Escher")
+
+
+# --- The boons on a held territory ------------------------------------------
+
+
+class TestAJournalTerritoryInPlay:
+    """Amneo-vats brings 15 to any holder and 10 more to a Goliath one;
+    Slug House gives a Goliath holder the Goliath Controlled rule and an
+    Escher holder nothing; the campaign page says who each boon is for."""
+
+    @pytest.fixture(autouse=True)
+    def flag(self, campaigns_open):
+        return campaigns_open
+
+    @pytest.fixture
+    def campaign(self, seeded, core, arbitrator):
+        return found_campaign("Dust Falls", core, owner=arbitrator, budget=1000)
+
+    @pytest.fixture
+    def gangs(self, campaign, gang_types):
+        made = {}
+        for name, house in (("Irontooth", "Goliath"), ("Wild Roses", "Escher")):
+            gang = found_gang(
+                name, gang_types[house], owner=User.objects.create_user(name)
+            )
+            join_campaign(gang, campaign)
+            made[house] = gang
+        return made
+
+    def test_amneo_vats_reads_25_for_goliath_and_15_for_escher(self, campaign, gangs):
+        vats = Asset.objects.get(name="Amneo-vats")
+        held = add_asset(campaign, vats)
+
+        assign_asset(held, gangs["Goliath"])
+        assert income_reading(gangs["Goliath"]) == 25
+        assert income_reading(gangs["Escher"]) == 0
+
+        held = add_asset(campaign, vats)
+        assign_asset(held, gangs["Escher"])
+        assert income_reading(gangs["Escher"]) == 15
+        for gang in gangs.values():
+            gang.refresh_from_db()
+            assert_reconciled(gang)
+
+    def test_slug_house_gives_goliath_the_rule_and_escher_nothing(
+        self, campaign, gangs
+    ):
+        slug_house = Asset.objects.get(name="Slug House")
+        rule = Rule.objects.get(
+            name=controlled_rule_name("Goliath"), annotation="Slug House"
+        )
+        for gang in gangs.values():
+            assign_asset(add_asset(campaign, slug_house), gang)
+
+        assert rule in gang_rules(gangs["Goliath"])
+        assert rule not in gang_rules(gangs["Escher"])
+        assert income_reading(gangs["Goliath"]) == 20
+        assert income_reading(gangs["Escher"]) == 20
+
+    def test_the_campaign_page_prints_each_boon_with_its_scope(self, campaign, gangs):
+        for name in ("Amneo-vats", "Slug House"):
+            add_asset(campaign, Asset.objects.get(name=name))
+
+        (territories,) = render_campaign(campaign, viewer=campaign.owner).assets
+        by_name = {entry.name: entry for entry in territories.entries}
+
+        vats = by_name["Amneo-vats"]
+        assert vats.income == 15
+        (boon,) = vats.boons
+        assert "gangs that have picked Goliath" in boon
+        assert "10" in boon and INCOME in boon
+
+        slug = by_name["Slug House"]
+        assert slug.income == 20
+        (boon,) = slug.boons
+        assert "gangs that have picked Goliath" in boon
+        assert "Goliath Controlled" in boon and "Slug House" in boon
+
+
+# --- The House table and the starting roll ---------------------------------
+
+
+class TestTheHouseTable:
+    """A Goliath gang holds Goliath Territories through its pick and its
+    starting-roll dialog offers it; an Escher gang's does not until the
+    arbitrator opens the table. A staged table is offered only to a reader
+    who may see staged content."""
+
+    @pytest.fixture(autouse=True)
+    def flag(self, campaigns_open):
+        return campaigns_open
+
+    @pytest.fixture
+    def campaign(self, seeded, core, staff_arbitrator):
+        return found_campaign("Dust Falls", core, owner=staff_arbitrator)
+
+    @pytest.fixture
+    def gangs(self, campaign, gang_types):
+        made = {}
+        for name, house in (("Irontooth", "Goliath"), ("Wild Roses", "Escher")):
+            gang = found_gang(
+                name, gang_types[house], owner=User.objects.create_user(name)
+            )
+            join_campaign(gang, campaign)
+            made[house] = gang
+        return made
+
+    def dialog(self, client, campaign, gang):
+        territory = campaign.campaign_type.asset_types.get(label_singular="Territory")
+        page = reverse("n26-campaign", args=[campaign.pk])
+        return client.get(
+            f"{page}?starting={gang.pk}&type={territory.pk}"
+        ).content.decode()
+
+    def test_each_house_holds_its_own_table(self, campaign, gangs):
+        goliath = AssetTable.objects.get(name=GOLIATH_TABLE)
+        escher = AssetTable.objects.get(name=ESCHER_TABLE)
+        selection = AssetTable.objects.get(name=TABLE)
+        held = {
+            house: set(tables_held_by(gang, include_staged=True))
+            for house, gang in gangs.items()
+        }
+        assert held == {"Goliath": {goliath, selection}, "Escher": {escher, selection}}
+
+    def test_a_staff_arbitrator_is_offered_the_house_table(
+        self, client, campaign, gangs, staff_arbitrator
+    ):
+        client.force_login(staff_arbitrator)
+
+        kings = self.dialog(client, campaign, gangs["Goliath"])
+        assert GOLIATH_TABLE in kings and TABLE in kings
+        assert ESCHER_TABLE not in kings
+
+        cats = self.dialog(client, campaign, gangs["Escher"])
+        assert ESCHER_TABLE in cats and TABLE in cats
+        assert GOLIATH_TABLE not in cats
+
+    def test_opening_the_table_offers_it_to_the_other_house(
+        self, client, campaign, gangs, staff_arbitrator, propagating, task_queue
+    ):
+        goliath = AssetTable.objects.get(name=GOLIATH_TABLE)
+        with task_queue.capture():
+            open_table(campaign, goliath)
+        task_queue.deliver_all()
+
+        client.force_login(staff_arbitrator)
+        assert GOLIATH_TABLE in self.dialog(client, campaign, gangs["Escher"])
+        assert goliath in tables_held_by(gangs["Escher"], include_staged=True)
+
+    def test_a_reader_who_may_not_see_staged_content_is_not_offered_a_staged_table(
+        self, client, campaign, gangs, staff_arbitrator
+    ):
+        """The grant reaches the Goliath gang's card whoever is looking,
+        but rolling on a table is where a Territory is newly chosen for
+        the campaign, so the dialog holds a staged table back from a
+        reader who may not see staged content."""
+        goliath = AssetTable.objects.get(name=GOLIATH_TABLE)
+        assert goliath in tables_held_by(gangs["Goliath"], include_staged=True)
+        assert goliath not in tables_held_by(gangs["Goliath"])
+
+        player = User.objects.create_user("arbitrator-player")
+        campaign.owner = player
+        campaign.save(update_fields=["owner"])
+        client.force_login(player)
+        kings = self.dialog(client, campaign, gangs["Goliath"])
+        assert TABLE in kings
+        assert GOLIATH_TABLE not in kings
+
+        # Posting the staged table's key by hand is refused the same way.
+        territory = campaign.campaign_type.asset_types.get(label_singular="Territory")
+        response = client.post(
+            reverse(
+                "n26-campaign-roll-starting", args=[campaign.pk, gangs["Goliath"].pk]
+            ),
+            {"type": str(territory.pk), "table": str(goliath.pk), "rolled": "1"},
+            follow=True,
+        )
+        assert not CampaignAsset.objects.filter(
+            campaign=campaign, holder__gang=gangs["Goliath"]
+        ).exists()
+        assert response.status_code == 200
+
+        # The act itself refuses too, whoever calls it: the gate is not
+        # only the dialog's.
+        with pytest.raises(Refusal, match="cannot roll on Goliath Territories"):
+            roll_asset(campaign, goliath, gang=gangs["Goliath"], rolled=1, actor=player)
+        roll = roll_asset(
+            campaign, goliath, gang=gangs["Goliath"], rolled=1, actor=staff_arbitrator
+        )
+        assert roll.campaign_asset.asset.name == "Slug House"
+
+    def test_the_tables_page_shows_staged_tables_to_staff_only(
+        self, client, campaign, staff_arbitrator
+    ):
+        client.force_login(staff_arbitrator)
+        page = client.get(reverse("n26-campaign-tables", args=[campaign.pk]))
+        assert GOLIATH_TABLE in page.content.decode()
+
+        player = User.objects.create_user("arbitrator-player")
+        campaign.owner = player
+        campaign.save(update_fields=["owner"])
+        client.force_login(player)
+        page = client.get(reverse("n26-campaign-tables", args=[campaign.pk]))
+        assert GOLIATH_TABLE not in page.content.decode()
+        assert TABLE in page.content.decode()
+
+
+# --- Coverage ----------------------------------------------------------------
+
+
+class TestBothTablesCoverEveryRoll:
+    def test_every_roll_of_a_d6_lands_on_exactly_one_entry(self, seeded):
+        for table_name in (GOLIATH_TABLE, ESCHER_TABLE):
+            table = AssetTable.objects.get(name=table_name)
+            said = table.coverage()
+            assert said.whole
+            assert (said.covered, said.total) == (6, 6)
+            assert [table.landing(roll).roll_low for roll in range(1, 7)] == list(
+                range(1, 7)
+            )
+
+
+# --- The console -------------------------------------------------------------
+
+
+class TestTheMaintenanceOperation:
+    """The seed runs from the maintenance console: GET previews without
+    writing, POST records a run and enqueues it, the task writes its
+    outcome onto the record, and a redelivered message changes nothing."""
+
+    @pytest.fixture
+    def address(self):
+        return reverse(f"admin:maintenance_{Operation.SEED_JOURNAL_CONTENT.value}")
+
+    def test_the_preview_lists_the_rows_and_writes_nothing(
+        self, client, superuser, core, gang_types, clan_house, address
+    ):
+        client.force_login(superuser)
+
+        page = client.get(address).content.decode()
+
+        assert f"created the {SLOT_TYPE} slot type" in page
+        assert f"created the {GOLIATH_TABLE} table, staged" in page
+        assert "Create the missing rows" in page
+        assert not Backfill.objects.exists()
+        assert not SlotType.objects.filter(name=SLOT_TYPE).exists()
+
+    def test_posting_records_a_run_and_the_task_writes_its_outcome(
+        self, client, superuser, core, gang_types, clan_house, address
+    ):
+        client.force_login(superuser)
+
+        response = client.post(address)
+
+        assert response.status_code == 302
+        record = Backfill.objects.get(operation=Operation.SEED_JOURNAL_CONTENT)
+        assert str(record.pk) in response["Location"]
+        assert record.status == Backfill.Status.DONE
+        assert record.triggered_by == superuser
+        assert f"created the {SLOT_TYPE} slot type" in record.summary["report"]
+        assert record.summary["attempts"] == 1
+        assert AssetTable.objects.filter(name=GOLIATH_TABLE, staged=True).exists()
+
+        detail = client.get(
+            reverse("admin:maintenance_backfill_detail", args=[record.pk])
+        ).content.decode()
+        assert "What it did" in detail
+        assert f"Goliath gangs now hold the {GOLIATH_TABLE} table" in detail
+
+    def test_a_run_with_nothing_to_do_records_nothing(
+        self, client, superuser, seeded, address
+    ):
+        client.force_login(superuser)
+
+        response = client.post(address, follow=True)
+
+        assert NOTHING_TO_DO in response.content.decode()
+        assert not Backfill.objects.exists()
+        page = client.get(address).content.decode()
+        assert "Nothing to create" in page
+
+    def test_a_redelivered_message_creates_nothing_more(
+        self, core, gang_types, clan_house, task_queue
+    ):
+        record = Backfill.objects.create(
+            operation=Operation.SEED_JOURNAL_CONTENT,
+            status=Backfill.Status.RUNNING,
+            summary={"attempts": 0},
+        )
+
+        with task_queue.capture():
+            seed_journal_content.enqueue(backfill_id=str(record.pk))
+        task_queue.deliver_all()
+        task_queue.redeliver_last()
+
+        record.refresh_from_db()
+        assert record.status == Backfill.Status.DONE
+        assert record.summary["attempts"] == 1
+        assert SlotType.objects.filter(name=SLOT_TYPE).count() == 1
+        assert AssetTable.objects.filter(name=GOLIATH_TABLE).count() == 1
+        assert Modifier.objects.filter(name__endswith="Goliath Controlled").count() == 6
+
+    def test_only_a_superuser_reaches_it(self, client, staff_arbitrator, address):
+        client.force_login(staff_arbitrator)
+        assert client.get(address).status_code in (302, 403)

--- a/n26/tests/sandbox/test_journal_content.py
+++ b/n26/tests/sandbox/test_journal_content.py
@@ -701,7 +701,7 @@ class TestTheHouseTable:
         escher = AssetTable.objects.get(name=ESCHER_TABLE)
         selection = AssetTable.objects.get(name=TABLE)
         held = {
-            house: set(tables_held_by(gang, include_staged=True))
+            house: set(tables_held_by(gang, campaign, include_staged=True))
             for house, gang in gangs.items()
         }
         assert held == {"Goliath": {goliath, selection}, "Escher": {escher, selection}}
@@ -729,7 +729,7 @@ class TestTheHouseTable:
 
         client.force_login(staff_arbitrator)
         assert GOLIATH_TABLE in self.dialog(client, campaign, gangs["Escher"])
-        assert goliath in tables_held_by(gangs["Escher"], include_staged=True)
+        assert goliath in tables_held_by(gangs["Escher"], campaign, include_staged=True)
 
     def test_a_reader_who_may_not_see_staged_content_is_not_offered_a_staged_table(
         self, client, campaign, gangs, staff_arbitrator
@@ -739,8 +739,10 @@ class TestTheHouseTable:
         the campaign, so the dialog holds a staged table back from a
         reader who may not see staged content."""
         goliath = AssetTable.objects.get(name=GOLIATH_TABLE)
-        assert goliath in tables_held_by(gangs["Goliath"], include_staged=True)
-        assert goliath not in tables_held_by(gangs["Goliath"])
+        assert goliath in tables_held_by(
+            gangs["Goliath"], campaign, include_staged=True
+        )
+        assert goliath not in tables_held_by(gangs["Goliath"], campaign)
 
         player = User.objects.create_user("arbitrator-player")
         campaign.owner = player

--- a/n26/tests/sandbox/test_journal_content.py
+++ b/n26/tests/sandbox/test_journal_content.py
@@ -32,10 +32,11 @@ from django.urls import reverse
 
 from gyrinx.maintenance.models import Backfill
 from gyrinx.site.models import Availability, FeatureFlag
-from n26.core import select
+from n26.core import history, select
 from n26.core.campaigns import tables_held_by
 from n26.core.card import build_card, build_gang_card, build_modifier_index, carriers
 from n26.core.effects import _Facts, compute, compute_gang
+from n26.core.history import campaign_history
 from n26.core.models import BuiltInPropagationTask, CampaignAsset
 from n26.core.operations import Refusal
 from n26.core.reconcile import assert_reconciled
@@ -504,6 +505,83 @@ class TestWhoHasASupertype:
         assert has_picked(roses, "Escher") and not has_picked(roses, "Goliath")
         assert not has_picked(clanless, "Goliath")
         assert not has_picked(clanless, "Escher")
+
+
+# --- Nothing is told about the supertype ------------------------------------
+
+
+def told(acts):
+    """Every sentence and every line beneath one, flattened."""
+    lines = []
+    for act in acts:
+        lines.append("".join(span.text for span in act.spans))
+        lines.extend(f"{sub.name} {sub.note}" for sub in act.subs)
+    return lines
+
+
+class TestNothingIsToldAboutTheSupertype:
+    """The supertype is a classification players never see, so the gang
+    history and the campaign log say nothing when a gang gets it — at
+    founding, or when propagation catches an older gang up — while a
+    visible slot's pick is told as it always was."""
+
+    @pytest.fixture(autouse=True)
+    def flag(self, campaigns_open):
+        return campaigns_open
+
+    def test_founding_a_goliath_gang_writes_no_line_naming_it(
+        self, seeded, gang_types, owner
+    ):
+        gang = found_gang("Irontooth", gang_types["Goliath"], owner=owner, budget=1000)
+
+        lines = told(history.build(gang))
+
+        assert lines
+        assert not any(SLOT_TYPE in line for line in lines)
+        assert not any("Goliath comes with" in line for line in lines)
+
+    def test_the_propagation_pass_writes_no_line_naming_it(
+        self,
+        core,
+        gang_types,
+        clan_house,
+        owner,
+        arbitrator,
+        propagating,
+        task_queue,
+    ):
+        gang = found_gang("Old Guard", gang_types["Goliath"], owner=owner, budget=1000)
+        campaign = found_campaign("Dust Falls", core, owner=arbitrator)
+        join_campaign(gang, campaign)
+
+        with task_queue.capture():
+            seed_all()
+        task_queue.deliver_all()
+
+        assert has_picked(gang, "Goliath")
+        for lines in (told(history.build(gang)), told(campaign_history(campaign))):
+            assert lines
+            assert not any(SLOT_TYPE in line for line in lines)
+            assert not any("comes with" in line for line in lines)
+
+    def test_a_visible_slots_pick_is_still_told(
+        self, seeded, gang_types, clan_house, owner
+    ):
+        gang = found_gang(
+            "The Cast Out", gang_types["Outcast"], owner=owner, budget=1000
+        )
+        boss = hire(gang, clan_house["leader"], "Boss")
+        card = build_card(boss, with_statlines=True)
+        computed = compute(
+            card, build_modifier_index([n.assignable for n in card.all_nodes()])
+        )
+        (choice,) = [c for c in computed.choices if c.kind_label == "Clan House"]
+        choose(choice.anchor.assignment, clan_house["picks"]["Goliath"])
+
+        lines = told(history.build(gang))
+
+        assert any("House Goliath" in line for line in lines)
+        assert not any(SLOT_TYPE in line for line in lines)
 
 
 # --- The boons on a held territory ------------------------------------------


### PR DESCRIPTION
Slice 4 of the territory-tables programme, stacked on #2507 (slice 3). No schema change: `makemigrations --check` is clean.

## What changed

The content the Underhive Journals need now exists as one repeatable seed, run from the maintenance console as a Backfill operation on the tasks framework (`n26: the Gang supertype and the Underhive Journal territories are created`). It follows the `_run_recorded` discipline in `n26/maintenance.py`: one transaction, an advisory lock so a redelivered message stands down, an attempt count, and every ending written onto the record. GET shows a dry run — the seed itself, run and rolled back, so the preview is exactly what a run does; POST enqueues the task and redirects to the record. Every row is matched by name and pack and left alone if it is there, so running it twice creates nothing and the record says so.

**Gang supertype** (`n26/library/gang_supertypes.py`): the SlotType "Gang supertype", six marker Pickables (Goliath, Escher, Orlock, Van Saar, Delaque, Cawdor), the Picklist "Gang supertypes", and one hidden gang-level Slot. Each of the six Clan House gang types gets a built-in member for the slot with its own House as the starting pick, through `add_built_in`, so the propagation pass that gives existing gangs their pick is filed. Each Outcast "House Goliath" (etc.) pickable on the Clan House slot type gets a modifier *targets the gang alone → adds the Gang supertype slot, picked Goliath*, so a Clan House Goliath Outcast gang matches "has picked Goliath" as a Goliath gang does. Nothing here is staged: the slot is hidden.

Two things worth knowing about the supertype rows:

- **The marker pickables carry a qualifier.** The Venator Gang Legacy picks already hold the bare names Goliath, Escher and the rest, and a pickable's name is unique in its pack whatever its slot type. The six markers are named bare (that is what a condition prints: "gangs that have picked Goliath") with the author-facing qualifier "Gang supertype". The design's "bare names" were not possible in the N26 pack.
- **The Goliath and Escher markers each carry one modifier: the grant of their House table.** The design's "marker" rule meant no boon logic hangs off them; a table grant is how a House table reaches its gangs, so it is the one modifier they carry. The other four carry nothing.

**Journal territories** (`n26/library/journal_content.py`), all `staged` until Tom has looked: twelve Territory assets under the Territory campaign type's Territory asset type — the six Goliath and six Escher territories, named as the books print them, each with the book's income figure as an Income contribution. The House Controlled boons: Amneo-vats' "10 more credits" is a second Income contribution scoped to gangs that have picked Goliath; every other boon is a Rule named "Goliath Controlled" or "Escher Controlled" with the territory's name as its annotation, given to the gang alone under the same condition. Where the book offers the boon *instead of* the income (Flesh-makers Theatre, Wyld Den, Rogue Las Factoria, Chem Arena), both the income and the rule are stored; the either/or is a choice the app does not offer yet, said in a code comment. Battlefield effects are stored nowhere. Two D6 AssetTables, "Goliath Territories" and "Escher Territories", six entries each on bands 1–1 to 6–6 in the book's order, each granted by a modifier on the matching supertype pickable — not built into the campaign type.

**Two changes outside the seed:**

- `n26/library/tables.py`: `build_in_missing` and `give_back` now skip a table a grant names. Without this, any rerun of `seed_territory_table` (the rule builds every N26-pack table of the campaign type's asset types into the type) would have built the two House tables into the Territory campaign type and handed them to every gang. A test proves the rerun leaves them alone.
- Staged tables and the roll dialogs: a staged table a pick grants reaches a Goliath gang's card whoever is looking, but rolling on it is where a Territory is newly chosen for the campaign. `tables_on` / `tables_held_by` gain `include_staged` (default False, like every other discovery helper); `render_campaign`, `roll_starting_asset` and `Campaign.roll_asset` pass `sees_staged` for the viewer or actor. A staff arbitrator sees "Goliath Territories" in a Goliath gang's starting-roll dialog; a non-staff one does not, and a hand-posted key is refused by the operation as well as the view. The pool roll's table list (`tables_in_play`) is not gated: a staged table only enters it when a staff arbitrator opens it to every gang, which is the documented escape hatch.

## Smoke on a fork of gyrinx_main

`createdb -T gyrinx_main gyrinx_smoke_jay`, migrated to this branch, then the seed's preview, run, rerun, and a second run after creating the Outcast Clan House pickables by hand (the local mirror has none; prod has them as `House Cawdor` … `House Van Saar` on the `Clan House` slot type). The fork was dropped afterwards.

| Step | Time | Rows |
| --- | --- | --- |
| preview | 0.19 s | no writes |
| run | 0.22 s | SlotType 1, Pickable 6, Picklist 1, PicklistMember 6, Slot 1, DefaultAssignment 6, Asset 12, AssetTable 2, AssetTableEntry 12, Rule 11, Modifier 26 (+ their 26 scopes, 12 conditions, 13 grants, 13 counter effects), BuiltInPropagationTask 6 |
| rerun | 0.06 s | none — "Nothing to do" |
| run with Clan House picks standing | 0.07 s | Modifier 6 (the with_pick grants) |

Verified from outside after the run: each Clan House gang type's built-in member and its default pick; each territory staged with income and exactly one boon; both tables staged and whole; the four unused markers carry no modifier; neither House table built into the Territory campaign type.

The local mirror holds no gangs of the six types, so the propagation volume was not exercised here. On prod (read-only count) the six passes will reach 1,084 unarchived Clan House gangs (Goliath 198, Escher 292, Orlock 138, Van Saar 169, Delaque 139, Cawdor 148); that is the existing propagation machinery's job, batched as it already is.

On a fresh database the seed skips and names on the record: the six gang types (`skipped Goliath: no gang type of that name`) and the six Outcast picks (`skipped House Goliath: no Outcast Clan House pickable of that name`). On prod all twelve exist, so nothing should be skipped.

## Tests

`n26/tests/sandbox/test_journal_content.py`, 33 tests: every row created once and a rerun reports nothing to do; the preview writes nothing, propagation filings included; a Goliath gang founded after the seed has the pick, one founded before catches up by propagation, a Clan House Goliath Outcast gang has it once House Goliath is picked, an Escher gang and a Clanless Outcast never do; Amneo-vats reads 25 for a Goliath holder and 15 for an Escher one, Slug House gives the Goliath holder the rule and the Escher holder nothing, and the campaign page prints each boon with its scope wording; the starting-roll dialog offers the House table to its own House and to the other once opened; a reader who may not see staged content is not offered a staged table and the operation refuses it too; both D6 tables cover every roll once; the House tables are never built into the campaign type, even after a rerun of `seed_territory_table`; the console previews without writing, records and completes a run, records nothing when there is nothing to do, and a redelivered message creates nothing more. Full `pytest n26 -n 4`: 5988 passed, 1 xfailed (before the final review fixes; the five affected files pass after them and a second full run is reported on the board).

## How to try it

1. Sign in as a superuser, open `/admin/maintenance/` and click **n26: the Gang supertype and the Underhive Journal territories are created**. The page lists every row the seed would create (`/admin/maintenance/n26-seed-journal-content/`). Click **Create the missing rows**; the record page shows what it did.
2. `/n26/authoring/` → the Territory campaign type's page: under the Territory asset type, the two staged tables and twelve staged territories (staff see staged content).
3. Found a campaign on the Territory campaign type, add a Goliath gang and an Escher gang, then on the campaign page click **Roll starting territory** for the Goliath gang: the dialog offers Goliath Territories and the Territory Selection Table. The Escher gang's dialog offers only the Territory Selection Table until you open Goliath Territories on the campaign's **Tables** page.

Do not run the seed on production until Tom has looked at the staged rows.

## Review

Review round 2026-09-09 (independent code review, briefed on the prod run): nothing at or above the bar — idempotency, dry run writing nothing, `_run_recorded` being right for library-only work, the qualifier lookup and the history fix all checked clean. One sub-threshold note fixed: the POST branch now refuses an unexpected library shape in words as the GET already did. Before running on prod: the propagation the seed files walks ~1,084 gangs through the existing propagation framework (self-healing, but not `run_batched`); time one Goliath gang's `reconcile_defaults` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTc5N9DniP5LSspvHpDANs

