### PR TITLE
feat: put notes, pictures and write-in space on n26 print cards

### DIFF
--- a/n26/core/migrations/0063_print_notes_cover_pictures_and_writing_space.py
+++ b/n26/core/migrations/0063_print_notes_cover_pictures_and_writing_space.py
@@ -1,0 +1,29 @@
+"""The notes toggle covers pictures and writing space too.
+
+``include_notes`` used to mean a notes card per model. It now means the
+footer strip on each model card: the notes themselves, a box to write
+in during a game, and the picture if there is one. The gang's notes
+still print as their own card.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("n26", "0062_credits_move_between_gangs"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="printconfig",
+            name="include_notes",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "Print the gang's notes, and on each model card its notes, "
+                    "picture, and space to write during a game."
+                ),
+            ),
+        ),
+    ]

--- a/n26/core/models/print_config.py
+++ b/n26/core/models/print_config.py
@@ -1,10 +1,11 @@
 """Print configs — what one print run of a gang includes.
 
 A config names a selection over the gang: which models get a card, which
-of each model's weapons show, and whether the gang header and the stash
-print at all. It is the print screen's memory, nothing more — pure
-display state, like ``AssignmentSet``, so it moves no money, changes no
-rating and never goes through ``n26.operations``.
+of each model's weapons show, and whether the gang header, the stash,
+and the notes strip (notes, picture, space to write) print at all. It is
+the print screen's memory, nothing more — pure display state, like
+``AssignmentSet``, so it moves no money, changes no rating and never
+goes through ``n26.operations``.
 
 Selections are literal: a config prints exactly what was ticked, and
 nothing joins it by being acquired later. A model hired after a config
@@ -43,7 +44,10 @@ class PrintConfig(Base):
     )
     include_notes = models.BooleanField(
         default=True,
-        help_text="Print the gang's notes and a notes card per model that has any.",
+        help_text=(
+            "Print the gang's notes, and on each model card its notes, "
+            "picture, and space to write during a game."
+        ),
     )
     miniatures = models.ManyToManyField(
         "n26.Miniature",

--- a/n26/core/templates/n26/print_gang.html
+++ b/n26/core/templates/n26/print_gang.html
@@ -86,6 +86,33 @@
                     <c-n26.print.card title="{{ row.card.name }}"
                                       subtitle="{{ row.card.profile_name }}"
                                       badge="{{ row.card.rating }}¢">
+                        {% if include_notes %}
+                            {% comment %}
+                            Notes, a box to write in, and the picture share
+                            one footer so they sit together at the bottom of
+                            the card. The same toggle takes the whole strip
+                            off. Lore never prints — it is read once, not at
+                            the table.
+                            {% endcomment %}
+                            <c-slot name="foot">
+                                <div class="n26-print-foot">
+                                    <div class="n26-print-foot-fields">
+                                        {% if row.card.notes %}
+                                            <div class="n26-print-notes">
+                                                <div class="n26-print-label">Notes</div>
+                                                <div class="n26-print-notes-body">{{ row.card.notes|safe_rich_text }}</div>
+                                            </div>
+                                        {% endif %}
+                                        <c-n26.print.field height="10mm" label="{% if not row.card.notes %}Notes{% endif %}" />
+                                    </div>
+                                    {% if row.card.image_url %}
+                                        <div class="n26-print-photo">
+                                            <img src="{{ row.card.image_url }}" alt="A picture of {{ row.card.name }}">
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </c-slot>
+                        {% endif %}
                         <c-n26.print.statline :statline="row.card.statline"
                                               type_line="{{ row.card.type_line }}"
                                               xp="{{ row.card.xp_display }}"
@@ -104,22 +131,7 @@
                                 </c-n26.print.column>
                             {% endfor %}
                         </c-n26.print.columns>
-                        {% if row.card.image_url %}
-                            <div class="n26-print-photo">
-                                <img src="{{ row.card.image_url }}" alt="A picture of {{ row.card.name }}">
-                            </div>
-                        {% endif %}
                     </c-n26.print.card>
-                    {% comment %}
-                    The notes are a card of their own, beside the model's, so
-                    the sheet can be cut into cards without splitting one.
-                    Lore never prints — it is read once, not at the table.
-                    {% endcomment %}
-                    {% if include_notes and row.card.notes %}
-                        <c-n26.print.card title="{{ row.card.name }}" subtitle="Notes">
-                            {{ row.card.notes|safe_rich_text }}
-                        </c-n26.print.card>
-                    {% endif %}
                 {% endfor %}
             </c-n26.print.grid>
         </c-n26.print.sheet>

--- a/n26/core/templates/n26/print_setup.html
+++ b/n26/core/templates/n26/print_setup.html
@@ -10,10 +10,10 @@ above the form fields they are the alternative to.
 
 Saved configs come first — each is one click to print again, which is the
 whole reason configs have names. The form under them describes a new run:
-name (optional — naming is what saves it), the two toggles, and a card per
-model with its weapons as checkboxes. Everything starts ticked, because the
-common print is the whole gang and the screen should cost nothing when that
-is what you want.
+name (optional — naming is what saves it), the header, stash and notes
+toggles, and a card per model with its weapons as checkboxes. Everything
+starts ticked, because the common print is the whole gang and the screen
+should cost nothing when that is what you want.
 
 Loading a saved config (?config=) pre-fills the same form — editing a config
 and creating one are one screen, not two.
@@ -87,7 +87,7 @@ that said it twice would be spending the width the name needs.
                                     {{ config.model_count }} model{{ config.model_count|pluralize }}
                                     {% if not config.include_header %}· no header{% endif %}
                                     {% if not config.include_stash %}· no stash{% endif %}
-                                    {% if not config.include_notes %}· no notes{% endif %}
+                                    {% if not config.include_notes %}· no notes or pictures{% endif %}
                                 </p>
                             </div>
                             <div class="flex shrink-0 items-center gap-2">
@@ -126,7 +126,7 @@ that said it twice would be spending the width the name needs.
             {% endif %}
             {% comment %}
             Plain inputs, as the picker rows use — the kit's checkbox is wired
-            for its own group scope and these are two independent toggles.
+            for its own group scope and these are independent toggles.
             {% endcomment %}
             <div class="flex flex-col gap-1">
                 <label class="flex min-h-9 cursor-pointer items-center gap-2.5">
@@ -148,7 +148,7 @@ that said it twice would be spending the width the name needs.
                            name="include_notes"
                            {% if include_notes %}checked{% endif %}
                            class="size-4 shrink-0 accent-[var(--color-accent)] focus-ring">
-                    <span class="text-sm text-ink-900 dark:text-ink-100">Include notes</span>
+                    <span class="text-sm text-ink-900 dark:text-ink-100">Include notes, pictures, and space to write</span>
                 </label>
             </div>
         </c-n26.form-section>

--- a/n26/core/templates/n26/print_setup.html
+++ b/n26/core/templates/n26/print_setup.html
@@ -87,7 +87,7 @@ that said it twice would be spending the width the name needs.
                                     {{ config.model_count }} model{{ config.model_count|pluralize }}
                                     {% if not config.include_header %}· no header{% endif %}
                                     {% if not config.include_stash %}· no stash{% endif %}
-                                    {% if not config.include_notes %}· no notes or pictures{% endif %}
+                                    {% if not config.include_notes %}· no notes, pictures, or space to write{% endif %}
                                 </p>
                             </div>
                             <div class="flex shrink-0 items-center gap-2">

--- a/n26/core/test_views_print.py
+++ b/n26/core/test_views_print.py
@@ -462,6 +462,12 @@ class TestNotesOnPaper:
         client.force_login(tester)
         body = client.get(setup_url(gang)).content.decode()
         assert "Include notes, pictures, and space to write" in body
+        client.post(
+            setup_url(gang),
+            {"name": "no-notes", "include_header": "on", "fighters": [str(roster[0].pk)]},
+        )
+        listed = client.get(setup_url(gang)).content.decode()
+        assert "no notes, pictures, or space to write" in listed
 
 
 class TestPrintingSomebodyElsesGang:

--- a/n26/core/test_views_print.py
+++ b/n26/core/test_views_print.py
@@ -464,7 +464,11 @@ class TestNotesOnPaper:
         assert "Include notes, pictures, and space to write" in body
         client.post(
             setup_url(gang),
-            {"name": "no-notes", "include_header": "on", "fighters": [str(roster[0].pk)]},
+            {
+                "name": "no-notes",
+                "include_header": "on",
+                "fighters": [str(roster[0].pk)],
+            },
         )
         listed = client.get(setup_url(gang)).content.decode()
         assert "no notes, pictures, or space to write" in listed

--- a/n26/core/test_views_print.py
+++ b/n26/core/test_views_print.py
@@ -373,11 +373,9 @@ class TestNotesOnPaper:
         )
         assert "n26-print-notes" in vex_card
         assert "n26-print-foot" in vex_card
-        # Notes are no longer a sibling card of their own.
-        assert not any(
-            "n26-print-card-sub" in card and ">Notes<" in card
-            for card in _print_cards(body)
-        )
+        # A sibling notes card used this as its subtitle. The write-in
+        # label is also "Notes", so match the subtitle class specifically.
+        assert 'n26-print-card-sub">Notes' not in body
 
     def test_each_card_leaves_space_to_write(self, client, tester, gang, written):
         client.force_login(tester)

--- a/n26/core/test_views_print.py
+++ b/n26/core/test_views_print.py
@@ -314,9 +314,34 @@ class TestThePrintPage:
         assert setup_url(gang) in body
 
 
+def _print_cards(body):
+    """Each printed card's markup, split on the card shell class.
+
+    The space after the class name is load-bearing: without it this
+    would also split on ``n26-print-card-head`` and the rest of the
+    card's inner classes.
+    """
+    return body.split('class="n26-print-card ')
+
+
+def _give_picture(op, miniature):
+    from io import BytesIO
+
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image
+
+    buffer = BytesIO()
+    Image.new("RGB", (40, 50), "purple").save(buffer, format="PNG")
+    op.set_image(
+        miniature,
+        SimpleUploadedFile("vex.png", buffer.getvalue(), content_type="image/png"),
+    )
+
+
 class TestNotesOnPaper:
-    """The written fields on paper: notes print as cards of their own,
-    lore never does, and the toggle takes the lot off."""
+    """The written fields on paper: a model's notes sit on its card next
+    to the picture, with space to write underneath; lore never prints;
+    and the toggle takes the whole strip off."""
 
     @pytest.fixture
     def written(self, gang, roster, tester):
@@ -336,6 +361,36 @@ class TestNotesOnPaper:
         assert "Nobody knows where Vex came from" not in body
         assert "Founded on a debt" not in body
 
+    def test_a_models_notes_sit_on_its_card(self, client, tester, gang, written):
+        client.force_login(tester)
+        body = client.get(print_url(gang)).content.decode()
+        vex_card = next(
+            card
+            for card in _print_cards(body)
+            if "n26-print-card-title" in card
+            and "Vex" in card
+            and "Remember the toxin reroll" in card
+        )
+        assert "n26-print-notes" in vex_card
+        assert "n26-print-foot" in vex_card
+        # Notes are no longer a sibling card of their own.
+        assert not any(
+            "n26-print-card-sub" in card and ">Notes<" in card
+            for card in _print_cards(body)
+        )
+
+    def test_each_card_leaves_space_to_write(self, client, tester, gang, written):
+        client.force_login(tester)
+        body = client.get(print_url(gang)).content.decode()
+        fighter_cards = [
+            card
+            for card in _print_cards(body)
+            if "n26-print-card-title" in card and ("Vex" in card or "Sull" in card)
+        ]
+        assert len(fighter_cards) == 2
+        for card in fighter_cards:
+            assert "n26-print-field" in card
+
     def test_the_toggle_takes_every_note_off(self, client, tester, gang, written):
         client.force_login(tester)
         body = client.get(
@@ -344,6 +399,8 @@ class TestNotesOnPaper:
         ).content.decode()
         assert "Remember the toxin reroll" not in body
         assert "Meet at the sump gate" not in body
+        assert "n26-print-foot" not in body
+        assert "n26-print-field" not in body
 
     def test_a_config_remembers_the_choice(self, client, tester, gang, written):
         client.force_login(tester)
@@ -374,26 +431,39 @@ class TestNotesOnPaper:
     def test_a_pictured_model_prints_its_picture(
         self, client, tester, gang, roster, own_storage
     ):
-        from io import BytesIO
-
-        from django.core.files.uploadedfile import SimpleUploadedFile
-        from PIL import Image
-
         vex, _ = roster
-        buffer = BytesIO()
-        Image.new("RGB", (40, 50), "purple").save(buffer, format="PNG")
         with operation(gang, actor=tester) as op:
-            op.set_image(
-                vex,
-                SimpleUploadedFile(
-                    "vex.png", buffer.getvalue(), content_type="image/png"
-                ),
-            )
+            _give_picture(op, vex)
         client.force_login(tester)
         vex.refresh_from_db()
         body = client.get(print_url(gang)).content.decode()
-        assert "n26-print-photo" in body
-        assert vex.image.url in body
+        vex_card = next(
+            card
+            for card in _print_cards(body)
+            if "n26-print-card-title" in card and "Vex" in card
+        )
+        assert "n26-print-photo" in vex_card
+        assert "n26-print-foot" in vex_card
+        assert vex.image.url in vex_card
+
+    def test_the_toggle_takes_pictures_off_too(
+        self, client, tester, gang, roster, own_storage
+    ):
+        vex, sull = roster
+        with operation(gang, actor=tester) as op:
+            _give_picture(op, vex)
+        client.force_login(tester)
+        body = client.get(
+            print_url(gang),
+            {"pick": "1", "fighters": [str(vex.pk), str(sull.pk)]},
+        ).content.decode()
+        assert "n26-print-photo" not in body
+        assert "n26-print-foot" not in body
+
+    def test_the_setup_names_the_whole_strip(self, client, tester, gang, roster):
+        client.force_login(tester)
+        body = client.get(setup_url(gang)).content.decode()
+        assert "Include notes, pictures, and space to write" in body
 
 
 class TestPrintingSomebodyElsesGang:

--- a/n26/core/views/printing.py
+++ b/n26/core/views/printing.py
@@ -179,10 +179,10 @@ def print_setup(request, pk):
     """Choose what a print includes, before the paper is committed.
 
     GET lists the gang's saved configs — each a one-click print — above
-    the form for a new run: an optional name, the two toggles, and every
-    model with its weapons as checkboxes, all ticked to start. Loading a
-    saved config (?config=) pre-fills the form instead, which is how one
-    is edited.
+    the form for a new run: an optional name, the header, stash and notes
+    toggles, and every model with its weapons as checkboxes, all ticked
+    to start. Loading a saved config (?config=) pre-fills the form
+    instead, which is how one is edited.
 
     POST writes a config and redirects to the print page carrying its
     id. A named POST saves under that name; an unnamed one rewrites the

--- a/n26/designsystem/assets/print.css
+++ b/n26/designsystem/assets/print.css
@@ -310,18 +310,60 @@
  * Card — one unit that arrives on paper whole.
  * =========================================================================== */
 
-/* A model's photograph, in the card's bottom-right corner. The card is
- * auto-height, so the picture takes a row of its own at the end rather
- * than overlaying content it cannot know the shape of. */
-.n26-print-photo {
+/* Notes, a write-in box, and the photograph share one footer strip so
+ * they sit together at the bottom of the card. Flex is safe here: the
+ * card itself is an atomic inline, so the page fold cannot cut the
+ * strip even though the strip is a flex row. */
+.n26-print-foot {
     display: flex;
-    justify-content: flex-end;
+    align-items: stretch;
+    gap: 2mm;
     margin-top: 2mm;
 }
 
-.n26-print-photo img {
+.n26-print-foot-fields {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.n26-print-foot-fields > .n26-print-field {
+    flex: 1 1 auto;
+    margin-bottom: 0;
+}
+
+.n26-print-notes {
+    margin-bottom: 1mm;
+}
+
+.n26-print-notes-body {
+    font-size: 0.92em;
+    line-height: 1.25;
+}
+
+.n26-print-notes-body > :last-child {
+    margin-bottom: 0;
+}
+
+/* A model's photograph, in the card foot's right-hand column. Width is
+ * fixed; height stretches to the notes beside it, and never shorter
+ * than the 4:5 portrait the upload crops to. */
+.n26-print-photo {
+    position: relative;
+    flex: 0 0 22mm;
     width: 22mm;
+    min-height: 27.5mm;
+    overflow: hidden;
     border-radius: 1mm;
+}
+
+.n26-print-photo img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .n26-print-card {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fighter notes on an n26 printout used to land on a card of their own, while the picture sat at the bottom of the rules card with no room to write during a game.

Notes now print in the footer of the fighter’s card, beside the picture if there is one, with a write-in box underneath. The existing **Include notes** toggle on the print setup screen covers that whole strip — notes, pictures, and the box — so it can come off the paper in one go. Gang notes still print as their own card. Lore still never prints.

**How to try it**
1. Open a gang’s print setup (`/n26/gangs/<id>/print/setup/`).
2. Leave “Include notes, pictures, and space to write” ticked and print.
3. Check a fighter with notes and a picture: both sit at the bottom of that fighter’s card, with space to write below the notes.
4. Untick the option and print again: notes, pictures, and the write-in box should all be gone.

[Print setup toggle for notes, pictures, and space to write](https://cursor.com/agents/bc-84d735e5-0b86-533a-9b10-d30d1897a6c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprint_setup_notes_toggle.png)
[Vex print card with notes, write-in box, and picture](https://cursor.com/agents/bc-84d735e5-0b86-533a-9b10-d30d1897a6c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprint_card_vex_notes_and_picture.png)
[Print sheet with notes and pictures turned off](https://cursor.com/agents/bc-84d735e5-0b86-533a-9b10-d30d1897a6c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprint_sheet_notes_off.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gyrinx.slack.com/archives/C0BQKP2AW20/p1788804731431939?thread_ts=1788804731.431939&cid=C0BQKP2AW20)

<div><a href="https://cursor.com/agents/bc-84d735e5-0b86-533a-9b10-d30d1897a6c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84d735e5-0b86-533a-9b10-d30d1897a6c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

